### PR TITLE
fix(search): escape backslashes in LIKE pattern before percent and underscore

### DIFF
--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -531,7 +531,10 @@ export function searchConversations(
   const db = getDb();
   const limit = opts?.limit ?? 20;
   const maxMsgsPerConv = opts?.maxMessagesPerConversation ?? 3;
-  const pattern = `%${query.replace(/%/g, '\\%').replace(/_/g, '\\_')}%`;
+  // Escape backslashes first so they don't interfere with subsequent % and _ escaping.
+  // With ESCAPE '\\', SQLite treats \\ as a literal backslash, \% as a literal percent,
+  // and \_ as a literal underscore — so all three characters must be escaped in that order.
+  const pattern = `%${query.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_')}%`;
 
   // Find conversations whose title or at least one message content matches the query.
   // leftJoin ensures title-only matches are included even for empty conversations


### PR DESCRIPTION
Addresses review feedback on #7810: when a user searches for a string containing a literal backslash (e.g. C:\Users\file), the backslash was not escaped before building the LIKE pattern. Since ESCAPE '\\' is now active, SQLite treats \U as "escaped U" (i.e. literal U), silently dropping the backslash. Fix: escape \\ → \\\\ first, then escape % and _ as before.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
