### PR TITLE
docs: align inbound detection wording in phone-calls skill

### DIFF
--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -40,7 +40,7 @@ When someone dials the assistant's Twilio phone number:
 1. Twilio sends a voice webhook to the gateway at `/webhooks/twilio/voice` (no `callSessionId` in the URL)
 2. The gateway resolves which assistant owns the dialed number via `resolveAssistantByPhoneNumber`, falling back to the standard routing chain (chat_id, user_id, default/reject). Unmapped numbers are rejected with TwiML `<Reject>`.
 3. The runtime creates a new session keyed by the Twilio CallSid (`createInboundVoiceSession`)
-4. Twilio opens a ConversationRelay WebSocket. The relay detects the call is inbound (no task) and optionally gates the call behind **guardian voice verification** if a pending challenge exists.
+4. Twilio opens a ConversationRelay WebSocket. The relay detects the call is inbound when `initiatedFromConversationId == null` and optionally gates the call behind **guardian voice verification** if a pending challenge exists.
 5. Once verified (or if no challenge is pending), the LLM orchestrator greets the caller in a receptionist style: "Hello, this is [user]'s assistant. How can I help you today?"
 6. The assistant converses naturally, using ASK_GUARDIAN to consult the user when needed, just like outbound calls.
 


### PR DESCRIPTION
## Summary
- align phone-calls skill inbound call detection wording with runtime behavior

## Change
- update inbound detection language in `assistant/src/config/bundled-skills/phone-calls/SKILL.md` from task-based wording to `initiatedFromConversationId == null`

## Why
- keeps docs/skills consistent with current relay-server implementation and avoids future confusion during debugging/refactors
