### PR TITLE
fix(macos): hide Temporary chat toggle once thread has messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -560,11 +560,16 @@ struct MainWindowView: View {
                                 toggleVoiceMode()
                             }
 
-                            TemporaryChatToggle(
-                                isActive: threadManager.activeThread?.kind == .private,
-                                tooltip: threadManager.activeThread?.kind == .private ? "Exit temporary chat" : "Temporary chat",
-                                onToggle: { toggleTemporaryChat() }
-                            )
+                            // Temporary chat toggle — only visible on brand new threads with no messages
+                            if threadManager.activeViewModel?.messages.contains(where: {
+                                !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            }) != true {
+                                TemporaryChatToggle(
+                                    isActive: threadManager.activeThread?.kind == .private,
+                                    tooltip: threadManager.activeThread?.kind == .private ? "Exit temporary chat" : "Temporary chat",
+                                    onToggle: { toggleTemporaryChat() }
+                                )
+                            }
                         }
                     }
                     .padding(.leading, trafficLightPadding)


### PR DESCRIPTION
## Summary
- Wrap the `TemporaryChatToggle` in a condition that checks for the absence of non-empty messages, the exact inverse of the "Copy thread" button's visibility condition
- On brand new threads (no messages): Temporary chat toggle is visible, Copy thread is hidden
- Once a message is sent: Temporary chat toggle is hidden, Copy thread becomes visible

## Original prompt
the "Temporary chat" button in the mac app should only be present on brand new conversation threads and should be absent once there are one or more messages. Basically, the inverse of when the "Copy thread" button is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7895" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
