### PR TITLE
M1: Add Chat gallery category and scaffold ChatGallerySection

### DIFF
--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 enum GalleryCategory: String, CaseIterable, Identifiable {
     case buttons = "Buttons"
+    case chat = "Chat"
     case display = "Display"
     case feedback = "Feedback"
     case inputs = "Inputs"
@@ -16,6 +17,7 @@ enum GalleryCategory: String, CaseIterable, Identifiable {
     var icon: String {
         switch self {
         case .buttons: return "hand.tap"
+        case .chat: return "bubble.left.and.bubble.right"
         case .display: return "rectangle.on.rectangle"
         case .feedback: return "bell"
         case .inputs: return "character.cursor.ibeam"
@@ -46,6 +48,7 @@ struct ComponentGalleryView: View {
                     if let category = selectedCategory {
                         switch category {
                         case .buttons: ButtonsGallerySection()
+                        case .chat: ChatGallerySection()
                         case .display: DisplayGallerySection()
                         case .feedback: FeedbackGallerySection()
                         case .inputs: InputsGallerySection()

--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -1,0 +1,95 @@
+#if DEBUG
+import SwiftUI
+
+struct ChatGallerySection: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxl) {
+            // MARK: - Error Banners
+            GallerySectionHeader(
+                title: "Error Banners",
+                description: "ChatErrorBanner"
+            )
+            Text("Coming soon")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Skill Invocation
+            GallerySectionHeader(
+                title: "Skill Invocation",
+                description: "SkillInvocationChip"
+            )
+            Text("Coming soon")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Subagent Status
+            GallerySectionHeader(
+                title: "Subagent Status",
+                description: "SubagentStatusChip, SubagentThreadView"
+            )
+            Text("Coming soon")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Tool Chips
+            GallerySectionHeader(
+                title: "Tool Chips",
+                description: "ToolCallChip"
+            )
+            Text("Coming soon")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Step Indicators
+            GallerySectionHeader(
+                title: "Step Indicators",
+                description: "CurrentStepIndicator, ToolCallProgressBar"
+            )
+            Text("Coming soon")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Completion Lists
+            GallerySectionHeader(
+                title: "Completion Lists",
+                description: "UsedToolsListCompact"
+            )
+            Text("Coming soon")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Progress Indicators
+            GallerySectionHeader(
+                title: "Progress Indicators",
+                description: "LiveToolProgressView, TypingIndicatorView"
+            )
+            Text("Coming soon")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Tool Confirmations
+            GallerySectionHeader(
+                title: "Tool Confirmations",
+                description: "ToolConfirmationBubble"
+            )
+            Text("Coming soon")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add `chat` case to GalleryCategory enum with bubble icon
- Create ChatGallerySection.swift with placeholder subsections for all chat components
- Wire into ComponentGalleryView switch statement

Part of #7909
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
