### PR TITLE
fix: make origin-channel update best-effort in unknown slash handler

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -763,7 +763,11 @@ export class DaemonServer {
       session.getMessages().push(userMsg);
 
       if (serverTurnCtx) {
-        conversationStore.setConversationOriginChannelIfUnset(conversationId, serverTurnCtx.userMessageChannel);
+        try {
+          conversationStore.setConversationOriginChannelIfUnset(conversationId, serverTurnCtx.userMessageChannel);
+        } catch (err) {
+          log.warn({ err, conversationId }, 'Failed to set origin channel (best-effort)');
+        }
       }
 
       const assistantMsg = createAssistantMessage(slashResult.message);


### PR DESCRIPTION
Addresses review feedback on #7955:\n- Wrap setConversationOriginChannelIfUnset in try-catch so that transient SQLite errors don't break unknown-slash response handling\n- Log warning on failure instead of propagating the error
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
