### PR TITLE
fix(macos): align cursor with first line of multiline placeholder text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -893,11 +893,29 @@ private final class ComposerNativeTextView: NSTextView {
 private final class CenteringClipView: NSClipView {
     override func constrainBoundsRect(_ proposedBounds: NSRect) -> NSRect {
         var rect = super.constrainBoundsRect(proposedBounds)
-        if let textView = documentView as? NSTextView,
+        if let textView = documentView as? ComposerNativeTextView,
            let layoutManager = textView.layoutManager,
            let textContainer = textView.textContainer {
             layoutManager.ensureLayout(for: textContainer)
-            let usedHeight = layoutManager.usedRect(for: textContainer).height
+            var usedHeight = layoutManager.usedRect(for: textContainer).height
+
+            // When placeholder text is visible, use its rendered height instead
+            // of the (empty) layout manager height so the cursor stays aligned
+            // with the first line of placeholder text that may wrap.
+            if textView.string.isEmpty,
+               let placeholder = textView.placeholderText,
+               !placeholder.isEmpty {
+                let font = textView.font ?? NSFont.systemFont(ofSize: 13)
+                let linePadding = textContainer.lineFragmentPadding
+                let availableWidth = max(0, textView.bounds.width - textView.textContainerInset.width * 2 - linePadding * 2)
+                let placeholderSize = (placeholder as NSString).boundingRect(
+                    with: NSSize(width: availableWidth, height: .greatestFiniteMagnitude),
+                    options: [.usesLineFragmentOrigin],
+                    attributes: [.font: font]
+                )
+                usedHeight = max(usedHeight, placeholderSize.height)
+            }
+
             // Include the textContainerInset in the total content height so
             // centering accounts for the top/bottom padding the text view adds.
             let insetHeight = textView.textContainerInset.height * 2


### PR DESCRIPTION
## Summary
- When the composer's placeholder text wraps to two lines, the cursor crosshair was vertically centered instead of aligning with the first line
- Updated `CenteringClipView` to measure the placeholder text's rendered height when the text view is empty, so centering accounts for multi-line placeholder layout
- The cursor now stays aligned with the first line of placeholder text regardless of wrapping

## Original prompt
When the mac app's chat input placeholder text spans two lines, the cursor indicator crosshair is still centered whereas it should be aligned with the first line of the placeholder text. Are you able to see what I mean from the attached screenshot? Let's fix that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)