### PR TITLE
feat: add assistant inbox config booleans

### DIFF
--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -261,4 +261,10 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     enabled: undefined,
     publicBaseUrl: '',
   },
+  assistantInbox: {
+    enabled: false,
+    invitesEnabled: false,
+    memberAclEnabled: false,
+    policyEnabled: false,
+  },
 };

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -1059,6 +1059,21 @@ export const SkillsConfigSchema = z.object({
   allowBundled: z.array(z.string()).nullable().default(null),
 });
 
+export const AssistantInboxConfigSchema = z.object({
+  enabled: z
+    .boolean({ error: 'assistantInbox.enabled must be a boolean' })
+    .default(false),
+  invitesEnabled: z
+    .boolean({ error: 'assistantInbox.invitesEnabled must be a boolean' })
+    .default(false),
+  memberAclEnabled: z
+    .boolean({ error: 'assistantInbox.memberAclEnabled must be a boolean' })
+    .default(false),
+  policyEnabled: z
+    .boolean({ error: 'assistantInbox.policyEnabled must be a boolean' })
+    .default(false),
+});
+
 export const SmsConfigSchema = z.object({
   enabled: z
     .boolean({ error: 'sms.enabled must be a boolean' })
@@ -1378,6 +1393,12 @@ export const AssistantConfigSchema = z.object({
     phoneNumber: '',
   }),
   ingress: IngressConfigSchema,
+  assistantInbox: AssistantInboxConfigSchema.default({
+    enabled: false,
+    invitesEnabled: false,
+    memberAclEnabled: false,
+    policyEnabled: false,
+  }),
 }).superRefine((config, ctx) => {
   if (config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {
     ctx.addIssue({
@@ -1443,3 +1464,4 @@ export type CallsElevenLabsConfig = z.infer<typeof CallsElevenLabsConfigSchema>;
 export type CallerIdentityConfig = z.infer<typeof CallerIdentityConfigSchema>;
 export type SmsConfig = z.infer<typeof SmsConfigSchema>;
 export type IngressConfig = z.infer<typeof IngressConfigSchema>;
+export type AssistantInboxConfig = z.infer<typeof AssistantInboxConfigSchema>;

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -39,4 +39,5 @@ export type {
   CallerIdentityConfig,
   SmsConfig,
   IngressConfig,
+  AssistantInboxConfig,
 } from './schema.js';

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -12,6 +12,7 @@ import { getPendingConfirmationsByConversation } from '../../memory/runs-store.j
 import { renderHistoryContent } from '../../daemon/handlers.js';
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { IngressBlockedError } from '../../util/errors.js';
+import { getConfig } from '../../config/loader.js';
 import { getLogger } from '../../util/logger.js';
 import {
   getGuardianBinding,
@@ -383,6 +384,13 @@ export async function handleChannelInbound(
   if (trimmedContent.length === 0 && !hasAttachments && !isEdit && !hasCallbackData) {
     return Response.json({ error: 'content or attachmentIds is required' }, { status: 400 });
   }
+
+  // ── Assistant Inbox config access ──
+  // Load inbox config so downstream guards can check feature flags.
+  // Currently a no-op — ingress ACL enforcement will be added here by A-07/A-08
+  // when assistantInbox.memberAclEnabled is true.
+  const _inboxConfig = getConfig().assistantInbox;
+  void _inboxConfig;
 
   if (hasAttachments) {
     const resolved = attachmentsStore.getAttachmentsByIds(attachmentIds);


### PR DESCRIPTION
Add AssistantInboxConfigSchema with four feature flags (enabled, invitesEnabled, memberAclEnabled, policyEnabled) all defaulting to false (fail-closed). Wire config access in handleChannelInbound for future ACL enforcement. Part of the Assistant Inbox rollout (A-01).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
