### PR TITLE
fix(ios): resolve iOS build errors

### DIFF
--- a/clients/shared/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/shared/Features/Avatar/AvatarAppearanceManager.swift
@@ -22,7 +22,7 @@ public final class AvatarAppearanceManager {
     }
 
     private var homeDirectory: String {
-        FileManager.default.homeDirectoryForCurrentUser.path
+        NSHomeDirectory()
     }
 
     public func start() {

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -32,12 +32,12 @@ public final class ChatAttachmentManager: ObservableObject {
     // MARK: - Limits
 
     /// Maximum file size per attachment (20 MB).
-    static let maxFileSize = 20 * 1024 * 1024
+    nonisolated(unsafe) static let maxFileSize = 20 * 1024 * 1024
     /// Maximum image size before compression (4 MB - leaves headroom for base64 encoding).
     /// Anthropic has a 5 MB limit per image; base64 encoding adds ~33% overhead.
-    static let maxImageSize = 4 * 1024 * 1024
+    nonisolated(unsafe) static let maxImageSize = 4 * 1024 * 1024
     /// Maximum number of attachments per message.
-    public static let maxAttachments = 5
+    nonisolated(unsafe) public static let maxAttachments = 5
 
     // MARK: - Error callback
 
@@ -321,7 +321,7 @@ public final class ChatAttachmentManager: ObservableObject {
     // MARK: - Static helpers (shared with ChatViewModel+Attachments and mapIPCAttachments)
 
     /// Resize image data to fit within `maxDimension` and return PNG data.
-    public static func generateThumbnail(from data: Data, maxDimension: CGFloat) -> Data? {
+    nonisolated public static func generateThumbnail(from data: Data, maxDimension: CGFloat) -> Data? {
         #if os(macOS)
         guard let image = NSImage(data: data) else { return nil }
         let size = image.size
@@ -362,7 +362,7 @@ public final class ChatAttachmentManager: ObservableObject {
 
     /// Compress image data if it exceeds the size limit.
     /// Returns (compressedData, wasCompressed) tuple.
-    public static func compressImageIfNeeded(data: Data, maxSize: Int) -> (Data, Bool) {
+    nonisolated public static func compressImageIfNeeded(data: Data, maxSize: Int) -> (Data, Bool) {
         // Check if compression is needed
         guard data.count > maxSize else {
             return (data, false)

--- a/clients/shared/Features/Chat/OfflineMessageQueue.swift
+++ b/clients/shared/Features/Chat/OfflineMessageQueue.swift
@@ -1,7 +1,6 @@
 #if canImport(UIKit)
 import Foundation
 import os
-import VellumAssistantShared
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "OfflineMessageQueue")
 


### PR DESCRIPTION
## Summary

- Replace `homeDirectoryForCurrentUser` (unavailable on iOS) with `NSHomeDirectory()` in AvatarAppearanceManager
- Mark `compressImageIfNeeded` and `generateThumbnail` as `nonisolated` and static constants as `nonisolated(unsafe)` to fix async-without-await errors in `Task.detached` blocks in ChatAttachmentManager
- Move `OfflineMessageQueue.swift` from `clients/ios/App/` to `clients/shared/Features/Chat/` so it's part of VellumAssistantShared (where ChatViewModel references it)

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22354356396

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
