### PR TITLE
fix: set expectedSessionListGeneration after successful send, not before

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -164,8 +164,13 @@ class IOSThreadStore: ObservableObject {
     /// for any response that arrives between the generation bump and this send.  If the send
     /// throws, the expected generation is not advanced and the guard stays closed.
     private func sendPageOneSessionList(daemon: DaemonClient) {
-        expectedSessionListGeneration = sessionListGeneration
-        try? daemon.sendSessionList(offset: 0, limit: Self.threadPageSize)
+        do {
+            try daemon.sendSessionList(offset: 0, limit: Self.threadPageSize)
+            expectedSessionListGeneration = sessionListGeneration
+        } catch {
+            // Send failed — leave expectedSessionListGeneration unchanged so the
+            // guard stays closed and stale responses are rejected.
+        }
     }
 
     /// Re-point the store at a freshly constructed DaemonClient after `rebuildClient()`.


### PR DESCRIPTION
Fixes the reconnect-generation guard: expectedSessionListGeneration is now only advanced after the send succeeds. Previously it was set before the send, so a failed send would incorrectly open the guard, allowing stale responses from the old connection to slip through.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
