### PR TITLE
feat: add daemon handlers for member IPC operations

### DIFF
--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -1,5 +1,5 @@
 import * as net from 'node:net';
-import type { IngressInviteRequest } from '../ipc-protocol.js';
+import type { IngressInviteRequest, IngressMemberRequest } from '../ipc-protocol.js';
 import { log, defineHandlers, type HandlerContext } from './shared.js';
 import {
   createInvite,
@@ -8,6 +8,13 @@ import {
   redeemInvite,
   type InviteStatus,
 } from '../../memory/ingress-invite-store.js';
+import {
+  upsertMember,
+  listMembers,
+  revokeMember,
+  blockMember,
+  type IngressMember,
+} from '../../memory/ingress-member-store.js';
 
 export function handleIngressInvite(
   msg: IngressInviteRequest,
@@ -141,6 +148,116 @@ export function handleIngressInvite(
   }
 }
 
+function memberToResponse(m: IngressMember) {
+  return {
+    id: m.id,
+    sourceChannel: m.sourceChannel,
+    externalUserId: m.externalUserId ?? undefined,
+    externalChatId: m.externalChatId ?? undefined,
+    displayName: m.displayName ?? undefined,
+    username: m.username ?? undefined,
+    status: m.status,
+    policy: m.policy,
+    lastSeenAt: m.lastSeenAt ?? undefined,
+    createdAt: m.createdAt,
+  };
+}
+
+export function handleIngressMember(
+  msg: IngressMemberRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  try {
+    switch (msg.action) {
+      case 'list': {
+        const members = listMembers({
+          sourceChannel: msg.sourceChannel,
+          status: msg.status,
+          policy: msg.policy,
+        });
+        ctx.send(socket, {
+          type: 'ingress_member_response',
+          success: true,
+          members: members.map(memberToResponse),
+        });
+        return;
+      }
+
+      case 'upsert': {
+        if (!msg.sourceChannel) {
+          ctx.send(socket, { type: 'ingress_member_response', success: false, error: 'sourceChannel is required for upsert' });
+          return;
+        }
+        if (!msg.externalUserId && !msg.externalChatId) {
+          ctx.send(socket, { type: 'ingress_member_response', success: false, error: 'At least one of externalUserId or externalChatId is required for upsert' });
+          return;
+        }
+        const member = upsertMember({
+          sourceChannel: msg.sourceChannel,
+          externalUserId: msg.externalUserId,
+          externalChatId: msg.externalChatId,
+          displayName: msg.displayName,
+          username: msg.username,
+          policy: msg.policy,
+          status: msg.status,
+        });
+        ctx.send(socket, {
+          type: 'ingress_member_response',
+          success: true,
+          member: memberToResponse(member),
+        });
+        return;
+      }
+
+      case 'revoke': {
+        if (!msg.memberId) {
+          ctx.send(socket, { type: 'ingress_member_response', success: false, error: 'memberId is required for revoke' });
+          return;
+        }
+        const revoked = revokeMember(msg.memberId, msg.reason);
+        if (!revoked) {
+          ctx.send(socket, { type: 'ingress_member_response', success: false, error: 'Member not found or cannot be revoked' });
+          return;
+        }
+        ctx.send(socket, {
+          type: 'ingress_member_response',
+          success: true,
+          member: memberToResponse(revoked),
+        });
+        return;
+      }
+
+      case 'block': {
+        if (!msg.memberId) {
+          ctx.send(socket, { type: 'ingress_member_response', success: false, error: 'memberId is required for block' });
+          return;
+        }
+        const blocked = blockMember(msg.memberId, msg.reason);
+        if (!blocked) {
+          ctx.send(socket, { type: 'ingress_member_response', success: false, error: 'Member not found or already blocked' });
+          return;
+        }
+        ctx.send(socket, {
+          type: 'ingress_member_response',
+          success: true,
+          member: memberToResponse(blocked),
+        });
+        return;
+      }
+
+      default: {
+        ctx.send(socket, { type: 'ingress_member_response', success: false, error: `Unknown action: ${String((msg as Record<string, unknown>).action)}` });
+      }
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'ingress_member handler error');
+    ctx.send(socket, { type: 'ingress_member_response', success: false, error: message });
+  }
+}
+
 export const inboxInviteHandlers = defineHandlers({
   ingress_invite: handleIngressInvite,
+  ingress_member: handleIngressMember,
 });

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -90,9 +90,6 @@ const inlineHandlers = defineHandlers({
   integration_disconnect: () => { /* no-op — integration registry removed */ },
 
   // Stub handlers: inbox operations — real implementations will be added in a follow-up PR.
-  ingress_member: (_msg, socket, ctx) => {
-    ctx.send(socket, { type: 'ingress_member_response', success: false, error: 'Not yet implemented' });
-  },
   assistant_inbox: (_msg, socket, ctx) => {
     ctx.send(socket, { type: 'assistant_inbox_response', success: false, error: 'Not yet implemented' });
   },


### PR DESCRIPTION
## Summary
- Add ingress_member handler to config-inbox.ts (alongside invite handler)
- Handle all 4 actions: list, upsert, revoke, block
- Remove stub from index.ts
- Wire through to member store methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7975" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
