### PR TITLE
fix: preserve cross-provider failover when deriving default call model

### DIFF
--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -878,11 +878,12 @@ describe('call-orchestrator', () => {
 
   // ── Model override from config ──────────────────────────────────────
 
-  test('uses default model when calls.model is not set', async () => {
+  test('does not override model when calls.model is not set (preserves cross-provider failover)', async () => {
     mockCallModel = undefined;
-    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { config?: { model: string }; onEvent?: (event: { type: string; text?: string }) => void }) => {
-      // Default model is derived from the active provider (anthropic → claude-opus-4-6)
-      expect(options?.config?.model).toBe('claude-opus-4-6');
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { config?: { model?: string }; onEvent?: (event: { type: string; text?: string }) => void }) => {
+      // When calls.model is unset, no model override should be passed so each
+      // provider in the failover chain uses its own default model.
+      expect(options?.config?.model).toBeUndefined();
       const tokens = ['Default model response.'];
       for (const token of tokens) {
         options?.onEvent?.({ type: 'text_delta', text: token });
@@ -921,11 +922,11 @@ describe('call-orchestrator', () => {
     orchestrator.destroy();
   });
 
-  test('treats empty string calls.model as unset and falls back to default', async () => {
+  test('treats empty string calls.model as unset and omits model override', async () => {
     mockCallModel = '';
-    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { config?: { model: string }; onEvent?: (event: { type: string; text?: string }) => void }) => {
-      // Empty string falls back to provider default (anthropic → claude-opus-4-6)
-      expect(options?.config?.model).toBe('claude-opus-4-6');
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { config?: { model?: string }; onEvent?: (event: { type: string; text?: string }) => void }) => {
+      // Empty string is treated as unset — no model override
+      expect(options?.config?.model).toBeUndefined();
       const tokens = ['Fallback model response.'];
       for (const token of tokens) {
         options?.onEvent?.({ type: 'text_delta', text: token });
@@ -943,11 +944,11 @@ describe('call-orchestrator', () => {
     orchestrator.destroy();
   });
 
-  test('treats whitespace-only calls.model as unset and falls back to default', async () => {
+  test('treats whitespace-only calls.model as unset and omits model override', async () => {
     mockCallModel = '   ';
-    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { config?: { model: string }; onEvent?: (event: { type: string; text?: string }) => void }) => {
-      // Whitespace-only falls back to provider default (anthropic → claude-opus-4-6)
-      expect(options?.config?.model).toBe('claude-opus-4-6');
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { config?: { model?: string }; onEvent?: (event: { type: string; text?: string }) => void }) => {
+      // Whitespace-only is treated as unset — no model override
+      expect(options?.config?.model).toBeUndefined();
       const tokens = ['Fallback model response.'];
       for (const token of tokens) {
         options?.onEvent?.({ type: 'text_delta', text: token });

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -7,7 +7,7 @@
  */
 
 import { getConfig } from '../config/loader.js';
-import { getDefaultModel, getFailoverProvider, listProviders } from '../providers/registry.js';
+import { getFailoverProvider, listProviders } from '../providers/registry.js';
 import type { ProviderEvent } from '../providers/types.js';
 import { resolveUserReference } from '../config/user-reference.js';
 import { getLogger } from '../util/logger.js';
@@ -356,7 +356,12 @@ export class CallOrchestrator {
     try {
       this.state = 'speaking';
 
-      const callModel = config.calls.model?.trim() || getDefaultModel(providerName);
+      // Only override the model when the user has explicitly configured one.
+      // When unset, each provider in the failover chain uses its own default
+      // model (set at initialization). Forwarding the primary provider's
+      // default to fallback providers would cause cross-provider 4xx errors
+      // (e.g., sending "gpt-5.2" to Anthropic).
+      const callModel = config.calls.model?.trim() || undefined;
 
       // Buffer incoming tokens so we can strip control markers ([ASK_GUARDIAN:...], [END_CALL])
       // before they reach TTS. We hold text whenever an unmatched '[' appears, since it
@@ -431,7 +436,7 @@ export class CallOrchestrator {
         this.buildSystemPrompt(),
         {
           config: {
-            model: callModel,
+            ...(callModel ? { model: callModel } : {}),
             max_tokens: 512,
           },
           onEvent: (event: ProviderEvent) => {


### PR DESCRIPTION
Address Codex feedback on PR #7616: when calls.model is unset, only apply the primary provider's default model to the primary provider, not to failover providers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7934" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
