### PR TITLE
fix(ci): add ingress invite/member responses to Swift decoder omit allowlist

### DIFF
--- a/assistant/scripts/ipc/check-swift-decoder-drift.ts
+++ b/assistant/scripts/ipc/check-swift-decoder-drift.ts
@@ -53,6 +53,9 @@ const SWIFT_OMIT_ALLOWLIST = new Set<string>([
   'browser_handoff_request',
   // Guardian verification — daemon-internal for Telegram channel setup
   'guardian_verification_response',
+  // Ingress invite/member management — not yet consumed by the macOS client
+  'ingress_invite_response',
+  'ingress_member_response',
   // Work item messages — not yet consumed by the macOS client
   'work_item_get_response',
   'work_item_run_task_response',


### PR DESCRIPTION
## Summary
- Add `ingress_invite_response` and `ingress_member_response` to the Swift decoder omit allowlist
- These inbox management IPC types are not consumed by the macOS client
- Fixes the `ipc:check-swift-drift` CI step that has been failing on main

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22358705846

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
