### PR TITLE
Polish sidebar drawer positioning, padding, and colors

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -616,7 +616,7 @@ struct MainWindowView: View {
                             }
                         )
                         .frame(width: drawerWidth)
-                        .offset(x: drawerX, y: -52)
+                        .offset(x: drawerX, y: -28)
                         .zIndex(10)
                         .transition(.opacity)
                     }
@@ -1077,6 +1077,8 @@ struct MainWindowView: View {
     @ViewBuilder
     private var collapsedSidebarContent: some View {
         VStack(spacing: VSpacing.sm) {
+            Spacer().frame(height: 0)
+
             SidebarNavRow(icon: "square.grid.2x2", label: "Home Base", isActive: windowState.activePanel == .directory, isExpanded: false) {
                 windowState.togglePanel(.directory)
             }
@@ -1103,6 +1105,8 @@ struct MainWindowView: View {
                     showControlCenterDrawer.toggle()
                 }
             }
+
+            Spacer().frame(height: 0)
         }
     }
 
@@ -1260,7 +1264,7 @@ private struct SidebarNavRow: View {
             .padding(.trailing, isExpanded ? VSpacing.sm : 0)
             .padding(.vertical, VSpacing.sm)
             .frame(maxWidth: .infinity, alignment: isExpanded ? .leading : .center)
-            .background(isActive ? adaptiveColor(light: Moss._100, dark: Moss._700) : isHovered ? adaptiveColor(light: Moss._100, dark: Moss._700).opacity(0.5) : .clear)
+            .background(isActive ? adaptiveColor(light: Color(hex: 0xD4DFD0), dark: Moss._700) : isHovered ? adaptiveColor(light: Color(hex: 0xD4DFD0), dark: Moss._700).opacity(0.5) : .clear)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())
         }
@@ -1325,7 +1329,7 @@ private struct DrawerMenuView: View {
             DrawerMenuItem(icon: "stethoscope", label: "Vellum Doctor", action: onDoctor)
         }
         .padding(.vertical, VSpacing.sm)
-        .background(VColor.surface)
+        .background(VColor.surfaceSubtle)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.lg)


### PR DESCRIPTION
## Summary
- Adjust control center drawer Y offset for better vertical alignment with the sidebar icon
- Add consistent top/bottom padding in collapsed sidebar nav using 0-height spacers
- Use `#D4DFD0` for sidebar nav row active/hover background in light mode
- Change drawer popover background from `VColor.surface` to `VColor.surfaceSubtle` to match theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
