### PR TITLE
fix(macos): keep temp chat toggle visible on private threads

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -557,8 +557,9 @@ struct MainWindowView: View {
                                 toggleVoiceMode()
                             }
 
-                            // Temporary chat toggle — only visible on brand new threads with no messages
-                            if threadManager.activeViewModel?.messages.contains(where: {
+                            // Temporary chat toggle — always visible on private threads (so users can exit temp chat),
+                            // only visible on normal threads when no messages exist yet
+                            if threadManager.activeThread?.kind == .private || threadManager.activeViewModel?.messages.contains(where: {
                                 !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                             }) != true {
                                 TemporaryChatToggle(


### PR DESCRIPTION
Address Codex+Devin feedback on PR #7895: always show the TemporaryChatToggle on private/temporary threads so users can exit temp chat, while still hiding it on normal threads with messages.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
