### PR TITLE
fix: nil out old DaemonClient callbacks before rebinding

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -164,6 +164,19 @@ class IOSThreadStore: ObservableObject {
         // publisher from setupDaemonCallbacks doesn't fire against the wrong daemon.
         cancellables.removeAll()
 
+        // Nil out callbacks on the old daemon before replacing the reference.
+        // In-flight HTTP responses (session-list, history, subagent-detail) are launched
+        // in fire-and-forget Tasks and are not cancelled by disconnect.  Without this,
+        // a response arriving after the rebind would invoke the closures registered by
+        // the previous setupDaemonCallbacks call, which capture [weak self] and would
+        // still call back into this store — potentially corrupting the thread list with
+        // stale sessions from the old connection.
+        if let oldDaemon = daemonClient as? DaemonClient {
+            oldDaemon.onSessionListResponse = nil
+            oldDaemon.onHistoryResponse = nil
+            oldDaemon.onSubagentDetailResponse = nil
+        }
+
         daemonClient = newClient
 
         // Existing ViewModels hold a reference to the old, disconnected client inside


### PR DESCRIPTION
## Summary

- In `IOSThreadStore.rebindDaemonClient`, before replacing the `daemonClient` reference, nil out the old daemon's `onSessionListResponse`, `onHistoryResponse`, and `onSubagentDetailResponse` callbacks.
- This prevents in-flight HTTP responses from the old transport (launched as fire-and-forget Tasks, not cancelled on disconnect) from calling back into the store after a reconnect and corrupting the thread list with stale sessions.

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/7855#discussion_r2847567886

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
