### PR TITLE
fix: move covering index rebuild to one-time migration

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -15,6 +15,7 @@ import {
   migrateMemoryFtsBackfill,
   migrateGuardianActionTables,
   migrateBackfillInboxThreadStateFromBindings,
+  migrateDropActiveSearchIndex,
   validateMigrationState,
 } from './schema-migration.js';
 
@@ -571,7 +572,7 @@ export function initializeDb(): void {
   // Partial covering index for directItemSearch: the LIKE '%term%' pattern can't
   // seek a B-tree, but this index lets SQLite scan only active non-invalidated rows
   // and evaluate LIKE + return columns without touching the main table.
-  database.run(/*sql*/ `DROP INDEX IF EXISTS idx_memory_items_active_search`);
+  migrateDropActiveSearchIndex(database);
   database.run(/*sql*/ `
     CREATE INDEX IF NOT EXISTS idx_memory_items_active_search
     ON memory_items(status, invalid_at, last_seen_at DESC, subject, statement, id, kind, confidence, importance, first_seen_at, scope_id)

--- a/assistant/src/memory/schema-migration.ts
+++ b/assistant/src/memory/schema-migration.ts
@@ -74,6 +74,11 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     version: 8,
     description: 'Seed assistant_inbox_thread_state from external_conversation_bindings',
   },
+  {
+    key: 'drop_active_search_index_v1',
+    version: 9,
+    description: 'Drop old idx_memory_items_active_search so it can be recreated with updated covering columns',
+  },
 ];
 
 export interface MigrationValidationResult {
@@ -1279,4 +1284,24 @@ export function migrateBackfillInboxThreadStateFromBindings(database: Db): void 
     try { raw.exec('ROLLBACK'); } catch { /* no active transaction */ }
     throw e;
   }
+}
+
+/**
+ * One-time migration to drop the old idx_memory_items_active_search index so
+ * it can be recreated with updated covering columns by the idempotent
+ * CREATE INDEX IF NOT EXISTS in db-init.
+ */
+export function migrateDropActiveSearchIndex(database: Db): void {
+  const raw = getSqliteFrom(database);
+  const checkpointKey = 'drop_active_search_index_v1';
+  const checkpoint = raw.query(
+    `SELECT 1 FROM memory_checkpoints WHERE key = ?`,
+  ).get(checkpointKey);
+  if (checkpoint) return;
+
+  raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_memory_items_active_search`);
+
+  raw.query(
+    `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,
+  ).run(checkpointKey, Date.now());
 }


### PR DESCRIPTION
Move DROP INDEX for idx_memory_items_active_search from initializeDb() (runs every startup) to a one-time schema migration, avoiding O(N) index rebuild on every init call.

Addresses feedback on #8001.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
