### PR TITLE
fix: handle legacy mac channel and derive error channel list from CHANNEL_IDS

### DIFF
--- a/assistant/src/calls/guardian-action-sweep.ts
+++ b/assistant/src/calls/guardian-action-sweep.ts
@@ -53,7 +53,7 @@ export function sweepExpiredGuardianActions(
     for (const delivery of deliveries) {
       if (delivery.status !== 'sent' && delivery.status !== 'pending') continue;
 
-      if (delivery.destinationChannel === 'macos' && delivery.destinationConversationId) {
+      if ((delivery.destinationChannel === 'macos' || delivery.destinationChannel === 'mac') && delivery.destinationConversationId) {
         // Add expiry message to mac guardian thread
         addMessage(
           delivery.destinationConversationId,

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -2,7 +2,7 @@
  * Route handlers for channel inbound messages, delivery acks, and
  * conversation deletion.
  */
-import { isChannelId } from '../../channels/types.js';
+import { isChannelId, CHANNEL_IDS } from '../../channels/types.js';
 import type { ChannelId, TurnChannelContext } from '../../channels/types.js';
 import { timingSafeEqual } from 'node:crypto';
 import { deleteConversationKey } from '../../memory/conversation-key-store.js';
@@ -389,7 +389,7 @@ export async function handleChannelInbound(
   // only sends well-known channel strings, so an unknown value is rejected.
   if (!isChannelId(body.sourceChannel)) {
     return Response.json(
-      { error: `Invalid sourceChannel: ${body.sourceChannel}. Valid values: telegram, sms, voice, macos, ios, whatsapp, slack, email` },
+      { error: `Invalid sourceChannel: ${body.sourceChannel}. Valid values: ${CHANNEL_IDS.join(', ')}` },
       { status: 400 },
     );
   }


### PR DESCRIPTION
Addresses review feedback on #7951:\n- Accept both 'mac' and 'macos' in guardian action sweep for backward compatibility with legacy pending deliveries\n- Derive valid channel list in error message from CHANNEL_IDS constant instead of hardcoding
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
