### PR TITLE
M3: Fix SkillInvocationChip colors and add to gallery

### DIFF
--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -20,9 +20,26 @@ struct ChatGallerySection: View {
                 title: "Skill Invocation",
                 description: "SkillInvocationChip"
             )
-            Text("Coming soon")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    SkillInvocationChip(
+                        data: SkillInvocationData(
+                            name: "Summarize",
+                            emoji: "\u{1F4DD}",
+                            description: "Condense long text into key points and takeaways."
+                        )
+                    )
+
+                    SkillInvocationChip(
+                        data: SkillInvocationData(
+                            name: "Web Search",
+                            emoji: "\u{1F50D}",
+                            description: "Search the web for up-to-date information."
+                        )
+                    )
+                }
+            }
 
             Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
 

--- a/clients/shared/Features/Chat/SkillInvocationChip.swift
+++ b/clients/shared/Features/Chat/SkillInvocationChip.swift
@@ -31,11 +31,11 @@ public struct SkillInvocationChip: View {
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.md)
-        .background(Moss._700)
+        .background(adaptiveColor(light: Moss._100, dark: Moss._700))
         .clipShape(PixelBorderShape())
         .overlay(
             PixelBorderShape()
-                .stroke(Amber._600.opacity(0.6), lineWidth: 2)
+                .stroke(adaptiveColor(light: Amber._400, dark: Amber._600).opacity(0.6), lineWidth: 2)
         )
     }
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded Moss/Amber color scales with adaptiveColor pairs for light/dark theme support
- Add SkillInvocationChip examples to ChatGallerySection

Part of #7909
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
