### PR TITLE
fix(macos): add accessibilityLabel to parental settings toggles

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
@@ -132,6 +132,7 @@ struct SettingsParentalTab: View {
                 ))
                 .toggleStyle(.switch)
                 .labelsHidden()
+                .accessibilityLabel("Enable Parental Controls")
                 .disabled(isLoading)
             }
 
@@ -221,6 +222,7 @@ struct SettingsParentalTab: View {
                     ))
                     .toggleStyle(.switch)
                     .labelsHidden()
+                    .accessibilityLabel(topic.displayName)
                     .disabled(isLoading)
                 }
             }
@@ -257,6 +259,7 @@ struct SettingsParentalTab: View {
                         ))
                         .toggleStyle(.switch)
                         .labelsHidden()
+                        .accessibilityLabel(category.displayName)
                         .disabled(isLoading)
                     }
                     Text(category.description)


### PR DESCRIPTION
Addresses Codex feedback on #7942. When using Toggle("", isOn:).labelsHidden(), the visible label is detached from the control for assistive tech. Add .accessibilityLabel() to each toggle in SettingsParentalTab so screen readers can identify them.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
