### PR TITLE
fix(macos): eagerly load available skills for accurate global search counts

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -77,6 +77,7 @@ struct AgentPanelContent: View {
         }
         .onAppear {
             skillsManager.fetchSkills()
+            skillsManager.searchSkills()
         }
         .onDisappear {
             installTimeoutTask?.cancel()


### PR DESCRIPTION
Address Codex+Devin feedback on PR #7877: call searchSkills() on panel appear so Available tab count is accurate from the start.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
