### PR TITLE
fix: validate origin channel from DB

### DIFF
--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -4,6 +4,7 @@ import { getDb, rawGet, rawExec } from './db.js';
 import { conversations, messages, toolInvocations, messageRuns, channelInboundEvents, memoryItemSources, memoryItems, memoryEmbeddings, memoryItemEntities, memorySegments, messageAttachments, llmRequestLogs } from './schema.js';
 import { getConfig } from '../config/loader.js';
 import { indexMessageNow } from './indexer.js';
+import { parseChannelId } from '../channels/types.js';
 import type { ChannelId } from '../channels/types.js';
 import { getLogger } from '../util/logger.js';
 import { deleteOrphanAttachments } from './attachments-store.js';
@@ -665,5 +666,5 @@ export function getConversationOriginChannel(conversationId: string): ChannelId 
     .from(conversations)
     .where(eq(conversations.id, conversationId))
     .get();
-  return (row?.originChannel as ChannelId) ?? null;
+  return parseChannelId(row?.originChannel) ?? null;
 }


### PR DESCRIPTION
Addresses review feedback on #7900. Replaces unsafe as-cast with parseChannelId to validate DB values in getConversationOriginChannel.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
