### PR TITLE
Fix: Enforce allowed actions and validate targetRunId

### DIFF
--- a/assistant/src/__tests__/approval-conversation-turn.test.ts
+++ b/assistant/src/__tests__/approval-conversation-turn.test.ts
@@ -98,6 +98,61 @@ describe('runApprovalConversationTurn', () => {
     expect(result.replyText).toContain("couldn't process");
   });
 
+  test('fail-closed when disposition is not in allowedActions', async () => {
+    // Context only allows approve_once and reject (no approve_always)
+    const restrictedContext = makeContext({
+      allowedActions: ['approve_once', 'reject'],
+    });
+
+    const result = await runApprovalConversationTurn(
+      restrictedContext,
+      makeGenerator({
+        disposition: 'approve_always',
+        replyText: 'Approved permanently!',
+        targetRunId: 'run-1',
+      }),
+    );
+    expect(result.disposition).toBe('keep_pending');
+    expect(result.replyText).toContain("couldn't process");
+  });
+
+  test('keep_pending is always allowed regardless of allowedActions', async () => {
+    const restrictedContext = makeContext({
+      allowedActions: ['approve_once', 'reject'],
+    });
+
+    const result = await runApprovalConversationTurn(
+      restrictedContext,
+      makeGenerator({
+        disposition: 'keep_pending',
+        replyText: 'Can you tell me more about this request?',
+      }),
+    );
+    expect(result.disposition).toBe('keep_pending');
+    expect(result.replyText).toBe('Can you tell me more about this request?');
+  });
+
+  test('fail-closed when targetRunId does not match any pending approval', async () => {
+    const contextWithMultiple = makeContext({
+      pendingApprovals: [
+        { runId: 'run-1', toolName: 'execute_shell' },
+        { runId: 'run-2', toolName: 'file_write' },
+      ],
+    });
+
+    // Hallucinated run ID that doesn't match any pending approval
+    const result = await runApprovalConversationTurn(
+      contextWithMultiple,
+      makeGenerator({
+        disposition: 'approve_once',
+        replyText: 'Approved!',
+        targetRunId: 'run-nonexistent',
+      }),
+    );
+    expect(result.disposition).toBe('keep_pending');
+    expect(result.replyText).toContain("couldn't process");
+  });
+
   test('targetRunId validation when multiple pending approvals', async () => {
     const contextWithMultiple = makeContext({
       pendingApprovals: [

--- a/assistant/src/runtime/approval-conversation-turn.ts
+++ b/assistant/src/runtime/approval-conversation-turn.ts
@@ -72,14 +72,25 @@ export async function runApprovalConversationTurn(
     return failClosed();
   }
 
+  // Enforce allowed-actions policy: the model must not return a disposition
+  // that the caller did not offer (keep_pending is always acceptable).
+  if (
+    result.disposition !== 'keep_pending'
+    && !context.allowedActions.includes(result.disposition)
+  ) {
+    return failClosed();
+  }
+
   // When multiple approvals are pending and the user is making a decision,
-  // targetRunId must be present so the system knows which request to act on.
+  // targetRunId must be present AND match a known pending approval so a
+  // hallucinated or stale ID cannot slip through.
   if (
     context.pendingApprovals.length > 1
     && DECISION_BEARING_DISPOSITIONS.has(result.disposition)
-    && !result.targetRunId
   ) {
-    return failClosed();
+    if (!result.targetRunId) return failClosed();
+    const validRunIds = new Set(context.pendingApprovals.map((p) => p.runId));
+    if (!validRunIds.has(result.targetRunId)) return failClosed();
   }
 
   return result;


### PR DESCRIPTION
Addresses feedback on #7849. Adds allowed-actions enforcement and targetRunId validation against pending approvals in runApprovalConversationTurn. Fail-closed on disallowed dispositions and hallucinated run IDs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
