### PR TITLE
Componentize chat UI elements and add to gallery

### DIFF
--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 enum GalleryCategory: String, CaseIterable, Identifiable {
     case buttons = "Buttons"
+    case chat = "Chat"
     case display = "Display"
     case feedback = "Feedback"
     case inputs = "Inputs"
@@ -16,6 +17,7 @@ enum GalleryCategory: String, CaseIterable, Identifiable {
     var icon: String {
         switch self {
         case .buttons: return "hand.tap"
+        case .chat: return "bubble.left.and.bubble.right"
         case .display: return "rectangle.on.rectangle"
         case .feedback: return "bell"
         case .inputs: return "character.cursor.ibeam"
@@ -46,6 +48,7 @@ struct ComponentGalleryView: View {
                     if let category = selectedCategory {
                         switch category {
                         case .buttons: ButtonsGallerySection()
+                        case .chat: ChatGallerySection()
                         case .display: DisplayGallerySection()
                         case .feedback: FeedbackGallerySection()
                         case .inputs: InputsGallerySection()

--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -141,22 +141,173 @@ struct ChatGallerySection: View {
             // MARK: - Tool Chips
             GallerySectionHeader(
                 title: "Tool Chips",
-                description: "ToolCallChip"
+                description: "ToolCallChip — collapsed chips showing tool call status with expandable details."
             )
-            Text("Coming soon")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    Text("Completed (success)")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ToolCallChip(toolCall: ToolCallData(
+                        toolName: "bash",
+                        inputSummary: "ls -la /Users/test/project",
+                        result: "total 42\ndrwxr-xr-x  10 user  staff  320 Jan  1 12:00 .\ndrwxr-xr-x   5 user  staff  160 Jan  1 11:00 ..",
+                        isComplete: true
+                    ))
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("Completed (error)")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ToolCallChip(toolCall: ToolCallData(
+                        toolName: "bash",
+                        inputSummary: "rm -rf /important",
+                        result: "Permission denied",
+                        isError: true,
+                        isComplete: true
+                    ))
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("File edit (success)")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ToolCallChip(toolCall: ToolCallData(
+                        toolName: "file_edit",
+                        inputSummary: "/src/Config.swift",
+                        result: "File updated successfully.",
+                        isComplete: true
+                    ))
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("In progress")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ToolCallChip(toolCall: ToolCallData(
+                        toolName: "file_read",
+                        inputSummary: "/src/main.swift",
+                        isComplete: false
+                    ))
+                }
+            }
 
             Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
 
             // MARK: - Step Indicators
             GallerySectionHeader(
                 title: "Step Indicators",
-                description: "CurrentStepIndicator, ToolCallProgressBar"
+                description: "CurrentStepIndicator — shows current step with progress count. ToolCallProgressBar — horizontal progress bar with clickable steps."
             )
-            Text("Coming soon")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    Text("CurrentStepIndicator — in progress with multiple steps")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    CurrentStepIndicator(
+                        toolCalls: [
+                            ToolCallData(
+                                toolName: "Web Search",
+                                inputSummary: "flights from New York to London",
+                                isComplete: true
+                            ),
+                            ToolCallData(
+                                toolName: "Browser Navigate",
+                                inputSummary: "https://google.com/flights",
+                                isComplete: false
+                            ),
+                            ToolCallData(
+                                toolName: "Browser Click",
+                                inputSummary: "Departure field",
+                                isComplete: false
+                            )
+                        ],
+                        isStreaming: true,
+                        onTap: {}
+                    )
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("CurrentStepIndicator — completed")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    CurrentStepIndicator(
+                        toolCalls: [
+                            ToolCallData(
+                                toolName: "Web Search",
+                                inputSummary: "flights",
+                                isComplete: true
+                            ),
+                            ToolCallData(
+                                toolName: "Browser Navigate",
+                                inputSummary: "url",
+                                isComplete: true
+                            )
+                        ],
+                        isStreaming: false,
+                        onTap: {}
+                    )
+                }
+            }
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    Text("ToolCallProgressBar — multi-step with one in progress")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ToolCallProgressBar(toolCalls: [
+                        ToolCallData(
+                            toolName: "Web Search",
+                            inputSummary: "flights from New York to London",
+                            isComplete: true
+                        ),
+                        ToolCallData(
+                            toolName: "Browser Navigate",
+                            inputSummary: "https://www.google.com/travel/flights",
+                            result: "Navigated to Google Flights",
+                            isComplete: true
+                        ),
+                        ToolCallData(
+                            toolName: "Browser Screenshot",
+                            inputSummary: "",
+                            isComplete: true
+                        ),
+                        ToolCallData(
+                            toolName: "Browser Click",
+                            inputSummary: "[aria-label=\"Departure\"]",
+                            isComplete: false
+                        )
+                    ])
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("ToolCallProgressBar — completed with error")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ToolCallProgressBar(toolCalls: [
+                        ToolCallData(
+                            toolName: "Web Search",
+                            inputSummary: "flights NYC to London",
+                            isComplete: true
+                        ),
+                        ToolCallData(
+                            toolName: "Browser Navigate",
+                            inputSummary: "https://www.google.com/travel/flights",
+                            isComplete: true
+                        ),
+                        ToolCallData(
+                            toolName: "Browser Click",
+                            inputSummary: "invalid selector",
+                            result: "Element not found",
+                            isError: true,
+                            isComplete: true
+                        )
+                    ])
+                }
+            }
 
             Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
 

--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -314,22 +314,99 @@ struct ChatGallerySection: View {
             // MARK: - Completion Lists
             GallerySectionHeader(
                 title: "Completion Lists",
-                description: "UsedToolsListCompact"
+                description: "UsedToolsListCompact — collapsible pill summarising completed tool steps."
             )
-            Text("Coming soon")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    Text("Completed 3 steps (mix of success and error)")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+
+                    UsedToolsListCompact(toolCalls: [
+                        ToolCallData(
+                            toolName: "file_read",
+                            inputSummary: "Sources/App/main.swift",
+                            isError: false,
+                            isComplete: true,
+                            startedAt: Date().addingTimeInterval(-3.2),
+                            completedAt: Date()
+                        ),
+                        ToolCallData(
+                            toolName: "bash",
+                            inputSummary: "swift build",
+                            isError: true,
+                            isComplete: true,
+                            startedAt: Date().addingTimeInterval(-12.5),
+                            completedAt: Date()
+                        ),
+                        ToolCallData(
+                            toolName: "file_edit",
+                            inputSummary: "Package.swift",
+                            isError: false,
+                            isComplete: true,
+                            startedAt: Date().addingTimeInterval(-1.8),
+                            completedAt: Date()
+                        ),
+                    ])
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("Single step (shows action description instead of count)")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+
+                    UsedToolsListCompact(toolCalls: [
+                        ToolCallData(
+                            toolName: "web_search",
+                            inputSummary: "SwiftUI adaptive layout",
+                            isError: false,
+                            isComplete: true,
+                            startedAt: Date().addingTimeInterval(-2.0),
+                            completedAt: Date()
+                        ),
+                    ])
+                }
+            }
 
             Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
 
             // MARK: - Progress Indicators
             GallerySectionHeader(
                 title: "Progress Indicators",
-                description: "LiveToolProgressView, TypingIndicatorView"
+                description: "TypingIndicatorView, LiveToolProgressView, RunningIndicator"
             )
-            Text("Coming soon")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    Text("TypingIndicatorView — animated dots while assistant is thinking")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+
+                    HStack {
+                        TypingIndicatorView()
+                        Spacer()
+                    }
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("LiveToolProgressView — macOS only (clients/macos/)")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    Text("Shows live progress for running tool calls with a spinning indicator and step list. Not available in the shared gallery because it depends on macOS-only imports.")
+                        .font(VFont.small)
+                        .foregroundColor(VColor.textMuted)
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("RunningIndicator — macOS only (clients/macos/)")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    Text("Spinning arc indicator used alongside tool progress views. Not available in the shared gallery because it depends on macOS-only imports.")
+                        .font(VFont.small)
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
 
             Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
 

--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -71,9 +71,70 @@ struct ChatGallerySection: View {
                 title: "Subagent Status",
                 description: "SubagentStatusChip, SubagentThreadView"
             )
-            Text("Coming soon")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    Text("SubagentStatusChip")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textSecondary)
+
+                    SubagentStatusChip(
+                        subagent: SubagentInfo(id: "g-1", label: "Research Agent", status: .running)
+                    )
+
+                    SubagentStatusChip(
+                        subagent: SubagentInfo(id: "g-2", label: "Code Review Agent", status: .completed)
+                    )
+
+                    SubagentStatusChip(
+                        subagent: {
+                            var info = SubagentInfo(id: "g-3", label: "Deploy Agent", status: .failed)
+                            info.error = "Connection timed out"
+                            return info
+                        }()
+                    )
+
+                    SubagentStatusChip(
+                        subagent: SubagentInfo(id: "g-4", label: "Cleanup Agent", status: .aborted)
+                    )
+                }
+            }
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    Text("SubagentThreadView")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textSecondary)
+
+                    SubagentThreadView(
+                        subagent: SubagentInfo(id: "t-1", label: "Research Agent", status: .running),
+                        events: [
+                            SubagentEventItem(timestamp: Date(), kind: .toolUse(name: "web_search"), content: "SwiftUI adaptive colors"),
+                            SubagentEventItem(timestamp: Date(), kind: .text, content: "Found several relevant resources on adaptive color tokens.")
+                        ]
+                    )
+
+                    SubagentThreadView(
+                        subagent: SubagentInfo(id: "t-2", label: "Code Review Agent", status: .completed),
+                        events: [
+                            SubagentEventItem(timestamp: Date(), kind: .text, content: "All checks passed. No issues found."),
+                            SubagentEventItem(timestamp: Date(), kind: .text, content: "LGTM — ready to merge.")
+                        ]
+                    )
+
+                    SubagentThreadView(
+                        subagent: SubagentInfo(id: "t-3", label: "Deploy Agent", status: .failed),
+                        events: [
+                            SubagentEventItem(timestamp: Date(), kind: .error, content: "Connection timed out after 30s")
+                        ]
+                    )
+
+                    SubagentThreadView(
+                        subagent: SubagentInfo(id: "t-4", label: "Cleanup Agent", status: .aborted),
+                        events: []
+                    )
+                }
+            }
 
             Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
 

--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -413,11 +413,136 @@ struct ChatGallerySection: View {
             // MARK: - Tool Confirmations
             GallerySectionHeader(
                 title: "Tool Confirmations",
-                description: "ToolConfirmationBubble"
+                description: "ToolConfirmationBubble — inline permission prompts with risk badges and collapsed decided states."
             )
-            Text("Coming soon")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    Text("Collapsed — approved")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ToolConfirmationBubble(
+                        confirmation: ToolConfirmationData(
+                            requestId: "gallery-approved",
+                            toolName: "host_bash",
+                            input: ["command": AnyCodable("npm install")],
+                            riskLevel: "medium",
+                            state: .approved
+                        ),
+                        isKeyboardActive: false,
+                        onAllow: {},
+                        onDeny: {},
+                        onAlwaysAllow: { _, _, _, _ in }
+                    )
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("Collapsed — denied")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ToolConfirmationBubble(
+                        confirmation: ToolConfirmationData(
+                            requestId: "gallery-denied",
+                            toolName: "host_file_write",
+                            input: ["path": AnyCodable("/etc/hosts")],
+                            riskLevel: "high",
+                            state: .denied
+                        ),
+                        isKeyboardActive: false,
+                        onAllow: {},
+                        onDeny: {},
+                        onAlwaysAllow: { _, _, _, _ in }
+                    )
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("Collapsed — timed out")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ToolConfirmationBubble(
+                        confirmation: ToolConfirmationData(
+                            requestId: "gallery-timeout",
+                            toolName: "host_bash",
+                            input: ["command": AnyCodable("rm -rf /tmp/cache")],
+                            riskLevel: "medium",
+                            state: .timedOut
+                        ),
+                        isKeyboardActive: false,
+                        onAllow: {},
+                        onDeny: {},
+                        onAlwaysAllow: { _, _, _, _ in }
+                    )
+                }
+            }
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    Text("Pending — low risk")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ToolConfirmationBubble(
+                        confirmation: ToolConfirmationData(
+                            requestId: "gallery-low",
+                            toolName: "host_bash",
+                            input: ["command": AnyCodable("ls -la ~/Documents")],
+                            riskLevel: "low",
+                            executionTarget: "host"
+                        ),
+                        isKeyboardActive: false,
+                        onAllow: {},
+                        onDeny: {},
+                        onAlwaysAllow: { _, _, _, _ in }
+                    )
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("Pending — medium risk with always-allow")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ToolConfirmationBubble(
+                        confirmation: ToolConfirmationData(
+                            requestId: "gallery-medium",
+                            toolName: "host_bash",
+                            input: ["command": AnyCodable("npm install express")],
+                            riskLevel: "medium",
+                            allowlistOptions: [
+                                ConfirmationRequestMessage.ConfirmationAllowlistOption(
+                                    label: "exact", description: "This exact command", pattern: "npm install express"
+                                ),
+                            ],
+                            scopeOptions: [
+                                ConfirmationRequestMessage.ConfirmationScopeOption(
+                                    label: "This project", scope: "project"
+                                ),
+                            ],
+                            executionTarget: "host"
+                        ),
+                        isKeyboardActive: false,
+                        onAllow: {},
+                        onDeny: {},
+                        onAlwaysAllow: { _, _, _, _ in }
+                    )
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("Pending — high risk")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ToolConfirmationBubble(
+                        confirmation: ToolConfirmationData(
+                            requestId: "gallery-high",
+                            toolName: "host_file_write",
+                            input: ["path": AnyCodable("/Users/me/project/main.swift")],
+                            riskLevel: "high",
+                            executionTarget: "host"
+                        ),
+                        isKeyboardActive: false,
+                        onAllow: {},
+                        onDeny: {},
+                        onAlwaysAllow: { _, _, _, _ in }
+                    )
+                }
+            }
         }
     }
 }

--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -7,11 +7,34 @@ struct ChatGallerySection: View {
             // MARK: - Error Banners
             GallerySectionHeader(
                 title: "Error Banners",
-                description: "ChatErrorBanner"
+                description: "ChatErrorBanner — dismissible banner for non-retryable session errors."
             )
-            Text("Coming soon")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    Text("Without dismiss")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ChatErrorBanner(message: "Connection lost.")
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("Medium message")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ChatErrorBanner(message: "The AI provider returned an error. Please try again later.")
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("With dismiss action")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    ChatErrorBanner(
+                        message: "Your session has expired. Please start a new conversation.",
+                        onDismiss: {}
+                    )
+                }
+            }
 
             Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
 

--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -43,9 +43,26 @@ struct ChatGallerySection: View {
                 title: "Skill Invocation",
                 description: "SkillInvocationChip"
             )
-            Text("Coming soon")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    SkillInvocationChip(
+                        data: SkillInvocationData(
+                            name: "Summarize",
+                            emoji: "\u{1F4DD}",
+                            description: "Condense long text into key points and takeaways."
+                        )
+                    )
+
+                    SkillInvocationChip(
+                        data: SkillInvocationData(
+                            name: "Web Search",
+                            emoji: "\u{1F50D}",
+                            description: "Search the web for up-to-date information."
+                        )
+                    )
+                }
+            }
 
             Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
 

--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -1,0 +1,95 @@
+#if DEBUG
+import SwiftUI
+
+struct ChatGallerySection: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxl) {
+            // MARK: - Error Banners
+            GallerySectionHeader(
+                title: "Error Banners",
+                description: "ChatErrorBanner"
+            )
+            Text("Coming soon")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Skill Invocation
+            GallerySectionHeader(
+                title: "Skill Invocation",
+                description: "SkillInvocationChip"
+            )
+            Text("Coming soon")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Subagent Status
+            GallerySectionHeader(
+                title: "Subagent Status",
+                description: "SubagentStatusChip, SubagentThreadView"
+            )
+            Text("Coming soon")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Tool Chips
+            GallerySectionHeader(
+                title: "Tool Chips",
+                description: "ToolCallChip"
+            )
+            Text("Coming soon")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Step Indicators
+            GallerySectionHeader(
+                title: "Step Indicators",
+                description: "CurrentStepIndicator, ToolCallProgressBar"
+            )
+            Text("Coming soon")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Completion Lists
+            GallerySectionHeader(
+                title: "Completion Lists",
+                description: "UsedToolsListCompact"
+            )
+            Text("Coming soon")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Progress Indicators
+            GallerySectionHeader(
+                title: "Progress Indicators",
+                description: "LiveToolProgressView, TypingIndicatorView"
+            )
+            Text("Coming soon")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Tool Confirmations
+            GallerySectionHeader(
+                title: "Tool Confirmations",
+                description: "ToolConfirmationBubble"
+            )
+            Text("Coming soon")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+        }
+    }
+}
+#endif

--- a/clients/shared/Features/Chat/ChatErrorBanner.swift
+++ b/clients/shared/Features/Chat/ChatErrorBanner.swift
@@ -13,22 +13,22 @@ public struct ChatErrorBanner: View {
     public var body: some View {
         HStack(spacing: 8) {
             Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.orange)
+                .foregroundStyle(VColor.warning)
             Text(message)
                 .font(.footnote)
-                .foregroundStyle(.primary)
+                .foregroundStyle(VColor.textPrimary)
             Spacer()
             if let onDismiss {
                 Button(action: onDismiss) {
                     Image(systemName: "xmark")
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(VColor.textSecondary)
                 }
                 .buttonStyle(.plain)
             }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .background(.quaternary, in: RoundedRectangle(cornerRadius: 8))
+        .background(VColor.surface, in: RoundedRectangle(cornerRadius: 8))
         .padding(.horizontal)
     }
 }

--- a/clients/shared/Features/Chat/SkillInvocationChip.swift
+++ b/clients/shared/Features/Chat/SkillInvocationChip.swift
@@ -31,11 +31,11 @@ public struct SkillInvocationChip: View {
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.md)
-        .background(Moss._700)
+        .background(adaptiveColor(light: Moss._100, dark: Moss._700))
         .clipShape(PixelBorderShape())
         .overlay(
             PixelBorderShape()
-                .stroke(Amber._600.opacity(0.6), lineWidth: 2)
+                .stroke(adaptiveColor(light: Amber._400, dark: Amber._600).opacity(0.6), lineWidth: 2)
         )
     }
 }

--- a/clients/shared/Features/Chat/SubagentStatusChip.swift
+++ b/clients/shared/Features/Chat/SubagentStatusChip.swift
@@ -10,9 +10,9 @@ public struct SubagentStatusChip: View {
 
     private var statusColor: Color {
         switch subagent.status {
-        case .completed: return Emerald._500
-        case .failed, .aborted: return Danger._500
-        default: return Forest._500
+        case .completed: return VColor.success
+        case .failed, .aborted: return VColor.error
+        default: return adaptiveColor(light: Forest._600, dark: Forest._400)
         }
     }
 
@@ -59,7 +59,7 @@ public struct SubagentStatusChip: View {
                 if let error = subagent.error, !error.isEmpty {
                     Text(error)
                         .font(VFont.caption)
-                        .foregroundColor(Danger._400)
+                        .foregroundColor(VColor.error)
                         .lineLimit(2)
                 }
             }

--- a/clients/shared/Features/Chat/SubagentThreadView.swift
+++ b/clients/shared/Features/Chat/SubagentThreadView.swift
@@ -22,9 +22,9 @@ public struct SubagentThreadView: View {
 
     private var statusColor: Color {
         switch subagent.status {
-        case .completed: return Emerald._500
-        case .failed, .aborted: return Danger._500
-        default: return Forest._500
+        case .completed: return VColor.success
+        case .failed, .aborted: return VColor.error
+        default: return adaptiveColor(light: Forest._600, dark: Forest._400)
         }
     }
 
@@ -101,7 +101,7 @@ public struct SubagentThreadView: View {
             // Label (clickable, turns blue on hover like Slack)
             Text(subagent.label)
                 .font(VFont.captionMedium)
-                .foregroundColor(isHovered ? Forest._400 : VColor.textPrimary)
+                .foregroundColor(isHovered ? VColor.iconAccent : VColor.textPrimary)
 
             // Status icon
             Image(systemName: statusIcon)
@@ -119,7 +119,7 @@ public struct SubagentThreadView: View {
             if replyCount > 0 {
                 Text("\(replyCount) repl\(replyCount == 1 ? "y" : "ies")")
                     .font(VFont.captionMedium)
-                    .foregroundColor(isHovered ? Forest._400 : Forest._500)
+                    .foregroundColor(isHovered ? VColor.iconAccent : adaptiveColor(light: Forest._600, dark: Forest._400))
             } else if isRunning {
                 Text("Working...")
                     .font(VFont.caption)
@@ -142,7 +142,7 @@ public struct SubagentThreadView: View {
             // View thread arrow
             Image(systemName: "chevron.right")
                 .font(.system(size: 9, weight: .semibold))
-                .foregroundColor(isHovered ? Forest._400 : VColor.textMuted)
+                .foregroundColor(isHovered ? VColor.iconAccent : VColor.textMuted)
         }
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.sm)

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -614,7 +614,7 @@ public struct ToolConfirmationBubble: View {
                 .foregroundColor(isPrimary || isDanger ? .white : VColor.textSecondary)
                 .padding(.horizontal, VSpacing.sm)
                 .padding(.vertical, VSpacing.xxs + 1)
-                .background(isDanger ? Color(hex: 0xC1421B) : isPrimary ? Forest._600 : Color.clear)
+                .background(isDanger ? VColor.error : isPrimary ? VColor.buttonPrimary : Color.clear)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.sm)


### PR DESCRIPTION
## Summary
Componentize all agent-facing chat UI elements, fix hardcoded colors to use design tokens with proper light/dark theme support, and add a new "Chat" gallery section to visually catalogue every chat component.

## Changes
- Add "Chat" category to component gallery with 8 subsections
- Fix ChatErrorBanner: replace system colors (.orange, .primary, .quaternary) with VColor tokens
- Fix SkillInvocationChip: replace hardcoded Moss/Amber scales with adaptiveColor pairs
- Fix SubagentStatusChip & SubagentThreadView: replace Emerald/Danger/Forest scales with VColor semantic tokens
- Fix ToolConfirmationBubble: replace Color(hex: 0xC1421B) and Forest._600 with VColor.error and VColor.buttonPrimary
- Add gallery entries for ToolCallChip, CurrentStepIndicator, ToolCallProgressBar (all states)
- Add gallery entries for UsedToolsListCompact, TypingIndicatorView
- Add gallery entries for ToolConfirmationBubble (pending, approved, denied, timed-out states with risk badges)

## Milestone PRs (merged into feature branch)
- #7918: M1 — Add Chat gallery category and scaffold ChatGallerySection
- #7919: M2 — Fix ChatErrorBanner colors and add to gallery
- #7920: M3 — Fix SkillInvocationChip colors and add to gallery
- #7922: M4 — Fix SubagentStatusChip and SubagentThreadView colors and add to gallery
- #7925: M5 — Add ToolCallChip, CurrentStepIndicator, and ToolCallProgressBar to gallery
- #7926: M6 — Add UsedToolsList, TypingIndicator to gallery
- #7928: M7 — Fix ToolConfirmationBubble hardcoded colors and add to gallery

## Project issue
Closes #7909

## Test plan
- [ ] Open component gallery (Settings > Gallery), navigate to "Chat" category
- [ ] Verify all 8 subsections render without crashes
- [ ] Toggle between light and dark mode — confirm all components adapt correctly
- [ ] Verify ChatErrorBanner, SkillInvocationChip, SubagentStatusChip use theme-appropriate colors in both modes
- [ ] Verify ToolConfirmationBubble danger button uses VColor.error (not hardcoded hex)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7933" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
