### PR TITLE
feat: inbox polling refresh loop (U-07)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AssistantInboxPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AssistantInboxPanel.swift
@@ -37,9 +37,17 @@ struct AssistantInboxPanel: View {
             }
             .task {
                 await viewModel.loadThreads()
-            }
-            .task {
                 await viewModel.loadEscalations()
+
+                // Poll for updates every 15 seconds while the panel is visible
+                while !Task.isCancelled {
+                    try? await Task.sleep(nanoseconds: 15_000_000_000)
+                    guard !Task.isCancelled else { break }
+                    // Don't poll while a decision is being processed
+                    guard viewModel.decidingEscalationId == nil else { continue }
+                    await viewModel.loadThreads(isPolling: true)
+                    await viewModel.loadEscalations(isPolling: true)
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/InboxThreadDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/InboxThreadDetailView.swift
@@ -144,6 +144,15 @@ struct InboxThreadDetailView: View {
         }
         .task {
             await viewModel.loadMessages(conversationId: thread.conversationId)
+
+            // Poll for new messages every 15 seconds while viewing this thread
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 15_000_000_000)
+                guard !Task.isCancelled else { break }
+                // Don't poll while user is sending a reply
+                guard !viewModel.isSendingReply else { continue }
+                await viewModel.loadMessages(conversationId: thread.conversationId, isPolling: true)
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/InboxViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/InboxViewModel.swift
@@ -139,9 +139,13 @@ final class InboxViewModel: ObservableObject {
         self.daemonClient = daemonClient
     }
 
-    func loadThreads() async {
+    func loadThreads(isPolling: Bool = false) async {
+        // Skip if already loading to avoid redundant requests
+        guard !isLoading else { return }
+
         isLoading = true
-        error = nil
+        // Only clear error on initial load, not polling refreshes
+        if !isPolling { error = nil }
 
         let stream = daemonClient.subscribe()
 
@@ -187,10 +191,15 @@ final class InboxViewModel: ObservableObject {
         self.threads = (response.threads ?? []).map { InboxThread(from: $0) }
     }
 
-    func loadMessages(conversationId: String) async {
+    func loadMessages(conversationId: String, isPolling: Bool = false) async {
+        // Skip if already loading to avoid redundant requests
+        guard !isLoadingMessages else { return }
+
         isLoadingMessages = true
-        messagesError = nil
-        messages = []
+        if !isPolling {
+            messagesError = nil
+            messages = []
+        }
 
         let stream = daemonClient.subscribe()
 
@@ -285,9 +294,12 @@ final class InboxViewModel: ObservableObject {
         return true
     }
 
-    func loadEscalations() async {
+    func loadEscalations(isPolling: Bool = false) async {
+        // Skip if already loading to avoid redundant requests
+        guard !isLoadingEscalations else { return }
+
         isLoadingEscalations = true
-        escalationsError = nil
+        if !isPolling { escalationsError = nil }
 
         let stream = daemonClient.subscribe()
 


### PR DESCRIPTION
## Summary
- Add 15-second polling loop for threads and escalations in inbox panel
- Add polling for messages in thread detail view
- Auto-cancels when views disappear (SwiftUI .task lifecycle)
- Guards against redundant loads when already loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
