### PR TITLE
Refactor helper LLM callsites to use configured provider/failover

### DIFF
--- a/assistant/src/__tests__/clarification-resolver.test.ts
+++ b/assistant/src/__tests__/clarification-resolver.test.ts
@@ -7,7 +7,7 @@ let llmResolvedStatement = '';
 let llmExplanation = 'Unclear response from user.';
 
 mock.module('../providers/anthropic-send-message.js', () => ({
-  getAnthropicProvider: () => ({
+  getConfiguredProvider: () => ({
     sendMessage: async (
       _messages: unknown,
       _tools: unknown,

--- a/assistant/src/__tests__/contradiction-checker.test.ts
+++ b/assistant/src/__tests__/contradiction-checker.test.ts
@@ -31,7 +31,7 @@ const classifyRelationshipMock = mock(async () => {
 });
 
 mock.module('../providers/anthropic-send-message.js', () => ({
-  getAnthropicProvider: () => ({
+  getConfiguredProvider: () => ({
     sendMessage: classifyRelationshipMock,
   }),
   createTimeout: (ms: number) => {

--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
-import { getAnthropicProvider, extractText, userMessageWithImages } from '../../../../providers/anthropic-send-message.js';
+import { getConfiguredProvider, extractText, userMessageWithImages } from '../../../../providers/anthropic-send-message.js';
 import { initializeProviders } from '../../../../providers/registry.js';
 import { loadConfig, invalidateConfigCache } from '../../../../config/loader.js';
 import {
@@ -171,21 +171,19 @@ export async function analyzeKeyframesForAsset(
   // Use the same provider the main agent uses. If the provider registry
   // was cleared or not yet initialized, force-reload the config from
   // keychain/secure storage and re-initialize providers.
-  let provider = getAnthropicProvider();
+  let provider = getConfiguredProvider();
   if (!provider) {
     invalidateConfigCache();
     const freshConfig = loadConfig();
-    if (freshConfig.apiKeys.anthropic) {
-      initializeProviders(freshConfig);
-      provider = getAnthropicProvider();
-    }
+    initializeProviders(freshConfig);
+    provider = getConfiguredProvider();
   }
   if (!provider) {
     updateProcessingStage(stage.id, {
       status: 'failed',
-      lastError: 'Anthropic API key not configured',
+      lastError: 'Configured provider unavailable',
     });
-    throw new Error('No Anthropic API key available. Add one in Settings → Integrations.');
+    throw new Error('No configured provider available. Check your provider settings in Settings → Integrations.');
   }
 
   const effectiveChunkSize = chunkSize ?? 10;
@@ -343,7 +341,7 @@ export async function run(
       msg === 'batch_size must be greater than 0.' ||
       msg.startsWith('Media asset not found:') ||
       msg === 'No keyframes found for this asset. Run extract_keyframes first.' ||
-      msg === 'No Anthropic API key available. Add one in Settings → Integrations.'
+      msg === 'No configured provider available. Check your provider settings in Settings → Integrations.'
     ) {
       return { content: msg, isError: true };
     }

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -6,7 +6,7 @@ import { stripCommentLines } from './system-prompt.js';
 import { parseFrontmatterFields } from '../skills/frontmatter.js';
 import { parseToolManifestFile } from '../skills/tool-manifest.js';
 import { computeSkillVersionHash } from '../skills/version-hash.js';
-import { getAnthropicProvider, extractAllText, userMessage } from '../providers/anthropic-send-message.js';
+import { getConfiguredProvider, extractAllText, userMessage } from '../providers/anthropic-send-message.js';
 
 const log = getLogger('skills');
 
@@ -886,9 +886,9 @@ export function loadSkillBySelector(selector: string, workspaceSkillsDir?: strin
 // ─── Icon generation ─────────────────────────────────────────────────────────
 
 async function generateSkillIcon(name: string, description: string): Promise<string> {
-  const provider = getAnthropicProvider();
+  const provider = getConfiguredProvider();
   if (!provider) {
-    throw new Error('No Anthropic API key available for icon generation');
+    throw new Error('Configured provider unavailable for icon generation');
   }
 
   const response = await provider.sendMessage(

--- a/assistant/src/daemon/classifier.ts
+++ b/assistant/src/daemon/classifier.ts
@@ -1,4 +1,4 @@
-import { getAnthropicProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
+import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('classifier');
@@ -17,9 +17,9 @@ export async function classifyInteraction(task: string, source?: 'voice' | 'text
     return 'text_qa';
   }
 
-  const provider = getAnthropicProvider();
+  const provider = getConfiguredProvider();
   if (!provider) {
-    log.warn('No API key available, falling back to heuristic classification');
+    log.warn('No configured provider available, falling back to heuristic classification');
     return classifyHeuristic(task);
   }
 

--- a/assistant/src/daemon/watch-handler.ts
+++ b/assistant/src/daemon/watch-handler.ts
@@ -1,5 +1,5 @@
 import type * as net from 'node:net';
-import { getAnthropicProvider, extractText, userMessage } from '../providers/anthropic-send-message.js';
+import { getConfiguredProvider, extractText, userMessage } from '../providers/anthropic-send-message.js';
 import { getLogger } from '../util/logger.js';
 import type { WatchObservation } from './ipc-protocol.js';
 import type { HandlerContext } from './handlers.js';
@@ -84,9 +84,9 @@ export async function handleWatchObservation(
 
 async function generateCommentary(session: WatchSession): Promise<void> {
   try {
-    const provider = getAnthropicProvider();
+    const provider = getConfiguredProvider();
     if (!provider) {
-      log.warn({ watchId: session.watchId }, 'No Anthropic API key available for commentary generation');
+      log.warn({ watchId: session.watchId }, 'Configured provider unavailable for commentary generation');
       return;
     }
     const lastThree = session.observations.slice(-3);
@@ -157,10 +157,10 @@ export async function generateSummary(session: WatchSession): Promise<void> {
       { watchId: session.watchId, sessionId: session.sessionId, observationCount: session.observations.length, commentaryCount: session.commentaryCount },
       'generateSummary starting — calling Sonnet',
     );
-    const provider = getAnthropicProvider();
+    const provider = getConfiguredProvider();
     if (!provider) {
-      log.warn({ watchId: session.watchId }, 'No Anthropic API key available for summary generation');
-      lastSummaryBySession.set(session.sessionId, '[error] No Anthropic API key configured. Check your settings.');
+      log.warn({ watchId: session.watchId }, 'Configured provider unavailable for summary generation');
+      lastSummaryBySession.set(session.sessionId, '[error] Configured provider unavailable. Check your settings.');
       fireWatchCompletionNotifier(session.sessionId, session);
       return;
     }

--- a/assistant/src/memory/clarification-resolver.ts
+++ b/assistant/src/memory/clarification-resolver.ts
@@ -1,4 +1,4 @@
-import { getAnthropicProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
+import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
 import { truncate } from '../util/truncate.js';
 
 const DEFAULT_RESOLVER_MODEL = 'claude-haiku-4-5-20251001';
@@ -54,13 +54,13 @@ export async function resolveConflictClarification(
   const heuristicResult = resolveWithHeuristics(input);
   if (heuristicResult) return heuristicResult;
 
-  const provider = getAnthropicProvider();
+  const provider = getConfiguredProvider();
   if (!provider) {
     return {
       resolution: 'still_unclear',
       strategy: 'no_llm_key',
       resolvedStatement: null,
-      explanation: 'No Anthropic API key available for clarification fallback.',
+      explanation: 'Configured provider unavailable for clarification fallback.',
     };
   }
 
@@ -167,7 +167,7 @@ async function resolveWithLlm(
   input: ClarificationResolverInput,
   options: { model: string; timeoutMs: number },
 ): Promise<ClarificationResolverResult> {
-  const provider = getAnthropicProvider()!;
+  const provider = getConfiguredProvider()!;
   const userPrompt = [
     'You are resolving a memory clarification response.',
     '',

--- a/assistant/src/memory/contradiction-checker.ts
+++ b/assistant/src/memory/contradiction-checker.ts
@@ -2,7 +2,7 @@ import { eq } from 'drizzle-orm';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 import { truncate } from '../util/truncate.js';
-import { getAnthropicProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
+import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
 import { areStatementsCoherent } from './conflict-intent.js';
 import { isConflictKindEligible, isStatementConflictEligible } from './conflict-policy.js';
 import { createOrUpdatePendingConflict } from './conflict-store.js';
@@ -56,9 +56,9 @@ export async function checkContradictions(newItemId: string): Promise<void> {
     return;
   }
 
-  const provider = getAnthropicProvider();
+  const provider = getConfiguredProvider();
   if (!provider) {
-    log.debug('No Anthropic API key available for contradiction checking');
+    log.debug('Configured provider unavailable for contradiction checking');
     return;
   }
 
@@ -208,7 +208,7 @@ async function classifyRelationship(
   existingItem: MemoryItemRow,
   newItem: MemoryItemRow,
 ): Promise<ClassifyResult> {
-  const provider = getAnthropicProvider()!;
+  const provider = getConfiguredProvider()!;
 
   const userContent = [
     `Subject: ${newItem.subject}`,

--- a/assistant/src/memory/entity-extractor.ts
+++ b/assistant/src/memory/entity-extractor.ts
@@ -2,7 +2,7 @@ import { eq, sql } from 'drizzle-orm';
 import type { MemoryEntityConfig } from '../config/types.js';
 import { getLogger } from '../util/logger.js';
 import { truncate } from '../util/truncate.js';
-import { getAnthropicProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
+import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
 import { getDb } from './db.js';
 import { memoryEntities, memoryEntityRelations, memoryItemEntities } from './schema.js';
 
@@ -122,9 +122,9 @@ export async function extractEntitiesWithLLM(
   text: string,
   entityConfig: MemoryEntityConfig,
 ): Promise<ExtractedEntityGraph> {
-  const provider = getAnthropicProvider();
+  const provider = getConfiguredProvider();
   if (!provider) {
-    log.debug('No Anthropic API key available for entity extraction');
+    log.debug('Configured provider unavailable for entity extraction');
     return { entities: [], relations: [] };
   }
 

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -4,7 +4,7 @@ import { getConfig } from '../config/loader.js';
 import type { MemoryExtractionConfig } from '../config/types.js';
 import { getLogger } from '../util/logger.js';
 import { truncate } from '../util/truncate.js';
-import { getAnthropicProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
+import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
 import { computeMemoryFingerprint } from './fingerprint.js';
 import { enqueueMemoryJob } from './jobs-store.js';
 import { extractTextFromStoredMessageContent } from './message-content.js';
@@ -114,9 +114,9 @@ async function extractItemsWithLLM(
   extractionConfig: MemoryExtractionConfig,
   scopeId: string,
 ): Promise<ExtractedItem[]> {
-  const provider = getAnthropicProvider();
+  const provider = getConfiguredProvider();
   if (!provider) {
-    log.debug('No Anthropic API key available for LLM extraction, falling back to pattern-based');
+    log.debug('Configured provider unavailable for LLM extraction, falling back to pattern-based');
     return extractItemsPatternBased(text, scopeId);
   }
 

--- a/assistant/src/memory/job-handlers/summarization.ts
+++ b/assistant/src/memory/job-handlers/summarization.ts
@@ -3,7 +3,7 @@ import { v4 as uuid } from 'uuid';
 import type { AssistantConfig } from '../../config/types.js';
 import { estimateTextTokens } from '../../context/token-estimator.js';
 import { getLogger } from '../../util/logger.js';
-import { getAnthropicProvider, createTimeout, extractText, userMessage } from '../../providers/anthropic-send-message.js';
+import { getConfiguredProvider, createTimeout, extractText, userMessage } from '../../providers/anthropic-send-message.js';
 import { getConversationMemoryScopeId } from '../conversation-store.js';
 import { getDb } from '../db.js';
 import { enqueueMemoryJob, type MemoryJob } from '../jobs-store.js';
@@ -230,9 +230,9 @@ async function summarizeWithLLM(
     return buildFallbackSummary(existingSummary, newContent, label);
   }
 
-  const provider = getAnthropicProvider();
+  const provider = getConfiguredProvider();
   if (!provider) {
-    log.debug({ label }, 'No Anthropic API key available for summarization, using fallback');
+    log.debug({ label }, 'Configured provider unavailable for summarization, using fallback');
     return buildFallbackSummary(existingSummary, newContent, label);
   }
 

--- a/assistant/src/memory/search/ranking.ts
+++ b/assistant/src/memory/search/ranking.ts
@@ -2,7 +2,7 @@ import { inArray, sql } from 'drizzle-orm';
 import type { AssistantConfig, MemoryRerankingConfig } from '../../config/types.js';
 import { estimateTextTokens } from '../../context/token-estimator.js';
 import { getLogger } from '../../util/logger.js';
-import { getAnthropicProvider, extractText, userMessage } from '../../providers/anthropic-send-message.js';
+import { getConfiguredProvider, extractText, userMessage } from '../../providers/anthropic-send-message.js';
 import { getDb } from '../db.js';
 import { memoryItems } from '../schema.js';
 import type { Candidate, CandidateSource, ItemMetadata } from './types.js';
@@ -295,9 +295,9 @@ export async function rerankWithLLM(
   candidates: Candidate[],
   rerankingConfig: MemoryRerankingConfig,
 ): Promise<Candidate[]> {
-  const provider = getAnthropicProvider();
+  const provider = getConfiguredProvider();
   if (!provider) {
-    log.debug('No Anthropic API key available for LLM re-ranking, skipping');
+    log.debug('Configured provider unavailable for LLM re-ranking, skipping');
     return candidates;
   }
 

--- a/assistant/src/messaging/thread-summarizer.ts
+++ b/assistant/src/messaging/thread-summarizer.ts
@@ -1,4 +1,4 @@
-import { getAnthropicProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
+import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
 import { getLogger } from '../util/logger.js';
 import { truncate } from '../util/truncate.js';
 import type { ThreadMessage, ThreadSummary } from './types.js';
@@ -188,9 +188,9 @@ async function summarizeWithLLM(
   messages: ThreadMessage[],
   maxTokens: number,
 ): Promise<ThreadSummary> {
-  const provider = getAnthropicProvider();
+  const provider = getConfiguredProvider();
   if (!provider) {
-    log.warn('No Anthropic API key available for thread summarization, returning basic summary');
+    log.warn('Configured provider unavailable for thread summarization, returning basic summary');
     return buildFallbackSummary(messages);
   }
 

--- a/assistant/src/messaging/triage-engine.ts
+++ b/assistant/src/messaging/triage-engine.ts
@@ -7,7 +7,7 @@
  * table for accuracy review.
  */
 
-import { getAnthropicProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
+import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
 import { truncate } from '../util/truncate.js';
 import { v4 as uuid } from 'uuid';
 import { and, eq, isNull, desc } from 'drizzle-orm';
@@ -188,9 +188,9 @@ export async function triageMessage(
   const playbookMatches = fetchMatchingPlaybooks(message.channel, scopeId);
 
   // Step 3: Classify with LLM
-  const provider = getAnthropicProvider();
+  const provider = getConfiguredProvider();
   if (!provider) {
-    log.warn('No Anthropic API key available for triage classification, returning fallback');
+    log.warn('Configured provider unavailable for triage classification, returning fallback');
     const result = buildFallbackResult();
     persistTriageResult(message, result, playbookMatches);
     return result;
@@ -216,7 +216,7 @@ async function classifyWithLLM(
   contact: ContactWithChannels | null,
   playbookMatches: PlaybookMatch[],
 ): Promise<TriageResult> {
-  const provider = getAnthropicProvider()!;
+  const provider = getConfiguredProvider()!;
   const { signal, cleanup } = createTimeout(TRIAGE_CLASSIFICATION_TIMEOUT_MS);
 
   const systemPrompt = buildSystemPrompt(contact, playbookMatches);

--- a/assistant/src/providers/anthropic-send-message.ts
+++ b/assistant/src/providers/anthropic-send-message.ts
@@ -1,36 +1,56 @@
 /**
- * Helper for callsites that need the Anthropic provider without direct SDK
- * coupling. Provides lazy Anthropic provider resolution, timeout utilities,
+ * Helper utilities for provider callsites that should stay decoupled from
+ * provider SDK details. Includes provider resolution, timeout utilities,
  * and response extraction helpers.
  */
 
 import type { Provider, ProviderResponse, Message, ContentBlock, ToolUseContent } from './types.js';
-import { getProvider, listProviders, initializeProviders } from './registry.js';
+import { getFailoverProvider, getProvider, listProviders, initializeProviders } from './registry.js';
 import { getConfig } from '../config/loader.js';
 
 /**
- * Lazily resolve the Anthropic provider from the registry.
+ * Resolve the configured provider through the registry/failover path.
  * If providers haven't been initialized yet (e.g. non-daemon code paths),
  * performs a one-shot `initializeProviders(getConfig())`.
  *
- * Returns `null` when no Anthropic API key is configured.
+ * Returns `null` when the configured provider is unavailable.
  */
-export function getAnthropicProvider(): Provider | null {
-  if (!listProviders().includes('anthropic')) {
-    const config = getConfig();
-    if (!config.apiKeys.anthropic && !process.env.ANTHROPIC_API_KEY) {
+export function getConfiguredProvider(): Provider | null {
+  const config = getConfig();
+
+  if (listProviders().length === 0) {
+    try {
+      initializeProviders(config);
+    } catch {
       return null;
     }
-    // Ensure the key is present in the config before initializing
-    const effectiveConfig = {
-      ...config,
-      apiKeys: {
-        ...config.apiKeys,
-        anthropic: config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY!,
-      },
-    };
-    initializeProviders(effectiveConfig);
   }
+
+  if (!listProviders().includes(config.provider)) {
+    return null;
+  }
+
+  try {
+    const providerOrder = Array.isArray(config.providerOrder) ? config.providerOrder : [];
+    return getFailoverProvider(config.provider, providerOrder);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Legacy Anthropic-only resolver kept for compatibility while callsites
+ * migrate to `getConfiguredProvider`.
+ */
+export function getAnthropicProvider(): Provider | null {
+  if (listProviders().length === 0) {
+    try {
+      initializeProviders(getConfig());
+    } catch {
+      return null;
+    }
+  }
+
   try {
     return getProvider('anthropic');
   } catch {


### PR DESCRIPTION
## Summary
- add `getConfiguredProvider()` to `anthropic-send-message.ts` to resolve providers through configured primary + failover path
- migrate daemon, messaging, memory, and skills callsites from `getAnthropicProvider()` to `getConfiguredProvider()`
- update media keyframe analysis provider bootstrap/error handling to be provider-agnostic
- update affected tests to mock the new provider resolver

## Validation
- `cd assistant && bunx tsc --noEmit`
- `cd assistant && bun test src/__tests__/clarification-resolver.test.ts src/__tests__/contradiction-checker.test.ts`
- `cd assistant && bun test src/__tests__/classifier.test.ts src/__tests__/skills.test.ts src/__tests__/entity-extractor.test.ts src/__tests__/hooks-watch.test.ts src/__tests__/no-direct-anthropic-sdk-imports.test.ts`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
