### PR TITLE
M3: Guardian Interception Migration + Disambiguation

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -54,6 +54,7 @@ import * as conversationStore from '../memory/conversation-store.js';
 import {
   createBinding,
   createApprovalRequest,
+  getAllPendingApprovalsByGuardianChat,
   getPendingApprovalForRun,
   getUnresolvedApprovalForRun,
 } from '../memory/channel-guardian-store.js';
@@ -2479,18 +2480,28 @@ describe('ambiguous plain-text decision with multiple pending requests', () => {
 
     const orchestrator = makeMockOrchestrator();
 
-    // Guardian sends plain-text "yes" — ambiguous because two approvals are pending
+    // Conversational engine that returns keep_pending for disambiguation
+    const mockConversationGenerator = mock(async () => ({
+      disposition: 'keep_pending' as const,
+      replyText: 'You have 2 pending requests. Which one?',
+    }));
+
+    // Guardian sends plain-text "yes" — ambiguous because two approvals are pending.
+    // The conversational engine handles disambiguation by returning keep_pending.
     const req = makeInboundRequest({
       content: 'yes',
       externalChatId: 'guardian-ambig-chat',
       senderExternalUserId: 'guardian-ambig-user',
     });
 
-    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const res = await handleChannelInbound(
+      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
+      mockConversationGenerator,
+    );
     const body = await res.json() as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
-    expect(body.approval).toBe('guardian_decision_applied');
+    expect(body.approval).toBe('assistant_turn');
 
     // Neither approval should have been resolved — disambiguation was required
     const approvalA = getPendingApprovalForRun(runA.id);
@@ -2501,9 +2512,14 @@ describe('ambiguous plain-text decision with multiple pending requests', () => {
     // submitDecision should NOT have been called — no decision was applied
     expect(orchestrator.submitDecision).not.toHaveBeenCalled();
 
-    // A disambiguation message should have been sent to the guardian
+    // The conversational engine should have been called with both pending approvals
+    expect(mockConversationGenerator).toHaveBeenCalledTimes(1);
+    const engineCtx = mockConversationGenerator.mock.calls[0][0] as Record<string, unknown>;
+    expect((engineCtx.pendingApprovals as Array<unknown>)).toHaveLength(2);
+
+    // A disambiguation reply should have been sent to the guardian
     const disambigCalls = deliverSpy.mock.calls.filter(
-      (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.toLowerCase().includes('pending'),
+      (call) => typeof call[1] === 'object' && (call[1] as { text?: string }).text?.includes('pending'),
     );
     expect(disambigCalls.length).toBeGreaterThanOrEqual(1);
 
@@ -3739,6 +3755,299 @@ describe('conversational approval engine — standard path', () => {
     // The callback button should have been used directly, not the engine
     expect(mockConversationGenerator).not.toHaveBeenCalled();
     expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'allow');
+
+    deliverSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Guardian conversational approval engine tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('guardian conversational approval via conversation engine', () => {
+  beforeEach(() => {
+  });
+
+  test('guardian follow-up clarification: engine returns keep_pending, reply sent, run remains pending', async () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-conv-user',
+      guardianDeliveryChatId: 'guardian-conv-chat',
+    });
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const convId = 'conv-guardian-clarify';
+    ensureConversation(convId);
+    const run = createRun(convId);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    createApprovalRequest({
+      runId: run.id,
+      conversationId: convId,
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-clarify',
+      requesterChatId: 'chat-requester-clarify',
+      guardianExternalUserId: 'guardian-conv-user',
+      guardianChatId: 'guardian-conv-chat',
+      toolName: 'shell',
+      expiresAt: Date.now() + 300_000,
+    });
+
+    const orchestrator = makeMockOrchestrator();
+
+    // Engine returns keep_pending for a clarification question
+    const mockConversationGenerator = mock(async () => ({
+      disposition: 'keep_pending' as const,
+      replyText: 'Could you clarify which action you want me to approve?',
+    }));
+
+    const req = makeInboundRequest({
+      content: 'hmm what does this do?',
+      externalChatId: 'guardian-conv-chat',
+      senderExternalUserId: 'guardian-conv-user',
+    });
+
+    const res = await handleChannelInbound(
+      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
+      mockConversationGenerator,
+    );
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('assistant_turn');
+
+    // The engine should have been called with role: 'guardian'
+    expect(mockConversationGenerator).toHaveBeenCalledTimes(1);
+    const callCtx = mockConversationGenerator.mock.calls[0][0] as Record<string, unknown>;
+    expect(callCtx.role).toBe('guardian');
+    expect(callCtx.allowedActions).toEqual(['approve_once', 'reject']);
+    expect(callCtx.userMessage).toBe('hmm what does this do?');
+
+    // Clarification reply delivered to the guardian's chat
+    const replyCall = deliverSpy.mock.calls.find(
+      (call) => (call[1] as { text?: string }).text === 'Could you clarify which action you want me to approve?',
+    );
+    expect(replyCall).toBeTruthy();
+
+    // The orchestrator should NOT have received a decision
+    expect(orchestrator.submitDecision).not.toHaveBeenCalled();
+
+    // The approval should still be pending
+    const pending = getAllPendingApprovalsByGuardianChat('telegram', 'guardian-conv-chat', 'self');
+    expect(pending).toHaveLength(1);
+
+    deliverSpy.mockRestore();
+  });
+
+  test('guardian natural-language approval: engine returns approve_once, decision applied', async () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-nlp-user',
+      guardianDeliveryChatId: 'guardian-nlp-chat',
+    });
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const convId = 'conv-guardian-nlp';
+    ensureConversation(convId);
+    const run = createRun(convId);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    createApprovalRequest({
+      runId: run.id,
+      conversationId: convId,
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-nlp',
+      requesterChatId: 'chat-requester-nlp',
+      guardianExternalUserId: 'guardian-nlp-user',
+      guardianChatId: 'guardian-nlp-chat',
+      toolName: 'shell',
+      expiresAt: Date.now() + 300_000,
+    });
+
+    const orchestrator = makeMockOrchestrator();
+
+    // Engine returns approve_once decision
+    const mockConversationGenerator = mock(async () => ({
+      disposition: 'approve_once' as const,
+      replyText: 'Approved! The shell command will proceed.',
+    }));
+
+    const req = makeInboundRequest({
+      content: 'yes go ahead and run it',
+      externalChatId: 'guardian-nlp-chat',
+      senderExternalUserId: 'guardian-nlp-user',
+    });
+
+    const res = await handleChannelInbound(
+      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
+      mockConversationGenerator,
+    );
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('guardian_decision_applied');
+
+    // The orchestrator should have received an 'allow' decision
+    expect(orchestrator.submitDecision).toHaveBeenCalledTimes(1);
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'allow');
+
+    // The approval record should have been updated (no longer pending)
+    const pending = getAllPendingApprovalsByGuardianChat('telegram', 'guardian-nlp-chat', 'self');
+    expect(pending).toHaveLength(0);
+
+    // The engine context excluded approve_always for guardians
+    const callCtx = mockConversationGenerator.mock.calls[0][0] as Record<string, unknown>;
+    expect(callCtx.allowedActions).toEqual(['approve_once', 'reject']);
+    expect((callCtx.allowedActions as string[])).not.toContain('approve_always');
+
+    deliverSpy.mockRestore();
+  });
+
+  test('guardian callback button approve_always is downgraded to approve_once', async () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-dg-user',
+      guardianDeliveryChatId: 'guardian-dg-chat',
+    });
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const convId = 'conv-guardian-downgrade';
+    ensureConversation(convId);
+    const run = createRun(convId);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    createApprovalRequest({
+      runId: run.id,
+      conversationId: convId,
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-dg',
+      requesterChatId: 'chat-requester-dg',
+      guardianExternalUserId: 'guardian-dg-user',
+      guardianChatId: 'guardian-dg-chat',
+      toolName: 'shell',
+      expiresAt: Date.now() + 300_000,
+    });
+
+    const orchestrator = makeMockOrchestrator();
+
+    // Guardian clicks approve_always via callback button
+    const req = makeInboundRequest({
+      content: '',
+      externalChatId: 'guardian-dg-chat',
+      callbackData: `apr:${run.id}:approve_always`,
+      senderExternalUserId: 'guardian-dg-user',
+    });
+
+    const res = await handleChannelInbound(
+      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
+      undefined,
+    );
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('guardian_decision_applied');
+
+    // approve_always should have been downgraded to approve_once ('allow')
+    expect(orchestrator.submitDecision).toHaveBeenCalledTimes(1);
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'allow');
+
+    deliverSpy.mockRestore();
+  });
+
+  test('multi-pending guardian disambiguation: engine requests clarification', async () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-multi-user',
+      guardianDeliveryChatId: 'guardian-multi-chat',
+    });
+
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const convA = 'conv-multi-a';
+    const convB = 'conv-multi-b';
+    ensureConversation(convA);
+    ensureConversation(convB);
+
+    const runA = createRun(convA);
+    setRunConfirmation(runA.id, { ...sampleConfirmation, toolUseId: 'req-multi-a' });
+
+    const runB = createRun(convB);
+    setRunConfirmation(runB.id, { ...sampleConfirmation, toolName: 'file_edit', toolUseId: 'req-multi-b' });
+
+    createApprovalRequest({
+      runId: runA.id,
+      conversationId: convA,
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-multi-a',
+      requesterChatId: 'chat-requester-multi-a',
+      guardianExternalUserId: 'guardian-multi-user',
+      guardianChatId: 'guardian-multi-chat',
+      toolName: 'shell',
+      expiresAt: Date.now() + 300_000,
+    });
+
+    createApprovalRequest({
+      runId: runB.id,
+      conversationId: convB,
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-multi-b',
+      requesterChatId: 'chat-requester-multi-b',
+      guardianExternalUserId: 'guardian-multi-user',
+      guardianChatId: 'guardian-multi-chat',
+      toolName: 'file_edit',
+      expiresAt: Date.now() + 300_000,
+    });
+
+    const orchestrator = makeMockOrchestrator();
+
+    // Engine returns keep_pending for disambiguation
+    const mockConversationGenerator = mock(async () => ({
+      disposition: 'keep_pending' as const,
+      replyText: 'You have 2 pending requests: shell and file_edit. Which one?',
+    }));
+
+    const req = makeInboundRequest({
+      content: 'approve it',
+      externalChatId: 'guardian-multi-chat',
+      senderExternalUserId: 'guardian-multi-user',
+    });
+
+    const res = await handleChannelInbound(
+      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
+      mockConversationGenerator,
+    );
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('assistant_turn');
+
+    // The engine should have received both pending approvals
+    expect(mockConversationGenerator).toHaveBeenCalledTimes(1);
+    const engineCtx = mockConversationGenerator.mock.calls[0][0] as Record<string, unknown>;
+    expect((engineCtx.pendingApprovals as Array<unknown>)).toHaveLength(2);
+    expect(engineCtx.role).toBe('guardian');
+
+    // Both approvals should remain pending
+    const pendingA = getPendingApprovalForRun(runA.id);
+    const pendingB = getPendingApprovalForRun(runB.id);
+    expect(pendingA).not.toBeNull();
+    expect(pendingB).not.toBeNull();
+
+    // submitDecision should NOT have been called
+    expect(orchestrator.submitDecision).not.toHaveBeenCalled();
+
+    // Disambiguation reply delivered to guardian
+    const disambigCall = deliverSpy.mock.calls.find(
+      (call) => (call[1] as { text?: string }).text?.includes('2 pending requests'),
+    );
+    expect(disambigCall).toBeTruthy();
 
     deliverSpy.mockRestore();
   });

--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -40,7 +40,6 @@ import {
   getChannelApprovalPrompt,
   buildApprovalUIMetadata,
   handleChannelDecision,
-  buildReminderPrompt,
   buildGuardianApprovalPrompt,
   channelSupportsRichApprovalUI,
 } from '../runtime/channel-approvals.js';
@@ -488,67 +487,7 @@ describe('handleChannelDecision', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// 4. buildReminderPrompt
-// ═══════════════════════════════════════════════════════════════════════════
-
-describe('buildReminderPrompt', () => {
-  test('prefixes promptText with a reminder', () => {
-    const original: ChannelApprovalPrompt = {
-      promptText: 'Allow shell?',
-      actions: [
-        { id: 'approve_once', label: 'Approve once' },
-        { id: 'reject', label: 'Reject' },
-      ],
-      plainTextFallback: 'Reply yes or no.',
-    };
-
-    const reminder = buildReminderPrompt(original);
-    expect(reminder.promptText).toContain("I'm still waiting");
-    expect(reminder.promptText).toContain('Allow shell?');
-  });
-
-  test('preserves the original actions', () => {
-    const original: ChannelApprovalPrompt = {
-      promptText: 'Approve file_edit?',
-      actions: [
-        { id: 'approve_once', label: 'Approve once' },
-        { id: 'approve_always', label: 'Approve always' },
-        { id: 'reject', label: 'Reject' },
-      ],
-      plainTextFallback: 'Reply yes, always, or no.',
-    };
-
-    const reminder = buildReminderPrompt(original);
-    expect(reminder.actions).toEqual(original.actions);
-  });
-
-  test('prefixes plainTextFallback with a reminder', () => {
-    const original: ChannelApprovalPrompt = {
-      promptText: 'Allow bash?',
-      actions: [],
-      plainTextFallback: 'Reply yes or no.',
-    };
-
-    const reminder = buildReminderPrompt(original);
-    expect(reminder.plainTextFallback).toContain("I'm still waiting");
-    expect(reminder.plainTextFallback).toContain('Reply yes or no.');
-  });
-
-  test('does not mutate the original prompt', () => {
-    const original: ChannelApprovalPrompt = {
-      promptText: 'Allow grep?',
-      actions: [{ id: 'approve_once', label: 'Approve once' }],
-      plainTextFallback: 'Reply yes.',
-    };
-
-    const originalText = original.promptText;
-    buildReminderPrompt(original);
-    expect(original.promptText).toBe(originalText);
-  });
-});
-
-// ═══════════════════════════════════════════════════════════════════════════
-// 5. buildGuardianApprovalPrompt
+// 4. buildGuardianApprovalPrompt
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe('buildGuardianApprovalPrompt', () => {
@@ -594,7 +533,7 @@ describe('buildGuardianApprovalPrompt', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// 6. channelSupportsRichApprovalUI
+// 5. channelSupportsRichApprovalUI
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe('channelSupportsRichApprovalUI', () => {

--- a/assistant/src/runtime/channel-approval-parser.ts
+++ b/assistant/src/runtime/channel-approval-parser.ts
@@ -5,11 +5,10 @@
  * rejection, or "approve always" intent. This module is transport-agnostic
  * and can be used by any channel adapter (Telegram, SMS, etc.).
  *
- * NOTE: The standard (non-guardian) approval flow now uses the conversational
- * approval engine (M2) as the primary classifier. This deterministic parser
- * is retained as a legacy fallback for when the conversational engine is not
- * available, and is still used by the guardian approval path. M3 will migrate
- * the guardian path and this file can then be removed entirely.
+ * Both the standard and guardian approval flows now use the conversational
+ * approval engine as the primary classifier. This deterministic parser is
+ * retained only as a legacy fallback for when the conversational engine is
+ * not injected (i.e. approvalConversationGenerator is undefined).
  */
 
 import type { ApprovalAction, ApprovalDecisionResult } from './channel-approval-types.js';

--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -7,7 +7,6 @@
  *   1. Detect pending confirmations for a conversation
  *   2. Build human-readable approval prompts with action buttons
  *   3. Consume user decisions and apply them to the underlying run
- *   4. Build reminder prompts when non-decision messages arrive
  */
 
 import { getPendingConfirmationsByConversation, getRun } from '../memory/runs-store.js';
@@ -205,28 +204,4 @@ const RICH_APPROVAL_CHANNELS: ReadonlySet<string> = new Set(['telegram']);
  */
 export function channelSupportsRichApprovalUI(channel: string): boolean {
   return RICH_APPROVAL_CHANNELS.has(channel);
-}
-
-// ---------------------------------------------------------------------------
-// 6. Reminder prompt for non-decision messages
-// ---------------------------------------------------------------------------
-
-/**
- * Build a reminder prompt when the user sends a non-decision message while
- * an approval is pending. Reuses the original actions and fallback text
- * but prefixes the prompt text with a reminder.
- *
- * NOTE: Only used by the guardian reminder path. The standard (non-guardian)
- * approval flow now uses the conversational approval engine (M2). This
- * function will be removed when M3 migrates the guardian path.
- */
-export function buildReminderPrompt(
-  pendingPrompt: ChannelApprovalPrompt,
-): ChannelApprovalPrompt {
-  const reminderPrefix = composeApprovalMessage({ scenario: 'reminder_prompt' });
-  return {
-    promptText: `${reminderPrefix}\n\n${pendingPrompt.promptText}`,
-    actions: pendingPrompt.actions,
-    plainTextFallback: `${reminderPrefix}\n\n${pendingPrompt.plainTextFallback}`,
-  };
 }

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -1679,15 +1679,72 @@ async function handleApprovalInterception(
             legacyGuardianDecision.action = 'approve_once';
           }
 
+          // Resolve the target approval: when a [ref:<runId>] tag is
+          // present, look up the specific pending approval by that runId
+          // so the decision applies to the correct conversation even when
+          // multiple guardian approvals are pending.
+          let targetLegacyApproval = guardianApproval;
+          if (legacyGuardianDecision.runId) {
+            const resolvedByRun = getPendingApprovalByRunAndGuardianChat(
+              legacyGuardianDecision.runId,
+              sourceChannel,
+              externalChatId,
+              assistantId,
+            );
+            if (!resolvedByRun) {
+              // The referenced run doesn't match any pending guardian
+              // approval — it may have expired or already been resolved.
+              try {
+                const staleText = await composeApprovalMessageGenerative({
+                  scenario: 'guardian_disambiguation',
+                  channel: sourceChannel,
+                }, {}, approvalCopyGenerator);
+                await deliverChannelReply(replyCallbackUrl, {
+                  chatId: externalChatId,
+                  text: staleText,
+                  assistantId,
+                }, bearerToken);
+              } catch (err) {
+                log.error({ err, externalChatId }, 'Failed to deliver stale approval notice (legacy path)');
+              }
+              return { handled: true, type: 'stale_ignored' };
+            }
+            targetLegacyApproval = resolvedByRun;
+          }
+
+          // Re-validate guardian identity against the resolved target.
+          // The default guardianApproval was already checked, but a
+          // runId-resolved approval may belong to a different guardian.
+          if (senderExternalUserId !== targetLegacyApproval.guardianExternalUserId) {
+            log.warn(
+              { externalChatId, senderExternalUserId, expectedGuardian: targetLegacyApproval.guardianExternalUserId, runId: legacyGuardianDecision.runId },
+              'Guardian identity mismatch on legacy run-ref resolved target approval',
+            );
+            try {
+              const mismatchText = await composeApprovalMessageGenerative({
+                scenario: 'guardian_identity_mismatch',
+                channel: sourceChannel,
+              }, {}, approvalCopyGenerator);
+              await deliverChannelReply(replyCallbackUrl, {
+                chatId: externalChatId,
+                text: mismatchText,
+                assistantId,
+              }, bearerToken);
+            } catch (err) {
+              log.error({ err, externalChatId }, 'Failed to deliver guardian identity mismatch notice (legacy path)');
+            }
+            return { handled: true, type: 'guardian_decision_applied' };
+          }
+
           const result = handleChannelDecision(
-            guardianApproval.conversationId,
+            targetLegacyApproval.conversationId,
             legacyGuardianDecision,
             orchestrator,
           );
 
           if (result.applied) {
             const approvalStatus = legacyGuardianDecision.action === 'reject' ? 'denied' as const : 'approved' as const;
-            updateApprovalDecision(guardianApproval.id, {
+            updateApprovalDecision(targetLegacyApproval.id, {
               status: approvalStatus,
               decidedByExternalUserId: senderExternalUserId,
             });
@@ -1696,25 +1753,25 @@ async function handleApprovalInterception(
             const outcomeText = await composeApprovalMessageGenerative({
               scenario: 'guardian_decision_outcome',
               decision: legacyGuardianDecision.action === 'reject' ? 'denied' : 'approved',
-              toolName: guardianApproval.toolName,
+              toolName: targetLegacyApproval.toolName,
               channel: sourceChannel,
             }, {}, approvalCopyGenerator);
             try {
               await deliverChannelReply(replyCallbackUrl, {
-                chatId: guardianApproval.requesterChatId,
+                chatId: targetLegacyApproval.requesterChatId,
                 text: outcomeText,
                 assistantId,
               }, bearerToken);
             } catch (err) {
-              log.error({ err, conversationId: guardianApproval.conversationId }, 'Failed to notify requester of guardian decision (legacy path)');
+              log.error({ err, conversationId: targetLegacyApproval.conversationId }, 'Failed to notify requester of guardian decision (legacy path)');
             }
 
             if (result.runId) {
               schedulePostDecisionDelivery(
                 orchestrator,
                 result.runId,
-                guardianApproval.conversationId,
-                guardianApproval.requesterChatId,
+                targetLegacyApproval.conversationId,
+                targetLegacyApproval.requesterChatId,
                 replyCallbackUrl,
                 bearerToken,
                 assistantId,

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -26,7 +26,6 @@ import {
 import { answerCall } from '../../calls/call-domain.js';
 import {
   createApprovalRequest,
-  getPendingApprovalByGuardianChat,
   getPendingApprovalByRunAndGuardianChat,
   getAllPendingApprovalsByGuardianChat,
   getPendingApprovalForRun,
@@ -41,7 +40,6 @@ import {
   buildApprovalUIMetadata,
   buildGuardianApprovalPrompt,
   handleChannelDecision,
-  buildReminderPrompt,
   channelSupportsRichApprovalUI,
 } from '../channel-approvals.js';
 import { runApprovalConversationTurn } from '../approval-conversation-turn.js';
@@ -1390,57 +1388,39 @@ async function handleApprovalInterception(
     guardianCtx.actorRole === 'guardian' &&
     senderExternalUserId
   ) {
-    // First, try to parse the inbound payload to determine if it carries
-    // a run ID (callback button) or is plain text. This governs how we
-    // look up the target approval request.
-    let decision: ApprovalDecisionResult | null = null;
+    // Callback/button path: deterministic and takes priority.
+    let callbackDecision: ApprovalDecisionResult | null = null;
     if (callbackData) {
-      decision = parseCallbackData(callbackData);
-    }
-    if (!decision && content) {
-      decision = parseApprovalDecision(content);
+      callbackDecision = parseCallbackData(callbackData);
     }
 
     // When a callback button provides a run ID, use the scoped lookup so
     // the decision resolves to exactly the right approval even when
     // multiple approvals target the same guardian chat.
-    let guardianApproval = decision?.runId
-      ? getPendingApprovalByRunAndGuardianChat(decision.runId, sourceChannel, externalChatId, assistantId)
+    let guardianApproval = callbackDecision?.runId
+      ? getPendingApprovalByRunAndGuardianChat(callbackDecision.runId, sourceChannel, externalChatId, assistantId)
       : null;
 
     // When the scoped lookup didn't resolve an approval (either because
-    // the decision had no runId, or the runId pointed to a stale/expired
-    // run), fall back to checking all pending approvals for this guardian
-    // chat. If there are multiple, the guardian must use buttons to
-    // disambiguate.
-    if (!guardianApproval && decision) {
+    // there was no callback or the runId pointed to a stale/expired run),
+    // fall back to checking all pending approvals for this guardian chat.
+    if (!guardianApproval && callbackDecision) {
       const allPending = getAllPendingApprovalsByGuardianChat(sourceChannel, externalChatId, assistantId);
-      if (allPending.length > 1) {
-        try {
-          const disambiguationText = await composeApprovalMessageGenerative({
-            scenario: 'guardian_disambiguation',
-            pendingCount: allPending.length,
-            channel: sourceChannel,
-          }, {}, approvalCopyGenerator);
-          await deliverChannelReply(replyCallbackUrl, {
-            chatId: externalChatId,
-            text: disambiguationText,
-            assistantId,
-          }, bearerToken);
-        } catch (err) {
-          log.error({ err, externalChatId }, 'Failed to deliver disambiguation notice');
-        }
-        return { handled: true, type: 'guardian_decision_applied' };
-      }
       if (allPending.length === 1) {
         guardianApproval = allPending[0];
       }
     }
 
-    // Fall back to the single-result lookup for non-decision messages
-    // (reminder path) or when the scoped lookup found nothing.
-    if (!guardianApproval && !decision) {
-      guardianApproval = getPendingApprovalByGuardianChat(sourceChannel, externalChatId, assistantId);
+    // For plain-text messages (no callback), check if there are any pending
+    // approvals for this guardian chat to route through the conversation engine.
+    if (!guardianApproval && !callbackDecision) {
+      const allPending = getAllPendingApprovalsByGuardianChat(sourceChannel, externalChatId, assistantId);
+      if (allPending.length === 1) {
+        guardianApproval = allPending[0];
+      } else if (allPending.length > 1) {
+        // Multiple pending — delegate to the conversation engine for disambiguation
+        guardianApproval = allPending[0]; // Use first as primary context; engine sees all via pendingApprovals
+      }
     }
 
     if (guardianApproval) {
@@ -1470,24 +1450,24 @@ async function handleApprovalInterception(
         return { handled: true, type: 'guardian_decision_applied' };
       }
 
-      if (decision) {
+      if (callbackDecision) {
         // approve_always is not available for guardian approvals — guardians
         // should not be able to permanently allowlist tools on behalf of the
         // requester. Downgrade to approve_once.
-        if (decision.action === 'approve_always') {
-          decision = { ...decision, action: 'approve_once' };
+        if (callbackDecision.action === 'approve_always') {
+          callbackDecision = { ...callbackDecision, action: 'approve_once' };
         }
 
         // Apply the decision to the underlying run using the requester's
         // conversation context
         const result = handleChannelDecision(
           guardianApproval.conversationId,
-          decision,
+          callbackDecision,
           orchestrator,
         );
 
         // Update the guardian approval request record
-        const approvalStatus = decision.action === 'reject' ? 'denied' as const : 'approved' as const;
+        const approvalStatus = callbackDecision.action === 'reject' ? 'denied' as const : 'approved' as const;
         updateApprovalDecision(guardianApproval.id, {
           status: approvalStatus,
           decidedByExternalUserId: senderExternalUserId,
@@ -1497,7 +1477,7 @@ async function handleApprovalInterception(
           // Notify the requester's chat about the outcome with the tool name
           const outcomeText = await composeApprovalMessageGenerative({
             scenario: 'guardian_decision_outcome',
-            decision: decision.action === 'reject' ? 'denied' : 'approved',
+            decision: callbackDecision.action === 'reject' ? 'denied' : 'approved',
             toolName: guardianApproval.toolName,
             channel: sourceChannel,
           }, {}, approvalCopyGenerator);
@@ -1529,43 +1509,119 @@ async function handleApprovalInterception(
         return { handled: true, type: 'guardian_decision_applied' };
       }
 
-      // Non-decision message from guardian while approval is pending — remind them
-      const pendingInfo = getPendingConfirmationsByConversation(guardianApproval.conversationId);
-      if (pendingInfo.length > 0) {
-        const guardianPrompt = buildGuardianApprovalPrompt(
-          pendingInfo[0],
-          `user ${guardianApproval.requesterExternalUserId}`,
+      // ── Conversational engine for guardian plain-text messages ──
+      // Gather all pending guardian approvals for this chat so the engine
+      // can handle disambiguation when multiple are pending.
+      const allGuardianPending = getAllPendingApprovalsByGuardianChat(sourceChannel, externalChatId, assistantId);
+      if (allGuardianPending.length > 0 && approvalConversationGenerator && content) {
+        const guardianAllowedActions = ['approve_once', 'reject'];
+        const engineContext: ApprovalConversationContext = {
+          toolName: guardianApproval.toolName,
+          allowedActions: guardianAllowedActions,
+          role: 'guardian',
+          pendingApprovals: allGuardianPending.map((a) => ({ runId: a.runId, toolName: a.toolName })),
+          userMessage: content,
+        };
+
+        const engineResult = await runApprovalConversationTurn(engineContext, approvalConversationGenerator);
+
+        if (engineResult.disposition === 'keep_pending') {
+          // Non-decision follow-up (clarification, disambiguation, etc.)
+          try {
+            await deliverChannelReply(replyCallbackUrl, {
+              chatId: externalChatId,
+              text: engineResult.replyText,
+              assistantId,
+            }, bearerToken);
+          } catch (err) {
+            log.error({ err, conversationId: guardianApproval.conversationId }, 'Failed to deliver guardian conversation reply');
+          }
+          return { handled: true, type: 'assistant_turn' };
+        }
+
+        // Decision-bearing disposition from the engine
+        let decisionAction = engineResult.disposition as 'approve_once' | 'approve_always' | 'reject';
+
+        // Belt-and-suspenders: guardians cannot approve_always even if the
+        // engine returns it (the engine's allowedActions validation should
+        // already prevent this, but enforce it here too).
+        if (decisionAction === 'approve_always') {
+          decisionAction = 'approve_once';
+        }
+
+        // Resolve the target approval: use targetRunId from the engine if
+        // provided, otherwise use the single guardian approval.
+        const targetApproval = engineResult.targetRunId
+          ? allGuardianPending.find((a) => a.runId === engineResult.targetRunId) ?? guardianApproval
+          : guardianApproval;
+
+        const engineDecision: ApprovalDecisionResult = {
+          action: decisionAction,
+          source: 'plain_text',
+          ...(engineResult.targetRunId ? { runId: engineResult.targetRunId } : {}),
+        };
+
+        const result = handleChannelDecision(
+          targetApproval.conversationId,
+          engineDecision,
+          orchestrator,
         );
-        const reminder = buildReminderPrompt(guardianPrompt);
-        const uiMetadata = buildApprovalUIMetadata(reminder, pendingInfo[0]);
-        try {
-          const delivered = await deliverGeneratedApprovalPrompt({
-            replyCallbackUrl,
-            chatId: externalChatId,
-            sourceChannel,
-            assistantId,
-            bearerToken,
-            prompt: reminder,
-            uiMetadata,
-            messageContext: {
-              scenario: 'reminder_prompt',
-              channel: sourceChannel,
-              toolName: pendingInfo[0].toolName,
-            },
-            approvalCopyGenerator,
-          });
-          if (!delivered) {
-            log.error(
-              { conversationId: guardianApproval.conversationId, externalChatId },
-              'Failed to deliver guardian approval reminder',
+
+        // Update the guardian approval request record
+        const approvalStatus = decisionAction === 'reject' ? 'denied' as const : 'approved' as const;
+        updateApprovalDecision(targetApproval.id, {
+          status: approvalStatus,
+          decidedByExternalUserId: senderExternalUserId,
+        });
+
+        if (result.applied) {
+          // Notify the requester's chat about the outcome
+          const outcomeText = await composeApprovalMessageGenerative({
+            scenario: 'guardian_decision_outcome',
+            decision: decisionAction === 'reject' ? 'denied' : 'approved',
+            toolName: targetApproval.toolName,
+            channel: sourceChannel,
+          }, {}, approvalCopyGenerator);
+          try {
+            await deliverChannelReply(replyCallbackUrl, {
+              chatId: targetApproval.requesterChatId,
+              text: outcomeText,
+              assistantId,
+            }, bearerToken);
+          } catch (err) {
+            log.error({ err, conversationId: targetApproval.conversationId }, 'Failed to notify requester of guardian decision');
+          }
+
+          // Schedule post-decision delivery to the requester's chat
+          if (result.runId) {
+            schedulePostDecisionDelivery(
+              orchestrator,
+              result.runId,
+              targetApproval.conversationId,
+              targetApproval.requesterChatId,
+              replyCallbackUrl,
+              bearerToken,
+              assistantId,
             );
           }
-        } catch (err) {
-          log.error({ err, conversationId: guardianApproval.conversationId }, 'Failed to deliver guardian approval reminder');
         }
+
+        // Deliver the engine's reply to the guardian
+        try {
+          await deliverChannelReply(replyCallbackUrl, {
+            chatId: externalChatId,
+            text: engineResult.replyText,
+            assistantId,
+          }, bearerToken);
+        } catch (err) {
+          log.error({ err, conversationId: targetApproval.conversationId }, 'Failed to deliver guardian decision reply');
+        }
+
+        return { handled: true, type: 'guardian_decision_applied' };
       }
 
-      return { handled: true, type: 'assistant_turn' };
+      // No conversational engine available or no content — fall through
+      // to standard approval interception below.
     }
   }
 

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -1408,6 +1408,24 @@ async function handleApprovalInterception(
       const allPending = getAllPendingApprovalsByGuardianChat(sourceChannel, externalChatId, assistantId);
       if (allPending.length === 1) {
         guardianApproval = allPending[0];
+      } else if (allPending.length > 1) {
+        // The callback targeted a stale/expired run but the guardian has other
+        // pending approvals. Inform them the clicked approval is no longer valid.
+        try {
+          const staleText = await composeApprovalMessageGenerative({
+            scenario: 'guardian_disambiguation',
+            pendingCount: allPending.length,
+            channel: sourceChannel,
+          }, {}, approvalCopyGenerator);
+          await deliverChannelReply(replyCallbackUrl, {
+            chatId: externalChatId,
+            text: staleText,
+            assistantId,
+          }, bearerToken);
+        } catch (err) {
+          log.error({ err, externalChatId }, 'Failed to deliver stale callback disambiguation notice');
+        }
+        return { handled: true, type: 'stale_ignored' };
       }
     }
 
@@ -1466,14 +1484,16 @@ async function handleApprovalInterception(
           orchestrator,
         );
 
-        // Update the guardian approval request record
-        const approvalStatus = callbackDecision.action === 'reject' ? 'denied' as const : 'approved' as const;
-        updateApprovalDecision(guardianApproval.id, {
-          status: approvalStatus,
-          decidedByExternalUserId: senderExternalUserId,
-        });
-
         if (result.applied) {
+          // Update the guardian approval request record only when the decision
+          // was actually applied. If the run was already resolved (race with
+          // expiry sweep or concurrent callback), skip to avoid inconsistency.
+          const approvalStatus = callbackDecision.action === 'reject' ? 'denied' as const : 'approved' as const;
+          updateApprovalDecision(guardianApproval.id, {
+            status: approvalStatus,
+            decidedByExternalUserId: senderExternalUserId,
+          });
+
           // Notify the requester's chat about the outcome with the tool name
           const outcomeText = await composeApprovalMessageGenerative({
             scenario: 'guardian_decision_outcome',
@@ -1555,6 +1575,32 @@ async function handleApprovalInterception(
           ? allGuardianPending.find((a) => a.runId === engineResult.targetRunId) ?? guardianApproval
           : guardianApproval;
 
+        // Re-validate guardian identity against the resolved target. The
+        // engine may select a different pending approval (via targetRunId)
+        // that was assigned to a different guardian. Without this check a
+        // currently bound guardian could act on a request assigned to a
+        // previous guardian after a binding rotation.
+        if (senderExternalUserId !== targetApproval.guardianExternalUserId) {
+          log.warn(
+            { externalChatId, senderExternalUserId, expectedGuardian: targetApproval.guardianExternalUserId, targetRunId: engineResult.targetRunId },
+            'Guardian identity mismatch on engine-selected target approval',
+          );
+          try {
+            const mismatchText = await composeApprovalMessageGenerative({
+              scenario: 'guardian_identity_mismatch',
+              channel: sourceChannel,
+            }, {}, approvalCopyGenerator);
+            await deliverChannelReply(replyCallbackUrl, {
+              chatId: externalChatId,
+              text: mismatchText,
+              assistantId,
+            }, bearerToken);
+          } catch (err) {
+            log.error({ err, externalChatId }, 'Failed to deliver guardian identity mismatch notice for engine target');
+          }
+          return { handled: true, type: 'guardian_decision_applied' };
+        }
+
         const engineDecision: ApprovalDecisionResult = {
           action: decisionAction,
           source: 'plain_text',
@@ -1567,14 +1613,16 @@ async function handleApprovalInterception(
           orchestrator,
         );
 
-        // Update the guardian approval request record
-        const approvalStatus = decisionAction === 'reject' ? 'denied' as const : 'approved' as const;
-        updateApprovalDecision(targetApproval.id, {
-          status: approvalStatus,
-          decidedByExternalUserId: senderExternalUserId,
-        });
-
         if (result.applied) {
+          // Update the guardian approval request record only when the decision
+          // was actually applied. If the run was already resolved (race with
+          // expiry sweep or concurrent callback), skip to avoid inconsistency.
+          const approvalStatus = decisionAction === 'reject' ? 'denied' as const : 'approved' as const;
+          updateApprovalDecision(targetApproval.id, {
+            status: approvalStatus,
+            decidedByExternalUserId: senderExternalUserId,
+          });
+
           // Notify the requester's chat about the outcome
           const outcomeText = await composeApprovalMessageGenerative({
             scenario: 'guardian_decision_outcome',
@@ -1620,8 +1668,83 @@ async function handleApprovalInterception(
         return { handled: true, type: 'guardian_decision_applied' };
       }
 
-      // No conversational engine available or no content — fall through
-      // to standard approval interception below.
+      // ── Legacy fallback when no conversational engine is available ──
+      // Use the deterministic parser to handle guardian plain-text so that
+      // simple yes/no replies still work when the engine is not injected.
+      if (content && !approvalConversationGenerator) {
+        const legacyGuardianDecision = parseApprovalDecision(content);
+        if (legacyGuardianDecision) {
+          // Guardians cannot approve_always — downgrade to approve_once.
+          if (legacyGuardianDecision.action === 'approve_always') {
+            legacyGuardianDecision.action = 'approve_once';
+          }
+
+          const result = handleChannelDecision(
+            guardianApproval.conversationId,
+            legacyGuardianDecision,
+            orchestrator,
+          );
+
+          if (result.applied) {
+            const approvalStatus = legacyGuardianDecision.action === 'reject' ? 'denied' as const : 'approved' as const;
+            updateApprovalDecision(guardianApproval.id, {
+              status: approvalStatus,
+              decidedByExternalUserId: senderExternalUserId,
+            });
+
+            // Notify the requester's chat about the outcome
+            const outcomeText = await composeApprovalMessageGenerative({
+              scenario: 'guardian_decision_outcome',
+              decision: legacyGuardianDecision.action === 'reject' ? 'denied' : 'approved',
+              toolName: guardianApproval.toolName,
+              channel: sourceChannel,
+            }, {}, approvalCopyGenerator);
+            try {
+              await deliverChannelReply(replyCallbackUrl, {
+                chatId: guardianApproval.requesterChatId,
+                text: outcomeText,
+                assistantId,
+              }, bearerToken);
+            } catch (err) {
+              log.error({ err, conversationId: guardianApproval.conversationId }, 'Failed to notify requester of guardian decision (legacy path)');
+            }
+
+            if (result.runId) {
+              schedulePostDecisionDelivery(
+                orchestrator,
+                result.runId,
+                guardianApproval.conversationId,
+                guardianApproval.requesterChatId,
+                replyCallbackUrl,
+                bearerToken,
+                assistantId,
+              );
+            }
+          }
+
+          return { handled: true, type: 'guardian_decision_applied' };
+        }
+
+        // No decision could be parsed — send a generic reminder to the guardian
+        try {
+          const reminderText = await composeApprovalMessageGenerative({
+            scenario: 'reminder_prompt',
+            toolName: guardianApproval.toolName,
+            channel: sourceChannel,
+          }, {}, approvalCopyGenerator);
+          await deliverChannelReply(replyCallbackUrl, {
+            chatId: externalChatId,
+            text: reminderText,
+            assistantId,
+          }, bearerToken);
+        } catch (err) {
+          log.error({ err, conversationId: guardianApproval.conversationId }, 'Failed to deliver guardian reminder (legacy path)');
+        }
+        return { handled: true, type: 'assistant_turn' };
+      }
+
+      // No content and no engine — nothing to do, fall through to standard
+      // approval interception below.
     }
   }
 


### PR DESCRIPTION
Part of #7618. Migrates guardian approval path to conversational engine, adds multi-pending disambiguation, removes deterministic parser and reminder code that is now fully unused.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
