### PR TITLE
fix: drop old covering index before recreation for existing databases

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -571,6 +571,7 @@ export function initializeDb(): void {
   // Partial covering index for directItemSearch: the LIKE '%term%' pattern can't
   // seek a B-tree, but this index lets SQLite scan only active non-invalidated rows
   // and evaluate LIKE + return columns without touching the main table.
+  database.run(/*sql*/ `DROP INDEX IF EXISTS idx_memory_items_active_search`);
   database.run(/*sql*/ `
     CREATE INDEX IF NOT EXISTS idx_memory_items_active_search
     ON memory_items(status, invalid_at, last_seen_at DESC, subject, statement, id, kind, confidence, importance, first_seen_at, scope_id)


### PR DESCRIPTION
Add DROP INDEX IF EXISTS before CREATE INDEX for idx_memory_items_active_search so existing databases get the updated covering index definition. Follows the existing migration pattern used for idx_media_assets_file_hash.

Addresses feedback on #7986.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
