### PR TITLE
fix(macos): smooth sidebar collapse animation and consistent nav spacing

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -575,12 +575,12 @@ struct MainWindowView: View {
                     // Main container: sidebar + content with uniform padding
                     HStack(spacing: 16) {
                         sidebarView
-                            .animation(VAnimation.panel, value: sidebarExpanded)
 
                         chatContentView(geometry: geometry)
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
                     }
                     .padding(16)
+                    .animation(VAnimation.panel, value: sidebarExpanded)
                 }
                 .overlay {
                     // Click-outside-to-dismiss background for control center drawer
@@ -966,8 +966,8 @@ struct MainWindowView: View {
 
     @ViewBuilder
     private var expandedSidebarContent: some View {
-        VStack(spacing: 0) {
-            Spacer().frame(height: VSpacing.sm)
+        VStack(spacing: VSpacing.sm) {
+            Spacer().frame(height: 0)
 
             // MARK: Nav Items (fixed)
             SidebarNavRow(icon: "square.grid.2x2", label: "Home Base", isActive: windowState.activePanel == .directory) {


### PR DESCRIPTION
## Summary
- Move `.animation(VAnimation.panel, value: sidebarExpanded)` from `sidebarView` to the parent `HStack` so both the sidebar and chat content animate together during collapse/expand
- Match expanded sidebar nav item spacing (`VSpacing.sm`) to collapsed sidebar for visual consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
