### PR TITLE
fix(ios): rebind IOSThreadStore to new DaemonClient after rebuildClient()

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -60,7 +60,7 @@ class IOSThreadStore: ObservableObject {
 
     /// ViewModels keyed by thread ID, created lazily on first access.
     private var viewModels: [UUID: ChatViewModel] = [:]
-    private let daemonClient: any DaemonClientProtocol
+    private var daemonClient: any DaemonClientProtocol
     private static let persistenceKey = "ios_threads_v1"
     private var cancellables: Set<AnyCancellable> = []
     /// Maps daemon session IDs to thread IDs for history loading.
@@ -136,6 +136,52 @@ class IOSThreadStore: ObservableObject {
                 try? daemon.sendSessionList(offset: 0, limit: Self.threadPageSize)
             }
             .store(in: &cancellables)
+    }
+
+    /// Re-point the store at a freshly constructed DaemonClient after `rebuildClient()`.
+    ///
+    /// `@StateObject` is initialised once by SwiftUI and never replaced when `ContentView`
+    /// re-initialises, so when the connection is rebuilt (QR pairing, settings change) the
+    /// store would otherwise keep sending messages to the old, disconnected client.  This
+    /// method swaps the client reference, cancels Combine subscriptions that captured the old
+    /// client, drops stale ChatViewModels (they reference the old client via `ChatViewModel`'s
+    /// own stored reference), resets pagination, and re-registers daemon callbacks on the new
+    /// client so the thread list is refreshed from the new connection.
+    func rebindDaemonClient(_ newClient: any DaemonClientProtocol) {
+        // Drop Combine subscriptions tied to the old DaemonClient so the reconnect
+        // publisher from setupDaemonCallbacks doesn't fire against the wrong daemon.
+        cancellables.removeAll()
+
+        daemonClient = newClient
+
+        // Existing ViewModels hold a reference to the old, disconnected client inside
+        // ChatViewModel.  Discard them so new ones are created with the new client.
+        viewModels.removeAll()
+        observedActivityThreadIds.removeAll()
+        pendingHistoryBySessionId.removeAll()
+
+        if let daemon = newClient as? DaemonClient {
+            // Connected mode — reset thread list and re-fetch from the new daemon.
+            isConnectedMode = true
+            threads = [IOSThread()]
+            threadListOffset = 0
+            sessionListToken += 1
+            inFlightSessionListToken = sessionListToken
+            hasMoreThreads = false
+            isLoadingMoreThreads = false
+            setupDaemonCallbacks(daemon)
+        } else {
+            // Switched back to standalone mode — reload persisted threads.
+            isConnectedMode = false
+            let loaded = Self.load()
+            if loaded.isEmpty {
+                let thread = IOSThread()
+                threads = [thread]
+                save()
+            } else {
+                threads = loaded
+            }
+        }
     }
 
     private func handleSessionListResponse(_ response: SessionListResponseMessage) {

--- a/clients/ios/Views/ContentView.swift
+++ b/clients/ios/Views/ContentView.swift
@@ -63,6 +63,12 @@ struct ContentView: View {
         .onChange(of: clientProvider.isConnected) { _, connected in
             if connected { connectPhase = .ready }
         }
+        // When rebuildClient() replaces the DaemonClient, re-bind the thread store
+        // to the new client so it doesn't keep targeting the old disconnected daemon.
+        // ObjectIdentifier changes whenever the client object is replaced.
+        .onChange(of: ObjectIdentifier(clientProvider.client as AnyObject)) { _, _ in
+            threadStore.rebindDaemonClient(clientProvider.client)
+        }
         // Ride Shotgun invitation sheet
         .sheet(isPresented: $ambientAgent.showInvitation) {
             RideShotgunInvitationSheet(


### PR DESCRIPTION
After rebuildClient() is called (QR pairing, connection settings change), the shared threadStore @StateObject retained a reference to the old, disconnected DaemonClient. SwiftUI only initializes @StateObject once, so subsequent ContentView inits with a new client were ignored.

- Add IOSThreadStore.rebindDaemonClient(_:) that swaps the client reference, cancels stale Combine subscriptions, drops all ChatViewModels (which hold their own reference to the old client), resets pagination state, and re-registers daemon callbacks on the new client
- Add .onChange(of: ObjectIdentifier(clientProvider.client as AnyObject)) in ContentView to call rebindDaemonClient when rebuildClient() replaces the client
- Change daemonClient from let to var to allow mutation

Addresses feedback on #7825 (Devin review: IOSThreadStore becomes stale after rebuildClient()).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
