### PR TITLE
Simplify settings by removing Integrations Public Ingress override UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -42,8 +42,6 @@ struct SettingsPanel: View {
     @State private var modelDropdownFrame: CGRect = .zero
     @State private var selectedTab: SettingsTab = .connect
     @State private var testerModel: ToolPermissionTesterModel?
-    @AppStorage("ingressUseOverride") private var ingressUseOverride: Bool = false
-    @AppStorage("ingressGatewayOverride") private var ingressGatewayOverride: String = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -304,40 +302,6 @@ struct SettingsPanel: View {
             }
             .animation(VAnimation.fast, value: showModelDropdown)
             .zIndex(showModelDropdown ? 1 : 0)
-
-            // PUBLIC INGRESS section
-            VStack(alignment: .leading, spacing: VSpacing.md) {
-                HStack {
-                    Text("Public Ingress")
-                        .font(VFont.sectionTitle)
-                        .foregroundColor(VColor.textPrimary)
-                    Spacer()
-                    Toggle("", isOn: Binding(
-                        get: { store.ingressEnabled },
-                        set: { store.setIngressEnabled($0) }
-                    ))
-                    .toggleStyle(.switch)
-                    .labelsHidden()
-                    .disabled(store.ingressPublicBaseUrl.isEmpty && !store.ingressEnabled)
-                }
-
-                HStack(alignment: .top, spacing: VSpacing.sm) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundColor(VColor.warning)
-                        .font(.system(size: 12))
-                    Text("Setting a public base URL may expose this computer to the public internet. Use with caution.")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                }
-
-                // Global Gateway & Token readout
-                ingressGlobalConfigCard
-
-                // Override section
-                ingressOverrideSection
-            }
-            .padding(VSpacing.lg)
-            .vCard(background: VColor.surfaceSubtle)
 
             // PERPLEXITY SEARCH section
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -1032,74 +996,6 @@ struct SettingsPanel: View {
 
         // Close the settings panel so the user sees the chat
         onClose()
-    }
-
-    // MARK: - Ingress Global Config Card
-
-    /// Card showing the resolved gateway URL, referencing global Connect config.
-    private var ingressGlobalConfigCard: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            Text("Using Global Gateway & Token")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
-                .textCase(.uppercase)
-
-            HStack(alignment: .top) {
-                Text("Gateway URL")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
-                    .frame(width: 90, alignment: .leading)
-                Text(store.resolvedIngressGatewayUrl.isEmpty ? "Not configured" : store.resolvedIngressGatewayUrl)
-                    .font(VFont.mono)
-                    .foregroundColor(store.resolvedIngressGatewayUrl.isEmpty ? VColor.textMuted : VColor.textPrimary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                Spacer()
-            }
-
-            Button("Manage in Connect tab") {
-                selectedTab = .connect
-            }
-            .font(VFont.caption)
-            .foregroundColor(VColor.accent)
-        }
-        .padding(VSpacing.md)
-        .background(VColor.surface.opacity(0.5))
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.md)
-                .stroke(VColor.surfaceBorder.opacity(0.3), lineWidth: 1)
-        )
-    }
-
-    /// Collapsed override section for per-integration gateway URL customization.
-    @State private var ingressOverrideExpanded: Bool = false
-
-    private var ingressOverrideSection: some View {
-        VDisclosureSection(
-            title: "Override",
-            icon: "arrow.triangle.swap",
-            isExpanded: $ingressOverrideExpanded
-        ) {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
-                Toggle("Use custom gateway URL", isOn: $ingressUseOverride)
-                    .toggleStyle(.switch)
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textSecondary)
-
-                if ingressUseOverride {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        Text("Gateway URL Override")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textSecondary)
-                        TextField("https://custom-gateway.example.com", text: $ingressGatewayOverride)
-                            .vInputStyle()
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textPrimary)
-                    }
-                }
-            }
-        }
     }
 
     // MARK: - Permission Row

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1155,19 +1155,6 @@ public final class SettingsStore: ObservableObject {
         PairingConfiguration.resolvedBearerToken(fallback: readHttpToken() ?? "")
     }
 
-    /// Resolved gateway URL — uses per-integration override if enabled, else global.
-    var resolvedIngressGatewayUrl: String {
-        UserDefaults.standard.bool(forKey: "ingressUseOverride")
-            ? (nonEmpty(UserDefaults.standard.string(forKey: "ingressGatewayOverride")) ?? ingressPublicBaseUrl)
-            : ingressPublicBaseUrl
-    }
-
-    /// Returns the string if it is non-nil and non-empty after trimming, otherwise nil.
-    private func nonEmpty(_ value: String?) -> String? {
-        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else { return nil }
-        return value
-    }
-
     // MARK: - Model Actions
 
     func setModel(_ model: String) {

--- a/clients/macos/vellum-assistantTests/SettingsStoreOverrideResolutionTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreOverrideResolutionTests.swift
@@ -10,8 +10,6 @@ final class SettingsStoreOverrideResolutionTests: XCTestCase {
         UserDefaults.standard.removeObject(forKey: "iosPairingUseOverride")
         UserDefaults.standard.removeObject(forKey: "iosPairingGatewayOverride")
         UserDefaults.standard.removeObject(forKey: "iosPairingTokenOverride")
-        UserDefaults.standard.removeObject(forKey: "ingressUseOverride")
-        UserDefaults.standard.removeObject(forKey: "ingressGatewayOverride")
         super.tearDown()
     }
 
@@ -56,37 +54,5 @@ final class SettingsStoreOverrideResolutionTests: XCTestCase {
         store.ingressPublicBaseUrl = "https://global.example.com"
 
         XCTAssertEqual(store.resolvedIosGatewayUrl, "https://global.example.com")
-    }
-
-    // MARK: - Ingress Gateway URL
-
-    func testIngressGatewayReturnsGlobalWhenOverrideOff() {
-        UserDefaults.standard.set(false, forKey: "ingressUseOverride")
-        UserDefaults.standard.set("https://custom-ingress.example.com", forKey: "ingressGatewayOverride")
-
-        let store = SettingsStore()
-        store.ingressPublicBaseUrl = "https://global.example.com"
-
-        XCTAssertEqual(store.resolvedIngressGatewayUrl, "https://global.example.com")
-    }
-
-    func testIngressGatewayReturnsOverrideWhenOverrideOn() {
-        UserDefaults.standard.set(true, forKey: "ingressUseOverride")
-        UserDefaults.standard.set("https://custom-ingress.example.com", forKey: "ingressGatewayOverride")
-
-        let store = SettingsStore()
-        store.ingressPublicBaseUrl = "https://global.example.com"
-
-        XCTAssertEqual(store.resolvedIngressGatewayUrl, "https://custom-ingress.example.com")
-    }
-
-    func testIngressGatewayFallsBackToGlobalWhenOverrideOnButEmpty() {
-        UserDefaults.standard.set(true, forKey: "ingressUseOverride")
-        UserDefaults.standard.set("", forKey: "ingressGatewayOverride")
-
-        let store = SettingsStore()
-        store.ingressPublicBaseUrl = "https://global.example.com"
-
-        XCTAssertEqual(store.resolvedIngressGatewayUrl, "https://global.example.com")
     }
 }


### PR DESCRIPTION
## Summary
- remove the Public Ingress card from the Integrations settings pane
- remove the custom gateway override toggle + field from Integrations
- delete now-unused ingress override resolution path in SettingsStore
- remove ingress override tests that targeted the deleted path

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build` (clients/macos)
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter SettingsStoreOverrideResolutionTests` (fails due unrelated pre-existing `MediaEmbedSettings` test compile errors in other test files)