### PR TITLE
M3: Turn Context Plumbing Across Message Entry Points

### DIFF
--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -18,3 +18,8 @@ export function assertChannelId(value: unknown, field: string): ChannelId {
   }
   return value;
 }
+
+export interface TurnChannelContext {
+  userMessageChannel: ChannelId;
+  assistantMessageChannel: ChannelId;
+}

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -1,5 +1,5 @@
 import * as net from 'node:net';
-import { isChannelId } from '../../channels/types.js';
+import { isChannelId, parseChannelId } from '../../channels/types.js';
 import type { ChannelId } from '../../channels/types.js';
 import { silentlyWithLog } from '../../util/silently.js';
 import { v4 as uuid } from 'uuid';
@@ -77,6 +77,12 @@ export async function handleUserMessage(
         return;
       }
     }
+
+    const ipcChannel = parseChannelId(msg.channel) ?? 'macos';
+    session.setTurnChannelContext({
+      userMessageChannel: ipcChannel,
+      assistantMessageChannel: ipcChannel,
+    });
 
     session.traceEmitter.emit('request_received', 'User message received', {
       requestId,

--- a/assistant/src/daemon/ipc-contract/messages.ts
+++ b/assistant/src/daemon/ipc-contract/messages.ts
@@ -1,5 +1,6 @@
 // User/assistant messages, tool results, confirmations, secrets, errors, and generation lifecycle.
 
+import type { ChannelId } from '../../channels/types.js';
 import type { UserMessageAttachment } from './shared.js';
 
 // === Client → Server ===
@@ -14,6 +15,8 @@ export interface UserMessage {
   currentPage?: string;
   /** When true, skip the secret-ingress check. Set by the client when the user clicks "Send Anyway". */
   bypassSecretCheck?: boolean;
+  /** Originating channel identifier (e.g. 'macos', 'ios'). Defaults to 'macos' when absent. */
+  channel?: ChannelId;
 }
 
 export interface ConfirmationResponse {

--- a/assistant/src/daemon/ipc-validate.ts
+++ b/assistant/src/daemon/ipc-validate.ts
@@ -1,3 +1,4 @@
+import { isChannelId } from '../channels/types.js';
 import type { ClientMessage } from './ipc-contract.js';
 import inventory from './ipc-contract-inventory.json' with { type: 'json' };
 
@@ -81,6 +82,9 @@ const HIGH_RISK_VALIDATORS: Record<string, PropertyValidator> = {
     }
     if (obj.activeSurfaceId !== undefined && typeof obj.activeSurfaceId !== 'string') {
       return 'user_message "activeSurfaceId" must be a string when present';
+    }
+    if (obj.channel !== undefined && !isChannelId(obj.channel)) {
+      return 'user_message "channel" must be a valid channel ID when present';
     }
     return null;
   },

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -15,6 +15,7 @@ import { IngressBlockedError } from '../util/errors.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import * as attachmentsStore from '../memory/attachments-store.js';
 import { Session, DEFAULT_MEMORY_POLICY, type SessionMemoryPolicy } from './session.js';
+import { parseChannelId } from '../channels/types.js';
 import { resolveChannelCapabilities } from './session-runtime-assembly.js';
 import { ComputerUseSession } from './computer-use-session.js';
 import {
@@ -683,6 +684,11 @@ export class DaemonServer {
     session.setGuardianContext(options?.guardianContext ?? null);
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
     session.setCommandIntent(options?.commandIntent ?? null);
+    const resolvedChannel = parseChannelId(sourceChannel) ?? parseChannelId(options?.transport?.channelId) ?? 'macos';
+    session.setTurnChannelContext({
+      userMessageChannel: resolvedChannel,
+      assistantMessageChannel: resolvedChannel,
+    });
 
     const attachments = attachmentIds
       ? attachmentsStore.getAttachmentsByIds(attachmentIds).map((a) => ({
@@ -725,6 +731,11 @@ export class DaemonServer {
     session.setGuardianContext(options?.guardianContext ?? null);
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
     session.setCommandIntent(options?.commandIntent ?? null);
+    const resolvedChannel2 = parseChannelId(sourceChannel) ?? parseChannelId(options?.transport?.channelId) ?? 'macos';
+    session.setTurnChannelContext({
+      userMessageChannel: resolvedChannel2,
+      assistantMessageChannel: resolvedChannel2,
+    });
 
     const attachments = attachmentIds
       ? attachmentsStore.getAttachmentsByIds(attachmentIds).map((a) => ({

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -16,6 +16,7 @@
  */
 
 import type { Message } from '../providers/types.js';
+import type { TurnChannelContext } from '../channels/types.js';
 import type { ServerMessage, UsageStats, UserMessageAttachment, SurfaceType, SurfaceData } from './ipc-protocol.js';
 import { AgentLoop } from '../agent/loop.js';
 import type { Provider } from '../providers/types.js';
@@ -143,6 +144,7 @@ export class Session {
   /** @internal */ turnCount = 0;
   public lastAssistantAttachments: AssistantAttachmentDraft[] = [];
   public lastAttachmentWarnings: string[] = [];
+  /** @internal */ currentTurnChannelContext: TurnChannelContext | null = null;
 
   constructor(
     conversationId: string,
@@ -340,6 +342,14 @@ export class Session {
 
   setCommandIntent(intent: { type: string; payload?: string; languageCode?: string } | null): void {
     this.commandIntent = intent ?? undefined;
+  }
+
+  setTurnChannelContext(ctx: TurnChannelContext): void {
+    this.currentTurnChannelContext = ctx;
+  }
+
+  getTurnChannelContext(): TurnChannelContext | null {
+    return this.currentTurnChannelContext;
   }
 
   persistUserMessage(

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -3,7 +3,7 @@
  * conversation deletion.
  */
 import { assertChannelId } from '../../channels/types.js';
-import type { ChannelId } from '../../channels/types.js';
+import type { ChannelId, TurnChannelContext } from '../../channels/types.js';
 import { timingSafeEqual } from 'node:crypto';
 import { deleteConversationKey } from '../../memory/conversation-key-store.js';
 import * as conversationStore from '../../memory/conversation-store.js';
@@ -1063,6 +1063,11 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
 
   (async () => {
     try {
+      const turnChannelContext: TurnChannelContext = {
+        userMessageChannel: sourceChannel,
+        assistantMessageChannel: sourceChannel,
+      };
+
       const run = await orchestrator.startRun(
         conversationId,
         content,
@@ -1075,6 +1080,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
           assistantId,
           guardianContext: toGuardianRuntimeContext(sourceChannel, guardianCtx),
           ...(cmdIntent ? { commandIntent: cmdIntent } : {}),
+          turnChannelContext,
         },
       );
 

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -13,7 +13,8 @@
  * status and submit a decision or secret via the respective endpoints.
  */
 
-import type { ChannelId } from '../channels/types.js';
+import type { ChannelId, TurnChannelContext } from '../channels/types.js';
+import { parseChannelId } from '../channels/types.js';
 import * as runsStore from '../memory/runs-store.js';
 import type { Run } from '../memory/runs-store.js';
 import type { Session } from '../daemon/session.js';
@@ -89,6 +90,8 @@ export interface RunStartOptions {
   guardianContext?: GuardianRuntimeContext;
   /** Channel command intent metadata (e.g. Telegram /start). */
   commandIntent?: { type: string; payload?: string; languageCode?: string };
+  /** Resolved channel context for this turn. */
+  turnChannelContext?: TurnChannelContext;
 }
 
 // ---------------------------------------------------------------------------
@@ -156,6 +159,10 @@ export class RunOrchestrator {
     session.setAssistantId(options?.assistantId ?? 'self');
     session.setGuardianContext(options?.guardianContext ?? null);
     session.setCommandIntent(options?.commandIntent ?? null);
+    session.setTurnChannelContext(options?.turnChannelContext ?? {
+      userMessageChannel: parseChannelId(options?.sourceChannel) ?? 'macos',
+      assistantMessageChannel: parseChannelId(options?.sourceChannel) ?? 'macos',
+    });
 
     const attachments = attachmentIds
       ? this.deps.resolveAttachments(attachmentIds)

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -4818,8 +4818,10 @@ public struct IPCUserMessage: Codable, Sendable {
     public let currentPage: String?
     /// When true, skip the secret-ingress check. Set by the client when the user clicks "Send Anyway".
     public let bypassSecretCheck: Bool?
+    /// Originating channel identifier (e.g. 'macos', 'ios'). Defaults to 'macos' when absent.
+    public let channel: String?
 
-    public init(type: String, sessionId: String, content: String? = nil, attachments: [IPCUserMessageAttachment]? = nil, activeSurfaceId: String? = nil, currentPage: String? = nil, bypassSecretCheck: Bool? = nil) {
+    public init(type: String, sessionId: String, content: String? = nil, attachments: [IPCUserMessageAttachment]? = nil, activeSurfaceId: String? = nil, currentPage: String? = nil, bypassSecretCheck: Bool? = nil, channel: String? = nil) {
         self.type = type
         self.sessionId = sessionId
         self.content = content
@@ -4827,6 +4829,7 @@ public struct IPCUserMessage: Codable, Sendable {
         self.activeSurfaceId = activeSurfaceId
         self.currentPage = currentPage
         self.bypassSecretCheck = bypassSecretCheck
+        self.channel = channel
     }
 }
 

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -291,8 +291,17 @@ extension IPCSessionCreateRequest {
 public typealias UserMessageMessage = IPCUserMessage
 
 extension IPCUserMessage {
-    public init(sessionId: String, content: String, attachments: [IPCAttachment]?, activeSurfaceId: String? = nil, currentPage: String? = nil, bypassSecretCheck: Bool? = nil) {
-        self.init(type: "user_message", sessionId: sessionId, content: content, attachments: attachments, activeSurfaceId: activeSurfaceId, currentPage: currentPage, bypassSecretCheck: bypassSecretCheck)
+    /// Platform-derived default channel identifier.
+    private static var defaultChannel: String {
+        #if os(iOS)
+        return "ios"
+        #else
+        return "macos"
+        #endif
+    }
+
+    public init(sessionId: String, content: String, attachments: [IPCAttachment]?, activeSurfaceId: String? = nil, currentPage: String? = nil, bypassSecretCheck: Bool? = nil, channel: String? = nil) {
+        self.init(type: "user_message", sessionId: sessionId, content: content, attachments: attachments, activeSurfaceId: activeSurfaceId, currentPage: currentPage, bypassSecretCheck: bypassSecretCheck, channel: channel ?? Self.defaultChannel)
     }
 }
 


### PR DESCRIPTION
Part of #7878. Adds TurnChannelContext interface, plumbs it through daemon, HTTP, and channel inbound paths. Adds channel field to IPC user_message payload. Desktop client sends macos as channel.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
