### PR TITLE
fix: add hasPendingChallenge to status + revoke challenges on cancel

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -1,5 +1,5 @@
 import * as net from 'node:net';
-import { createVerificationChallenge, getGuardianBinding, revokeBinding as revokeGuardianBinding } from '../../runtime/channel-guardian-service.js';
+import { createVerificationChallenge, getGuardianBinding, getPendingChallenge, revokeBinding as revokeGuardianBinding, revokePendingChallenges } from '../../runtime/channel-guardian-service.js';
 import { createReadinessService, type ChannelReadinessService } from '../../runtime/channel-readiness-service.js';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
 import type {
@@ -67,6 +67,7 @@ export function handleGuardianVerification(
           guardianDisplayName = ext.displayName;
         }
       }
+      const hasPendingChallenge = getPendingChallenge(assistantId, channel) != null;
       ctx.send(socket, {
         type: 'guardian_verification_response',
         success: true,
@@ -77,9 +78,11 @@ export function handleGuardianVerification(
         channel,
         assistantId,
         guardianDeliveryChatId: binding?.guardianDeliveryChatId,
+        hasPendingChallenge,
       });
     } else if (msg.action === 'revoke') {
       revokeGuardianBinding(assistantId, channel);
+      revokePendingChallenges(assistantId, channel);
       ctx.send(socket, {
         type: 'guardian_verification_response',
         success: true,

--- a/assistant/src/memory/channel-guardian-store.ts
+++ b/assistant/src/memory/channel-guardian-store.ts
@@ -257,6 +257,20 @@ export function createChallenge(params: {
   return rowToChallenge(row);
 }
 
+export function revokePendingChallenges(assistantId: string, channel: string): void {
+  const db = getDb();
+  db.update(channelGuardianVerificationChallenges)
+    .set({ status: 'revoked', updatedAt: Date.now() })
+    .where(
+      and(
+        eq(channelGuardianVerificationChallenges.assistantId, assistantId),
+        eq(channelGuardianVerificationChallenges.channel, channel),
+        eq(channelGuardianVerificationChallenges.status, 'pending'),
+      ),
+    )
+    .run();
+}
+
 export function findPendingChallengeByHash(
   assistantId: string,
   channel: string,

--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -12,6 +12,7 @@ import {
   createBinding,
   getActiveBinding,
   revokeBinding as storeRevokeBinding,
+  revokePendingChallenges as storeRevokePendingChallenges,
   createChallenge,
   findPendingChallengeByHash,
   findPendingChallengeForChannel,
@@ -251,6 +252,18 @@ export function revokeBinding(
   channel: string,
 ): boolean {
   return storeRevokeBinding(assistantId, channel);
+}
+
+/**
+ * Revoke all pending challenges for a given assistant and channel.
+ * Called when the user cancels verification so that stale challenges
+ * don't gate inbound calls.
+ */
+export function revokePendingChallenges(
+  assistantId: string,
+  channel: string,
+): void {
+  storeRevokePendingChallenges(assistantId, channel);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `hasPendingChallenge` field to guardian verification status response in `config-channels.ts` (lost during main refactoring merge)
- Revoke pending challenges when user cancels verification (action: "revoke") so stale challenges don't gate inbound calls
- Add `revokePendingChallenges` function to store and service layers

Addresses Devin and Codex P1 feedback on #7931.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7950" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
