### PR TITLE
M1: Canonical Channel Primitive + Type Adoption

### DIFF
--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -1,11 +1,12 @@
 import { describe, test, expect, beforeEach } from 'bun:test';
 import { ChannelReadinessService, REMOTE_TTL_MS } from '../runtime/channel-readiness-service.js';
+import type { ChannelId } from '../channels/types.js';
 import type { ChannelProbe, ReadinessCheckResult } from '../runtime/channel-readiness-types.js';
 
 // ── Test helpers ────────────────────────────────────────────────────────────
 
 function makeProbe(
-  channel: string,
+  channel: ChannelId,
   localResults: ReadinessCheckResult[],
   remoteResults?: ReadinessCheckResult[],
 ): ChannelProbe & { localCallCount: number; remoteCallCount: number } {
@@ -166,9 +167,10 @@ describe('ChannelReadinessService', () => {
   });
 
   test('unknown channel returns unsupported_channel reason', async () => {
-    const [snapshot] = await service.getReadiness('carrier_pigeon');
+    // Cast to exercise runtime handling of an unrecognized channel value
+    const [snapshot] = await service.getReadiness('carrier_pigeon' as ChannelId);
 
-    expect(snapshot.channel).toBe('carrier_pigeon');
+    expect(snapshot.channel).toBe('carrier_pigeon' as ChannelId);
     expect(snapshot.ready).toBe(false);
     expect(snapshot.reasons).toEqual([
       { code: 'unsupported_channel', text: 'Channel carrier_pigeon is not supported' },
@@ -177,13 +179,13 @@ describe('ChannelReadinessService', () => {
   });
 
   test('all checks passing yields ready=true', async () => {
-    const probe = makeProbe('test', [
+    const probe = makeProbe('telegram', [
       { name: 'a', passed: true, message: 'ok' },
       { name: 'b', passed: true, message: 'ok' },
     ]);
     service.registerProbe(probe);
 
-    const [snapshot] = await service.getReadiness('test');
+    const [snapshot] = await service.getReadiness('telegram');
 
     expect(snapshot.ready).toBe(true);
     expect(snapshot.reasons).toHaveLength(0);

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -41,7 +41,7 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     title: 'New session',
     correlationId: 'corr-001',
     transport: {
-      channelId: 'desktop',
+      channelId: 'macos',
       hints: ['dashboard-capable'],
       uxBrief: 'Prefer dashboard-first onboarding.',
     },

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -1,0 +1,20 @@
+export const CHANNEL_IDS = [
+  'telegram', 'sms', 'voice', 'macos', 'ios', 'whatsapp', 'slack', 'email',
+] as const;
+
+export type ChannelId = (typeof CHANNEL_IDS)[number];
+
+export function isChannelId(value: unknown): value is ChannelId {
+  return typeof value === 'string' && (CHANNEL_IDS as readonly string[]).includes(value);
+}
+
+export function parseChannelId(value: unknown): ChannelId | null {
+  return isChannelId(value) ? value : null;
+}
+
+export function assertChannelId(value: unknown, field: string): ChannelId {
+  if (!isChannelId(value)) {
+    throw new Error(`Invalid channel ID for ${field}: ${String(value)}. Valid values: ${CHANNEL_IDS.join(', ')}`);
+  }
+  return value;
+}

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -1,4 +1,6 @@
 import * as net from 'node:net';
+import { isChannelId } from '../../channels/types.js';
+import type { ChannelId } from '../../channels/types.js';
 import { silentlyWithLog } from '../../util/silently.js';
 import { v4 as uuid } from 'uuid';
 import * as conversationStore from '../../memory/conversation-store.js';
@@ -219,7 +221,7 @@ export function handleSessionList(socket: net.Socket, ctx: HandlerContext, offse
         updatedAt: c.updatedAt,
         threadType: normalizeThreadType(c.threadType),
         source: c.source ?? 'user',
-        ...(binding ? {
+        ...(binding && isChannelId(binding.sourceChannel) ? {
           channelBinding: {
             sourceChannel: binding.sourceChannel,
             externalChatId: binding.externalChatId,

--- a/assistant/src/daemon/ipc-contract/integrations.ts
+++ b/assistant/src/daemon/ipc-contract/integrations.ts
@@ -1,5 +1,7 @@
 // External service integrations: Slack, Telegram, Twilio, Twitter, Vercel, ingress, channel readiness, guardian.
 
+import type { ChannelId } from '../../channels/types.js';
+
 // === Client → Server ===
 
 export interface SlackWebhookConfigRequest {
@@ -69,7 +71,7 @@ export interface TwilioConfigRequest {
 export interface ChannelReadinessRequest {
   type: 'channel_readiness';
   action: 'get' | 'refresh';
-  channel?: string;
+  channel?: ChannelId;
   assistantId?: string;
   includeRemote?: boolean;
 }
@@ -77,7 +79,7 @@ export interface ChannelReadinessRequest {
 export interface GuardianVerificationRequest {
   type: 'guardian_verification';
   action: 'create_challenge' | 'status' | 'revoke';
-  channel?: string;  // Defaults to 'telegram'
+  channel?: ChannelId;  // Defaults to 'telegram'
   sessionId?: string;
   assistantId?: string;  // Defaults to 'self'
 }
@@ -203,7 +205,7 @@ export interface ChannelReadinessResponse {
   type: 'channel_readiness_response';
   success: boolean;
   snapshots?: Array<{
-    channel: string;
+    channel: ChannelId;
     ready: boolean;
     checkedAt: number;
     stale: boolean;
@@ -223,7 +225,7 @@ export interface GuardianVerificationResponse {
   bound?: boolean;
   guardianExternalUserId?: string;
   /** The channel this status pertains to (e.g. "telegram", "sms"). Present when action is 'status'. */
-  channel?: string;
+  channel?: ChannelId;
   /** The assistant ID scoped to this status. Present when action is 'status'. */
   assistantId?: string;
   /** The delivery chat ID for the guardian (e.g. Telegram chat ID). Present when action is 'status' and bound is true. */

--- a/assistant/src/daemon/ipc-contract/sessions.ts
+++ b/assistant/src/daemon/ipc-contract/sessions.ts
@@ -1,5 +1,6 @@
 // Session lifecycle, auth, model config, and history types.
 
+import type { ChannelId } from '../../channels/types.js';
 import type { ThreadType } from './shared.js';
 import type { UserMessageAttachment } from './shared.js';
 
@@ -16,7 +17,7 @@ export interface SessionListRequest {
 /** Lightweight session transport metadata for channel identity and natural-language guidance. */
 export interface SessionTransportMetadata {
   /** Logical channel identifier (e.g. "desktop", "telegram", "mobile"). */
-  channelId: string;
+  channelId: ChannelId;
   /** Optional natural-language hints for channel-specific UX behavior. */
   hints?: string[];
   /** Optional concise UX brief for this channel. */
@@ -148,7 +149,7 @@ export interface SessionInfo {
 
 /** Channel binding metadata exposed in session/conversation list APIs. */
 export interface ChannelBinding {
-  sourceChannel: string;
+  sourceChannel: ChannelId;
   externalChatId: string;
   externalUserId?: string | null;
   displayName?: string | null;

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -5,6 +5,7 @@
  * before it is sent to the provider.  They are pure (no side effects).
  */
 
+import type { ChannelId } from '../channels/types.js';
 import type { Message } from '../providers/types.js';
 import { listAppFiles, getAppsDir } from '../memory/app-store.js';
 import { statSync } from 'node:fs';
@@ -27,7 +28,7 @@ export interface ChannelCapabilities {
 
 /** Guardian identity/trust context for external chat channels. */
 export interface GuardianRuntimeContext {
-  sourceChannel: string;
+  sourceChannel: ChannelId;
   actorRole: 'guardian' | 'non-guardian' | 'unverified_channel';
   guardianChatId?: string;
   guardianExternalUserId?: string;

--- a/assistant/src/runtime/channel-readiness-types.ts
+++ b/assistant/src/runtime/channel-readiness-types.ts
@@ -1,7 +1,8 @@
 // Channel readiness types — reusable primitive for all channels.
 
-/** Logical channel identifier. Well-known channels have literal types; custom channels use string. */
-export type ChannelId = 'sms' | 'telegram' | 'voice' | string;
+import type { ChannelId } from '../channels/types.js';
+
+export type { ChannelId };
 
 /** Result of a single readiness check (local or remote). */
 export interface ReadinessCheckResult {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -9,6 +9,7 @@ import { existsSync, readFileSync, statSync, statfsSync } from 'node:fs';
 import { resolve, join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { timingSafeEqual } from 'node:crypto';
+import { assertChannelId, isChannelId } from '../channels/types.js';
 import { ConfigError, IngressBlockedError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
 import { getWorkspacePromptPath, readLockfile } from '../util/platform.js';
@@ -128,10 +129,11 @@ function parseGuardianRuntimeContext(value: unknown): GuardianRuntimeContext | u
   ) {
     return undefined;
   }
-  const sourceChannel = typeof raw.sourceChannel === 'string' && raw.sourceChannel.trim().length > 0
+  const rawSourceChannel = typeof raw.sourceChannel === 'string' && raw.sourceChannel.trim().length > 0
     ? raw.sourceChannel
     : undefined;
-  if (!sourceChannel) return undefined;
+  if (!rawSourceChannel || !isChannelId(rawSourceChannel)) return undefined;
+  const sourceChannel = rawSourceChannel;
   const denialReason =
     raw.denialReason === 'no_binding' || raw.denialReason === 'no_identity'
       ? raw.denialReason
@@ -957,7 +959,7 @@ export class RuntimeHttpServer {
 
       const content = typeof payload.content === 'string' ? payload.content.trim() : '';
       const attachmentIds = Array.isArray(payload.attachmentIds) ? payload.attachmentIds as string[] : undefined;
-      const sourceChannel = payload.sourceChannel as string;
+      const sourceChannel = assertChannelId(payload.sourceChannel, 'sourceChannel');
       const sourceMetadata = payload.sourceMetadata as Record<string, unknown> | undefined;
       const assistantId = typeof payload.assistantId === 'string'
         ? payload.assistantId

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -1,6 +1,7 @@
 /**
  * Shared types for the runtime HTTP server and its route handlers.
  */
+import type { ChannelId } from '../channels/types.js';
 import type { RunOrchestrator } from './run-orchestrator.js';
 import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
 import type { ApprovalMessageContext, ComposeApprovalMessageGenerativeOptions } from './approval-message-composer.js';
@@ -16,7 +17,7 @@ export type ApprovalCopyGenerator = (
 
 export interface RuntimeMessageSessionOptions {
   transport?: {
-    channelId: string;
+    channelId: ChannelId;
     hints?: string[];
     uxBrief?: string;
   };
@@ -31,7 +32,7 @@ export type MessageProcessor = (
   content: string,
   attachmentIds?: string[],
   options?: RuntimeMessageSessionOptions,
-  sourceChannel?: string,
+  sourceChannel?: ChannelId,
 ) => Promise<{ messageId: string }>;
 
 /**
@@ -44,7 +45,7 @@ export type NonBlockingMessageProcessor = (
   content: string,
   attachmentIds?: string[],
   options?: RuntimeMessageSessionOptions,
-  sourceChannel?: string,
+  sourceChannel?: ChannelId,
 ) => Promise<{ messageId: string }>;
 
 export interface RuntimeHttpServerOptions {

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -2,6 +2,8 @@
  * Route handlers for channel inbound messages, delivery acks, and
  * conversation deletion.
  */
+import { assertChannelId } from '../../channels/types.js';
+import type { ChannelId } from '../../channels/types.js';
 import { timingSafeEqual } from 'node:crypto';
 import { deleteConversationKey } from '../../memory/conversation-key-store.js';
 import * as conversationStore from '../../memory/conversation-store.js';
@@ -125,7 +127,7 @@ export interface GuardianContext {
   denialReason?: DenialReason;
 }
 
-function toGuardianRuntimeContext(sourceChannel: string, ctx: GuardianContext): GuardianRuntimeContext {
+function toGuardianRuntimeContext(sourceChannel: ChannelId, ctx: GuardianContext): GuardianRuntimeContext {
   return {
     sourceChannel,
     actorRole: ctx.actorRole,
@@ -153,7 +155,7 @@ function requiredDecisionKeywords(actions: ApprovalUIMetadata['actions']): strin
 interface DeliverGeneratedApprovalPromptParams {
   replyCallbackUrl: string;
   chatId: string;
-  sourceChannel: string;
+  sourceChannel: ChannelId;
   assistantId: string;
   bearerToken?: string;
   prompt: ChannelApprovalPrompt;
@@ -262,7 +264,7 @@ async function deliverGeneratedApprovalPrompt(params: DeliverGeneratedApprovalPr
 function buildGuardianDenyContext(
   toolName: string,
   denialReason: DenialReason,
-  _sourceChannel: string,
+  _sourceChannel: ChannelId,
 ): string {
   if (denialReason === 'no_identity') {
     return `Permission denied for "${toolName}": guardian approval was required, but requester identity could not be verified for this channel. In your next assistant reply, explain this clearly, avoid retrying yet, and ask the user to message from a verifiable direct account/chat before retrying.`;
@@ -371,7 +373,6 @@ export async function handleChannelInbound(
   };
 
   const {
-    sourceChannel,
     externalChatId,
     externalMessageId,
     content,
@@ -380,9 +381,12 @@ export async function handleChannelInbound(
     sourceMetadata,
   } = body;
 
-  if (!sourceChannel || typeof sourceChannel !== 'string') {
+  if (!body.sourceChannel || typeof body.sourceChannel !== 'string') {
     return Response.json({ error: 'sourceChannel is required' }, { status: 400 });
   }
+  // Validate and narrow to canonical ChannelId at the boundary — the gateway
+  // only sends well-known channel strings, so an unknown value is rejected.
+  const sourceChannel = assertChannelId(body.sourceChannel, 'sourceChannel');
   if (!externalChatId || typeof externalChatId !== 'string') {
     return Response.json({ error: 'externalChatId is required' }, { status: 400 });
   }
@@ -900,7 +904,7 @@ interface BackgroundProcessingParams {
   eventId: string;
   content: string;
   attachmentIds?: string[];
-  sourceChannel: string;
+  sourceChannel: ChannelId;
   externalChatId: string;
   guardianCtx: GuardianContext;
   metadataHints: string[];
@@ -1006,7 +1010,7 @@ interface ApprovalProcessingParams {
   content: string;
   attachmentIds?: string[];
   externalChatId: string;
-  sourceChannel: string;
+  sourceChannel: ChannelId;
   replyCallbackUrl: string;
   bearerToken?: string;
   guardianCtx: GuardianContext;
@@ -1332,7 +1336,7 @@ interface ApprovalInterceptionParams {
   callbackData?: string;
   content: string;
   externalChatId: string;
-  sourceChannel: string;
+  sourceChannel: ChannelId;
   senderExternalUserId?: string;
   replyCallbackUrl: string;
   bearerToken?: string;

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1,6 +1,7 @@
 /**
  * Route handlers for conversation messages and suggestions.
  */
+import { parseChannelId } from '../../channels/types.js';
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import {
@@ -148,7 +149,8 @@ export async function handleSendMessage(
     sourceChannel?: string;
   };
 
-  const { conversationKey, content, attachmentIds, sourceChannel } = body;
+  const { conversationKey, content, attachmentIds } = body;
+  const sourceChannel = parseChannelId(body.sourceChannel) ?? undefined;
 
   if (!conversationKey) {
     return Response.json(

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -13,6 +13,7 @@
  * status and submit a decision or secret via the respective endpoints.
  */
 
+import type { ChannelId } from '../channels/types.js';
 import * as runsStore from '../memory/runs-store.js';
 import type { Run } from '../memory/runs-store.js';
 import type { Session } from '../daemon/session.js';
@@ -39,7 +40,7 @@ interface PendingRunState {
 
 export interface RunOrchestratorDeps {
   getOrCreateSession: (conversationId: string, transport?: {
-    channelId: string;
+    channelId: ChannelId;
     hints?: string[];
     uxBrief?: string;
   }) => Promise<Session>;
@@ -71,7 +72,7 @@ export interface RunStartOptions {
    * channel capabilities are resolved for this channel instead of the
    * default 'http-api'.
    */
-  sourceChannel?: string;
+  sourceChannel?: ChannelId;
   /**
    * Transport hints from sourceMetadata (e.g. reply-context cues).
    * Forwarded to the session so the agent loop can incorporate them.

--- a/gateway/src/__tests__/runtime-client.test.ts
+++ b/gateway/src/__tests__/runtime-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
-import type { RuntimeAttachmentMeta } from "../runtime/client.js";
+import type { RuntimeAttachmentMeta, RuntimeInboundPayload } from "../runtime/client.js";
 import type { GatewayConfig } from "../config.js";
 
 type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
@@ -66,7 +66,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return merged;
 }
 
-const payload = {
+const payload: RuntimeInboundPayload = {
   sourceChannel: "telegram",
   externalChatId: "99001",
   externalMessageId: "123",

--- a/gateway/src/channels/types.ts
+++ b/gateway/src/channels/types.ts
@@ -1,0 +1,20 @@
+export const CHANNEL_IDS = [
+  'telegram', 'sms', 'voice', 'macos', 'ios', 'whatsapp', 'slack', 'email',
+] as const;
+
+export type ChannelId = (typeof CHANNEL_IDS)[number];
+
+export function isChannelId(value: unknown): value is ChannelId {
+  return typeof value === 'string' && (CHANNEL_IDS as readonly string[]).includes(value);
+}
+
+export function parseChannelId(value: unknown): ChannelId | null {
+  return isChannelId(value) ? value : null;
+}
+
+export function assertChannelId(value: unknown, field: string): ChannelId {
+  if (!isChannelId(value)) {
+    throw new Error(`Invalid channel ID for ${field}: ${String(value)}. Valid values: ${CHANNEL_IDS.join(', ')}`);
+  }
+  return value;
+}

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -1,3 +1,4 @@
+import type { ChannelId } from '../channels/types.js';
 import type { GatewayConfig } from "../config.js";
 import { fetchImpl } from "../fetch.js";
 import { getLogger } from "../logger.js";
@@ -40,7 +41,7 @@ export class AttachmentValidationError extends Error {
 }
 
 export type RuntimeInboundPayload = {
-  sourceChannel: string;
+  sourceChannel: ChannelId;
   externalChatId: string;
   externalMessageId: string;
   content: string;
@@ -161,7 +162,7 @@ export async function forwardToRuntime(
 export async function resetConversation(
   config: GatewayConfig,
   assistantId: string,
-  sourceChannel: string,
+  sourceChannel: ChannelId,
   externalChatId: string,
 ): Promise<void> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/channels/conversation`;

--- a/gateway/src/types.ts
+++ b/gateway/src/types.ts
@@ -1,6 +1,8 @@
+import type { ChannelId } from './channels/types.js';
+
 export type GatewayInboundEventV1 = {
   version: "v1";
-  sourceChannel: "telegram" | "sms" | "whatsapp";
+  sourceChannel: Extract<ChannelId, 'telegram' | 'sms' | 'whatsapp'>;
   receivedAt: string;
   routing: {
     assistantId: string;


### PR DESCRIPTION
Part of #7878. Introduces a canonical ChannelId union type (telegram|sms|voice|macos|ios|whatsapp|slack|email) with type guards and adopts it across assistant and gateway channel-typed surfaces. Removes the | string escape hatch from channel readiness types.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
