### PR TITLE
fix(memory-ux): preserve memory degradation state across reconnects

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -425,11 +425,12 @@ public final class ChatViewModel: ObservableObject {
                 self?.pendingMessageIds.removeAll()
                 self?.requestIdToMessageId.removeAll()
                 self?.pendingLocalDeletions.removeAll()
-                // Clear stale degradation state so users don't see a warning banner
-                // from a previous session if the new session is healthy. The daemon
-                // will re-emit memory_status if degradation persists after reconnect.
-                self?.isMemoryDegraded = false
-                self?.memoryDegradedReason = nil
+                // Do NOT reset isMemoryDegraded/memoryDegradedReason here: the daemon
+                // only emits memory_status during turn processing (prepareMemoryContext),
+                // not as part of a reconnect handshake. Clearing on reconnect would
+                // produce a false healthy state after transient disconnects — the banner
+                // would disappear until the user sends another message. Preserve the
+                // last-known state; it will be updated when the next turn is processed.
                 #if os(iOS)
                 // If we already have a session ID, flush immediately. Otherwise
                 // defer: sessionId's didSet will trigger flushOfflineQueue() once


### PR DESCRIPTION
Addresses Codex review feedback on #7794.

The previous implementation cleared isMemoryDegraded and memoryDegradedReason on IPC reconnect. The daemon only emits memory_status during turn processing (prepareMemoryContext), not as part of reconnect handshakes — so clearing on reconnect produces a false healthy state: the warning banner disappears immediately after a transient disconnect and stays gone until the user sends another message.

Fix: remove the reset on reconnect and preserve the last-known degradation state. The state will be updated when the next turn is processed and the daemon emits a new memory_status event.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
