### PR TITLE
fix: channel metadata edge cases in persistence

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -762,6 +762,10 @@ export class DaemonServer {
       );
       session.getMessages().push(userMsg);
 
+      if (serverTurnCtx) {
+        conversationStore.setConversationOriginChannelIfUnset(conversationId, serverTurnCtx.userMessageChannel);
+      }
+
       const assistantMsg = createAssistantMessage(slashResult.message);
       conversationStore.addMessage(
         conversationId,

--- a/assistant/src/daemon/session-messaging.ts
+++ b/assistant/src/daemon/session-messaging.ts
@@ -87,8 +87,12 @@ export function persistUserMessage(
     const turnCtx = ctx.getTurnChannelContext();
     const channelMetadata = turnCtx
       ? { userMessageChannel: turnCtx.userMessageChannel, assistantMessageChannel: turnCtx.assistantMessageChannel }
-      : {};
-    const mergedMetadata = { ...metadata, ...channelMetadata };
+      : undefined;
+    // NOTE: When a message is queued and persisted later, turnCtx reflects the
+    // session's *current* channel context at persistence time, which may differ
+    // from the channel that was active when the user originally sent the message.
+    // A proper fix would capture channel context per queued request at enqueue time.
+    const mergedMetadata = (metadata || channelMetadata) ? { ...metadata, ...channelMetadata } : undefined;
 
     const persistedUserMessage = conversationStore.addMessage(
       ctx.conversationId,


### PR DESCRIPTION
Addresses review feedback on #7921. Prevents empty {} metadata objects from being stored when no channel context exists. Adds origin channel initialization on direct user message writes. Adds comment noting queued-request channel context limitation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
