### PR TITLE
M2: Conversation Origin Channel in Persistence

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -1,5 +1,5 @@
 import * as net from 'node:net';
-import { isChannelId } from '../../channels/types.js';
+import { isChannelId, parseChannelId } from '../../channels/types.js';
 import type { ChannelId } from '../../channels/types.js';
 import { silentlyWithLog } from '../../util/silently.js';
 import { v4 as uuid } from 'uuid';
@@ -215,6 +215,7 @@ export function handleSessionList(socket: net.Socket, ctx: HandlerContext, offse
     type: 'session_list_response',
     sessions: conversations.map((c) => {
       const binding = bindings.get(c.id);
+      const originChannel = parseChannelId(c.originChannel);
       return {
         id: c.id,
         title: c.title ?? 'Untitled',
@@ -230,6 +231,7 @@ export function handleSessionList(socket: net.Socket, ctx: HandlerContext, offse
             username: binding.username,
           },
         } : {}),
+        ...(originChannel ? { conversationOriginChannel: originChannel } : {}),
       };
     }),
     hasMore: offset + conversations.length < totalCount,

--- a/assistant/src/daemon/ipc-contract/sessions.ts
+++ b/assistant/src/daemon/ipc-contract/sessions.ts
@@ -164,7 +164,7 @@ export interface ChannelBinding {
 
 export interface SessionListResponse {
   type: 'session_list_response';
-  sessions: Array<{ id: string; title: string; updatedAt: number; threadType?: ThreadType; source?: string; channelBinding?: ChannelBinding }>;
+  sessions: Array<{ id: string; title: string; updatedAt: number; threadType?: ThreadType; source?: string; channelBinding?: ChannelBinding; conversationOriginChannel?: ChannelId }>;
   /** Whether more sessions exist beyond the returned page. */
   hasMore?: boolean;
 }

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -1,9 +1,10 @@
-import { eq, desc, asc, and, count, sql, inArray, or } from 'drizzle-orm';
+import { eq, desc, asc, and, count, sql, inArray, or, isNull } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb, rawGet, rawExec } from './db.js';
 import { conversations, messages, toolInvocations, messageRuns, channelInboundEvents, memoryItemSources, memoryItems, memoryEmbeddings, memoryItemEntities, memorySegments, messageAttachments, llmRequestLogs } from './schema.js';
 import { getConfig } from '../config/loader.js';
 import { indexMessageNow } from './indexer.js';
+import type { ChannelId } from '../channels/types.js';
 import { getLogger } from '../util/logger.js';
 import { deleteOrphanAttachments } from './attachments-store.js';
 
@@ -648,4 +649,21 @@ function buildExcerpt(rawContent: string, query: string): string {
   const end = Math.min(text.length, idx + query.length + WINDOW);
   const excerpt = (start > 0 ? '…' : '') + text.slice(start, end).replace(/\s+/g, ' ').trim() + (end < text.length ? '…' : '');
   return excerpt;
+}
+
+export function setConversationOriginChannelIfUnset(conversationId: string, channel: ChannelId): void {
+  const db = getDb();
+  db.update(conversations)
+    .set({ originChannel: channel })
+    .where(and(eq(conversations.id, conversationId), isNull(conversations.originChannel)))
+    .run();
+}
+
+export function getConversationOriginChannel(conversationId: string): ChannelId | null {
+  const db = getDb();
+  const row = db.select({ originChannel: conversations.originChannel })
+    .from(conversations)
+    .where(eq(conversations.id, conversationId))
+    .get();
+  return (row?.originChannel as ChannelId) ?? null;
 }

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -529,6 +529,7 @@ export function initializeDb(): void {
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN thread_type TEXT NOT NULL DEFAULT 'standard'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN source TEXT NOT NULL DEFAULT 'user'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN memory_scope_id TEXT NOT NULL DEFAULT 'default'`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN origin_channel TEXT`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE attachments ADD COLUMN thumbnail_base64 TEXT`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE cron_jobs ADD COLUMN schedule_syntax TEXT NOT NULL DEFAULT 'cron'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE messages ADD COLUMN metadata TEXT`); } catch { /* already exists */ }

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -14,6 +14,7 @@ export const conversations = sqliteTable('conversations', {
   threadType: text('thread_type').notNull().default('standard'),
   source: text('source').notNull().default('user'),
   memoryScopeId: text('memory_scope_id').notNull().default('default'),
+  originChannel: text('origin_channel'),
 });
 
 export const messages = sqliteTable('messages', {


### PR DESCRIPTION
Part of #7878. Adds origin_channel column to conversations table, setConversationOriginChannelIfUnset/getConversationOriginChannel helpers, and surfaces conversationOriginChannel in session list responses.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
