### PR TITLE
feat: escalation queue list in inbox (U-05)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AssistantInboxPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AssistantInboxPanel.swift
@@ -5,6 +5,7 @@ struct AssistantInboxPanel: View {
     var onClose: () -> Void
     @StateObject private var viewModel: InboxViewModel
     @State private var selectedThread: InboxThread?
+    @State private var selectedTab: Int = 0
 
     init(onClose: @escaping () -> Void, daemonClient: DaemonClient) {
         self.onClose = onClose
@@ -20,32 +21,54 @@ struct AssistantInboxPanel: View {
             )
         } else {
             VSidePanel(title: "Inbox", onClose: onClose) {
-                if viewModel.isLoading {
-                    VStack {
-                        Spacer()
-                        VLoadingIndicator()
-                        Spacer()
+                VStack(spacing: 0) {
+                    VSegmentedControl(items: ["Threads", "Escalations"], selection: $selectedTab)
+                        .padding(.bottom, VSpacing.sm)
+
+                    Divider()
+                        .background(VColor.surfaceBorder)
+
+                    if selectedTab == 0 {
+                        threadsContent
+                    } else {
+                        escalationsContent
                     }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                } else if let error = viewModel.error {
-                    VEmptyState(
-                        title: "Failed to load",
-                        subtitle: error,
-                        icon: "exclamationmark.triangle.fill"
-                    )
-                } else if viewModel.threads.isEmpty {
-                    VEmptyState(
-                        title: "No messages",
-                        subtitle: "Messages from your assistant will appear here",
-                        icon: "tray.fill"
-                    )
-                } else {
-                    threadListView
                 }
             }
             .task {
                 await viewModel.loadThreads()
             }
+            .task {
+                await viewModel.loadEscalations()
+            }
+        }
+    }
+
+    // MARK: - Threads Tab
+
+    @ViewBuilder
+    private var threadsContent: some View {
+        if viewModel.isLoading {
+            VStack {
+                Spacer()
+                VLoadingIndicator()
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let error = viewModel.error {
+            VEmptyState(
+                title: "Failed to load",
+                subtitle: error,
+                icon: "exclamationmark.triangle.fill"
+            )
+        } else if viewModel.threads.isEmpty {
+            VEmptyState(
+                title: "No messages",
+                subtitle: "Messages from your assistant will appear here",
+                icon: "tray.fill"
+            )
+        } else {
+            threadListView
         }
     }
 
@@ -59,6 +82,49 @@ struct AssistantInboxPanel: View {
                 }
                 .buttonStyle(.plain)
                 if thread.id != viewModel.threads.last?.id {
+                    Divider()
+                        .background(VColor.surfaceBorder)
+                        .padding(.horizontal, VSpacing.sm)
+                }
+            }
+        }
+    }
+
+    // MARK: - Escalations Tab
+
+    @ViewBuilder
+    private var escalationsContent: some View {
+        if viewModel.isLoadingEscalations {
+            VStack {
+                Spacer()
+                VLoadingIndicator()
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let error = viewModel.escalationsError {
+            VEmptyState(
+                title: "Failed to load",
+                subtitle: error,
+                icon: "exclamationmark.triangle.fill"
+            )
+        } else if viewModel.escalations.isEmpty {
+            VEmptyState(
+                title: "No escalations",
+                subtitle: "Pending approval requests will appear here",
+                icon: "shield.lefthalf.filled"
+            )
+        } else {
+            escalationListView
+        }
+    }
+
+    private var escalationListView: some View {
+        VStack(spacing: 0) {
+            ForEach(viewModel.escalations) { escalation in
+                VListRow {
+                    InboxEscalationRow(escalation: escalation)
+                }
+                if escalation.id != viewModel.escalations.last?.id {
                     Divider()
                         .background(VColor.surfaceBorder)
                         .padding(.horizontal, VSpacing.sm)
@@ -118,6 +184,94 @@ private struct InboxThreadRow: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(thread.resolvedName), \(thread.sourceChannel), \(thread.unreadCount) unread")
+    }
+
+    private func relativeTimestamp(_ date: Date) -> String {
+        let now = Date()
+        let interval = now.timeIntervalSince(date)
+
+        if interval < 60 {
+            return "now"
+        } else if interval < 3600 {
+            let minutes = Int(interval / 60)
+            return "\(minutes)m"
+        } else if interval < 86400 {
+            let hours = Int(interval / 3600)
+            return "\(hours)h"
+        } else if interval < 604800 {
+            let days = Int(interval / 86400)
+            return "\(days)d"
+        } else {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "MMM d"
+            return formatter.string(from: date)
+        }
+    }
+}
+
+private struct InboxEscalationRow: View {
+    let escalation: InboxEscalation
+
+    var body: some View {
+        HStack(spacing: VSpacing.md) {
+            Image(systemName: escalation.channelIcon)
+                .font(VFont.body)
+                .foregroundColor(VColor.warning)
+                .frame(width: 24, alignment: .center)
+                .accessibilityLabel(escalation.channel)
+
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                HStack {
+                    Text(escalation.resolvedRequester)
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(VColor.textPrimary)
+                        .lineLimit(1)
+
+                    Spacer()
+
+                    if let createdAt = escalation.createdAt {
+                        Text(relativeTimestamp(createdAt))
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                }
+
+                HStack {
+                    if let summary = escalation.requestSummary {
+                        Text(summary)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                            .lineLimit(1)
+                    } else {
+                        Text(escalation.channel.capitalized)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+
+                    Spacer()
+
+                    VBadge(
+                        style: .label(escalation.status.capitalized),
+                        color: badgeColor(for: escalation.status)
+                    )
+                }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(escalation.resolvedRequester), \(escalation.channel), \(escalation.status)")
+    }
+
+    private func badgeColor(for status: String) -> Color {
+        switch status.lowercased() {
+        case "pending":
+            return VColor.warning
+        case "approved":
+            return VColor.success
+        case "denied":
+            return VColor.error
+        default:
+            return VColor.textMuted
+        }
     }
 
     private func relativeTimestamp(_ date: Date) -> String {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/InboxViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/InboxViewModel.swift
@@ -67,6 +67,52 @@ struct InboxThread: Identifiable {
     }
 }
 
+/// A pending escalation request awaiting guardian approval.
+struct InboxEscalation: Identifiable {
+    let id: String
+    let runId: String
+    let conversationId: String
+    let channel: String
+    let requesterExternalUserId: String
+    let requesterChatId: String
+    let status: String
+    let requestSummary: String?
+    let createdAt: Date?
+
+    init(from ipc: IPCAssistantInboxEscalationResponseEscalation) {
+        self.id = ipc.id
+        self.runId = ipc.runId
+        self.conversationId = ipc.conversationId
+        self.channel = ipc.channel
+        self.requesterExternalUserId = ipc.requesterExternalUserId
+        self.requesterChatId = ipc.requesterChatId
+        self.status = ipc.status
+        self.requestSummary = ipc.requestSummary
+        self.createdAt = Date(timeIntervalSince1970: Double(ipc.createdAt) / 1000.0)
+    }
+
+    /// SF Symbol name for the source channel icon.
+    var channelIcon: String {
+        switch channel.lowercased() {
+        case "telegram":
+            return "paperplane.fill"
+        case "sms", "twilio":
+            return "message.fill"
+        case "email":
+            return "envelope.fill"
+        case "web":
+            return "globe"
+        default:
+            return "bubble.left.fill"
+        }
+    }
+
+    /// Human-readable requester identifier, falling back to the chat ID.
+    var resolvedRequester: String {
+        requesterExternalUserId.isEmpty ? requesterChatId : requesterExternalUserId
+    }
+}
+
 @MainActor
 final class InboxViewModel: ObservableObject {
     @Published var threads: [InboxThread] = []
@@ -78,6 +124,10 @@ final class InboxViewModel: ObservableObject {
     @Published var messagesError: String?
     @Published var isSendingReply: Bool = false
     @Published var sendReplyError: String?
+
+    @Published var escalations: [InboxEscalation] = []
+    @Published var isLoadingEscalations: Bool = false
+    @Published var escalationsError: String?
 
     private let daemonClient: DaemonClient
 
@@ -229,5 +279,52 @@ final class InboxViewModel: ObservableObject {
         // Reload messages to show the new reply
         await loadMessages(conversationId: conversationId)
         return true
+    }
+
+    func loadEscalations() async {
+        isLoadingEscalations = true
+        escalationsError = nil
+
+        let stream = daemonClient.subscribe()
+
+        do {
+            try daemonClient.sendAssistantInboxListEscalations()
+        } catch {
+            self.escalationsError = error.localizedDescription
+            self.isLoadingEscalations = false
+            return
+        }
+
+        let response: IPCAssistantInboxEscalationResponse? = await withTaskGroup(of: IPCAssistantInboxEscalationResponse?.self) { group in
+            group.addTask {
+                for await message in stream {
+                    if case .assistantInboxEscalationResponse(let msg) = message {
+                        return msg
+                    }
+                }
+                return nil
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 10_000_000_000)
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
+        }
+
+        isLoadingEscalations = false
+
+        guard let response else {
+            self.escalationsError = "Request timed out"
+            return
+        }
+
+        if !response.success {
+            self.escalationsError = response.error ?? "Unknown error"
+            return
+        }
+
+        self.escalations = (response.escalations ?? []).map { InboxEscalation(from: $0) }
     }
 }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -408,6 +408,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends an `assistant_inbox_reply_response` message.
     public var onAssistantInboxReplyResponse: ((IPCAssistantInboxReplyResponse) -> Void)?
 
+    /// Called when the daemon sends an `assistant_inbox_escalation_response` message.
+    public var onAssistantInboxEscalationResponse: ((IPCAssistantInboxEscalationResponse) -> Void)?
+
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     public var onError: ((ErrorMessage) -> Void)?
 
@@ -1077,6 +1080,16 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             limit: limit.map { Double($0) },
             conversationId: conversationId,
             beforeMessageId: beforeMessageId
+        ))
+    }
+
+    /// Request the list of pending escalations from the daemon.
+    public func sendAssistantInboxListEscalations(assistantId: String? = nil, status: String? = nil) throws {
+        try send(IPCAssistantInboxEscalationRequest(
+            type: "assistant_inbox_escalation",
+            action: "list",
+            assistantId: assistantId,
+            status: status
         ))
     }
 

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -252,6 +252,8 @@ extension DaemonClient {
             onAssistantInboxResponse?(msg)
         case .assistantInboxReplyResponse(let msg):
             onAssistantInboxReplyResponse?(msg)
+        case .assistantInboxEscalationResponse(let msg):
+            onAssistantInboxEscalationResponse?(msg)
         default:
             break
         }

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2204,6 +2204,7 @@ public enum ServerMessage: Decodable, Sendable {
     case conversationSearchResponse(ConversationSearchResponseMessage)
     case assistantInboxResponse(IPCAssistantInboxResponse)
     case assistantInboxReplyResponse(IPCAssistantInboxReplyResponse)
+    case assistantInboxEscalationResponse(IPCAssistantInboxEscalationResponse)
     case pong
     case unknown(String)
 
@@ -2597,6 +2598,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "assistant_inbox_reply_response":
             let message = try IPCAssistantInboxReplyResponse(from: decoder)
             self = .assistantInboxReplyResponse(message)
+        case "assistant_inbox_escalation_response":
+            let message = try IPCAssistantInboxEscalationResponse(from: decoder)
+            self = .assistantInboxEscalationResponse(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Add InboxEscalation data model with channel icon and requester resolution
- Add IPC support for listing pending escalations (ServerMessage case, DaemonClient send method, message routing)
- Add VSegmentedControl (Threads/Escalations) to inbox panel for tab switching
- Display pending escalation items with channel icon, requester, status badge, timestamp, and request summary
- Include loading, error, and empty states for escalations tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
