### PR TITLE
fix(context): let force=true bypass cooldown; fix stale test assertion

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -287,7 +287,7 @@ describe('ContextWindowManager', () => {
     expect(getSummaryFromContextMessage(userMessage)).toBeNull();
   });
 
-  test('skips compaction during cooldown when projected gain is too low', async () => {
+  test('skips compaction during cooldown', async () => {
     const provider = createProvider(() => {
       throw new Error('summarizer should not be called while cooldown skip is active');
     });
@@ -307,7 +307,7 @@ describe('ContextWindowManager', () => {
       lastCompactedAt: Date.now() - 30_000,
     });
     expect(result.compacted).toBe(false);
-    expect(result.reason).toBe('compaction cooldown active with low projected gain');
+    expect(result.reason).toBe('compaction cooldown active');
   });
 
   test('ignores cooldown and compacts under severe token pressure', async () => {
@@ -333,6 +333,34 @@ describe('ContextWindowManager', () => {
 
     const result = await manager.maybeCompact(history, undefined, {
       lastCompactedAt: Date.now() - 30_000,
+    });
+    expect(result.compacted).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
+
+  test('force=true bypasses cooldown for context-too-large recovery', async () => {
+    const provider = createProvider(() => ({
+      content: [{ type: 'text', text: '## Goals\n- forced compaction' }],
+      model: 'mock-model',
+      usage: { inputTokens: 60, outputTokens: 12 },
+      stopReason: 'end_turn',
+    }));
+    const manager = new ContextWindowManager(
+      provider,
+      'system prompt',
+      makeConfig({ maxInputTokens: 260, targetInputTokens: 180, preserveRecentUserTurns: 1 }),
+    );
+    const long = 'c'.repeat(220);
+    const history: Message[] = [
+      message('user', `u1 ${long}`),
+      message('assistant', `a1 ${long}`),
+      message('user', `u2 ${long}`),
+    ];
+
+    // Same setup as the cooldown test, but with force=true — should compact.
+    const result = await manager.maybeCompact(history, undefined, {
+      lastCompactedAt: Date.now() - 30_000,
+      force: true,
     });
     expect(result.compacted).toBe(true);
     expect(result.reason).toBeUndefined();

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -203,9 +203,12 @@ export class ContextWindowManager {
     // Removing the redundant MIN_GAIN_TOKENS_DURING_COOLDOWN guard here lets
     // that shorter cooldown actually gate compaction: high-growth conversations
     // break out of the cooldown sooner and compact more frequently.
+    // force=true bypasses the cooldown so context-too-large recovery can always
+    // attempt a compaction even within the cooldown window.
     if (
       withinCooldown
       && !severePressure
+      && !options?.force
     ) {
       log.debug(
         { projectedGainTokens, adaptiveCooldownMs, growthRateMultiplier, msSinceCompaction: typeof lastCompactedAt === 'number' ? Date.now() - lastCompactedAt : null },


### PR DESCRIPTION
Addresses review feedback on #7793.

- **Codex feedback**: The cooldown guard in `window-manager.ts` now also respects `force: true`, so context-too-large recovery (which calls `maybeCompact(..., { force: true })`) can always attempt compaction without being blocked by the cooldown window.
- **Devin feedback**: Updated the test name and reason string assertion to match the new reason `'compaction cooldown active'` (was `'compaction cooldown active with low projected gain'`).
- Added a new test `force=true bypasses cooldown for context-too-large recovery` to cover the regression path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7838" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
