### PR TITLE
fix: apply fail-open provider semantics to commit message generation

### DIFF
--- a/assistant/src/__tests__/provider-commit-message-generator.test.ts
+++ b/assistant/src/__tests__/provider-commit-message-generator.test.ts
@@ -55,18 +55,21 @@ const mockProvider: Provider = {
   name: 'mock-provider',
   sendMessage: mockSendMessage,
 };
-let getProviderShouldThrow = false;
 
-mock.module('../providers/registry.js', () => ({
-  getProvider: (_name: string) => {
-    if (getProviderShouldThrow) {
-      throw new Error('Provider not initialized');
-    }
-    return mockProvider;
-  },
-  registerProvider: () => {},
-  listProviders: () => ['mock-provider'],
-  initializeProviders: () => {},
+let resolvedProvider: {
+  provider: Provider;
+  configuredProviderName: string;
+  selectedProviderName: string;
+  usedFallbackPrimary: boolean;
+} | null = {
+  provider: mockProvider,
+  configuredProviderName: 'anthropic',
+  selectedProviderName: 'anthropic',
+  usedFallbackPrimary: false,
+};
+
+mock.module('../providers/provider-send-message.js', () => ({
+  resolveConfiguredProvider: () => resolvedProvider,
 }));
 
 // ---------------------------------------------------------------------------
@@ -113,7 +116,12 @@ describe('ProviderCommitMessageGenerator', () => {
     _resetCommitMessageGenerator();
     currentConfig = cloneConfig();
     mockSendMessage.mockReset();
-    getProviderShouldThrow = false;
+    resolvedProvider = {
+      provider: mockProvider,
+      configuredProviderName: 'anthropic',
+      selectedProviderName: 'anthropic',
+      usedFallbackPrimary: false,
+    };
   });
 
   // 1. disabled
@@ -147,6 +155,32 @@ describe('ProviderCommitMessageGenerator', () => {
     });
     expect(result.source).toBe('deterministic');
     expect(result.reason).toBe('missing_provider_api_key');
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  // 3b. No resolvable provider and no keys
+  test('no resolvable provider + no keys → returns deterministic, reason "missing_provider_api_key"', async () => {
+    currentConfig.apiKeys = {} as Record<string, string>;
+    resolvedProvider = null;
+    const gen = getCommitMessageGenerator();
+    const result = await gen.generateCommitMessage(baseContext, {
+      changedFiles: baseContext.changedFiles,
+    });
+    expect(result.source).toBe('deterministic');
+    expect(result.reason).toBe('missing_provider_api_key');
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  // 3c. No resolvable provider despite keys
+  test('no resolvable provider with keys present → returns deterministic, reason "provider_not_initialized"', async () => {
+    currentConfig.apiKeys = { anthropic: 'sk-test-key' } as Record<string, string>;
+    resolvedProvider = null;
+    const gen = getCommitMessageGenerator();
+    const result = await gen.generateCommitMessage(baseContext, {
+      changedFiles: baseContext.changedFiles,
+    });
+    expect(result.source).toBe('deterministic');
+    expect(result.reason).toBe('provider_not_initialized');
     expect(mockSendMessage).not.toHaveBeenCalled();
   });
 
@@ -295,6 +329,12 @@ describe('ProviderCommitMessageGenerator', () => {
   test('Ollama without API key or fast model → returns deterministic, reason "missing_fast_model"', async () => {
     (currentConfig as Record<string, unknown>).provider = 'ollama';
     currentConfig.apiKeys = {} as Record<string, string>;
+    resolvedProvider = {
+      provider: mockProvider,
+      configuredProviderName: 'ollama',
+      selectedProviderName: 'ollama',
+      usedFallbackPrimary: false,
+    };
     const gen = getCommitMessageGenerator();
     const result = await gen.generateCommitMessage(baseContext, {
       changedFiles: baseContext.changedFiles,
@@ -309,6 +349,12 @@ describe('ProviderCommitMessageGenerator', () => {
   test('Unknown provider without fast model default → returns deterministic, reason "missing_fast_model"', async () => {
     (currentConfig as Record<string, unknown>).provider = 'exotic-provider';
     currentConfig.apiKeys = { 'exotic-provider': 'sk-exotic' } as Record<string, string>;
+    resolvedProvider = {
+      provider: mockProvider,
+      configuredProviderName: 'exotic-provider',
+      selectedProviderName: 'exotic-provider',
+      usedFallbackPrimary: false,
+    };
     const gen = getCommitMessageGenerator();
     const result = await gen.generateCommitMessage(baseContext, {
       changedFiles: baseContext.changedFiles,
@@ -322,6 +368,12 @@ describe('ProviderCommitMessageGenerator', () => {
   test('fast-model override enables LLM path for provider without built-in default', async () => {
     (currentConfig as Record<string, unknown>).provider = 'ollama';
     currentConfig.apiKeys = {} as Record<string, string>; // Ollama is keyless
+    resolvedProvider = {
+      provider: mockProvider,
+      configuredProviderName: 'ollama',
+      selectedProviderName: 'ollama',
+      usedFallbackPrimary: false,
+    };
     currentConfig.workspaceGit.commitMessageLLM.providerFastModelOverrides = {
       ollama: 'llama3.2:3b',
     };
@@ -338,5 +390,29 @@ describe('ProviderCommitMessageGenerator', () => {
     const callArgs = mockSendMessage.mock.calls[0];
     const options = callArgs[3] as { config: { model: string } };
     expect(options.config.model).toBe('llama3.2:3b');
+  });
+
+  // 15. Fail-open fallback provider uses fallback provider's fast-model mapping
+  test('configured provider unavailable -> selected fallback provider model mapping is used', async () => {
+    currentConfig.provider = 'anthropic';
+    currentConfig.providerOrder = ['openai'];
+    currentConfig.apiKeys = { openai: 'sk-openai' } as Record<string, string>;
+    resolvedProvider = {
+      provider: mockProvider,
+      configuredProviderName: 'anthropic',
+      selectedProviderName: 'openai',
+      usedFallbackPrimary: true,
+    };
+    mockSendMessage.mockResolvedValueOnce(makeSuccessResponse('fix: fail-open commit'));
+
+    const gen = getCommitMessageGenerator();
+    const result = await gen.generateCommitMessage(baseContext, {
+      changedFiles: baseContext.changedFiles,
+    });
+
+    expect(result.source).toBe('llm');
+    const callArgs = mockSendMessage.mock.calls[0];
+    const options = callArgs[3] as { config: { model: string } };
+    expect(options.config.model).toBe('gpt-4o-mini');
   });
 });

--- a/assistant/src/workspace/provider-commit-message-generator.ts
+++ b/assistant/src/workspace/provider-commit-message-generator.ts
@@ -3,6 +3,7 @@ import { getConfig } from '../config/loader.js';
 import type { CommitContext } from './commit-message-provider.js';
 import { DefaultCommitMessageProvider } from './commit-message-provider.js';
 import type { Message } from '../providers/types.js';
+import { resolveConfiguredProvider } from '../providers/provider-send-message.js';
 
 const log = getLogger('commit-message-llm');
 
@@ -48,6 +49,18 @@ const PROVIDER_DEFAULT_FAST_MODELS: Record<string, string> = {
 const KEYLESS_PROVIDERS = new Set(['ollama']);
 
 const deterministicProvider = new DefaultCommitMessageProvider();
+
+function getProviderCandidates(config: ReturnType<typeof getConfig>): string[] {
+  const order = Array.isArray(config.providerOrder) ? config.providerOrder : [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const name of [config.provider, ...order]) {
+    if (seen.has(name)) continue;
+    seen.add(name);
+    out.push(name);
+  }
+  return out;
+}
 
 function buildDeterministicResult(
   context: CommitContext,
@@ -106,11 +119,12 @@ export class ProviderCommitMessageGenerator {
 
     // ── Fallback check order (canonical) ──────────────────────────────
     // 1. disabled
-    // 2. missing_provider_api_key  (except keyless providers like ollama)
-    // 3. breaker_open
-    // 4. insufficient_budget
-    // 5. missing_fast_model
-    // 6. provider_not_initialized
+    // 2. resolve configured provider via fail-open selection:
+    //    - missing_provider_api_key OR provider_not_initialized
+    // 3. selected-provider API key preflight (except keyless providers)
+    // 4. breaker_open
+    // 5. insufficient_budget
+    // 6. missing_fast_model
     // 7. call provider → timeout / provider_error / invalid_output
     // ──────────────────────────────────────────────────────────────────
 
@@ -122,11 +136,36 @@ export class ProviderCommitMessageGenerator {
       return buildDeterministicResult(context, 'disabled');
     }
 
-    // Step 2: API key preflight (skip for providers that run without a key)
-    if (!KEYLESS_PROVIDERS.has(config.provider)) {
-      const providerApiKey = config.apiKeys[config.provider];
+    // Step 2: Resolve configured provider using fail-open semantics.
+    // If nothing is resolvable, differentiate likely missing-key cases from
+    // true registry/init failures.
+    const resolved = resolveConfiguredProvider();
+    if (!resolved) {
+      const candidates = getProviderCandidates(config);
+      const hasAnyKeylessCandidate = candidates.some((name) => KEYLESS_PROVIDERS.has(name));
+      const hasAnyProviderKey = candidates.some((name) => {
+        const value = config.apiKeys[name];
+        return typeof value === 'string' && value.length > 0;
+      });
+      if (!hasAnyKeylessCandidate && !hasAnyProviderKey) {
+        log.debug('No API keys available for configured/fallback providers; falling back to deterministic');
+        return buildDeterministicResult(context, 'missing_provider_api_key');
+      }
+      log.debug({ provider: config.provider }, 'Provider not initialized; falling back to deterministic');
+      return buildDeterministicResult(context, 'provider_not_initialized');
+    }
+
+    const provider = resolved.provider;
+    const selectedProviderName = resolved.selectedProviderName;
+
+    // Step 2b: API key preflight for the selected provider (skip keyless).
+    if (!KEYLESS_PROVIDERS.has(selectedProviderName)) {
+      const providerApiKey = config.apiKeys[selectedProviderName];
       if (!providerApiKey || providerApiKey === '') {
-        log.debug('Provider API key missing; falling back to deterministic');
+        log.debug(
+          { selectedProvider: selectedProviderName, configuredProvider: config.provider },
+          'Selected provider API key missing; falling back to deterministic',
+        );
         return buildDeterministicResult(context, 'missing_provider_api_key');
       }
     }
@@ -153,12 +192,12 @@ export class ProviderCommitMessageGenerator {
     }
 
     // Step 5: Fast model preflight — resolve before any provider call
-    const fastModel = llmConfig.providerFastModelOverrides[config.provider]
-      ?? PROVIDER_DEFAULT_FAST_MODELS[config.provider];
+    const fastModel = llmConfig.providerFastModelOverrides[selectedProviderName]
+      ?? PROVIDER_DEFAULT_FAST_MODELS[selectedProviderName];
 
     if (!fastModel) {
       log.debug(
-        { provider: config.provider },
+        { provider: selectedProviderName, configuredProvider: config.provider },
         'No fast model resolvable for provider; falling back to deterministic',
       );
       return buildDeterministicResult(context, 'missing_fast_model');
@@ -166,16 +205,6 @@ export class ProviderCommitMessageGenerator {
 
     // Step 6 + 7: Call the provider
     try {
-      const { getProvider } = await import('../providers/registry.js');
-
-      let provider;
-      try {
-        provider = getProvider(config.provider);
-      } catch {
-        log.debug({ provider: config.provider }, 'Provider not initialized; falling back to deterministic');
-        return buildDeterministicResult(context, 'provider_not_initialized');
-      }
-
       // Build prompt
       const fileList = options.changedFiles
         .slice(0, llmConfig.maxFilesInPrompt)


### PR DESCRIPTION
## Summary
- migrate `workspace/provider-commit-message-generator.ts` from direct `getProvider(config.provider)` lookup to `resolveConfiguredProvider()` so commit-message generation follows fail-open provider selection
- align fast-model resolution with the actually selected provider to avoid cross-provider model mismatches when fallback primary is used
- add regression tests for no-provider outcomes and fallback-primary model mapping

## Why
`#7991` applied fail-open behavior broadly, but this commit-message path still failed closed on configured-primary lookup. This closes that remaining gap for workspace git commit message generation.

## Validation
- `cd assistant && bun test src/__tests__/provider-commit-message-generator.test.ts`
- `cd assistant && bun test src/__tests__/commit-message-enrichment-service.test.ts`
- `cd assistant && bun test src/__tests__/provider-fail-open-selection.test.ts`

## Notes
- `cd assistant && bunx tsc --noEmit` currently fails on existing `config-inbox.ts` type issues present on `main`; no new type errors from this change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
