### PR TITLE
feat: fail-open provider selection when configured primary is unavailable

### DIFF
--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -114,6 +114,22 @@ mock.module('../providers/registry.js', () => {
   };
 });
 
+mock.module('../providers/provider-send-message.js', () => ({
+  resolveConfiguredProvider: () => ({
+    provider: {
+      name: 'anthropic',
+      sendMessage: (...args: unknown[]) => mockSendMessage(...args),
+    },
+    configuredProviderName: 'anthropic',
+    selectedProviderName: 'anthropic',
+    usedFallbackPrimary: false,
+  }),
+  getConfiguredProvider: () => ({
+    name: 'anthropic',
+    sendMessage: (...args: unknown[]) => mockSendMessage(...args),
+  }),
+}));
+
 // ── Import source modules after all mocks are registered ────────────
 
 import { initializeDb, getDb, resetDb } from '../memory/db.js';

--- a/assistant/src/__tests__/provider-fail-open-selection.test.ts
+++ b/assistant/src/__tests__/provider-fail-open-selection.test.ts
@@ -1,0 +1,119 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  initializeProviders,
+  resolveProviderSelection,
+  getFailoverProvider,
+} from '../providers/registry.js';
+
+/**
+ * Tests for fail-open provider selection: when the configured primary provider
+ * is unavailable, the system should automatically fall back to the first
+ * available provider in the provider order.
+ */
+
+/** Initialize registry with anthropic + openai for most tests. */
+function setupTwoProviders() {
+  initializeProviders({
+    apiKeys: { anthropic: 'test-key', openai: 'test-key' },
+    provider: 'anthropic',
+    model: 'test-model',
+  });
+}
+
+/** Initialize registry with no providers (empty keys, non-registerable primary). */
+function setupNoProviders() {
+  initializeProviders({
+    apiKeys: {},
+    provider: 'gemini',
+    model: 'test-model',
+  });
+}
+
+describe('resolveProviderSelection', () => {
+  test('configured primary available → selected as primary', () => {
+    setupTwoProviders();
+    const result = resolveProviderSelection('anthropic', ['openai']);
+    expect(result.selectedPrimary).toBe('anthropic');
+    expect(result.usedFallbackPrimary).toBe(false);
+    expect(result.availableProviders).toEqual(['anthropic', 'openai']);
+  });
+
+  test('configured primary unavailable + alternate available → alternate selected', () => {
+    setupTwoProviders();
+    const result = resolveProviderSelection('gemini', ['anthropic', 'openai']);
+    expect(result.selectedPrimary).toBe('anthropic');
+    expect(result.usedFallbackPrimary).toBe(true);
+    expect(result.availableProviders).toEqual(['anthropic', 'openai']);
+  });
+
+  test('configured primary unavailable + first alternate also unavailable → second alternate selected', () => {
+    setupTwoProviders();
+    const result = resolveProviderSelection('gemini', ['fireworks', 'openai']);
+    expect(result.selectedPrimary).toBe('openai');
+    expect(result.usedFallbackPrimary).toBe(true);
+    expect(result.availableProviders).toEqual(['openai']);
+  });
+
+  test('deduplicates entries in providerOrder', () => {
+    setupTwoProviders();
+    const result = resolveProviderSelection('anthropic', ['anthropic', 'openai', 'openai']);
+    expect(result.availableProviders).toEqual(['anthropic', 'openai']);
+  });
+
+  test('unknown entries in providerOrder are filtered out', () => {
+    setupTwoProviders();
+    const result = resolveProviderSelection('anthropic', ['nonexistent', 'openai']);
+    expect(result.availableProviders).toEqual(['anthropic', 'openai']);
+  });
+
+  test('no available providers → null selectedPrimary', () => {
+    setupTwoProviders();
+    const result = resolveProviderSelection('gemini', ['fireworks', 'ollama']);
+    expect(result.selectedPrimary).toBeNull();
+    expect(result.usedFallbackPrimary).toBe(false);
+    expect(result.availableProviders).toEqual([]);
+  });
+
+  test('empty providerOrder with available primary → primary only', () => {
+    setupTwoProviders();
+    const result = resolveProviderSelection('anthropic', []);
+    expect(result.selectedPrimary).toBe('anthropic');
+    expect(result.usedFallbackPrimary).toBe(false);
+    expect(result.availableProviders).toEqual(['anthropic']);
+  });
+
+  test('empty providerOrder with unavailable primary → null', () => {
+    setupTwoProviders();
+    const result = resolveProviderSelection('gemini', []);
+    expect(result.selectedPrimary).toBeNull();
+    expect(result.availableProviders).toEqual([]);
+  });
+});
+
+describe('getFailoverProvider (fail-open)', () => {
+  test('returns provider when primary is available', () => {
+    setupTwoProviders();
+    const provider = getFailoverProvider('anthropic', ['openai']);
+    expect(provider).toBeDefined();
+  });
+
+  test('returns provider when primary is unavailable but alternate exists', () => {
+    setupTwoProviders();
+    const provider = getFailoverProvider('gemini', ['anthropic', 'openai']);
+    expect(provider).toBeDefined();
+  });
+
+  test('throws ConfigError when no providers are available', () => {
+    setupNoProviders();
+    expect(() => getFailoverProvider('gemini', ['fireworks'])).toThrow(
+      /No providers available/,
+    );
+  });
+
+  test('single available provider returns it directly (no failover wrapper)', () => {
+    setupTwoProviders();
+    const provider = getFailoverProvider('gemini', ['anthropic']);
+    // Should be a RetryProvider wrapping AnthropicProvider, not a FailoverProvider
+    expect(provider.name).not.toBe('failover');
+  });
+});

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -7,7 +7,7 @@
  */
 
 import { getConfig } from '../config/loader.js';
-import { getFailoverProvider, listProviders } from '../providers/registry.js';
+import { resolveConfiguredProvider } from '../providers/provider-send-message.js';
 import type { ProviderEvent } from '../providers/types.js';
 import { resolveUserReference } from '../config/user-reference.js';
 import { getLogger } from '../util/logger.js';
@@ -380,14 +380,14 @@ export class CallOrchestrator {
    */
   private async runLlm(): Promise<void> {
     const config = getConfig();
-    const providerName = config.provider;
-    if (!listProviders().includes(providerName)) {
+    const resolved = resolveConfiguredProvider();
+    if (!resolved) {
       log.error({ callSessionId: this.callSessionId }, 'No provider available');
       this.relay.sendTextToken('I\'m sorry, I\'m having a technical issue. Please try again later.', true);
       this.state = 'idle';
       return;
     }
-    const provider = getFailoverProvider(providerName, config.providerOrder);
+    const { provider } = resolved;
 
     const runVersion = ++this.llmRunVersion;
     const runSignal = this.abortController.signal;
@@ -395,12 +395,13 @@ export class CallOrchestrator {
     try {
       this.state = 'speaking';
 
-      // Only override the model when the user has explicitly configured one.
-      // When unset, each provider in the failover chain uses its own default
-      // model (set at initialization). Forwarding the primary provider's
-      // default to fallback providers would cause cross-provider 4xx errors
-      // (e.g., sending "gpt-5.2" to Anthropic).
-      const callModel = config.calls.model?.trim() || undefined;
+      // Only override the model when the user has explicitly configured one
+      // AND the selected provider matches the configured provider. Forwarding
+      // a provider-specific model to a fallback provider would cause
+      // cross-provider 4xx errors (e.g., sending "gpt-5.2" to Anthropic).
+      const callModel = !resolved.usedFallbackPrimary
+        ? (config.calls.model?.trim() || undefined)
+        : undefined;
 
       // Buffer incoming tokens so we can strip control markers ([ASK_GUARDIAN:...], [END_CALL])
       // before they reach TTS. We hold text whenever an unmatched '[' appears, since it

--- a/assistant/src/daemon/handlers/dictation.ts
+++ b/assistant/src/daemon/handlers/dictation.ts
@@ -1,6 +1,5 @@
 import * as net from 'node:net';
-import { getConfig } from '../../config/loader.js';
-import { getFailoverProvider, listProviders } from '../../providers/registry.js';
+import { getConfiguredProvider } from '../../providers/provider-send-message.js';
 import type { DictationRequest } from '../ipc-protocol.js';
 import { log, defineHandlers, type HandlerContext } from './shared.js';
 
@@ -147,15 +146,14 @@ export async function handleDictationRequest(
     : msg.transcription; // command prompt already embeds the selected text and instruction
 
   try {
-    const config = getConfig();
-    if (!listProviders().includes(config.provider)) {
-      log.warn({ provider: config.provider }, 'Dictation: no provider available, returning raw transcription');
+    const provider = getConfiguredProvider();
+    if (!provider) {
+      log.warn('Dictation: no provider available, returning raw transcription');
       const fallbackText = mode === 'command' ? (msg.context.selectedText ?? msg.transcription) : msg.transcription;
       ctx.send(socket, { type: 'dictation_response', text: fallbackText, mode });
       return;
     }
 
-    const provider = getFailoverProvider(config.provider, config.providerOrder);
     const response = await provider.sendMessage(
       [{ role: 'user', content: [{ type: 'text', text: userText }] }],
       [], // no tools

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -3,8 +3,7 @@ import { v4 as uuid } from 'uuid';
 import { readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import * as conversationStore from '../../memory/conversation-store.js';
-import { getConfig } from '../../config/loader.js';
-import { getFailoverProvider, listProviders } from '../../providers/registry.js';
+import { getConfiguredProvider } from '../../providers/provider-send-message.js';
 import type { Provider } from '../../providers/types.js';
 import { classifyInteraction } from '../classifier.js';
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
@@ -172,10 +171,9 @@ export async function handleSuggestionRequest(
     }
 
     // Try LLM suggestion using the configured provider
-    const config = getConfig();
-    if (listProviders().includes(config.provider)) {
+    const provider = getConfiguredProvider();
+    if (provider) {
       try {
-        const provider = getFailoverProvider(config.provider, config.providerOrder);
         let promise = suggestionInFlight.get(m.id);
         if (!promise) {
           promise = generateSuggestion(provider, text);

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -18,7 +18,7 @@ import {
 } from '../util/platform.js';
 import { initializeDb } from '../memory/db.js';
 import { rotateToolInvocations } from '../memory/tool-usage-store.js';
-import { initializeProviders, getFailoverProvider, listProviders } from '../providers/registry.js';
+import { initializeProviders, getFailoverProvider } from '../providers/registry.js';
 import { initializeTools } from '../tools/registry.js';
 import { loadConfig } from '../config/loader.js';
 import {
@@ -290,10 +290,12 @@ function loadDotEnv(): void {
 function createApprovalCopyGenerator(): ApprovalCopyGenerator {
   return async (context, options = {}) => {
     const config = loadConfig();
-    if (!listProviders().includes(config.provider)) {
+    let provider;
+    try {
+      provider = getFailoverProvider(config.provider, config.providerOrder);
+    } catch {
       return null;
     }
-    const provider = getFailoverProvider(config.provider, config.providerOrder);
 
     const fallbackText = options.fallbackText?.trim() || getFallbackMessage(context);
     const requiredKeywords = options.requiredKeywords?.map((kw) => kw.trim()).filter((kw) => kw.length > 0);

--- a/assistant/src/messaging/style-analyzer.ts
+++ b/assistant/src/messaging/style-analyzer.ts
@@ -9,8 +9,7 @@
 import type { Message as ProviderMessage } from './provider-types.js';
 import type { Message, ToolDefinition } from '../providers/types.js';
 import { truncate } from '../util/truncate.js';
-import { getProvider } from '../providers/registry.js';
-import { getConfig } from '../config/loader.js';
+import { getConfiguredProvider } from '../providers/provider-send-message.js';
 
 export interface StylePattern {
   aspect: string;
@@ -118,8 +117,10 @@ export async function extractStylePatterns(
 
   const corpus = corpusEntries.map((e, i) => `--- Message ${i + 1} ---\n${e}`).join('\n\n');
 
-  const config = getConfig();
-  const provider = getProvider(config.provider);
+  const provider = getConfiguredProvider();
+  if (!provider) {
+    return { stylePatterns: [], contactObservations: [] };
+  }
   const promptMessages: Message[] = [{
     role: 'user',
     content: [{ type: 'text', text: `Analyze these ${corpusEntries.length} sent messages for writing style patterns:\n\n${corpus}` }],

--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -5,17 +5,31 @@
  */
 
 import type { Provider, ProviderResponse, Message, ContentBlock, ToolUseContent } from './types.js';
-import { getFailoverProvider, listProviders, initializeProviders } from './registry.js';
+import { getFailoverProvider, listProviders, initializeProviders, resolveProviderSelection } from './registry.js';
 import { getConfig } from '../config/loader.js';
+import { getLogger } from '../util/logger.js';
+
+export interface ConfiguredProviderResult {
+  provider: Provider;
+  configuredProviderName: string;
+  selectedProviderName: string;
+  usedFallbackPrimary: boolean;
+}
+
+const providerSelectionLog = getLogger('provider-selection');
+let fallbackWarningLogged = false;
 
 /**
- * Resolve the configured provider through the registry/failover path.
+ * Resolve the configured provider with full selection metadata.
  * If providers haven't been initialized yet (e.g. non-daemon code paths),
  * performs a one-shot `initializeProviders(getConfig())`.
  *
- * Returns `null` when the configured provider is unavailable.
+ * Uses fail-open selection: if `config.provider` is unavailable but
+ * alternates from `config.providerOrder` exist, selects the first available.
+ *
+ * Returns `null` when no providers are available at all.
  */
-export function getConfiguredProvider(): Provider | null {
+export function resolveConfiguredProvider(): ConfiguredProviderResult | null {
   const config = getConfig();
 
   if (listProviders().length === 0) {
@@ -26,16 +40,45 @@ export function getConfiguredProvider(): Provider | null {
     }
   }
 
-  if (!listProviders().includes(config.provider)) {
+  const providerOrder = Array.isArray(config.providerOrder) ? config.providerOrder : [];
+  const selection = resolveProviderSelection(config.provider, providerOrder);
+
+  if (!selection.selectedPrimary) {
     return null;
   }
 
+  if (selection.usedFallbackPrimary) {
+    const level = fallbackWarningLogged ? 'debug' : 'warn';
+    providerSelectionLog[level](
+      { configured: config.provider, selected: selection.selectedPrimary },
+      'Configured provider unavailable, using fallback',
+    );
+    fallbackWarningLogged = true;
+  }
+
   try {
-    const providerOrder = Array.isArray(config.providerOrder) ? config.providerOrder : [];
-    return getFailoverProvider(config.provider, providerOrder);
+    const provider = getFailoverProvider(config.provider, providerOrder);
+    return {
+      provider,
+      configuredProviderName: config.provider,
+      selectedProviderName: selection.selectedPrimary,
+      usedFallbackPrimary: selection.usedFallbackPrimary,
+    };
   } catch {
     return null;
   }
+}
+
+/**
+ * Resolve the configured provider through the registry/failover path.
+ * Thin wrapper around `resolveConfiguredProvider()` for callsites
+ * that only need the Provider instance.
+ *
+ * Returns `null` when no providers are available.
+ */
+export function getConfiguredProvider(): Provider | null {
+  const result = resolveConfiguredProvider();
+  return result?.provider ?? null;
 }
 
 /**

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -29,33 +29,74 @@ export function getProvider(name: string): Provider {
   return provider;
 }
 
+export interface ProviderSelection {
+  /** Ordered list of available provider names */
+  availableProviders: string[];
+  /** The selected (effective) primary provider name, or null if none available */
+  selectedPrimary: string | null;
+  /** Whether the effective primary differs from the requested primary */
+  usedFallbackPrimary: boolean;
+}
+
 /**
- * Build a provider that tries the primary provider first, then falls back to
- * others in the configured order. If providerOrder is empty or only contains
- * the primary, returns the primary provider directly (no wrapper overhead).
- * Caches the FailoverProvider instance so health state persists across calls.
+ * Resolve provider selection from requested primary and provider order.
+ * Dedupes [requestedPrimary, ...providerOrder], filtered to initialized providers.
+ * Returns null selectedPrimary when no providers are available.
  */
-export function getFailoverProvider(primaryName: string, providerOrder: string[]): Provider {
-  const primary = getProvider(primaryName);
+export function resolveProviderSelection(
+  requestedPrimary: string,
+  providerOrder: string[],
+): ProviderSelection {
+  const ordered: string[] = [];
+  const seen = new Set<string>();
 
-  // Build the ordered list: primary first, then remaining from providerOrder
-  const orderedProviders: Provider[] = [primary];
-  const seen = new Set<string>([primaryName]);
-
-  for (const name of providerOrder) {
+  for (const name of [requestedPrimary, ...providerOrder]) {
     if (seen.has(name)) continue;
-    const p = providers.get(name);
-    if (p) {
-      orderedProviders.push(p);
-      seen.add(name);
+    seen.add(name);
+    if (providers.has(name)) {
+      ordered.push(name);
     }
   }
 
-  if (orderedProviders.length === 1) {
-    return primary;
+  if (ordered.length === 0) {
+    return { availableProviders: [], selectedPrimary: null, usedFallbackPrimary: false };
   }
 
-  const cacheKey = `${primaryName}:${providerOrder.join(',')}`;
+  return {
+    availableProviders: ordered,
+    selectedPrimary: ordered[0],
+    usedFallbackPrimary: ordered[0] !== requestedPrimary,
+  };
+}
+
+/**
+ * Build a provider that tries the effective primary provider first, then falls
+ * back to others in the configured order. If the requested primary is not
+ * available, automatically selects the first available provider from the
+ * deduped [primaryName, ...providerOrder] list (fail-open).
+ *
+ * Throws ConfigError only when NO providers are available at all.
+ * Caches the FailoverProvider instance so health state persists across calls.
+ */
+export function getFailoverProvider(primaryName: string, providerOrder: string[]): Provider {
+  const selection = resolveProviderSelection(primaryName, providerOrder);
+
+  if (!selection.selectedPrimary) {
+    throw new ConfigError(
+      `No providers available. Requested: "${primaryName}". Registered: ${listProviders().join(", ") || "none"}`,
+    );
+  }
+
+  const orderedProviders: Provider[] = selection.availableProviders.map(
+    (name) => providers.get(name)!,
+  );
+
+  if (orderedProviders.length === 1) {
+    return orderedProviders[0];
+  }
+
+  // Cache key from effective ordered providers (not raw input strings)
+  const cacheKey = selection.availableProviders.join(',');
   if (cachedFailoverProvider && cachedFailoverKey === cacheKey) {
     return cachedFailoverProvider;
   }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -11,8 +11,7 @@ import {
 import * as conversationStore from '../../memory/conversation-store.js';
 import * as attachmentsStore from '../../memory/attachments-store.js';
 import { renderHistoryContent, mergeToolResults } from '../../daemon/handlers.js';
-import { getConfig } from '../../config/loader.js';
-import { getFailoverProvider, listProviders } from '../../providers/registry.js';
+import { getConfiguredProvider } from '../../providers/provider-send-message.js';
 import type { Provider } from '../../providers/types.js';
 import type {
   MessageProcessor,
@@ -313,10 +312,9 @@ export async function handleGetSuggestion(
     }
 
     // Try LLM suggestion using the configured provider
-    const config = getConfig();
-    if (listProviders().includes(config.provider)) {
+    const provider = getConfiguredProvider();
+    if (provider) {
       try {
-        const provider = getFailoverProvider(config.provider, config.providerOrder);
         // Deduplicate concurrent requests
         let promise = suggestionInFlight.get(msg.id);
         if (!promise) {


### PR DESCRIPTION
## Summary
- Centralizes fail-open provider selection in `registry.ts` via `resolveProviderSelection()` — when the configured primary provider is unavailable, automatically falls back to the first available provider from `providerOrder`
- Migrates all 6 strict callsites (conversation-routes, misc handlers, dictation, lifecycle, call-orchestrator, style-analyzer) to use the new fail-open helpers instead of `listProviders().includes(config.provider)` gates
- Guards `config.calls.model` override in call-orchestrator to prevent cross-provider model 4xx errors when a fallback provider is selected

## Original prompt
.private/plans/provider-fail-open-configured-provider-one-pr-plan-2026-02-24.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/7991" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
