### PR TITLE
fix: only evict Linear state cache on watcher deletion, not on auto-disable

### DIFF
--- a/assistant/src/watcher/engine.ts
+++ b/assistant/src/watcher/engine.ts
@@ -118,10 +118,10 @@ export async function runWatchersOnce(
       if ((watcher.consecutiveErrors + 1) >= MAX_CONSECUTIVE_ERRORS) {
         const reason = `Disabled after ${MAX_CONSECUTIVE_ERRORS} consecutive errors. Last: ${message}`;
         disableWatcher(watcher.id, reason);
-        // Evict in-process provider state (e.g. Linear issue-state cache) so
-        // that a permanently-disabled watcher's UUID doesn't leak memory for
-        // the lifetime of the daemon.
-        provider.cleanup?.(watcher.id);
+        // Do NOT call provider.cleanup() here — auto-disable is reversible.
+        // If the watcher is re-enabled later, it must diff against the same
+        // baseline to avoid missing events that occurred while disabled.
+        // Cleanup is only correct on true deletion (see tools/watcher/delete.ts).
         log.warn({ watcherId: watcher.id, name: watcher.name }, 'Watcher disabled by circuit breaker');
         notify({
           title: `Watcher disabled: ${watcher.name}`,

--- a/assistant/src/watcher/provider-types.ts
+++ b/assistant/src/watcher/provider-types.ts
@@ -55,9 +55,12 @@ export interface WatcherProvider {
 
   /**
    * Release any in-process state held for a watcher instance.
-   * Called when a watcher is deleted or permanently disabled so that
-   * providers with per-watcher caches (e.g. the Linear issue-state map)
-   * can evict the stale entry and prevent unbounded memory growth.
+   * Called only when a watcher is truly deleted so that providers with
+   * per-watcher caches (e.g. the Linear issue-state map) can evict the
+   * stale entry and prevent unbounded memory growth.
+   *
+   * Must NOT be called on circuit-breaker auto-disable — that path is
+   * reversible, and clearing state would cause missed events on re-enable.
    *
    * Optional — providers with no per-watcher state need not implement this.
    */


### PR DESCRIPTION
Remove cleanup() call from circuit-breaker auto-disable path in engine.ts. Auto-disable is reversible — clearing state would cause missed events on re-enable. Keep cleanup only on true deletion.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
