### PR TITLE
fix: allow quoted comments after dotted clientSecret refs in pre-commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -70,10 +70,10 @@ declare -a SAFE_LINE_PATTERNS=(
     # Avoids false positives like `oauth2ClientSecret: typeof record.oauth2ClientSecret`.
     "[a-zA-Z0-9_]*[Cc]lient[Ss]ecret[[:space:]]*[:=]+[[:space:]]*(typeof[[:space:]]|null[[:space:];,){}]|undefined[[:space:];,){}])"
     # TS/JS: dotted property access like `record.oauth2ClientSecret` or
-    # `policy?.oauth2ClientSecret`. Only matches when the rest of the line after
-    # the dotted identifier contains NO quoted strings — prevents masking lines
-    # like `clientSecret: config.clientSecret || "real_secret"`.
-    "[.?]+[a-zA-Z0-9_]*[Cc]lient[Ss]ecret[^\"']*$"
+    # `policy?.oauth2ClientSecret`. Allows quoted text only inside trailing
+    # `//` comments — prevents masking real fallback assignments like
+    # `clientSecret: config.clientSecret || "real_secret"`.
+    "[.?]+[a-zA-Z0-9_]*[Cc]lient[Ss]ecret([^\"'/]*$|[^\"'/]*//.*)$"
 )
 
 matches_safe_line_pattern() {
@@ -160,6 +160,12 @@ if [ "${1:-}" = "--self-test" ]; then
 
     # Dotted reference with a fallback string literal — must NOT be whitelisted
     UNSAFE_TS_FALLBACK='clientSecret: config.clientSecret || "sk_live_12345678901234567890"'
+
+    # Dotted reference with quoted text in a trailing comment — must be whitelisted
+    SAFE_TS_COMMENT_QUOTE='oauth2ClientSecret: policy.oauth2ClientSecret, // "optional"'
+
+    # Dotted reference with nullish coalescing fallback — must NOT be whitelisted
+    UNSAFE_TS_NULLISH_FALLBACK='clientSecret: config.clientSecret ?? "real_secret_value_1234"'
 
     if matches_secret_pattern "$SAFE_ARCHITECTURE_LINE"; then
         echo -e "${RED}Self-test failed:${NC} ARCHITECTURE allowlist case still matches"
@@ -331,6 +337,14 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$UNSAFE_TS_FALLBACK" && matches_safe_line_pattern "$UNSAFE_TS_FALLBACK"; then
         echo -e "${RED}Self-test failed:${NC} dotted clientSecret with fallback string literal was incorrectly whitelisted"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_TS_COMMENT_QUOTE" && ! matches_safe_line_pattern "$SAFE_TS_COMMENT_QUOTE"; then
+        echo -e "${RED}Self-test failed:${NC} dotted clientSecret with quoted text in trailing comment false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$UNSAFE_TS_NULLISH_FALLBACK" && matches_safe_line_pattern "$UNSAFE_TS_NULLISH_FALLBACK"; then
+        echo -e "${RED}Self-test failed:${NC} dotted clientSecret with nullish coalescing fallback was incorrectly whitelisted"
         exit 1
     fi
 


### PR DESCRIPTION
Refine the dotted clientSecret safe-pattern to allow quoted content in trailing comments while still catching real secret assignments via fallback operators.

Addresses feedback on #7989.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
