### PR TITLE
feat(cli): detect orphaned processes in `vellum ps`

### DIFF
--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -245,6 +245,57 @@ async function showAssistantProcesses(entry: AssistantEntry): Promise<void> {
   printTable(rows);
 }
 
+// ── Orphaned process detection ──────────────────────────────────
+
+interface OrphanedProcess {
+  name: string;
+  pid: string;
+  source: string;
+}
+
+async function detectOrphanedProcesses(): Promise<OrphanedProcess[]> {
+  const results: OrphanedProcess[] = [];
+  const seenPids = new Set<string>();
+  const vellumDir = join(homedir(), ".vellum");
+
+  // Strategy 1: PID file scan
+  const pidFiles: Array<{ file: string; name: string }> = [
+    { file: join(vellumDir, "vellum.pid"), name: "daemon" },
+    { file: join(vellumDir, "gateway.pid"), name: "gateway" },
+    { file: join(vellumDir, "qdrant.pid"), name: "qdrant" },
+  ];
+
+  for (const { file, name } of pidFiles) {
+    const result = checkPidFile(file);
+    if (result.status === "running" && result.pid) {
+      results.push({ name, pid: result.pid, source: "pid file" });
+      seenPids.add(result.pid);
+    }
+  }
+
+  // Strategy 2: Process table scan
+  try {
+    const output = await execOutput("sh", [
+      "-c",
+      "ps ax -o pid=,ppid=,args= | grep -E 'vellum|gateway|qdrant|openclaw' | grep -v grep",
+    ]);
+    const procs = parseRemotePs(output);
+    const ownPid = String(process.pid);
+
+    for (const p of procs) {
+      if (p.pid === ownPid || seenPids.has(p.pid)) continue;
+      const type = classifyProcess(p.command);
+      if (type === "unknown") continue;
+      results.push({ name: type, pid: p.pid, source: "process table" });
+      seenPids.add(p.pid);
+    }
+  } catch {
+    // grep exits 1 when no matches found — ignore
+  }
+
+  return results;
+}
+
 // ── List all assistants (no arg) ────────────────────────────────
 
 async function listAllAssistants(): Promise<void> {
@@ -252,6 +303,20 @@ async function listAllAssistants(): Promise<void> {
 
   if (assistants.length === 0) {
     console.log("No assistants found.");
+
+    const orphans = await detectOrphanedProcesses();
+    if (orphans.length > 0) {
+      console.log("\nOrphaned processes detected:\n");
+      const rows: TableRow[] = orphans.map((o) => ({
+        name: o.name,
+        status: withStatusEmoji("running"),
+        info: `PID ${o.pid} (from ${o.source})`,
+      }));
+      printTable(rows);
+      const pids = orphans.map((o) => o.pid).join(" ");
+      console.log(`\nHint: Run \`kill ${pids}\` to clean up orphaned processes.`);
+    }
+
     return;
   }
 


### PR DESCRIPTION
## Summary
- When `vellum ps` finds no assistants in the lockfile, it now scans for orphaned daemon, gateway, and qdrant processes that may still be running (from a crashed retire, manual lockfile edit, or killed CLI)
- Uses two detection strategies: PID file scan (`~/.vellum/*.pid`) and process table scan (`ps ax | grep`), deduplicated via a `seenPids` set
- If orphans are found, prints them in a table with a `kill <pids>` hint; if none found, output is unchanged

## Test plan
- [ ] `vellum ps` with no assistants and no orphans → "No assistants found." (unchanged)
- [ ] Manually start a daemon, remove the lockfile entry, `vellum ps` → shows orphaned daemon with PID
- [ ] `tsc --noEmit` in `cli/` → no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
