### PR TITLE
fix: reset cached unlock PIN after PIN change

### DIFF
--- a/clients/ios/Views/Settings/IOSParentalControlSection.swift
+++ b/clients/ios/Views/Settings/IOSParentalControlSection.swift
@@ -301,7 +301,9 @@ struct IOSParentalControlSection: View {
         case .success(let mode):
             switch mode {
             case .set: hasPIN = true; successMessage = "PIN set."
-            case .change: successMessage = "PIN changed."
+            // The old PIN is now invalid; clear the cache so subsequent
+            // updates don't silently send a stale credential.
+            case .change: isUnlocked = false; unlockedPIN = nil; successMessage = "PIN changed."
             case .clear: hasPIN = false; isUnlocked = false; unlockedPIN = nil; successMessage = "PIN cleared."
             }
         case .failure(let msg):

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
@@ -72,6 +72,10 @@ struct SettingsParentalTab: View {
                             hasPIN = true
                             successMessage = "PIN set."
                         case .change:
+                            // The old PIN is now invalid; clear the cache so subsequent
+                            // updates don't silently send a stale credential.
+                            isUnlocked = false
+                            unlockedPIN = nil
                             successMessage = "PIN changed."
                         case .clear:
                             hasPIN = false


### PR DESCRIPTION
Addresses feedback from PR #7801: after a successful PIN change, the old cached `unlockedPIN` was left stale while the UI remained unlocked. Subsequent `sendParentalControlUpdate` calls would then forward the old (now-invalid) PIN, causing daemon updates to silently fail until the user re-authenticated.

Fix: in both macOS (`SettingsParentalTab.swift`) and iOS (`IOSParentalControlSection.swift`), clear `unlockedPIN` and reset `isUnlocked = false` on the `.change` success path, mirroring what already happened on the `.clear` path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
