### PR TITLE
feat: escalation queue actions (U-06)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AssistantInboxPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AssistantInboxPanel.swift
@@ -120,9 +120,52 @@ struct AssistantInboxPanel: View {
 
     private var escalationListView: some View {
         VStack(spacing: 0) {
+            if let error = viewModel.decideError {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(VColor.error)
+                    Text(error)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.error)
+                        .lineLimit(2)
+                    Spacer()
+                    Button(action: { viewModel.decideError = nil }) {
+                        Image(systemName: "xmark")
+                            .font(VFont.small)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.horizontal, VSpacing.md)
+                .padding(.vertical, VSpacing.sm)
+                .background(VColor.error.opacity(0.1))
+
+                Divider()
+                    .background(VColor.surfaceBorder)
+            }
+
             ForEach(viewModel.escalations) { escalation in
                 VListRow {
-                    InboxEscalationRow(escalation: escalation)
+                    InboxEscalationRow(
+                        escalation: escalation,
+                        isDeciding: viewModel.decidingEscalationId == escalation.id,
+                        onApprove: {
+                            Task {
+                                await viewModel.decideEscalation(
+                                    approvalRequestId: escalation.id,
+                                    decision: "approve"
+                                )
+                            }
+                        },
+                        onDeny: {
+                            Task {
+                                await viewModel.decideEscalation(
+                                    approvalRequestId: escalation.id,
+                                    decision: "deny"
+                                )
+                            }
+                        }
+                    )
                 }
                 if escalation.id != viewModel.escalations.last?.id {
                     Divider()
@@ -211,6 +254,9 @@ private struct InboxThreadRow: View {
 
 private struct InboxEscalationRow: View {
     let escalation: InboxEscalation
+    var isDeciding: Bool = false
+    var onApprove: (() -> Void)?
+    var onDeny: (() -> Void)?
 
     var body: some View {
         HStack(spacing: VSpacing.md) {
@@ -250,10 +296,44 @@ private struct InboxEscalationRow: View {
 
                     Spacer()
 
-                    VBadge(
-                        style: .label(escalation.status.capitalized),
-                        color: badgeColor(for: escalation.status)
-                    )
+                    if escalation.status.lowercased() == "pending" {
+                        if isDeciding {
+                            ProgressView()
+                                .controlSize(.small)
+                                .padding(.trailing, VSpacing.xs)
+                        } else {
+                            HStack(spacing: VSpacing.xs) {
+                                Button(action: { onApprove?() }) {
+                                    Text("Approve")
+                                        .font(VFont.caption)
+                                        .foregroundColor(.white)
+                                        .padding(.horizontal, VSpacing.sm)
+                                        .padding(.vertical, VSpacing.xxs)
+                                        .background(VColor.success)
+                                        .cornerRadius(VRadius.sm)
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityLabel("Approve escalation from \(escalation.resolvedRequester)")
+
+                                Button(action: { onDeny?() }) {
+                                    Text("Deny")
+                                        .font(VFont.caption)
+                                        .foregroundColor(.white)
+                                        .padding(.horizontal, VSpacing.sm)
+                                        .padding(.vertical, VSpacing.xxs)
+                                        .background(VColor.error)
+                                        .cornerRadius(VRadius.sm)
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityLabel("Deny escalation from \(escalation.resolvedRequester)")
+                            }
+                        }
+                    } else {
+                        VBadge(
+                            style: .label(escalation.status.capitalized),
+                            color: badgeColor(for: escalation.status)
+                        )
+                    }
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/InboxViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/InboxViewModel.swift
@@ -129,6 +129,10 @@ final class InboxViewModel: ObservableObject {
     @Published var isLoadingEscalations: Bool = false
     @Published var escalationsError: String?
 
+    /// The ID of the escalation currently being decided (approve/deny in progress).
+    @Published var decidingEscalationId: String?
+    @Published var decideError: String?
+
     private let daemonClient: DaemonClient
 
     init(daemonClient: DaemonClient) {
@@ -326,5 +330,58 @@ final class InboxViewModel: ObservableObject {
         }
 
         self.escalations = (response.escalations ?? []).map { InboxEscalation(from: $0) }
+    }
+
+    /// Approve or deny a pending escalation and refresh the list on success.
+    func decideEscalation(approvalRequestId: String, decision: String, reason: String? = nil) async {
+        decidingEscalationId = approvalRequestId
+        decideError = nil
+
+        let stream = daemonClient.subscribe()
+
+        do {
+            try daemonClient.sendAssistantInboxEscalationDecide(
+                approvalRequestId: approvalRequestId,
+                decision: decision,
+                reason: reason
+            )
+        } catch {
+            self.decideError = error.localizedDescription
+            self.decidingEscalationId = nil
+            return
+        }
+
+        let response: IPCAssistantInboxEscalationResponse? = await withTaskGroup(of: IPCAssistantInboxEscalationResponse?.self) { group in
+            group.addTask {
+                for await message in stream {
+                    if case .assistantInboxEscalationResponse(let msg) = message {
+                        return msg
+                    }
+                }
+                return nil
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 10_000_000_000)
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
+        }
+
+        decidingEscalationId = nil
+
+        guard let response else {
+            self.decideError = "Request timed out"
+            return
+        }
+
+        if !response.success {
+            self.decideError = response.error ?? "Unknown error"
+            return
+        }
+
+        // Refresh the escalation list to reflect the decision
+        await loadEscalations()
     }
 }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1102,6 +1102,17 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         ))
     }
 
+    /// Approve or deny a pending escalation request.
+    public func sendAssistantInboxEscalationDecide(approvalRequestId: String, decision: String, reason: String? = nil) throws {
+        try send(IPCAssistantInboxEscalationRequest(
+            type: "assistant_inbox_escalation",
+            action: "decide",
+            approvalRequestId: approvalRequestId,
+            decision: decision,
+            reason: reason
+        ))
+    }
+
     // MARK: - Model Config
 
     /// Request the current model/provider configuration from the daemon.


### PR DESCRIPTION
## Summary
- Add approve/deny buttons to pending escalation rows
- Wire decide IPC through DaemonClient and InboxViewModel
- Show loading state during decision and refresh list on success
- Error handling with inline error display

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
