### PR TITLE
feat(macos): add inline OpenAI API key input to voice mode panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -99,6 +99,7 @@ extension MainWindowView {
             VoiceModePanel(
                 manager: voiceModeManager,
                 voiceService: voiceModeManager.voiceService,
+                settingsStore: settingsStore,
                 onClose: {
                     voiceModeManager.deactivate()
                     windowState.selection = nil

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModePanel.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModePanel.swift
@@ -4,12 +4,14 @@ import VellumAssistantShared
 struct VoiceModePanel: View {
     @ObservedObject var manager: VoiceModeManager
     @ObservedObject var voiceService: OpenAIVoiceService
+    @ObservedObject var settingsStore: SettingsStore
     let onClose: () -> Void
 
     @State private var showingInfo = false
     @State private var spinAngle: Double = 0
     @State private var ringJitter: [CGFloat] = [0, 0, 0]
     @State private var jitterTimer: Timer?
+    @State private var openaiKeyText: String = ""
 
     private let orbSize: CGFloat = 120
 
@@ -83,12 +85,31 @@ struct VoiceModePanel: View {
                         .font(VFont.bodyMedium)
                         .foregroundColor(VColor.textSecondary)
                         .textSelection(.enabled)
-                    Text("Add your OpenAI API key in Settings to use voice mode with Whisper and TTS.")
+                    Text("Enter your OpenAI API key to use voice mode with Whisper and TTS.")
                         .font(VFont.caption)
                         .foregroundColor(VColor.textMuted)
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, VSpacing.xl)
                         .textSelection(.enabled)
+
+                    VStack(spacing: VSpacing.md) {
+                        SecureField("Your OpenAI API key", text: $openaiKeyText)
+                            .vInputStyle()
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                            .onSubmit {
+                                guard !openaiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+                                settingsStore.saveOpenAIKey(openaiKeyText)
+                                openaiKeyText = ""
+                            }
+
+                        VButton(label: "Save", style: .primary) {
+                            settingsStore.saveOpenAIKey(openaiKeyText)
+                            openaiKeyText = ""
+                        }
+                        .disabled(openaiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                    .padding(.horizontal, VSpacing.xl)
                 }
             } else {
                 // Voice orb


### PR DESCRIPTION
## Summary
- Added a SecureField + Save button directly in the voice mode panel's "API key required" state
- Uses the same `SettingsStore.saveOpenAIKey()` path as the Settings > Integrations page, keeping all state in sync
- Supports pressing Enter to submit; Save button is disabled when the field is empty

## Original prompt
let's make it possible to configure your OpenAI API Key directly from within the voice mode panel (if it hasn't yet been configured) rather than requiring the user to go to the settings page. It shoudl still update the same piece of state as if they had set it from the settings page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)