### PR TITLE
M4: Persist Channel Context on User + Assistant Messages

### DIFF
--- a/assistant/src/calls/call-conversation-messages.ts
+++ b/assistant/src/calls/call-conversation-messages.ts
@@ -27,6 +27,7 @@ export function persistCallCompletionMessage(conversationId: string, callSession
     conversationId,
     'assistant',
     JSON.stringify([{ type: 'text', text: summaryText }]),
+    { userMessageChannel: 'voice', assistantMessageChannel: 'voice' },
   );
   return summaryText;
 }

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -474,6 +474,7 @@ export class CallOrchestrator {
             session.conversationId,
             'assistant',
             JSON.stringify([{ type: 'text', text: spokenText }]),
+            { userMessageChannel: 'voice', assistantMessageChannel: 'voice' },
           );
           fireCallTranscriptNotifier(session.conversationId, this.callSessionId, 'assistant', spokenText);
         }

--- a/assistant/src/calls/call-pointer-messages.ts
+++ b/assistant/src/calls/call-pointer-messages.ts
@@ -37,6 +37,7 @@ export function addPointerMessage(
     conversationId,
     'assistant',
     JSON.stringify([{ type: 'text', text }]),
+    { userMessageChannel: 'voice', assistantMessageChannel: 'voice' },
   );
 }
 

--- a/assistant/src/calls/guardian-action-sweep.ts
+++ b/assistant/src/calls/guardian-action-sweep.ts
@@ -59,6 +59,7 @@ export function sweepExpiredGuardianActions(
           delivery.destinationConversationId,
           'assistant',
           JSON.stringify([{ type: 'text', text: 'This guardian question has expired without a response.' }]),
+          { userMessageChannel: 'voice', assistantMessageChannel: 'macos' },
         );
       } else if (delivery.destinationChatId) {
         // External channel — send expiry notice

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -122,6 +122,7 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
           macConversationId,
           'assistant',
           JSON.stringify([{ type: 'text', text: `Your assistant needs your input during a phone call.\n\nQuestion: ${request.questionText}\n\nReply to this message with your answer.` }]),
+          { userMessageChannel: 'voice', assistantMessageChannel: 'macos' },
         );
 
         // Emit IPC event for the mac client with the server-created conversation

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -406,6 +406,7 @@ export class RelayConnection {
         session.initiatedFromConversationId,
         'assistant',
         JSON.stringify([{ type: 'text', text: codeMsg }]),
+        { userMessageChannel: 'voice', assistantMessageChannel: 'voice' },
       );
     }
 
@@ -462,6 +463,7 @@ export class RelayConnection {
         session.conversationId,
         'user',
         JSON.stringify([{ type: 'text', text: msg.voicePrompt }]),
+        { userMessageChannel: 'voice', assistantMessageChannel: 'voice' },
       );
       fireCallTranscriptNotifier(session.conversationId, this.callSessionId, 'caller', msg.voicePrompt);
     }

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -749,11 +749,16 @@ export class DaemonServer {
     const slashResult = resolveSlash(content);
 
     if (slashResult.kind === 'unknown') {
+      const serverTurnCtx = session.getTurnChannelContext();
+      const serverChannelMeta = serverTurnCtx
+        ? { userMessageChannel: serverTurnCtx.userMessageChannel, assistantMessageChannel: serverTurnCtx.assistantMessageChannel }
+        : undefined;
       const userMsg = createUserMessage(content, attachments);
       const persisted = conversationStore.addMessage(
         conversationId,
         'user',
         JSON.stringify(userMsg.content),
+        serverChannelMeta,
       );
       session.getMessages().push(userMsg);
 
@@ -762,6 +767,7 @@ export class DaemonServer {
         conversationId,
         'assistant',
         JSON.stringify(assistantMsg.content),
+        serverChannelMeta,
       );
       session.getMessages().push(assistantMsg);
       return { messageId: persisted.id };

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -8,6 +8,7 @@
 
 import type pino from 'pino';
 import type { ContentBlock, ImageContent } from '../providers/types.js';
+import type { TurnChannelContext } from '../channels/types.js';
 import type { ServerMessage } from './ipc-protocol.js';
 import type { AgentEvent } from '../agent/loop.js';
 import type { AgentLoopSessionContext } from './session-agent-loop.js';
@@ -308,10 +309,15 @@ export function handleMessageComplete(
     } as unknown as ContentBlock);
   }
 
+  const turnCtx: TurnChannelContext | null = deps.ctx.getTurnChannelContext();
+  const assistantChannelMetadata = turnCtx
+    ? { userMessageChannel: turnCtx.userMessageChannel, assistantMessageChannel: turnCtx.assistantMessageChannel }
+    : undefined;
   const assistantMsg = conversationStore.addMessage(
     deps.ctx.conversationId,
     'assistant',
     JSON.stringify(contentWithSurfaces),
+    assistantChannelMetadata,
   );
   state.lastAssistantMessageId = assistantMsg.id;
 

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -9,6 +9,7 @@
 
 import { v4 as uuid } from 'uuid';
 import type { Message, ContentBlock } from '../providers/types.js';
+import type { TurnChannelContext } from '../channels/types.js';
 import type { ServerMessage, UsageStats, SurfaceType, SurfaceData, DynamicPageSurfaceData } from './ipc-protocol.js';
 import type { AgentLoop, CheckpointDecision, AgentEvent } from '../agent/loop.js';
 import type { Provider } from '../providers/types.js';
@@ -126,6 +127,7 @@ export interface AgentLoopSessionContext {
   hasQueuedMessages(): boolean;
   canHandoffAtCheckpoint(): boolean;
   drainQueue(reason: QueueDrainReason): void;
+  getTurnChannelContext(): TurnChannelContext | null;
 }
 
 // ── runAgentLoop ─────────────────────────────────────────────────────
@@ -226,11 +228,16 @@ export async function runAgentLoopImpl(
     );
 
     if (memoryResult.conflictClarification) {
+      const loopTurnCtx = ctx.getTurnChannelContext();
+      const loopChannelMeta = loopTurnCtx
+        ? { userMessageChannel: loopTurnCtx.userMessageChannel, assistantMessageChannel: loopTurnCtx.assistantMessageChannel }
+        : undefined;
       const assistantMessage = createAssistantMessage(memoryResult.conflictClarification);
       conversationStore.addMessage(
         ctx.conversationId,
         'assistant',
         JSON.stringify(assistantMessage.content),
+        loopChannelMeta,
       );
       ctx.messages.push(assistantMessage);
       onEvent({
@@ -499,11 +506,16 @@ export async function runAgentLoopImpl(
 
     const hasAssistantResponse = newMessages.some((msg) => msg.role === 'assistant');
     if (!hasAssistantResponse && state.providerErrorUserMessage && !abortController.signal.aborted && !yieldedForHandoff) {
+      const errTurnCtx = ctx.getTurnChannelContext();
+      const errChannelMeta = errTurnCtx
+        ? { userMessageChannel: errTurnCtx.userMessageChannel, assistantMessageChannel: errTurnCtx.assistantMessageChannel }
+        : undefined;
       const errorAssistantMessage = createAssistantMessage(state.providerErrorUserMessage);
       conversationStore.addMessage(
         ctx.conversationId,
         'assistant',
         JSON.stringify(errorAssistantMessage.content),
+        errChannelMeta,
       );
       newMessages.push(errorAssistantMessage);
       onEvent({

--- a/assistant/src/daemon/session-messaging.ts
+++ b/assistant/src/daemon/session-messaging.ts
@@ -7,6 +7,7 @@
 
 import { v4 as uuid } from 'uuid';
 import type { Message } from '../providers/types.js';
+import type { TurnChannelContext } from '../channels/types.js';
 import type { ServerMessage, UserMessageAttachment } from './ipc-protocol.js';
 import { createUserMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
@@ -25,6 +26,7 @@ export interface MessagingSessionContext {
   abortController: AbortController | null;
   currentRequestId?: string;
   readonly queue: MessageQueue;
+  getTurnChannelContext(): TurnChannelContext | null;
 }
 
 // ── enqueueMessage ───────────────────────────────────────────────────
@@ -82,12 +84,22 @@ export function persistUserMessage(
   ctx.messages.push(userMessage);
 
   try {
+    const turnCtx = ctx.getTurnChannelContext();
+    const channelMetadata = turnCtx
+      ? { userMessageChannel: turnCtx.userMessageChannel, assistantMessageChannel: turnCtx.assistantMessageChannel }
+      : {};
+    const mergedMetadata = { ...metadata, ...channelMetadata };
+
     const persistedUserMessage = conversationStore.addMessage(
       ctx.conversationId,
       'user',
       JSON.stringify(userMessage.content),
-      metadata,
+      mergedMetadata,
     );
+
+    if (turnCtx) {
+      conversationStore.setConversationOriginChannelIfUnset(ctx.conversationId, turnCtx.userMessageChannel);
+    }
 
     if (!persistedUserMessage.id) {
       throw new Error('Failed to persist user message');

--- a/assistant/src/daemon/session-notifiers.ts
+++ b/assistant/src/daemon/session-notifiers.ts
@@ -102,6 +102,7 @@ export function registerSessionNotifiers(
       conversationId,
       'assistant',
       JSON.stringify([{ type: 'text', text: questionText }]),
+      { userMessageChannel: 'voice', assistantMessageChannel: 'voice' },
     );
 
     ctx.messages.push(createAssistantMessage(questionText));

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Message } from '../providers/types.js';
+import type { TurnChannelContext } from '../channels/types.js';
 import type { ServerMessage, UserMessageAttachment } from './ipc-protocol.js';
 import type { UsageStats } from './ipc-contract.js';
 import type { MessageQueue } from './session-queue-manager.js';
@@ -73,6 +74,7 @@ export interface ProcessSessionContext {
     onEvent: (msg: ServerMessage) => void,
     options?: { skipPreMessageRollback?: boolean },
   ): Promise<void>;
+  getTurnChannelContext(): TurnChannelContext | null;
 }
 
 /** Build a SlashContext from the current session state and config. */
@@ -125,11 +127,16 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
   // failed write never leaves an unpersisted message in memory.
   if (slashResult.kind === 'unknown') {
     try {
+      const drainTurnCtx = session.getTurnChannelContext();
+      const drainChannelMeta = drainTurnCtx
+        ? { userMessageChannel: drainTurnCtx.userMessageChannel, assistantMessageChannel: drainTurnCtx.assistantMessageChannel }
+        : undefined;
       const userMsg = createUserMessage(next.content, next.attachments);
       conversationStore.addMessage(
         session.conversationId,
         'user',
         JSON.stringify(userMsg.content),
+        drainChannelMeta,
       );
       session.messages.push(userMsg);
 
@@ -138,6 +145,7 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
         session.conversationId,
         'assistant',
         JSON.stringify(assistantMsg.content),
+        drainChannelMeta,
       );
       session.messages.push(assistantMsg);
 
@@ -236,11 +244,13 @@ export async function processMessage(
   if (guardianDelivery) {
     const guardianRequest = getGuardianActionRequest(guardianDelivery.requestId);
     if (guardianRequest && guardianRequest.status === 'pending') {
+      const guardianChannelMeta = { userMessageChannel: 'macos' as const, assistantMessageChannel: 'macos' as const };
       const userMsg = createUserMessage(content, attachments);
       const persisted = conversationStore.addMessage(
         session.conversationId,
         'user',
         JSON.stringify(userMsg.content),
+        guardianChannelMeta,
       );
       session.messages.push(userMsg);
 
@@ -251,7 +261,7 @@ export async function processMessage(
       const answerResult = await answerCall({ callSessionId: guardianRequest.callSessionId, answer: content });
 
       if ('ok' in answerResult && answerResult.ok) {
-        const resolved = resolveGuardianActionRequest(guardianRequest.id, content, 'mac');
+        const resolved = resolveGuardianActionRequest(guardianRequest.id, content, 'macos');
         const replyText = resolved
           ? 'Your answer has been relayed to the call.'
           : 'This question has already been answered from another channel.';
@@ -260,6 +270,7 @@ export async function processMessage(
           session.conversationId,
           'assistant',
           JSON.stringify(replyMsg.content),
+          guardianChannelMeta,
         );
         session.messages.push(replyMsg);
         onEvent({ type: 'assistant_text_delta', text: replyText });
@@ -271,6 +282,7 @@ export async function processMessage(
           session.conversationId,
           'assistant',
           JSON.stringify(failMsg.content),
+          guardianChannelMeta,
         );
         session.messages.push(failMsg);
         onEvent({ type: 'assistant_text_delta', text: 'Failed to deliver your answer to the call. Please try again.' });
@@ -287,11 +299,16 @@ export async function processMessage(
   // messageId is real.  Persist each message before pushing to session.messages
   // so that a failed write never leaves an unpersisted message in memory.
   if (slashResult.kind === 'unknown') {
+    const pmTurnCtx = session.getTurnChannelContext();
+    const pmChannelMeta = pmTurnCtx
+      ? { userMessageChannel: pmTurnCtx.userMessageChannel, assistantMessageChannel: pmTurnCtx.assistantMessageChannel }
+      : undefined;
     const userMsg = createUserMessage(content, attachments);
     const persisted = conversationStore.addMessage(
       session.conversationId,
       'user',
       JSON.stringify(userMsg.content),
+      pmChannelMeta,
     );
     session.messages.push(userMsg);
 
@@ -300,6 +317,7 @@ export async function processMessage(
       session.conversationId,
       'assistant',
       JSON.stringify(assistantMsg.content),
+      pmChannelMeta,
     );
     session.messages.push(assistantMsg);
 


### PR DESCRIPTION
Part of #7878. Writes userMessageChannel and assistantMessageChannel into per-message metadata on all user and assistant message persistence paths. Sets conversationOriginChannel on first user message. Includes voice and guardian dispatch paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
