### PR TITLE
fix: add double-cast through unknown for TS type-check in config-inbox handlers

### DIFF
--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -154,7 +154,7 @@ export function handleIngressInvite(
       }
 
       default: {
-        ctx.send(socket, { type: 'ingress_invite_response', success: false, error: `Unknown action: ${String((msg as Record<string, unknown>).action)}` });
+        ctx.send(socket, { type: 'ingress_invite_response', success: false, error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}` });
       }
     }
   } catch (err) {
@@ -263,7 +263,7 @@ export function handleIngressMember(
       }
 
       default: {
-        ctx.send(socket, { type: 'ingress_member_response', success: false, error: `Unknown action: ${String((msg as Record<string, unknown>).action)}` });
+        ctx.send(socket, { type: 'ingress_member_response', success: false, error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}` });
       }
     }
   } catch (err) {
@@ -344,7 +344,7 @@ export function handleInboxEscalation(
       }
 
       default: {
-        ctx.send(socket, { type: 'assistant_inbox_escalation_response', success: false, error: `Unknown action: ${String((msg as Record<string, unknown>).action)}` });
+        ctx.send(socket, { type: 'assistant_inbox_escalation_response', success: false, error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}` });
       }
     }
   } catch (err) {


### PR DESCRIPTION
Fix 3 TypeScript type-check errors in config-inbox.ts where IngressInviteRequest, IngressMemberRequest, and AssistantInboxEscalationRequest were directly cast to Record<string, unknown>. TypeScript requires casting through unknown first.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
