### PR TITLE
feat: inbox reply composer + send path (U-04)

### DIFF
--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -1,5 +1,5 @@
 import * as net from 'node:net';
-import type { IngressInviteRequest, IngressMemberRequest } from '../ipc-protocol.js';
+import type { IngressInviteRequest, IngressMemberRequest, AssistantInboxReplyRequest } from '../ipc-protocol.js';
 import { log, defineHandlers, type HandlerContext } from './shared.js';
 import {
   createInvite,
@@ -15,6 +15,9 @@ import {
   blockMember,
   type IngressMember,
 } from '../../memory/ingress-member-store.js';
+import { addMessage } from '../../memory/conversation-store.js';
+import { getBindingByConversation } from '../../memory/external-conversation-store.js';
+import { updateThreadActivity } from '../../memory/inbox-thread-store.js';
 
 export function handleIngressInvite(
   msg: IngressInviteRequest,
@@ -257,7 +260,46 @@ export function handleIngressMember(
   }
 }
 
+export function handleAssistantInboxReply(
+  msg: AssistantInboxReplyRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  try {
+    const { conversationId, content } = msg;
+
+    if (!conversationId || !content) {
+      ctx.send(socket, { type: 'assistant_inbox_reply_response', success: false, error: 'conversationId and content are required' });
+      return;
+    }
+
+    // Verify the conversation has an external binding
+    const binding = getBindingByConversation(conversationId);
+    if (!binding) {
+      ctx.send(socket, { type: 'assistant_inbox_reply_response', success: false, error: 'No external binding found for conversation' });
+      return;
+    }
+
+    // Store the reply as an assistant message
+    const message = addMessage(conversationId, 'assistant', content);
+
+    // Update thread activity timestamps (resets unread count, updates last_outbound_at)
+    updateThreadActivity(conversationId, 'outbound');
+
+    ctx.send(socket, {
+      type: 'assistant_inbox_reply_response',
+      success: true,
+      messageId: message.id,
+    });
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'assistant_inbox_reply handler error');
+    ctx.send(socket, { type: 'assistant_inbox_reply_response', success: false, error: errorMessage });
+  }
+}
+
 export const inboxInviteHandlers = defineHandlers({
   ingress_invite: handleIngressInvite,
   ingress_member: handleIngressMember,
+  assistant_inbox_reply: handleAssistantInboxReply,
 });

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -96,9 +96,6 @@ const inlineHandlers = defineHandlers({
   assistant_inbox_escalation: (_msg, socket, ctx) => {
     ctx.send(socket, { type: 'assistant_inbox_escalation_response', success: false, error: 'Not yet implemented' });
   },
-  assistant_inbox_reply: (_msg, socket, ctx) => {
-    ctx.send(socket, { type: 'assistant_inbox_reply_response', success: false, error: 'Not yet implemented' });
-  },
 
 });
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/InboxThreadDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/InboxThreadDetailView.swift
@@ -1,11 +1,18 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Displays the message history for a selected inbox thread in a scrollable timeline.
+/// Displays the message history for a selected inbox thread in a scrollable timeline,
+/// with a reply composer bar at the bottom.
 struct InboxThreadDetailView: View {
     let thread: InboxThread
     @ObservedObject var viewModel: InboxViewModel
     let onBack: () -> Void
+
+    @State private var replyText: String = ""
+
+    private var canSend: Bool {
+        !replyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !viewModel.isSendingReply
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -73,16 +80,86 @@ struct InboxThreadDetailView: View {
                         .padding(VSpacing.lg)
                     }
                     .onAppear {
-                        // Scroll to the latest message
                         if let lastMessage = viewModel.messages.last {
                             proxy.scrollTo(lastMessage.id, anchor: .bottom)
                         }
                     }
+                    .onChange(of: viewModel.messages.count) { _ in
+                        if let lastMessage = viewModel.messages.last {
+                            withAnimation(VAnimation.fast) {
+                                proxy.scrollTo(lastMessage.id, anchor: .bottom)
+                            }
+                        }
+                    }
                 }
+            }
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            // Reply composer bar
+            HStack(spacing: VSpacing.sm) {
+                TextField("Reply...", text: $replyText)
+                    .textFieldStyle(.plain)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .padding(.horizontal, VSpacing.md)
+                    .padding(.vertical, VSpacing.sm)
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .fill(VColor.surface)
+                    )
+                    .onSubmit {
+                        sendReply()
+                    }
+
+                Button(action: sendReply) {
+                    Group {
+                        if viewModel.isSendingReply {
+                            ProgressView()
+                                .controlSize(.small)
+                                .frame(width: 20, height: 20)
+                        } else {
+                            Image(systemName: "arrow.up.circle.fill")
+                                .font(.system(size: 24))
+                        }
+                    }
+                    .foregroundColor(canSend ? VColor.accent : VColor.textMuted)
+                }
+                .buttonStyle(.plain)
+                .disabled(!canSend)
+                .accessibilityLabel("Send reply")
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.sm)
+
+            // Send error display
+            if let sendError = viewModel.sendReplyError {
+                Text(sendError)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
+                    .padding(.horizontal, VSpacing.lg)
+                    .padding(.bottom, VSpacing.xs)
             }
         }
         .task {
             await viewModel.loadMessages(conversationId: thread.conversationId)
+        }
+    }
+
+    private func sendReply() {
+        let content = replyText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !content.isEmpty, !viewModel.isSendingReply else { return }
+
+        let conversationId = thread.conversationId
+        replyText = ""
+
+        Task {
+            let success = await viewModel.sendReply(conversationId: conversationId, content: content)
+            if !success {
+                // Restore text so the user can retry
+                replyText = content
+            }
         }
     }
 }
@@ -97,6 +174,8 @@ struct InboxThreadDetailView_Preview: PreviewProvider {
 }
 
 private struct InboxThreadDetailPreviewWrapper: View {
+    @State private var previewReplyText: String = ""
+
     var body: some View {
         ZStack {
             VColor.background.ignoresSafeArea()
@@ -140,6 +219,28 @@ private struct InboxThreadDetailPreviewWrapper: View {
                     }
                     .padding(VSpacing.lg)
                 }
+
+                Divider().background(VColor.surfaceBorder)
+
+                // Simulated composer
+                HStack(spacing: VSpacing.sm) {
+                    TextField("Reply...", text: $previewReplyText)
+                        .textFieldStyle(.plain)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                        .padding(.horizontal, VSpacing.md)
+                        .padding(.vertical, VSpacing.sm)
+                        .background(
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .fill(VColor.surface)
+                        )
+
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.system(size: 24))
+                        .foregroundColor(previewReplyText.isEmpty ? VColor.textMuted : VColor.accent)
+                }
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.vertical, VSpacing.sm)
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/InboxViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/InboxViewModel.swift
@@ -76,6 +76,8 @@ final class InboxViewModel: ObservableObject {
     @Published var messages: [InboxMessage] = []
     @Published var isLoadingMessages: Bool = false
     @Published var messagesError: String?
+    @Published var isSendingReply: Bool = false
+    @Published var sendReplyError: String?
 
     private let daemonClient: DaemonClient
 
@@ -177,5 +179,55 @@ final class InboxViewModel: ObservableObject {
         }
 
         self.messages = (response.messages ?? []).map { InboxMessage(from: $0) }
+    }
+
+    /// Send a reply to a conversation and reload messages on success.
+    func sendReply(conversationId: String, content: String) async -> Bool {
+        isSendingReply = true
+        sendReplyError = nil
+
+        let stream = daemonClient.subscribe()
+
+        do {
+            try daemonClient.sendAssistantInboxReply(conversationId: conversationId, content: content)
+        } catch {
+            self.sendReplyError = error.localizedDescription
+            self.isSendingReply = false
+            return false
+        }
+
+        let response: IPCAssistantInboxReplyResponse? = await withTaskGroup(of: IPCAssistantInboxReplyResponse?.self) { group in
+            group.addTask {
+                for await message in stream {
+                    if case .assistantInboxReplyResponse(let msg) = message {
+                        return msg
+                    }
+                }
+                return nil
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 10_000_000_000)
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
+        }
+
+        isSendingReply = false
+
+        guard let response else {
+            self.sendReplyError = "Request timed out"
+            return false
+        }
+
+        if !response.success {
+            self.sendReplyError = response.error ?? "Unknown error"
+            return false
+        }
+
+        // Reload messages to show the new reply
+        await loadMessages(conversationId: conversationId)
+        return true
     }
 }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -405,6 +405,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends an `assistant_inbox_response` message.
     public var onAssistantInboxResponse: ((IPCAssistantInboxResponse) -> Void)?
 
+    /// Called when the daemon sends an `assistant_inbox_reply_response` message.
+    public var onAssistantInboxReplyResponse: ((IPCAssistantInboxReplyResponse) -> Void)?
+
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     public var onError: ((ErrorMessage) -> Void)?
 
@@ -1074,6 +1077,15 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             limit: limit.map { Double($0) },
             conversationId: conversationId,
             beforeMessageId: beforeMessageId
+        ))
+    }
+
+    /// Send a reply to an inbox thread conversation.
+    public func sendAssistantInboxReply(conversationId: String, content: String) throws {
+        try send(IPCAssistantInboxReplyRequest(
+            type: "assistant_inbox_reply",
+            conversationId: conversationId,
+            content: content
         ))
     }
 

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -250,6 +250,8 @@ extension DaemonClient {
             onParentalControlUpdateResponse?(msg)
         case .assistantInboxResponse(let msg):
             onAssistantInboxResponse?(msg)
+        case .assistantInboxReplyResponse(let msg):
+            onAssistantInboxReplyResponse?(msg)
         default:
             break
         }

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2203,6 +2203,7 @@ public enum ServerMessage: Decodable, Sendable {
     case parentalControlUpdateResponse(ParentalControlUpdateResponseMessage)
     case conversationSearchResponse(ConversationSearchResponseMessage)
     case assistantInboxResponse(IPCAssistantInboxResponse)
+    case assistantInboxReplyResponse(IPCAssistantInboxReplyResponse)
     case pong
     case unknown(String)
 
@@ -2593,6 +2594,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "assistant_inbox_response":
             let message = try IPCAssistantInboxResponse(from: decoder)
             self = .assistantInboxResponse(message)
+        case "assistant_inbox_reply_response":
+            let message = try IPCAssistantInboxReplyResponse(from: decoder)
+            self = .assistantInboxReplyResponse(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Implement daemon handler for `assistant_inbox_reply` IPC message
- Add reply composer UI to InboxThreadDetailView with text input and send button
- Wire DaemonClient to send replies and receive responses
- Refresh messages after successful send

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
