### PR TITLE
fix: return HTTP 500 on batch failure in WhatsApp webhook to enable Meta retries

### DIFF
--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -141,6 +141,11 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
       return Response.json({ ok: true });
     }
 
+    // Track whether any message failed so we can signal Meta to retry the batch.
+    // Returning 500 causes Meta to resend the webhook; the dedup cache ensures
+    // already-processed messages are skipped while failed ones are retried.
+    let hasFailure = false;
+
     for (const normalized of normalizedMessages) {
       const { event, whatsappMessageId } = normalized;
       const from = event.message.externalChatId;
@@ -246,7 +251,7 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
         if (!result.forwarded) {
           tlog.error({ whatsappMessageId }, "Failed to forward WhatsApp message to runtime");
           dedupCache.unreserve(whatsappMessageId);
-          // Continue processing remaining messages even if one fails to forward
+          hasFailure = true;
           continue;
         }
 
@@ -255,8 +260,12 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
       } catch (err) {
         tlog.error({ err, whatsappMessageId }, "Failed to process inbound WhatsApp message");
         dedupCache.unreserve(whatsappMessageId);
-        // Continue processing remaining messages even if one throws
+        hasFailure = true;
       }
+    }
+
+    if (hasFailure) {
+      return Response.json({ error: "Internal error" }, { status: 500 });
     }
 
     return Response.json({ ok: true });


### PR DESCRIPTION
## Summary

- Add a `hasFailure` flag before the batch processing loop in the WhatsApp webhook handler
- Set `hasFailure = true` in the `!result.forwarded` branch and the `catch` block
- Return HTTP 500 after the loop if any message failed, so Meta will retry the webhook delivery

## Why

When the PR #7813 converted the single-message handler to a batch loop, it introduced a regression: the handler always returned HTTP 200 even when individual messages failed to forward. Meta only retries webhooks that receive non-2xx responses, so failed messages were silently dropped — the `dedupCache.unreserve()` calls were ineffective since Meta never resent the webhook.

This fix preserves the batch processing behavior (all messages are attempted) while restoring the retry signal. On retry, already-processed messages are deduplicated via `dedupCache.mark()`, so only the failed ones are reprocessed.

Addresses review feedback from Devin and Codex on PR #7813.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
