### PR TITLE
fix: track summaryTask to prevent stale summary sheet in AmbientAgentManager

### DIFF
--- a/clients/ios/App/AmbientAgentManager.swift
+++ b/clients/ios/App/AmbientAgentManager.swift
@@ -35,6 +35,10 @@ final class AmbientAgentManager: ObservableObject {
     private let trigger = RideShotgunTrigger()
     private var triggerCancellable: AnyCancellable?
     private var sessionCancellable: AnyCancellable?
+    /// Tracks the delayed task that sets completedSummary so it can be cancelled
+    /// if the manager transitions to a state where showing the old summary would
+    /// be incorrect (e.g. teardown, cancel, or a new session starting).
+    private var summaryTask: Task<Void, Never>?
 
     // MARK: - Setup / Teardown
 
@@ -60,6 +64,8 @@ final class AmbientAgentManager: ObservableObject {
         sessionCancellable = nil
         activeSession?.cancel()
         activeSession = nil
+        summaryTask?.cancel()
+        summaryTask = nil
         completedSummary = nil
         showInvitation = false
         log.info("AmbientAgentManager torn down")
@@ -88,6 +94,11 @@ final class AmbientAgentManager: ObservableObject {
             log.warning("Ride shotgun session already active")
             return
         }
+        // Cancel any pending summary from a previous session before starting a
+        // new one, so a stale summary sheet cannot appear on top of the new
+        // session's progress sheet.
+        summaryTask?.cancel()
+        summaryTask = nil
 
         // iOS sends the ride_shotgun_start IPC message to the Mac daemon,
         // which owns screen capture. The daemon will send back progress and
@@ -110,6 +121,8 @@ final class AmbientAgentManager: ObservableObject {
         activeSession = nil
         sessionCancellable?.cancel()
         sessionCancellable = nil
+        summaryTask?.cancel()
+        summaryTask = nil
         log.info("Ride shotgun session cancelled by user")
     }
 
@@ -147,9 +160,10 @@ final class AmbientAgentManager: ObservableObject {
             // would be silently dropped on many iOS versions.  A short delay lets
             // the dismissal animation finish before we request the next presentation.
             let pendingSummary = CompletedSummary(text: displayText, recordingId: recordingId)
-            Task { @MainActor [weak self] in
+            summaryTask = Task { @MainActor [weak self] in
                 try? await Task.sleep(nanoseconds: 600_000_000) // 0.6 s
-                self?.completedSummary = pendingSummary
+                guard let self, !Task.isCancelled else { return }
+                self.completedSummary = pendingSummary
             }
 
         case .failed(let reason):


### PR DESCRIPTION
Addresses Devin review feedback on PR #7819.

The fire-and-forget Task that delays setting completedSummary by 0.6s was not tracked, so it could not be cancelled. This caused two races:
- Starting a new session within the 0.6s window would get the old summary sheet overlaid on top of the new progress sheet.
- Calling teardown() during the delay would cause the summary sheet to reappear after teardown.

**Fix:** Store the Task in a new private property summaryTask and cancel it in teardown(), cancelSession(), and startSession() (after the guard). Also add a Task.isCancelled check inside the closure as a belt-and-suspenders guard.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7846" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
