### PR TITLE
feat: implement escalation queue IPC handlers (P-02)

### DIFF
--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -1,5 +1,5 @@
 import * as net from 'node:net';
-import type { IngressInviteRequest, IngressMemberRequest } from '../ipc-protocol.js';
+import type { IngressInviteRequest, IngressMemberRequest, AssistantInboxEscalationRequest } from '../ipc-protocol.js';
 import { log, defineHandlers, type HandlerContext } from './shared.js';
 import {
   createInvite,
@@ -15,6 +15,12 @@ import {
   blockMember,
   type IngressMember,
 } from '../../memory/ingress-member-store.js';
+import {
+  listPendingApprovalRequests,
+  resolveApprovalRequest,
+  type ApprovalRequestStatus,
+} from '../../memory/channel-guardian-store.js';
+import { refreshThreadEscalation } from '../../memory/inbox-escalation-projection.js';
 
 export function handleIngressInvite(
   msg: IngressInviteRequest,
@@ -257,7 +263,82 @@ export function handleIngressMember(
   }
 }
 
+export function handleInboxEscalation(
+  msg: AssistantInboxEscalationRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  try {
+    switch (msg.action) {
+      case 'list': {
+        const escalations = listPendingApprovalRequests({
+          assistantId: msg.assistantId,
+          status: (msg.status as ApprovalRequestStatus) ?? undefined,
+        });
+        ctx.send(socket, {
+          type: 'assistant_inbox_escalation_response',
+          success: true,
+          escalations: escalations.map((req) => ({
+            id: req.id,
+            runId: req.runId,
+            conversationId: req.conversationId,
+            channel: req.channel,
+            requesterExternalUserId: req.requesterExternalUserId,
+            requesterChatId: req.requesterChatId,
+            status: req.status,
+            requestSummary: req.reason ?? undefined,
+            createdAt: req.createdAt,
+          })),
+        });
+        return;
+      }
+
+      case 'decide': {
+        if (!msg.approvalRequestId) {
+          ctx.send(socket, { type: 'assistant_inbox_escalation_response', success: false, error: 'approvalRequestId is required for decide' });
+          return;
+        }
+        if (!msg.decision) {
+          ctx.send(socket, { type: 'assistant_inbox_escalation_response', success: false, error: 'decision is required for decide' });
+          return;
+        }
+
+        const mappedDecision = msg.decision === 'approve' ? 'approved' : 'denied';
+        const resolved = resolveApprovalRequest(msg.approvalRequestId, mappedDecision);
+
+        if (!resolved) {
+          ctx.send(socket, { type: 'assistant_inbox_escalation_response', success: false, error: 'Approval request not found or already resolved' });
+          return;
+        }
+
+        // Update thread escalation state so inbox badges stay accurate
+        refreshThreadEscalation(resolved.conversationId, resolved.assistantId);
+
+        ctx.send(socket, {
+          type: 'assistant_inbox_escalation_response',
+          success: true,
+          decision: {
+            id: resolved.id,
+            status: resolved.status,
+            decidedAt: resolved.updatedAt,
+          },
+        });
+        return;
+      }
+
+      default: {
+        ctx.send(socket, { type: 'assistant_inbox_escalation_response', success: false, error: `Unknown action: ${String((msg as Record<string, unknown>).action)}` });
+      }
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'assistant_inbox_escalation handler error');
+    ctx.send(socket, { type: 'assistant_inbox_escalation_response', success: false, error: message });
+  }
+}
+
 export const inboxInviteHandlers = defineHandlers({
   ingress_invite: handleIngressInvite,
   ingress_member: handleIngressMember,
+  assistant_inbox_escalation: handleInboxEscalation,
 });

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -89,12 +89,9 @@ const inlineHandlers = defineHandlers({
   },
   integration_disconnect: () => { /* no-op — integration registry removed */ },
 
-  // Stub handlers: inbox operations — real implementations will be added in a follow-up PR.
+  // Stub handlers: inbox operations — real implementations will be added in follow-up PRs.
   assistant_inbox: (_msg, socket, ctx) => {
     ctx.send(socket, { type: 'assistant_inbox_response', success: false, error: 'Not yet implemented' });
-  },
-  assistant_inbox_escalation: (_msg, socket, ctx) => {
-    ctx.send(socket, { type: 'assistant_inbox_escalation_response', success: false, error: 'Not yet implemented' });
   },
   assistant_inbox_reply: (_msg, socket, ctx) => {
     ctx.send(socket, { type: 'assistant_inbox_reply_response', success: false, error: 'Not yet implemented' });


### PR DESCRIPTION
## Summary
- Implement real handler for `assistant_inbox_escalation` IPC message with `list` and `decide` actions
- `list` queries `listPendingApprovalRequests()` from channel-guardian-store
- `decide` resolves approval requests and refreshes thread escalation projection
- Removes stub handler from index.ts, adds to config-inbox.ts handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
