### PR TITLE
fix(swift): add missing VellumAssistantShared import for MediaEmbedSettings tests

### DIFF
--- a/clients/macos/vellum-assistantTests/MediaEmbedSettingsDefaultsTests.swift
+++ b/clients/macos/vellum-assistantTests/MediaEmbedSettingsDefaultsTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class MediaEmbedSettingsDefaultsTests: XCTestCase {

--- a/clients/macos/vellum-assistantTests/SettingsPanelMediaControlsTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsPanelMediaControlsTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class SettingsPanelMediaControlsTests: XCTestCase {

--- a/clients/macos/vellum-assistantTests/SettingsStoreMediaAllowlistTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreMediaAllowlistTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class SettingsStoreMediaAllowlistTests: XCTestCase {

--- a/clients/macos/vellum-assistantTests/SettingsStoreMediaLoadTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreMediaLoadTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class SettingsStoreMediaLoadTests: XCTestCase {

--- a/clients/macos/vellum-assistantTests/SettingsViewMediaAllowlistTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsViewMediaAllowlistTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class SettingsViewMediaAllowlistTests: XCTestCase {


### PR DESCRIPTION
## Summary
- Add `@testable import VellumAssistantShared` to 5 test files that reference `MediaEmbedSettings`, which was moved from `VellumAssistantLib` to the shared module in #7862
- Fixes CI build failure: `cannot find 'MediaEmbedSettings' in scope`

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22356571623

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
