### PR TITLE
fix(ios): require valid URL when adding pinned app

### DIFF
--- a/clients/ios/Views/HomeBaseView.swift
+++ b/clients/ios/Views/HomeBaseView.swift
@@ -600,18 +600,22 @@ struct HomeBaseView: View {
                     Button("Add") {
                         let trimmedName = newPinName.trimmingCharacters(in: .whitespaces)
                         let trimmedURL = newPinURL.trimmingCharacters(in: .whitespaces)
-                        guard !trimmedName.isEmpty else { return }
+                        guard !trimmedName.isEmpty, !trimmedURL.isEmpty, URL(string: trimmedURL) != nil else { return }
                         pinnedAppsStore.pin(PinnedAppLink(
                             id: UUID().uuidString,
                             name: trimmedName,
                             icon: newPinIcon.isEmpty ? nil : newPinIcon,
-                            url: trimmedURL.isEmpty ? nil : trimmedURL,
+                            url: trimmedURL,
                             appType: nil,
                             pinnedOrder: pinnedAppsStore.pins.count
                         ))
                         showAddPinSheet = false
                     }
-                    .disabled(newPinName.trimmingCharacters(in: .whitespaces).isEmpty)
+                    .disabled({
+                        let trimmedName = newPinName.trimmingCharacters(in: .whitespaces)
+                        let trimmedURL = newPinURL.trimmingCharacters(in: .whitespaces)
+                        return trimmedName.isEmpty || trimmedURL.isEmpty || URL(string: trimmedURL) == nil
+                    }())
                 }
             }
         }


### PR DESCRIPTION
Addresses Codex P2 feedback on #7821.

The Add Pinned App sheet previously only validated that the name was non-empty, allowing users to save a pin with no URL or an unparseable URL. Such pins appeared tappable (and had an Open context menu item) but silently did nothing on tap.

This change:
- Requires a non-empty, URL-parseable string in the URL field before the Add button is enabled
- Passes the validated URL directly (no longer wraps in Optional since nil is no longer possible at save time)
- Guards the button action with the same validation to prevent bypasses
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
