### PR TITLE
fix(macos): align Copy thread button with Voice mode button

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -520,7 +520,13 @@ struct MainWindowView: View {
                             if threadManager.activeViewModel?.messages.contains(where: {
                                 !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                             }) == true {
-                                Button {
+                                VIconButton(
+                                    label: "Copy thread",
+                                    icon: showCopyThreadConfirmation ? "checkmark" : "list.clipboard",
+                                    isActive: showCopyThreadConfirmation,
+                                    iconOnly: true,
+                                    tooltip: showCopyThreadConfirmation ? "Copied!" : "Copy thread"
+                                ) {
                                     let messages = threadManager.activeViewModel?.messages ?? []
                                     let title = threadManager.activeThread?.title
                                     let names = resolveParticipantNames()
@@ -537,16 +543,7 @@ struct MainWindowView: View {
                                     let timer = DispatchWorkItem { showCopyThreadConfirmation = false }
                                     copyThreadConfirmationTimer = timer
                                     DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: timer)
-                                } label: {
-                                    Image(systemName: showCopyThreadConfirmation ? "checkmark" : "list.clipboard")
-                                        .font(.system(size: 12, weight: .medium))
-                                        .foregroundColor(showCopyThreadConfirmation ? VColor.success : VColor.textMuted)
-                                        .frame(width: 28, height: 28)
-                                        .contentShape(Rectangle())
                                 }
-                                .buttonStyle(.plain)
-                                .accessibilityLabel("Copy thread")
-                                .help(showCopyThreadConfirmation ? "Copied!" : "Copy thread")
                             }
 
                             // Voice mode toggle


### PR DESCRIPTION
## Summary
- Replaced the raw `Button` used for "Copy thread" with the `VIconButton` component, matching the adjacent "Voice mode" button's styling, hover states, and interaction patterns
- Uses `isActive: showCopyThreadConfirmation` for visual feedback when thread is copied

## Original prompt
the "Copy thread" button looks different than the "Voice mode" button to the right of it. Lets align it so that the former looks like the latter in every way except for the icon used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
