### PR TITLE
fix: remove incorrect originalUrl from status/connect-action docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3931,7 +3931,7 @@ sequenceDiagram
 
     TwilioAPI->>Gateway: POST /webhooks/twilio/status
     Gateway->>Gateway: validateTwilioWebhookRequest()
-    Gateway->>Routes: forward to runtime /v1/internal/twilio/status (+ params, originalUrl)
+    Gateway->>Routes: forward to runtime /v1/internal/twilio/status (+ params)
     Routes->>CallStore: updateCallSession(status)
 ```
 
@@ -4117,8 +4117,8 @@ Internet-facing Twilio callbacks terminate at the gateway, which validates signa
 | Gateway Route | Validates | Forwards To (Runtime) |
 |---------------|-----------|----------------------|
 | `POST /webhooks/twilio/voice` | HMAC-SHA1 signature, payload size | `POST /v1/internal/twilio/voice-webhook` (JSON: `{ params, originalUrl, assistantId? }`) |
-| `POST /webhooks/twilio/status` | HMAC-SHA1 signature, payload size | `POST /v1/internal/twilio/status` (JSON: `{ params, originalUrl }`) |
-| `POST /webhooks/twilio/connect-action` | HMAC-SHA1 signature, payload size | `POST /v1/internal/twilio/connect-action` (JSON: `{ params, originalUrl }`) |
+| `POST /webhooks/twilio/status` | HMAC-SHA1 signature, payload size | `POST /v1/internal/twilio/status` (JSON: `{ params }`) |
+| `POST /webhooks/twilio/connect-action` | HMAC-SHA1 signature, payload size | `POST /v1/internal/twilio/connect-action` (JSON: `{ params }`) |
 | `WS /webhooks/twilio/relay` | WebSocket upgrade | `WS /v1/calls/relay` (bidirectional proxy) |
 | `POST /webhooks/twilio/sms` | HMAC-SHA1 signature, payload size, MessageSid dedup | `POST /v1/channels/inbound` (normalized `GatewayInboundEventV1` with `sourceChannel: "sms"`) |
 
@@ -4151,8 +4151,8 @@ This makes ingress URL updates smoother in local tunnel workflows because Twilio
 | POST | `/v1/calls/:callSessionId/cancel` | Cancel an active call |
 | POST | `/v1/calls/:callSessionId/answer` | Answer a pending question via HTTP (alternative to in-thread bridge) |
 | POST | `/v1/calls/:callSessionId/instruction` | Relay a steering instruction to an active call's orchestrator (alternative to in-thread bridge) |
-| POST | `/v1/internal/twilio/status` | Internal status callback used by gateway; accepts JSON `{ params, originalUrl }` |
-| POST | `/v1/internal/twilio/connect-action` | Internal connect action callback used by gateway; accepts JSON `{ params, originalUrl }` |
+| POST | `/v1/internal/twilio/status` | Internal status callback used by gateway; accepts JSON `{ params }` |
+| POST | `/v1/internal/twilio/connect-action` | Internal connect action callback used by gateway; accepts JSON `{ params }` |
 | WS | `/v1/calls/relay` | ConversationRelay WebSocket (bidirectional: prompt/interrupt/dtmf from Twilio, text tokens/end to Twilio) |
 
 ### Tools


### PR DESCRIPTION
## Summary
- Remove incorrect originalUrl from status and connect-action endpoint docs in ARCHITECTURE.md
- Only voice-webhook sends originalUrl; status and connect-action send { params } only
- Fixes Mermaid diagram, gateway webhook ingress table, and runtime HTTP endpoints table

Addresses Devin feedback on #7899 (rebased after #7907 was closed due to merge conflict).

## Original prompt
Address feedback on PR #7899 about incorrect originalUrl references
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
