### PR TITLE
M4: Voice Guardian Verification UX in Channels Settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -907,9 +907,28 @@ struct SettingsConnectTab: View {
         return String(instruction[range]).trimmingCharacters(in: CharacterSet(charactersIn: "`"))
     }
 
+    /// Extracts a six-digit verification code from voice-style instruction text.
+    /// Voice instructions use a format like "...six-digit code: 123456..." instead of the
+    /// `/guardian_verify <hex>` command used by Telegram and SMS channels.
+    private func extractVoiceGuardianCode(from instruction: String) -> String? {
+        guard let range = instruction.range(of: #"six-digit code:\s*(\d{6})"#, options: .regularExpression) else {
+            return nil
+        }
+        let match = String(instruction[range])
+        // Extract just the digits from "six-digit code: 123456"
+        guard let digitRange = match.range(of: #"\d{6}"#, options: .regularExpression) else {
+            return nil
+        }
+        return String(match[digitRange])
+    }
+
     @ViewBuilder
     private func guardianInstructionView(channel: String, instruction: String) -> some View {
-        let command = extractGuardianCommand(from: instruction)
+        // Voice uses a different instruction format ("six-digit code: 123456") vs
+        // Telegram/SMS which use "/guardian_verify <hex>".
+        let command: String? = channel == "voice"
+            ? extractVoiceGuardianCode(from: instruction)
+            : extractGuardianCommand(from: instruction)
         let isCopied = guardianCommandCopiedChannel == channel
 
         VStack(alignment: .leading, spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -57,6 +57,7 @@ struct SettingsConnectTab: View {
             refreshBearerToken()
             store.refreshChannelGuardianStatus(channel: "telegram")
             store.refreshChannelGuardianStatus(channel: "sms")
+            store.refreshChannelGuardianStatus(channel: "voice")
             gatewayExpanded = store.ingressPublicBaseUrl.isEmpty
         }
         .onChange(of: store.ingressPublicBaseUrl) { _, newValue in
@@ -533,6 +534,9 @@ struct SettingsConnectTab: View {
                     value: store.twilioPhoneNumber ?? "",
                     valueFont: VFont.mono
                 )
+
+                Divider().background(VColor.surfaceBorder)
+                guardianStatusRow(channel: "voice")
             } else if store.twilioHasCredentials {
                 channelStatusRow(
                     label: "Credentials",
@@ -754,6 +758,11 @@ struct SettingsConnectTab: View {
                !displayName.isEmpty {
                 return displayName
             }
+        } else if channel == "voice" {
+            if let displayName = store.voiceGuardianDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !displayName.isEmpty {
+                return displayName
+            }
         }
         return identity
     }
@@ -773,11 +782,46 @@ struct SettingsConnectTab: View {
 
     @ViewBuilder
     private func guardianStatusRow(channel: String) -> some View {
-        let identity: String? = channel == "telegram" ? store.telegramGuardianIdentity : store.smsGuardianIdentity
-        let verified: Bool = channel == "telegram" ? store.telegramGuardianVerified : store.smsGuardianVerified
-        let inProgress: Bool = channel == "telegram" ? store.telegramGuardianVerificationInProgress : store.smsGuardianVerificationInProgress
-        let instruction: String? = channel == "telegram" ? store.telegramGuardianInstruction : store.smsGuardianInstruction
-        let error: String? = channel == "telegram" ? store.telegramGuardianError : store.smsGuardianError
+        let identity: String? = {
+            switch channel {
+            case "telegram": return store.telegramGuardianIdentity
+            case "sms": return store.smsGuardianIdentity
+            case "voice": return store.voiceGuardianIdentity
+            default: return nil
+            }
+        }()
+        let verified: Bool = {
+            switch channel {
+            case "telegram": return store.telegramGuardianVerified
+            case "sms": return store.smsGuardianVerified
+            case "voice": return store.voiceGuardianVerified
+            default: return false
+            }
+        }()
+        let inProgress: Bool = {
+            switch channel {
+            case "telegram": return store.telegramGuardianVerificationInProgress
+            case "sms": return store.smsGuardianVerificationInProgress
+            case "voice": return store.voiceGuardianVerificationInProgress
+            default: return false
+            }
+        }()
+        let instruction: String? = {
+            switch channel {
+            case "telegram": return store.telegramGuardianInstruction
+            case "sms": return store.smsGuardianInstruction
+            case "voice": return store.voiceGuardianInstruction
+            default: return nil
+            }
+        }()
+        let error: String? = {
+            switch channel {
+            case "telegram": return store.telegramGuardianError
+            case "sms": return store.smsGuardianError
+            case "voice": return store.voiceGuardianError
+            default: return nil
+            }
+        }()
         let primaryIdentity = guardianPrimaryIdentity(channel: channel, identity: identity)
         let secondaryIdentity = guardianSecondaryIdentity(primary: primaryIdentity, identity: identity)
 
@@ -846,6 +890,9 @@ struct SettingsConnectTab: View {
         if channel == "telegram" {
             let handle = store.telegramBotUsername.map { "@\($0)" } ?? "your bot"
             return "Message \(handle) with the below command within the next 10 minutes"
+        } else if channel == "voice" {
+            let number = store.twilioPhoneNumber ?? "your assistant"
+            return "Call \(number) and say the six-digit code below within the next 10 minutes"
         } else {
             let number = store.twilioPhoneNumber ?? "your assistant"
             return "Text \(number) with the below command within the next 10 minutes"

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -121,6 +121,16 @@ public final class SettingsStore: ObservableObject {
     @Published var smsGuardianInstruction: String?
     @Published var smsGuardianError: String?
 
+    // MARK: - Channel Guardian State (Voice)
+
+    @Published var voiceGuardianIdentity: String?
+    @Published var voiceGuardianUsername: String?
+    @Published var voiceGuardianDisplayName: String?
+    @Published var voiceGuardianVerified: Bool = false
+    @Published var voiceGuardianVerificationInProgress: Bool = false
+    @Published var voiceGuardianInstruction: String?
+    @Published var voiceGuardianError: String?
+
     // MARK: - Ingress Config State
 
     @Published var ingressEnabled: Bool = false
@@ -419,6 +429,23 @@ public final class SettingsStore: ObservableObject {
                 } else {
                     self.smsGuardianError = response.error
                 }
+            case "voice":
+                self.voiceGuardianVerificationInProgress = false
+                if response.success {
+                    self.voiceGuardianIdentity = response.guardianExternalUserId
+                    self.voiceGuardianUsername = Self.reflectedString(response, key: "guardianUsername")
+                    self.voiceGuardianDisplayName = Self.reflectedString(response, key: "guardianDisplayName")
+                    let isVerified = response.bound ?? false
+                    self.voiceGuardianVerified = isVerified
+                    if isVerified {
+                        self.voiceGuardianInstruction = nil
+                    } else if let instruction = response.instruction {
+                        self.voiceGuardianInstruction = instruction
+                    }
+                    self.voiceGuardianError = nil
+                } else {
+                    self.voiceGuardianError = response.error
+                }
             default:
                 break
             }
@@ -456,6 +483,7 @@ public final class SettingsStore: ObservableObject {
         // Refresh channel guardian status on init
         refreshChannelGuardianStatus(channel: "telegram")
         refreshChannelGuardianStatus(channel: "sms")
+        refreshChannelGuardianStatus(channel: "voice")
 
         // Ingress config is refreshed by onAppear in SettingsPanel,
         // not here, to avoid duplicate get requests whose
@@ -875,6 +903,10 @@ public final class SettingsStore: ObservableObject {
             smsGuardianVerificationInProgress = true
             smsGuardianError = nil
             smsGuardianInstruction = nil
+        case "voice":
+            voiceGuardianVerificationInProgress = true
+            voiceGuardianError = nil
+            voiceGuardianInstruction = nil
         default:
             return
         }
@@ -888,6 +920,9 @@ public final class SettingsStore: ObservableObject {
                 case "sms":
                     smsGuardianVerificationInProgress = false
                     smsGuardianError = "Daemon is not connected. Reconnect and try again."
+                case "voice":
+                    voiceGuardianVerificationInProgress = false
+                    voiceGuardianError = "Daemon is not connected. Reconnect and try again."
                 default:
                     break
                 }
@@ -906,6 +941,9 @@ public final class SettingsStore: ObservableObject {
             case "sms":
                 smsGuardianVerificationInProgress = false
                 smsGuardianError = "Failed to start verification. Try again."
+            case "voice":
+                voiceGuardianVerificationInProgress = false
+                voiceGuardianError = "Failed to start verification. Try again."
             default:
                 break
             }
@@ -922,6 +960,9 @@ public final class SettingsStore: ObservableObject {
         case "sms":
             smsGuardianVerificationInProgress = false
             smsGuardianInstruction = nil
+        case "voice":
+            voiceGuardianVerificationInProgress = false
+            voiceGuardianInstruction = nil
         default:
             break
         }
@@ -943,6 +984,8 @@ public final class SettingsStore: ObservableObject {
             telegramGuardianInstruction = nil
         case "sms":
             smsGuardianInstruction = nil
+        case "voice":
+            voiceGuardianInstruction = nil
         default:
             break
         }
@@ -960,8 +1003,14 @@ public final class SettingsStore: ObservableObject {
         if let pendingGuardianChallengeChannel {
             return pendingGuardianChallengeChannel
         }
-        if telegramGuardianVerificationInProgress != smsGuardianVerificationInProgress {
-            return telegramGuardianVerificationInProgress ? "telegram" : "sms"
+        // Disambiguate when exactly one channel has verification in progress
+        let inProgressChannels = [
+            ("telegram", telegramGuardianVerificationInProgress),
+            ("sms", smsGuardianVerificationInProgress),
+            ("voice", voiceGuardianVerificationInProgress),
+        ].filter(\.1)
+        if inProgressChannels.count == 1 {
+            return inProgressChannels.first?.0
         }
         return nil
     }
@@ -979,6 +1028,8 @@ public final class SettingsStore: ObservableObject {
             telegramGuardianInstruction = nil
         case "sms":
             smsGuardianInstruction = nil
+        case "voice":
+            voiceGuardianInstruction = nil
         default:
             break
         }
@@ -1003,6 +1054,12 @@ public final class SettingsStore: ObservableObject {
                 if self.smsGuardianError == nil {
                     self.smsGuardianError = "Timed out waiting for verification instructions. Try again."
                 }
+            case "voice":
+                self.voiceGuardianVerificationInProgress = false
+                self.voiceGuardianInstruction = nil
+                if self.voiceGuardianError == nil {
+                    self.voiceGuardianError = "Timed out waiting for verification instructions. Try again."
+                }
             default:
                 break
             }
@@ -1012,7 +1069,7 @@ public final class SettingsStore: ObservableObject {
     }
 
     private func startGuardianStatusPolling(for channel: String) {
-        guard channel == "telegram" || channel == "sms" else { return }
+        guard channel == "telegram" || channel == "sms" || channel == "voice" else { return }
         stopGuardianStatusPolling(for: channel)
         guardianStatusPollingDeadlines[channel] = Date().addingTimeInterval(guardianStatusPollWindow)
         scheduleGuardianStatusPoll(for: channel, delay: guardianStatusPollInterval)

--- a/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
@@ -52,6 +52,12 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         XCTAssertFalse(store.smsGuardianVerificationInProgress)
         XCTAssertNil(store.smsGuardianInstruction)
         XCTAssertNil(store.smsGuardianError)
+
+        XCTAssertNil(store.voiceGuardianIdentity)
+        XCTAssertFalse(store.voiceGuardianVerified)
+        XCTAssertFalse(store.voiceGuardianVerificationInProgress)
+        XCTAssertNil(store.voiceGuardianInstruction)
+        XCTAssertNil(store.voiceGuardianError)
     }
 
     // MARK: - refreshChannelGuardianStatus
@@ -467,10 +473,13 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         // None of these should crash
         orphanStore.refreshChannelGuardianStatus(channel: "telegram")
         orphanStore.refreshChannelGuardianStatus(channel: "sms")
+        orphanStore.refreshChannelGuardianStatus(channel: "voice")
         orphanStore.startChannelGuardianVerification(channel: "telegram")
         orphanStore.startChannelGuardianVerification(channel: "sms")
+        orphanStore.startChannelGuardianVerification(channel: "voice")
         orphanStore.revokeChannelGuardian(channel: "telegram")
         orphanStore.revokeChannelGuardian(channel: "sms")
+        orphanStore.revokeChannelGuardian(channel: "voice")
     }
 
     // MARK: - Successful response clears previous error
@@ -524,17 +533,20 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
 
     // MARK: - Init sends status requests for both channels
 
-    func testInitSendsGuardianStatusRequestsForBothChannels() {
+    func testInitSendsGuardianStatusRequestsForAllChannels() {
         let guardianMessages = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
         let statusMessages = guardianMessages.filter { $0.action == "status" }
 
         let telegramStatus = statusMessages.filter { $0.channel == "telegram" }
         let smsStatus = statusMessages.filter { $0.channel == "sms" }
+        let voiceStatus = statusMessages.filter { $0.channel == "voice" }
 
         XCTAssertEqual(telegramStatus.count, 1)
         XCTAssertEqual(smsStatus.count, 1)
+        XCTAssertEqual(voiceStatus.count, 1)
         XCTAssertEqual(telegramStatus.first?.assistantId, testAssistantId)
         XCTAssertEqual(smsStatus.first?.assistantId, testAssistantId)
+        XCTAssertEqual(voiceStatus.first?.assistantId, testAssistantId)
     }
 
     func testStatusPollResponseDoesNotClearGuardianChallengePending() {
@@ -704,5 +716,132 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         // The SMS timeout should have fired, clearing the spinner and setting an error
         XCTAssertFalse(shortTimeoutStore.smsGuardianVerificationInProgress)
         XCTAssertEqual(shortTimeoutStore.smsGuardianError, "Timed out waiting for verification instructions. Try again.")
+    }
+
+    // MARK: - Voice Guardian Verification
+
+    func testStartVoiceVerificationSetsInProgressAndSendsChallenge() {
+        store.startChannelGuardianVerification(channel: "voice")
+
+        XCTAssertTrue(store.voiceGuardianVerificationInProgress)
+        XCTAssertNil(store.voiceGuardianError)
+
+        let guardianMessages = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
+        let challengeMessages = guardianMessages.filter { $0.action == "create_challenge" && $0.channel == "voice" }
+        XCTAssertEqual(challengeMessages.count, 1)
+        XCTAssertEqual(challengeMessages.first?.assistantId, testAssistantId)
+    }
+
+    func testSuccessfulStatusResponseUpdatesVoiceGuardianState() {
+        daemonClient.onGuardianVerificationResponse?(GuardianVerificationResponseMessage(
+            type: "guardian_verification_response",
+            success: true,
+            secret: nil,
+            instruction: nil,
+            bound: true,
+            guardianExternalUserId: "+15559876543",
+            channel: "voice",
+            assistantId: "self",
+            guardianDeliveryChatId: nil,
+            error: nil
+        ))
+
+        let predicate = NSPredicate { _, _ in self.store.voiceGuardianVerified }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(store.voiceGuardianIdentity, "+15559876543")
+        XCTAssertTrue(store.voiceGuardianVerified)
+        XCTAssertFalse(store.voiceGuardianVerificationInProgress)
+        XCTAssertNil(store.voiceGuardianError)
+    }
+
+    func testFailedResponseSetsVoiceError() {
+        store.voiceGuardianVerificationInProgress = true
+
+        daemonClient.onGuardianVerificationResponse?(GuardianVerificationResponseMessage(
+            type: "guardian_verification_response",
+            success: false,
+            secret: nil,
+            instruction: nil,
+            bound: nil,
+            guardianExternalUserId: nil,
+            channel: "voice",
+            assistantId: "self",
+            guardianDeliveryChatId: nil,
+            error: "Voice channel not configured"
+        ))
+
+        let predicate = NSPredicate { _, _ in !self.store.voiceGuardianVerificationInProgress }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertFalse(store.voiceGuardianVerificationInProgress)
+        XCTAssertEqual(store.voiceGuardianError, "Voice channel not configured")
+    }
+
+    func testRevokeVoiceGuardianSendsRevokeAction() {
+        store.revokeChannelGuardian(channel: "voice")
+
+        let guardianMessages = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
+        let revokeMessages = guardianMessages.filter { $0.action == "revoke" && $0.channel == "voice" }
+        XCTAssertEqual(revokeMessages.count, 1)
+        XCTAssertEqual(revokeMessages.first?.assistantId, testAssistantId)
+    }
+
+    func testRevokeVoiceGuardianClearsInstruction() {
+        store.voiceGuardianInstruction = "Call and say 123456"
+
+        store.revokeChannelGuardian(channel: "voice")
+
+        XCTAssertNil(store.voiceGuardianInstruction)
+    }
+
+    func testTimeoutClearsVoiceInstruction() {
+        sentMessages.removeAll()
+        let shortTimeoutStore = SettingsStore(
+            daemonClient: daemonClient,
+            guardianChallengeTimeoutDuration: 0.15,
+            guardianStatusPollInterval: 0.05,
+            guardianStatusPollWindow: 2.0
+        )
+
+        shortTimeoutStore.startChannelGuardianVerification(channel: "voice")
+
+        shortTimeoutStore.voiceGuardianInstruction = "Call and say 123456"
+
+        let predicate = NSPredicate { _, _ in
+            shortTimeoutStore.voiceGuardianError != nil
+        }
+        let timeoutExpectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [timeoutExpectation], timeout: 2.0)
+
+        XCTAssertNil(shortTimeoutStore.voiceGuardianInstruction)
+        XCTAssertFalse(shortTimeoutStore.voiceGuardianVerificationInProgress)
+    }
+
+    func testVoiceResponseDoesNotAffectTelegramOrSmsState() {
+        daemonClient.onGuardianVerificationResponse?(GuardianVerificationResponseMessage(
+            type: "guardian_verification_response",
+            success: true,
+            secret: nil,
+            instruction: nil,
+            bound: true,
+            guardianExternalUserId: "+15559876543",
+            channel: "voice",
+            assistantId: "self",
+            guardianDeliveryChatId: nil,
+            error: nil
+        ))
+
+        let predicate = NSPredicate { _, _ in self.store.voiceGuardianVerified }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [expectation], timeout: 2.0)
+
+        // Telegram and SMS should be unaffected
+        XCTAssertNil(store.telegramGuardianIdentity)
+        XCTAssertFalse(store.telegramGuardianVerified)
+        XCTAssertNil(store.smsGuardianIdentity)
+        XCTAssertFalse(store.smsGuardianVerified)
     }
 }


### PR DESCRIPTION
## Summary
- Adds voice guardian verification UI to the Voice card in Connect settings
- Unverified → Verify button, pending → six-digit code display + copy, verified → identity + Revoke
- Follows existing Telegram guardian verification patterns exactly
- Voice instruction text is call-centric

Closes #7581

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
