### PR TITLE
fix: restore main-actor AppKit isolation and remove unused VLM_PROMPT

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -15,17 +15,6 @@ import {
   type ProcessingStage,
 } from '../../../../memory/media-store.js';
 
-const _VLM_PROMPT = `Analyze this image frame extracted from a video. Return a JSON object with the following fields:
-
-{
-  "sceneDescription": "A concise description of the overall scene",
-  "subjects": ["List of identifiable subjects/objects/people in the frame"],
-  "actions": ["List of actions or activities occurring"],
-  "context": "Environmental or situational context (setting, conditions, etc.)"
-}
-
-Return ONLY the JSON object, no additional text.`;
-
 const CHUNKED_VLM_PROMPT = `You are analyzing a sequence of {N} consecutive video frames extracted at regular intervals from a video. The frames are in chronological order.
 
 For EACH frame, provide a JSON object with:

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -372,70 +372,76 @@ public final class ChatAttachmentManager: ObservableObject {
         }
 
         #if os(macOS)
-        guard let image = NSImage(data: data),
-              let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
-            return (data, false)
-        }
-
-        let originalWidth = CGFloat(cgImage.width)
-        let originalHeight = CGFloat(cgImage.height)
-        guard originalWidth > 0 && originalHeight > 0 else {
-            return (data, false)
-        }
-
-        // Calculate scale factor needed to reduce file size
-        // Rough heuristic: file size scales roughly with pixel count
-        let sizeReduction = Double(maxSize) / Double(data.count)
-        let pixelReduction = sqrt(sizeReduction * 0.85) // Target 85% of max for safety margin
-        let scale = min(CGFloat(pixelReduction), 1.0)
-
-        let newWidth = Int(originalWidth * scale)
-        let newHeight = Int(originalHeight * scale)
-
-        guard let colorSpace = cgImage.colorSpace,
-              let context = CGContext(
-                data: nil,
-                width: newWidth,
-                height: newHeight,
-                bitsPerComponent: 8,
-                bytesPerRow: 0,
-                space: colorSpace,
-                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-              ) else {
-            return (data, false)
-        }
-
-        context.interpolationQuality = .high
-        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: newWidth, height: newHeight))
-
-        guard let scaledCGImage = context.makeImage() else {
-            return (data, false)
-        }
-
-        let scaledImage = NSImage(cgImage: scaledCGImage, size: NSSize(width: newWidth, height: newHeight))
-
-        // Try JPEG compression first (better for photos)
-        if let tiffData = scaledImage.tiffRepresentation,
-           let bitmap = NSBitmapImageRep(data: tiffData),
-           let jpeg = bitmap.representation(using: .jpeg, properties: [.compressionFactor: 0.75]) {
-            if jpeg.count <= maxSize {
-                log.info("Compressed image from \(data.count) to \(jpeg.count) bytes (JPEG, \(newWidth)×\(newHeight))")
-                return (jpeg, true)
+        // NSImage, tiffRepresentation, and NSBitmapImageRep are not thread-safe
+        // off the main thread. This method is nonisolated and called from
+        // Task.detached, so we must hop AppKit work onto the main thread.
+        let compressBlock = { () -> (Data, Bool) in
+            guard let image = NSImage(data: data),
+                  let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+                return (data, false)
             }
-        }
 
-        // Fallback: try PNG
-        if let tiffData = scaledImage.tiffRepresentation,
-           let bitmap = NSBitmapImageRep(data: tiffData),
-           let png = bitmap.representation(using: .png, properties: [:]) {
-            if png.count <= maxSize {
-                log.info("Compressed image from \(data.count) to \(png.count) bytes (PNG, \(newWidth)×\(newHeight))")
-                return (png, true)
+            let originalWidth = CGFloat(cgImage.width)
+            let originalHeight = CGFloat(cgImage.height)
+            guard originalWidth > 0 && originalHeight > 0 else {
+                return (data, false)
             }
-        }
 
-        log.warning("Failed to compress image to \(maxSize) bytes, final size: \(data.count)")
-        return (data, false)
+            // Calculate scale factor needed to reduce file size
+            // Rough heuristic: file size scales roughly with pixel count
+            let sizeReduction = Double(maxSize) / Double(data.count)
+            let pixelReduction = sqrt(sizeReduction * 0.85) // Target 85% of max for safety margin
+            let scale = min(CGFloat(pixelReduction), 1.0)
+
+            let newWidth = Int(originalWidth * scale)
+            let newHeight = Int(originalHeight * scale)
+
+            guard let colorSpace = cgImage.colorSpace,
+                  let context = CGContext(
+                    data: nil,
+                    width: newWidth,
+                    height: newHeight,
+                    bitsPerComponent: 8,
+                    bytesPerRow: 0,
+                    space: colorSpace,
+                    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+                  ) else {
+                return (data, false)
+            }
+
+            context.interpolationQuality = .high
+            context.draw(cgImage, in: CGRect(x: 0, y: 0, width: newWidth, height: newHeight))
+
+            guard let scaledCGImage = context.makeImage() else {
+                return (data, false)
+            }
+
+            let scaledImage = NSImage(cgImage: scaledCGImage, size: NSSize(width: newWidth, height: newHeight))
+
+            // Try JPEG compression first (better for photos)
+            if let tiffData = scaledImage.tiffRepresentation,
+               let bitmap = NSBitmapImageRep(data: tiffData),
+               let jpeg = bitmap.representation(using: .jpeg, properties: [.compressionFactor: 0.75]) {
+                if jpeg.count <= maxSize {
+                    log.info("Compressed image from \(data.count) to \(jpeg.count) bytes (JPEG, \(newWidth)×\(newHeight))")
+                    return (jpeg, true)
+                }
+            }
+
+            // Fallback: try PNG
+            if let tiffData = scaledImage.tiffRepresentation,
+               let bitmap = NSBitmapImageRep(data: tiffData),
+               let png = bitmap.representation(using: .png, properties: [:]) {
+                if png.count <= maxSize {
+                    log.info("Compressed image from \(data.count) to \(png.count) bytes (PNG, \(newWidth)×\(newHeight))")
+                    return (png, true)
+                }
+            }
+
+            log.warning("Failed to compress image to \(maxSize) bytes, final size: \(data.count)")
+            return (data, false)
+        }
+        return Thread.isMainThread ? compressBlock() : DispatchQueue.main.sync(execute: compressBlock)
 
         #elseif os(iOS)
         guard let image = UIImage(data: data) else {


### PR DESCRIPTION
1. Wrap macOS AppKit compression in compressImageIfNeeded with DispatchQueue.main.sync (with Thread.isMainThread guard) to prevent thread-safety crashes when called from Task.detached.
2. Remove unused VLM_PROMPT constant left behind after analyzeKeyframe deletion.

Addresses feedback on #7829.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
