### PR TITLE
feat(skills): add screen-recording awareness skill

### DIFF
--- a/assistant/src/config/bundled-skills/screen-recording/SKILL.md
+++ b/assistant/src/config/bundled-skills/screen-recording/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: "Screen Recording"
+description: "Capture screen recordings during computer-use sessions. Records the display or a specific window as H.264 MP4 video with optional audio."
+user-invocable: false
+disable-model-invocation: false
+metadata:
+  vellum:
+    emoji: "🎥"
+    os: ["darwin"]
+---
+
+# Screen Recording
+
+You have access to a screen recording capability that captures what happens on the user's Mac during computer-use sessions.
+
+## How It Works
+
+- **Automatic in QA mode**: When a QA/test session starts, recording begins automatically before any destructive actions (clicks, typing, etc.)
+- **Can be requested explicitly**: Sessions can be configured with `requiresRecording: true` to enable recording outside of QA mode
+- **Recording gate**: When recording is required, destructive actions are blocked until the first video frame is confirmed captured
+
+## Recording Details
+
+- **Format**: H.264 MP4 video at 30 fps
+- **Resolution**: 1920×1080
+- **Bitrate**: 4 Mbps video, 128 kbps AAC audio (when audio is enabled)
+- **Capture scope**: Either the full display or a specific window
+- **Storage**: Files are saved to `~/Library/Application Support/vellum-assistant/recordings/`
+- **Naming**: `qa-recording-{timestamp}.mp4`
+
+## Health Checks
+
+A first-frame handshake verifies the capture pipeline is healthy within 5 seconds of starting. If no frames arrive:
+- **Required recording**: The session fails immediately with a clear error
+- **Optional recording**: A warning is shown but the session continues
+
+## After Recording
+
+When a recording completes:
+1. The video file is saved to disk
+2. A file-backed attachment is created (metadata in DB, file stays on disk)
+3. The attachment is linked to the originating chat message
+4. The video appears inline in the conversation for playback
+
+## Retention
+
+Recordings have an expiration timestamp (default: 7 days, configurable). An automatic cleanup worker runs periodically (every 6 hours) and deletes expired recording files from disk.
+
+## Limitations
+
+- Requires Screen Recording permission in System Settings > Privacy & Security
+- Only available on macOS
+- One recording at a time per session
+- Recording must be stopped explicitly (or stops when the session ends)
+- Large recordings consume disk space until cleanup runs
+
+## When to Mention Recording
+
+- Tell users their QA session is being recorded when relevant
+- Offer to analyze recordings using the media-processing skill (keyframe extraction, event detection)
+- Mention retention period if users ask about storage or cleanup
+- If recording fails, explain the specific error (permission denied, no display found, etc.)


### PR DESCRIPTION
## Summary
- Add a bundled `screen-recording` skill with SKILL.md that teaches the model about screen recording capabilities
- Awareness-only skill (no TOOLS.json) — prepares for future tool-bearing recording control
- Covers recording lifecycle, health checks, retention, limitations, and when to mention recording to users

## Test plan
- [x] Verify SKILL.md has valid YAML frontmatter
- [x] Verify file is in the correct bundled-skills directory
- [ ] No build step needed for SKILL.md-only skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
