### PR TITLE
fix: stabilize debug panel session selection while sheet is open

### DIFF
--- a/clients/ios/Views/Settings/DeveloperSettingsSection.swift
+++ b/clients/ios/Views/Settings/DeveloperSettingsSection.swift
@@ -25,6 +25,9 @@ private struct DeveloperSettingsSectionContent: View {
     let clientProvider: ClientProvider
     @ObservedObject var traceStore: TraceStore
     @State private var showDebugPanel = false
+    // Captured once when the sheet opens so the panel stays on the same session
+    // even if newer trace events arrive while the sheet is visible.
+    @State private var selectedSessionId: String?
 
     private var sessionCount: Int {
         traceStore.eventsBySession.count
@@ -48,6 +51,9 @@ private struct DeveloperSettingsSectionContent: View {
 
             Section("Debug Panel") {
                 Button {
+                    // Snapshot the most recent session at open time so the panel
+                    // doesn't jump to a different session if newer events arrive.
+                    selectedSessionId = traceStore.mostRecentSessionId
                     showDebugPanel = true
                 } label: {
                     Label("Open Debug Panel", systemImage: "ladybug")
@@ -61,11 +67,9 @@ private struct DeveloperSettingsSectionContent: View {
         .navigationTitle("Developer")
         .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: $showDebugPanel) {
-            // Use the most recently active session rather than an arbitrary dict key.
-            let sessionId = traceStore.mostRecentSessionId
             DebugPanelView(
                 traceStore: traceStore,
-                sessionId: sessionId,
+                sessionId: selectedSessionId,
                 onClose: { showDebugPanel = false }
             )
         }


### PR DESCRIPTION
Addresses Codex P2 feedback on #7820: capture `selectedSessionId` when the button is tapped instead of recomputing `traceStore.mostRecentSessionId` inside the sheet closure on every render. This prevents the panel from jumping to a different session mid-inspection when newer trace events arrive while the sheet is visible.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
