### PR TITLE
M6: Validation, API Surface Tightening, and Test Sweep

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -1771,19 +1771,19 @@ describe('plain-text fallback surfacing for non-rich channels', () => {
     });
     createBinding({
       assistantId: 'self',
-      channel: 'http-api',
+      channel: 'sms',
       guardianExternalUserId: 'telegram-user-default',
       guardianDeliveryChatId: 'chat-123',
     });
   });
 
-  test('reminder prompt includes plainTextFallback for non-rich channel (http-api)', async () => {
+  test('reminder prompt includes plainTextFallback for non-rich channel (sms)', async () => {
     const orchestrator = makeMockOrchestrator();
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
     const approvalSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockResolvedValue(undefined);
 
-    // Establish the conversation using http-api (non-rich channel)
-    const initReq = makeInboundRequest({ content: 'init', sourceChannel: 'http-api' });
+    // Establish the conversation using sms (non-rich channel)
+    const initReq = makeInboundRequest({ content: 'init', sourceChannel: 'sms' });
     await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
 
     const db = getDb();
@@ -1795,7 +1795,7 @@ describe('plain-text fallback surfacing for non-rich channels', () => {
     setRunConfirmation(run.id, sampleConfirmation);
 
     // Send a non-decision message to trigger a reminder
-    const req = makeInboundRequest({ content: 'what is happening?', sourceChannel: 'http-api' });
+    const req = makeInboundRequest({ content: 'what is happening?', sourceChannel: 'sms' });
     const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
     const body = await res.json() as Record<string, unknown>;
 

--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -602,8 +602,8 @@ describe('channelSupportsRichApprovalUI', () => {
     expect(channelSupportsRichApprovalUI('telegram')).toBe(true);
   });
 
-  test('returns false for http-api', () => {
-    expect(channelSupportsRichApprovalUI('http-api')).toBe(false);
+  test('returns false for macos', () => {
+    expect(channelSupportsRichApprovalUI('macos')).toBe(false);
   });
 
   test('returns false for sms', () => {

--- a/assistant/src/__tests__/guardian-action-store.test.ts
+++ b/assistant/src/__tests__/guardian-action-store.test.ts
@@ -97,7 +97,7 @@ describe('guardian-action-store', () => {
 
     const pendingDelivery = createGuardianActionDelivery({
       requestId: request.id,
-      destinationChannel: 'mac',
+      destinationChannel: 'macos',
       destinationConversationId: 'conv-mac-guardian',
     });
     const sentDelivery = createGuardianActionDelivery({

--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -118,7 +118,7 @@ describe('injectChannelCapabilityContext', () => {
 
   test('injects channel capabilities block for dashboard channel', () => {
     const caps: ChannelCapabilities = {
-      channel: 'dashboard',
+      channel: 'macos',
       dashboardCapable: true,
       supportsDynamicUi: true,
       supportsVoiceInput: true,

--- a/assistant/src/calls/guardian-action-sweep.ts
+++ b/assistant/src/calls/guardian-action-sweep.ts
@@ -53,7 +53,7 @@ export function sweepExpiredGuardianActions(
     for (const delivery of deliveries) {
       if (delivery.status !== 'sent' && delivery.status !== 'pending') continue;
 
-      if (delivery.destinationChannel === 'mac' && delivery.destinationConversationId) {
+      if (delivery.destinationChannel === 'macos' && delivery.destinationConversationId) {
         // Add expiry message to mac guardian thread
         addMessage(
           delivery.destinationConversationId,

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -3,7 +3,7 @@
  *
  * When a call orchestrator detects ASK_GUARDIAN, this module:
  * 1. Creates a guardian_action_request
- * 2. Determines delivery destinations (telegram, sms, mac)
+ * 2. Determines delivery destinations (telegram, sms, macos)
  * 3. Creates guardian_action_delivery rows for each destination
  * 4. Sends HTTP POST to gateway for external channels
  * 5. Emits IPC events for the mac channel
@@ -102,18 +102,18 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
     }
 
     // Mac (internal) delivery — always created
-    destinations.push({ channel: 'mac' });
+    destinations.push({ channel: 'macos' });
 
     // Create delivery rows and dispatch
     for (const dest of destinations) {
-      if (dest.channel === 'mac') {
+      if (dest.channel === 'macos') {
         // Create a dedicated server-side conversation for the mac guardian thread
         const macConvKey = `asst:${assistantId}:guardian:request:${request.id}`;
         const { conversationId: macConversationId } = getOrCreateConversation(macConvKey);
 
         const delivery = createGuardianActionDelivery({
           requestId: request.id,
-          destinationChannel: 'mac',
+          destinationChannel: 'macos',
           destinationConversationId: macConversationId,
         });
 
@@ -136,7 +136,7 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
           } as ServerMessage);
         }
         updateDeliveryStatus(delivery.id, 'sent');
-        log.info({ deliveryId: delivery.id, channel: 'mac', macConversationId }, 'Mac guardian delivery emitted');
+        log.info({ deliveryId: delivery.id, channel: 'macos', macConversationId }, 'Mac guardian delivery emitted');
       } else {
         const delivery = createGuardianActionDelivery({
           requestId: request.id,

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -16,7 +16,7 @@ import { join } from 'node:path';
  * interacting.  Used to gate UI-specific references and permission asks.
  */
 export interface ChannelCapabilities {
-  /** The raw channel identifier (e.g. "dashboard", "telegram", "http-api"). */
+  /** The raw channel identifier (e.g. "macos", "telegram", "sms"). */
   channel: string;
   /** Whether this channel can render the dashboard UI (apps, dynamic pages). */
   dashboardCapable: boolean;

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -816,7 +816,7 @@ export const guardianActionDeliveries = sqliteTable('guardian_action_deliveries'
   requestId: text('request_id')
     .notNull()
     .references(() => guardianActionRequests.id, { onDelete: 'cascade' }),
-  destinationChannel: text('destination_channel').notNull(),       // 'telegram' | 'sms' | 'mac'
+  destinationChannel: text('destination_channel').notNull(),       // 'telegram' | 'sms' | 'macos'
   destinationConversationId: text('destination_conversation_id'),
   destinationChatId: text('destination_chat_id'),
   destinationExternalUserId: text('destination_external_user_id'),

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -2,7 +2,7 @@
  * Route handlers for channel inbound messages, delivery acks, and
  * conversation deletion.
  */
-import { assertChannelId } from '../../channels/types.js';
+import { isChannelId } from '../../channels/types.js';
 import type { ChannelId, TurnChannelContext } from '../../channels/types.js';
 import { timingSafeEqual } from 'node:crypto';
 import { deleteConversationKey } from '../../memory/conversation-key-store.js';
@@ -386,7 +386,13 @@ export async function handleChannelInbound(
   }
   // Validate and narrow to canonical ChannelId at the boundary — the gateway
   // only sends well-known channel strings, so an unknown value is rejected.
-  const sourceChannel = assertChannelId(body.sourceChannel, 'sourceChannel');
+  if (!isChannelId(body.sourceChannel)) {
+    return Response.json(
+      { error: `Invalid sourceChannel: ${body.sourceChannel}. Valid values: telegram, sms, voice, macos, ios, whatsapp, slack, email` },
+      { status: 400 },
+    );
+  }
+  const sourceChannel = body.sourceChannel;
   if (!externalChatId || typeof externalChatId !== 'string') {
     return Response.json({ error: 'externalChatId is required' }, { status: 400 });
   }

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -71,7 +71,7 @@ export interface RunStartOptions {
   /**
    * The originating channel (e.g. 'telegram', 'slack'). When provided,
    * channel capabilities are resolved for this channel instead of the
-   * default 'http-api'.
+   * default 'macos'.
    */
   sourceChannel?: ChannelId;
   /**
@@ -174,8 +174,8 @@ export class RunOrchestrator {
 
     // Set channel capabilities based on the originating channel so capabilities
     // (e.g. attachment scope) match the actual transport rather than always
-    // defaulting to 'http-api'.
-    session.setChannelCapabilities(resolveChannelCapabilities(options?.sourceChannel ?? 'http-api'));
+    // defaulting to 'macos'.
+    session.setChannelCapabilities(resolveChannelCapabilities(options?.sourceChannel ?? 'macos'));
 
     // Serialized publish chain so hub subscribers observe events in order.
     let hubChain: Promise<void> = Promise.resolve();


### PR DESCRIPTION
Part of #7878. Validates channel IDs at API boundaries (HTTP, IPC, gateway). Updates tests for canonical channel values. Removes remaining pseudo channel IDs. Full type-check and test suite passing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7951" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
