### PR TITLE
fix: include conversationOriginChannel in HTTP sessions endpoint

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -700,6 +700,7 @@ export class RuntimeHttpServer {
         return Response.json({
           sessions: conversations.map((c) => {
             const binding = bindings.get(c.id);
+            const originChannel = parseChannelId(c.originChannel);
             return {
               id: c.id,
               title: c.title ?? 'Untitled',
@@ -714,6 +715,7 @@ export class RuntimeHttpServer {
                   username: binding.username,
                 },
               } : {}),
+              ...(originChannel ? { conversationOriginChannel: originChannel } : {}),
             };
           }),
           hasMore: offset + conversations.length < totalCount,


### PR DESCRIPTION
Add conversationOriginChannel to the GET /v1/conversations HTTP endpoint response, matching the IPC socket handler. Without this, iOS clients using HTTP transport always see nil for this field.

Addresses feedback on #7987.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
