### PR TITLE
fix(ios): add conversationOriginChannel to HTTPDaemonClient session mapping

### DIFF
--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -25,6 +25,7 @@ struct ConversationsListResponse: Decodable {
         let threadType: String?
         let source: String?
         let channelBinding: IPCChannelBinding?
+        let conversationOriginChannel: String?
     }
     let sessions: [Session]
     let hasMore: Bool?
@@ -411,7 +412,7 @@ final class HTTPTransport {
             do {
                 let decoded = try decoder.decode(ConversationsListResponse.self, from: data)
                 let sessions = decoded.sessions.map {
-                    IPCSessionListResponseSession(id: $0.id, title: $0.title, updatedAt: $0.updatedAt, threadType: $0.threadType, source: $0.source, channelBinding: $0.channelBinding)
+                    IPCSessionListResponseSession(id: $0.id, title: $0.title, updatedAt: $0.updatedAt, threadType: $0.threadType, source: $0.source, channelBinding: $0.channelBinding, conversationOriginChannel: $0.conversationOriginChannel)
                 }
                 onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: sessions, hasMore: decoded.hasMore)))
             } catch {


### PR DESCRIPTION
Add missing conversationOriginChannel field to ConversationsListResponse.Session struct and update the mapping to pass it through to IPCSessionListResponseSession, so iOS clients don't silently lose this data.

Addresses feedback on #7908.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
