### PR TITLE
fix(ios): await async attachment processing in image data test

### DIFF
--- a/clients/ios/Tests/AttachmentFlowIOSTests.swift
+++ b/clients/ios/Tests/AttachmentFlowIOSTests.swift
@@ -168,7 +168,14 @@ final class AttachmentFlowIOSTests: XCTestCase {
 
         viewModel.addAttachment(imageData: pngData, filename: "Screenshot.png")
 
-        XCTAssertEqual(viewModel.pendingAttachments.count, 1)
+        // addAttachment(imageData:) processes the image asynchronously via Task,
+        // so wait for the attachment to appear.
+        let appeared = XCTNSPredicateExpectation(
+            predicate: NSPredicate { _, _ in self.viewModel.pendingAttachments.count == 1 },
+            object: nil
+        )
+        wait(for: [appeared], timeout: 5)
+
         XCTAssertEqual(viewModel.pendingAttachments[0].filename, "Screenshot.png")
         XCTAssertEqual(viewModel.pendingAttachments[0].mimeType, "image/png")
     }


### PR DESCRIPTION
## Summary
- `testAddAttachmentFromImageData` was asserting synchronously on `pendingAttachments.count` immediately after calling `addAttachment(imageData:)`, which processes the image asynchronously via `Task`
- Added `XCTNSPredicateExpectation` to wait for the attachment to appear before asserting

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22357244556

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
