### PR TITLE
fix(ios): add missing VellumAssistantShared import in VoiceSettingsSection

### DIFF
--- a/clients/ios/Views/Settings/VoiceSettingsSection.swift
+++ b/clients/ios/Views/Settings/VoiceSettingsSection.swift
@@ -1,5 +1,6 @@
 #if canImport(UIKit)
 import SwiftUI
+import VellumAssistantShared
 
 /// TTS provider options surfaced in Voice settings.
 /// The system provider uses iOS AVSpeechSynthesizer; ElevenLabs uses the


### PR DESCRIPTION
## Summary
- Add missing `import VellumAssistantShared` to `VoiceSettingsSection.swift`, which uses `APIKeyManager` from the shared module
- Fixes iOS CI build failure: `cannot find 'APIKeyManager' in scope`

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22356470863

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
