### PR TITLE
fix: always start daemon HTTP server for iOS pairing

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -193,6 +193,7 @@ export async function startLocalDaemon(): Promise<void> {
       for (const key of [
         "ANTHROPIC_API_KEY",
         "BASE_DATA_DIR",
+        "RUNTIME_HTTP_PORT",
         "VELLUM_DAEMON_TCP_PORT",
         "VELLUM_DAEMON_TCP_HOST",
         "VELLUM_DAEMON_SOCKET",

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -557,12 +557,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let assistant = loadAssistantFromLockfile()
 
-        // Ensure the daemon starts its runtime HTTP server so the app
-        // can communicate over HTTP instead of IPC.
-        if FeatureFlagManager.shared.isEnabled(.localHttpEnabled) {
-            if ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] == nil {
-                setenv("RUNTIME_HTTP_PORT", "7821", 0)
-            }
+        // Ensure the daemon starts its runtime HTTP server so the
+        // gateway can proxy iOS traffic to it.
+        if ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] == nil {
+            setenv("RUNTIME_HTTP_PORT", "7821", 0)
         }
 
         configureDaemonTransport(for: assistant)

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -602,10 +602,9 @@ final class AssistantCli {
                     env[key] = val
                 }
             }
-            // Forward RUNTIME_HTTP_PORT only when the localHttpEnabled flag
-            // is active, so the daemon doesn't start its HTTP server by default.
-            if FeatureFlagManager.shared.isEnabled(.localHttpEnabled),
-               let port = fullEnv["RUNTIME_HTTP_PORT"] ?? getenv("RUNTIME_HTTP_PORT").flatMap({ String(cString: $0) }) {
+            // Always forward RUNTIME_HTTP_PORT so the daemon starts its
+            // HTTP server — required for iOS pairing via the gateway.
+            if let port = fullEnv["RUNTIME_HTTP_PORT"] ?? getenv("RUNTIME_HTTP_PORT").flatMap({ String(cString: $0) }) {
                 env["RUNTIME_HTTP_PORT"] = port
             }
             proc.environment = env


### PR DESCRIPTION
## Summary
- Remove `localHttpEnabled` feature flag gate from daemon HTTP server startup
- The daemon HTTP server (port 7821) is required for iOS pairing — the gateway proxies all iOS traffic through it
- Without this fix, iOS devices get HTTP 502 after QR pairing because the daemon never starts its HTTP server

## Implementation
Three changes across the env var forwarding chain:

1. **AppDelegate.swift**: Always set `RUNTIME_HTTP_PORT=7821` instead of gating behind `localHttpEnabled` flag
2. **AssistantCli.swift**: Always forward `RUNTIME_HTTP_PORT` to the CLI process instead of gating behind the flag
3. **cli/src/lib/local.ts**: Add `RUNTIME_HTTP_PORT` to the daemon env forwarding list — the CLI builds a minimal env when spawning the daemon and was stripping out this var

The `localHttpEnabled` flag still exists for switching the macOS app's own transport to HTTP (separate concern), but the daemon HTTP server now always starts.

## Test plan
- [x] Build succeeds (`swift build`)
- [ ] Launch macOS app — verify daemon listens on port 7821 (`lsof -i :7821`)
- [ ] Scan QR code from iOS — verify no HTTP 502 errors
- [ ] Verify gateway health returns 401 (not 502): `curl http://localhost:7830/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
