### PR TITLE
feat: build assistant inbox panel shell with thread list

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -112,7 +112,7 @@ extension MainWindowView {
                 }
             )
         case .assistantInbox:
-            AssistantInboxPanel(onClose: { windowState.selection = nil })
+            AssistantInboxPanel(onClose: { windowState.selection = nil }, daemonClient: daemonClient)
         }
     }
 
@@ -471,7 +471,7 @@ extension MainWindowView {
             EmptyView()
                 .onAppear { windowState.dismissOverlay() }
         case .assistantInbox:
-            AssistantInboxPanel(onClose: { windowState.dismissOverlay() })
+            AssistantInboxPanel(onClose: { windowState.dismissOverlay() }, daemonClient: daemonClient)
                 .overlay(alignment: .topTrailing) { panelDismissButton }
                 .background(adaptiveColor(light: Moss._50, dark: Moss._950))
         default:

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AssistantInboxPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AssistantInboxPanel.swift
@@ -3,18 +3,156 @@ import SwiftUI
 
 struct AssistantInboxPanel: View {
     var onClose: () -> Void
+    @StateObject private var viewModel: InboxViewModel
+
+    init(onClose: @escaping () -> Void, daemonClient: DaemonClient) {
+        self.onClose = onClose
+        self._viewModel = StateObject(wrappedValue: InboxViewModel(daemonClient: daemonClient))
+    }
 
     var body: some View {
         VSidePanel(title: "Inbox", onClose: onClose) {
-            VEmptyState(
-                title: "No messages",
-                subtitle: "Messages from your assistant will appear here",
-                icon: "tray.fill"
-            )
+            if viewModel.isLoading {
+                VStack {
+                    Spacer()
+                    VLoadingIndicator()
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let error = viewModel.error {
+                VEmptyState(
+                    title: "Failed to load",
+                    subtitle: error,
+                    icon: "exclamationmark.triangle.fill"
+                )
+            } else if viewModel.threads.isEmpty {
+                VEmptyState(
+                    title: "No messages",
+                    subtitle: "Messages from your assistant will appear here",
+                    icon: "tray.fill"
+                )
+            } else {
+                threadListView
+            }
+        }
+        .task {
+            await viewModel.loadThreads()
+        }
+    }
+
+    private var threadListView: some View {
+        VStack(spacing: 0) {
+            ForEach(viewModel.threads) { thread in
+                VListRow {
+                    InboxThreadRow(thread: thread)
+                }
+                if thread.id != viewModel.threads.last?.id {
+                    Divider()
+                        .background(VColor.surfaceBorder)
+                        .padding(.horizontal, VSpacing.sm)
+                }
+            }
         }
     }
 }
 
-#Preview {
-    AssistantInboxPanel(onClose: {})
+private struct InboxThreadRow: View {
+    let thread: InboxThread
+
+    var body: some View {
+        HStack(spacing: VSpacing.md) {
+            // Channel icon
+            Image(systemName: thread.channelIcon)
+                .font(VFont.body)
+                .foregroundColor(VColor.accent)
+                .frame(width: 24, alignment: .center)
+                .accessibilityLabel(thread.sourceChannel)
+
+            // Name and timestamp
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                HStack {
+                    Text(thread.resolvedName)
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(VColor.textPrimary)
+                        .lineLimit(1)
+
+                    Spacer()
+
+                    if let lastMessageAt = thread.lastMessageAt {
+                        Text(relativeTimestamp(lastMessageAt))
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                }
+
+                HStack {
+                    if thread.hasPendingEscalation {
+                        Text("Needs attention")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.warning)
+                    } else {
+                        Text(thread.sourceChannel.capitalized)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+
+                    Spacer()
+
+                    if thread.unreadCount > 0 {
+                        VBadge(style: .count(thread.unreadCount))
+                    }
+                }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(thread.resolvedName), \(thread.sourceChannel), \(thread.unreadCount) unread")
+    }
+
+    private func relativeTimestamp(_ date: Date) -> String {
+        let now = Date()
+        let interval = now.timeIntervalSince(date)
+
+        if interval < 60 {
+            return "now"
+        } else if interval < 3600 {
+            let minutes = Int(interval / 60)
+            return "\(minutes)m"
+        } else if interval < 86400 {
+            let hours = Int(interval / 3600)
+            return "\(hours)h"
+        } else if interval < 604800 {
+            let days = Int(interval / 86400)
+            return "\(days)d"
+        } else {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "MMM d"
+            return formatter.string(from: date)
+        }
+    }
 }
+
+#if DEBUG
+struct AssistantInboxPanel_Preview: PreviewProvider {
+    static var previews: some View {
+        AssistantInboxPanelPreviewWrapper()
+            .frame(width: 350, height: 500)
+            .previewDisplayName("AssistantInboxPanel")
+    }
+}
+
+private struct AssistantInboxPanelPreviewWrapper: View {
+    var body: some View {
+        ZStack {
+            VColor.background.ignoresSafeArea()
+            // Show the empty-state version for previews since we can't connect to a daemon
+            VSidePanel(title: "Inbox", onClose: {}) {
+                VEmptyState(
+                    title: "No messages",
+                    subtitle: "Messages from your assistant will appear here",
+                    icon: "tray.fill"
+                )
+            }
+        }
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/InboxViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/InboxViewModel.swift
@@ -1,0 +1,114 @@
+import Foundation
+import VellumAssistantShared
+
+/// A single inbox thread for display in the assistant inbox panel.
+struct InboxThread: Identifiable {
+    let id: String
+    let conversationId: String
+    let sourceChannel: String
+    let externalChatId: String
+    let displayName: String?
+    let username: String?
+    let lastMessageAt: Date?
+    let unreadCount: Int
+    let hasPendingEscalation: Bool
+
+    init(from ipcThread: IPCAssistantInboxResponseThread) {
+        self.id = ipcThread.conversationId
+        self.conversationId = ipcThread.conversationId
+        self.sourceChannel = ipcThread.sourceChannel
+        self.externalChatId = ipcThread.externalChatId
+        self.displayName = ipcThread.displayName
+        self.username = ipcThread.username
+        self.unreadCount = ipcThread.unreadCount
+        self.hasPendingEscalation = ipcThread.hasPendingEscalation
+
+        if let timestamp = ipcThread.lastMessageAt {
+            self.lastMessageAt = Date(timeIntervalSince1970: Double(timestamp) / 1000.0)
+        } else {
+            self.lastMessageAt = nil
+        }
+    }
+
+    /// Human-readable name for this thread, falling back through display name, username, and chat ID.
+    var resolvedName: String {
+        displayName ?? username ?? externalChatId
+    }
+
+    /// SF Symbol name for the source channel icon.
+    var channelIcon: String {
+        switch sourceChannel.lowercased() {
+        case "telegram":
+            return "paperplane.fill"
+        case "sms", "twilio":
+            return "message.fill"
+        case "email":
+            return "envelope.fill"
+        case "web":
+            return "globe"
+        default:
+            return "bubble.left.fill"
+        }
+    }
+}
+
+@MainActor
+final class InboxViewModel: ObservableObject {
+    @Published var threads: [InboxThread] = []
+    @Published var isLoading: Bool = false
+    @Published var error: String?
+
+    private let daemonClient: DaemonClient
+
+    init(daemonClient: DaemonClient) {
+        self.daemonClient = daemonClient
+    }
+
+    func loadThreads() async {
+        isLoading = true
+        error = nil
+
+        let stream = daemonClient.subscribe()
+
+        do {
+            try daemonClient.sendAssistantInboxListThreads()
+        } catch {
+            self.error = error.localizedDescription
+            self.isLoading = false
+            return
+        }
+
+        // Wait for the response with a timeout
+        let response: IPCAssistantInboxResponse? = await withTaskGroup(of: IPCAssistantInboxResponse?.self) { group in
+            group.addTask {
+                for await message in stream {
+                    if case .assistantInboxResponse(let msg) = message {
+                        return msg
+                    }
+                }
+                return nil
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 10_000_000_000)
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
+        }
+
+        isLoading = false
+
+        guard let response else {
+            self.error = "Request timed out"
+            return
+        }
+
+        if !response.success {
+            self.error = response.error ?? "Unknown error"
+            return
+        }
+
+        self.threads = (response.threads ?? []).map { InboxThread(from: $0) }
+    }
+}

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -402,6 +402,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `work_item_cancel_response` message.
     public var onWorkItemCancelResponse: ((IPCWorkItemCancelResponse) -> Void)?
 
+    /// Called when the daemon sends an `assistant_inbox_response` message.
+    public var onAssistantInboxResponse: ((IPCAssistantInboxResponse) -> Void)?
+
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     public var onError: ((ErrorMessage) -> Void)?
 
@@ -1048,6 +1051,19 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Unpublish a page and delete its Vercel deployment.
     public func sendUnpublishPage(deploymentId: String) throws {
         try send(UnpublishPageRequestMessage(deploymentId: deploymentId))
+    }
+
+    // MARK: - Assistant Inbox
+
+    /// Request the list of inbox threads from the daemon.
+    public func sendAssistantInboxListThreads(assistantId: String? = nil, limit: Int? = nil, offset: Int? = nil) throws {
+        try send(IPCAssistantInboxRequest(
+            type: "assistant_inbox",
+            action: "list_threads",
+            assistantId: assistantId,
+            limit: limit.map { Double($0) },
+            offset: offset.map { Double($0) }
+        ))
     }
 
     // MARK: - Model Config

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -248,6 +248,8 @@ extension DaemonClient {
             onParentalControlSetPinResponse?(msg)
         case .parentalControlUpdateResponse(let msg):
             onParentalControlUpdateResponse?(msg)
+        case .assistantInboxResponse(let msg):
+            onAssistantInboxResponse?(msg)
         default:
             break
         }

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2202,6 +2202,7 @@ public enum ServerMessage: Decodable, Sendable {
     case parentalControlSetPinResponse(ParentalControlSetPinResponseMessage)
     case parentalControlUpdateResponse(ParentalControlUpdateResponseMessage)
     case conversationSearchResponse(ConversationSearchResponseMessage)
+    case assistantInboxResponse(IPCAssistantInboxResponse)
     case pong
     case unknown(String)
 
@@ -2589,6 +2590,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "conversation_search_response":
             let message = try ConversationSearchResponseMessage(from: decoder)
             self = .conversationSearchResponse(message)
+        case "assistant_inbox_response":
+            let message = try IPCAssistantInboxResponse(from: decoder)
+            self = .assistantInboxResponse(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Create InboxViewModel with thread loading via daemon IPC
- Update AssistantInboxPanel with thread list UI, loading, error, and empty states
- Thread rows show display name, channel icon, last message time, unread badge
- Uses design system components (VSidePanel, VBadge, VEmptyState, etc.)
- Add assistant_inbox_response to ServerMessage enum and DaemonMessageRouter
- Add sendAssistantInboxListThreads convenience method on DaemonClient

## Test plan
- [ ] Verify panel shows loading indicator when first opened
- [ ] Verify empty state appears when no threads exist
- [ ] Verify error state appears when daemon is unreachable
- [ ] Verify thread list renders with channel icons, names, timestamps, and unread badges
- [ ] Verify escalation threads show 'Needs attention' label

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7974" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
