### PR TITLE
M4: Fix SubagentStatusChip and SubagentThreadView colors and add to gallery

### DIFF
--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -31,9 +31,70 @@ struct ChatGallerySection: View {
                 title: "Subagent Status",
                 description: "SubagentStatusChip, SubagentThreadView"
             )
-            Text("Coming soon")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    Text("SubagentStatusChip")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textSecondary)
+
+                    SubagentStatusChip(
+                        subagent: SubagentInfo(id: "g-1", label: "Research Agent", status: .running)
+                    )
+
+                    SubagentStatusChip(
+                        subagent: SubagentInfo(id: "g-2", label: "Code Review Agent", status: .completed)
+                    )
+
+                    SubagentStatusChip(
+                        subagent: {
+                            var info = SubagentInfo(id: "g-3", label: "Deploy Agent", status: .failed)
+                            info.error = "Connection timed out"
+                            return info
+                        }()
+                    )
+
+                    SubagentStatusChip(
+                        subagent: SubagentInfo(id: "g-4", label: "Cleanup Agent", status: .aborted)
+                    )
+                }
+            }
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    Text("SubagentThreadView")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textSecondary)
+
+                    SubagentThreadView(
+                        subagent: SubagentInfo(id: "t-1", label: "Research Agent", status: .running),
+                        events: [
+                            SubagentEventItem(timestamp: Date(), kind: .toolUse(name: "web_search"), content: "SwiftUI adaptive colors"),
+                            SubagentEventItem(timestamp: Date(), kind: .text, content: "Found several relevant resources on adaptive color tokens.")
+                        ]
+                    )
+
+                    SubagentThreadView(
+                        subagent: SubagentInfo(id: "t-2", label: "Code Review Agent", status: .completed),
+                        events: [
+                            SubagentEventItem(timestamp: Date(), kind: .text, content: "All checks passed. No issues found."),
+                            SubagentEventItem(timestamp: Date(), kind: .text, content: "LGTM — ready to merge.")
+                        ]
+                    )
+
+                    SubagentThreadView(
+                        subagent: SubagentInfo(id: "t-3", label: "Deploy Agent", status: .failed),
+                        events: [
+                            SubagentEventItem(timestamp: Date(), kind: .error, content: "Connection timed out after 30s")
+                        ]
+                    )
+
+                    SubagentThreadView(
+                        subagent: SubagentInfo(id: "t-4", label: "Cleanup Agent", status: .aborted),
+                        events: []
+                    )
+                }
+            }
 
             Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
 

--- a/clients/shared/Features/Chat/SubagentStatusChip.swift
+++ b/clients/shared/Features/Chat/SubagentStatusChip.swift
@@ -10,9 +10,9 @@ public struct SubagentStatusChip: View {
 
     private var statusColor: Color {
         switch subagent.status {
-        case .completed: return Emerald._500
-        case .failed, .aborted: return Danger._500
-        default: return Forest._500
+        case .completed: return VColor.success
+        case .failed, .aborted: return VColor.error
+        default: return adaptiveColor(light: Forest._600, dark: Forest._400)
         }
     }
 
@@ -59,7 +59,7 @@ public struct SubagentStatusChip: View {
                 if let error = subagent.error, !error.isEmpty {
                     Text(error)
                         .font(VFont.caption)
-                        .foregroundColor(Danger._400)
+                        .foregroundColor(VColor.error)
                         .lineLimit(2)
                 }
             }

--- a/clients/shared/Features/Chat/SubagentThreadView.swift
+++ b/clients/shared/Features/Chat/SubagentThreadView.swift
@@ -22,9 +22,9 @@ public struct SubagentThreadView: View {
 
     private var statusColor: Color {
         switch subagent.status {
-        case .completed: return Emerald._500
-        case .failed, .aborted: return Danger._500
-        default: return Forest._500
+        case .completed: return VColor.success
+        case .failed, .aborted: return VColor.error
+        default: return adaptiveColor(light: Forest._600, dark: Forest._400)
         }
     }
 
@@ -101,7 +101,7 @@ public struct SubagentThreadView: View {
             // Label (clickable, turns blue on hover like Slack)
             Text(subagent.label)
                 .font(VFont.captionMedium)
-                .foregroundColor(isHovered ? Forest._400 : VColor.textPrimary)
+                .foregroundColor(isHovered ? VColor.iconAccent : VColor.textPrimary)
 
             // Status icon
             Image(systemName: statusIcon)
@@ -119,7 +119,7 @@ public struct SubagentThreadView: View {
             if replyCount > 0 {
                 Text("\(replyCount) repl\(replyCount == 1 ? "y" : "ies")")
                     .font(VFont.captionMedium)
-                    .foregroundColor(isHovered ? Forest._400 : Forest._500)
+                    .foregroundColor(isHovered ? VColor.iconAccent : adaptiveColor(light: Forest._600, dark: Forest._400))
             } else if isRunning {
                 Text("Working...")
                     .font(VFont.caption)
@@ -142,7 +142,7 @@ public struct SubagentThreadView: View {
             // View thread arrow
             Image(systemName: "chevron.right")
                 .font(.system(size: 9, weight: .semibold))
-                .foregroundColor(isHovered ? Forest._400 : VColor.textMuted)
+                .foregroundColor(isHovered ? VColor.iconAccent : VColor.textMuted)
         }
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.sm)


### PR DESCRIPTION
## Summary
- Replace hardcoded Emerald/Danger/Forest color scales with VColor semantic tokens
- Add SubagentStatusChip examples to ChatGallerySection showing all states

Part of #7909
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
