### PR TITLE
fix: correct null vs undefined comparisons in ESLint null-equality cleanup

### DIFF
--- a/assistant/src/calls/call-conversation-messages.ts
+++ b/assistant/src/calls/call-conversation-messages.ts
@@ -12,7 +12,7 @@ export function buildCallCompletionMessage(callSessionId: string): string {
   const duration = callSession?.endedAt && callSession?.startedAt
     ? Math.round((callSession.endedAt - callSession.startedAt) / 1000)
     : null;
-  const durationStr = duration !== undefined ? ` (${duration}s)` : '';
+  const durationStr = duration != null ? ` (${duration}s)` : '';
   const statusLabel = callSession?.status === 'failed'
     ? 'Call failed'
     : callSession?.status === 'cancelled'

--- a/assistant/src/cli/core-commands.ts
+++ b/assistant/src/cli/core-commands.ts
@@ -527,7 +527,7 @@ export function registerDoctorCommand(program: Command): void {
         try {
           const rawTrust = readFileSync(trustPath, 'utf-8');
           const data = JSON.parse(rawTrust);
-          if (typeof data !== 'object' || data === undefined) {
+          if (typeof data !== 'object' || data == null) {
             fail('Trust rule syntax', 'trust.json is not a JSON object');
           } else if (typeof data.version !== 'number') {
             fail('Trust rule syntax', 'missing or invalid "version" field');
@@ -536,7 +536,7 @@ export function registerDoctorCommand(program: Command): void {
           } else {
             const invalid = data.rules.filter(
               (r: unknown) =>
-                typeof r !== 'object' || r === undefined ||
+                typeof r !== 'object' || r == null ||
                 typeof (r as Record<string, unknown>).tool !== 'string' ||
                 typeof (r as Record<string, unknown>).pattern !== 'string' ||
                 typeof (r as Record<string, unknown>).scope !== 'string',

--- a/assistant/src/config/bundled-skills/media-processing/tools/query-media-events.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/query-media-events.ts
@@ -227,7 +227,7 @@ export async function run(
 
   // Filter events by allowed capabilities, then apply the user-requested limit
   let filteredEvents = result.events;
-  if (allowedEventTypes !== undefined) {
+  if (allowedEventTypes != null) {
     filteredEvents = filteredEvents.filter((e) => allowedEventTypes!.has(e.eventType));
   }
   if (userLimit && filteredEvents.length > userLimit) {

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -173,7 +173,7 @@ export function checkSkillRequirements(
 
   // anyBins: at least one must exist
   if (requires.anyBins && requires.anyBins.length > 0) {
-    const hasAny = requires.anyBins.some((bin) => Bun.which(bin) !== undefined);
+    const hasAny = requires.anyBins.some((bin) => Bun.which(bin) != null);
     if (!hasAny) {
       missingBins.push(`(one of: ${requires.anyBins.join(', ')})`);
     }

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -112,7 +112,7 @@ export class ContextWindowManager {
       };
     }
 
-    const summaryOffset = existingSummary !== undefined ? 1 : 0;
+    const summaryOffset = existingSummary != null ? 1 : 0;
     const userTurnStarts = collectUserTurnStartIndexes(messages);
     if (userTurnStarts.length === 0) {
       return {

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -70,7 +70,7 @@ export function handleGuardianVerification(
       ctx.send(socket, {
         type: 'guardian_verification_response',
         success: true,
-        bound: binding !== undefined,
+        bound: binding != null,
         guardianExternalUserId: binding?.guardianExternalUserId,
         guardianUsername,
         guardianDisplayName,

--- a/assistant/src/daemon/session-dynamic-profile.ts
+++ b/assistant/src/daemon/session-dynamic-profile.ts
@@ -48,7 +48,7 @@ export function stripDynamicProfileMessages(messages: Message[], profileText: st
     changed = true;
     const stripped = nextText.replace(/\n{3,}/g, '\n\n').trimEnd();
     return stripped.length > 0 ? { ...block, text: stripped } : null;
-  }).filter((block): block is NonNullable<typeof block> => block !== undefined);
+  }).filter((block): block is NonNullable<typeof block> => block != null);
   if (!changed) return messages;
   // If stripping removed all content blocks, drop the message entirely
   // to avoid sending an empty content array to the provider.

--- a/assistant/src/daemon/session-history.ts
+++ b/assistant/src/daemon/session-history.ts
@@ -14,7 +14,7 @@ const log = getLogger('session-history');
 
 function isUndoableUserMessage(message: Message): boolean {
   if (message.role !== 'user') return false;
-  if (getSummaryFromContextMessage(message) !== undefined) return false;
+  if (getSummaryFromContextMessage(message) != null) return false;
   // A user message is undoable if it contains user-authored content (non-tool_result
   // blocks). Messages that contain ONLY tool_result blocks (e.g. automated tool
   // responses) are not undoable. Messages that have both tool_result and text blocks

--- a/assistant/src/daemon/session-media-retry.ts
+++ b/assistant/src/daemon/session-media-retry.ts
@@ -17,7 +17,7 @@ export function stripMediaPayloadsForRetry(messages: Message[]): { messages: Mes
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
     if (msg.role !== 'user') continue;
-    if (getSummaryFromContextMessage(msg) !== undefined) continue;
+    if (getSummaryFromContextMessage(msg) != null) continue;
     if (isToolResultOnlyMessage(msg)) continue;
     latestUserIndex = i;
     break;

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -356,7 +356,7 @@ export function stripUserTextBlocksByPrefix(messages: Message[], prefixes: strin
     if (nextContent.length === message.content.length) return message;
     if (nextContent.length === 0) return null;
     return { ...message, content: nextContent };
-  }).filter((message): message is NonNullable<typeof message> => message !== undefined);
+  }).filter((message): message is NonNullable<typeof message> => message != null);
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/session-workspace.ts
+++ b/assistant/src/daemon/session-workspace.ts
@@ -12,7 +12,7 @@ export interface WorkspaceSessionContext {
 
 /** Refresh workspace top-level directory context if needed. */
 export function refreshWorkspaceTopLevelContextIfNeeded(ctx: WorkspaceSessionContext): void {
-  if (!ctx.workspaceTopLevelDirty && ctx.workspaceTopLevelContext !== undefined) return;
+  if (!ctx.workspaceTopLevelDirty && ctx.workspaceTopLevelContext != null) return;
   const snapshot = scanTopLevelDirectories(ctx.workingDir);
   ctx.workspaceTopLevelContext = renderWorkspaceTopLevelContext(snapshot);
   ctx.workspaceTopLevelDirty = false;

--- a/assistant/src/hooks/discovery.ts
+++ b/assistant/src/hooks/discovery.ts
@@ -24,7 +24,7 @@ const VALID_EVENTS = new Set<string>([
  * (created before those fields were added) continue to be discovered.
  */
 export function isValidManifest(manifest: unknown): manifest is HookManifest {
-  if (typeof manifest !== 'object' || manifest === undefined) return false;
+  if (typeof manifest !== 'object' || manifest == null) return false;
   const m = manifest as Record<string, unknown>;
   if (typeof m.name !== 'string' || !m.name) return false;
   if (typeof m.script !== 'string' || !m.script) return false;

--- a/assistant/src/hooks/manager.ts
+++ b/assistant/src/hooks/manager.ts
@@ -50,7 +50,7 @@ export class HookManager {
     for (const hook of hooks) {
       try {
         const result = await runHookScript(hook, eventData);
-        if (result.exitCode !== undefined && result.exitCode !== 0) {
+        if (result.exitCode != null && result.exitCode !== 0) {
           // Blocking hooks on pre-* events cancel the action
           if (isPreEvent && hook.manifest.blocking) {
             log.info({ hook: hook.name, event, exitCode: result.exitCode }, 'Blocking hook rejected action');

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -322,7 +322,7 @@ export function getAttachmentsForMessage(
 
   if (links.length === 0) return [];
 
-  const ids = links.map((l) => l.attachmentId).filter((id): id is string => id !== undefined);
+  const ids = links.map((l) => l.attachmentId).filter((id): id is string => id != null);
   return getAttachmentsByIds(ids);
 }
 

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -327,7 +327,7 @@ export function deleteLastExchange(conversationId: string): number {
       .where(inArray(messageAttachments.messageId, messageIds))
       .all()
       .map((r) => r.attachmentId)
-      .filter((id): id is string => id !== undefined)
+      .filter((id): id is string => id != null)
     : [];
 
   db.transaction((tx) => {

--- a/assistant/src/memory/query-builder.ts
+++ b/assistant/src/memory/query-builder.ts
@@ -23,7 +23,7 @@ export function buildMemoryQuery(
   const requestText = clampSection(userRequest.trim(), maxUserRequestChars);
   const sessionSummary = messages
     .map((message) => getSummaryFromContextMessage(message))
-    .find((summary): summary is string => summary !== undefined);
+    .find((summary): summary is string => summary != null);
 
   const content = requestText.length > 0 ? requestText : '(empty)';
 

--- a/assistant/src/memory/search/semantic.ts
+++ b/assistant/src/memory/search/semantic.ts
@@ -62,7 +62,7 @@ export async function semanticSearch(
     if (payload.target_type === 'item') {
       // Validate the backing memory item is still active and has non-excluded evidence
       const item = db.select().from(memoryItems).where(eq(memoryItems.id, payload.target_id)).get();
-      if (!item || item.status !== 'active' || item.invalidAt !== undefined) continue;
+      if (!item || item.status !== 'active' || item.invalidAt != null) continue;
       if (scopeIds && !scopeIds.includes(item.scopeId)) continue;
       const sources = sourcesMap.get(payload.target_id);
       if (!sources || sources.length === 0) continue;

--- a/assistant/src/runtime/routes/call-routes.ts
+++ b/assistant/src/runtime/routes/call-routes.ts
@@ -62,7 +62,7 @@ export async function handleStartCall(req: Request, assistantId: string = 'self'
     return Response.json({ error: 'Invalid JSON in request body' }, { status: 400 });
   }
 
-  if (typeof body !== 'object' || body === undefined || Array.isArray(body)) {
+  if (typeof body !== 'object' || body == null || Array.isArray(body)) {
     return Response.json({ error: 'Request body must be a JSON object' }, { status: 400 });
   }
 
@@ -188,7 +188,7 @@ export async function handleAnswerCall(req: Request, callSessionId: string): Pro
     return Response.json({ error: 'Invalid JSON in request body' }, { status: 400 });
   }
 
-  if (typeof body !== 'object' || body === undefined || Array.isArray(body)) {
+  if (typeof body !== 'object' || body == null || Array.isArray(body)) {
     return Response.json({ error: 'Request body must be a JSON object' }, { status: 400 });
   }
 
@@ -217,7 +217,7 @@ export async function handleInstructionCall(req: Request, callSessionId: string)
     return Response.json({ error: 'Invalid JSON in request body' }, { status: 400 });
   }
 
-  if (typeof body !== 'object' || body === undefined || Array.isArray(body)) {
+  if (typeof body !== 'object' || body == null || Array.isArray(body)) {
     return Response.json({ error: 'Request body must be a JSON object' }, { status: 400 });
   }
 

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -123,7 +123,7 @@ export function deleteSecureKey(account: string): boolean {
   // backend — saveConfig routinely deletes keys for unset providers.
   // getKey now returns null for "not found" and throws on runtime errors.
   try {
-    if (keychain.getKey(account) === undefined) {
+    if (keychain.getKey(account) == null) {
       return false;
     }
   } catch {

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -801,7 +801,7 @@ export async function executeBrowserWaitFor(
   const text = typeof input.text === 'string' && input.text ? input.text : null;
   const duration = typeof input.duration === 'number' ? input.duration : null;
 
-  const modeCount = [selector, text, duration].filter((v) => v !== undefined).length;
+  const modeCount = [selector, text, duration].filter((v) => v != null).length;
   if (modeCount === 0) {
     return { content: 'Error: Exactly one of selector, text, or duration is required.', isError: true };
   }

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -194,7 +194,7 @@ class BrowserManager {
     this.contextCreating = (async () => {
       // Deterministic test mode: when launch is injected via setLaunchFn,
       // bypass ambient CDP probing/negotiation and use the injected launcher.
-      const hasInjectedLaunchFn = launchPersistentContext !== undefined;
+      const hasInjectedLaunchFn = launchPersistentContext != null;
 
       if (!hasInjectedLaunchFn) {
         // Try to detect or negotiate CDP before falling back to headless.
@@ -711,7 +711,7 @@ class BrowserManager {
   }
 
   hasContext(): boolean {
-    return this.context !== undefined;
+    return this.context != null;
   }
 }
 

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -300,7 +300,7 @@ class CredentialStoreTool implements Tool {
           injectionTemplates = [];
           for (let i = 0; i < rawTemplates.length; i++) {
             const t = rawTemplates[i] as Record<string, unknown>;
-            if (typeof t !== 'object' || t === undefined) {
+            if (typeof t !== 'object' || t == null) {
               templateErrors.push(`injection_templates[${i}] must be an object`);
               continue;
             }

--- a/assistant/src/util/promise-guard.ts
+++ b/assistant/src/util/promise-guard.ts
@@ -8,7 +8,7 @@ export class PromiseGuard<T> {
 
   /** Whether a promise is currently in-flight. */
   get active(): boolean {
-    return this.promise !== undefined;
+    return this.promise != null;
   }
 
   /**

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -651,7 +651,7 @@ export class WorkspaceGitService {
       return;
     }
 
-    const state = currentBranch === undefined ? 'detached HEAD' : `branch '${currentBranch}'`;
+    const state = currentBranch == null ? 'detached HEAD' : `branch '${currentBranch}'`;
     log.warn(
       { workspaceDir: this.workspaceDir, currentBranch },
       `Workspace repo is on ${state}; auto-switching to main`,


### PR DESCRIPTION
## Summary

PR #7856 fixed ESLint `no-eq-null` violations by replacing `=== null` / `!== null` with `=== undefined` / `!== undefined`, but this introduced bugs wherever values are typed `T | null` (never `undefined`). This PR corrects all 26+ instances identified in the Codex and Devin reviews.

### Fixes applied

- Used `== null` / `!= null` (loose equality, catches both null and undefined) in all places where the ESLint rule disallows strict null comparisons
- Fixed `typeof x !== 'object' || x === undefined` patterns where `typeof null === 'object'` means null slips through — changed to `|| x == null`
- Fixed `.filter(x !== undefined)` to `.filter(x != null)` for nullable DB values and mapped arrays that can return `null`
- Fixed `getSummaryFromContextMessage` call sites (returns `string | null`, never `undefined`) in session-history, session-media-retry, query-builder, and window-manager
- Fixed `PromiseGuard.active` — field is `Promise<T> | null`, so `!== undefined` was always true
- Fixed `browser-manager.ts` — `launchPersistentContext` and `this.context` are `null`-typed
- Fixed `browser-execution.ts` — wait mode count filter now correctly excludes null sentinels
- Fixed `call-routes.ts` (3 places) — `req.json()` can return null for a JSON `null` payload
- Fixed `config-channels.ts` — `getGuardianBinding` returns `GuardianBinding | null`
- Fixed `hooks/manager.ts` — `exitCode` can be null for unclean process exits
- Fixed `secure-keys.ts` — `keychain.getKey()` returns null for missing keys
- Fixed `workspace/git-service.ts` — detached HEAD sets `currentBranch = null`
- Verified `tools/credentials/metadata-store.ts` already correct (uses `== null` as sentinel)

All changes verified with `bun run lint` (passes) and `bunx tsc --noEmit` (no errors).

Addresses feedback from: https://github.com/vellum-ai/vellum-assistant/pull/7856
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
