### PR TITLE
fix: guard finishRecordingForAutoStop against double teardown and late isFinal overwrite

### DIFF
--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -27,6 +27,13 @@ struct InputBarView: View {
     /// and stopRecording). Prevents double-stop when the auto-stop path and the isFinal callback
     /// both reach teardown code.
     @State private var isAudioEngineStopped = false
+    /// True while the auto-stop path is waiting for the isFinal callback to arrive. During this
+    /// window the voice orb is already collapsed and the text field is visible, so the user may
+    /// start typing. textAtAutoStop captures the text value the moment auto-stop fires; the isFinal
+    /// handler only applies the final transcription when text still matches that snapshot, i.e.
+    /// the user has not typed anything in the interim.
+    @State private var isAutoStopPending = false
+    @State private var textAtAutoStop: String = ""
     @State private var recognitionTask: SFSpeechRecognitionTask?
     @State private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     @State private var audioEngine = AVAudioEngine()
@@ -348,6 +355,8 @@ struct InputBarView: View {
         lastSpeechTime = Date()
         hasSpeechOccurred = false
         isAudioEngineStopped = false
+        isAutoStopPending = false
+        textAtAutoStop = ""
 
         inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { buffer, _ in
             request.append(buffer)
@@ -382,8 +391,14 @@ struct InputBarView: View {
                     let transcribed = result.bestTranscription.formattedString
                     if result.isFinal {
                         log.info("Voice transcription final: \(transcribed, privacy: .public)")
-                        text = transcribed
-                        onVoiceResult?(transcribed)
+                        // Only apply the final transcription if the user has not typed anything
+                        // since auto-stop. When isAutoStopPending is true the voice orb has already
+                        // collapsed and the text field is visible, so the user may have started
+                        // editing; we respect their input by skipping the overwrite in that case.
+                        if !isAutoStopPending || text == textAtAutoStop {
+                            text = transcribed
+                            onVoiceResult?(transcribed)
+                        }
                         stopRecording()
                         isVoiceOrbExpanded = false
                     }
@@ -467,17 +482,15 @@ struct InputBarView: View {
         }
         cleanupRecognition()
         isRecording = false
+        isAutoStopPending = false
         micAmplitude = 0
     }
 
-    /// Ends the recording session without immediately cancelling the recognition task,
-    /// allowing SFSpeechRecognizer to deliver a final transcription result naturally.
-    /// The recognition callback will call stopRecording() once isFinal fires, which
-    /// performs full cleanup. Use this from auto-stop paths (silence detection, listening
-    /// timeout) so that in-flight speech is not dropped when the timer fires before the
-    /// last recognition result arrives.
     private func finishRecordingForAutoStop() {
-        guard isRecording else { return }
+        // isAudioEngineStopped guards against both timers queuing async blocks that both
+        // pass the isRecording check before either executes — the second call would otherwise
+        // call audioEngine.stop() and endAudio() a second time on the same session.
+        guard isRecording, !isAudioEngineStopped else { return }
         log.info("Voice recording finishing (auto-stop) — awaiting final transcription")
 
         // Disarm auto-stop timers so they don't fire again.
@@ -485,6 +498,11 @@ struct InputBarView: View {
         listeningTimeoutTimer = nil
         silenceTimer?.invalidate()
         silenceTimer = nil
+
+        // Snapshot the current text so the isFinal callback can detect whether the user has
+        // typed anything in the text field while we were waiting for the final result.
+        isAutoStopPending = true
+        textAtAutoStop = text
 
         // Stop the audio engine and signal end-of-audio to the recognizer.
         // Do NOT cancel the recognition task and do NOT clear isRecording — the existing


### PR DESCRIPTION
Addresses Devin and Codex review feedback on #7822.

## Changes

- **Double audio engine teardown (Devin)**: Add `!isAudioEngineStopped` to the guard in `finishRecordingForAutoStop()`. Previously, if both the silence timer and the listening timeout timer queued `DispatchQueue.main.async` blocks before either executed, the second call would pass the `isRecording` check (still `true`) and call `audioEngine.stop()`, `removeTap(onBus:)`, and `endAudio()` a second time on the same session — potentially causing undefined behavior in SFSpeechRecognizer.

- **Late isFinal clobbering user input (Codex)**: Add `isAutoStopPending` flag and `textAtAutoStop` snapshot. When `finishRecordingForAutoStop()` fires it sets the flag and captures the current text value. The `isFinal` callback only applies `text = transcribed` when `!isAutoStopPending || text == textAtAutoStop` — i.e. either we are not in auto-stop-pending state, or the user has not typed anything since auto-stop. If the user starts typing in the now-visible text field before `isFinal` arrives, their input is preserved. `stopRecording()` clears the flag on completion.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
