### PR TITLE
M5: Inject Channel Context Into Every LLM Turn

### DIFF
--- a/assistant/src/__tests__/run-orchestrator.test.ts
+++ b/assistant/src/__tests__/run-orchestrator.test.ts
@@ -52,6 +52,7 @@ function makeSessionWithConfirmation(message: ServerMessage): Session {
     setAssistantId: () => {},
     setGuardianContext: () => {},
     setCommandIntent: () => {},
+    setTurnChannelContext: () => {},
     updateClient: (handler: (msg: ServerMessage) => void) => {
       clientHandler = handler;
     },
@@ -76,6 +77,7 @@ function makeSessionWithEvent(message: ServerMessage): Session {
     setAssistantId: () => {},
     setGuardianContext: () => {},
     setCommandIntent: () => {},
+    setTurnChannelContext: () => {},
     updateClient: () => {},
     runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
       onEvent(message);
@@ -243,6 +245,7 @@ describe('startRun channel capability resolution', () => {
       setAssistantId: () => {},
       setGuardianContext: () => {},
     setCommandIntent: () => {},
+    setTurnChannelContext: () => {},
       updateClient: () => {},
       runAgentLoop: async () => {},
       handleConfirmationResponse: () => {},
@@ -266,7 +269,7 @@ describe('startRun channel capability resolution', () => {
     expect(capturedCapabilities!.dashboardCapable).toBe(false);
   });
 
-  test('defaults to http-api when no sourceChannel is provided', async () => {
+  test('defaults to macos (from http-api fallback) when no sourceChannel is provided', async () => {
     const conversation = createConversation('http-api default test');
     let capturedCapabilities: ChannelCapabilities | null = null;
 
@@ -280,6 +283,7 @@ describe('startRun channel capability resolution', () => {
       setAssistantId: () => {},
       setGuardianContext: () => {},
     setCommandIntent: () => {},
+    setTurnChannelContext: () => {},
       updateClient: () => {},
       runAgentLoop: async () => {},
       handleConfirmationResponse: () => {},
@@ -296,10 +300,10 @@ describe('startRun channel capability resolution', () => {
     await new Promise((r) => setTimeout(r, 50));
 
     expect(capturedCapabilities).not.toBeNull();
-    expect(capturedCapabilities!.channel).toBe('http-api');
+    expect(capturedCapabilities!.channel).toBe('macos');
   });
 
-  test('defaults to http-api when options are provided without sourceChannel', async () => {
+  test('defaults to macos (from http-api fallback) when options are provided without sourceChannel', async () => {
     const conversation = createConversation('options no channel test');
     let capturedCapabilities: ChannelCapabilities | null = null;
 
@@ -313,6 +317,7 @@ describe('startRun channel capability resolution', () => {
       setAssistantId: () => {},
       setGuardianContext: () => {},
     setCommandIntent: () => {},
+    setTurnChannelContext: () => {},
       updateClient: () => {},
       runAgentLoop: async () => {},
       handleConfirmationResponse: () => {},
@@ -331,7 +336,7 @@ describe('startRun channel capability resolution', () => {
     await new Promise((r) => setTimeout(r, 50));
 
     expect(capturedCapabilities).not.toBeNull();
-    expect(capturedCapabilities!.channel).toBe('http-api');
+    expect(capturedCapabilities!.channel).toBe('macos');
   });
 });
 
@@ -359,6 +364,7 @@ describe('strictSideEffects re-derivation across runs', () => {
       setAssistantId: () => {},
       setGuardianContext: () => {},
     setCommandIntent: () => {},
+    setTurnChannelContext: () => {},
       updateClient: () => {},
       runAgentLoop: async () => {},
       handleConfirmationResponse: () => {},
@@ -396,6 +402,7 @@ describe('strictSideEffects re-derivation across runs', () => {
       setAssistantId: () => {},
       setGuardianContext: () => {},
     setCommandIntent: () => {},
+    setTurnChannelContext: () => {},
       updateClient: () => {},
       runAgentLoop: async () => {},
       handleConfirmationResponse: () => {},
@@ -434,6 +441,7 @@ describe('strictSideEffects re-derivation across runs', () => {
       setAssistantId: () => {},
       setGuardianContext: () => {},
     setCommandIntent: () => {},
+    setTurnChannelContext: () => {},
       updateClient: () => {},
       runAgentLoop: async () => {},
       handleConfirmationResponse: () => {},

--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -2,15 +2,18 @@ import { describe, test, expect } from 'bun:test';
 import type { Message } from '../providers/types.js';
 import {
   applyRuntimeInjections,
+  buildChannelTurnContextBlock,
   injectChannelCapabilityContext,
+  injectChannelTurnContext,
   injectGuardianContext,
   injectTemporalContext,
   resolveChannelCapabilities,
   stripChannelCapabilityContext,
+  stripChannelTurnContext,
   stripGuardianContext,
   stripTemporalContext,
 } from '../daemon/session-runtime-assembly.js';
-import type { ChannelCapabilities, GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
+import type { ChannelCapabilities, ChannelTurnContextParams, GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
 import { buildChannelAwarenessSection } from '../config/system-prompt.js';
 
 // ---------------------------------------------------------------------------
@@ -18,26 +21,40 @@ import { buildChannelAwarenessSection } from '../config/system-prompt.js';
 // ---------------------------------------------------------------------------
 
 describe('resolveChannelCapabilities', () => {
-  test('defaults to dashboard when no source channel is provided', () => {
+  test('defaults to macos when no source channel is provided', () => {
     const caps = resolveChannelCapabilities();
-    expect(caps.channel).toBe('dashboard');
+    expect(caps.channel).toBe('macos');
     expect(caps.dashboardCapable).toBe(true);
     expect(caps.supportsDynamicUi).toBe(true);
     expect(caps.supportsVoiceInput).toBe(true);
   });
 
-  test('defaults to dashboard for null source channel', () => {
+  test('defaults to macos for null source channel', () => {
     const caps = resolveChannelCapabilities(null);
-    expect(caps.channel).toBe('dashboard');
+    expect(caps.channel).toBe('macos');
     expect(caps.dashboardCapable).toBe(true);
   });
 
-  test('resolves "dashboard" as dashboard-capable', () => {
+  test('normalises "dashboard" to "macos"', () => {
     const caps = resolveChannelCapabilities('dashboard');
-    expect(caps.channel).toBe('dashboard');
+    expect(caps.channel).toBe('macos');
     expect(caps.dashboardCapable).toBe(true);
     expect(caps.supportsDynamicUi).toBe(true);
     expect(caps.supportsVoiceInput).toBe(true);
+  });
+
+  test('normalises "http-api" to "macos"', () => {
+    const caps = resolveChannelCapabilities('http-api');
+    expect(caps.channel).toBe('macos');
+    expect(caps.dashboardCapable).toBe(true);
+    expect(caps.supportsDynamicUi).toBe(true);
+    expect(caps.supportsVoiceInput).toBe(true);
+  });
+
+  test('normalises "mac" to "macos"', () => {
+    const caps = resolveChannelCapabilities('mac');
+    expect(caps.channel).toBe('macos');
+    expect(caps.dashboardCapable).toBe(true);
   });
 
   test('resolves "telegram" as non-dashboard-capable', () => {
@@ -48,9 +65,41 @@ describe('resolveChannelCapabilities', () => {
     expect(caps.supportsVoiceInput).toBe(false);
   });
 
-  test('resolves "http-api" as non-dashboard-capable', () => {
-    const caps = resolveChannelCapabilities('http-api');
-    expect(caps.channel).toBe('http-api');
+  test('resolves "ios" with voice but no dashboard/dynamic-ui', () => {
+    const caps = resolveChannelCapabilities('ios');
+    expect(caps.channel).toBe('ios');
+    expect(caps.dashboardCapable).toBe(false);
+    expect(caps.supportsDynamicUi).toBe(false);
+    expect(caps.supportsVoiceInput).toBe(true);
+  });
+
+  test('resolves "whatsapp" as all-capabilities-false', () => {
+    const caps = resolveChannelCapabilities('whatsapp');
+    expect(caps.channel).toBe('whatsapp');
+    expect(caps.dashboardCapable).toBe(false);
+    expect(caps.supportsDynamicUi).toBe(false);
+    expect(caps.supportsVoiceInput).toBe(false);
+  });
+
+  test('resolves "slack" as all-capabilities-false', () => {
+    const caps = resolveChannelCapabilities('slack');
+    expect(caps.channel).toBe('slack');
+    expect(caps.dashboardCapable).toBe(false);
+    expect(caps.supportsDynamicUi).toBe(false);
+    expect(caps.supportsVoiceInput).toBe(false);
+  });
+
+  test('resolves "email" as all-capabilities-false', () => {
+    const caps = resolveChannelCapabilities('email');
+    expect(caps.channel).toBe('email');
+    expect(caps.dashboardCapable).toBe(false);
+    expect(caps.supportsDynamicUi).toBe(false);
+    expect(caps.supportsVoiceInput).toBe(false);
+  });
+
+  test('unknown channel defaults to all-capabilities-false', () => {
+    const caps = resolveChannelCapabilities('unknown-thing');
+    expect(caps.channel).toBe('unknown-thing');
     expect(caps.dashboardCapable).toBe(false);
     expect(caps.supportsDynamicUi).toBe(false);
     expect(caps.supportsVoiceInput).toBe(false);
@@ -292,8 +341,8 @@ describe('buildChannelAwarenessSection', () => {
 // ---------------------------------------------------------------------------
 
 describe('trust-gating via channel capabilities', () => {
-  test('dashboard channel does not add constraint rules', () => {
-    const caps = resolveChannelCapabilities('dashboard');
+  test('macos channel does not add constraint rules', () => {
+    const caps = resolveChannelCapabilities('macos');
     const message: Message = {
       role: 'user',
       content: [{ type: 'text', text: 'Enable my microphone' }],
@@ -556,5 +605,180 @@ describe('applyRuntimeInjections with guardianContext', () => {
     expect(result).toHaveLength(1);
     expect(result[0].content).toHaveLength(2);
     expect((result[0].content[0] as { type: 'text'; text: string }).text).toContain('<guardian_context>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildChannelTurnContextBlock
+// ---------------------------------------------------------------------------
+
+describe('buildChannelTurnContextBlock', () => {
+  test('formats block with all three channel fields', () => {
+    const block = buildChannelTurnContextBlock({
+      turnContext: { userMessageChannel: 'telegram', assistantMessageChannel: 'telegram' },
+      conversationOriginChannel: 'telegram',
+    });
+    expect(block).toBe(
+      '<channel_turn_context>\n' +
+      'user_message_channel: telegram\n' +
+      'assistant_message_channel: telegram\n' +
+      'conversation_origin_channel: telegram\n' +
+      '</channel_turn_context>',
+    );
+  });
+
+  test('uses "unknown" when conversationOriginChannel is null', () => {
+    const block = buildChannelTurnContextBlock({
+      turnContext: { userMessageChannel: 'macos', assistantMessageChannel: 'macos' },
+      conversationOriginChannel: null,
+    });
+    expect(block).toContain('conversation_origin_channel: unknown');
+  });
+
+  test('handles mixed channels', () => {
+    const block = buildChannelTurnContextBlock({
+      turnContext: { userMessageChannel: 'telegram', assistantMessageChannel: 'macos' },
+      conversationOriginChannel: 'ios',
+    });
+    expect(block).toContain('user_message_channel: telegram');
+    expect(block).toContain('assistant_message_channel: macos');
+    expect(block).toContain('conversation_origin_channel: ios');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// injectChannelTurnContext
+// ---------------------------------------------------------------------------
+
+describe('injectChannelTurnContext', () => {
+  const baseUserMessage: Message = {
+    role: 'user',
+    content: [{ type: 'text', text: 'Hello from telegram' }],
+  };
+
+  test('prepends channel_turn_context block to user message', () => {
+    const params: ChannelTurnContextParams = {
+      turnContext: { userMessageChannel: 'telegram', assistantMessageChannel: 'telegram' },
+      conversationOriginChannel: 'telegram',
+    };
+    const result = injectChannelTurnContext(baseUserMessage, params);
+    expect(result.content.length).toBe(2);
+    const injected = result.content[0];
+    expect(injected.type).toBe('text');
+    const text = (injected as { type: 'text'; text: string }).text;
+    expect(text).toContain('<channel_turn_context>');
+    expect(text).toContain('user_message_channel: telegram');
+    expect(text).toContain('</channel_turn_context>');
+  });
+
+  test('preserves original message content', () => {
+    const params: ChannelTurnContextParams = {
+      turnContext: { userMessageChannel: 'macos', assistantMessageChannel: 'macos' },
+      conversationOriginChannel: 'macos',
+    };
+    const result = injectChannelTurnContext(baseUserMessage, params);
+    const lastBlock = result.content[result.content.length - 1];
+    expect((lastBlock as { type: 'text'; text: string }).text).toBe('Hello from telegram');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripChannelTurnContext
+// ---------------------------------------------------------------------------
+
+describe('stripChannelTurnContext', () => {
+  test('strips channel_turn_context blocks from user messages', () => {
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: '<channel_turn_context>\nuser_message_channel: telegram\n</channel_turn_context>' },
+          { type: 'text', text: 'Hello' },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hi there' }],
+      },
+    ];
+
+    const result = stripChannelTurnContext(messages);
+
+    expect(result.length).toBe(2);
+    expect(result[0].content.length).toBe(1);
+    expect((result[0].content[0] as { type: 'text'; text: string }).text).toBe('Hello');
+    expect(result[1].content.length).toBe(1);
+  });
+
+  test('removes user messages that only contain channel_turn_context', () => {
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: '<channel_turn_context>\nuser_message_channel: macos\n</channel_turn_context>' },
+        ],
+      },
+    ];
+
+    const result = stripChannelTurnContext(messages);
+    expect(result.length).toBe(0);
+  });
+
+  test('leaves messages without channel_turn_context untouched', () => {
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Normal message' }],
+      },
+    ];
+
+    const result = stripChannelTurnContext(messages);
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(messages[0]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyRuntimeInjections with channelTurnContext
+// ---------------------------------------------------------------------------
+
+describe('applyRuntimeInjections with channelTurnContext', () => {
+  const baseMessages: Message[] = [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'What channel am I on?' }],
+    },
+  ];
+
+  test('injects channel turn context when provided', () => {
+    const params: ChannelTurnContextParams = {
+      turnContext: { userMessageChannel: 'telegram', assistantMessageChannel: 'telegram' },
+      conversationOriginChannel: 'telegram',
+    };
+
+    const result = applyRuntimeInjections(baseMessages, {
+      channelTurnContext: params,
+    });
+
+    expect(result.length).toBe(1);
+    expect(result[0].content.length).toBe(2);
+    const injected = result[0].content[0];
+    expect((injected as { type: 'text'; text: string }).text).toContain('<channel_turn_context>');
+  });
+
+  test('does not inject when channelTurnContext is null', () => {
+    const result = applyRuntimeInjections(baseMessages, {
+      channelTurnContext: null,
+    });
+
+    expect(result.length).toBe(1);
+    expect(result[0].content.length).toBe(1);
+  });
+
+  test('does not inject when channelTurnContext is omitted', () => {
+    const result = applyRuntimeInjections(baseMessages, {});
+
+    expect(result.length).toBe(1);
+    expect(result[0].content.length).toBe(1);
   });
 });

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -15,6 +15,7 @@ import type { AgentLoop, CheckpointDecision, AgentEvent } from '../agent/loop.js
 import type { Provider } from '../providers/types.js';
 import { createAssistantMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
+import { getConversationOriginChannel } from '../memory/conversation-store.js';
 import type { PermissionPrompter } from '../permissions/prompter.js';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
@@ -35,7 +36,7 @@ import {
   stripInjectedContext,
 } from './session-runtime-assembly.js';
 import { buildTemporalContext } from './date-context.js';
-import type { ActiveSurfaceContext, ChannelCapabilities, GuardianRuntimeContext } from './session-runtime-assembly.js';
+import type { ActiveSurfaceContext, ChannelCapabilities, ChannelTurnContextParams, GuardianRuntimeContext } from './session-runtime-assembly.js';
 import {
   cleanAssistantContent,
   type AssistantAttachmentDraft,
@@ -290,12 +291,20 @@ export async function runAgentLoopImpl(
       timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     });
 
+    // Build channel turn context so the model knows which channels are
+    // active for this turn and the conversation's origin channel.
+    const turnChannelCtx = ctx.getTurnChannelContext();
+    const channelTurnContext: ChannelTurnContextParams | null = turnChannelCtx
+      ? { turnContext: turnChannelCtx, conversationOriginChannel: getConversationOriginChannel(ctx.conversationId) }
+      : null;
+
     runMessages = applyRuntimeInjections(runMessages, {
       softConflictInstruction,
       activeSurface,
       workspaceTopLevelContext: ctx.workspaceTopLevelContext,
       channelCapabilities: ctx.channelCapabilities ?? null,
       channelCommandContext: ctx.commandIntent ?? null,
+      channelTurnContext,
       guardianContext: ctx.guardianContext ?? null,
       temporalContext,
     });
@@ -398,6 +407,7 @@ export async function runAgentLoopImpl(
           workspaceTopLevelContext: ctx.workspaceTopLevelContext,
           channelCapabilities: ctx.channelCapabilities ?? null,
           channelCommandContext: ctx.commandIntent ?? null,
+          channelTurnContext,
           guardianContext: ctx.guardianContext ?? null,
           temporalContext,
         });
@@ -432,6 +442,7 @@ export async function runAgentLoopImpl(
             workspaceTopLevelContext: ctx.workspaceTopLevelContext,
             channelCapabilities: ctx.channelCapabilities ?? null,
             channelCommandContext: ctx.commandIntent ?? null,
+            channelTurnContext,
             guardianContext: ctx.guardianContext ?? null,
             temporalContext,
           });

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -5,7 +5,7 @@
  * before it is sent to the provider.  They are pure (no side effects).
  */
 
-import type { ChannelId } from '../channels/types.js';
+import type { ChannelId, TurnChannelContext } from '../channels/types.js';
 import type { Message } from '../providers/types.js';
 import { listAppFiles, getAppsDir } from '../memory/app-store.js';
 import { statSync } from 'node:fs';
@@ -40,14 +40,35 @@ export interface GuardianRuntimeContext {
 
 /** Derive channel capabilities from a raw source channel identifier. */
 export function resolveChannelCapabilities(sourceChannel?: string | null): ChannelCapabilities {
-  const channel = sourceChannel ?? 'dashboard';
-  const isDashboard = channel === 'dashboard';
-  return {
-    channel,
-    dashboardCapable: isDashboard,
-    supportsDynamicUi: isDashboard,
-    supportsVoiceInput: isDashboard,
-  };
+  // Normalise legacy pseudo-channel IDs to canonical ChannelId values.
+  let channel: string;
+  switch (sourceChannel) {
+    case null:
+    case undefined:
+    case 'dashboard':
+    case 'http-api':
+    case 'mac':
+      channel = 'macos';
+      break;
+    default:
+      channel = sourceChannel;
+  }
+
+  switch (channel) {
+    case 'macos':
+      return { channel, dashboardCapable: true, supportsDynamicUi: true, supportsVoiceInput: true };
+    case 'ios':
+      return { channel, dashboardCapable: false, supportsDynamicUi: false, supportsVoiceInput: true };
+    case 'telegram':
+    case 'sms':
+    case 'voice':
+    case 'whatsapp':
+    case 'slack':
+    case 'email':
+      return { channel, dashboardCapable: false, supportsDynamicUi: false, supportsVoiceInput: false };
+    default:
+      return { channel, dashboardCapable: false, supportsDynamicUi: false, supportsVoiceInput: false };
+  }
 }
 
 /** Context about the active workspace surface, passed to applyRuntimeInjections. */
@@ -309,6 +330,46 @@ export function injectChannelCommandContext(message: Message, ctx: ChannelComman
   };
 }
 
+// ---------------------------------------------------------------------------
+// Channel turn context injection
+// ---------------------------------------------------------------------------
+
+/** Parameters for building the channel turn context block. */
+export interface ChannelTurnContextParams {
+  turnContext: TurnChannelContext;
+  conversationOriginChannel: ChannelId | null;
+}
+
+/**
+ * Build the `<channel_turn_context>` text block that informs the model
+ * which channels are active for the current turn and the conversation's
+ * origin channel.
+ */
+export function buildChannelTurnContextBlock(params: ChannelTurnContextParams): string {
+  const { turnContext, conversationOriginChannel } = params;
+  const lines: string[] = ['<channel_turn_context>'];
+  lines.push(`user_message_channel: ${turnContext.userMessageChannel}`);
+  lines.push(`assistant_message_channel: ${turnContext.assistantMessageChannel}`);
+  lines.push(`conversation_origin_channel: ${conversationOriginChannel ?? 'unknown'}`);
+  lines.push('</channel_turn_context>');
+  return lines.join('\n');
+}
+
+/**
+ * Prepend channel turn context to the last user message so the model
+ * knows which channels are involved in this turn.
+ */
+export function injectChannelTurnContext(message: Message, params: ChannelTurnContextParams): Message {
+  const block = buildChannelTurnContextBlock(params);
+  return {
+    ...message,
+    content: [
+      { type: 'text', text: block },
+      ...message.content,
+    ],
+  };
+}
+
 /**
  * Prepend guardian trust/identity facts to the last user message so the
  * model can reason about guardian status from deterministic runtime facts.
@@ -436,10 +497,16 @@ export function stripChannelCommandContext(messages: Message[]): Message[] {
   return stripUserTextBlocksByPrefix(messages, ['<channel_command_context>']);
 }
 
+/** Strip `<channel_turn_context>` blocks injected by `injectChannelTurnContext`. */
+export function stripChannelTurnContext(messages: Message[]): Message[] {
+  return stripUserTextBlocksByPrefix(messages, ['<channel_turn_context>']);
+}
+
 /** Prefixes stripped by the pipeline (order doesn't matter — single pass). */
 const RUNTIME_INJECTION_PREFIXES = [
   '<channel_capabilities>',
   '<channel_command_context>',
+  '<channel_turn_context>',
   '<guardian_context>',
   '<workspace_top_level>',
   TEMPORAL_INJECTED_PREFIX,
@@ -482,6 +549,7 @@ export function applyRuntimeInjections(
     workspaceTopLevelContext?: string | null;
     channelCapabilities?: ChannelCapabilities | null;
     channelCommandContext?: ChannelCommandContext | null;
+    channelTurnContext?: ChannelTurnContextParams | null;
     guardianContext?: GuardianRuntimeContext | null;
     temporalContext?: string | null;
   },
@@ -524,6 +592,16 @@ export function applyRuntimeInjections(
       result = [
         ...result.slice(0, -1),
         injectChannelCommandContext(userTail, options.channelCommandContext),
+      ];
+    }
+  }
+
+  if (options.channelTurnContext) {
+    const userTail = result[result.length - 1];
+    if (userTail && userTail.role === 'user') {
+      result = [
+        ...result.slice(0, -1),
+        injectChannelTurnContext(userTail, options.channelTurnContext),
       ];
     }
   }


### PR DESCRIPTION
Part of #7878. Injects a <channel_turn_context> block into every LLM provider call with userMessageChannel, assistantMessageChannel, and conversationOriginChannel. Updates resolveChannelCapabilities to use canonical ChannelId values (removes dashboard/http-api/mac pseudo-IDs). Strips injected context from persisted history.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
