### PR TITLE
fix(macos): reactivate voice mode after inline key save and fix button disabled state

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -103,6 +103,12 @@ extension MainWindowView {
                 onClose: {
                     voiceModeManager.deactivate()
                     windowState.selection = nil
+                },
+                onKeySaved: {
+                    if let viewModel = threadManager.activeViewModel {
+                        voiceModeManager.activate(chatViewModel: viewModel, settingsStore: settingsStore)
+                        voiceModeManager.startListening()
+                    }
                 }
             )
         }

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModePanel.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModePanel.swift
@@ -6,6 +6,7 @@ struct VoiceModePanel: View {
     @ObservedObject var voiceService: OpenAIVoiceService
     @ObservedObject var settingsStore: SettingsStore
     let onClose: () -> Void
+    var onKeySaved: (() -> Void)?
 
     @State private var showingInfo = false
     @State private var spinAngle: Double = 0
@@ -101,13 +102,14 @@ struct VoiceModePanel: View {
                                 guard !openaiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
                                 settingsStore.saveOpenAIKey(openaiKeyText)
                                 openaiKeyText = ""
+                                onKeySaved?()
                             }
 
-                        VButton(label: "Save", style: .primary) {
+                        VButton(label: "Save", style: .primary, isDisabled: openaiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
                             settingsStore.saveOpenAIKey(openaiKeyText)
                             openaiKeyText = ""
+                            onKeySaved?()
                         }
-                        .disabled(openaiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                     }
                     .padding(.horizontal, VSpacing.xl)
                 }


### PR DESCRIPTION
Address Codex+Devin feedback on PR #7898: (1) call voiceModeManager.activate() after saving API key so voice mode works immediately, (2) use VButton's isDisabled parameter for proper visual disabled feedback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
