### PR TITLE
fix: address codex feedback on PR #4431

### DIFF
--- a/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
@@ -67,6 +67,7 @@ Tell the user: "App created! Now let's configure the permissions it needs."
 > - `groups:history` — Read message history in private channels
 > - `im:read` — View direct message info
 > - `im:history` — Read direct message history
+> - `im:write` — Open and send direct messages
 > - `mpim:read` — View group DM info
 > - `mpim:history` — Read group DM history
 > - `users:read` — View user profiles

--- a/assistant/src/tools/credentials/post-connect-hooks.ts
+++ b/assistant/src/tools/credentials/post-connect-hooks.ts
@@ -1,0 +1,61 @@
+/**
+ * Post-connect hooks for OAuth2 services.
+ *
+ * This module decouples provider-specific post-connection side effects
+ * (e.g. sending a welcome DM after Slack OAuth) from the generic vault
+ * OAuth2 flow. Each hook is keyed by canonical service name and receives
+ * the raw token response so it can perform provider-specific actions.
+ */
+
+import { authTest, conversationsOpen, postMessage } from '../../messaging/providers/slack/client.js';
+import { getLogger } from '../../util/logger.js';
+
+const log = getLogger('post-connect-hooks');
+
+export interface PostConnectHookContext {
+  service: string;
+  rawTokenResponse: Record<string, unknown>;
+}
+
+type PostConnectHook = (ctx: PostConnectHookContext) => Promise<void>;
+
+// ---------------------------------------------------------------------------
+// Provider-specific hooks
+// ---------------------------------------------------------------------------
+
+async function slackWelcomeDM(ctx: PostConnectHookContext): Promise<void> {
+  const botToken = ctx.rawTokenResponse.access_token as string | undefined;
+  const authedUser = ctx.rawTokenResponse.authed_user as Record<string, unknown> | undefined;
+  const installingUserId = authedUser?.id as string | undefined;
+  if (!botToken || !installingUserId) return;
+
+  const identity = await authTest(botToken);
+  const dmChannel = await conversationsOpen(botToken, installingUserId);
+  const welcomeMsg =
+    `You have installed ${identity.user}, an AI Assistant, on ${identity.team}. ` +
+    `You can manage the assistant experience for this workspace by chatting with the assistant or from the Settings page.`;
+  await postMessage(botToken, dmChannel.channel.id, welcomeMsg);
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+const POST_CONNECT_HOOKS: Record<string, PostConnectHook> = {
+  'integration:slack': slackWelcomeDM,
+};
+
+/**
+ * Run the post-connect hook for a service, if one is registered.
+ * Failures are logged but never propagated -- they must not break the OAuth flow.
+ */
+export async function runPostConnectHook(ctx: PostConnectHookContext): Promise<void> {
+  const hook = POST_CONNECT_HOOKS[ctx.service];
+  if (!hook) return;
+
+  try {
+    await hook(ctx);
+  } catch (err) {
+    log.warn({ err, service: ctx.service }, 'Post-connect hook failed (non-fatal)');
+  }
+}

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -14,7 +14,7 @@ import { validatePolicyInput, toPolicyFromInput } from './policy-validate.js';
 import type { CredentialPolicyInput, CredentialInjectionTemplate } from './policy-types.js';
 import { credentialBroker } from './broker.js';
 import { startOAuth2Flow, type TokenEndpointAuthMethod } from '../../security/oauth2.js';
-import { authTest, conversationsOpen, postMessage } from '../../messaging/providers/slack/client.js';
+import { runPostConnectHook } from './post-connect-hooks.js';
 import { getConfig } from '../../config/loader.js';
 import { getLogger } from '../../util/logger.js';
 
@@ -661,24 +661,8 @@ class CredentialStoreTool implements Tool {
             }
           }
 
-          // Send a welcome DM for Slack connections
-          if (service === 'integration:slack') {
-            try {
-              const botToken = rawTokenResponse.access_token as string | undefined;
-              const authedUser = rawTokenResponse.authed_user as Record<string, unknown> | undefined;
-              const installingUserId = authedUser?.id as string | undefined;
-              if (botToken && installingUserId) {
-                const identity = await authTest(botToken);
-                const dmChannel = await conversationsOpen(botToken, installingUserId);
-                const welcomeMsg =
-                  `You have installed ${identity.user}, an AI Assistant, on ${identity.team}. ` +
-                  `You can manage the assistant experience for this workspace by chatting with the assistant or from the Settings page.`;
-                await postMessage(botToken, dmChannel.channel.id, welcomeMsg);
-              }
-            } catch (err) {
-              log.warn({ err }, 'Failed to send Slack welcome DM (non-fatal)');
-            }
-          }
+          // Run any provider-specific post-connect actions (e.g. Slack welcome DM)
+          await runPostConnectHook({ service, rawTokenResponse });
 
           return {
             content: `Successfully connected "${service}"${accountInfo ? ` as ${accountInfo}` : ''}. The service is now ready to use.`,


### PR DESCRIPTION
## Summary

Address Codex review feedback on PR #4431:

1. **Updated SKILL.md scope checklist to include `im:write` permission** - The OAuth `scopes` list already requested `im:write`, but the Step 3 approval text/scope checklist omitted it. Users were approving a narrower set than what was actually requested. Now the checklist matches the actual scopes.

2. **Extracted Slack-specific post-connect DM logic from generic vault.ts OAuth flow** - The Slack-only welcome DM side effect (`if (service === 'integration:slack')`) violated the extensibility principle by embedding provider-specific code in the generic credential store. Extracted into a new `post-connect-hooks.ts` module with a registry pattern that any provider can extend.

## Files changed

- `assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md` - Added `im:write` to scope checklist
- `assistant/src/tools/credentials/vault.ts` - Replaced inline Slack DM with generic hook call
- `assistant/src/tools/credentials/post-connect-hooks.ts` - New module for provider-specific post-connect actions