### PR TITLE
fix(swift): add missing VellumAssistantShared imports and public TraceStore init

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import VellumAssistantShared
 
 /// Loads avatar appearance from LOOKS.md, watches for changes, and provides
 /// the current DinoPalette for rendering. @Observable so SwiftUI views reactively update.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AvatarSpriteBuilder.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AvatarSpriteBuilder.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SceneKit
+import VellumAssistantShared
 
 /// Generates procedural 3D voxel dino characters seeded from a string.
 /// Native Swift port of the voxeldino Python package (github.com/avareed-assistant/voxeldino).

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AvatarView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import SceneKit
+import VellumAssistantShared
 
 /// 3D voxel dino avatar that the user can rotate by dragging.
 /// Seeded from a string so the same name always produces the same dino.

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/PixelSpriteBuilder.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/PixelSpriteBuilder.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SpriteKit
+import VellumAssistantShared
 
 /// Converts pixel-art grids into SpriteKit textures using CGBitmapContext.
 /// Each art pixel = `pixelSize` × `pixelSize` points. Uses `.nearest` filtering for crisp pixels.

--- a/clients/shared/Features/TraceStore.swift
+++ b/clients/shared/Features/TraceStore.swift
@@ -42,6 +42,8 @@ public final class TraceStore: ObservableObject {
     /// Maximum events retained per session.
     public static let retentionCap = 5000
 
+    public init() {}
+
     // MARK: - Ingestion
 
     /// Ingest a trace event message from the daemon.


### PR DESCRIPTION
## Summary
- Add `import VellumAssistantShared` to 4 macOS files that reference `DinoPalette`, `DinoOutfit`, and `LooksConfig` (moved to shared in a previous PR)
- Add explicit `public init()` to `TraceStore` so the macOS app target can instantiate it (Swift synthesizes `internal` init for public classes)

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22355281679

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
