### PR TITLE
fix: evict Linear issue-state cache on watcher delete/disable

### DIFF
--- a/assistant/src/tools/watcher/delete.ts
+++ b/assistant/src/tools/watcher/delete.ts
@@ -1,5 +1,6 @@
 import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { getWatcher, deleteWatcher } from '../../watcher/watcher-store.js';
+import { getWatcherProvider } from '../../watcher/provider-registry.js';
 
 export async function executeWatcherDelete(
   input: Record<string, unknown>,
@@ -19,6 +20,11 @@ export async function executeWatcherDelete(
   if (!deleted) {
     return { content: `Error: Failed to delete watcher: ${watcherId}`, isError: true };
   }
+
+  // Evict any in-process provider state (e.g. Linear issue-state cache) now
+  // that the watcher's DB row is gone, so its UUID doesn't leak memory.
+  const provider = getWatcherProvider(watcher.providerId);
+  provider?.cleanup?.(watcherId);
 
   return {
     content: `Watcher deleted: "${watcher.name}"`,

--- a/assistant/src/watcher/engine.ts
+++ b/assistant/src/watcher/engine.ts
@@ -118,6 +118,10 @@ export async function runWatchersOnce(
       if ((watcher.consecutiveErrors + 1) >= MAX_CONSECUTIVE_ERRORS) {
         const reason = `Disabled after ${MAX_CONSECUTIVE_ERRORS} consecutive errors. Last: ${message}`;
         disableWatcher(watcher.id, reason);
+        // Evict in-process provider state (e.g. Linear issue-state cache) so
+        // that a permanently-disabled watcher's UUID doesn't leak memory for
+        // the lifetime of the daemon.
+        provider.cleanup?.(watcher.id);
         log.warn({ watcherId: watcher.id, name: watcher.name }, 'Watcher disabled by circuit breaker');
         notify({
           title: `Watcher disabled: ${watcher.name}`,

--- a/assistant/src/watcher/provider-types.ts
+++ b/assistant/src/watcher/provider-types.ts
@@ -52,4 +52,14 @@ export interface WatcherProvider {
    * Get the initial watermark (start from "now" so we don't replay history).
    */
   getInitialWatermark(credentialService: string): Promise<string>;
+
+  /**
+   * Release any in-process state held for a watcher instance.
+   * Called when a watcher is deleted or permanently disabled so that
+   * providers with per-watcher caches (e.g. the Linear issue-state map)
+   * can evict the stale entry and prevent unbounded memory growth.
+   *
+   * Optional — providers with no per-watcher state need not implement this.
+   */
+  cleanup?(watcherKey: string): void;
 }

--- a/assistant/src/watcher/providers/linear.ts
+++ b/assistant/src/watcher/providers/linear.ts
@@ -303,6 +303,15 @@ function getStateCache(watcherKey: string): Map<string, string> {
   return cache;
 }
 
+/**
+ * Evict the state cache for a watcher that has been deleted or permanently
+ * disabled. Prevents unbounded growth of `knownIssueStateIdsByWatcher` in
+ * environments that create and delete watchers frequently (watcher churn).
+ */
+export function clearLinearStateCache(watcherKey: string): void {
+  knownIssueStateIdsByWatcher.delete(watcherKey);
+}
+
 // ── Event type mapping ────────────────────────────────────────────────────────
 
 /**
@@ -383,6 +392,10 @@ export const linearProvider: WatcherProvider = {
   async getInitialWatermark(_credentialService: string): Promise<string> {
     // Start from "now" so we don't replay all existing notifications
     return new Date().toISOString();
+  },
+
+  cleanup(watcherKey: string): void {
+    clearLinearStateCache(watcherKey);
   },
 
   async fetchNew(


### PR DESCRIPTION
## Summary

- Added optional `cleanup?(watcherKey: string): void` method to the `WatcherProvider` interface
- Implemented `cleanup` in `linearProvider` (calls new `clearLinearStateCache` helper) to delete the watcher's entry from `knownIssueStateIdsByWatcher`
- Called `provider.cleanup?.(watcher.id)` in `engine.ts` when the circuit breaker permanently disables a watcher
- Called `provider?.cleanup?.(watcherId)` in `tools/watcher/delete.ts` when a watcher is deleted via the delete tool

This addresses the Codex review finding on PR #7861: keying the cache by `watcherKey` (UUID) instead of `credentialService` fixed the baseline-corruption bug but introduced unbounded memory growth for environments with watcher churn. The eviction path now ties cache lifetime to watcher lifecycle.

## Files modified
- `assistant/src/watcher/provider-types.ts` — added optional `cleanup` method to `WatcherProvider`
- `assistant/src/watcher/providers/linear.ts` — added `clearLinearStateCache` export + `cleanup` on `linearProvider`
- `assistant/src/watcher/engine.ts` — call `provider.cleanup` on circuit-breaker disable
- `assistant/src/tools/watcher/delete.ts` — call `provider.cleanup` on watcher delete
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
