### PR TITLE
feat: add inbox side panel + feature flag (U-01)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 // MARK: - Domain Types
 
 public enum NativePanelId: String, Codable, Equatable, Sendable {
-    case chat, threadList, settings, agent, debug, doctor, directory, generated, identity, avatarCustomization, voiceMode
+    case chat, threadList, settings, agent, debug, doctor, directory, generated, identity, avatarCustomization, voiceMode, assistantInbox
 }
 
 public enum SlotContent: Equatable, Sendable {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -982,6 +982,11 @@ struct MainWindowView: View {
             SidebarNavRow(icon: "sparkles", label: "Skills", isActive: windowState.activePanel == .agent) {
                 windowState.togglePanel(.agent)
             }
+            if FeatureFlagManager.shared.isEnabled(.assistantInboxEnabled) {
+                SidebarNavRow(icon: "tray.fill", label: "Inbox", isActive: windowState.activePanel == .assistantInbox) {
+                    windowState.togglePanel(.assistantInbox)
+                }
+            }
 
             // Divider between nav items and threads
             VColor.divider
@@ -1090,6 +1095,11 @@ struct MainWindowView: View {
             }
             SidebarNavRow(icon: "sparkles", label: "Skills", isActive: windowState.activePanel == .agent, isExpanded: false) {
                 windowState.togglePanel(.agent)
+            }
+            if FeatureFlagManager.shared.isEnabled(.assistantInboxEnabled) {
+                SidebarNavRow(icon: "tray.fill", label: "Inbox", isActive: windowState.activePanel == .assistantInbox, isExpanded: false) {
+                    windowState.togglePanel(.assistantInbox)
+                }
             }
 
             VColor.divider

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -111,6 +111,8 @@ extension MainWindowView {
                     }
                 }
             )
+        case .assistantInbox:
+            AssistantInboxPanel(onClose: { windowState.selection = nil })
         }
     }
 
@@ -468,6 +470,10 @@ extension MainWindowView {
             // Document editor is handled inline in chatContentView
             EmptyView()
                 .onAppear { windowState.dismissOverlay() }
+        case .assistantInbox:
+            AssistantInboxPanel(onClose: { windowState.dismissOverlay() })
+                .overlay(alignment: .topTrailing) { panelDismissButton }
+                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
         default:
             EmptyView()
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AssistantInboxPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AssistantInboxPanel.swift
@@ -1,0 +1,20 @@
+import VellumAssistantShared
+import SwiftUI
+
+struct AssistantInboxPanel: View {
+    var onClose: () -> Void
+
+    var body: some View {
+        VSidePanel(title: "Inbox", onClose: onClose) {
+            VEmptyState(
+                title: "No messages",
+                subtitle: "Messages from your assistant will appear here",
+                icon: "tray.fill"
+            )
+        }
+    }
+}
+
+#Preview {
+    AssistantInboxPanel(onClose: {})
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
@@ -9,6 +9,7 @@ enum SidePanelType: Hashable, CaseIterable {
     case documentEditor
     case avatarCustomization
     case voiceMode
+    case assistantInbox
 
     init?(rawValue: String) {
         switch rawValue {
@@ -22,6 +23,7 @@ enum SidePanelType: Hashable, CaseIterable {
         case "documentEditor": self = .documentEditor
         case "avatarCustomization": self = .avatarCustomization
         case "voiceMode": self = .voiceMode
+        case "assistantInbox": self = .assistantInbox
         default: return nil
         }
     }

--- a/clients/shared/Utilities/FeatureFlagManager.swift
+++ b/clients/shared/Utilities/FeatureFlagManager.swift
@@ -8,6 +8,7 @@ public enum FeatureFlag: String, CaseIterable {
     case featureFlagEditorEnabled = "feature_flag_editor_enabled"
     case hatchNewAssistantEnabled = "hatch_new_assistant_enabled"
     case localHttpEnabled = "local_http_enabled"
+    case assistantInboxEnabled = "assistant_inbox_enabled"
 
     public var displayName: String {
         switch self {
@@ -16,6 +17,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .featureFlagEditorEnabled: return "Feature Flag Editor Enabled"
         case .hatchNewAssistantEnabled: return "Hatch New Assistant Enabled"
         case .localHttpEnabled: return "Local HTTP Enabled"
+        case .assistantInboxEnabled: return "Assistant Inbox Enabled"
         }
     }
 }


### PR DESCRIPTION
Add assistantInbox case to SidePanelType, toolbar button gated behind feature flag, and placeholder AssistantInboxPanel. Part of the Assistant Inbox rollout (U-01).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
