### PR TITLE
fix: graceful channel validation at API boundaries

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -9,7 +9,7 @@ import { existsSync, readFileSync, statSync, statfsSync } from 'node:fs';
 import { resolve, join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { timingSafeEqual } from 'node:crypto';
-import { assertChannelId, isChannelId } from '../channels/types.js';
+import { parseChannelId, isChannelId } from '../channels/types.js';
 import { ConfigError, IngressBlockedError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
 import { getWorkspacePromptPath, readLockfile } from '../util/platform.js';
@@ -959,7 +959,14 @@ export class RuntimeHttpServer {
 
       const content = typeof payload.content === 'string' ? payload.content.trim() : '';
       const attachmentIds = Array.isArray(payload.attachmentIds) ? payload.attachmentIds as string[] : undefined;
-      const sourceChannel = assertChannelId(payload.sourceChannel, 'sourceChannel');
+      const sourceChannel = parseChannelId(payload.sourceChannel);
+      if (!sourceChannel) {
+        channelDeliveryStore.recordProcessingFailure(
+          event.id,
+          new Error(`Invalid sourceChannel: ${String(payload.sourceChannel)}`),
+        );
+        continue;
+      }
       const sourceMetadata = payload.sourceMetadata as Record<string, unknown> | undefined;
       const assistantId = typeof payload.assistantId === 'string'
         ? payload.assistantId


### PR DESCRIPTION
Addresses review feedback on #7897. Replaces assertChannelId with parseChannelId at two API boundaries to return 400 instead of 500 for unrecognized channels, and prevent poisoned events from blocking the retry loop in sweepFailedEvents.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7954" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
