### PR TITLE
feat: add backfill migration for inbox thread state from conversation bindings

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -14,6 +14,7 @@ import {
   migrateCallSessionsAddInitiatedFrom,
   migrateMemoryFtsBackfill,
   migrateGuardianActionTables,
+  migrateBackfillInboxThreadStateFromBindings,
   validateMigrationState,
 } from './schema-migration.js';
 
@@ -1254,6 +1255,8 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_inbox_thread_state_channel ON assistant_inbox_thread_state(assistant_id, source_channel, external_chat_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_inbox_thread_state_last_msg ON assistant_inbox_thread_state(assistant_id, last_message_at)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_inbox_thread_state_escalation ON assistant_inbox_thread_state(assistant_id, has_pending_escalation, last_message_at)`);
+
+  migrateBackfillInboxThreadStateFromBindings(database);
 
   migrateGuardianActionTables(database);
 

--- a/assistant/src/memory/schema-migration.ts
+++ b/assistant/src/memory/schema-migration.ts
@@ -69,6 +69,11 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     dependsOn: ['migration_normalize_assistant_id_to_self_v1'],
     description: 'Remove assistant_id column from llm_usage_events (separate checkpoint from the four-table migration)',
   },
+  {
+    key: 'backfill_inbox_thread_state_from_bindings',
+    version: 8,
+    description: 'Seed assistant_inbox_thread_state from external_conversation_bindings',
+  },
 ];
 
 export interface MigrationValidationResult {
@@ -1199,4 +1204,79 @@ export function migrateGuardianActionTables(database: Db): void {
   raw.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_action_deliveries_request_id ON guardian_action_deliveries(request_id)`);
   raw.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_action_deliveries_status ON guardian_action_deliveries(status)`);
   raw.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_action_deliveries_destination ON guardian_action_deliveries(destination_channel, destination_chat_id)`);
+}
+
+/**
+ * One-shot migration: seed assistant_inbox_thread_state from existing
+ * external_conversation_bindings so that pre-existing conversations
+ * appear in the inbox without waiting for new inbound activity.
+ *
+ * Uses INSERT OR IGNORE for idempotency (conversation_id is PK).
+ * Counters (unread_count, pending_escalation_count, has_pending_escalation)
+ * are initialised to zero since historical state is unknown.
+ */
+export function migrateBackfillInboxThreadStateFromBindings(database: Db): void {
+  const raw = getSqliteFrom(database);
+  const checkpointKey = 'backfill_inbox_thread_state_from_bindings';
+  const checkpoint = raw.query(
+    `SELECT 1 FROM memory_checkpoints WHERE key = ?`,
+  ).get(checkpointKey);
+  if (checkpoint) return;
+
+  // Guard: skip if either table does not exist yet (first boot edge case).
+  const srcExists = raw.query(
+    `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'external_conversation_bindings'`,
+  ).get();
+  const dstExists = raw.query(
+    `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'assistant_inbox_thread_state'`,
+  ).get();
+  if (!srcExists || !dstExists) {
+    raw.query(
+      `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,
+    ).run(checkpointKey, Date.now());
+    return;
+  }
+
+  try {
+    raw.exec('BEGIN');
+
+    raw.exec(/*sql*/ `
+      INSERT OR IGNORE INTO assistant_inbox_thread_state (
+        conversation_id, assistant_id, source_channel, external_chat_id,
+        external_user_id, display_name, username,
+        last_inbound_at, last_outbound_at, last_message_at,
+        unread_count, pending_escalation_count, has_pending_escalation,
+        created_at, updated_at
+      )
+      SELECT
+        conversation_id,
+        'self',
+        source_channel,
+        external_chat_id,
+        external_user_id,
+        display_name,
+        username,
+        last_inbound_at,
+        last_outbound_at,
+        CASE
+          WHEN last_inbound_at IS NULL AND last_outbound_at IS NULL THEN NULL
+          ELSE MAX(COALESCE(last_inbound_at, 0), COALESCE(last_outbound_at, 0))
+        END,
+        0,
+        0,
+        0,
+        created_at,
+        updated_at
+      FROM external_conversation_bindings
+    `);
+
+    raw.query(
+      `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,
+    ).run(checkpointKey, Date.now());
+
+    raw.exec('COMMIT');
+  } catch (e) {
+    try { raw.exec('ROLLBACK'); } catch { /* no active transaction */ }
+    throw e;
+  }
 }


### PR DESCRIPTION
## Summary
- Add checkpoint-gated migration to seed assistant_inbox_thread_state from external_conversation_bindings
- Uses INSERT OR IGNORE for idempotency
- Maps all available fields from bindings including timestamps
- Initializes counters to zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
