### PR TITLE
fix: scope Linear issue-state cache by watcher instance, not credential

### DIFF
--- a/assistant/src/watcher/engine.ts
+++ b/assistant/src/watcher/engine.ts
@@ -85,7 +85,7 @@ export async function runWatchersOnce(
         log.info({ watcherId: watcher.id, watermark }, 'Initialized watermark');
       }
 
-      const result = await provider.fetchNew(watcher.credentialService, watermark, config);
+      const result = await provider.fetchNew(watcher.credentialService, watermark, config, watcher.id);
 
       // Store new events with dedup
       let newEvents = 0;

--- a/assistant/src/watcher/provider-types.ts
+++ b/assistant/src/watcher/provider-types.ts
@@ -34,11 +34,18 @@ export interface WatcherProvider {
   /**
    * Fetch new events since the given watermark.
    * Returns new items and an updated watermark.
+   *
+   * `watcherKey` is the unique watcher instance ID (e.g. the DB row UUID).
+   * Providers that maintain per-watcher in-process state (like the Linear
+   * issue-state cache) must key that state by `watcherKey` — not just
+   * `credentialService` — so that multiple watchers sharing the same
+   * credential maintain independent baselines.
    */
   fetchNew(
     credentialService: string,
     watermark: string | null,
     config: Record<string, unknown>,
+    watcherKey: string,
   ): Promise<FetchResult>;
 
   /**

--- a/assistant/src/watcher/providers/github.ts
+++ b/assistant/src/watcher/providers/github.ts
@@ -121,6 +121,7 @@ export const githubProvider: WatcherProvider = {
     credentialService: string,
     watermark: string | null,
     _config: Record<string, unknown>,
+    _watcherKey: string,
   ): Promise<FetchResult> {
     return withValidToken(credentialService, async (token) => {
       const since = watermark ?? new Date().toISOString();

--- a/assistant/src/watcher/providers/gmail.ts
+++ b/assistant/src/watcher/providers/gmail.ts
@@ -113,6 +113,7 @@ export const gmailProvider: WatcherProvider = {
     credentialService: string,
     watermark: string | null,
     _config: Record<string, unknown>,
+    _watcherKey: string,
   ): Promise<FetchResult> {
     return withValidToken(credentialService, async (token) => {
       if (!watermark) {

--- a/assistant/src/watcher/providers/google-calendar.ts
+++ b/assistant/src/watcher/providers/google-calendar.ts
@@ -139,6 +139,7 @@ export const googleCalendarProvider: WatcherProvider = {
     credentialService: string,
     watermark: string | null,
     _config: Record<string, unknown>,
+    _watcherKey: string,
   ): Promise<FetchResult> {
     return withValidToken(credentialService, async (token) => {
       if (!watermark) {

--- a/assistant/src/watcher/providers/linear.ts
+++ b/assistant/src/watcher/providers/linear.ts
@@ -278,22 +278,27 @@ async function fetchAssignedIssueUpdates(
 // ── Issue state tracking ──────────────────────────────────────────────────────
 
 /**
- * Tracks the last known state ID per issue, scoped by credentialService so
- * multiple Linear watchers in the same process (e.g. different accounts or
- * credential keys) maintain independent baselines and can't corrupt each
- * other's state. Outer key: credentialService; inner key: issue ID.
+ * Tracks the last known state ID per issue, scoped by watcher instance key
+ * (the watcher's DB UUID) so that multiple Linear watchers in the same process
+ * — even when they share the same `credentialService` string — maintain
+ * completely independent baselines.
+ *
+ * Keying by `credentialService` alone is insufficient: `runWatchersOnce` polls
+ * watchers sequentially, so watcher-1 would write its post-poll state into the
+ * shared map, and watcher-2 would then see already-updated IDs and silently
+ * skip emitting valid transitions. Outer key: watcherKey; inner key: issue ID.
  *
  * In-memory only; resets on daemon restart, which is acceptable — the first
  * poll after restart will seed the map without emitting false-positive events.
  */
-const knownIssueStateIdsByCredential = new Map<string, Map<string, string>>();
+const knownIssueStateIdsByWatcher = new Map<string, Map<string, string>>();
 
-/** Get (or lazily create) the per-credential state map. */
-function getStateCache(credentialService: string): Map<string, string> {
-  let cache = knownIssueStateIdsByCredential.get(credentialService);
+/** Get (or lazily create) the per-watcher state map. */
+function getStateCache(watcherKey: string): Map<string, string> {
+  let cache = knownIssueStateIdsByWatcher.get(watcherKey);
   if (!cache) {
     cache = new Map<string, string>();
-    knownIssueStateIdsByCredential.set(credentialService, cache);
+    knownIssueStateIdsByWatcher.set(watcherKey, cache);
   }
   return cache;
 }
@@ -384,6 +389,7 @@ export const linearProvider: WatcherProvider = {
     credentialService: string,
     watermark: string | null,
     _config: Record<string, unknown>,
+    watcherKey: string,
   ): Promise<FetchResult> {
     return withValidToken(credentialService, async (token) => {
       const since = watermark ?? new Date().toISOString();
@@ -416,9 +422,10 @@ export const linearProvider: WatcherProvider = {
       // On first sight of an issue we seed the map without emitting, so we don't
       // fire false-positive events after a daemon restart.
       const assignedIssues = await fetchAssignedIssueUpdates(token, viewer.id, since);
-      // Use a per-credential state cache so multiple Linear watchers in the same
-      // process don't overwrite each other's baselines and silently drop events.
-      const stateCache = getStateCache(credentialService);
+      // Scope the state cache by watcherKey (the watcher's DB UUID) rather than
+      // credentialService so that multiple Linear watchers sharing the same credential
+      // maintain independent baselines and cannot clobber each other's state.
+      const stateCache = getStateCache(watcherKey);
       for (const issue of assignedIssues) {
         const previousStateId = stateCache.get(issue.id);
         if (previousStateId !== undefined && previousStateId !== issue.state.id) {

--- a/assistant/src/watcher/providers/slack.ts
+++ b/assistant/src/watcher/providers/slack.ts
@@ -49,6 +49,7 @@ export const slackProvider: WatcherProvider = {
     credentialService: string,
     watermark: string | null,
     _config: Record<string, unknown>,
+    _watcherKey: string,
   ): Promise<FetchResult> {
     return withValidToken(credentialService, async (token) => {
       if (!watermark) {


### PR DESCRIPTION
Addresses Codex review feedback on #7840.

The previous fix scoped the issue-state cache by `credentialService`, but multiple Linear watchers sharing the same credential (the default `integration:linear`) still shared the same inner cache. When `runWatchersOnce` polls watchers sequentially, watcher-1 writes its post-poll state into the shared map and watcher-2 reads the already-updated IDs, silently skipping valid transitions.

## Changes

- **`provider-types.ts`**: Added `watcherKey: string` as a 4th parameter to the `fetchNew` interface method, documented as the unique watcher instance ID.
- **`engine.ts`**: Passes `watcher.id` (the DB UUID, unique per watcher instance) as `watcherKey` to `provider.fetchNew`.
- **`providers/linear.ts`**: Renamed cache map from `knownIssueStateIdsByCredential` to `knownIssueStateIdsByWatcher`, updated `getStateCache` to key by `watcherKey`, and updated `fetchNew` signature to accept and use `watcherKey`.
- **`providers/github.ts`, `gmail.ts`, `google-calendar.ts`, `slack.ts`**: Added `_watcherKey` parameter to satisfy the updated interface (these providers have no per-watcher in-process state, so the parameter is unused).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
