### PR TITLE
M5: In-Call Voice Guardian Verification Gate

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -920,7 +920,7 @@ describe('relay-server', () => {
       return createMockStream(['Your appointment is confirmed.']);
     });
 
-    const { ws, relay } = createMockWs(session.id);
+    const { ws: _ws, relay } = createMockWs(session.id);
 
     // Setup
     await relay.handleMessage(JSON.stringify({

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -115,6 +115,10 @@ import { getMessages } from '../memory/conversation-store.js';
 import { registerCallCompletionNotifier, unregisterCallCompletionNotifier } from '../calls/call-state.js';
 import { RelayConnection, activeRelayConnections } from '../calls/relay-server.js';
 import type { RelayWebSocketData } from '../calls/relay-server.js';
+import {
+  createVerificationChallenge,
+  getGuardianBinding,
+} from '../runtime/channel-guardian-service.js';
 
 initializeDb();
 
@@ -171,6 +175,9 @@ function resetTables() {
   db.run('DELETE FROM call_events');
   db.run('DELETE FROM call_sessions');
   db.run('DELETE FROM conversations');
+  db.run('DELETE FROM channel_guardian_verification_challenges');
+  db.run('DELETE FROM channel_guardian_bindings');
+  db.run('DELETE FROM channel_guardian_rate_limits');
   ensuredConvIds = new Set();
 }
 
@@ -953,6 +960,309 @@ describe('relay-server', () => {
     // Verify events were recorded for both caller utterances
     const events = getCallEvents(session.id).filter((e) => e.eventType === 'caller_spoke');
     expect(events.length).toBe(2);
+
+    relay.destroy();
+  });
+
+  // ── Inbound voice guardian verification gate ────────────────────────
+
+  test('inbound guardian verification: DTMF code entry succeeds and starts normal call flow', async () => {
+    ensureConversation('conv-guardian-dtmf-ok');
+    const session = createCallSession({
+      conversationId: 'conv-guardian-dtmf-ok',
+      provider: 'twilio',
+      fromNumber: '+15559999999',
+      toNumber: '+15551111111',
+      assistantId: 'test-assistant',
+      // no task — inbound call
+    });
+
+    // Create a pending voice guardian challenge
+    const challenge = createVerificationChallenge('test-assistant', 'voice');
+    const secret = challenge.secret;
+
+    mockStreamFn.mockImplementation(() => createMockStream(['Hello, how can I help you?']));
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_guardian_dtmf_ok',
+      from: '+15559999999',
+      to: '+15551111111',
+    }));
+
+    // Should be in verification-pending state
+    expect(relay.isGuardianVerificationActive()).toBe(true);
+    expect(relay.getConnectionState()).toBe('verification_pending');
+
+    // Verify TTS prompt was sent asking for code
+    const setupMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(setupMessages.some((m) => (m.token ?? '').includes('verification code'))).toBe(true);
+
+    // Enter the correct code via DTMF
+    for (const digit of secret) {
+      await relay.handleMessage(JSON.stringify({ type: 'dtmf', digit }));
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Verification should have succeeded
+    expect(relay.isGuardianVerificationActive()).toBe(false);
+    expect(relay.getConnectionState()).toBe('connected');
+
+    // Guardian binding should have been created
+    const binding = getGuardianBinding('test-assistant', 'voice');
+    expect(binding).not.toBeNull();
+
+    // Orchestrator greeting should have fired
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes('how can I help'))).toBe(true);
+
+    // Verify events recorded
+    const guardianEvents = getCallEvents(session.id);
+    expect(guardianEvents.some((e) => e.eventType === 'guardian_voice_verification_started')).toBe(true);
+    expect(guardianEvents.some((e) => e.eventType === 'guardian_voice_verification_succeeded')).toBe(true);
+
+    relay.destroy();
+  });
+
+  test('inbound guardian verification: speech-based code entry succeeds', async () => {
+    ensureConversation('conv-guardian-speech-ok');
+    const session = createCallSession({
+      conversationId: 'conv-guardian-speech-ok',
+      provider: 'twilio',
+      fromNumber: '+15559999999',
+      toNumber: '+15551111111',
+      assistantId: 'test-assistant',
+    });
+
+    const challenge = createVerificationChallenge('test-assistant', 'voice');
+    const secret = challenge.secret;
+
+    mockStreamFn.mockImplementation(() => createMockStream(['Hello, verified caller!']));
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_guardian_speech_ok',
+      from: '+15559999999',
+      to: '+15551111111',
+    }));
+
+    expect(relay.isGuardianVerificationActive()).toBe(true);
+
+    // Speak the code as individual digit characters
+    const spokenCode = secret.split('').join(' ');
+    await relay.handleMessage(JSON.stringify({
+      type: 'prompt',
+      voicePrompt: spokenCode,
+      lang: 'en-US',
+      last: true,
+    }));
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Verification should have succeeded
+    expect(relay.isGuardianVerificationActive()).toBe(false);
+    expect(relay.getConnectionState()).toBe('connected');
+
+    // Binding created
+    const binding = getGuardianBinding('test-assistant', 'voice');
+    expect(binding).not.toBeNull();
+
+    // Greeting should have started
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes('verified caller'))).toBe(true);
+
+    relay.destroy();
+  });
+
+  test('inbound guardian verification: invalid code triggers retry prompt', async () => {
+    ensureConversation('conv-guardian-retry');
+    const session = createCallSession({
+      conversationId: 'conv-guardian-retry',
+      provider: 'twilio',
+      fromNumber: '+15559999999',
+      toNumber: '+15551111111',
+      assistantId: 'test-assistant',
+    });
+
+    createVerificationChallenge('test-assistant', 'voice');
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_guardian_retry',
+      from: '+15559999999',
+      to: '+15551111111',
+    }));
+
+    expect(relay.isGuardianVerificationActive()).toBe(true);
+
+    // Enter a wrong code via DTMF
+    for (const digit of '000000') {
+      await relay.handleMessage(JSON.stringify({ type: 'dtmf', digit }));
+    }
+
+    // Should still be in verification-pending state (retry allowed)
+    expect(relay.isGuardianVerificationActive()).toBe(true);
+    expect(relay.getConnectionState()).toBe('verification_pending');
+
+    // Should have sent a retry prompt
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes('incorrect'))).toBe(true);
+
+    relay.destroy();
+  });
+
+  test('inbound guardian verification: max attempts exhaustion terminates call', async () => {
+    ensureConversation('conv-guardian-max-attempts');
+    const session = createCallSession({
+      conversationId: 'conv-guardian-max-attempts',
+      provider: 'twilio',
+      fromNumber: '+15559999999',
+      toNumber: '+15551111111',
+      assistantId: 'test-assistant',
+    });
+
+    createVerificationChallenge('test-assistant', 'voice');
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_guardian_max_attempts',
+      from: '+15559999999',
+      to: '+15551111111',
+    }));
+
+    expect(relay.isGuardianVerificationActive()).toBe(true);
+
+    // Enter wrong codes 3 times (max attempts = 3)
+    for (let attempt = 0; attempt < 3; attempt++) {
+      for (const digit of '000000') {
+        await relay.handleMessage(JSON.stringify({ type: 'dtmf', digit }));
+      }
+    }
+
+    // Call should be marked as failed
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('failed');
+    expect(updated!.lastError).toContain('Guardian voice verification failed');
+
+    // Should have sent goodbye message
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes('Verification failed. Goodbye.'))).toBe(true);
+
+    // Verify events
+    const events = getCallEvents(session.id);
+    expect(events.some((e) => e.eventType === 'guardian_voice_verification_failed')).toBe(true);
+
+    // Let the delayed endSession callback flush
+    await new Promise((resolve) => setTimeout(resolve, 2100));
+
+    // Verify end message was sent
+    const endMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string })
+      .filter((m) => m.type === 'end');
+    expect(endMessages.length).toBe(1);
+
+    relay.destroy();
+  });
+
+  test('inbound guardian verification: no pending challenge proceeds with normal flow', async () => {
+    ensureConversation('conv-guardian-no-challenge');
+    const session = createCallSession({
+      conversationId: 'conv-guardian-no-challenge',
+      provider: 'twilio',
+      fromNumber: '+15559999999',
+      toNumber: '+15551111111',
+      assistantId: 'test-assistant',
+      // no task — inbound call
+    });
+
+    // Do NOT create any pending challenge
+
+    mockStreamFn.mockImplementation(() => createMockStream(['Welcome to the line.']));
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_guardian_no_challenge',
+      from: '+15559999999',
+      to: '+15551111111',
+    }));
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Should NOT be in guardian verification state
+    expect(relay.isGuardianVerificationActive()).toBe(false);
+    expect(relay.getConnectionState()).toBe('connected');
+
+    // Should have started normal greeting
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes('Welcome to the line'))).toBe(true);
+
+    relay.destroy();
+  });
+
+  test('inbound guardian verification: speech with partial digits prompts for more', async () => {
+    ensureConversation('conv-guardian-partial-speech');
+    const session = createCallSession({
+      conversationId: 'conv-guardian-partial-speech',
+      provider: 'twilio',
+      fromNumber: '+15559999999',
+      toNumber: '+15551111111',
+      assistantId: 'test-assistant',
+    });
+
+    createVerificationChallenge('test-assistant', 'voice');
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_guardian_partial_speech',
+      from: '+15559999999',
+      to: '+15551111111',
+    }));
+
+    expect(relay.isGuardianVerificationActive()).toBe(true);
+
+    // Speak only 3 digits
+    await relay.handleMessage(JSON.stringify({
+      type: 'prompt',
+      voicePrompt: 'one two three',
+      lang: 'en-US',
+      last: true,
+    }));
+
+    // Should still be in verification state
+    expect(relay.isGuardianVerificationActive()).toBe(true);
+
+    // Should have prompted for more digits
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes('3 digits'))).toBe(true);
+    expect(textMessages.some((m) => (m.token ?? '').includes('all 6 digits'))).toBe(true);
 
     relay.destroy();
   });

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -555,16 +555,19 @@ export class RelayConnection {
       });
       log.info({ callSessionId: this.callSessionId }, 'Inbound guardian voice verification succeeded');
 
-      // Proceed to normal call flow
+      // Proceed to normal call flow (use startNormalCallFlow to respect
+      // the CALL_WELCOME_GREETING static greeting guard)
       if (this.orchestrator) {
-        this.orchestrator.startInitialGreeting().catch((err) =>
-          log.error({ err, callSessionId: this.callSessionId }, 'Failed to start initial inbound greeting after guardian verification'),
-        );
+        this.startNormalCallFlow(this.orchestrator, true);
       }
     } else {
       this.verificationAttempts++;
 
       if (this.verificationAttempts >= this.verificationMaxAttempts) {
+        // Immediately deactivate verification so DTMF/speech input during
+        // the goodbye window doesn't trigger more verification attempts.
+        this.guardianVerificationActive = false;
+
         recordCallEvent(this.callSessionId, 'guardian_voice_verification_failed', {
           attempts: this.verificationAttempts,
         });

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -27,6 +27,10 @@ import {
   type PromptSpeakerContext,
 } from './speaker-identification.js';
 import { isTerminalState } from './call-state-machine.js';
+import {
+  getPendingChallenge,
+  validateAndConsumeChallenge,
+} from '../runtime/channel-guardian-service.js';
 
 const log = getLogger('relay-server');
 
@@ -138,13 +142,18 @@ export class RelayConnection {
   private orchestrator: CallOrchestrator | null = null;
   private speakerIdentityTracker: SpeakerIdentityTracker;
 
-  // Verification state
+  // Verification state (outbound callee verification)
   private connectionState: RelayConnectionState = 'connected';
   private verificationCode: string | null = null;
   private verificationAttempts = 0;
   private verificationMaxAttempts = 3;
   private verificationCodeLength = 6;
   private dtmfBuffer = '';
+
+  // Inbound voice guardian verification state
+  private guardianVerificationActive = false;
+  private guardianChallengeAssistantId: string | null = null;
+  private guardianVerificationFromNumber: string | null = null;
 
   constructor(ws: ServerWebSocket<RelayWebSocketData>, callSessionId: string) {
     this.ws = ws;
@@ -159,6 +168,20 @@ export class RelayConnection {
    */
   getVerificationCode(): string | null {
     return this.verificationCode;
+  }
+
+  /**
+   * Whether inbound guardian voice verification is currently active.
+   */
+  isGuardianVerificationActive(): boolean {
+    return this.guardianVerificationActive;
+  }
+
+  /**
+   * Get the current connection state.
+   */
+  getConnectionState(): RelayConnectionState {
+    return this.connectionState;
   }
 
   /**
@@ -360,17 +383,19 @@ export class RelayConnection {
     const verificationConfig = config.calls.verification;
     if (!isInbound && verificationConfig.enabled) {
       this.startVerification(session, verificationConfig);
-    } else {
-      // Skip the LLM-driven opener when a static welcome greeting is already
-      // configured via CALL_WELCOME_GREETING — Twilio's ConversationRelay will
-      // speak it at the transport level, so firing the orchestrator opener too
-      // would cause a double greeting.
-      const hasStaticGreeting = !!process.env.CALL_WELCOME_GREETING?.trim();
-      if (!hasStaticGreeting) {
-        orchestrator.startInitialGreeting().catch((err) =>
-          log.error({ err, callSessionId: this.callSessionId }, `Failed to start initial ${isInbound ? 'inbound' : 'outbound'} greeting`),
-        );
+    } else if (isInbound) {
+      // For inbound calls, check if there's a pending voice guardian
+      // challenge that the caller needs to complete before proceeding.
+      const assistantId = session?.assistantId ?? 'self';
+      const pendingChallenge = getPendingChallenge(assistantId, 'voice');
+
+      if (pendingChallenge) {
+        this.startInboundGuardianVerification(assistantId, msg.from);
+      } else {
+        this.startNormalCallFlow(orchestrator, true);
       }
+    } else {
+      this.startNormalCallFlow(orchestrator, false);
     }
   }
 
@@ -418,16 +443,194 @@ export class RelayConnection {
     );
   }
 
+  /**
+   * Start normal call flow — fire the orchestrator greeting unless a
+   * static welcome greeting is configured.
+   */
+  private startNormalCallFlow(orchestrator: CallOrchestrator, isInbound: boolean): void {
+    const hasStaticGreeting = !!process.env.CALL_WELCOME_GREETING?.trim();
+    if (!hasStaticGreeting) {
+      orchestrator.startInitialGreeting().catch((err) =>
+        log.error({ err, callSessionId: this.callSessionId }, `Failed to start initial ${isInbound ? 'inbound' : 'outbound'} greeting`),
+      );
+    }
+  }
+
+  /**
+   * Enter verification-pending state for an inbound call with a pending
+   * voice guardian challenge. Prompts the caller to enter their six-digit
+   * verification code via DTMF or by speaking it.
+   */
+  private startInboundGuardianVerification(assistantId: string, fromNumber: string): void {
+    this.guardianVerificationActive = true;
+    this.guardianChallengeAssistantId = assistantId;
+    this.guardianVerificationFromNumber = fromNumber;
+    this.connectionState = 'verification_pending';
+    this.verificationAttempts = 0;
+    this.verificationMaxAttempts = 3;
+    this.verificationCodeLength = 6;
+    this.dtmfBuffer = '';
+
+    recordCallEvent(this.callSessionId, 'guardian_voice_verification_started', {
+      assistantId,
+      maxAttempts: this.verificationMaxAttempts,
+    });
+
+    this.sendTextToken(
+      'Welcome. Please enter your six-digit verification code using your keypad, or speak the digits now.',
+      true,
+    );
+
+    log.info(
+      { callSessionId: this.callSessionId, assistantId },
+      'Inbound guardian voice verification started',
+    );
+  }
+
+  /**
+   * Extract digit characters from a speech transcript. Recognizes both
+   * raw digit characters ("1 2 3") and spoken number words ("one two three").
+   */
+  private static parseDigitsFromSpeech(transcript: string): string {
+    const wordToDigit: Record<string, string> = {
+      zero: '0', oh: '0', o: '0',
+      one: '1', won: '1',
+      two: '2', too: '2', to: '2',
+      three: '3',
+      four: '4', for: '4', fore: '4',
+      five: '5',
+      six: '6',
+      seven: '7',
+      eight: '8', ate: '8',
+      nine: '9',
+    };
+
+    const digits: string[] = [];
+    const lower = transcript.toLowerCase();
+
+    // Split on whitespace and non-alphanumeric boundaries
+    const tokens = lower.split(/[\s,.\-;:!?]+/);
+    for (const token of tokens) {
+      if (/^\d$/.test(token)) {
+        digits.push(token);
+      } else if (wordToDigit[token]) {
+        digits.push(wordToDigit[token]);
+      } else if (/^\d+$/.test(token)) {
+        // Multi-digit number like "123456" — split into individual digits
+        digits.push(...token.split(''));
+      }
+    }
+
+    return digits.join('');
+  }
+
+  /**
+   * Attempt to validate an entered code against the pending voice guardian
+   * challenge via validateAndConsumeChallenge. On success, binds the
+   * guardian and transitions to normal call flow. On failure, enforces
+   * max attempts and terminates the call if exhausted.
+   */
+  private attemptGuardianCodeVerification(enteredCode: string): void {
+    if (!this.guardianChallengeAssistantId || !this.guardianVerificationFromNumber) {
+      return;
+    }
+
+    const result = validateAndConsumeChallenge(
+      this.guardianChallengeAssistantId,
+      'voice',
+      enteredCode,
+      this.guardianVerificationFromNumber,
+      this.guardianVerificationFromNumber,
+    );
+
+    if (result.success) {
+      // Guardian binding was created by validateAndConsumeChallenge
+      this.connectionState = 'connected';
+      this.guardianVerificationActive = false;
+      this.verificationAttempts = 0;
+      this.dtmfBuffer = '';
+
+      recordCallEvent(this.callSessionId, 'guardian_voice_verification_succeeded', {
+        bindingId: result.bindingId,
+      });
+      log.info({ callSessionId: this.callSessionId }, 'Inbound guardian voice verification succeeded');
+
+      // Proceed to normal call flow
+      if (this.orchestrator) {
+        this.orchestrator.startInitialGreeting().catch((err) =>
+          log.error({ err, callSessionId: this.callSessionId }, 'Failed to start initial inbound greeting after guardian verification'),
+        );
+      }
+    } else {
+      this.verificationAttempts++;
+
+      if (this.verificationAttempts >= this.verificationMaxAttempts) {
+        recordCallEvent(this.callSessionId, 'guardian_voice_verification_failed', {
+          attempts: this.verificationAttempts,
+        });
+        log.warn(
+          { callSessionId: this.callSessionId, attempts: this.verificationAttempts },
+          'Inbound guardian voice verification failed — max attempts reached',
+        );
+
+        this.sendTextToken('Verification failed. Goodbye.', true);
+
+        updateCallSession(this.callSessionId, {
+          status: 'failed',
+          endedAt: Date.now(),
+          lastError: 'Guardian voice verification failed — max attempts exceeded',
+        });
+
+        const session = getCallSession(this.callSessionId);
+        if (session) {
+          expirePendingQuestions(this.callSessionId);
+          persistCallCompletionMessage(session.conversationId, this.callSessionId);
+          fireCallCompletionNotifier(session.conversationId, this.callSessionId);
+        }
+
+        setTimeout(() => {
+          this.endSession('Guardian verification failed');
+        }, 2000);
+      } else {
+        log.info(
+          { callSessionId: this.callSessionId, attempt: this.verificationAttempts, maxAttempts: this.verificationMaxAttempts },
+          'Inbound guardian voice verification attempt failed — retrying',
+        );
+        this.sendTextToken('That code was incorrect. Please try again.', true);
+      }
+    }
+  }
+
   private async handlePrompt(msg: RelayPromptMessage): Promise<void> {
     if (!msg.last) {
       // Partial transcript, wait for final
       return;
     }
 
-    // During verification, ignore voice prompts — the callee should be
-    // entering DTMF digits, not speaking.
+    // During inbound guardian verification, attempt to parse spoken digits
+    // from the transcript and validate them.
+    if (this.connectionState === 'verification_pending' && this.guardianVerificationActive) {
+      const spokenDigits = RelayConnection.parseDigitsFromSpeech(msg.voicePrompt);
+      log.info(
+        { callSessionId: this.callSessionId, transcript: msg.voicePrompt, spokenDigits },
+        'Speech received during guardian voice verification',
+      );
+      if (spokenDigits.length >= this.verificationCodeLength) {
+        const enteredCode = spokenDigits.slice(0, this.verificationCodeLength);
+        this.attemptGuardianCodeVerification(enteredCode);
+      } else if (spokenDigits.length > 0) {
+        this.sendTextToken(
+          `I heard ${spokenDigits.length} digits. Please enter all ${this.verificationCodeLength} digits of your code.`,
+          true,
+        );
+      }
+      return;
+    }
+
+    // During outbound callee verification, ignore voice prompts — the callee
+    // should be entering DTMF digits, not speaking.
     if (this.connectionState === 'verification_pending') {
-      log.debug({ callSessionId: this.callSessionId }, 'Ignoring voice prompt during verification');
+      log.debug({ callSessionId: this.callSessionId }, 'Ignoring voice prompt during callee verification');
       return;
     }
 
@@ -504,7 +707,20 @@ export class RelayConnection {
       dtmfDigit: msg.digit,
     });
 
-    // If verification is pending, accumulate digits and check the code
+    // If inbound guardian verification is pending, accumulate digits and
+    // validate against the challenge via the guardian service.
+    if (this.connectionState === 'verification_pending' && this.guardianVerificationActive) {
+      this.dtmfBuffer += msg.digit;
+
+      if (this.dtmfBuffer.length >= this.verificationCodeLength) {
+        const enteredCode = this.dtmfBuffer.slice(0, this.verificationCodeLength);
+        this.dtmfBuffer = '';
+        this.attemptGuardianCodeVerification(enteredCode);
+      }
+      return;
+    }
+
+    // If outbound callee verification is pending, accumulate digits and check the code
     if (this.connectionState === 'verification_pending' && this.verificationCode) {
       this.dtmfBuffer += msg.digit;
 

--- a/assistant/src/calls/types.ts
+++ b/assistant/src/calls/types.ts
@@ -1,5 +1,5 @@
 export type CallStatus = 'initiated' | 'ringing' | 'in_progress' | 'waiting_on_user' | 'completed' | 'failed' | 'cancelled';
-export type CallEventType = 'call_started' | 'call_connected' | 'caller_spoke' | 'assistant_spoke' | 'user_question_asked' | 'user_answered' | 'user_instruction_relayed' | 'call_ended' | 'call_failed' | 'callee_verification_started' | 'callee_verification_succeeded' | 'callee_verification_failed';
+export type CallEventType = 'call_started' | 'call_connected' | 'caller_spoke' | 'assistant_spoke' | 'user_question_asked' | 'user_answered' | 'user_instruction_relayed' | 'call_ended' | 'call_failed' | 'callee_verification_started' | 'callee_verification_succeeded' | 'callee_verification_failed' | 'guardian_voice_verification_started' | 'guardian_voice_verification_succeeded' | 'guardian_voice_verification_failed';
 export type PendingQuestionStatus = 'pending' | 'answered' | 'expired' | 'cancelled';
 
 export interface CallSession {


### PR DESCRIPTION
## Summary
- Adds verification-pending state for inbound calls with pending voice guardian challenges
- DTMF and speech-based six-digit code entry during live calls
- Max attempt enforcement with call termination after exhaustion
- Guardian binding on successful verification, then normal call flow continues
- Full test coverage for DTMF, speech, success, failure, and max attempts

Closes #7582

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
