### PR TITLE
fix(macos): auto-enable ingress when gateway URL is saved

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1091,8 +1091,13 @@ public final class SettingsStore: ObservableObject {
         let previousLastChecked = gatewayLastChecked
         ingressReachable = nil
         gatewayLastChecked = nil
+        // Auto-enable ingress when a non-empty URL is saved, auto-disable when cleared.
+        // The dedicated Public Ingress toggle was removed, so this is the only path
+        // that controls the enabled flag.
+        let shouldEnable = !trimmed.isEmpty
+        ingressEnabled = shouldEnable
         do {
-            try daemonClient?.send(IngressConfigRequestMessage(action: "set", publicBaseUrl: trimmed, enabled: ingressEnabled))
+            try daemonClient?.send(IngressConfigRequestMessage(action: "set", publicBaseUrl: trimmed, enabled: shouldEnable))
         } catch {
             // IPC send failed — roll back the optimistic update
             ingressPublicBaseUrl = previous


### PR DESCRIPTION
Address Codex feedback on PR #7889: automatically enable ingress when a gateway URL is saved, since removing the Public Ingress UI section left no way to toggle it on.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
