### PR TITLE
fix(ios-tasks): resume refresh continuation on sendWorkItemsList failure

### DIFF
--- a/clients/ios/Views/Tasks/TasksViewModel.swift
+++ b/clients/ios/Views/Tasks/TasksViewModel.swift
@@ -188,6 +188,13 @@ class TasksViewModel: ObservableObject {
             // the next work-items-list response arrives, then clears itself.
             pendingRefreshContinuation = continuation
             fetchItems()
+            // If fetchItems() failed synchronously (e.g. send threw), the daemon
+            // callback will never fire — resume immediately to avoid a leaked
+            // continuation and an indefinitely-spinning refresh indicator.
+            if errorMessage != nil, let cont = pendingRefreshContinuation {
+                pendingRefreshContinuation = nil
+                cont.resume()
+            }
         }
     }
 


### PR DESCRIPTION
Addresses PR #7812 review feedback from Codex and Devin.

When fetchItemsAsync() is called via pull-to-refresh, it stores a CheckedContinuation and then calls fetchItems(). If sendWorkItemsList() throws (e.g. daemon unavailable or socket error), fetchItems() handles the error locally but the continuation is never resumed — causing the pull-to-refresh spinner to hang indefinitely, and a runtime warning/crash in debug builds when the continuation is deallocated without being resumed.

Fix: after calling fetchItems(), check if errorMessage is non-nil (which indicates a synchronous failure). If so, immediately resume and clear the pending continuation rather than waiting for onWorkItemsListResponse (which will never fire).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
