### PR TITLE
Fix: Route legacy guardian run refs to correct approval

### DIFF
--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -1679,15 +1679,72 @@ async function handleApprovalInterception(
             legacyGuardianDecision.action = 'approve_once';
           }
 
+          // Resolve the target approval: when a [ref:<runId>] tag is
+          // present, look up the specific pending approval by that runId
+          // so the decision applies to the correct conversation even when
+          // multiple guardian approvals are pending.
+          let targetLegacyApproval = guardianApproval;
+          if (legacyGuardianDecision.runId) {
+            const resolvedByRun = getPendingApprovalByRunAndGuardianChat(
+              legacyGuardianDecision.runId,
+              sourceChannel,
+              externalChatId,
+              assistantId,
+            );
+            if (!resolvedByRun) {
+              // The referenced run doesn't match any pending guardian
+              // approval — it may have expired or already been resolved.
+              try {
+                const staleText = await composeApprovalMessageGenerative({
+                  scenario: 'guardian_disambiguation',
+                  channel: sourceChannel,
+                }, {}, approvalCopyGenerator);
+                await deliverChannelReply(replyCallbackUrl, {
+                  chatId: externalChatId,
+                  text: staleText,
+                  assistantId,
+                }, bearerToken);
+              } catch (err) {
+                log.error({ err, externalChatId }, 'Failed to deliver stale approval notice (legacy path)');
+              }
+              return { handled: true, type: 'stale_ignored' };
+            }
+            targetLegacyApproval = resolvedByRun;
+          }
+
+          // Re-validate guardian identity against the resolved target.
+          // The default guardianApproval was already checked, but a
+          // runId-resolved approval may belong to a different guardian.
+          if (senderExternalUserId !== targetLegacyApproval.guardianExternalUserId) {
+            log.warn(
+              { externalChatId, senderExternalUserId, expectedGuardian: targetLegacyApproval.guardianExternalUserId, runId: legacyGuardianDecision.runId },
+              'Guardian identity mismatch on legacy run-ref resolved target approval',
+            );
+            try {
+              const mismatchText = await composeApprovalMessageGenerative({
+                scenario: 'guardian_identity_mismatch',
+                channel: sourceChannel,
+              }, {}, approvalCopyGenerator);
+              await deliverChannelReply(replyCallbackUrl, {
+                chatId: externalChatId,
+                text: mismatchText,
+                assistantId,
+              }, bearerToken);
+            } catch (err) {
+              log.error({ err, externalChatId }, 'Failed to deliver guardian identity mismatch notice (legacy path)');
+            }
+            return { handled: true, type: 'guardian_decision_applied' };
+          }
+
           const result = handleChannelDecision(
-            guardianApproval.conversationId,
+            targetLegacyApproval.conversationId,
             legacyGuardianDecision,
             orchestrator,
           );
 
           if (result.applied) {
             const approvalStatus = legacyGuardianDecision.action === 'reject' ? 'denied' as const : 'approved' as const;
-            updateApprovalDecision(guardianApproval.id, {
+            updateApprovalDecision(targetLegacyApproval.id, {
               status: approvalStatus,
               decidedByExternalUserId: senderExternalUserId,
             });
@@ -1696,25 +1753,25 @@ async function handleApprovalInterception(
             const outcomeText = await composeApprovalMessageGenerative({
               scenario: 'guardian_decision_outcome',
               decision: legacyGuardianDecision.action === 'reject' ? 'denied' : 'approved',
-              toolName: guardianApproval.toolName,
+              toolName: targetLegacyApproval.toolName,
               channel: sourceChannel,
             }, {}, approvalCopyGenerator);
             try {
               await deliverChannelReply(replyCallbackUrl, {
-                chatId: guardianApproval.requesterChatId,
+                chatId: targetLegacyApproval.requesterChatId,
                 text: outcomeText,
                 assistantId,
               }, bearerToken);
             } catch (err) {
-              log.error({ err, conversationId: guardianApproval.conversationId }, 'Failed to notify requester of guardian decision (legacy path)');
+              log.error({ err, conversationId: targetLegacyApproval.conversationId }, 'Failed to notify requester of guardian decision (legacy path)');
             }
 
             if (result.runId) {
               schedulePostDecisionDelivery(
                 orchestrator,
                 result.runId,
-                guardianApproval.conversationId,
-                guardianApproval.requesterChatId,
+                targetLegacyApproval.conversationId,
+                targetLegacyApproval.requesterChatId,
                 replyCallbackUrl,
                 bearerToken,
                 assistantId,


### PR DESCRIPTION
Addresses feedback on #7896. In the legacy guardian fallback, resolves the target approval from parseApprovalDecision's runId instead of always using the first pending approval.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
