### PR TITLE
fix(cli): update email client to match deployed platform API

### DIFF
--- a/cli/src/commands/email.ts
+++ b/cli/src/commands/email.ts
@@ -7,6 +7,7 @@
  */
 
 import { VellumEmailClient } from "../email/vellum.js";
+import { loadLatestAssistant } from "../lib/assistant-config.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -33,6 +34,7 @@ Subcommands:
   create <username>     Create a new email inbox for the given username
 
 Options:
+  --assistant <id>      Assistant ID (defaults to the most recently hatched)
   --help, -h            Show this help message
 `);
 }
@@ -49,12 +51,29 @@ export async function email(): Promise<void> {
     return;
   }
 
+  // Resolve assistant ID from --assistant flag or latest assistant
+  const assistantFlagIdx = args.indexOf("--assistant");
+  let assistantId: string | undefined;
+  if (assistantFlagIdx !== -1) {
+    assistantId = args[assistantFlagIdx + 1];
+    args.splice(assistantFlagIdx, 2);
+  }
+  if (!assistantId) {
+    assistantId = loadLatestAssistant()?.assistantId;
+  }
+  if (!assistantId) {
+    exitError(
+      "No assistant ID available. Pass --assistant <id> or hatch an assistant first.",
+    );
+    return;
+  }
+
   const subcommand = args[0];
 
   switch (subcommand) {
     case "status": {
       try {
-        const client = new VellumEmailClient();
+        const client = new VellumEmailClient(assistantId);
         const status = await client.status();
         output({
           ok: true,
@@ -73,7 +92,7 @@ export async function email(): Promise<void> {
         return;
       }
       try {
-        const client = new VellumEmailClient();
+        const client = new VellumEmailClient(assistantId);
         const inbox = await client.createInbox(username);
         output({ ok: true, inbox });
       } catch (err) {

--- a/cli/src/commands/email.ts
+++ b/cli/src/commands/email.ts
@@ -55,7 +55,12 @@ export async function email(): Promise<void> {
   const assistantFlagIdx = args.indexOf("--assistant");
   let assistantId: string | undefined;
   if (assistantFlagIdx !== -1) {
-    assistantId = args[assistantFlagIdx + 1];
+    const value = args[assistantFlagIdx + 1];
+    if (!value || value.startsWith("-")) {
+      exitError("--assistant requires a value.");
+      return;
+    }
+    assistantId = value;
     args.splice(assistantFlagIdx, 2);
   }
   if (!assistantId) {
@@ -74,12 +79,8 @@ export async function email(): Promise<void> {
     case "status": {
       try {
         const client = new VellumEmailClient(assistantId);
-        const status = await client.status();
-        output({
-          ok: true,
-          provider: status.provider,
-          inboxes: status.inboxes,
-        });
+        const addresses = await client.status();
+        output({ ok: true, addresses });
       } catch (err) {
         exitError(err instanceof Error ? err.message : String(err));
       }

--- a/cli/src/email/vellum.ts
+++ b/cli/src/email/vellum.ts
@@ -9,16 +9,10 @@ const DEFAULT_VELLUM_API_URL = "https://api.vellum.ai";
 // Types
 // ---------------------------------------------------------------------------
 
-export interface EmailInbox {
+export interface AssistantEmailAddress {
   id: string;
   address: string;
   created_at: string;
-}
-
-export interface EmailStatus {
-  provider: string;
-  ok: boolean;
-  inboxes: EmailInbox[];
 }
 
 // ---------------------------------------------------------------------------
@@ -78,18 +72,17 @@ export class VellumEmailClient {
   }
 
   /** List existing email addresses and check connectivity. */
-  async status(): Promise<EmailStatus> {
+  async status(): Promise<AssistantEmailAddress[]> {
     const result = await vellumFetch(
       this.apiKey,
       this.baseUrl,
       `/v1/assistants/${this.assistantId}/email-addresses/`,
     );
-    const inboxes = result as EmailInbox[];
-    return { provider: "vellum", ok: true, inboxes };
+    return result as AssistantEmailAddress[];
   }
 
   /** Provision a new email address for the given username. */
-  async createInbox(username: string): Promise<EmailInbox> {
+  async createInbox(username: string): Promise<AssistantEmailAddress> {
     const result = await vellumFetch(
       this.apiKey,
       this.baseUrl,
@@ -99,6 +92,6 @@ export class VellumEmailClient {
         body: { username },
       },
     );
-    return result as EmailInbox;
+    return result as AssistantEmailAddress;
   }
 }

--- a/cli/src/email/vellum.ts
+++ b/cli/src/email/vellum.ts
@@ -12,8 +12,7 @@ const DEFAULT_VELLUM_API_URL = "https://api.vellum.ai";
 export interface EmailInbox {
   id: string;
   address: string;
-  displayName?: string;
-  createdAt: string;
+  created_at: string;
 }
 
 export interface EmailStatus {
@@ -63,8 +62,10 @@ async function vellumFetch(
 export class VellumEmailClient {
   private apiKey: string;
   private baseUrl: string;
+  private assistantId: string;
 
-  constructor(apiKey?: string, baseUrl?: string) {
+  constructor(assistantId: string, apiKey?: string, baseUrl?: string) {
+    this.assistantId = assistantId;
     const resolvedKey = apiKey ?? process.env.VELLUM_API_KEY;
     if (!resolvedKey) {
       throw new Error(
@@ -81,9 +82,9 @@ export class VellumEmailClient {
     const result = await vellumFetch(
       this.apiKey,
       this.baseUrl,
-      "/v1/email-addresses",
+      `/v1/assistants/${this.assistantId}/email-addresses/`,
     );
-    const inboxes = (result as { inboxes: EmailInbox[] }).inboxes;
+    const inboxes = result as EmailInbox[];
     return { provider: "vellum", ok: true, inboxes };
   }
 
@@ -92,7 +93,7 @@ export class VellumEmailClient {
     const result = await vellumFetch(
       this.apiKey,
       this.baseUrl,
-      "/v1/email-addresses",
+      `/v1/assistants/${this.assistantId}/email-addresses/`,
       {
         method: "POST",
         body: { username },


### PR DESCRIPTION
## Summary
- Updated `VellumEmailClient` to accept a required `assistantId` and scope email endpoints under `/v1/assistants/{assistant_id}/email-addresses/`
- Changed GET response parsing from `{ inboxes: [...] }` wrapper to plain array
- Updated `EmailInbox` type: `createdAt` → `created_at`, removed `displayName`
- Added `--assistant <id>` flag to `vellum email` command with fallback to `loadLatestAssistant()`

## Test plan
- [x] `tsc --noEmit` passes with no type errors
- [ ] Manual test: `vellum email status --assistant <id>` returns inbox list
- [ ] Manual test: `vellum email create <username> --assistant <id>` provisions an inbox
- [ ] Verify fallback works when no `--assistant` flag is provided and an assistant has been hatched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8024" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
