### PR TITLE
fix(settings): restore correct dropFirst().debounce() ordering for activityNotificationsEnabled

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -256,11 +256,13 @@ public final class SettingsStore: ObservableObject {
             .store(in: &cancellables)
 
         // Debounce UserDefaults writes so rapid toggle changes don't thrash disk I/O.
-        // dropFirst comes after debounce so the first user-changed value is not dropped before
-        // it has a chance to be coalesced.
+        // dropFirst must come before debounce: it consumes the synchronous initial emission so that
+        // only genuine user-driven changes flow into debounce and are eventually persisted.
+        // Placing dropFirst after debounce would cause the first real user change to be silently
+        // dropped whenever it arrives within the 300ms debounce window of the initial value.
         $activityNotificationsEnabled
-            .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
             .dropFirst()
+            .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
             .sink { value in UserDefaults.standard.set(value, forKey: "activityNotificationsEnabled") }
             .store(in: &cancellables)
 


### PR DESCRIPTION
Fixes the operator ordering regression introduced in #7796 for the activityNotificationsEnabled Combine pipeline.

The previous PR changed .dropFirst().debounce() to .debounce().dropFirst() based on incorrect reasoning. The Devin review correctly identified that this ordering causes the first user-driven change to be silently dropped whenever it arrives within the 300ms debounce window after SettingsStore init:

1. `$activityNotificationsEnabled` emits the initial value synchronously on subscription.
2. .debounce() holds it for 300ms.
3. If the user toggles within that 300ms window, debounce coalesces the initial value with the user change.
4. .dropFirst() then drops the coalesced (user-changed) value — the change is never persisted.

Restored the original .dropFirst().debounce() order and updated the comment to clearly explain why dropFirst must precede debounce.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
