### PR TITLE
feat: allow requiresRecording to be set independently of QA intent

### DIFF
--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -87,8 +87,8 @@ export async function handleTaskSubmit(
     }
 
     const config = getConfig();
-    // Determine whether recording is required: (QA intent or active latch) + config flag
-    const requiresRecording = (isQa || (qaLatchActive && !isOptOut)) && config.qaRecording.enforceStartBeforeActions;
+    // Determine whether recording is required: explicit flag on the message, or (QA intent or active latch) + config flag
+    const requiresRecording = msg.requiresRecording ?? ((isQa || (qaLatchActive && !isOptOut)) && config.qaRecording.enforceStartBeforeActions);
 
     rlog.info({
       interactionType,

--- a/assistant/src/daemon/ipc-contract/computer-use.ts
+++ b/assistant/src/daemon/ipc-contract/computer-use.ts
@@ -100,6 +100,8 @@ export interface TaskSubmit {
   screenHeight: number;
   attachments?: UserMessageAttachment[];
   source?: 'voice' | 'text';
+  /** When set, overrides the QA-based requiresRecording computation. */
+  requiresRecording?: boolean;
 }
 
 export interface RideShotgunStart {


### PR DESCRIPTION
## Summary
- Add optional `requiresRecording` field to the `TaskSubmit` IPC message type
- Update `handleTaskSubmit` in `misc.ts` to use `msg.requiresRecording` as an explicit override, falling back to the existing QA-based computation when not set
- This decouples screen recording from QA mode so it can be triggered by other skills (e.g. a standalone screen-recording skill)

## Test plan
- [ ] Verify QA intent still triggers `requiresRecording=true` when `enforceStartBeforeActions` config is enabled
- [ ] Verify sending `task_submit` with `requiresRecording: true` forces recording even without QA intent
- [ ] Verify sending `task_submit` with `requiresRecording: false` suppresses recording even with QA intent
- [ ] Verify omitting `requiresRecording` preserves the existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
