### PR TITLE
M2: Fix ChatErrorBanner colors and add to gallery

### DIFF
--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -7,11 +7,34 @@ struct ChatGallerySection: View {
             // MARK: - Error Banners
             GallerySectionHeader(
                 title: "Error Banners",
-                description: "ChatErrorBanner"
+                description: "ChatErrorBanner — dismissible banner for non-retryable session errors."
             )
-            Text("Coming soon")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    Text("Without dismiss")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ChatErrorBanner(message: "Connection lost.")
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("Medium message")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ChatErrorBanner(message: "The AI provider returned an error. Please try again later.")
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("With dismiss action")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ChatErrorBanner(
+                        message: "Your session has expired. Please start a new conversation.",
+                        onDismiss: {}
+                    )
+                }
+            }
 
             Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
 

--- a/clients/shared/Features/Chat/ChatErrorBanner.swift
+++ b/clients/shared/Features/Chat/ChatErrorBanner.swift
@@ -13,22 +13,22 @@ public struct ChatErrorBanner: View {
     public var body: some View {
         HStack(spacing: 8) {
             Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.orange)
+                .foregroundStyle(VColor.warning)
             Text(message)
                 .font(.footnote)
-                .foregroundStyle(.primary)
+                .foregroundStyle(VColor.textPrimary)
             Spacer()
             if let onDismiss {
                 Button(action: onDismiss) {
                     Image(systemName: "xmark")
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(VColor.textSecondary)
                 }
                 .buttonStyle(.plain)
             }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .background(.quaternary, in: RoundedRectangle(cornerRadius: 8))
+        .background(VColor.surface, in: RoundedRectangle(cornerRadius: 8))
         .padding(.horizontal)
     }
 }


### PR DESCRIPTION
## Summary
- Replace system colors (.orange, .primary, .secondary, .quaternary) with VColor design tokens
- Add ChatErrorBanner examples to ChatGallerySection

Part of #7909
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
