### PR TITLE
Refactor provider helper module naming and remove Anthropic entrypoint

### DIFF
--- a/assistant/src/__tests__/clarification-resolver.test.ts
+++ b/assistant/src/__tests__/clarification-resolver.test.ts
@@ -6,7 +6,7 @@ let llmResolution: 'keep_existing' | 'keep_candidate' | 'merge' | 'still_unclear
 let llmResolvedStatement = '';
 let llmExplanation = 'Unclear response from user.';
 
-mock.module('../providers/anthropic-send-message.js', () => ({
+mock.module('../providers/provider-send-message.js', () => ({
   getConfiguredProvider: () => ({
     sendMessage: async (
       _messages: unknown,

--- a/assistant/src/__tests__/contradiction-checker.test.ts
+++ b/assistant/src/__tests__/contradiction-checker.test.ts
@@ -30,7 +30,7 @@ const classifyRelationshipMock = mock(async () => {
   };
 });
 
-mock.module('../providers/anthropic-send-message.js', () => ({
+mock.module('../providers/provider-send-message.js', () => ({
   getConfiguredProvider: () => ({
     sendMessage: classifyRelationshipMock,
   }),

--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
-import { getConfiguredProvider, extractText, userMessageWithImages } from '../../../../providers/anthropic-send-message.js';
+import { getConfiguredProvider, extractText, userMessageWithImages } from '../../../../providers/provider-send-message.js';
 import { initializeProviders } from '../../../../providers/registry.js';
 import { loadConfig, invalidateConfigCache } from '../../../../config/loader.js';
 import {

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -6,7 +6,7 @@ import { stripCommentLines } from './system-prompt.js';
 import { parseFrontmatterFields } from '../skills/frontmatter.js';
 import { parseToolManifestFile } from '../skills/tool-manifest.js';
 import { computeSkillVersionHash } from '../skills/version-hash.js';
-import { getConfiguredProvider, extractAllText, userMessage } from '../providers/anthropic-send-message.js';
+import { getConfiguredProvider, extractAllText, userMessage } from '../providers/provider-send-message.js';
 
 const log = getLogger('skills');
 

--- a/assistant/src/daemon/classifier.ts
+++ b/assistant/src/daemon/classifier.ts
@@ -1,4 +1,4 @@
-import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
+import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/provider-send-message.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('classifier');

--- a/assistant/src/daemon/watch-handler.ts
+++ b/assistant/src/daemon/watch-handler.ts
@@ -1,5 +1,5 @@
 import type * as net from 'node:net';
-import { getConfiguredProvider, extractText, userMessage } from '../providers/anthropic-send-message.js';
+import { getConfiguredProvider, extractText, userMessage } from '../providers/provider-send-message.js';
 import { getLogger } from '../util/logger.js';
 import type { WatchObservation } from './ipc-protocol.js';
 import type { HandlerContext } from './handlers.js';

--- a/assistant/src/memory/clarification-resolver.ts
+++ b/assistant/src/memory/clarification-resolver.ts
@@ -1,4 +1,4 @@
-import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
+import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/provider-send-message.js';
 import type { ModelIntent } from '../providers/types.js';
 import { truncate } from '../util/truncate.js';
 

--- a/assistant/src/memory/contradiction-checker.ts
+++ b/assistant/src/memory/contradiction-checker.ts
@@ -2,7 +2,7 @@ import { eq } from 'drizzle-orm';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 import { truncate } from '../util/truncate.js';
-import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
+import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/provider-send-message.js';
 import { areStatementsCoherent } from './conflict-intent.js';
 import { isConflictKindEligible, isStatementConflictEligible } from './conflict-policy.js';
 import { createOrUpdatePendingConflict } from './conflict-store.js';

--- a/assistant/src/memory/entity-extractor.ts
+++ b/assistant/src/memory/entity-extractor.ts
@@ -2,7 +2,7 @@ import { eq, sql } from 'drizzle-orm';
 import type { MemoryEntityConfig } from '../config/types.js';
 import { getLogger } from '../util/logger.js';
 import { truncate } from '../util/truncate.js';
-import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
+import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/provider-send-message.js';
 import { getDb } from './db.js';
 import { memoryEntities, memoryEntityRelations, memoryItemEntities } from './schema.js';
 

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -4,7 +4,7 @@ import { getConfig } from '../config/loader.js';
 import type { MemoryExtractionConfig } from '../config/types.js';
 import { getLogger } from '../util/logger.js';
 import { truncate } from '../util/truncate.js';
-import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
+import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/provider-send-message.js';
 import { computeMemoryFingerprint } from './fingerprint.js';
 import { enqueueMemoryJob } from './jobs-store.js';
 import { extractTextFromStoredMessageContent } from './message-content.js';

--- a/assistant/src/memory/job-handlers/summarization.ts
+++ b/assistant/src/memory/job-handlers/summarization.ts
@@ -3,7 +3,7 @@ import { v4 as uuid } from 'uuid';
 import type { AssistantConfig } from '../../config/types.js';
 import { estimateTextTokens } from '../../context/token-estimator.js';
 import { getLogger } from '../../util/logger.js';
-import { getConfiguredProvider, createTimeout, extractText, userMessage } from '../../providers/anthropic-send-message.js';
+import { getConfiguredProvider, createTimeout, extractText, userMessage } from '../../providers/provider-send-message.js';
 import { getConversationMemoryScopeId } from '../conversation-store.js';
 import { getDb } from '../db.js';
 import { enqueueMemoryJob, type MemoryJob } from '../jobs-store.js';

--- a/assistant/src/memory/search/ranking.ts
+++ b/assistant/src/memory/search/ranking.ts
@@ -2,7 +2,7 @@ import { inArray, sql } from 'drizzle-orm';
 import type { AssistantConfig, MemoryRerankingConfig } from '../../config/types.js';
 import { estimateTextTokens } from '../../context/token-estimator.js';
 import { getLogger } from '../../util/logger.js';
-import { getConfiguredProvider, extractText, userMessage } from '../../providers/anthropic-send-message.js';
+import { getConfiguredProvider, extractText, userMessage } from '../../providers/provider-send-message.js';
 import { getDb } from '../db.js';
 import { memoryItems } from '../schema.js';
 import type { Candidate, CandidateSource, ItemMetadata } from './types.js';

--- a/assistant/src/messaging/thread-summarizer.ts
+++ b/assistant/src/messaging/thread-summarizer.ts
@@ -1,4 +1,4 @@
-import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
+import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/provider-send-message.js';
 import { getLogger } from '../util/logger.js';
 import { truncate } from '../util/truncate.js';
 import type { ThreadMessage, ThreadSummary } from './types.js';

--- a/assistant/src/messaging/triage-engine.ts
+++ b/assistant/src/messaging/triage-engine.ts
@@ -7,7 +7,7 @@
  * table for accuracy review.
  */
 
-import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/anthropic-send-message.js';
+import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/provider-send-message.js';
 import { truncate } from '../util/truncate.js';
 import { v4 as uuid } from 'uuid';
 import { and, eq, isNull, desc } from 'drizzle-orm';

--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Provider, ProviderResponse, Message, ContentBlock, ToolUseContent } from './types.js';
-import { getFailoverProvider, getProvider, listProviders, initializeProviders } from './registry.js';
+import { getFailoverProvider, listProviders, initializeProviders } from './registry.js';
 import { getConfig } from '../config/loader.js';
 
 /**
@@ -33,26 +33,6 @@ export function getConfiguredProvider(): Provider | null {
   try {
     const providerOrder = Array.isArray(config.providerOrder) ? config.providerOrder : [];
     return getFailoverProvider(config.provider, providerOrder);
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Legacy Anthropic-only resolver kept for compatibility while callsites
- * migrate to `getConfiguredProvider`.
- */
-export function getAnthropicProvider(): Provider | null {
-  if (listProviders().length === 0) {
-    try {
-      initializeProviders(getConfig());
-    } catch {
-      return null;
-    }
-  }
-
-  try {
-    return getProvider('anthropic');
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- rename `assistant/src/providers/anthropic-send-message.ts` to `assistant/src/providers/provider-send-message.ts`
- remove the legacy `getAnthropicProvider()` export to eliminate the Anthropic-only entrypoint
- update all production imports and relevant tests to the renamed provider-agnostic helper module

## Validation
- `cd assistant && bunx tsc --noEmit`
- `cd assistant && bun test src/__tests__/clarification-resolver.test.ts src/__tests__/contradiction-checker.test.ts src/__tests__/classifier.test.ts src/__tests__/skills.test.ts src/__tests__/entity-extractor.test.ts src/__tests__/hooks-watch.test.ts src/__tests__/no-direct-anthropic-sdk-imports.test.ts`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
