### PR TITLE
fix(linear-watcher): scope issue-state cache per credential to prevent cross-watcher event loss

### DIFF
--- a/assistant/src/watcher/providers/linear.ts
+++ b/assistant/src/watcher/providers/linear.ts
@@ -278,12 +278,25 @@ async function fetchAssignedIssueUpdates(
 // ── Issue state tracking ──────────────────────────────────────────────────────
 
 /**
- * Tracks the last known state ID per issue (keyed by issue ID).
- * Populated on every poll so we can detect transitions across consecutive polls.
+ * Tracks the last known state ID per issue, scoped by credentialService so
+ * multiple Linear watchers in the same process (e.g. different accounts or
+ * credential keys) maintain independent baselines and can't corrupt each
+ * other's state. Outer key: credentialService; inner key: issue ID.
+ *
  * In-memory only; resets on daemon restart, which is acceptable — the first
  * poll after restart will seed the map without emitting false-positive events.
  */
-const knownIssueStateIds = new Map<string, string>();
+const knownIssueStateIdsByCredential = new Map<string, Map<string, string>>();
+
+/** Get (or lazily create) the per-credential state map. */
+function getStateCache(credentialService: string): Map<string, string> {
+  let cache = knownIssueStateIdsByCredential.get(credentialService);
+  if (!cache) {
+    cache = new Map<string, string>();
+    knownIssueStateIdsByCredential.set(credentialService, cache);
+  }
+  return cache;
+}
 
 // ── Event type mapping ────────────────────────────────────────────────────────
 
@@ -403,13 +416,16 @@ export const linearProvider: WatcherProvider = {
       // On first sight of an issue we seed the map without emitting, so we don't
       // fire false-positive events after a daemon restart.
       const assignedIssues = await fetchAssignedIssueUpdates(token, viewer.id, since);
+      // Use a per-credential state cache so multiple Linear watchers in the same
+      // process don't overwrite each other's baselines and silently drop events.
+      const stateCache = getStateCache(credentialService);
       for (const issue of assignedIssues) {
-        const previousStateId = knownIssueStateIds.get(issue.id);
+        const previousStateId = stateCache.get(issue.id);
         if (previousStateId !== undefined && previousStateId !== issue.state.id) {
           items.push(issueToStatusChangeItem(issue, previousStateId));
         }
         // Always update the map so the next poll has an accurate baseline.
-        knownIssueStateIds.set(issue.id, issue.state.id);
+        stateCache.set(issue.id, issue.state.id);
       }
 
       const newWatermark = new Date().toISOString();


### PR DESCRIPTION
Addresses the P1 feedback from Codex review on #7806.

## Problem
`knownIssueStateIds` was a module-level `Map<string, string>` (keyed only by issue ID). When multiple Linear watchers ran in the same process — even with different credential services — they shared the same map. The first watcher to poll would update the baseline for an issue; subsequent watchers would then see `previousStateId === issue.state.id` for that same issue and silently skip the `linear_status_changed` event.

## Fix
- Replaced the flat module-level map with a two-level `Map<credentialService, Map<issueId, stateId>>`  named `knownIssueStateIdsByCredential`.
- Added a `getStateCache(credentialService)` helper that lazily initialises the inner map.
- `fetchNew` now passes `credentialService` to `getStateCache` so each distinct credential (= each distinct watcher account) gets its own isolated baseline.

## Files Modified
- `assistant/src/watcher/providers/linear.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
