### PR TITLE
fix: guardian verification state cleanup and consistent greeting

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -555,16 +555,19 @@ export class RelayConnection {
       });
       log.info({ callSessionId: this.callSessionId }, 'Inbound guardian voice verification succeeded');
 
-      // Proceed to normal call flow
+      // Proceed to normal call flow (use startNormalCallFlow to respect
+      // the CALL_WELCOME_GREETING static greeting guard)
       if (this.orchestrator) {
-        this.orchestrator.startInitialGreeting().catch((err) =>
-          log.error({ err, callSessionId: this.callSessionId }, 'Failed to start initial inbound greeting after guardian verification'),
-        );
+        this.startNormalCallFlow(this.orchestrator, true);
       }
     } else {
       this.verificationAttempts++;
 
       if (this.verificationAttempts >= this.verificationMaxAttempts) {
+        // Immediately deactivate verification so DTMF/speech input during
+        // the goodbye window doesn't trigger more verification attempts.
+        this.guardianVerificationActive = false;
+
         recordCallEvent(this.callSessionId, 'guardian_voice_verification_failed', {
           attempts: this.verificationAttempts,
         });


### PR DESCRIPTION
## Summary
- Clears guardianVerificationActive on max attempts to prevent input during goodbye window
- Uses startNormalCallFlow() after successful verification for consistent greeting behavior
- Addresses feedback on #7871

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
