### PR TITLE
Polish app toolbar and memory degradation banner

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -686,31 +686,17 @@ struct ChatView: View {
     private var memoryDegradedBanner: some View {
         if isMemoryDegraded {
             HStack(spacing: VSpacing.sm) {
-                Image(systemName: "memorychip")
+                Image(systemName: "brain")
                     .font(VFont.caption)
-                    .foregroundColor(VColor.warning)
-                VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                    Text("Memory search limited")
-                        .font(VFont.captionMedium)
-                        .foregroundColor(VColor.textPrimary)
-                    if let reason = memoryDegradedReason {
-                        Text(reason)
-                            .font(VFont.small)
-                            .foregroundColor(VColor.textSecondary)
-                            .lineLimit(1)
-                    }
-                }
+                    .foregroundColor(VColor.textMuted)
+                Text("Memory is temporarily unavailable")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
                 Spacer()
             }
             .padding(.horizontal, VSpacing.lg)
-            .padding(.vertical, VSpacing.sm)
-            .background(VColor.warning.opacity(0.1))
-            .overlay(
-                Rectangle()
-                    .fill(VColor.warning)
-                    .frame(width: 3),
-                alignment: .leading
-            )
+            .padding(.vertical, VSpacing.xs)
+            .background(VColor.surface)
             .transition(.move(edge: .top).combined(with: .opacity))
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -809,14 +809,14 @@ struct DynamicWorkspaceWrapper: View {
 
             VStack(spacing: 0) {
                 HStack {
-                    // Left: Done Editing primary CTA in edit mode, Edit ghost button otherwise
+                    // Left: Done Editing primary CTA in edit mode, Edit primary button otherwise
                     if case .appEditing = windowState.selection {
                         VButton(label: "Done Editing", style: .primary) {
                             onToggleChatDock()
                         }
                         .controlSize(.small)
                     } else {
-                        VButton(label: "Edit", icon: "pencil", style: .tertiary) {
+                        VButton(label: "Edit", icon: "pencil", style: .primary) {
                             if !isChatDockOpen {
                                 windowState.workspaceComposerExpanded = false
                             }
@@ -826,18 +826,7 @@ struct DynamicWorkspaceWrapper: View {
                         .accessibilityLabel("Edit app")
                     }
 
-                    Spacer()
-
-                    // Center: App name
-                    if let title = data.preview?.title {
-                        Text(title)
-                            .font(VFont.bodyMedium)
-                            .foregroundColor(VColor.textPrimary)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                    }
-
-                    Spacer()
+                    Spacer(minLength: 0)
 
                     // Right: History + Share + Close tertiary buttons
                     HStack(spacing: VSpacing.sm) {
@@ -876,7 +865,7 @@ struct DynamicWorkspaceWrapper: View {
                         .accessibilityLabel("Close workspace")
                     }
                 }
-                .padding(.leading, isChatDockOpen ? VSpacing.md : trafficLightPadding)
+                .padding(.leading, VSpacing.md)
                 .padding(.trailing, VSpacing.md)
                 .padding(.vertical, VSpacing.sm)
                 .background(


### PR DESCRIPTION
## Summary
- Simplify memory degradation banner: remove technical jargon, use brain icon, subtle surface background
- Make Edit button primary style (filled) and left-aligned in full-screen app toolbar
- Remove center app title from toolbar to prevent Edit button from centering
- Reduce toolbar leading padding to VSpacing.md consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
