### PR TITLE
fix: address three approval flow feedback issues

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -4052,3 +4052,625 @@ describe('guardian conversational approval via conversation engine', () => {
     deliverSpy.mockRestore();
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Fix: deterministic fallback when engine returns keep_pending (P1)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('deterministic fallback on engine keep_pending — standard path', () => {
+  beforeEach(() => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'telegram-user-default',
+      guardianDeliveryChatId: 'chat-123',
+    });
+  });
+
+  test('explicit "approve" text falls through to deterministic parser when engine returns keep_pending', async () => {
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const initReq = makeInboundRequest({ content: 'init' });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    deliverSpy.mockClear();
+
+    // Engine fails to classify and returns keep_pending
+    const mockConversationGenerator = mock(async (_ctx: unknown) => ({
+      disposition: 'keep_pending' as const,
+      replyText: 'I could not understand your message. Please try again.',
+    }));
+
+    const req = makeInboundRequest({ content: 'approve' });
+    const res = await handleChannelInbound(
+      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
+      mockConversationGenerator,
+    );
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('decision_applied');
+
+    // Deterministic parser should have resolved the decision
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'allow');
+
+    deliverSpy.mockRestore();
+  });
+
+  test('explicit "deny" text falls through to deterministic parser when engine returns keep_pending', async () => {
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const initReq = makeInboundRequest({ content: 'init' });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    deliverSpy.mockClear();
+
+    const mockConversationGenerator = mock(async (_ctx: unknown) => ({
+      disposition: 'keep_pending' as const,
+      replyText: 'Sorry, I had trouble processing that.',
+    }));
+
+    const req = makeInboundRequest({ content: 'deny' });
+    const res = await handleChannelInbound(
+      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
+      mockConversationGenerator,
+    );
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('decision_applied');
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'deny');
+
+    deliverSpy.mockRestore();
+  });
+
+  test('non-decision text with keep_pending still returns assistant_turn', async () => {
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const initReq = makeInboundRequest({ content: 'init' });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    deliverSpy.mockClear();
+
+    const mockConversationGenerator = mock(async (_ctx: unknown) => ({
+      disposition: 'keep_pending' as const,
+      replyText: 'What would you like to do?',
+    }));
+
+    const req = makeInboundRequest({ content: 'tell me more about this command' });
+    const res = await handleChannelInbound(
+      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
+      mockConversationGenerator,
+    );
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('assistant_turn');
+    expect(orchestrator.submitDecision).not.toHaveBeenCalled();
+
+    deliverSpy.mockRestore();
+  });
+});
+
+describe('deterministic fallback on engine keep_pending — guardian path', () => {
+  test('guardian explicit "yes" text falls through to deterministic parser when engine returns keep_pending', async () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-user-fb',
+      guardianDeliveryChatId: 'guardian-chat-fb',
+    });
+
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // Create requester conversation and run
+    const initReq = makeInboundRequest({
+      content: 'init',
+      externalChatId: 'requester-chat-fb',
+      senderExternalUserId: 'requester-user-fb',
+    });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    // Create guardian approval request
+    createApprovalRequest({
+      runId: run.id,
+      conversationId: conversationId!,
+      assistantId: 'self',
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-user-fb',
+      requesterChatId: 'requester-chat-fb',
+      guardianExternalUserId: 'guardian-user-fb',
+      guardianChatId: 'guardian-chat-fb',
+      toolName: 'shell',
+      expiresAt: Date.now() + 300_000,
+    });
+
+    deliverSpy.mockClear();
+
+    // Engine returns keep_pending (simulating failure/timeout)
+    const mockConversationGenerator = mock(async (_ctx: unknown) => ({
+      disposition: 'keep_pending' as const,
+      replyText: 'I could not understand that.',
+    }));
+
+    const guardianReq = makeInboundRequest({
+      content: 'yes',
+      externalChatId: 'guardian-chat-fb',
+      senderExternalUserId: 'guardian-user-fb',
+    });
+    const res = await handleChannelInbound(
+      guardianReq, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
+      mockConversationGenerator,
+    );
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('guardian_decision_applied');
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'allow');
+
+    // Approval record should be updated
+    const approval = getPendingApprovalForRun(run.id);
+    expect(approval).toBeNull(); // No longer pending — it was resolved
+
+    deliverSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Fix: requester cancel of guardian-gated pending request (P2)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('requester cancel of guardian-gated pending request', () => {
+  beforeEach(() => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-cancel',
+      guardianDeliveryChatId: 'guardian-cancel-chat',
+    });
+  });
+
+  test('requester explicit "deny" cancels their own guardian-gated request', async () => {
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    // Create requester conversation and run
+    const initReq = makeInboundRequest({
+      content: 'init',
+      externalChatId: 'requester-cancel-chat',
+      senderExternalUserId: 'requester-cancel-user',
+    });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    // Create guardian approval request
+    createApprovalRequest({
+      runId: run.id,
+      conversationId: conversationId!,
+      assistantId: 'self',
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-cancel-user',
+      requesterChatId: 'requester-cancel-chat',
+      guardianExternalUserId: 'guardian-cancel',
+      guardianChatId: 'guardian-cancel-chat',
+      toolName: 'shell',
+      expiresAt: Date.now() + 300_000,
+    });
+
+    deliverSpy.mockClear();
+
+    // Requester sends "deny" — should cancel their own request
+    const req = makeInboundRequest({
+      content: 'deny',
+      externalChatId: 'requester-cancel-chat',
+      senderExternalUserId: 'requester-cancel-user',
+    });
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('decision_applied');
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'deny');
+
+    // Guardian approval should be resolved
+    const approval = getPendingApprovalForRun(run.id);
+    expect(approval).toBeNull();
+
+    // Requester should have been notified (cancel notice)
+    const requesterReply = deliverSpy.mock.calls.find(
+      (call) => (call[1] as { chatId?: string }).chatId === 'requester-cancel-chat',
+    );
+    expect(requesterReply).toBeDefined();
+
+    // Guardian should have been notified of the cancellation
+    const guardianNotice = deliverSpy.mock.calls.find(
+      (call) => (call[1] as { chatId?: string }).chatId === 'guardian-cancel-chat',
+    );
+    expect(guardianNotice).toBeDefined();
+
+    deliverSpy.mockRestore();
+  });
+
+  test('requester "nevermind" via conversational engine cancels guardian-gated request', async () => {
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const initReq = makeInboundRequest({
+      content: 'init',
+      externalChatId: 'requester-cancel-chat',
+      senderExternalUserId: 'requester-cancel-user',
+    });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    createApprovalRequest({
+      runId: run.id,
+      conversationId: conversationId!,
+      assistantId: 'self',
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-cancel-user',
+      requesterChatId: 'requester-cancel-chat',
+      guardianExternalUserId: 'guardian-cancel',
+      guardianChatId: 'guardian-cancel-chat',
+      toolName: 'shell',
+      expiresAt: Date.now() + 300_000,
+    });
+
+    deliverSpy.mockClear();
+
+    // Conversational engine recognises cancel intent and returns reject
+    const mockConversationGenerator = mock(async (_ctx: unknown) => ({
+      disposition: 'reject' as const,
+      replyText: 'OK, I have cancelled the pending request.',
+    }));
+
+    const req = makeInboundRequest({
+      content: 'actually never mind, cancel it',
+      externalChatId: 'requester-cancel-chat',
+      senderExternalUserId: 'requester-cancel-user',
+    });
+    const res = await handleChannelInbound(
+      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
+      mockConversationGenerator,
+    );
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('decision_applied');
+    expect(orchestrator.submitDecision).toHaveBeenCalledWith(run.id, 'deny');
+
+    // Engine should have been called with reject-only allowed actions
+    expect(mockConversationGenerator).toHaveBeenCalledTimes(1);
+    const engineCtx = mockConversationGenerator.mock.calls[0][0] as Record<string, unknown>;
+    expect(engineCtx.allowedActions).toEqual(['reject']);
+
+    // Engine reply should have been delivered to requester
+    const replyCall = deliverSpy.mock.calls.find(
+      (call) => (call[1] as { text?: string }).text?.includes('cancelled the pending request'),
+    );
+    expect(replyCall).toBeDefined();
+
+    deliverSpy.mockRestore();
+  });
+
+  test('requester non-cancel message still gets guardian-pending notice', async () => {
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const initReq = makeInboundRequest({
+      content: 'init',
+      externalChatId: 'requester-cancel-chat',
+      senderExternalUserId: 'requester-cancel-user',
+    });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    createApprovalRequest({
+      runId: run.id,
+      conversationId: conversationId!,
+      assistantId: 'self',
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-cancel-user',
+      requesterChatId: 'requester-cancel-chat',
+      guardianExternalUserId: 'guardian-cancel',
+      guardianChatId: 'guardian-cancel-chat',
+      toolName: 'shell',
+      expiresAt: Date.now() + 300_000,
+    });
+
+    deliverSpy.mockClear();
+
+    // Engine returns keep_pending (not a cancel intent)
+    const mockConversationGenerator = mock(async (_ctx: unknown) => ({
+      disposition: 'keep_pending' as const,
+      replyText: 'Still waiting.',
+    }));
+
+    const req = makeInboundRequest({
+      content: 'what is happening?',
+      externalChatId: 'requester-cancel-chat',
+      senderExternalUserId: 'requester-cancel-user',
+    });
+    const res = await handleChannelInbound(
+      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
+      mockConversationGenerator,
+    );
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('assistant_turn');
+    expect(orchestrator.submitDecision).not.toHaveBeenCalled();
+
+    // Should have received the guardian-pending notice
+    const pendingReply = deliverSpy.mock.calls.find(
+      (call) => (call[1] as { text?: string }).text?.includes('pending guardian approval'),
+    );
+    expect(pendingReply).toBeDefined();
+
+    deliverSpy.mockRestore();
+  });
+
+  test('requester "approve" is blocked — self-approval not allowed even during cancel check', async () => {
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const initReq = makeInboundRequest({
+      content: 'init',
+      externalChatId: 'requester-cancel-chat',
+      senderExternalUserId: 'requester-cancel-user',
+    });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    createApprovalRequest({
+      runId: run.id,
+      conversationId: conversationId!,
+      assistantId: 'self',
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-cancel-user',
+      requesterChatId: 'requester-cancel-chat',
+      guardianExternalUserId: 'guardian-cancel',
+      guardianChatId: 'guardian-cancel-chat',
+      toolName: 'shell',
+      expiresAt: Date.now() + 300_000,
+    });
+
+    deliverSpy.mockClear();
+
+    // Requester tries to self-approve — "approve" matches deterministic parser
+    // but with action 'approve_once', NOT 'reject', so it should be blocked
+    const req = makeInboundRequest({
+      content: 'approve',
+      externalChatId: 'requester-cancel-chat',
+      senderExternalUserId: 'requester-cancel-user',
+    });
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    // Should get the guardian-pending notice, NOT decision_applied
+    expect(body.approval).toBe('assistant_turn');
+    expect(orchestrator.submitDecision).not.toHaveBeenCalled();
+
+    deliverSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Fix: stale_ignored when engine decision races with concurrent resolution
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('engine decision race condition — standard path', () => {
+  beforeEach(() => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'telegram-user-default',
+      guardianDeliveryChatId: 'chat-123',
+    });
+  });
+
+  test('returns stale_ignored when engine approves but run was already resolved', async () => {
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const initReq = makeInboundRequest({ content: 'init' });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    deliverSpy.mockClear();
+
+    // Engine returns approve_once, but clears the pending confirmation
+    // before handleChannelDecision is called (simulating race condition)
+    const mockConversationGenerator = mock(async (_ctx: unknown) => {
+      db.$client.prepare('UPDATE message_runs SET pending_confirmation = NULL WHERE id = ?').run(run.id);
+      return {
+        disposition: 'approve_once' as const,
+        replyText: 'Approved! Running the command now.',
+      };
+    });
+
+    const req = makeInboundRequest({ content: 'go ahead' });
+    const res = await handleChannelInbound(
+      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
+      mockConversationGenerator,
+    );
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('stale_ignored');
+
+    // submitDecision should NOT have been called since there was no pending
+    expect(orchestrator.submitDecision).not.toHaveBeenCalled();
+
+    // The engine's optimistic "Approved!" reply should NOT have been delivered
+    const approvedReply = deliverSpy.mock.calls.find(
+      (call) => (call[1] as { text?: string }).text?.includes('Approved!'),
+    );
+    expect(approvedReply).toBeUndefined();
+
+    // A stale notice should have been delivered instead
+    const staleReply = deliverSpy.mock.calls.find(
+      (call) => (call[1] as { text?: string }).text?.includes('already been resolved'),
+    );
+    expect(staleReply).toBeDefined();
+
+    deliverSpy.mockRestore();
+  });
+});
+
+describe('engine decision race condition — guardian path', () => {
+  test('returns stale_ignored when guardian engine approves but run was already resolved', async () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-race-user',
+      guardianDeliveryChatId: 'guardian-race-chat',
+    });
+
+    const orchestrator = makeMockOrchestrator();
+    const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+
+    const initReq = makeInboundRequest({
+      content: 'init',
+      externalChatId: 'requester-race-chat',
+      senderExternalUserId: 'requester-race-user',
+    });
+    await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
+
+    const db = getDb();
+    const events = db.$client.prepare('SELECT conversation_id FROM channel_inbound_events').all() as Array<{ conversation_id: string }>;
+    const conversationId = events[0]?.conversation_id;
+    ensureConversation(conversationId!);
+
+    const run = createRun(conversationId!);
+    setRunConfirmation(run.id, sampleConfirmation);
+
+    createApprovalRequest({
+      runId: run.id,
+      conversationId: conversationId!,
+      assistantId: 'self',
+      channel: 'telegram',
+      requesterExternalUserId: 'requester-race-user',
+      requesterChatId: 'requester-race-chat',
+      guardianExternalUserId: 'guardian-race-user',
+      guardianChatId: 'guardian-race-chat',
+      toolName: 'shell',
+      expiresAt: Date.now() + 300_000,
+    });
+
+    deliverSpy.mockClear();
+
+    // Guardian engine returns approve_once, but clears pending confirmation
+    // to simulate a concurrent resolution (expiry sweep or requester cancel)
+    const mockConversationGenerator = mock(async (_ctx: unknown) => {
+      db.$client.prepare('UPDATE message_runs SET pending_confirmation = NULL WHERE id = ?').run(run.id);
+      return {
+        disposition: 'approve_once' as const,
+        replyText: 'Approved the request.',
+      };
+    });
+
+    const guardianReq = makeInboundRequest({
+      content: 'approve it',
+      externalChatId: 'guardian-race-chat',
+      senderExternalUserId: 'guardian-race-user',
+    });
+    const res = await handleChannelInbound(
+      guardianReq, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
+      mockConversationGenerator,
+    );
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.approval).toBe('stale_ignored');
+
+    // submitDecision should NOT have been called
+    expect(orchestrator.submitDecision).not.toHaveBeenCalled();
+
+    // The engine's "Approved the request." should NOT be delivered
+    const optimisticReply = deliverSpy.mock.calls.find(
+      (call) => (call[1] as { text?: string }).text?.includes('Approved the request'),
+    );
+    expect(optimisticReply).toBeUndefined();
+
+    // A stale notice should have been delivered instead
+    const staleReply = deliverSpy.mock.calls.find(
+      (call) => (call[1] as { text?: string }).text?.includes('already been resolved'),
+    );
+    expect(staleReply).toBeDefined();
+
+    deliverSpy.mockRestore();
+  });
+});

--- a/assistant/src/runtime/approval-message-composer.ts
+++ b/assistant/src/runtime/approval-message-composer.ts
@@ -33,7 +33,9 @@ export type ApprovalMessageScenario =
   | 'guardian_verify_status_bound'
   | 'guardian_verify_status_unbound'
   | 'guardian_deny_no_identity'
-  | 'guardian_deny_no_binding';
+  | 'guardian_deny_no_binding'
+  | 'requester_cancel'
+  | 'approval_already_resolved';
 
 export interface ApprovalMessageContext {
   scenario: ApprovalMessageScenario;
@@ -228,6 +230,14 @@ export function getFallbackMessage(context: ApprovalMessageContext): string {
 
     case 'guardian_deny_no_binding':
       return 'This action requires guardian approval, but no guardian has been configured for this channel. The request has been denied for safety.';
+
+    case 'requester_cancel':
+      return context.toolName
+        ? `Your request to use "${context.toolName}" has been cancelled.`
+        : 'Your pending request has been cancelled.';
+
+    case 'approval_already_resolved':
+      return 'This approval request has already been resolved.';
 
     default: {
       // Exhaustive check — TypeScript will flag if a scenario is missing.

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -1563,6 +1563,40 @@ async function handleApprovalInterception(
         const engineResult = await runApprovalConversationTurn(engineContext, approvalConversationGenerator);
 
         if (engineResult.disposition === 'keep_pending') {
+          // Safety net: if the guardian sent an explicit decision phrase that
+          // the deterministic parser recognises, honour it even when the engine
+          // returned keep_pending (e.g. model timeout). This prevents deadlock
+          // on non-rich channels where "approve"/"deny" must always resolve.
+          // Only apply when a single approval is pending — when multiple are
+          // pending the engine's keep_pending is for disambiguation and should
+          // be respected.
+          const guardianDeterministic = parseApprovalDecision(content);
+          if (guardianDeterministic && effectivePending.length === 1) {
+            // Guardians cannot approve_always — downgrade.
+            if (guardianDeterministic.action === 'approve_always') {
+              guardianDeterministic.action = 'approve_once';
+            }
+            const fbResult = handleChannelDecision(
+              guardianApproval.conversationId,
+              { ...guardianDeterministic, source: 'plain_text' },
+              orchestrator,
+            );
+            if (fbResult.applied) {
+              const fbStatus = guardianDeterministic.action === 'reject' ? 'denied' as const : 'approved' as const;
+              updateApprovalDecision(guardianApproval.id, {
+                status: fbStatus,
+                decidedByExternalUserId: senderExternalUserId,
+              });
+              if (fbResult.runId) {
+                schedulePostDecisionDelivery(
+                  orchestrator, fbResult.runId, guardianApproval.conversationId,
+                  guardianApproval.requesterChatId, replyCallbackUrl, bearerToken, assistantId,
+                );
+              }
+            }
+            return { handled: true, type: 'guardian_decision_applied' };
+          }
+
           // Non-decision follow-up (clarification, disambiguation, etc.)
           try {
             await deliverChannelReply(replyCallbackUrl, {
@@ -1669,20 +1703,38 @@ async function handleApprovalInterception(
               assistantId,
             );
           }
+
+          // Deliver the engine's reply to the guardian
+          try {
+            await deliverChannelReply(replyCallbackUrl, {
+              chatId: externalChatId,
+              text: engineResult.replyText,
+              assistantId,
+            }, bearerToken);
+          } catch (err) {
+            log.error({ err, conversationId: targetApproval.conversationId }, 'Failed to deliver guardian decision reply');
+          }
+
+          return { handled: true, type: 'guardian_decision_applied' };
         }
 
-        // Deliver the engine's reply to the guardian
+        // Race condition: run was already resolved. Deliver a stale notice
+        // instead of the engine's optimistic reply.
         try {
+          const staleText = await composeApprovalMessageGenerative({
+            scenario: 'approval_already_resolved',
+            channel: sourceChannel,
+          }, {}, approvalCopyGenerator);
           await deliverChannelReply(replyCallbackUrl, {
             chatId: externalChatId,
-            text: engineResult.replyText,
+            text: staleText,
             assistantId,
           }, bearerToken);
         } catch (err) {
-          log.error({ err, conversationId: targetApproval.conversationId }, 'Failed to deliver guardian decision reply');
+          log.error({ err, conversationId: targetApproval.conversationId }, 'Failed to deliver stale guardian approval notice');
         }
 
-        return { handled: true, type: 'guardian_decision_applied' };
+        return { handled: true, type: 'stale_ignored' };
       }
 
       // ── Legacy fallback when no conversational engine is available ──
@@ -1864,6 +1916,92 @@ async function handleApprovalInterception(
     if (pending.length > 0) {
       const guardianApprovalForRun = getPendingApprovalForRun(pending[0].runId);
       if (guardianApprovalForRun) {
+        // Allow the requester to cancel their own pending guardian request.
+        // Only reject/cancel is permitted — self-approval is still blocked.
+        if (content) {
+          let requesterCancelIntent = false;
+          let cancelReplyText: string | undefined;
+
+          // 1. Check deterministic parser for explicit reject phrase
+          const deterministicDecision = parseApprovalDecision(content);
+          if (deterministicDecision && deterministicDecision.action === 'reject') {
+            requesterCancelIntent = true;
+          }
+
+          // 2. If no deterministic match, try the conversational engine
+          //    with reject-only so the requester can say "nevermind"/"cancel it"
+          if (!requesterCancelIntent && approvalConversationGenerator) {
+            const cancelContext: ApprovalConversationContext = {
+              toolName: pending[0].toolName,
+              allowedActions: ['reject'],
+              role: 'requester',
+              pendingApprovals: pending.map(p => ({ runId: p.runId, toolName: p.toolName })),
+              userMessage: content,
+            };
+            const cancelResult = await runApprovalConversationTurn(cancelContext, approvalConversationGenerator);
+            if (cancelResult.disposition === 'reject') {
+              requesterCancelIntent = true;
+              cancelReplyText = cancelResult.replyText;
+            }
+          }
+
+          if (requesterCancelIntent) {
+            const rejectDecision: ApprovalDecisionResult = {
+              action: 'reject',
+              source: 'plain_text',
+            };
+            const cancelApplyResult = handleChannelDecision(conversationId, rejectDecision, orchestrator);
+            if (cancelApplyResult.applied) {
+              updateApprovalDecision(guardianApprovalForRun.id, {
+                status: 'denied',
+                decidedByExternalUserId: senderExternalUserId,
+              });
+
+              // Notify requester
+              const replyText = cancelReplyText ?? await composeApprovalMessageGenerative({
+                scenario: 'requester_cancel',
+                toolName: pending[0].toolName,
+                channel: sourceChannel,
+              }, {}, approvalCopyGenerator);
+              try {
+                await deliverChannelReply(replyCallbackUrl, {
+                  chatId: externalChatId,
+                  text: replyText,
+                  assistantId,
+                }, bearerToken);
+              } catch (err) {
+                log.error({ err, conversationId }, 'Failed to deliver requester cancel notice');
+              }
+
+              // Notify guardian that the request was cancelled
+              try {
+                const guardianNotice = await composeApprovalMessageGenerative({
+                  scenario: 'guardian_decision_outcome',
+                  decision: 'denied',
+                  toolName: pending[0].toolName,
+                  channel: sourceChannel,
+                }, {}, approvalCopyGenerator);
+                await deliverChannelReply(replyCallbackUrl, {
+                  chatId: guardianApprovalForRun.guardianChatId,
+                  text: guardianNotice,
+                  assistantId,
+                }, bearerToken);
+              } catch (err) {
+                log.error({ err, conversationId }, 'Failed to notify guardian of requester cancellation');
+              }
+
+              if (cancelApplyResult.runId) {
+                schedulePostDecisionDelivery(
+                  orchestrator, cancelApplyResult.runId, conversationId, externalChatId,
+                  replyCallbackUrl, bearerToken, assistantId,
+                );
+              }
+            }
+            return { handled: true, type: 'decision_applied' };
+          }
+        }
+
+        // Not a cancel intent — tell the requester their request is pending
         try {
           const pendingText = await composeApprovalMessageGenerative({
             scenario: 'request_pending_guardian',
@@ -1974,6 +2112,24 @@ async function handleApprovalInterception(
     const engineResult = await runApprovalConversationTurn(engineContext, approvalConversationGenerator);
 
     if (engineResult.disposition === 'keep_pending') {
+      // Safety net: if the user sent an explicit decision phrase that the
+      // deterministic parser recognises, honour it even when the engine
+      // returned keep_pending (e.g. model timeout). This prevents deadlock
+      // on non-rich channels where "approve"/"deny" must always resolve.
+      // Only apply when a single confirmation is pending — when multiple
+      // are pending the engine's keep_pending may be for disambiguation.
+      const deterministicFallback = parseApprovalDecision(content);
+      if (deterministicFallback && pending.length === 1) {
+        const fbResult = handleChannelDecision(conversationId, deterministicFallback, orchestrator);
+        if (fbResult.applied && fbResult.runId) {
+          schedulePostDecisionDelivery(
+            orchestrator, fbResult.runId, conversationId, externalChatId,
+            replyCallbackUrl, bearerToken, assistantId,
+          );
+        }
+        return { handled: true, type: 'decision_applied' };
+      }
+
       // Non-decision follow-up — deliver the engine's reply and keep the run pending
       try {
         await deliverChannelReply(replyCallbackUrl, {
@@ -1997,30 +2153,51 @@ async function handleApprovalInterception(
 
     const result = handleChannelDecision(conversationId, engineDecision, orchestrator);
 
-    if (result.applied && result.runId) {
-      schedulePostDecisionDelivery(
-        orchestrator,
-        result.runId,
-        conversationId,
-        externalChatId,
-        replyCallbackUrl,
-        bearerToken,
-        assistantId,
-      );
+    if (result.applied) {
+      if (result.runId) {
+        schedulePostDecisionDelivery(
+          orchestrator,
+          result.runId,
+          conversationId,
+          externalChatId,
+          replyCallbackUrl,
+          bearerToken,
+          assistantId,
+        );
+      }
+
+      // Deliver the engine's reply text to the user
+      try {
+        await deliverChannelReply(replyCallbackUrl, {
+          chatId: externalChatId,
+          text: engineResult.replyText,
+          assistantId,
+        }, bearerToken);
+      } catch (err) {
+        log.error({ err, conversationId }, 'Failed to deliver approval decision reply');
+      }
+
+      return { handled: true, type: 'decision_applied' };
     }
 
-    // Deliver the engine's reply text to the user
+    // Race condition: run was already resolved by expiry sweep or
+    // concurrent callback. Deliver a stale notice instead of the
+    // engine's optimistic reply.
     try {
+      const staleText = await composeApprovalMessageGenerative({
+        scenario: 'approval_already_resolved',
+        channel: sourceChannel,
+      }, {}, approvalCopyGenerator);
       await deliverChannelReply(replyCallbackUrl, {
         chatId: externalChatId,
-        text: engineResult.replyText,
+        text: staleText,
         assistantId,
       }, bearerToken);
     } catch (err) {
-      log.error({ err, conversationId }, 'Failed to deliver approval decision reply');
+      log.error({ err, conversationId }, 'Failed to deliver stale approval notice');
     }
 
-    return { handled: true, type: 'decision_applied' };
+    return { handled: true, type: 'stale_ignored' };
   }
 
   // Fallback: no conversational generator available or no content — use


### PR DESCRIPTION
## Summary

Addresses three review feedback issues from PR #7940:

### P1: Non-rich channels deadlock when engine fails
When `approvalConversationGenerator` is injected and the engine returns `keep_pending` (e.g. model timeout), the deterministic parser fallback was never reached. On SMS/plain-text channels, explicit "approve"/"deny" messages would deadlock indefinitely.

**Fix:** After the engine returns `keep_pending`, check the deterministic parser as a safety net. If the user's text matches an explicit decision phrase (and there's only one pending approval — multi-pending disambiguation is respected), apply the decision directly. Applies to both standard and guardian paths.

### P2: Requester cannot cancel their own guardian-gated request
When a non-guardian requester has a pending guardian approval, ALL messages were short-circuited to `request_pending_guardian`. The requester saying "nevermind"/"cancel"/"deny" had no effect.

**Fix:** Before short-circuiting, check for requester cancel intent via (1) deterministic parser for explicit `reject` phrases, then (2) conversational engine with `allowedActions: ['reject']`. Only reject/cancel is permitted — self-approval remains blocked. On cancel, the requester is notified, the guardian is notified, and the approval record is updated.

### Race condition: misleading reply when decision already resolved
In both standard and guardian engine paths, `engineResult.replyText` (e.g. "Approved!") was delivered unconditionally even when `handleChannelDecision` returned `applied: false` (race with expiry sweep or concurrent callback). The response type was also wrong (`decision_applied` instead of `stale_ignored`).

**Fix:** Check `result.applied` — if false, deliver an "already resolved" notice instead of the engine's optimistic reply, and return `stale_ignored`.

## Files changed
- `assistant/src/runtime/routes/channel-routes.ts` — All three fixes
- `assistant/src/runtime/approval-message-composer.ts` — Two new message scenarios (`requester_cancel`, `approval_already_resolved`)
- `assistant/src/__tests__/channel-approval-routes.test.ts` — 10 new tests covering all three fixes

## Test plan
- [x] All 96 approval route tests pass (10 new + 86 existing)
- [x] TypeScript type-check passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
