### PR TITLE
Fix: Validate targetRunId for single pending approval

### DIFF
--- a/assistant/src/__tests__/approval-conversation-turn.test.ts
+++ b/assistant/src/__tests__/approval-conversation-turn.test.ts
@@ -132,6 +132,22 @@ describe('runApprovalConversationTurn', () => {
     expect(result.replyText).toBe('Can you tell me more about this request?');
   });
 
+  test('fail-closed when single pending approval and hallucinated targetRunId', async () => {
+    // Only one pending approval, but model returns a non-matching targetRunId
+    const result = await runApprovalConversationTurn(
+      makeContext({
+        pendingApprovals: [{ runId: 'run-1', toolName: 'execute_shell' }],
+      }),
+      makeGenerator({
+        disposition: 'approve_once',
+        replyText: 'Approved!',
+        targetRunId: 'run-nonexistent',
+      }),
+    );
+    expect(result.disposition).toBe('keep_pending');
+    expect(result.replyText).toContain("couldn't process");
+  });
+
   test('fail-closed when targetRunId does not match any pending approval', async () => {
     const contextWithMultiple = makeContext({
       pendingApprovals: [

--- a/assistant/src/runtime/approval-conversation-turn.ts
+++ b/assistant/src/runtime/approval-conversation-turn.ts
@@ -81,16 +81,16 @@ export async function runApprovalConversationTurn(
     return failClosed();
   }
 
-  // When multiple approvals are pending and the user is making a decision,
-  // targetRunId must be present AND match a known pending approval so a
-  // hallucinated or stale ID cannot slip through.
-  if (
-    context.pendingApprovals.length > 1
-    && DECISION_BEARING_DISPOSITIONS.has(result.disposition)
-  ) {
-    if (!result.targetRunId) return failClosed();
-    const validRunIds = new Set(context.pendingApprovals.map((p) => p.runId));
-    if (!validRunIds.has(result.targetRunId)) return failClosed();
+  // Validate targetRunId for decision-bearing dispositions:
+  // 1. When multiple approvals are pending, targetRunId is required.
+  // 2. When targetRunId is present, it must match a known pending approval
+  //    regardless of how many approvals are pending.
+  if (DECISION_BEARING_DISPOSITIONS.has(result.disposition)) {
+    if (context.pendingApprovals.length > 1 && !result.targetRunId) return failClosed();
+    if (result.targetRunId) {
+      const validRunIds = new Set(context.pendingApprovals.map((p) => p.runId));
+      if (!validRunIds.has(result.targetRunId)) return failClosed();
+    }
   }
 
   return result;


### PR DESCRIPTION
Addresses feedback on #7854. Validates targetRunId against pendingApprovals whenever present and decision-bearing, not just when multiple approvals are pending.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
