### PR TITLE
M7: Fix ToolConfirmationBubble hardcoded colors and add to gallery

### DIFF
--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -185,11 +185,136 @@ struct ChatGallerySection: View {
             // MARK: - Tool Confirmations
             GallerySectionHeader(
                 title: "Tool Confirmations",
-                description: "ToolConfirmationBubble"
+                description: "ToolConfirmationBubble — inline permission prompts with risk badges and collapsed decided states."
             )
-            Text("Coming soon")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    Text("Collapsed — approved")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ToolConfirmationBubble(
+                        confirmation: ToolConfirmationData(
+                            requestId: "gallery-approved",
+                            toolName: "host_bash",
+                            input: ["command": AnyCodable("npm install")],
+                            riskLevel: "medium",
+                            state: .approved
+                        ),
+                        isKeyboardActive: false,
+                        onAllow: {},
+                        onDeny: {},
+                        onAlwaysAllow: { _, _, _, _ in }
+                    )
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("Collapsed — denied")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ToolConfirmationBubble(
+                        confirmation: ToolConfirmationData(
+                            requestId: "gallery-denied",
+                            toolName: "host_file_write",
+                            input: ["path": AnyCodable("/etc/hosts")],
+                            riskLevel: "high",
+                            state: .denied
+                        ),
+                        isKeyboardActive: false,
+                        onAllow: {},
+                        onDeny: {},
+                        onAlwaysAllow: { _, _, _, _ in }
+                    )
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("Collapsed — timed out")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ToolConfirmationBubble(
+                        confirmation: ToolConfirmationData(
+                            requestId: "gallery-timeout",
+                            toolName: "host_bash",
+                            input: ["command": AnyCodable("rm -rf /tmp/cache")],
+                            riskLevel: "medium",
+                            state: .timedOut
+                        ),
+                        isKeyboardActive: false,
+                        onAllow: {},
+                        onDeny: {},
+                        onAlwaysAllow: { _, _, _, _ in }
+                    )
+                }
+            }
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    Text("Pending — low risk")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ToolConfirmationBubble(
+                        confirmation: ToolConfirmationData(
+                            requestId: "gallery-low",
+                            toolName: "host_bash",
+                            input: ["command": AnyCodable("ls -la ~/Documents")],
+                            riskLevel: "low",
+                            executionTarget: "host"
+                        ),
+                        isKeyboardActive: false,
+                        onAllow: {},
+                        onDeny: {},
+                        onAlwaysAllow: { _, _, _, _ in }
+                    )
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("Pending — medium risk with always-allow")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ToolConfirmationBubble(
+                        confirmation: ToolConfirmationData(
+                            requestId: "gallery-medium",
+                            toolName: "host_bash",
+                            input: ["command": AnyCodable("npm install express")],
+                            riskLevel: "medium",
+                            allowlistOptions: [
+                                ConfirmationRequestMessage.ConfirmationAllowlistOption(
+                                    label: "exact", description: "This exact command", pattern: "npm install express"
+                                ),
+                            ],
+                            scopeOptions: [
+                                ConfirmationRequestMessage.ConfirmationScopeOption(
+                                    label: "This project", scope: "project"
+                                ),
+                            ],
+                            executionTarget: "host"
+                        ),
+                        isKeyboardActive: false,
+                        onAllow: {},
+                        onDeny: {},
+                        onAlwaysAllow: { _, _, _, _ in }
+                    )
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("Pending — high risk")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ToolConfirmationBubble(
+                        confirmation: ToolConfirmationData(
+                            requestId: "gallery-high",
+                            toolName: "host_file_write",
+                            input: ["path": AnyCodable("/Users/me/project/main.swift")],
+                            riskLevel: "high",
+                            executionTarget: "host"
+                        ),
+                        isKeyboardActive: false,
+                        onAllow: {},
+                        onDeny: {},
+                        onAlwaysAllow: { _, _, _, _ in }
+                    )
+                }
+            }
         }
     }
 }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -614,7 +614,7 @@ public struct ToolConfirmationBubble: View {
                 .foregroundColor(isPrimary || isDanger ? .white : VColor.textSecondary)
                 .padding(.horizontal, VSpacing.sm)
                 .padding(.vertical, VSpacing.xxs + 1)
-                .background(isDanger ? Color(hex: 0xC1421B) : isPrimary ? Forest._600 : Color.clear)
+                .background(isDanger ? VColor.error : isPrimary ? VColor.buttonPrimary : Color.clear)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.sm)


### PR DESCRIPTION
## Summary
- Replace Color(hex: 0xC1421B) with VColor.error
- Replace Forest._600 with VColor.buttonPrimary
- Audit and fix other non-semantic colors
- Add ToolConfirmationBubble examples to ChatGallerySection

Part of #7909
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7928" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
