### PR TITLE
fix(swift): remove duplicate TraceStore init()

### DIFF
--- a/clients/shared/Features/TraceStore.swift
+++ b/clients/shared/Features/TraceStore.swift
@@ -44,8 +44,6 @@ public final class TraceStore: ObservableObject {
     /// Maximum events retained per session.
     public static let retentionCap = 5000
 
-    public init() {}
-
     // MARK: - Ingestion
 
     /// Ingest a trace event message from the daemon.


### PR DESCRIPTION
## Summary
- Remove duplicate `public init() {}` in `TraceStore.swift` (lines 10 and 47) that caused "invalid redeclaration of init()" build errors on both macOS and iOS CI

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22355281679

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
