### PR TITLE
fix: move setTurnChannelContext after enqueue check

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -77,12 +77,6 @@ export async function handleUserMessage(
       }
     }
 
-    const ipcChannel = parseChannelId(msg.channel) ?? 'macos';
-    session.setTurnChannelContext({
-      userMessageChannel: ipcChannel,
-      assistantMessageChannel: ipcChannel,
-    });
-
     session.traceEmitter.emit('request_received', 'User message received', {
       requestId,
       status: 'info',
@@ -123,6 +117,11 @@ export async function handleUserMessage(
     }
 
     rlog.info('Processing user message');
+    const ipcChannel = parseChannelId(msg.channel) ?? 'macos';
+    session.setTurnChannelContext({
+      userMessageChannel: ipcChannel,
+      assistantMessageChannel: ipcChannel,
+    });
     session.setAssistantId('self');
     session.setGuardianContext(null);
     session.setCommandIntent(null);


### PR DESCRIPTION
Addresses review feedback on #7905. Moves setTurnChannelContext to after the enqueue check to prevent a queued message from corrupting the in-flight turn's channel context.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7953" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
