### PR TITLE
feat: add ingress member store (A-05)

### DIFF
--- a/assistant/src/memory/ingress-member-store.ts
+++ b/assistant/src/memory/ingress-member-store.ts
@@ -1,0 +1,350 @@
+/**
+ * CRUD store for assistant ingress members — external users who have been
+ * granted (or denied) access to interact with the assistant via a specific
+ * channel. Members are keyed by raw channel identity fields (sourceChannel +
+ * externalUserId / externalChatId).
+ */
+
+import { and, desc, eq, or } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+import { getDb } from './db.js';
+import { assistantIngressMembers } from './schema.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type MemberStatus = 'pending' | 'active' | 'revoked' | 'blocked';
+export type MemberPolicy = 'allow' | 'deny' | 'escalate';
+
+export interface IngressMember {
+  id: string;
+  assistantId: string;
+  sourceChannel: string;
+  externalUserId: string | null;
+  externalChatId: string | null;
+  displayName: string | null;
+  username: string | null;
+  status: MemberStatus;
+  policy: MemberPolicy;
+  inviteId: string | null;
+  createdBySessionId: string | null;
+  revokedReason: string | null;
+  blockedReason: string | null;
+  lastSeenAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function rowToMember(row: typeof assistantIngressMembers.$inferSelect): IngressMember {
+  return {
+    id: row.id,
+    assistantId: row.assistantId,
+    sourceChannel: row.sourceChannel,
+    externalUserId: row.externalUserId,
+    externalChatId: row.externalChatId,
+    displayName: row.displayName,
+    username: row.username,
+    status: row.status as MemberStatus,
+    policy: row.policy as MemberPolicy,
+    inviteId: row.inviteId,
+    createdBySessionId: row.createdBySessionId,
+    revokedReason: row.revokedReason,
+    blockedReason: row.blockedReason,
+    lastSeenAt: row.lastSeenAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// upsertMember
+// ---------------------------------------------------------------------------
+
+export function upsertMember(params: {
+  sourceChannel: string;
+  externalUserId?: string;
+  externalChatId?: string;
+  displayName?: string;
+  username?: string;
+  policy?: MemberPolicy;
+  status?: MemberStatus;
+  inviteId?: string;
+  createdBySessionId?: string;
+  assistantId?: string;
+}): IngressMember {
+  const assistantId = params.assistantId ?? 'self';
+
+  if (!params.externalUserId && !params.externalChatId) {
+    throw new Error('At least one of externalUserId or externalChatId must be provided');
+  }
+
+  const db = getDb();
+  const now = Date.now();
+
+  // Try to find an existing member by (assistantId, sourceChannel, externalUserId)
+  // or (assistantId, sourceChannel, externalChatId)
+  const matchConditions = [];
+  if (params.externalUserId) {
+    matchConditions.push(
+      and(
+        eq(assistantIngressMembers.assistantId, assistantId),
+        eq(assistantIngressMembers.sourceChannel, params.sourceChannel),
+        eq(assistantIngressMembers.externalUserId, params.externalUserId),
+      ),
+    );
+  }
+  if (params.externalChatId) {
+    matchConditions.push(
+      and(
+        eq(assistantIngressMembers.assistantId, assistantId),
+        eq(assistantIngressMembers.sourceChannel, params.sourceChannel),
+        eq(assistantIngressMembers.externalChatId, params.externalChatId),
+      ),
+    );
+  }
+
+  const existing = db
+    .select()
+    .from(assistantIngressMembers)
+    .where(matchConditions.length === 1 ? matchConditions[0] : or(...matchConditions))
+    .get();
+
+  if (existing) {
+    // Update the existing member
+    const updates: Record<string, unknown> = { updatedAt: now };
+    if (params.externalUserId !== undefined) updates.externalUserId = params.externalUserId;
+    if (params.externalChatId !== undefined) updates.externalChatId = params.externalChatId;
+    if (params.displayName !== undefined) updates.displayName = params.displayName;
+    if (params.username !== undefined) updates.username = params.username;
+    if (params.policy !== undefined) updates.policy = params.policy;
+    if (params.status !== undefined) updates.status = params.status;
+    if (params.inviteId !== undefined) updates.inviteId = params.inviteId;
+    if (params.createdBySessionId !== undefined) updates.createdBySessionId = params.createdBySessionId;
+
+    db.update(assistantIngressMembers)
+      .set(updates)
+      .where(eq(assistantIngressMembers.id, existing.id))
+      .run();
+
+    // Re-read to return the updated row
+    const updated = db
+      .select()
+      .from(assistantIngressMembers)
+      .where(eq(assistantIngressMembers.id, existing.id))
+      .get();
+
+    return rowToMember(updated!);
+  }
+
+  // Create a new member
+  const id = uuid();
+  const row = {
+    id,
+    assistantId,
+    sourceChannel: params.sourceChannel,
+    externalUserId: params.externalUserId ?? null,
+    externalChatId: params.externalChatId ?? null,
+    displayName: params.displayName ?? null,
+    username: params.username ?? null,
+    status: params.status ?? 'pending',
+    policy: params.policy ?? 'allow',
+    inviteId: params.inviteId ?? null,
+    createdBySessionId: params.createdBySessionId ?? null,
+    revokedReason: null,
+    blockedReason: null,
+    lastSeenAt: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  db.insert(assistantIngressMembers).values(row).run();
+
+  return rowToMember(row);
+}
+
+// ---------------------------------------------------------------------------
+// listMembers
+// ---------------------------------------------------------------------------
+
+export function listMembers(params?: {
+  assistantId?: string;
+  sourceChannel?: string;
+  status?: MemberStatus;
+  policy?: MemberPolicy;
+  limit?: number;
+  offset?: number;
+}): IngressMember[] {
+  const db = getDb();
+  const assistantId = params?.assistantId ?? 'self';
+
+  const conditions = [eq(assistantIngressMembers.assistantId, assistantId)];
+  if (params?.sourceChannel) {
+    conditions.push(eq(assistantIngressMembers.sourceChannel, params.sourceChannel));
+  }
+  if (params?.status) {
+    conditions.push(eq(assistantIngressMembers.status, params.status));
+  }
+  if (params?.policy) {
+    conditions.push(eq(assistantIngressMembers.policy, params.policy));
+  }
+
+  let query = db
+    .select()
+    .from(assistantIngressMembers)
+    .where(and(...conditions))
+    .orderBy(desc(assistantIngressMembers.updatedAt))
+    .$dynamic();
+
+  if (params?.limit !== undefined) {
+    query = query.limit(params.limit);
+  }
+  if (params?.offset !== undefined) {
+    query = query.offset(params.offset);
+  }
+
+  return query.all().map(rowToMember);
+}
+
+// ---------------------------------------------------------------------------
+// revokeMember
+// ---------------------------------------------------------------------------
+
+export function revokeMember(memberId: string, reason?: string): IngressMember | null {
+  const db = getDb();
+  const now = Date.now();
+
+  const existing = db
+    .select()
+    .from(assistantIngressMembers)
+    .where(eq(assistantIngressMembers.id, memberId))
+    .get();
+
+  if (!existing) return null;
+
+  // Only revoke from active or pending status
+  if (existing.status !== 'active' && existing.status !== 'pending') {
+    return null;
+  }
+
+  db.update(assistantIngressMembers)
+    .set({
+      status: 'revoked',
+      revokedReason: reason ?? null,
+      updatedAt: now,
+    })
+    .where(eq(assistantIngressMembers.id, memberId))
+    .run();
+
+  const updated = db
+    .select()
+    .from(assistantIngressMembers)
+    .where(eq(assistantIngressMembers.id, memberId))
+    .get();
+
+  return updated ? rowToMember(updated) : null;
+}
+
+// ---------------------------------------------------------------------------
+// blockMember
+// ---------------------------------------------------------------------------
+
+export function blockMember(memberId: string, reason?: string): IngressMember | null {
+  const db = getDb();
+  const now = Date.now();
+
+  const existing = db
+    .select()
+    .from(assistantIngressMembers)
+    .where(eq(assistantIngressMembers.id, memberId))
+    .get();
+
+  if (!existing) return null;
+
+  // Can block from any non-blocked status
+  if (existing.status === 'blocked') {
+    return null;
+  }
+
+  db.update(assistantIngressMembers)
+    .set({
+      status: 'blocked',
+      blockedReason: reason ?? null,
+      updatedAt: now,
+    })
+    .where(eq(assistantIngressMembers.id, memberId))
+    .run();
+
+  const updated = db
+    .select()
+    .from(assistantIngressMembers)
+    .where(eq(assistantIngressMembers.id, memberId))
+    .get();
+
+  return updated ? rowToMember(updated) : null;
+}
+
+// ---------------------------------------------------------------------------
+// findMember
+// ---------------------------------------------------------------------------
+
+export function findMember(params: {
+  assistantId?: string;
+  sourceChannel: string;
+  externalUserId?: string;
+  externalChatId?: string;
+}): IngressMember | null {
+  if (!params.externalUserId && !params.externalChatId) {
+    return null;
+  }
+
+  const db = getDb();
+  const assistantId = params.assistantId ?? 'self';
+
+  // Prefer lookup by externalUserId when available, fall back to externalChatId
+  const matchConditions = [];
+  if (params.externalUserId) {
+    matchConditions.push(
+      and(
+        eq(assistantIngressMembers.assistantId, assistantId),
+        eq(assistantIngressMembers.sourceChannel, params.sourceChannel),
+        eq(assistantIngressMembers.externalUserId, params.externalUserId),
+      ),
+    );
+  }
+  if (params.externalChatId) {
+    matchConditions.push(
+      and(
+        eq(assistantIngressMembers.assistantId, assistantId),
+        eq(assistantIngressMembers.sourceChannel, params.sourceChannel),
+        eq(assistantIngressMembers.externalChatId, params.externalChatId),
+      ),
+    );
+  }
+
+  const row = db
+    .select()
+    .from(assistantIngressMembers)
+    .where(matchConditions.length === 1 ? matchConditions[0] : or(...matchConditions))
+    .get();
+
+  return row ? rowToMember(row) : null;
+}
+
+// ---------------------------------------------------------------------------
+// updateLastSeen
+// ---------------------------------------------------------------------------
+
+export function updateLastSeen(memberId: string): void {
+  const db = getDb();
+  const now = Date.now();
+
+  db.update(assistantIngressMembers)
+    .set({ lastSeenAt: now, updatedAt: now })
+    .where(eq(assistantIngressMembers.id, memberId))
+    .run();
+}


### PR DESCRIPTION
Implement assistant_ingress_members store with upsert/list/revoke/block/find/updateLastSeen methods. Includes status transitions (pending→active→revoked|blocked), policy field (allow|deny|escalate), and identity-based lookups. Part of the Assistant Inbox rollout (A-05).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
