### PR TITLE
fix: allow users to exit LoginView when cloud auth is canceled or fails

### DIFF
--- a/clients/ios/Views/LoginView.swift
+++ b/clients/ios/Views/LoginView.swift
@@ -6,6 +6,8 @@ struct LoginView: View {
     @Bindable var authManager: AuthManager
     /// Called after a successful login so the onboarding flow can advance.
     var onContinue: (() -> Void)?
+    /// Called when the user cancels or auth fails and they want to go back.
+    var onCancel: (() -> Void)?
 
     var body: some View {
         VStack(spacing: VSpacing.xl) {
@@ -50,6 +52,13 @@ struct LoginView: View {
                 }
             }
             .buttonStyle(.borderedProminent)
+            .disabled(authManager.isSubmitting)
+
+            // Allow users to go back if they cancel or can't complete login right now.
+            Button("Back") {
+                onCancel?()
+            }
+            .foregroundColor(VColor.textSecondary)
             .disabled(authManager.isSubmitting)
 
             Spacer()

--- a/clients/ios/Views/OnboardingView.swift
+++ b/clients/ios/Views/OnboardingView.swift
@@ -31,8 +31,12 @@ struct OnboardingView: View {
                 )
                 .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
             case .login:
-                LoginView(authManager: authManager, onContinue: { currentStep = .permissions })
-                    .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
+                LoginView(
+                    authManager: authManager,
+                    onContinue: { currentStep = .permissions },
+                    onCancel: { currentStep = .choosePath }
+                )
+                .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
             case .daemonSetup:
                 DaemonSetupStep(onContinue: { currentStep = .permissions })
                     .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))


### PR DESCRIPTION
Addresses feedback from #7764.

The cloud login path introduced in #7764 left users stuck on LoginView with no way back if they canceled the WorkOS auth or encountered an error. This was a functional dead-end requiring a force-quit to recover.

Changes:
- Added an `onCancel` callback to `LoginView` (optional, backward-compatible)
- Added a "Back" button below the Sign In button that calls `onCancel`; disabled while auth is in progress to avoid navigation during an in-flight request
- Wired `onCancel: { currentStep = .choosePath }` in `OnboardingView` so canceling returns to the path selection screen
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
