### PR TITLE
fix(ios): await async attachment load in testAddAttachmentFromImageData

### DIFF
--- a/clients/ios/Tests/AttachmentFlowIOSTests.swift
+++ b/clients/ios/Tests/AttachmentFlowIOSTests.swift
@@ -168,6 +168,14 @@ final class AttachmentFlowIOSTests: XCTestCase {
 
         viewModel.addAttachment(imageData: pngData, filename: "Screenshot.png")
 
+        // addAttachment(imageData:) processes the image in a background Task,
+        // so we need to wait for the attachment to appear.
+        let predicate = NSPredicate { _, _ in
+            self.viewModel.pendingAttachments.count == 1
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [expectation], timeout: 5.0)
+
         XCTAssertEqual(viewModel.pendingAttachments.count, 1)
         XCTAssertEqual(viewModel.pendingAttachments[0].filename, "Screenshot.png")
         XCTAssertEqual(viewModel.pendingAttachments[0].mimeType, "image/png")


### PR DESCRIPTION
## Summary
- `addAttachment(imageData:)` processes images in a background `Task`, but `testAddAttachmentFromImageData` was asserting synchronously before the task completed
- Added `XCTNSPredicateExpectation` to wait for the pending attachment to appear before asserting

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22357244556

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
