### PR TITLE
fix: voice guardian code extraction for formatted UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -907,9 +907,28 @@ struct SettingsConnectTab: View {
         return String(instruction[range]).trimmingCharacters(in: CharacterSet(charactersIn: "`"))
     }
 
+    /// Extracts a six-digit verification code from voice-style instruction text.
+    /// Voice instructions use a format like "...six-digit code: 123456..." instead of the
+    /// `/guardian_verify <hex>` command used by Telegram and SMS channels.
+    private func extractVoiceGuardianCode(from instruction: String) -> String? {
+        guard let range = instruction.range(of: #"six-digit code:\s*(\d{6})"#, options: .regularExpression) else {
+            return nil
+        }
+        let match = String(instruction[range])
+        // Extract just the digits from "six-digit code: 123456"
+        guard let digitRange = match.range(of: #"\d{6}"#, options: .regularExpression) else {
+            return nil
+        }
+        return String(match[digitRange])
+    }
+
     @ViewBuilder
     private func guardianInstructionView(channel: String, instruction: String) -> some View {
-        let command = extractGuardianCommand(from: instruction)
+        // Voice uses a different instruction format ("six-digit code: 123456") vs
+        // Telegram/SMS which use "/guardian_verify <hex>".
+        let command: String? = channel == "voice"
+            ? extractVoiceGuardianCode(from: instruction)
+            : extractGuardianCommand(from: instruction)
         let isCopied = guardianCommandCopiedChannel == channel
 
         VStack(alignment: .leading, spacing: VSpacing.sm) {


### PR DESCRIPTION
## Summary
- Adds voice-specific code extraction from instruction text
- Voice verification now shows formatted six-digit code + copy button instead of raw text fallback
- Addresses feedback on #7858

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
