### PR TITLE
M1: Approval Conversation Engine Foundation

### DIFF
--- a/assistant/src/__tests__/approval-conversation-turn.test.ts
+++ b/assistant/src/__tests__/approval-conversation-turn.test.ts
@@ -98,6 +98,61 @@ describe('runApprovalConversationTurn', () => {
     expect(result.replyText).toContain("couldn't process");
   });
 
+  test('fail-closed when disposition is not in allowedActions', async () => {
+    // Context only allows approve_once and reject (no approve_always)
+    const restrictedContext = makeContext({
+      allowedActions: ['approve_once', 'reject'],
+    });
+
+    const result = await runApprovalConversationTurn(
+      restrictedContext,
+      makeGenerator({
+        disposition: 'approve_always',
+        replyText: 'Approved permanently!',
+        targetRunId: 'run-1',
+      }),
+    );
+    expect(result.disposition).toBe('keep_pending');
+    expect(result.replyText).toContain("couldn't process");
+  });
+
+  test('keep_pending is always allowed regardless of allowedActions', async () => {
+    const restrictedContext = makeContext({
+      allowedActions: ['approve_once', 'reject'],
+    });
+
+    const result = await runApprovalConversationTurn(
+      restrictedContext,
+      makeGenerator({
+        disposition: 'keep_pending',
+        replyText: 'Can you tell me more about this request?',
+      }),
+    );
+    expect(result.disposition).toBe('keep_pending');
+    expect(result.replyText).toBe('Can you tell me more about this request?');
+  });
+
+  test('fail-closed when targetRunId does not match any pending approval', async () => {
+    const contextWithMultiple = makeContext({
+      pendingApprovals: [
+        { runId: 'run-1', toolName: 'execute_shell' },
+        { runId: 'run-2', toolName: 'file_write' },
+      ],
+    });
+
+    // Hallucinated run ID that doesn't match any pending approval
+    const result = await runApprovalConversationTurn(
+      contextWithMultiple,
+      makeGenerator({
+        disposition: 'approve_once',
+        replyText: 'Approved!',
+        targetRunId: 'run-nonexistent',
+      }),
+    );
+    expect(result.disposition).toBe('keep_pending');
+    expect(result.replyText).toContain("couldn't process");
+  });
+
   test('targetRunId validation when multiple pending approvals', async () => {
     const contextWithMultiple = makeContext({
       pendingApprovals: [

--- a/assistant/src/__tests__/approval-conversation-turn.test.ts
+++ b/assistant/src/__tests__/approval-conversation-turn.test.ts
@@ -1,0 +1,143 @@
+import { describe, test, expect } from 'bun:test';
+import { runApprovalConversationTurn } from '../runtime/approval-conversation-turn.js';
+import type {
+  ApprovalConversationContext,
+  ApprovalConversationGenerator,
+  ApprovalConversationResult,
+} from '../runtime/http-types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContext(overrides: Partial<ApprovalConversationContext> = {}): ApprovalConversationContext {
+  return {
+    toolName: 'execute_shell',
+    allowedActions: ['approve_once', 'approve_always', 'reject'],
+    role: 'guardian',
+    pendingApprovals: [{ runId: 'run-1', toolName: 'execute_shell' }],
+    userMessage: 'yes, go ahead',
+    ...overrides,
+  };
+}
+
+function makeGenerator(result: ApprovalConversationResult): ApprovalConversationGenerator {
+  return async () => result;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('runApprovalConversationTurn', () => {
+  test('successful keep_pending response (non-decision message)', async () => {
+    const result = await runApprovalConversationTurn(
+      makeContext({ userMessage: 'what does this tool do?' }),
+      makeGenerator({
+        disposition: 'keep_pending',
+        replyText: 'This tool runs shell commands. Would you like to approve it?',
+      }),
+    );
+    expect(result.disposition).toBe('keep_pending');
+    expect(result.replyText).toBe('This tool runs shell commands. Would you like to approve it?');
+    expect(result.targetRunId).toBeUndefined();
+  });
+
+  test('successful approve_once response', async () => {
+    const result = await runApprovalConversationTurn(
+      makeContext(),
+      makeGenerator({
+        disposition: 'approve_once',
+        replyText: 'Approved! Running the command now.',
+        targetRunId: 'run-1',
+      }),
+    );
+    expect(result.disposition).toBe('approve_once');
+    expect(result.replyText).toBe('Approved! Running the command now.');
+    expect(result.targetRunId).toBe('run-1');
+  });
+
+  test('successful reject response', async () => {
+    const result = await runApprovalConversationTurn(
+      makeContext(),
+      makeGenerator({
+        disposition: 'reject',
+        replyText: 'Request denied.',
+        targetRunId: 'run-1',
+      }),
+    );
+    expect(result.disposition).toBe('reject');
+    expect(result.replyText).toBe('Request denied.');
+  });
+
+  test('fail-closed on generator throwing an error', async () => {
+    const throwingGenerator: ApprovalConversationGenerator = async () => {
+      throw new Error('provider timeout');
+    };
+    const result = await runApprovalConversationTurn(makeContext(), throwingGenerator);
+    expect(result.disposition).toBe('keep_pending');
+    expect(result.replyText).toContain("couldn't process");
+  });
+
+  test('fail-closed on generator returning malformed output', async () => {
+    const malformedGenerator: ApprovalConversationGenerator = async () => {
+      // Return an object missing the required replyText
+      return { disposition: 'approve_once', replyText: '' } as ApprovalConversationResult;
+    };
+    const result = await runApprovalConversationTurn(makeContext(), malformedGenerator);
+    expect(result.disposition).toBe('keep_pending');
+    expect(result.replyText).toContain("couldn't process");
+  });
+
+  test('fail-closed on invalid disposition', async () => {
+    const badDisposition: ApprovalConversationGenerator = async () => {
+      return { disposition: 'yolo' as 'approve_once', replyText: 'Sure!' };
+    };
+    const result = await runApprovalConversationTurn(makeContext(), badDisposition);
+    expect(result.disposition).toBe('keep_pending');
+    expect(result.replyText).toContain("couldn't process");
+  });
+
+  test('targetRunId validation when multiple pending approvals', async () => {
+    const contextWithMultiple = makeContext({
+      pendingApprovals: [
+        { runId: 'run-1', toolName: 'execute_shell' },
+        { runId: 'run-2', toolName: 'file_write' },
+      ],
+    });
+
+    // Decision-bearing disposition without targetRunId should fail-close
+    const resultWithoutTarget = await runApprovalConversationTurn(
+      contextWithMultiple,
+      makeGenerator({
+        disposition: 'approve_once',
+        replyText: 'Approved!',
+        // no targetRunId
+      }),
+    );
+    expect(resultWithoutTarget.disposition).toBe('keep_pending');
+    expect(resultWithoutTarget.replyText).toContain("couldn't process");
+
+    // Decision-bearing disposition with targetRunId should succeed
+    const resultWithTarget = await runApprovalConversationTurn(
+      contextWithMultiple,
+      makeGenerator({
+        disposition: 'approve_once',
+        replyText: 'Approved!',
+        targetRunId: 'run-1',
+      }),
+    );
+    expect(resultWithTarget.disposition).toBe('approve_once');
+    expect(resultWithTarget.targetRunId).toBe('run-1');
+
+    // Non-decision disposition without targetRunId should pass through fine
+    const resultKeepPending = await runApprovalConversationTurn(
+      contextWithMultiple,
+      makeGenerator({
+        disposition: 'keep_pending',
+        replyText: 'Which request would you like to approve?',
+      }),
+    );
+    expect(resultKeepPending.disposition).toBe('keep_pending');
+  });
+});

--- a/assistant/src/__tests__/approval-conversation-turn.test.ts
+++ b/assistant/src/__tests__/approval-conversation-turn.test.ts
@@ -132,6 +132,22 @@ describe('runApprovalConversationTurn', () => {
     expect(result.replyText).toBe('Can you tell me more about this request?');
   });
 
+  test('fail-closed when single pending approval and hallucinated targetRunId', async () => {
+    // Only one pending approval, but model returns a non-matching targetRunId
+    const result = await runApprovalConversationTurn(
+      makeContext({
+        pendingApprovals: [{ runId: 'run-1', toolName: 'execute_shell' }],
+      }),
+      makeGenerator({
+        disposition: 'approve_once',
+        replyText: 'Approved!',
+        targetRunId: 'run-nonexistent',
+      }),
+    );
+    expect(result.disposition).toBe('keep_pending');
+    expect(result.replyText).toContain("couldn't process");
+  });
+
   test('fail-closed when targetRunId does not match any pending approval', async () => {
     const contextWithMultiple = makeContext({
       pendingApprovals: [

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -46,7 +46,7 @@ import { telegramBotMessagingProvider } from '../messaging/providers/telegram-bo
 import { smsMessagingProvider } from '../messaging/providers/sms/adapter.js';
 import { browserManager } from '../tools/browser/browser-manager.js';
 import { RuntimeHttpServer } from '../runtime/http-server.js';
-import type { ApprovalCopyGenerator } from '../runtime/http-types.js';
+import type { ApprovalCopyGenerator, ApprovalConversationGenerator, ApprovalConversationResult, ApprovalConversationDisposition } from '../runtime/http-types.js';
 import {
   buildGenerationPrompt,
   includesRequiredKeywords,
@@ -313,6 +313,136 @@ function createApprovalCopyGenerator(): ApprovalCopyGenerator {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Approval conversation generator constants
+// ---------------------------------------------------------------------------
+
+const APPROVAL_CONVERSATION_TIMEOUT_MS = 8_000;
+const APPROVAL_CONVERSATION_MAX_TOKENS = 300;
+
+const APPROVAL_CONVERSATION_SYSTEM_PROMPT =
+  'You are an assistant helping a user manage a pending tool approval request. '
+  + 'Analyze the user\'s message to determine if they are making a decision '
+  + '(approve, reject, or cancel) or just asking a question / making conversation. '
+  + 'When uncertain, default to keep_pending — never approve or reject without clear intent. '
+  + 'For guardians: explain what tool is requesting approval and from whom. '
+  + 'Always provide a natural, helpful reply along with your decision.';
+
+const APPROVAL_CONVERSATION_TOOL_NAME = 'approval_decision';
+
+const APPROVAL_CONVERSATION_TOOL_SCHEMA = {
+  name: APPROVAL_CONVERSATION_TOOL_NAME,
+  description:
+    'Record the disposition of the approval conversation turn. '
+    + 'Call this tool with the determined disposition and a natural reply to the user.',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      disposition: {
+        type: 'string',
+        enum: ['keep_pending', 'approve_once', 'approve_always', 'reject'],
+        description:
+          'The decision: keep_pending if the user is asking questions or unclear, '
+          + 'approve_once to approve this single request, approve_always to approve '
+          + 'this tool permanently, reject to deny the request.',
+      },
+      replyText: {
+        type: 'string',
+        description: 'A natural language reply to send back to the user.',
+      },
+      targetRunId: {
+        type: 'string',
+        description:
+          'The run ID of the specific pending approval being acted on. '
+          + 'Required when there are multiple pending approvals and the disposition is decision-bearing.',
+      },
+    },
+    required: ['disposition', 'replyText'],
+  },
+};
+
+const VALID_DISPOSITIONS: ReadonlySet<string> = new Set([
+  'keep_pending',
+  'approve_once',
+  'approve_always',
+  'reject',
+]);
+
+/**
+ * Create the daemon-owned approval conversation generator that resolves
+ * providers and uses tool_use / function calling for structured output.
+ * Follows the same provider-aware pattern as createApprovalCopyGenerator().
+ */
+function createApprovalConversationGenerator(): ApprovalConversationGenerator {
+  return async (context) => {
+    const config = loadConfig();
+    if (!listProviders().includes(config.provider)) {
+      throw new Error('No provider available for approval conversation');
+    }
+    const provider = getFailoverProvider(config.provider, config.providerOrder);
+
+    const pendingDescription = context.pendingApprovals
+      .map((p) => `- Run ${p.runId}: tool "${p.toolName}"`)
+      .join('\n');
+
+    const userPrompt = [
+      `Role: ${context.role}`,
+      `Tool requesting approval: "${context.toolName}"`,
+      `Allowed actions: ${context.allowedActions.join(', ')}`,
+      `Pending approvals:\n${pendingDescription}`,
+      `\nUser message: ${context.userMessage}`,
+    ].join('\n');
+
+    const response = await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: userPrompt }] }],
+      [APPROVAL_CONVERSATION_TOOL_SCHEMA],
+      APPROVAL_CONVERSATION_SYSTEM_PROMPT,
+      {
+        config: {
+          max_tokens: APPROVAL_CONVERSATION_MAX_TOKENS,
+        },
+        signal: AbortSignal.timeout(APPROVAL_CONVERSATION_TIMEOUT_MS),
+      },
+    );
+
+    // Extract the tool_use block from the response
+    const toolUseBlock = response.content.find(
+      (block) => block.type === 'tool_use' && block.name === APPROVAL_CONVERSATION_TOOL_NAME,
+    );
+
+    if (!toolUseBlock || toolUseBlock.type !== 'tool_use') {
+      throw new Error('Provider did not return a tool_use block for approval decision');
+    }
+
+    const input = toolUseBlock.input as Record<string, unknown>;
+
+    // Strict validation of the structured output
+    const disposition = input.disposition;
+    if (typeof disposition !== 'string' || !VALID_DISPOSITIONS.has(disposition)) {
+      throw new Error(`Invalid disposition: ${String(disposition)}`);
+    }
+
+    const replyText = input.replyText;
+    if (typeof replyText !== 'string' || replyText.trim().length === 0) {
+      throw new Error('Missing or empty replyText in tool_use response');
+    }
+
+    const targetRunId = input.targetRunId;
+    if (targetRunId !== undefined && typeof targetRunId !== 'string') {
+      throw new Error('Invalid targetRunId in tool_use response');
+    }
+
+    const result: ApprovalConversationResult = {
+      disposition: disposition as ApprovalConversationDisposition,
+      replyText: replyText.trim(),
+    };
+    if (typeof targetRunId === 'string' && targetRunId.length > 0) {
+      result.targetRunId = targetRunId;
+    }
+    return result;
+  };
+}
+
 // Entry point for the daemon process itself
 export async function runDaemon(): Promise<void> {
   loadDotEnv();
@@ -517,6 +647,7 @@ export async function runDaemon(): Promise<void> {
         runOrchestrator: server.createRunOrchestrator(),
         interfacesDir: getInterfacesDir(),
         approvalCopyGenerator: createApprovalCopyGenerator(),
+        approvalConversationGenerator: createApprovalConversationGenerator(),
       });
       try {
         log.info({ port, hostname }, 'Daemon startup: starting runtime HTTP server');

--- a/assistant/src/runtime/approval-conversation-turn.ts
+++ b/assistant/src/runtime/approval-conversation-turn.ts
@@ -72,14 +72,25 @@ export async function runApprovalConversationTurn(
     return failClosed();
   }
 
+  // Enforce allowed-actions policy: the model must not return a disposition
+  // that the caller did not offer (keep_pending is always acceptable).
+  if (
+    result.disposition !== 'keep_pending'
+    && !context.allowedActions.includes(result.disposition)
+  ) {
+    return failClosed();
+  }
+
   // When multiple approvals are pending and the user is making a decision,
-  // targetRunId must be present so the system knows which request to act on.
+  // targetRunId must be present AND match a known pending approval so a
+  // hallucinated or stale ID cannot slip through.
   if (
     context.pendingApprovals.length > 1
     && DECISION_BEARING_DISPOSITIONS.has(result.disposition)
-    && !result.targetRunId
   ) {
-    return failClosed();
+    if (!result.targetRunId) return failClosed();
+    const validRunIds = new Set(context.pendingApprovals.map((p) => p.runId));
+    if (!validRunIds.has(result.targetRunId)) return failClosed();
   }
 
   return result;

--- a/assistant/src/runtime/approval-conversation-turn.ts
+++ b/assistant/src/runtime/approval-conversation-turn.ts
@@ -1,0 +1,86 @@
+/**
+ * Approval conversation turn engine.
+ *
+ * Processes a single turn of the conversational approval flow by delegating
+ * to a generator function (typically backed by a language model) and
+ * validating the structured result. Fails closed on any error — returning
+ * a safe keep_pending disposition — so that a broken model call never
+ * silently approves or rejects a request.
+ */
+
+// Hook point: a deterministic classifier could be inserted here as an
+// alternative to model-based inference
+
+import type {
+  ApprovalConversationContext,
+  ApprovalConversationGenerator,
+  ApprovalConversationResult,
+  ApprovalConversationDisposition,
+} from './http-types.js';
+
+const VALID_DISPOSITIONS: ReadonlySet<ApprovalConversationDisposition> = new Set([
+  'keep_pending',
+  'approve_once',
+  'approve_always',
+  'reject',
+]);
+
+/** Dispositions that represent an actual decision (not just "keep waiting"). */
+const DECISION_BEARING_DISPOSITIONS: ReadonlySet<ApprovalConversationDisposition> = new Set([
+  'approve_once',
+  'approve_always',
+  'reject',
+]);
+
+const FAIL_CLOSED_REPLY =
+  "I couldn't process that. Please reply with approve, deny, or cancel to decide on the pending request.";
+
+function failClosed(): ApprovalConversationResult {
+  return { disposition: 'keep_pending', replyText: FAIL_CLOSED_REPLY };
+}
+
+function isValidResult(value: unknown): value is ApprovalConversationResult {
+  if (!value || typeof value !== 'object') return false;
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.disposition !== 'string') return false;
+  if (!VALID_DISPOSITIONS.has(obj.disposition as ApprovalConversationDisposition)) return false;
+  if (typeof obj.replyText !== 'string' || obj.replyText.trim().length === 0) return false;
+  if (obj.targetRunId !== undefined && typeof obj.targetRunId !== 'string') return false;
+  return true;
+}
+
+/**
+ * Run one turn of the approval conversation engine.
+ *
+ * Calls the provided generator, validates the result, and returns a
+ * structured decision. On ANY failure (timeout, malformed output,
+ * exception) the function returns a safe keep_pending fallback.
+ */
+export async function runApprovalConversationTurn(
+  context: ApprovalConversationContext,
+  generator: ApprovalConversationGenerator,
+): Promise<ApprovalConversationResult> {
+  let result: ApprovalConversationResult;
+
+  try {
+    result = await generator(context);
+  } catch {
+    return failClosed();
+  }
+
+  if (!isValidResult(result)) {
+    return failClosed();
+  }
+
+  // When multiple approvals are pending and the user is making a decision,
+  // targetRunId must be present so the system knows which request to act on.
+  if (
+    context.pendingApprovals.length > 1
+    && DECISION_BEARING_DISPOSITIONS.has(result.disposition)
+    && !result.targetRunId
+  ) {
+    return failClosed();
+  }
+
+  return result;
+}

--- a/assistant/src/runtime/approval-conversation-turn.ts
+++ b/assistant/src/runtime/approval-conversation-turn.ts
@@ -81,16 +81,16 @@ export async function runApprovalConversationTurn(
     return failClosed();
   }
 
-  // When multiple approvals are pending and the user is making a decision,
-  // targetRunId must be present AND match a known pending approval so a
-  // hallucinated or stale ID cannot slip through.
-  if (
-    context.pendingApprovals.length > 1
-    && DECISION_BEARING_DISPOSITIONS.has(result.disposition)
-  ) {
-    if (!result.targetRunId) return failClosed();
-    const validRunIds = new Set(context.pendingApprovals.map((p) => p.runId));
-    if (!validRunIds.has(result.targetRunId)) return failClosed();
+  // Validate targetRunId for decision-bearing dispositions:
+  // 1. When multiple approvals are pending, targetRunId is required.
+  // 2. When targetRunId is present, it must match a known pending approval
+  //    regardless of how many approvals are pending.
+  if (DECISION_BEARING_DISPOSITIONS.has(result.disposition)) {
+    if (context.pendingApprovals.length > 1 && !result.targetRunId) return failClosed();
+    if (result.targetRunId) {
+      const validRunIds = new Set(context.pendingApprovals.map((p) => p.runId));
+      if (!validRunIds.has(result.targetRunId)) return failClosed();
+    }
   }
 
   return result;

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -88,6 +88,7 @@ export type {
   RuntimeHttpServerOptions,
   RuntimeAttachmentMetadata,
   ApprovalCopyGenerator,
+  ApprovalConversationGenerator,
 } from './http-types.js';
 
 import type {
@@ -95,6 +96,7 @@ import type {
   NonBlockingMessageProcessor,
   RuntimeHttpServerOptions,
   ApprovalCopyGenerator,
+  ApprovalConversationGenerator,
 } from './http-types.js';
 
 const log = getLogger('runtime-http');
@@ -387,6 +389,7 @@ export class RuntimeHttpServer {
   private persistAndProcessMessage?: NonBlockingMessageProcessor;
   private runOrchestrator?: RunOrchestrator;
   private approvalCopyGenerator?: ApprovalCopyGenerator;
+  private approvalConversationGenerator?: ApprovalConversationGenerator;
   private interfacesDir: string | null;
   private suggestionCache = new Map<string, string>();
   private suggestionInFlight = new Map<string, Promise<string | null>>();
@@ -401,6 +404,7 @@ export class RuntimeHttpServer {
     this.persistAndProcessMessage = options.persistAndProcessMessage;
     this.runOrchestrator = options.runOrchestrator;
     this.approvalCopyGenerator = options.approvalCopyGenerator;
+    this.approvalConversationGenerator = options.approvalConversationGenerator;
     this.interfacesDir = options.interfacesDir ?? null;
   }
 
@@ -790,7 +794,7 @@ export class RuntimeHttpServer {
 
       if (endpoint === 'channels/inbound' && req.method === 'POST') {
         const gatewayOriginSecret = process.env.RUNTIME_GATEWAY_ORIGIN_SECRET || undefined;
-        return await handleChannelInbound(req, this.processMessage, this.bearerToken, this.runOrchestrator, assistantId, gatewayOriginSecret, this.approvalCopyGenerator);
+        return await handleChannelInbound(req, this.processMessage, this.bearerToken, this.runOrchestrator, assistantId, gatewayOriginSecret, this.approvalCopyGenerator, this.approvalConversationGenerator);
       }
 
       if (endpoint === 'channels/delivery-ack' && req.method === 'POST') {

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -14,6 +14,42 @@ export type ApprovalCopyGenerator = (
   options?: ComposeApprovalMessageGenerativeOptions,
 ) => Promise<string | null>;
 
+// ---------------------------------------------------------------------------
+// Approval conversation flow types
+// ---------------------------------------------------------------------------
+
+/** The disposition returned by the approval conversation engine. */
+export type ApprovalConversationDisposition =
+  | 'keep_pending'
+  | 'approve_once'
+  | 'approve_always'
+  | 'reject';
+
+/** Structured result from a single turn of the approval conversation. */
+export interface ApprovalConversationResult {
+  disposition: ApprovalConversationDisposition;
+  replyText: string;
+  /** Required when there are multiple pending approvals and the disposition is decision-bearing. */
+  targetRunId?: string;
+}
+
+/** Input context for the approval conversation engine. */
+export interface ApprovalConversationContext {
+  toolName: string;
+  allowedActions: string[];
+  role: 'requester' | 'guardian';
+  pendingApprovals: Array<{ runId: string; toolName: string }>;
+  userMessage: string;
+}
+
+/**
+ * Daemon-injected function that processes one turn of an approval conversation.
+ * Takes conversation context and returns a structured approval decision + reply.
+ */
+export type ApprovalConversationGenerator = (
+  context: ApprovalConversationContext,
+) => Promise<ApprovalConversationResult>;
+
 export interface RuntimeMessageSessionOptions {
   transport?: {
     channelId: string;
@@ -62,6 +98,8 @@ export interface RuntimeHttpServerOptions {
   interfacesDir?: string;
   /** Daemon-injected generator for approval copy (provider-backed). */
   approvalCopyGenerator?: ApprovalCopyGenerator;
+  /** Daemon-injected generator for conversational approval flow (provider-backed). */
+  approvalConversationGenerator?: ApprovalConversationGenerator;
 }
 
 export interface RuntimeAttachmentMetadata {

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -55,6 +55,7 @@ import type {
   MessageProcessor,
   RuntimeAttachmentMetadata,
   ApprovalCopyGenerator,
+  ApprovalConversationGenerator,
 } from '../http-types.js';
 import type { GuardianRuntimeContext } from '../../daemon/session-runtime-assembly.js';
 import { composeApprovalMessageGenerative } from '../approval-message-composer.js';
@@ -342,6 +343,7 @@ export async function handleChannelInbound(
   assistantId: string = 'self',
   gatewayOriginSecret?: string,
   approvalCopyGenerator?: ApprovalCopyGenerator,
+  _approvalConversationGenerator?: ApprovalConversationGenerator,
 ): Promise<Response> {
   // Reject requests that lack valid gateway-origin proof. This ensures
   // channel inbound messages can only arrive via the gateway (which


### PR DESCRIPTION
Part of #7618. Adds the foundational types, conversation engine module, daemon lifecycle wiring, and HTTP server passthrough for the new conversational approval flow. Includes tests for the conversation turn engine.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
