### PR TITLE
fix: return stale_ignored on race condition in all legacy approval paths

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -68,11 +68,12 @@ declare -a SAFE_LINE_PATTERNS=(
     # TS/JS: camelCase property names containing clientSecret used as identifiers
     # (typeof checks, null/undefined comparisons, variable/property references).
     # Avoids false positives like `oauth2ClientSecret: typeof record.oauth2ClientSecret`.
-    "[a-zA-Z0-9_]*[Cc]lient[Ss]ecret[[:space:]]*[:=]+[[:space:]]*(typeof[[:space:]]|null[[:space:];,){}]|undefined[[:space:];,){}]|[a-zA-Z_][a-zA-Z0-9_]*[.?]+[a-zA-Z_])"
+    "[a-zA-Z0-9_]*[Cc]lient[Ss]ecret[[:space:]]*[:=]+[[:space:]]*(typeof[[:space:]]|null[[:space:];,){}]|undefined[[:space:];,){}])"
     # TS/JS: dotted property access like `record.oauth2ClientSecret` or
-    # `policy?.oauth2ClientSecret`. Handles lines with multiple clientSecret
-    # references where the first pattern strips one occurrence but others remain.
-    "[.?]+[a-zA-Z0-9_]*[Cc]lient[Ss]ecret"
+    # `policy?.oauth2ClientSecret`. Only matches when the rest of the line after
+    # the dotted identifier contains NO quoted strings — prevents masking lines
+    # like `clientSecret: config.clientSecret || "real_secret"`.
+    "[.?]+[a-zA-Z0-9_]*[Cc]lient[Ss]ecret[^\"']*$"
 )
 
 matches_safe_line_pattern() {
@@ -156,6 +157,9 @@ if [ "${1:-}" = "--self-test" ]; then
     SAFE_TS_DOTREF_LINE='    existing.oauth2ClientSecret = policy.oauth2ClientSecret;'
     SAFE_TS_NULLCHECK_LINE='      if (policy.oauth2ClientSecret === null) {'
     SAFE_TS_OPTIONAL_LINE='    oauth2ClientSecret: policy?.oauth2ClientSecret ?? undefined,'
+
+    # Dotted reference with a fallback string literal — must NOT be whitelisted
+    UNSAFE_TS_FALLBACK='clientSecret: config.clientSecret || "sk_live_12345678901234567890"'
 
     if matches_secret_pattern "$SAFE_ARCHITECTURE_LINE"; then
         echo -e "${RED}Self-test failed:${NC} ARCHITECTURE allowlist case still matches"
@@ -323,6 +327,10 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$SAFE_TS_OPTIONAL_LINE" && ! matches_safe_line_pattern "$SAFE_TS_OPTIONAL_LINE"; then
         echo -e "${RED}Self-test failed:${NC} TS optional chaining clientSecret false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$UNSAFE_TS_FALLBACK" && matches_safe_line_pattern "$UNSAFE_TS_FALLBACK"; then
+        echo -e "${RED}Self-test failed:${NC} dotted clientSecret with fallback string literal was incorrectly whitelisted"
         exit 1
     fi
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -70,10 +70,10 @@ declare -a SAFE_LINE_PATTERNS=(
     # Avoids false positives like `oauth2ClientSecret: typeof record.oauth2ClientSecret`.
     "[a-zA-Z0-9_]*[Cc]lient[Ss]ecret[[:space:]]*[:=]+[[:space:]]*(typeof[[:space:]]|null[[:space:];,){}]|undefined[[:space:];,){}])"
     # TS/JS: dotted property access like `record.oauth2ClientSecret` or
-    # `policy?.oauth2ClientSecret`. Only matches when the rest of the line after
-    # the dotted identifier contains NO quoted strings — prevents masking lines
-    # like `clientSecret: config.clientSecret || "real_secret"`.
-    "[.?]+[a-zA-Z0-9_]*[Cc]lient[Ss]ecret[^\"']*$"
+    # `policy?.oauth2ClientSecret`. Allows quoted text only inside trailing
+    # `//` comments — prevents masking real fallback assignments like
+    # `clientSecret: config.clientSecret || "real_secret"`.
+    "[.?]+[a-zA-Z0-9_]*[Cc]lient[Ss]ecret([^\"'/]*$|[^\"'/]*//.*)$"
 )
 
 matches_safe_line_pattern() {
@@ -160,6 +160,12 @@ if [ "${1:-}" = "--self-test" ]; then
 
     # Dotted reference with a fallback string literal — must NOT be whitelisted
     UNSAFE_TS_FALLBACK='clientSecret: config.clientSecret || "sk_live_12345678901234567890"'
+
+    # Dotted reference with quoted text in a trailing comment — must be whitelisted
+    SAFE_TS_COMMENT_QUOTE='oauth2ClientSecret: policy.oauth2ClientSecret, // "optional"'
+
+    # Dotted reference with nullish coalescing fallback — must NOT be whitelisted
+    UNSAFE_TS_NULLISH_FALLBACK='clientSecret: config.clientSecret ?? "real_secret_value_1234"'
 
     if matches_secret_pattern "$SAFE_ARCHITECTURE_LINE"; then
         echo -e "${RED}Self-test failed:${NC} ARCHITECTURE allowlist case still matches"
@@ -331,6 +337,14 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$UNSAFE_TS_FALLBACK" && matches_safe_line_pattern "$UNSAFE_TS_FALLBACK"; then
         echo -e "${RED}Self-test failed:${NC} dotted clientSecret with fallback string literal was incorrectly whitelisted"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_TS_COMMENT_QUOTE" && ! matches_safe_line_pattern "$SAFE_TS_COMMENT_QUOTE"; then
+        echo -e "${RED}Self-test failed:${NC} dotted clientSecret with quoted text in trailing comment false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$UNSAFE_TS_NULLISH_FALLBACK" && matches_safe_line_pattern "$UNSAFE_TS_NULLISH_FALLBACK"; then
+        echo -e "${RED}Self-test failed:${NC} dotted clientSecret with nullish coalescing fallback was incorrectly whitelisted"
         exit 1
     fi
 

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -1,0 +1,30 @@
+name: Playwright Tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  playwright:
+    name: Playwright Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: playwright
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: bun run test

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4037,11 +4037,11 @@ In multi-assistant mode, the operator must configure `GATEWAY_ASSISTANT_ROUTING_
 
 ---
 
-## Outgoing AI Phone Calls — Twilio ConversationRelay
+## AI Phone Calls — Twilio ConversationRelay
 
-The Calls subsystem enables the assistant to place outgoing phone calls on behalf of the user via Twilio's ConversationRelay protocol. The assistant uses an LLM-driven conversation loop to speak with the callee in real time. Voice is a first-class channel with its own per-call conversation (key pattern: `asst:${assistantId}:voice:call:${callSessionId}`). When the AI needs guardian input during a call, it dispatches ASK_GUARDIAN requests cross-channel to mac/telegram/sms via the guardian dispatch engine. Answer resolution uses first-writer-wins semantics -- the first channel to respond provides the answer, and remaining channels receive a "already answered" notice.
+The Calls subsystem supports both **outbound** and **inbound** voice calls via Twilio's ConversationRelay protocol. The assistant uses an LLM-driven conversation loop to speak in real time. Voice is a first-class channel with its own per-call conversation (outbound key: `asst:${assistantId}:voice:call:${callSessionId}`, inbound key: `asst:${assistantId}:voice:inbound:${callSid}`). When the AI needs guardian input during a call, it dispatches ASK_GUARDIAN requests cross-channel to mac/telegram/sms via the guardian dispatch engine. Answer resolution uses first-writer-wins semantics -- the first channel to respond provides the answer, and remaining channels receive a "already answered" notice.
 
-### Call Flow
+### Outbound Call Flow
 
 ```mermaid
 sequenceDiagram
@@ -4070,7 +4070,7 @@ sequenceDiagram
 
     TwilioAPI->>Gateway: POST /webhooks/twilio/voice
     Gateway->>Gateway: validateTwilioWebhookRequest()
-    Gateway->>Routes: forward to runtime /v1/calls/voice-webhook
+    Gateway->>Routes: forward to runtime /v1/internal/twilio/voice-webhook (+ params, originalUrl)
     Routes->>CallStore: getCallSession()
     Routes-->>Gateway: TwiML (ConversationRelay connect)
     Gateway-->>TwilioAPI: TwiML response
@@ -4111,9 +4111,97 @@ sequenceDiagram
 
     TwilioAPI->>Gateway: POST /webhooks/twilio/status
     Gateway->>Gateway: validateTwilioWebhookRequest()
-    Gateway->>Routes: forward to runtime /v1/calls/status-callback
+    Gateway->>Routes: forward to runtime /v1/internal/twilio/status (+ params)
     Routes->>CallStore: updateCallSession(status)
 ```
+
+### Inbound Call Flow
+
+Inbound calls are triggered when someone dials the assistant's Twilio phone number. The gateway resolves which assistant owns the number, the runtime bootstraps a session keyed by CallSid, and the relay connection optionally gates the call behind guardian voice verification before handing off to the LLM orchestrator.
+
+```mermaid
+sequenceDiagram
+    participant Caller as External Caller
+    participant TwilioAPI as Twilio
+    participant Gateway as Gateway (public)
+    participant Routes as twilio-routes.ts (runtime)
+    participant CallDomain as CallDomain
+    participant CallStore as CallStore (SQLite)
+    participant WS as RelayConnection (WebSocket)
+    participant GuardianSvc as ChannelGuardianService
+    participant Orch as CallOrchestrator
+    participant LLM as Anthropic Claude
+
+    Caller->>TwilioAPI: Dials assistant phone number
+    TwilioAPI->>Gateway: POST /webhooks/twilio/voice (no callSessionId)
+    Gateway->>Gateway: validateTwilioWebhookRequest()
+    Gateway->>Gateway: resolveAssistantByPhoneNumber(config, To)
+    alt Phone number matches an assistant
+        Gateway->>Gateway: assistantId resolved
+    else No phone number match
+        Gateway->>Gateway: resolveAssistant(From, From) — fallback routing chain
+        alt Unmapped policy = reject
+            Gateway-->>TwilioAPI: TwiML <Reject reason="rejected"/>
+        else Unmapped policy = default
+            Gateway->>Gateway: use defaultAssistantId
+        end
+    end
+
+    Gateway->>Routes: forward to runtime /v1/internal/twilio/voice-webhook (+ params, originalUrl, assistantId)
+    Routes->>CallDomain: createInboundVoiceSession(callSid, from, to, assistantId)
+    CallDomain->>CallStore: getOrCreateConversation(voice:inbound:${callSid})
+    CallDomain->>CallStore: createCallSession() — task=null for inbound
+    Routes-->>Gateway: TwiML (ConversationRelay connect)
+    Gateway-->>TwilioAPI: TwiML response
+
+    TwilioAPI->>Gateway: WebSocket /webhooks/twilio/relay
+    Gateway->>WS: proxy WS to runtime /v1/calls/relay
+    WS->>WS: setup message (callSid)
+    WS->>WS: detect isInbound (session.task == null)
+
+    alt Pending voice guardian challenge exists
+        WS->>GuardianSvc: getPendingChallenge(assistantId, 'voice')
+        WS->>WS: enter verification_pending state
+        WS->>Caller: TTS "Please enter your six-digit verification code"
+        loop DTMF / spoken digit attempts (max 3)
+            Caller->>WS: DTMF digits or spoken digits
+            WS->>GuardianSvc: validateAndConsumeChallenge(code)
+            alt Code matches
+                GuardianSvc-->>WS: success + guardian binding created
+                WS->>Orch: startNormalCallFlow(isInbound=true)
+            else Code incorrect + attempts remaining
+                WS->>Caller: TTS "That code was incorrect. Please try again."
+            else Max attempts exceeded
+                WS->>Caller: TTS "Verification failed. Goodbye."
+                WS->>CallStore: updateCallSession(failed)
+                WS->>WS: endSession()
+            end
+        end
+    else No pending guardian challenge
+        WS->>Orch: startNormalCallFlow(isInbound=true)
+    end
+
+    Orch->>Orch: buildInboundSystemPrompt()
+    Note over Orch: "You are answering an incoming call<br/>on behalf of [user]. Greet warmly,<br/>find out what they need."
+    Orch->>LLM: initial greeting turn
+    LLM-->>Orch: receptionist-style greeting
+    Orch->>WS: sendTextToken() (TTS to caller)
+
+    loop Conversation turns
+        Caller->>WS: prompt (caller utterance)
+        WS->>Orch: handleCallerUtterance(transcript, speakerContext)
+        Orch->>LLM: messages.stream()
+        LLM-->>Orch: text tokens (streaming)
+        Orch->>WS: sendTextToken() (for TTS)
+        Orch->>CallStore: recordCallEvent()
+    end
+```
+
+**Inbound vs. outbound detection**: The relay server determines call direction by checking `session.task`. Outbound calls always have a task (the user-provided objective). Inbound calls have `task == null` because the caller dialed in — the assistant's role is to greet and assist rather than execute a specific task.
+
+**Inbound system prompt**: The `CallOrchestrator.buildInboundSystemPrompt()` generates a receptionist-style prompt: "You are on a live phone call, answering an incoming call on behalf of [user]. The caller dialed in to reach you. You do not have a specific task -- your role is to greet them warmly, find out what they need, and assist them."
+
+**Guardian voice verification gate**: When a pending voice guardian challenge exists (created via the desktop UI), inbound callers must enter a six-digit code via DTMF or by speaking the digits before the call proceeds. Up to 3 attempts are allowed. On success, a guardian binding is created and the call transitions to normal flow. On failure, the call ends with a "Verification failed" message. This allows guardians to verify their identity over voice before being granted channel access.
 
 ### Key Components
 
@@ -4124,6 +4212,8 @@ sequenceDiagram
 | `assistant/src/calls/guardian-dispatch.ts` | Cross-channel dispatch engine: fans out ASK_GUARDIAN questions to mac/telegram/sms, creates server-side guardian conversations, manages deliveries |
 | `assistant/src/memory/guardian-action-store.ts` | CRUD for guardian action requests and deliveries; first-writer-wins resolution via atomic status check |
 | `assistant/src/calls/guardian-action-sweep.ts` | Periodic 60s sweep for expired guardian action requests; sends expiry notices to all delivery channels |
+| `assistant/src/calls/call-domain.ts:createInboundVoiceSession()` | Creates or reuses a voice session for an inbound call keyed by CallSid (idempotent replay protection) |
+| `assistant/src/runtime/channel-guardian-service.ts` | Guardian verification challenge lifecycle: create challenge with six-digit code, find pending challenges, validate and consume on match |
 | `assistant/src/calls/call-state-machine.ts` | Deterministic state transition validator with allowed-transition table and terminal-state enforcement |
 | `assistant/src/calls/call-recovery.ts` | Startup reconciliation of non-terminal calls: fetches provider status and transitions stale sessions |
 | `assistant/src/calls/twilio-provider.ts` | Twilio Voice REST API integration (initiateCall, endCall, getCallStatus) using direct fetch — no Twilio SDK dependency |
@@ -4190,7 +4280,7 @@ When the LLM emits `[ASK_GUARDIAN: question]` during a voice call, the orchestra
 
 All five tables live in `~/.vellum/workspace/data/db/assistant.db` alongside existing tables:
 
-- **`call_sessions`** — One row per outgoing call. Tracks conversation association, provider info (Twilio CallSid), phone numbers, task description, status lifecycle (`initiated` -> `ringing` -> `in_progress` -> `waiting_on_user` -> `completed`/`failed`), and timestamps. Foreign key to `conversations(id)` with cascade delete.
+- **`call_sessions`** — One row per call (inbound or outbound). Tracks conversation association, provider info (Twilio CallSid), phone numbers, task description (null for inbound calls), status lifecycle (`initiated` -> `ringing` -> `in_progress` -> `waiting_on_user` -> `completed`/`failed`), and timestamps. For inbound calls, the session is keyed by CallSid via `createInboundVoiceSession()` with idempotent replay protection. Foreign key to `conversations(id)` with cascade delete.
 
 - **`call_events`** — Append-only event log for each call session. Event types include `call_started`, `call_connected`, `caller_spoke`, `assistant_spoke`, `user_question_asked`, `user_answered`, `call_ended`, `call_failed`. For voice prompts, `caller_spoke` payloads include speaker context (`speakerId`, `speakerLabel`, `speakerConfidence`, `speakerSource`) when available. Foreign key to `call_sessions(id)` with cascade delete. Includes a unique index on `(call_session_id, dedupe_key)` for callback idempotency.
 
@@ -4206,9 +4296,9 @@ Internet-facing Twilio callbacks terminate at the gateway, which validates signa
 
 | Gateway Route | Validates | Forwards To (Runtime) |
 |---------------|-----------|----------------------|
-| `POST /webhooks/twilio/voice` | HMAC-SHA1 signature, payload size | `POST /v1/calls/voice-webhook` |
-| `POST /webhooks/twilio/status` | HMAC-SHA1 signature, payload size | `POST /v1/calls/status-callback` |
-| `POST /webhooks/twilio/connect-action` | HMAC-SHA1 signature, payload size | `POST /v1/calls/connect-action` |
+| `POST /webhooks/twilio/voice` | HMAC-SHA1 signature, payload size | `POST /v1/internal/twilio/voice-webhook` (JSON: `{ params, originalUrl, assistantId? }`) |
+| `POST /webhooks/twilio/status` | HMAC-SHA1 signature, payload size | `POST /v1/internal/twilio/status` (JSON: `{ params }`) |
+| `POST /webhooks/twilio/connect-action` | HMAC-SHA1 signature, payload size | `POST /v1/internal/twilio/connect-action` (JSON: `{ params }`) |
 | `WS /webhooks/twilio/relay` | WebSocket upgrade | `WS /v1/calls/relay` (bidirectional proxy) |
 | `POST /webhooks/twilio/sms` | HMAC-SHA1 signature, payload size, MessageSid dedup | `POST /v1/channels/inbound` (normalized `GatewayInboundEventV1` with `sourceChannel: "sms"`) |
 
@@ -4235,13 +4325,14 @@ This makes ingress URL updates smoother in local tunnel workflows because Twilio
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/v1/calls/start` | Initiate a new outgoing call (gated by `calls.enabled` config) |
+| POST | `/v1/calls/twilio/voice-webhook` | Twilio voice webhook (direct access; **blocked with 410 in gateway-only mode**) |
+| POST | `/v1/internal/twilio/voice-webhook` | Internal voice webhook used by gateway; accepts JSON `{ params, originalUrl, assistantId? }`, creates inbound session or returns TwiML |
 | GET | `/v1/calls/:callSessionId` | Get call status, including any pending question |
 | POST | `/v1/calls/:callSessionId/cancel` | Cancel an active call |
 | POST | `/v1/calls/:callSessionId/answer` | Answer a pending question via HTTP (alternative to in-thread bridge) |
 | POST | `/v1/calls/:callSessionId/instruction` | Relay a steering instruction to an active call's orchestrator (alternative to in-thread bridge) |
-| POST | `/v1/calls/voice-webhook` | Twilio voice webhook; returns TwiML with ConversationRelay connect |
-| POST | `/v1/calls/status-callback` | Twilio status callback (ringing, in-progress, completed, failed) |
-| POST | `/v1/calls/connect-action` | TwiML connect action callback when ConversationRelay ends |
+| POST | `/v1/internal/twilio/status` | Internal status callback used by gateway; accepts JSON `{ params }` |
+| POST | `/v1/internal/twilio/connect-action` | Internal connect action callback used by gateway; accepts JSON `{ params }` |
 | WS | `/v1/calls/relay` | ConversationRelay WebSocket (bidirectional: prompt/interrupt/dtmf from Twilio, text tokens/end to Twilio) |
 
 ### Tools
@@ -4252,7 +4343,7 @@ This makes ingress URL updates smoother in local tunnel workflows because Twilio
 | `call_status` | Retrieves the current status of a call session |
 | `call_end` | Terminates an active call |
 
-Both tools and HTTP routes delegate to the same domain functions in `call-domain.ts` (`startCall`, `getCallStatus`, `cancelCall`, `answerCall`, `relayInstruction`), ensuring consistent validation and behavior.
+Both tools and HTTP routes delegate to the same domain functions in `call-domain.ts` (`startCall`, `getCallStatus`, `cancelCall`, `answerCall`, `relayInstruction`), ensuring consistent validation and behavior. Inbound calls do not use tools — they are initiated by the external caller and bootstrapped automatically by the voice webhook and relay server.
 
 ### Control Markers
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -119,6 +119,9 @@ graph TB
             DB_TASKS["tasks"]
             DB_TASK_RUNS["task_runs"]
             DB_WORK_ITEMS["work_items"]
+            DB_INGRESS_INVITES["assistant_ingress_invites"]
+            DB_INGRESS_MEMBERS["assistant_ingress_members"]
+            DB_INBOX_THREADS["assistant_inbox_thread_state"]
         end
 
         subgraph "Tracing"
@@ -1389,6 +1392,11 @@ graph LR
         C11["work_items_list / work_item_get<br/>work_item_create / work_item_update<br/>work_item_complete / work_item_run_task<br/>(planned)"]
         C12["tool_permission_simulate<br/>toolName, input, workingDir?,<br/>isInteractive?, forcePromptSideEffects?,<br/>executionTarget?"]
         C13["conversation_search<br/>query, limit?,<br/>maxMessagesPerConversation?"]
+        C14["ingress_invite<br/>create / list / revoke / redeem"]
+        C15["ingress_member<br/>list / upsert / revoke / block"]
+        C16["assistant_inbox<br/>list_threads / get_thread_messages"]
+        C17["assistant_inbox_escalation<br/>list / decide"]
+        C18["assistant_inbox_reply<br/>conversationId, content"]
     end
 
     SOCKET["Unix Socket<br/>~/.vellum/vellum.sock<br/>───────────────<br/>Newline-delimited JSON<br/>Max 96MB per message<br/>Ping/pong every 30s<br/>Auto-reconnect<br/>1s → 30s backoff"]
@@ -1419,6 +1427,11 @@ graph LR
         S21["work_item_status_changed<br/>workItemId, newStatus<br/>(planned push)"]
         S22["tool_permission_simulate_response<br/>decision, riskLevel, reason?,<br/>promptPayload?, matchedRuleId?"]
         S23["conversation_search_response<br/>query, results[]: conversationId,<br/>title, updatedAt, matchingMessages[]"]
+        S24["ingress_invite_response<br/>invite / invites"]
+        S25["ingress_member_response<br/>member / members"]
+        S26["assistant_inbox_response<br/>threads / messages"]
+        S27["assistant_inbox_escalation_response<br/>escalations / decision"]
+        S28["assistant_inbox_reply_response<br/>messageId"]
     end
 
     C0 --> SOCKET
@@ -1435,6 +1448,11 @@ graph LR
     C11 --> SOCKET
     C12 --> SOCKET
     C13 --> SOCKET
+    C14 --> SOCKET
+    C15 --> SOCKET
+    C16 --> SOCKET
+    C17 --> SOCKET
+    C18 --> SOCKET
 
     SOCKET --> S0
     SOCKET --> S1
@@ -1459,6 +1477,11 @@ graph LR
     SOCKET --> S20
     SOCKET --> S21
     SOCKET --> S22
+    SOCKET --> S24
+    SOCKET --> S25
+    SOCKET --> S26
+    SOCKET --> S27
+    SOCKET --> S28
 ```
 
 ---
@@ -3863,6 +3886,101 @@ The `channelGuardianApprovalRequests` table tracks per-run approval state. Each 
 | `assistant/src/calls/guardian-action-sweep.ts` | Periodic 60s sweep for expired guardian action requests; sends expiry notices to delivery channels |
 | `assistant/src/memory/guardian-action-store.ts` | CRUD for guardian_action_requests and guardian_action_deliveries tables; first-writer-wins resolution via atomic status check |
 
+### Assistant Inbox — Ingress Membership and Escalation
+
+The assistant inbox extends the guardian security model to support controlled cross-user access. External users interact with the assistant through channels (Telegram, SMS) under an invite-based membership system with per-member access policies.
+
+#### Ingress Membership ACL
+
+The channel inbound handler (`channel-routes.ts`) enforces an access control layer between message receipt and agent processing:
+
+1. When `inbox_enabled` is true and the sender is not the guardian, the handler looks up the sender in `assistant_ingress_members` by `(sourceChannel, externalUserId)`.
+2. If no member record exists, the `inbox_default_policy` config determines behavior (allow, deny, or escalate).
+3. If a member exists, their individual `policy` field takes precedence.
+
+Invite tokens are created via the `ingress_invite` IPC contract. Each token is SHA-256 hashed before storage — the raw token is returned exactly once at creation time. External users redeem invites by sending the token as a channel message, which creates a member record with the default policy.
+
+#### Escalation Data Flow
+
+When a member's policy is `escalate`:
+
+```mermaid
+sequenceDiagram
+    participant Ext as External User
+    participant GW as Gateway
+    participant RT as Runtime (channel-routes)
+    participant DB as SQLite
+    participant Guardian as Guardian (Dual-Surface)
+    participant Desktop as Desktop Inbox UI
+
+    Ext->>GW: Send message via channel
+    GW->>RT: POST /channels/inbound
+    RT->>DB: Look up ingress member → policy = escalate
+    RT->>DB: Store raw payload (channel-delivery-store)
+    RT->>DB: Create channel_guardian_approval_request
+    RT->>DB: Update assistant_inbox_thread_state (escalation count)
+    RT->>GW: Notify guardian via channel push notification
+    GW->>Guardian: Deliver escalation notice (Telegram/SMS)
+
+    par Desktop polling
+        Desktop->>RT: assistant_inbox_escalation (list, 15s poll)
+        RT->>Desktop: Pending escalations with approve/deny
+    end
+
+    alt Guardian approves (desktop or channel)
+        Guardian->>RT: Approve decision
+        RT->>DB: Resolve approval request
+        RT->>DB: Recover stored payload
+        RT->>RT: Process message through agent pipeline
+        RT->>GW: Deliver assistant reply
+        GW->>Ext: Reply via channel
+    else Guardian denies
+        Guardian->>RT: Deny decision
+        RT->>GW: Deliver refusal message
+        GW->>Ext: Refusal via channel
+    end
+```
+
+The escalation system is **dual-surface**: the guardian can approve or deny from either their channel (Telegram/SMS push notification) or the desktop inbox UI (`AssistantInboxPanel`). Both surfaces write to the same `channel_guardian_approval_requests` table. The desktop UI polls every 15 seconds for updates.
+
+If no guardian binding exists for the channel, escalation fails closed — the message is denied with `escalate_no_guardian`.
+
+#### Inbox Thread State
+
+The `assistant_inbox_thread_state` table provides a denormalized projection of per-contact conversation metadata:
+
+| Column | Description |
+|--------|-------------|
+| `conversation_id` | PK, FK to conversations |
+| `assistant_id` | Scopes threads per assistant |
+| `source_channel` | Channel the contact uses (telegram, sms) |
+| `external_chat_id` | Contact's chat ID on the channel |
+| `unread_count` | Incremented on inbound, reset on outbound |
+| `pending_escalation_count` | Count of pending approval requests for this thread |
+| `has_pending_escalation` | Boolean (0/1) derived from pending count |
+| `last_inbound_at` / `last_outbound_at` | Directional activity timestamps |
+
+The escalation projection (`inbox-escalation-projection.ts`) keeps badge counts in sync by querying pending `channel_guardian_approval_requests` and updating thread state. This runs after approval decisions and can be triggered for a single thread or all threads.
+
+#### SQLite Tables
+
+| Table | Purpose |
+|-------|---------|
+| `assistant_ingress_invites` | Invite tokens with SHA-256 hashes, expiry, use counts |
+| `assistant_ingress_members` | Member records with per-member access policy (allow/deny/escalate) |
+| `assistant_inbox_thread_state` | Denormalized thread metadata (unread counts, escalation badges, timestamps) |
+
+#### Key Modules
+
+| Module | Purpose |
+|--------|---------|
+| `assistant/src/memory/ingress-invite-store.ts` | CRUD for invite tokens with SHA-256 hashing and expiry |
+| `assistant/src/memory/ingress-member-store.ts` | CRUD for ingress members with policy enforcement |
+| `assistant/src/memory/inbox-thread-store.ts` | Inbox thread state queries (unread counts, escalation badges) |
+| `assistant/src/memory/inbox-escalation-projection.ts` | Projects escalation state from approval requests onto thread state |
+| `assistant/src/daemon/handlers/config-inbox.ts` | IPC handlers for all inbox contracts (invite, member, escalation, reply) |
+| `assistant/src/runtime/routes/channel-routes.ts` | ACL enforcement point — member lookup, policy check, escalation creation |
+
 ### Telegram Credential Flow
 
 In desktop deployments, Telegram bot tokens are stored in secure storage (macOS Keychain or the encrypted file fallback) and never in plaintext config files. When deploying the gateway standalone, operators may also supply credentials via environment variables (`TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET`).
@@ -4358,6 +4476,9 @@ Keep-alive heartbeats (every 30 s by default):
 | Guardian bindings | `~/.vellum/workspace/data/db/assistant.db` | SQLite | Drizzle ORM | Permanent; revoked bindings retained |
 | Guardian verification challenges | `~/.vellum/workspace/data/db/assistant.db` | SQLite | Drizzle ORM | Permanent; consumed/expired challenges retained |
 | Guardian approval requests | `~/.vellum/workspace/data/db/assistant.db` | SQLite | Drizzle ORM | Permanent; decision outcome retained |
+| Ingress invites | `~/.vellum/workspace/data/db/assistant.db` | SQLite | Drizzle ORM | Permanent; token hash stored, raw token never persisted |
+| Ingress members | `~/.vellum/workspace/data/db/assistant.db` | SQLite | Drizzle ORM | Permanent; revoked/blocked members retained |
+| Inbox thread state | `~/.vellum/workspace/data/db/assistant.db` | SQLite | Drizzle ORM | Permanent; denormalized projection of per-contact threads |
 | IPC transport | `~/.vellum/vellum.sock` | Unix domain socket | NWConnection (Swift) / Bun net | Ephemeral |
 
 ## SMS/Twilio Parity Verification Checklist

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -286,6 +286,57 @@ Response type: `channel_readiness_response` with `success`, optional `snapshots`
 | `src/runtime/channel-readiness-service.ts` | Service class with probe registration, cached readiness evaluation, and built-in SMS/Telegram probes |
 | `src/daemon/handlers/config.ts` | `handleChannelReadiness` — IPC handler for `channel_readiness` messages |
 
+## Assistant Inbox (Ingress Membership + Escalation)
+
+The assistant inbox provides secure cross-user messaging, allowing external users (non-guardians) to interact with the assistant through channels (Telegram, SMS) under the owner's control. Access is governed by an invite-based membership system with per-member policy enforcement.
+
+### Ingress Membership
+
+External users join through **invite tokens** — the owner creates an invite via the desktop UI or IPC, and the external user redeems the token by sending it as a channel message. Redemption auto-creates a **member** record with a configurable access policy:
+
+- **`allow`** — Messages are processed normally through the agent pipeline.
+- **`deny`** — Messages are rejected with a refusal notice.
+- **`escalate`** — Messages are held for guardian (owner) approval before processing.
+
+The default policy for new members is controlled by the `inbox_default_policy` config. Members can be listed, updated, revoked, or blocked via the `ingress_member` IPC contract.
+
+### Escalation Flow (Dual-Surface)
+
+When a member's policy is `escalate`, inbound messages create a `channel_guardian_approval_request` and notify the guardian through two surfaces:
+
+1. **Channel push notification** — The guardian receives a message on their configured channel (Telegram/SMS) describing the escalation, allowing quick approve/deny from their phone.
+2. **Desktop inbox UI** — The macOS `AssistantInboxPanel` shows pending escalations with approve/deny buttons in the Escalations tab. A 15-second polling loop keeps the queue current.
+
+On **approve**: the original message payload is recovered from the channel delivery store and processed through the agent pipeline. The assistant's reply is delivered back to the external user via the gateway. On **deny**: a refusal message is sent to the external user.
+
+If no guardian binding exists, escalation fails closed — the message is denied rather than left in a silent wait state.
+
+### Inbox Thread State
+
+The `assistant_inbox_thread_state` table provides a denormalized view of per-contact conversation threads, tracking unread counts, pending escalation counts, and last message timestamps. Threads are keyed by `conversationId` and bound to `(assistantId, sourceChannel, externalChatId)`. The escalation projection (`inbox-escalation-projection.ts`) keeps badge counts in sync with the `channel_guardian_approval_requests` table.
+
+### IPC Contracts
+
+| Message Type | Actions | Description |
+|---|---|---|
+| `ingress_invite` | create, list, revoke, redeem | Manage invite tokens (SHA-256 hashed, raw token returned once on create) |
+| `ingress_member` | list, upsert, revoke, block | Manage member records and access policies |
+| `assistant_inbox` | list_threads, get_thread_messages | Query inbox threads and message history |
+| `assistant_inbox_escalation` | list, decide | List pending escalations and approve/deny from desktop |
+| `assistant_inbox_reply` | — | Send a reply to an external user from the desktop inbox |
+
+### Key Modules
+
+| File | Purpose |
+|------|---------|
+| `src/memory/ingress-invite-store.ts` | CRUD for invite tokens with SHA-256 hashing and expiry |
+| `src/memory/ingress-member-store.ts` | CRUD for ingress members with policy enforcement |
+| `src/memory/inbox-thread-store.ts` | Inbox thread state queries (unread counts, escalation badges) |
+| `src/memory/inbox-escalation-projection.ts` | Projects escalation state from approval requests onto thread state |
+| `src/daemon/handlers/config-inbox.ts` | IPC handlers for all inbox contracts |
+| `src/daemon/ipc-contract/inbox.ts` | TypeScript type definitions for inbox IPC messages |
+| `src/runtime/routes/channel-routes.ts` | ACL enforcement point — member lookup, policy check, escalation creation |
+
 ## Database
 
 SQLite via Drizzle ORM, stored at `~/.vellum/workspace/data/db/assistant.db`. Key tables include conversations, messages, tool invocations, attachments, memory segments (with FTS5), memory items, entities, reminders, and recurrence schedules (cron + RRULE).

--- a/assistant/scripts/ipc/check-swift-decoder-drift.ts
+++ b/assistant/scripts/ipc/check-swift-decoder-drift.ts
@@ -53,6 +53,9 @@ const SWIFT_OMIT_ALLOWLIST = new Set<string>([
   'browser_handoff_request',
   // Guardian verification — daemon-internal for Telegram channel setup
   'guardian_verification_response',
+  // Ingress invite/member management — not yet consumed by the macOS client
+  'ingress_invite_response',
+  'ingress_member_response',
   // Work item messages — not yet consumed by the macOS client
   'work_item_get_response',
   'work_item_run_task_response',

--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -1298,4 +1298,183 @@ describe('call-orchestrator', () => {
     await orchestrator.handleCallerUtterance('Hello');
     orchestrator.destroy();
   });
+
+  // ── Inbound call orchestration ──────────────────────────────────────
+
+  test('inbound call (no task) uses receptionist-style system prompt', async () => {
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
+      // Should contain inbound-specific language
+      expect(systemPrompt as string).toContain('answering an incoming call');
+      expect(systemPrompt as string).toContain('find out what they need');
+      // Should NOT contain outbound-specific language
+      expect(systemPrompt as string).not.toContain('state why you are calling');
+      expect(systemPrompt as string).not.toContain('Task:');
+      const tokens = ['Hello, how can I help you today?'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
+    });
+
+    // setupOrchestrator with no task creates an inbound-style session
+    const { orchestrator } = setupOrchestrator(undefined);
+    await orchestrator.handleCallerUtterance('Hi there');
+    orchestrator.destroy();
+  });
+
+  test('outbound call (with task) uses task-driven system prompt', async () => {
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
+      expect(systemPrompt as string).toContain('Task: Confirm Friday appointment');
+      expect(systemPrompt as string).toContain('state why you are calling');
+      expect(systemPrompt as string).not.toContain('answering an incoming call');
+      const tokens = ['Hi, I am calling about your appointment.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
+    });
+
+    const { orchestrator } = setupOrchestrator('Confirm Friday appointment');
+    await orchestrator.handleCallerUtterance('Hello?');
+    orchestrator.destroy();
+  });
+
+  test('inbound call initial greeting sends receptionist opener', async () => {
+    mockSendMessage.mockImplementation(async (messages: unknown[], _tools: unknown[], systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
+      // The system prompt should use inbound framing
+      expect(systemPrompt as string).toContain('answering an incoming call');
+      // The opening marker should be present
+      const msgs = messages as Array<{ role: string; content: Array<{ type: string; text: string }> }>;
+      const userMsgs = msgs.filter((m) => m.role === 'user');
+      expect(userMsgs.some((m) => m.content?.[0]?.text?.includes('[CALL_OPENING]'))).toBe(true);
+      const tokens = ['Hello, this is my human\'s assistant. How can I help you?'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
+    });
+
+    const { relay, orchestrator } = setupOrchestrator(undefined);
+    await orchestrator.startInitialGreeting();
+
+    const allText = relay.sentTokens.map((t) => t.token).join('');
+    expect(allText).toContain('How can I help you');
+
+    orchestrator.destroy();
+  });
+
+  test('inbound call multi-turn conversation uses inbound prompt consistently', async () => {
+    let turnNumber = 0;
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
+      turnNumber++;
+      // Every turn should use the inbound system prompt
+      expect(systemPrompt as string).toContain('answering an incoming call');
+      expect(systemPrompt as string).not.toContain('Task:');
+
+      let tokens: string[];
+      if (turnNumber === 1) tokens = ['Hello, how can I help you?'];
+      else if (turnNumber === 2) tokens = ['Sure, let me help with scheduling.'];
+      else tokens = ['Your meeting is set for 3pm.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
+    });
+
+    const { orchestrator } = setupOrchestrator(undefined);
+
+    await orchestrator.startInitialGreeting();
+    await orchestrator.handleCallerUtterance('I need to schedule a meeting');
+    await orchestrator.handleCallerUtterance('How about 3pm?');
+
+    expect(turnNumber).toBe(3);
+    orchestrator.destroy();
+  });
+
+  test('inbound call system prompt includes greet-the-caller guidance for CALL_OPENING', async () => {
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
+      // Should tell the model to greet warmly and ask how to help
+      expect(systemPrompt as string).toContain('greet the caller warmly');
+      expect(systemPrompt as string).toContain('how you can help');
+      const tokens = ['Hello!'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
+    });
+
+    const { orchestrator } = setupOrchestrator(undefined);
+    await orchestrator.handleCallerUtterance('Hi');
+    orchestrator.destroy();
+  });
+
+  test('inbound call system prompt respects disclosure setting', async () => {
+    mockDisclosure = {
+      enabled: true,
+      text: 'Disclose that you are an AI at the start.',
+    };
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
+      expect(systemPrompt as string).toContain('answering an incoming call');
+      expect(systemPrompt as string).toContain('Disclose that you are an AI at the start.');
+      const tokens = ['Hello, I am an AI assistant.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
+    });
+
+    const { orchestrator } = setupOrchestrator(undefined);
+    await orchestrator.handleCallerUtterance('Who is this?');
+    orchestrator.destroy();
+  });
+
+  test('inbound call persists assistant response to voice conversation', async () => {
+    mockSendMessage.mockImplementation(createMockProviderResponse(['I can definitely help you with that.']));
+
+    const { session, orchestrator } = setupOrchestrator(undefined);
+    await orchestrator.startInitialGreeting();
+
+    // Verify assistant transcript was persisted
+    const messages = (await import('../memory/conversation-store.js')).getMessages('conv-orch-test');
+    const assistantMsgs = messages.filter((m) => m.role === 'assistant');
+    expect(assistantMsgs.length).toBeGreaterThan(0);
+    const lastAssistant = assistantMsgs[assistantMsgs.length - 1];
+    expect(lastAssistant.content).toContain('I can definitely help you with that');
+
+    // Verify event was recorded
+    const events = getCallEvents(session.id).filter((e) => e.eventType === 'assistant_spoke');
+    expect(events.length).toBeGreaterThan(0);
+
+    orchestrator.destroy();
+  });
 });

--- a/assistant/src/__tests__/call-orchestrator.test.ts
+++ b/assistant/src/__tests__/call-orchestrator.test.ts
@@ -114,6 +114,22 @@ mock.module('../providers/registry.js', () => {
   };
 });
 
+mock.module('../providers/provider-send-message.js', () => ({
+  resolveConfiguredProvider: () => ({
+    provider: {
+      name: 'anthropic',
+      sendMessage: (...args: unknown[]) => mockSendMessage(...args),
+    },
+    configuredProviderName: 'anthropic',
+    selectedProviderName: 'anthropic',
+    usedFallbackPrimary: false,
+  }),
+  getConfiguredProvider: () => ({
+    name: 'anthropic',
+    sendMessage: (...args: unknown[]) => mockSendMessage(...args),
+  }),
+}));
+
 // ── Import source modules after all mocks are registered ────────────
 
 import { initializeDb, getDb, resetDb } from '../memory/db.js';

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -36,6 +36,7 @@ import {
   revokeBinding,
   createChallenge,
   findPendingChallengeByHash,
+  findPendingChallengeForChannel,
   consumeChallenge,
   createApprovalRequest,
   getPendingApprovalForRun,
@@ -51,6 +52,7 @@ import {
   getGuardianBinding,
   isGuardian,
   revokeBinding as serviceRevokeBinding,
+  getPendingChallenge,
 } from '../runtime/channel-guardian-service.js';
 import { handleGuardianVerification } from '../daemon/handlers/config.js';
 import type { GuardianVerificationRequest, GuardianVerificationResponse } from '../daemon/ipc-contract.js';
@@ -1423,5 +1425,559 @@ describe('IPC handler channel-aware guardian status', () => {
     expect(resp!.bound).toBe(false);
     expect(resp!.guardianDeliveryChatId).toBeUndefined();
     expect(resp!.guardianExternalUserId).toBeUndefined();
+  });
+
+  test('status action includes hasPendingChallenge when challenge exists', () => {
+    createVerificationChallenge('self', 'voice');
+
+    const { ctx, lastResponse } = createMockCtx();
+    const msg: GuardianVerificationRequest = {
+      type: 'guardian_verification',
+      action: 'status',
+      channel: 'voice',
+      assistantId: 'self',
+    };
+
+    handleGuardianVerification(msg, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(true);
+    expect(resp!.hasPendingChallenge).toBe(true);
+  });
+
+  test('status action hasPendingChallenge is false when no challenge exists', () => {
+    const { ctx, lastResponse } = createMockCtx();
+    const msg: GuardianVerificationRequest = {
+      type: 'guardian_verification',
+      action: 'status',
+      channel: 'voice',
+      assistantId: 'self',
+    };
+
+    handleGuardianVerification(msg, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(true);
+    expect(resp!.hasPendingChallenge).toBe(false);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 11. Voice Guardian Challenge — Six-Digit Secret Generation
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('voice guardian challenge generation', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test('createVerificationChallenge for voice returns a six-digit numeric secret', () => {
+    const result = createVerificationChallenge('asst-1', 'voice');
+
+    expect(result.challengeId).toBeDefined();
+    expect(result.secret).toBeDefined();
+    expect(result.secret).toMatch(/^\d{6}$/);
+    const num = parseInt(result.secret, 10);
+    expect(num).toBeGreaterThanOrEqual(100000);
+    expect(num).toBeLessThanOrEqual(999999);
+  });
+
+  test('createVerificationChallenge for non-voice returns 64-char hex secret', () => {
+    const result = createVerificationChallenge('asst-1', 'telegram');
+
+    expect(result.secret.length).toBe(64);
+    expect(result.secret).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  test('voice challenge verifyCommand contains the six-digit secret', () => {
+    const result = createVerificationChallenge('asst-1', 'voice');
+
+    expect(result.verifyCommand).toBe(`/guardian_verify ${result.secret}`);
+  });
+
+  test('voice challenge instruction contains voice-specific copy', () => {
+    const result = createVerificationChallenge('asst-1', 'voice');
+
+    expect(result.instruction).toContain('six-digit code');
+    expect(result.instruction).toContain(result.secret);
+    expect(result.instruction).toContain('minutes');
+  });
+
+  test('voice challenge secrets are different across calls', () => {
+    const result1 = createVerificationChallenge('asst-1', 'voice');
+    const result2 = createVerificationChallenge('asst-2', 'voice');
+
+    // While technically they could collide, the probability is ~1/900000
+    // so this is a reasonable smoke test for randomness
+    expect(result1.secret).toMatch(/^\d{6}$/);
+    expect(result2.secret).toMatch(/^\d{6}$/);
+  });
+
+  test('voice ttlSeconds is 600 (10 minutes)', () => {
+    const result = createVerificationChallenge('asst-1', 'voice');
+    expect(result.ttlSeconds).toBe(600);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 12. Voice Guardian Challenge Validation
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('voice guardian challenge validation', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test('validateAndConsumeChallenge succeeds with correct voice secret', () => {
+    const { secret } = createVerificationChallenge('asst-1', 'voice');
+
+    const result = validateAndConsumeChallenge(
+      'asst-1',
+      'voice',
+      secret,
+      'voice-user-1',
+      'voice-chat-1',
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.bindingId).toBeDefined();
+    }
+  });
+
+  test('validateAndConsumeChallenge creates a guardian binding for voice', () => {
+    const { secret } = createVerificationChallenge('asst-1', 'voice');
+
+    validateAndConsumeChallenge('asst-1', 'voice', secret, 'voice-user-1', 'voice-chat-1');
+
+    const binding = getActiveBinding('asst-1', 'voice');
+    expect(binding).not.toBeNull();
+    expect(binding!.guardianExternalUserId).toBe('voice-user-1');
+    expect(binding!.guardianDeliveryChatId).toBe('voice-chat-1');
+    expect(binding!.channel).toBe('voice');
+    expect(binding!.verifiedVia).toBe('challenge');
+  });
+
+  test('validateAndConsumeChallenge fails with wrong voice secret', () => {
+    createVerificationChallenge('asst-1', 'voice');
+
+    const result = validateAndConsumeChallenge(
+      'asst-1',
+      'voice',
+      '000000',
+      'voice-user-1',
+      'voice-chat-1',
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.reason).toBeDefined();
+      expect(result.reason.length).toBeGreaterThan(0);
+      expect(result.reason.toLowerCase()).toContain('failed');
+    }
+  });
+
+  test('voice and telegram guardian challenges are independent', () => {
+    const voiceChallenge = createVerificationChallenge('asst-1', 'voice');
+    const telegramChallenge = createVerificationChallenge('asst-1', 'telegram');
+
+    // Voice secret against telegram channel should fail
+    const crossResult = validateAndConsumeChallenge(
+      'asst-1',
+      'telegram',
+      voiceChallenge.secret,
+      'user-1',
+      'chat-1',
+    );
+    expect(crossResult.success).toBe(false);
+
+    // Voice secret against correct channel should succeed
+    const voiceResult = validateAndConsumeChallenge(
+      'asst-1',
+      'voice',
+      voiceChallenge.secret,
+      'voice-user-1',
+      'voice-chat-1',
+    );
+    expect(voiceResult.success).toBe(true);
+
+    // Telegram challenge should still be valid
+    const telegramResult = validateAndConsumeChallenge(
+      'asst-1',
+      'telegram',
+      telegramChallenge.secret,
+      'user-2',
+      'chat-2',
+    );
+    expect(telegramResult.success).toBe(true);
+  });
+
+  test('consumed voice challenge cannot be reused', () => {
+    const { secret } = createVerificationChallenge('asst-1', 'voice');
+
+    const result1 = validateAndConsumeChallenge(
+      'asst-1', 'voice', secret, 'voice-user-1', 'voice-chat-1',
+    );
+    expect(result1.success).toBe(true);
+
+    const result2 = validateAndConsumeChallenge(
+      'asst-1', 'voice', secret, 'voice-user-2', 'voice-chat-2',
+    );
+    expect(result2.success).toBe(false);
+  });
+
+  test('validateAndConsumeChallenge revokes existing voice binding before creating new one', () => {
+    createBinding({
+      assistantId: 'asst-1',
+      channel: 'voice',
+      guardianExternalUserId: 'old-voice-user',
+      guardianDeliveryChatId: 'old-voice-chat',
+    });
+
+    const oldBinding = getActiveBinding('asst-1', 'voice');
+    expect(oldBinding).not.toBeNull();
+    expect(oldBinding!.guardianExternalUserId).toBe('old-voice-user');
+
+    const { secret } = createVerificationChallenge('asst-1', 'voice');
+    validateAndConsumeChallenge('asst-1', 'voice', secret, 'new-voice-user', 'new-voice-chat');
+
+    const newBinding = getActiveBinding('asst-1', 'voice');
+    expect(newBinding).not.toBeNull();
+    expect(newBinding!.guardianExternalUserId).toBe('new-voice-user');
+    expect(newBinding!.guardianDeliveryChatId).toBe('new-voice-chat');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 13. Voice Guardian Identity and Revocation
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('voice guardian identity and revocation', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test('isGuardian works for voice channel', () => {
+    createBinding({
+      assistantId: 'asst-1',
+      channel: 'voice',
+      guardianExternalUserId: 'voice-user-1',
+      guardianDeliveryChatId: 'voice-chat-1',
+    });
+
+    expect(isGuardian('asst-1', 'voice', 'voice-user-1')).toBe(true);
+    expect(isGuardian('asst-1', 'voice', 'voice-user-2')).toBe(false);
+    // Voice guardian should not match telegram channel
+    expect(isGuardian('asst-1', 'telegram', 'voice-user-1')).toBe(false);
+  });
+
+  test('getGuardianBinding returns voice binding', () => {
+    createBinding({
+      assistantId: 'asst-1',
+      channel: 'voice',
+      guardianExternalUserId: 'voice-user-1',
+      guardianDeliveryChatId: 'voice-chat-1',
+    });
+
+    const binding = getGuardianBinding('asst-1', 'voice');
+    expect(binding).not.toBeNull();
+    expect(binding!.channel).toBe('voice');
+    expect(binding!.guardianExternalUserId).toBe('voice-user-1');
+  });
+
+  test('revokeBinding clears active voice guardian binding', () => {
+    createBinding({
+      assistantId: 'asst-1',
+      channel: 'voice',
+      guardianExternalUserId: 'voice-user-1',
+      guardianDeliveryChatId: 'voice-chat-1',
+    });
+
+    const result = serviceRevokeBinding('asst-1', 'voice');
+    expect(result).toBe(true);
+    expect(getGuardianBinding('asst-1', 'voice')).toBeNull();
+  });
+
+  test('revokeBinding for voice does not affect telegram binding', () => {
+    createBinding({
+      assistantId: 'asst-1',
+      channel: 'voice',
+      guardianExternalUserId: 'voice-user-1',
+      guardianDeliveryChatId: 'voice-chat-1',
+    });
+    createBinding({
+      assistantId: 'asst-1',
+      channel: 'telegram',
+      guardianExternalUserId: 'tg-user-1',
+      guardianDeliveryChatId: 'tg-chat-1',
+    });
+
+    serviceRevokeBinding('asst-1', 'voice');
+
+    expect(getGuardianBinding('asst-1', 'voice')).toBeNull();
+    expect(getGuardianBinding('asst-1', 'telegram')).not.toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 14. Voice Guardian Rate Limiting
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('voice guardian rate limiting', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test('repeated invalid voice submissions hit rate limit', () => {
+    createVerificationChallenge('asst-1', 'voice');
+
+    for (let i = 0; i < 5; i++) {
+      const result = validateAndConsumeChallenge(
+        'asst-1', 'voice', `${100000 + i}`, 'voice-user-1', 'voice-chat-1',
+      );
+      expect(result.success).toBe(false);
+    }
+
+    // The 6th attempt should be rate-limited
+    const result = validateAndConsumeChallenge(
+      'asst-1', 'voice', '999999', 'voice-user-1', 'voice-chat-1',
+    );
+    expect(result.success).toBe(false);
+
+    const rl = getRateLimit('asst-1', 'voice', 'voice-user-1', 'voice-chat-1');
+    expect(rl).not.toBeNull();
+    expect(rl!.lockedUntil).not.toBeNull();
+  });
+
+  test('voice rate limit does not affect telegram rate limit', () => {
+    createVerificationChallenge('asst-1', 'voice');
+    for (let i = 0; i < 5; i++) {
+      validateAndConsumeChallenge('asst-1', 'voice', `${100000 + i}`, 'user-1', 'chat-1');
+    }
+
+    const voiceRl = getRateLimit('asst-1', 'voice', 'user-1', 'chat-1');
+    expect(voiceRl).not.toBeNull();
+    expect(voiceRl!.lockedUntil).not.toBeNull();
+
+    // Telegram should be unaffected
+    const telegramRl = getRateLimit('asst-1', 'telegram', 'user-1', 'chat-1');
+    expect(telegramRl).toBeNull();
+  });
+
+  test('successful voice verification resets rate limit', () => {
+    const { secret: _s } = createVerificationChallenge('asst-1', 'voice');
+    validateAndConsumeChallenge('asst-1', 'voice', '000000', 'voice-user-1', 'voice-chat-1');
+    validateAndConsumeChallenge('asst-1', 'voice', '111111', 'voice-user-1', 'voice-chat-1');
+
+    // Valid attempt should succeed (under the 5-attempt threshold)
+    const { secret } = createVerificationChallenge('asst-1', 'voice');
+    const result = validateAndConsumeChallenge(
+      'asst-1', 'voice', secret, 'voice-user-1', 'voice-chat-1',
+    );
+    expect(result.success).toBe(true);
+
+    const rl = getRateLimit('asst-1', 'voice', 'voice-user-1', 'voice-chat-1');
+    expect(rl).not.toBeNull();
+    expect(rl!.invalidAttempts).toBe(0);
+    expect(rl!.lockedUntil).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 15. Pending Challenge Lookup (Store + Service)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('pending challenge lookup', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test('findPendingChallengeForChannel returns pending challenge', () => {
+    createVerificationChallenge('asst-1', 'voice');
+
+    const pending = findPendingChallengeForChannel('asst-1', 'voice');
+    expect(pending).not.toBeNull();
+    expect(pending!.channel).toBe('voice');
+    expect(pending!.status).toBe('pending');
+  });
+
+  test('findPendingChallengeForChannel returns null when no challenge exists', () => {
+    const pending = findPendingChallengeForChannel('asst-1', 'voice');
+    expect(pending).toBeNull();
+  });
+
+  test('findPendingChallengeForChannel returns null for different channel', () => {
+    createVerificationChallenge('asst-1', 'telegram');
+
+    const pending = findPendingChallengeForChannel('asst-1', 'voice');
+    expect(pending).toBeNull();
+  });
+
+  test('findPendingChallengeForChannel returns null after challenge is consumed', () => {
+    const { secret } = createVerificationChallenge('asst-1', 'voice');
+    validateAndConsumeChallenge('asst-1', 'voice', secret, 'voice-user-1', 'voice-chat-1');
+
+    const pending = findPendingChallengeForChannel('asst-1', 'voice');
+    expect(pending).toBeNull();
+  });
+
+  test('getPendingChallenge service helper returns pending voice challenge', () => {
+    createVerificationChallenge('asst-1', 'voice');
+
+    const pending = getPendingChallenge('asst-1', 'voice');
+    expect(pending).not.toBeNull();
+    expect(pending!.channel).toBe('voice');
+  });
+
+  test('getPendingChallenge returns null when no challenge exists', () => {
+    const pending = getPendingChallenge('asst-1', 'voice');
+    expect(pending).toBeNull();
+  });
+
+  test('creating a new challenge revokes prior pending challenges', () => {
+    createVerificationChallenge('asst-1', 'voice');
+    const pending1 = findPendingChallengeForChannel('asst-1', 'voice');
+    expect(pending1).not.toBeNull();
+    const firstId = pending1!.id;
+
+    // Creating a second challenge should revoke the first
+    createVerificationChallenge('asst-1', 'voice');
+    const pending2 = findPendingChallengeForChannel('asst-1', 'voice');
+    expect(pending2).not.toBeNull();
+    expect(pending2!.id).not.toBe(firstId);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 16. IPC handler — voice guardian verification
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('IPC handler voice guardian verification', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test('create_challenge for voice returns a six-digit secret', () => {
+    const { ctx, lastResponse } = createMockCtx();
+    const msg: GuardianVerificationRequest = {
+      type: 'guardian_verification',
+      action: 'create_challenge',
+      channel: 'voice',
+      assistantId: 'self',
+    };
+
+    handleGuardianVerification(msg, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(true);
+    expect(resp!.secret).toBeDefined();
+    expect(resp!.secret).toMatch(/^\d{6}$/);
+    expect(resp!.instruction).toBeDefined();
+    expect(resp!.instruction).toContain('six-digit code');
+    expect(resp!.channel).toBe('voice');
+  });
+
+  test('status for voice reflects unbound state', () => {
+    const { ctx, lastResponse } = createMockCtx();
+    const msg: GuardianVerificationRequest = {
+      type: 'guardian_verification',
+      action: 'status',
+      channel: 'voice',
+      assistantId: 'self',
+    };
+
+    handleGuardianVerification(msg, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(true);
+    expect(resp!.channel).toBe('voice');
+    expect(resp!.bound).toBe(false);
+    expect(resp!.guardianExternalUserId).toBeUndefined();
+  });
+
+  test('status for voice reflects bound state', () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'voice',
+      guardianExternalUserId: 'voice-user-1',
+      guardianDeliveryChatId: 'voice-chat-1',
+    });
+
+    const { ctx, lastResponse } = createMockCtx();
+    const msg: GuardianVerificationRequest = {
+      type: 'guardian_verification',
+      action: 'status',
+      channel: 'voice',
+      assistantId: 'self',
+    };
+
+    handleGuardianVerification(msg, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(true);
+    expect(resp!.bound).toBe(true);
+    expect(resp!.guardianExternalUserId).toBe('voice-user-1');
+    expect(resp!.guardianDeliveryChatId).toBe('voice-chat-1');
+    expect(resp!.channel).toBe('voice');
+  });
+
+  test('revoke for voice clears active binding', () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'voice',
+      guardianExternalUserId: 'voice-user-1',
+      guardianDeliveryChatId: 'voice-chat-1',
+    });
+
+    const { ctx, lastResponse } = createMockCtx();
+    const msg: GuardianVerificationRequest = {
+      type: 'guardian_verification',
+      action: 'revoke',
+      channel: 'voice',
+      assistantId: 'self',
+    };
+
+    handleGuardianVerification(msg, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(true);
+    expect(resp!.bound).toBe(false);
+
+    // Verify binding is actually revoked
+    expect(getGuardianBinding('self', 'voice')).toBeNull();
+  });
+
+  test('revoke for voice does not affect telegram binding', () => {
+    createBinding({
+      assistantId: 'self',
+      channel: 'voice',
+      guardianExternalUserId: 'voice-user-1',
+      guardianDeliveryChatId: 'voice-chat-1',
+    });
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'tg-user-1',
+      guardianDeliveryChatId: 'tg-chat-1',
+    });
+
+    const { ctx } = createMockCtx();
+    const msg: GuardianVerificationRequest = {
+      type: 'guardian_verification',
+      action: 'revoke',
+      channel: 'voice',
+      assistantId: 'self',
+    };
+
+    handleGuardianVerification(msg, mockSocket, ctx);
+
+    expect(getGuardianBinding('self', 'voice')).toBeNull();
+    expect(getGuardianBinding('self', 'telegram')).not.toBeNull();
   });
 });

--- a/assistant/src/__tests__/provider-fail-open-selection.test.ts
+++ b/assistant/src/__tests__/provider-fail-open-selection.test.ts
@@ -1,0 +1,119 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  initializeProviders,
+  resolveProviderSelection,
+  getFailoverProvider,
+} from '../providers/registry.js';
+
+/**
+ * Tests for fail-open provider selection: when the configured primary provider
+ * is unavailable, the system should automatically fall back to the first
+ * available provider in the provider order.
+ */
+
+/** Initialize registry with anthropic + openai for most tests. */
+function setupTwoProviders() {
+  initializeProviders({
+    apiKeys: { anthropic: 'test-key', openai: 'test-key' },
+    provider: 'anthropic',
+    model: 'test-model',
+  });
+}
+
+/** Initialize registry with no providers (empty keys, non-registerable primary). */
+function setupNoProviders() {
+  initializeProviders({
+    apiKeys: {},
+    provider: 'gemini',
+    model: 'test-model',
+  });
+}
+
+describe('resolveProviderSelection', () => {
+  test('configured primary available → selected as primary', () => {
+    setupTwoProviders();
+    const result = resolveProviderSelection('anthropic', ['openai']);
+    expect(result.selectedPrimary).toBe('anthropic');
+    expect(result.usedFallbackPrimary).toBe(false);
+    expect(result.availableProviders).toEqual(['anthropic', 'openai']);
+  });
+
+  test('configured primary unavailable + alternate available → alternate selected', () => {
+    setupTwoProviders();
+    const result = resolveProviderSelection('gemini', ['anthropic', 'openai']);
+    expect(result.selectedPrimary).toBe('anthropic');
+    expect(result.usedFallbackPrimary).toBe(true);
+    expect(result.availableProviders).toEqual(['anthropic', 'openai']);
+  });
+
+  test('configured primary unavailable + first alternate also unavailable → second alternate selected', () => {
+    setupTwoProviders();
+    const result = resolveProviderSelection('gemini', ['fireworks', 'openai']);
+    expect(result.selectedPrimary).toBe('openai');
+    expect(result.usedFallbackPrimary).toBe(true);
+    expect(result.availableProviders).toEqual(['openai']);
+  });
+
+  test('deduplicates entries in providerOrder', () => {
+    setupTwoProviders();
+    const result = resolveProviderSelection('anthropic', ['anthropic', 'openai', 'openai']);
+    expect(result.availableProviders).toEqual(['anthropic', 'openai']);
+  });
+
+  test('unknown entries in providerOrder are filtered out', () => {
+    setupTwoProviders();
+    const result = resolveProviderSelection('anthropic', ['nonexistent', 'openai']);
+    expect(result.availableProviders).toEqual(['anthropic', 'openai']);
+  });
+
+  test('no available providers → null selectedPrimary', () => {
+    setupTwoProviders();
+    const result = resolveProviderSelection('gemini', ['fireworks', 'ollama']);
+    expect(result.selectedPrimary).toBeNull();
+    expect(result.usedFallbackPrimary).toBe(false);
+    expect(result.availableProviders).toEqual([]);
+  });
+
+  test('empty providerOrder with available primary → primary only', () => {
+    setupTwoProviders();
+    const result = resolveProviderSelection('anthropic', []);
+    expect(result.selectedPrimary).toBe('anthropic');
+    expect(result.usedFallbackPrimary).toBe(false);
+    expect(result.availableProviders).toEqual(['anthropic']);
+  });
+
+  test('empty providerOrder with unavailable primary → null', () => {
+    setupTwoProviders();
+    const result = resolveProviderSelection('gemini', []);
+    expect(result.selectedPrimary).toBeNull();
+    expect(result.availableProviders).toEqual([]);
+  });
+});
+
+describe('getFailoverProvider (fail-open)', () => {
+  test('returns provider when primary is available', () => {
+    setupTwoProviders();
+    const provider = getFailoverProvider('anthropic', ['openai']);
+    expect(provider).toBeDefined();
+  });
+
+  test('returns provider when primary is unavailable but alternate exists', () => {
+    setupTwoProviders();
+    const provider = getFailoverProvider('gemini', ['anthropic', 'openai']);
+    expect(provider).toBeDefined();
+  });
+
+  test('throws ConfigError when no providers are available', () => {
+    setupNoProviders();
+    expect(() => getFailoverProvider('gemini', ['fireworks'])).toThrow(
+      /No providers available/,
+    );
+  });
+
+  test('single available provider returns it directly (no failover wrapper)', () => {
+    setupTwoProviders();
+    const provider = getFailoverProvider('gemini', ['anthropic']);
+    // Should be a RetryProvider wrapping AnthropicProvider, not a FailoverProvider
+    expect(provider.name).not.toBe('failover');
+  });
+});

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -130,6 +130,10 @@ import { getMessages } from '../memory/conversation-store.js';
 import { registerCallCompletionNotifier, unregisterCallCompletionNotifier } from '../calls/call-state.js';
 import { RelayConnection, activeRelayConnections } from '../calls/relay-server.js';
 import type { RelayWebSocketData } from '../calls/relay-server.js';
+import {
+  createVerificationChallenge,
+  getGuardianBinding,
+} from '../runtime/channel-guardian-service.js';
 
 initializeDb();
 
@@ -190,6 +194,9 @@ function resetTables() {
   db.run('DELETE FROM tool_invocations');
   db.run('DELETE FROM messages');
   db.run('DELETE FROM conversations');
+  db.run('DELETE FROM channel_guardian_verification_challenges');
+  db.run('DELETE FROM channel_guardian_bindings');
+  db.run('DELETE FROM channel_guardian_rate_limits');
   ensuredConvIds = new Set();
 }
 
@@ -560,11 +567,13 @@ describe('relay-server', () => {
 
   test('verification failure remains failed if transport closes during goodbye delay', async () => {
     ensureConversation('conv-relay-verify-race');
+    ensureConversation('conv-relay-verify-race-initiator');
     const session = createCallSession({
       conversationId: 'conv-relay-verify-race',
       provider: 'twilio',
       fromNumber: '+15551111111',
       toNumber: '+15552222222',
+      initiatedFromConversationId: 'conv-relay-verify-race-initiator',
     });
 
     mockConfig.calls.verification.enabled = true;
@@ -825,5 +834,467 @@ describe('relay-server', () => {
 
     relay.destroy();
     expect(() => relay.destroy()).not.toThrow();
+  });
+
+  // ── Inbound call setup ────────────────────────────────────────────
+
+  test('handleMessage: inbound call (no task) triggers greeting without verification', async () => {
+    ensureConversation('conv-relay-inbound-greet');
+    // Inbound sessions have no task and no initiatedFromConversationId
+    const session = createCallSession({
+      conversationId: 'conv-relay-inbound-greet',
+      provider: 'twilio',
+      fromNumber: '+15559999999',
+      toNumber: '+15551111111',
+      // no task — inbound call
+    });
+
+    // Enable verification to prove inbound calls skip it
+    mockConfig.calls.verification.enabled = true;
+
+    mockSendMessage.mockImplementation(createMockProviderResponse(['Hello, how can I help you today?']));
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_inbound_greet_123',
+      from: '+15559999999',
+      to: '+15551111111',
+    }));
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Should NOT have started verification (no verification code prompt)
+    expect(relay.getVerificationCode()).toBeNull();
+
+    // Should have generated a greeting via the orchestrator
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string; last?: boolean })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes('how can I help'))).toBe(true);
+    expect(textMessages.some((m) => m.last === true)).toBe(true);
+
+    relay.destroy();
+  });
+
+  test('handleMessage: inbound call persists caller transcript to voice conversation', async () => {
+    ensureConversation('conv-relay-inbound-persist');
+    const session = createCallSession({
+      conversationId: 'conv-relay-inbound-persist',
+      provider: 'twilio',
+      fromNumber: '+15559999999',
+      toNumber: '+15551111111',
+      // no task — inbound call
+    });
+
+    mockSendMessage.mockImplementation(createMockProviderResponse(['Sure, let me help with that.']));
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_inbound_persist_123',
+      from: '+15559999999',
+      to: '+15551111111',
+    }));
+
+    // Wait for initial greeting to settle
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Send a caller utterance
+    await relay.handleMessage(JSON.stringify({
+      type: 'prompt',
+      voicePrompt: 'I would like to schedule an appointment',
+      lang: 'en-US',
+      last: true,
+    }));
+
+    // Verify caller transcript is persisted to the voice conversation
+    const userMessages = getMessages('conv-relay-inbound-persist').filter((m) => m.role === 'user');
+    expect(userMessages.length).toBeGreaterThan(0);
+    const lastUserMsg = userMessages[userMessages.length - 1];
+    expect(lastUserMsg.content).toContain('schedule an appointment');
+
+    // Verify assistant response is also persisted
+    const assistantMessages = getMessages('conv-relay-inbound-persist').filter((m) => m.role === 'assistant');
+    expect(assistantMessages.length).toBeGreaterThan(0);
+
+    relay.destroy();
+  });
+
+  test('handleMessage: inbound call supports multi-turn conversation', async () => {
+    ensureConversation('conv-relay-inbound-multi');
+    const session = createCallSession({
+      conversationId: 'conv-relay-inbound-multi',
+      provider: 'twilio',
+      fromNumber: '+15559999999',
+      toNumber: '+15551111111',
+      // no task — inbound call
+    });
+
+    let turnCount = 0;
+    mockSendMessage.mockImplementation(async (_messages: unknown[], _tools: unknown[], _systemPrompt: unknown, options?: { onEvent?: (event: { type: string; text?: string }) => void }) => {
+      turnCount++;
+      let tokens: string[];
+      if (turnCount === 1) tokens = ['Hello, how can I help you?'];
+      else if (turnCount === 2) tokens = ['Sure, I can help with that.'];
+      else tokens = ['Your appointment is confirmed.'];
+      for (const token of tokens) {
+        options?.onEvent?.({ type: 'text_delta', text: token });
+      }
+      return {
+        content: [{ type: 'text', text: tokens.join('') }],
+        model: 'claude-sonnet-4-20250514',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
+    });
+
+    const { ws: _ws, relay } = createMockWs(session.id);
+
+    // Setup
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_inbound_multi_123',
+      from: '+15559999999',
+      to: '+15551111111',
+    }));
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // First caller turn
+    await relay.handleMessage(JSON.stringify({
+      type: 'prompt',
+      voicePrompt: 'I need to schedule something',
+      lang: 'en-US',
+      last: true,
+    }));
+
+    // Second caller turn
+    await relay.handleMessage(JSON.stringify({
+      type: 'prompt',
+      voicePrompt: 'How about next Tuesday?',
+      lang: 'en-US',
+      last: true,
+    }));
+
+    // Verify conversation history has multiple turns
+    const history = relay.getConversationHistory();
+    expect(history.length).toBe(2);
+    expect(history[0].text).toBe('I need to schedule something');
+    expect(history[1].text).toBe('How about next Tuesday?');
+
+    // Verify LLM was called for each turn (greeting + 2 caller turns)
+    expect(turnCount).toBe(3);
+
+    // Verify events were recorded for both caller utterances
+    const events = getCallEvents(session.id).filter((e) => e.eventType === 'caller_spoke');
+    expect(events.length).toBe(2);
+
+    relay.destroy();
+  });
+
+  // ── Inbound voice guardian verification gate ────────────────────────
+
+  test('inbound guardian verification: DTMF code entry succeeds and starts normal call flow', async () => {
+    ensureConversation('conv-guardian-dtmf-ok');
+    const session = createCallSession({
+      conversationId: 'conv-guardian-dtmf-ok',
+      provider: 'twilio',
+      fromNumber: '+15559999999',
+      toNumber: '+15551111111',
+      assistantId: 'test-assistant',
+      // no task — inbound call
+    });
+
+    // Create a pending voice guardian challenge
+    const challenge = createVerificationChallenge('test-assistant', 'voice');
+    const secret = challenge.secret;
+
+    mockSendMessage.mockImplementation(createMockProviderResponse(['Hello, how can I help you?']));
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_guardian_dtmf_ok',
+      from: '+15559999999',
+      to: '+15551111111',
+    }));
+
+    // Should be in verification-pending state
+    expect(relay.isGuardianVerificationActive()).toBe(true);
+    expect(relay.getConnectionState()).toBe('verification_pending');
+
+    // Verify TTS prompt was sent asking for code
+    const setupMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(setupMessages.some((m) => (m.token ?? '').includes('verification code'))).toBe(true);
+
+    // Enter the correct code via DTMF
+    for (const digit of secret) {
+      await relay.handleMessage(JSON.stringify({ type: 'dtmf', digit }));
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Verification should have succeeded
+    expect(relay.isGuardianVerificationActive()).toBe(false);
+    expect(relay.getConnectionState()).toBe('connected');
+
+    // Guardian binding should have been created
+    const binding = getGuardianBinding('test-assistant', 'voice');
+    expect(binding).not.toBeNull();
+
+    // Orchestrator greeting should have fired
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes('how can I help'))).toBe(true);
+
+    // Verify events recorded
+    const guardianEvents = getCallEvents(session.id);
+    expect(guardianEvents.some((e) => e.eventType === 'guardian_voice_verification_started')).toBe(true);
+    expect(guardianEvents.some((e) => e.eventType === 'guardian_voice_verification_succeeded')).toBe(true);
+
+    relay.destroy();
+  });
+
+  test('inbound guardian verification: speech-based code entry succeeds', async () => {
+    ensureConversation('conv-guardian-speech-ok');
+    const session = createCallSession({
+      conversationId: 'conv-guardian-speech-ok',
+      provider: 'twilio',
+      fromNumber: '+15559999999',
+      toNumber: '+15551111111',
+      assistantId: 'test-assistant',
+    });
+
+    const challenge = createVerificationChallenge('test-assistant', 'voice');
+    const secret = challenge.secret;
+
+    mockSendMessage.mockImplementation(createMockProviderResponse(['Hello, verified caller!']));
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_guardian_speech_ok',
+      from: '+15559999999',
+      to: '+15551111111',
+    }));
+
+    expect(relay.isGuardianVerificationActive()).toBe(true);
+
+    // Speak the code as individual digit characters
+    const spokenCode = secret.split('').join(' ');
+    await relay.handleMessage(JSON.stringify({
+      type: 'prompt',
+      voicePrompt: spokenCode,
+      lang: 'en-US',
+      last: true,
+    }));
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Verification should have succeeded
+    expect(relay.isGuardianVerificationActive()).toBe(false);
+    expect(relay.getConnectionState()).toBe('connected');
+
+    // Binding created
+    const binding = getGuardianBinding('test-assistant', 'voice');
+    expect(binding).not.toBeNull();
+
+    // Greeting should have started
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes('verified caller'))).toBe(true);
+
+    relay.destroy();
+  });
+
+  test('inbound guardian verification: invalid code triggers retry prompt', async () => {
+    ensureConversation('conv-guardian-retry');
+    const session = createCallSession({
+      conversationId: 'conv-guardian-retry',
+      provider: 'twilio',
+      fromNumber: '+15559999999',
+      toNumber: '+15551111111',
+      assistantId: 'test-assistant',
+    });
+
+    createVerificationChallenge('test-assistant', 'voice');
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_guardian_retry',
+      from: '+15559999999',
+      to: '+15551111111',
+    }));
+
+    expect(relay.isGuardianVerificationActive()).toBe(true);
+
+    // Enter a wrong code via DTMF
+    for (const digit of '000000') {
+      await relay.handleMessage(JSON.stringify({ type: 'dtmf', digit }));
+    }
+
+    // Should still be in verification-pending state (retry allowed)
+    expect(relay.isGuardianVerificationActive()).toBe(true);
+    expect(relay.getConnectionState()).toBe('verification_pending');
+
+    // Should have sent a retry prompt
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes('incorrect'))).toBe(true);
+
+    relay.destroy();
+  });
+
+  test('inbound guardian verification: max attempts exhaustion terminates call', async () => {
+    ensureConversation('conv-guardian-max-attempts');
+    const session = createCallSession({
+      conversationId: 'conv-guardian-max-attempts',
+      provider: 'twilio',
+      fromNumber: '+15559999999',
+      toNumber: '+15551111111',
+      assistantId: 'test-assistant',
+    });
+
+    createVerificationChallenge('test-assistant', 'voice');
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_guardian_max_attempts',
+      from: '+15559999999',
+      to: '+15551111111',
+    }));
+
+    expect(relay.isGuardianVerificationActive()).toBe(true);
+
+    // Enter wrong codes 3 times (max attempts = 3)
+    for (let attempt = 0; attempt < 3; attempt++) {
+      for (const digit of '000000') {
+        await relay.handleMessage(JSON.stringify({ type: 'dtmf', digit }));
+      }
+    }
+
+    // Call should be marked as failed
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('failed');
+    expect(updated!.lastError).toContain('Guardian voice verification failed');
+
+    // Should have sent goodbye message
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes('Verification failed. Goodbye.'))).toBe(true);
+
+    // Verify events
+    const events = getCallEvents(session.id);
+    expect(events.some((e) => e.eventType === 'guardian_voice_verification_failed')).toBe(true);
+
+    // Let the delayed endSession callback flush
+    await new Promise((resolve) => setTimeout(resolve, 2100));
+
+    // Verify end message was sent
+    const endMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string })
+      .filter((m) => m.type === 'end');
+    expect(endMessages.length).toBe(1);
+
+    relay.destroy();
+  });
+
+  test('inbound guardian verification: no pending challenge proceeds with normal flow', async () => {
+    ensureConversation('conv-guardian-no-challenge');
+    const session = createCallSession({
+      conversationId: 'conv-guardian-no-challenge',
+      provider: 'twilio',
+      fromNumber: '+15559999999',
+      toNumber: '+15551111111',
+      assistantId: 'test-assistant',
+      // no task — inbound call
+    });
+
+    // Do NOT create any pending challenge
+
+    mockSendMessage.mockImplementation(createMockProviderResponse(['Welcome to the line.']));
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_guardian_no_challenge',
+      from: '+15559999999',
+      to: '+15551111111',
+    }));
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Should NOT be in guardian verification state
+    expect(relay.isGuardianVerificationActive()).toBe(false);
+    expect(relay.getConnectionState()).toBe('connected');
+
+    // Should have started normal greeting
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes('Welcome to the line'))).toBe(true);
+
+    relay.destroy();
+  });
+
+  test('inbound guardian verification: speech with partial digits prompts for more', async () => {
+    ensureConversation('conv-guardian-partial-speech');
+    const session = createCallSession({
+      conversationId: 'conv-guardian-partial-speech',
+      provider: 'twilio',
+      fromNumber: '+15559999999',
+      toNumber: '+15551111111',
+      assistantId: 'test-assistant',
+    });
+
+    createVerificationChallenge('test-assistant', 'voice');
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_guardian_partial_speech',
+      from: '+15559999999',
+      to: '+15551111111',
+    }));
+
+    expect(relay.isGuardianVerificationActive()).toBe(true);
+
+    // Speak only 3 digits
+    await relay.handleMessage(JSON.stringify({
+      type: 'prompt',
+      voicePrompt: 'one two three',
+      lang: 'en-US',
+      last: true,
+    }));
+
+    // Should still be in verification state
+    expect(relay.isGuardianVerificationActive()).toBe(true);
+
+    // Should have prompted for more digits
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === 'text');
+    expect(textMessages.some((m) => (m.token ?? '').includes('3 digits'))).toBe(true);
+    expect(textMessages.some((m) => (m.token ?? '').includes('all 6 digits'))).toBe(true);
+
+    relay.destroy();
   });
 });

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -97,6 +97,7 @@ import * as callStore from '../calls/call-store.js';
 import {
   createCallSession,
   getCallSession,
+  getCallSessionByCallSid,
   updateCallSession,
   getCallEvents,
 } from '../calls/call-store.js';
@@ -130,6 +131,8 @@ function resetTables() {
   db.run('DELETE FROM call_pending_questions');
   db.run('DELETE FROM call_events');
   db.run('DELETE FROM call_sessions');
+  db.run('DELETE FROM external_conversation_bindings');
+  db.run('DELETE FROM conversation_keys');
   db.run('DELETE FROM tool_invocations');
   db.run('DELETE FROM messages');
   db.run('DELETE FROM conversations');
@@ -159,6 +162,14 @@ function makeStatusRequest(params: Record<string, string>): Request {
 
 function makeVoiceRequest(sessionId: string, params: Record<string, string>): Request {
   return new Request(`http://127.0.0.1/v1/calls/twilio/voice-webhook?callSessionId=${sessionId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams(params).toString(),
+  });
+}
+
+function makeInboundVoiceRequest(params: Record<string, string>): Request {
+  return new Request('http://127.0.0.1/v1/calls/twilio/voice-webhook', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams(params).toString(),
@@ -629,6 +640,94 @@ describe('twilio webhook routes', () => {
 
       const events2 = getCallEvents(session.id);
       expect(events2.filter(e => e.eventType === 'call_ended').length).toBe(1);
+    });
+  });
+
+  // ── Inbound voice webhook tests ─────────────────────────────────────
+  // Tests the inbound mode where callSessionId is absent and a session
+  // is created/reused from the Twilio CallSid.
+
+  describe('inbound voice webhook', () => {
+    test('creates a new session from CallSid when callSessionId is absent', async () => {
+      const req = makeInboundVoiceRequest({
+        CallSid: 'CA_inbound_new_1',
+        From: '+14155551234',
+        To: '+15550001111',
+      });
+
+      const res = await handleVoiceWebhook(req);
+
+      expect(res.status).toBe(200);
+      const twiml = await res.text();
+      expect(twiml).toContain('<ConversationRelay');
+      expect(twiml).toContain('callSessionId=');
+
+      // Verify session was created with the CallSid
+      const session = getCallSessionByCallSid('CA_inbound_new_1');
+      expect(session).not.toBeNull();
+      expect(session!.fromNumber).toBe('+14155551234');
+      expect(session!.toNumber).toBe('+15550001111');
+      expect(session!.providerCallSid).toBe('CA_inbound_new_1');
+    });
+
+    test('replayed inbound webhook for same CallSid does not create duplicate sessions', async () => {
+      const params = {
+        CallSid: 'CA_inbound_replay_1',
+        From: '+14155551234',
+        To: '+15550001111',
+      };
+
+      // First call — creates the session
+      const res1 = await handleVoiceWebhook(makeInboundVoiceRequest(params));
+      expect(res1.status).toBe(200);
+
+      const session1 = getCallSessionByCallSid('CA_inbound_replay_1');
+      expect(session1).not.toBeNull();
+
+      // Second call (replay) — reuses the same session
+      const res2 = await handleVoiceWebhook(makeInboundVoiceRequest(params));
+      expect(res2.status).toBe(200);
+
+      const session2 = getCallSessionByCallSid('CA_inbound_replay_1');
+      expect(session2).not.toBeNull();
+      expect(session2!.id).toBe(session1!.id);
+    });
+
+    test('inbound webhook without CallSid returns 400', async () => {
+      const req = makeInboundVoiceRequest({
+        From: '+14155551234',
+        To: '+15550001111',
+      });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(400);
+    });
+
+    test('inbound webhook with forwarded assistantId creates session with correct assistantId', async () => {
+      const req = makeInboundVoiceRequest({
+        CallSid: 'CA_inbound_assist_1',
+        From: '+14155551234',
+        To: '+15550001111',
+      });
+
+      const res = await handleVoiceWebhook(req, 'my-assistant-id');
+
+      expect(res.status).toBe(200);
+      const session = getCallSessionByCallSid('CA_inbound_assist_1');
+      expect(session).not.toBeNull();
+      expect(session!.assistantId).toBe('my-assistant-id');
+    });
+
+    test('outbound call flow remains non-regressed with callSessionId present', async () => {
+      const session = createTestSession('conv-outbound-compat-1', 'CA_outbound_compat_1');
+      const req = makeVoiceRequest(session.id, { CallSid: 'CA_outbound_compat_1' });
+
+      const res = await handleVoiceWebhook(req);
+
+      expect(res.status).toBe(200);
+      const twiml = await res.text();
+      expect(twiml).toContain('<ConversationRelay');
+      expect(twiml).toContain(`callSessionId=${session.id}`);
     });
   });
 });

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -11,6 +11,7 @@ import { isDeniedNumber } from './call-constants.js';
 import {
   createCallSession,
   getCallSession,
+  getCallSessionByCallSid,
   getActiveCallSessionForConversation,
   updateCallSession,
   getPendingQuestion,
@@ -175,6 +176,72 @@ export async function resolveCallerIdentity(
 
   log.info({ mode, source: numberSource, fromNumber: userNumber }, 'Resolved caller identity');
   return { ok: true, mode, fromNumber: userNumber, source: numberSource };
+}
+
+// ── Inbound voice session bootstrap ──────────────────────────────────
+
+export type CreateInboundVoiceSessionInput = {
+  callSid: string;
+  fromNumber: string;
+  toNumber: string;
+  assistantId?: string;
+};
+
+export type CreateInboundVoiceSessionResult = {
+  session: CallSession;
+  created: boolean;
+};
+
+/**
+ * Create (or reuse) a voice call session for an inbound call identified
+ * by its Twilio CallSid.
+ *
+ * Idempotent: if a session already exists for the given CallSid, it is
+ * returned without creating a duplicate. This handles Twilio webhook
+ * replays gracefully.
+ */
+export function createInboundVoiceSession(
+  input: CreateInboundVoiceSessionInput,
+): CreateInboundVoiceSessionResult {
+  const { callSid, fromNumber, toNumber, assistantId = 'self' } = input;
+
+  // Check if a session already exists for this CallSid (replay protection)
+  const existing = getCallSessionByCallSid(callSid);
+  if (existing) {
+    log.info({ callSid, callSessionId: existing.id }, 'Reusing existing session for inbound CallSid');
+    return { session: existing, created: false };
+  }
+
+  // Create a dedicated voice conversation keyed by CallSid so inbound calls
+  // get their own conversation thread.
+  const voiceConvKey = assistantId && assistantId !== 'self'
+    ? `asst:${assistantId}:voice:inbound:${callSid}`
+    : `voice:inbound:${callSid}`;
+  const { conversationId: voiceConversationId } = getOrCreateConversation(voiceConvKey);
+
+  upsertBinding({
+    conversationId: voiceConversationId,
+    sourceChannel: 'voice',
+    externalChatId: callSid,
+  });
+
+  const session = createCallSession({
+    conversationId: voiceConversationId,
+    provider: 'twilio',
+    fromNumber,
+    toNumber,
+    assistantId,
+  });
+
+  updateCallSession(session.id, { providerCallSid: callSid });
+  session.providerCallSid = callSid;
+
+  log.info(
+    { callSessionId: session.id, callSid, voiceConversationId, from: fromNumber, to: toNumber, assistantId },
+    'Created new inbound voice session',
+  );
+
+  return { session, created: true };
 }
 
 // ── Domain operations ────────────────────────────────────────────────

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -65,9 +65,11 @@ export class CallOrchestrator {
   private consultationTimer: ReturnType<typeof setTimeout> | null = null;
   private durationEndTimer: ReturnType<typeof setTimeout> | null = null;
   private task: string | null;
+  /** True when the call session was created via the inbound path (no outbound task). */
+  private isInbound: boolean;
   /** Instructions queued while an LLM turn is in-flight or during waiting_on_user */
   private pendingInstructions: string[] = [];
-  /** Ensures the outbound-call opener is triggered at most once per call. */
+  /** Ensures the call opener is triggered at most once per call. */
   private initialGreetingStarted = false;
   /** Marks that the next caller turn should be treated as an opening acknowledgment. */
   private awaitingOpeningAck = false;
@@ -82,6 +84,7 @@ export class CallOrchestrator {
     this.callSessionId = callSessionId;
     this.relay = relay;
     this.task = task;
+    this.isInbound = task === null;
     this.broadcast = opts?.broadcast;
     this.assistantId = opts?.assistantId ?? 'self';
     this.startDurationTimer();
@@ -301,6 +304,10 @@ export class CallOrchestrator {
       ? `1. ${config.calls.disclosure.text}`
       : '1. Begin the conversation naturally.';
 
+    if (this.isInbound) {
+      return this.buildInboundSystemPrompt(disclosureRule);
+    }
+
     return [
       `You are on a live phone call on behalf of ${resolveUserReference()}.`,
       this.task ? `Task: ${this.task}` : '',
@@ -322,6 +329,38 @@ export class CallOrchestrator {
       '10. If the latest user turn is [CALL_OPENING], generate a natural, context-specific opener: briefly introduce yourself once as an assistant, state why you are calling using the Task context, and ask a short permission/check-in question. Vary the wording; do not use a fixed template.',
       '11. If the latest user turn includes [CALL_OPENING_ACK], treat it as the callee acknowledging your opener and continue the conversation naturally without re-introducing yourself or repeating the initial check-in question.',
       '12. Do not repeat your introduction within the same call unless the callee explicitly asks who you are.',
+    ]
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  /**
+   * Build a system prompt tailored for inbound calls where the caller
+   * reached out to us. The assistant greets naturally and helps the
+   * caller with whatever they need, rather than delivering an outbound
+   * task message.
+   */
+  private buildInboundSystemPrompt(disclosureRule: string): string {
+    return [
+      `You are on a live phone call, answering an incoming call on behalf of ${resolveUserReference()}.`,
+      '',
+      'The caller dialed in to reach you. You do not have a specific task — your role is to greet them warmly, find out what they need, and assist them.',
+      'Respond naturally and conversationally — speak as you would in a real phone conversation.',
+      '',
+      'IMPORTANT RULES:',
+      '0. When introducing yourself, refer to yourself as an assistant. Avoid the phrase "AI assistant" unless directly asked.',
+      disclosureRule,
+      '2. Be concise — phone conversations should be brief and natural.',
+      '3. If the caller asks something you don\'t know or need to verify, include [ASK_GUARDIAN: your question here] in your response along with a hold message like "Let me check on that for you."',
+      '4. If information is provided preceded by [USER_ANSWERED: ...], use that answer naturally in the conversation.',
+      '5. If you see [USER_INSTRUCTION: ...], treat it as a high-priority steering directive from your user. Follow the instruction immediately, adjusting your approach or response accordingly.',
+      '6. When the caller indicates they are done or the conversation reaches a natural conclusion, include [END_CALL] in your response along with a polite goodbye.',
+      '7. Do not make up information — ask the user if unsure.',
+      '8. Keep responses short — 1-3 sentences is ideal for phone conversation.',
+      '9. When caller text includes [SPEAKER id="..." label="..."], treat each speaker as a distinct person and personalize responses using that speaker\'s prior context in this call.',
+      '10. If the latest user turn is [CALL_OPENING], greet the caller warmly and ask how you can help. For example: "Hello, this is [name]\'s assistant. How can I help you today?" Vary the wording; do not use a fixed template.',
+      '11. If the latest user turn includes [CALL_OPENING_ACK], treat it as the caller acknowledging your greeting and continue the conversation naturally.',
+      '12. Do not repeat your introduction within the same call unless the caller explicitly asks who you are.',
     ]
       .filter(Boolean)
       .join('\n');

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -84,7 +84,7 @@ export class CallOrchestrator {
     this.callSessionId = callSessionId;
     this.relay = relay;
     this.task = task;
-    this.isInbound = task === null;
+    this.isInbound = !task;
     this.broadcast = opts?.broadcast;
     this.assistantId = opts?.assistantId ?? 'self';
     this.startDurationTimer();

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -7,7 +7,7 @@
  */
 
 import { getConfig } from '../config/loader.js';
-import { getFailoverProvider, listProviders } from '../providers/registry.js';
+import { resolveConfiguredProvider } from '../providers/provider-send-message.js';
 import type { ProviderEvent } from '../providers/types.js';
 import { resolveUserReference } from '../config/user-reference.js';
 import { getLogger } from '../util/logger.js';
@@ -380,14 +380,14 @@ export class CallOrchestrator {
    */
   private async runLlm(): Promise<void> {
     const config = getConfig();
-    const providerName = config.provider;
-    if (!listProviders().includes(providerName)) {
+    const resolved = resolveConfiguredProvider();
+    if (!resolved) {
       log.error({ callSessionId: this.callSessionId }, 'No provider available');
       this.relay.sendTextToken('I\'m sorry, I\'m having a technical issue. Please try again later.', true);
       this.state = 'idle';
       return;
     }
-    const provider = getFailoverProvider(providerName, config.providerOrder);
+    const { provider } = resolved;
 
     const runVersion = ++this.llmRunVersion;
     const runSignal = this.abortController.signal;
@@ -395,12 +395,13 @@ export class CallOrchestrator {
     try {
       this.state = 'speaking';
 
-      // Only override the model when the user has explicitly configured one.
-      // When unset, each provider in the failover chain uses its own default
-      // model (set at initialization). Forwarding the primary provider's
-      // default to fallback providers would cause cross-provider 4xx errors
-      // (e.g., sending "gpt-5.2" to Anthropic).
-      const callModel = config.calls.model?.trim() || undefined;
+      // Only override the model when the user has explicitly configured one
+      // AND the selected provider matches the configured provider. Forwarding
+      // a provider-specific model to a fallback provider would cause
+      // cross-provider 4xx errors (e.g., sending "gpt-5.2" to Anthropic).
+      const callModel = !resolved.usedFallbackPrimary
+        ? (config.calls.model?.trim() || undefined)
+        : undefined;
 
       // Buffer incoming tokens so we can strip control markers ([ASK_GUARDIAN:...], [END_CALL])
       // before they reach TTS. We hold text whenever an unmatched '[' appears, since it

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -11,7 +11,6 @@ import { randomInt } from 'node:crypto';
 import { getLogger } from '../util/logger.js';
 import { parseJsonSafe } from '../util/json.js';
 import { getConfig } from '../config/loader.js';
-import { getCallWelcomeGreeting } from '../config/env.js';
 import {
   getCallSession,
   updateCallSession,

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -29,6 +29,10 @@ import {
   type PromptSpeakerContext,
 } from './speaker-identification.js';
 import { isTerminalState } from './call-state-machine.js';
+import {
+  getPendingChallenge,
+  validateAndConsumeChallenge,
+} from '../runtime/channel-guardian-service.js';
 
 const log = getLogger('relay-server');
 
@@ -140,13 +144,18 @@ export class RelayConnection {
   private orchestrator: CallOrchestrator | null = null;
   private speakerIdentityTracker: SpeakerIdentityTracker;
 
-  // Verification state
+  // Verification state (outbound callee verification)
   private connectionState: RelayConnectionState = 'connected';
   private verificationCode: string | null = null;
   private verificationAttempts = 0;
   private verificationMaxAttempts = 3;
   private verificationCodeLength = 6;
   private dtmfBuffer = '';
+
+  // Inbound voice guardian verification state
+  private guardianVerificationActive = false;
+  private guardianChallengeAssistantId: string | null = null;
+  private guardianVerificationFromNumber: string | null = null;
 
   constructor(ws: ServerWebSocket<RelayWebSocketData>, callSessionId: string) {
     this.ws = ws;
@@ -161,6 +170,20 @@ export class RelayConnection {
    */
   getVerificationCode(): string | null {
     return this.verificationCode;
+  }
+
+  /**
+   * Whether inbound guardian voice verification is currently active.
+   */
+  isGuardianVerificationActive(): boolean {
+    return this.guardianVerificationActive;
+  }
+
+  /**
+   * Get the current connection state.
+   */
+  getConnectionState(): RelayConnectionState {
+    return this.connectionState;
   }
 
   /**
@@ -352,22 +375,32 @@ export class RelayConnection {
     });
     this.setOrchestrator(orchestrator);
 
-    // Check if callee verification is enabled
+    // Inbound calls skip callee verification — verification is an
+    // outbound-call concern where we need to confirm the callee's identity.
+    // We use initiatedFromConversationId rather than task == null because
+    // outbound calls always have an initiating conversation, while inbound
+    // calls (created via createInboundVoiceSession) never do. Relying on
+    // task == null is unreliable: task-less outbound sessions would
+    // incorrectly bypass outbound verification.
+    const isInbound = session?.initiatedFromConversationId == null;
+
     const config = getConfig();
     const verificationConfig = config.calls.verification;
-    if (verificationConfig.enabled) {
+    if (!isInbound && verificationConfig.enabled) {
       this.startVerification(session, verificationConfig);
-    } else {
-      // Skip the LLM-driven opener when a static welcome greeting is already
-      // configured via CALL_WELCOME_GREETING — Twilio's ConversationRelay will
-      // speak it at the transport level, so firing the orchestrator opener too
-      // would cause a double greeting.
-      const hasStaticGreeting = !!getCallWelcomeGreeting();
-      if (!hasStaticGreeting) {
-        orchestrator.startInitialGreeting().catch((err) =>
-          log.error({ err, callSessionId: this.callSessionId }, 'Failed to start initial outbound greeting'),
-        );
+    } else if (isInbound) {
+      // For inbound calls, check if there's a pending voice guardian
+      // challenge that the caller needs to complete before proceeding.
+      const assistantId = session?.assistantId ?? 'self';
+      const pendingChallenge = getPendingChallenge(assistantId, 'voice');
+
+      if (pendingChallenge) {
+        this.startInboundGuardianVerification(assistantId, msg.from);
+      } else {
+        this.startNormalCallFlow(orchestrator, true);
       }
+    } else {
+      this.startNormalCallFlow(orchestrator, false);
     }
   }
 
@@ -416,16 +449,197 @@ export class RelayConnection {
     );
   }
 
+  /**
+   * Start normal call flow — fire the orchestrator greeting unless a
+   * static welcome greeting is configured.
+   */
+  private startNormalCallFlow(orchestrator: CallOrchestrator, isInbound: boolean): void {
+    const hasStaticGreeting = !!process.env.CALL_WELCOME_GREETING?.trim();
+    if (!hasStaticGreeting) {
+      orchestrator.startInitialGreeting().catch((err) =>
+        log.error({ err, callSessionId: this.callSessionId }, `Failed to start initial ${isInbound ? 'inbound' : 'outbound'} greeting`),
+      );
+    }
+  }
+
+  /**
+   * Enter verification-pending state for an inbound call with a pending
+   * voice guardian challenge. Prompts the caller to enter their six-digit
+   * verification code via DTMF or by speaking it.
+   */
+  private startInboundGuardianVerification(assistantId: string, fromNumber: string): void {
+    this.guardianVerificationActive = true;
+    this.guardianChallengeAssistantId = assistantId;
+    this.guardianVerificationFromNumber = fromNumber;
+    this.connectionState = 'verification_pending';
+    this.verificationAttempts = 0;
+    this.verificationMaxAttempts = 3;
+    this.verificationCodeLength = 6;
+    this.dtmfBuffer = '';
+
+    recordCallEvent(this.callSessionId, 'guardian_voice_verification_started', {
+      assistantId,
+      maxAttempts: this.verificationMaxAttempts,
+    });
+
+    this.sendTextToken(
+      'Welcome. Please enter your six-digit verification code using your keypad, or speak the digits now.',
+      true,
+    );
+
+    log.info(
+      { callSessionId: this.callSessionId, assistantId },
+      'Inbound guardian voice verification started',
+    );
+  }
+
+  /**
+   * Extract digit characters from a speech transcript. Recognizes both
+   * raw digit characters ("1 2 3") and spoken number words ("one two three").
+   */
+  private static parseDigitsFromSpeech(transcript: string): string {
+    const wordToDigit: Record<string, string> = {
+      zero: '0', oh: '0', o: '0',
+      one: '1', won: '1',
+      two: '2', too: '2', to: '2',
+      three: '3',
+      four: '4', for: '4', fore: '4',
+      five: '5',
+      six: '6',
+      seven: '7',
+      eight: '8', ate: '8',
+      nine: '9',
+    };
+
+    const digits: string[] = [];
+    const lower = transcript.toLowerCase();
+
+    // Split on whitespace and non-alphanumeric boundaries
+    const tokens = lower.split(/[\s,.\-;:!?]+/);
+    for (const token of tokens) {
+      if (/^\d$/.test(token)) {
+        digits.push(token);
+      } else if (wordToDigit[token]) {
+        digits.push(wordToDigit[token]);
+      } else if (/^\d+$/.test(token)) {
+        // Multi-digit number like "123456" — split into individual digits
+        digits.push(...token.split(''));
+      }
+    }
+
+    return digits.join('');
+  }
+
+  /**
+   * Attempt to validate an entered code against the pending voice guardian
+   * challenge via validateAndConsumeChallenge. On success, binds the
+   * guardian and transitions to normal call flow. On failure, enforces
+   * max attempts and terminates the call if exhausted.
+   */
+  private attemptGuardianCodeVerification(enteredCode: string): void {
+    if (!this.guardianChallengeAssistantId || !this.guardianVerificationFromNumber) {
+      return;
+    }
+
+    const result = validateAndConsumeChallenge(
+      this.guardianChallengeAssistantId,
+      'voice',
+      enteredCode,
+      this.guardianVerificationFromNumber,
+      this.guardianVerificationFromNumber,
+    );
+
+    if (result.success) {
+      // Guardian binding was created by validateAndConsumeChallenge
+      this.connectionState = 'connected';
+      this.guardianVerificationActive = false;
+      this.verificationAttempts = 0;
+      this.dtmfBuffer = '';
+
+      recordCallEvent(this.callSessionId, 'guardian_voice_verification_succeeded', {
+        bindingId: result.bindingId,
+      });
+      log.info({ callSessionId: this.callSessionId }, 'Inbound guardian voice verification succeeded');
+
+      // Proceed to normal call flow (use startNormalCallFlow to respect
+      // the CALL_WELCOME_GREETING static greeting guard)
+      if (this.orchestrator) {
+        this.startNormalCallFlow(this.orchestrator, true);
+      }
+    } else {
+      this.verificationAttempts++;
+
+      if (this.verificationAttempts >= this.verificationMaxAttempts) {
+        // Immediately deactivate verification so DTMF/speech input during
+        // the goodbye window doesn't trigger more verification attempts.
+        this.guardianVerificationActive = false;
+
+        recordCallEvent(this.callSessionId, 'guardian_voice_verification_failed', {
+          attempts: this.verificationAttempts,
+        });
+        log.warn(
+          { callSessionId: this.callSessionId, attempts: this.verificationAttempts },
+          'Inbound guardian voice verification failed — max attempts reached',
+        );
+
+        this.sendTextToken('Verification failed. Goodbye.', true);
+
+        updateCallSession(this.callSessionId, {
+          status: 'failed',
+          endedAt: Date.now(),
+          lastError: 'Guardian voice verification failed — max attempts exceeded',
+        });
+
+        const session = getCallSession(this.callSessionId);
+        if (session) {
+          expirePendingQuestions(this.callSessionId);
+          persistCallCompletionMessage(session.conversationId, this.callSessionId);
+          fireCallCompletionNotifier(session.conversationId, this.callSessionId);
+        }
+
+        setTimeout(() => {
+          this.endSession('Guardian verification failed');
+        }, 2000);
+      } else {
+        log.info(
+          { callSessionId: this.callSessionId, attempt: this.verificationAttempts, maxAttempts: this.verificationMaxAttempts },
+          'Inbound guardian voice verification attempt failed — retrying',
+        );
+        this.sendTextToken('That code was incorrect. Please try again.', true);
+      }
+    }
+  }
+
   private async handlePrompt(msg: RelayPromptMessage): Promise<void> {
     if (!msg.last) {
       // Partial transcript, wait for final
       return;
     }
 
-    // During verification, ignore voice prompts — the callee should be
-    // entering DTMF digits, not speaking.
+    // During inbound guardian verification, attempt to parse spoken digits
+    // from the transcript and validate them.
+    if (this.connectionState === 'verification_pending' && this.guardianVerificationActive) {
+      const spokenDigits = RelayConnection.parseDigitsFromSpeech(msg.voicePrompt);
+      log.info(
+        { callSessionId: this.callSessionId, transcript: msg.voicePrompt, spokenDigits },
+        'Speech received during guardian voice verification',
+      );
+      if (spokenDigits.length >= this.verificationCodeLength) {
+        const enteredCode = spokenDigits.slice(0, this.verificationCodeLength);
+        this.attemptGuardianCodeVerification(enteredCode);
+      } else if (spokenDigits.length > 0) {
+        this.sendTextToken(
+          `I heard ${spokenDigits.length} digits. Please enter all ${this.verificationCodeLength} digits of your code.`,
+          true,
+        );
+      }
+      return;
+    }
+
+    // During outbound callee verification, ignore voice prompts — the callee
+    // should be entering DTMF digits, not speaking.
     if (this.connectionState === 'verification_pending') {
-      log.debug({ callSessionId: this.callSessionId }, 'Ignoring voice prompt during verification');
+      log.debug({ callSessionId: this.callSessionId }, 'Ignoring voice prompt during callee verification');
       return;
     }
 
@@ -503,7 +717,20 @@ export class RelayConnection {
       dtmfDigit: msg.digit,
     });
 
-    // If verification is pending, accumulate digits and check the code
+    // If inbound guardian verification is pending, accumulate digits and
+    // validate against the challenge via the guardian service.
+    if (this.connectionState === 'verification_pending' && this.guardianVerificationActive) {
+      this.dtmfBuffer += msg.digit;
+
+      if (this.dtmfBuffer.length >= this.verificationCodeLength) {
+        const enteredCode = this.dtmfBuffer.slice(0, this.verificationCodeLength);
+        this.dtmfBuffer = '';
+        this.attemptGuardianCodeVerification(enteredCode);
+      }
+      return;
+    }
+
+    // If outbound callee verification is pending, accumulate digits and check the code
     if (this.connectionState === 'verification_pending' && this.verificationCode) {
       this.dtmfBuffer += msg.digit;
 

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -28,6 +28,7 @@ import { getTwilioRelayUrl } from '../inbound/public-ingress-urls.js';
 import { fireCallCompletionNotifier } from './call-state.js';
 import { persistCallCompletionMessage } from './call-conversation-messages.js';
 import { resolveVoiceQualityProfile, isVoiceProfileValid } from './voice-quality.js';
+import { createInboundVoiceSession } from './call-domain.js';
 
 const log = getLogger('twilio-routes');
 
@@ -121,16 +122,43 @@ function mapTwilioStatus(twilioStatus: string): CallStatus | null {
 /**
  * Receives the initial voice webhook when Twilio connects the call.
  * Returns TwiML XML that tells Twilio to open a ConversationRelay WebSocket.
+ *
+ * Supports two modes:
+ * - **Outbound** (callSessionId present in query): uses the existing session
+ * - **Inbound** (callSessionId absent): creates or reuses a session keyed
+ *   by the Twilio CallSid. The optional `forwardedAssistantId` is resolved
+ *   by the gateway from the "To" phone number.
  */
-export async function handleVoiceWebhook(req: Request): Promise<Response> {
+export async function handleVoiceWebhook(req: Request, forwardedAssistantId?: string): Promise<Response> {
   const url = new URL(req.url);
   const callSessionId = url.searchParams.get('callSessionId');
 
+  // Parse the Twilio POST body to capture CallSid and caller metadata.
+  const formBody = new URLSearchParams(await req.text());
+  const callSid = formBody.get('CallSid');
+  const callerFrom = formBody.get('From') ?? '';
+  const callerTo = formBody.get('To') ?? '';
+
+  // ── Inbound mode: no callSessionId in query ─────────────────────
   if (!callSessionId) {
-    log.warn('Voice webhook called without callSessionId');
-    return new Response('Missing callSessionId', { status: 400 });
+    if (!callSid) {
+      log.warn('Inbound voice webhook called without CallSid');
+      return new Response('Missing CallSid', { status: 400 });
+    }
+
+    log.info({ callSid, from: callerFrom, to: callerTo, assistantId: forwardedAssistantId }, 'Inbound voice webhook — creating/reusing session');
+
+    const { session } = createInboundVoiceSession({
+      callSid,
+      fromNumber: callerFrom,
+      toNumber: callerTo,
+      assistantId: forwardedAssistantId,
+    });
+
+    return buildVoiceWebhookTwiml(session.id, session.assistantId ?? undefined, session.task);
   }
 
+  // ── Outbound mode: callSessionId is present ─────────────────────
   const session = getCallSession(callSessionId);
   if (!session) {
     log.warn({ callSessionId }, 'Voice webhook: call session not found');
@@ -142,16 +170,25 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
     return new Response('Call session is no longer active', { status: 410 });
   }
 
-  // Parse the Twilio POST body to capture CallSid immediately, so status
-  // callbacks (keyed by CallSid) can locate this session even if the
-  // WebSocket relay hasn't been set up yet.
-  const formBody = new URLSearchParams(await req.text());
-  const callSid = formBody.get('CallSid');
+  // Capture CallSid immediately so status callbacks can locate this session
   if (callSid && callSid !== session.providerCallSid) {
     updateCallSession(callSessionId, { providerCallSid: callSid });
     log.info({ callSessionId, callSid }, 'Stored CallSid from voice webhook');
   }
 
+  return buildVoiceWebhookTwiml(callSessionId, session.assistantId ?? undefined, session.task);
+}
+
+/**
+ * Shared TwiML generation for both inbound and outbound voice webhooks.
+ * Resolves voice quality profile, relay URL, and welcome greeting,
+ * then returns a Response with the generated TwiML.
+ */
+function buildVoiceWebhookTwiml(
+  callSessionId: string,
+  assistantId: string | undefined,
+  task: string | null,
+): Response {
   let profile = resolveVoiceQualityProfile(loadConfig());
 
   log.info({ callSessionId, mode: profile.mode, ttsProvider: profile.ttsProvider, voice: profile.voice }, 'Voice quality profile resolved');
@@ -190,7 +227,7 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
     });
   }
 
-  const twilioConfig = getTwilioConfig(session.assistantId ?? undefined);
+  const twilioConfig = getTwilioConfig(assistantId);
   let relayUrl: string;
   try {
     relayUrl = getTwilioRelayUrl(loadConfig());
@@ -198,7 +235,7 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
     // Fallback to legacy resolution when ingress is not configured
     relayUrl = resolveRelayUrl(twilioConfig.wssBaseUrl, twilioConfig.webhookBaseUrl);
   }
-  const welcomeGreeting = buildWelcomeGreeting(session.task, getCallWelcomeGreeting());
+  const welcomeGreeting = buildWelcomeGreeting(task, getCallWelcomeGreeting());
 
   const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, profile);
 

--- a/assistant/src/calls/types.ts
+++ b/assistant/src/calls/types.ts
@@ -1,5 +1,5 @@
 export type CallStatus = 'initiated' | 'ringing' | 'in_progress' | 'waiting_on_user' | 'completed' | 'failed' | 'cancelled';
-export type CallEventType = 'call_started' | 'call_connected' | 'caller_spoke' | 'assistant_spoke' | 'user_question_asked' | 'user_answered' | 'user_instruction_relayed' | 'call_ended' | 'call_failed' | 'callee_verification_started' | 'callee_verification_succeeded' | 'callee_verification_failed';
+export type CallEventType = 'call_started' | 'call_connected' | 'caller_spoke' | 'assistant_spoke' | 'user_question_asked' | 'user_answered' | 'user_instruction_relayed' | 'call_ended' | 'call_failed' | 'callee_verification_started' | 'callee_verification_succeeded' | 'callee_verification_failed' | 'guardian_voice_verification_started' | 'guardian_voice_verification_succeeded' | 'guardian_voice_verification_failed';
 export type PendingQuestionStatus = 'pending' | 'answered' | 'expired' | 'cancelled';
 
 export interface CallSession {

--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -15,17 +15,6 @@ import {
   type ProcessingStage,
 } from '../../../../memory/media-store.js';
 
-const _VLM_PROMPT = `Analyze this image frame extracted from a video. Return a JSON object with the following fields:
-
-{
-  "sceneDescription": "A concise description of the overall scene",
-  "subjects": ["List of identifiable subjects/objects/people in the frame"],
-  "actions": ["List of actions or activities occurring"],
-  "context": "Environmental or situational context (setting, conditions, etc.)"
-}
-
-Return ONLY the JSON object, no additional text.`;
-
 const CHUNKED_VLM_PROMPT = `You are analyzing a sequence of {N} consecutive video frames extracted at regular intervals from a video. The frames are in chronological order.
 
 For EACH frame, provide a JSON object with:

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -20,7 +20,12 @@ Gmail, Slack, and Telegram setup all require a publicly reachable URL for OAuth 
 2. **If it fails because no client_id is found:** The user needs to create Google Cloud OAuth credentials first. Install and load the **google-oauth-setup** skill (which depends on **public-ingress** for the redirect URI):
    - Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "google-oauth-setup"`.
    - Then call `skill_load` with `skill: "google-oauth-setup"`.
-   - Tell the user: *"Gmail isn't connected yet. I've loaded a setup guide that will walk you through creating Google credentials and connecting your account."*
+   - Tell the user Gmail isn't connected yet and briefly explain what the setup involves, then use `ui_show` with `surface_type: "confirmation"` to ask for permission to start:
+     - **message:** "Ready to set up Gmail?"
+     - **detail:** "I'll walk you through creating Google Cloud credentials and connecting your account. The process takes a few minutes, and I'll ask for your approval before each step."
+     - **confirmLabel:** "Get Started"
+     - **cancelLabel:** "Not Now"
+   - Wait for the user to confirm before proceeding with the setup guide. If they decline, acknowledge and let them know they can set it up later.
 3. **If the user provides a client_id directly in chat:** Call `credential_store` with `action: "oauth2_connect"`, `service: "gmail"`, and `client_id: "<their value>"`. Include `client_secret` too if they provide one. Everything else is auto-filled.
 
 ### Slack
@@ -28,7 +33,12 @@ Gmail, Slack, and Telegram setup all require a publicly reachable URL for OAuth 
 2. **If it fails because no client_id is found:** The user needs to create a Slack App first. Install and load the **slack-oauth-setup** skill (which depends on **public-ingress** for the redirect URI):
    - Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "slack-oauth-setup"`.
    - Then call `skill_load` with `skill: "slack-oauth-setup"`.
-   - Tell the user: *"Slack isn't connected yet. I've loaded a setup guide that will walk you through creating a Slack App and connecting your workspace."*
+   - Tell the user Slack isn't connected yet and briefly explain what the setup involves, then use `ui_show` with `surface_type: "confirmation"` to ask for permission to start:
+     - **message:** "Ready to set up Slack?"
+     - **detail:** "I'll walk you through creating a Slack App and connecting your workspace. The process takes a few minutes, and I'll ask for your approval before each step."
+     - **confirmLabel:** "Get Started"
+     - **cancelLabel:** "Not Now"
+   - Wait for the user to confirm before proceeding with the setup guide. If they decline, acknowledge and let them know they can set it up later.
 3. **If the user provides client_id and client_secret directly in chat:** Call `credential_store` with `action: "oauth2_connect"`, `service: "slack"`, `client_id`, and `client_secret`. Everything else is auto-filled. Note: Slack always requires a client_secret.
 
 ### Telegram

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: "Phone Calls"
-description: "Set up Twilio for outgoing phone calls and place AI-powered voice calls on behalf of the user"
+description: "Set up Twilio for AI-powered voice calls — both outgoing calls on behalf of the user and incoming calls where the assistant answers as a receptionist"
 user-invocable: true
 metadata: {"vellum": {"emoji": "📞", "requires": {"config": ["calls.enabled"]}}}
 includes: ["public-ingress"]
 ---
 
-You are helping the user set up and make outgoing phone calls via Twilio. This skill covers the full lifecycle: Twilio account setup, credential storage, public ingress configuration, enabling the calls feature, placing calls, and monitoring live transcripts.
+You are helping the user set up and manage phone calls via Twilio. This skill covers the full lifecycle: Twilio account setup, credential storage, public ingress configuration, enabling the calls feature, placing outbound calls, receiving inbound calls, and monitoring live transcripts.
 
 ## Prerequisites — Shared Twilio Setup
 
@@ -21,7 +21,9 @@ If Twilio is already configured (check `twilio_config` with `action: "get"`), sk
 
 ## Overview
 
-The calling system uses Twilio's ConversationRelay to place outbound phone calls. Twilio works out of the box as the default voice provider. Optionally, you can enable ElevenLabs integration for higher-quality, more natural-sounding voices — but this is entirely optional.
+The calling system uses Twilio's ConversationRelay for both **outbound** and **inbound** voice calls. Twilio works out of the box as the default voice provider. Optionally, you can enable ElevenLabs integration for higher-quality, more natural-sounding voices — but this is entirely optional.
+
+### Outbound calls
 
 When a call is placed:
 
@@ -30,6 +32,17 @@ When a call is placed:
 3. Twilio opens a ConversationRelay WebSocket for real-time voice streaming
 4. An LLM-driven orchestrator manages the conversation — receiving caller speech (transcribed by Deepgram), generating responses via Claude, and streaming text back for TTS playback
 5. The transcript is relayed live to the user's conversation thread
+
+### Inbound calls
+
+When someone dials the assistant's Twilio phone number:
+
+1. Twilio sends a voice webhook to the gateway at `/webhooks/twilio/voice` (no `callSessionId` in the URL)
+2. The gateway resolves which assistant owns the dialed number via `resolveAssistantByPhoneNumber`, falling back to the standard routing chain (chat_id, user_id, default/reject). Unmapped numbers are rejected with TwiML `<Reject>`.
+3. The runtime creates a new session keyed by the Twilio CallSid (`createInboundVoiceSession`)
+4. Twilio opens a ConversationRelay WebSocket. The relay detects the call is inbound (no task) and optionally gates the call behind **guardian voice verification** if a pending challenge exists.
+5. Once verified (or if no challenge is pending), the LLM orchestrator greets the caller in a receptionist style: "Hello, this is [user]'s assistant. How can I help you today?"
+6. The assistant converses naturally, using ASK_GUARDIAN to consult the user when needed, just like outbound calls.
 
 Three voice quality modes are available:
 - **`twilio_standard`** (default) — Fully supported. Standard Twilio TTS with Google voices. No extra setup required.
@@ -283,7 +296,7 @@ To go back to the default voice at any time:
 vellum config set calls.voice.mode twilio_standard
 ```
 
-## Making Calls
+## Making Outbound Calls
 
 Use the `call_start` tool to place outbound calls. Every call requires:
 - **phone_number**: The number to call in E.164 format (e.g. `+14155551234`)
@@ -337,6 +350,30 @@ If the user provides a number in a different format, convert it to E.164 before 
 On Twilio trial accounts, outbound calls can ONLY be made to **verified numbers**. If a call fails with a "not verified" error:
 1. Tell the user they need to verify the number at https://console.twilio.com/us1/develop/phone-numbers/manage/verified
 2. Or upgrade to a paid Twilio account to call any number
+
+## Receiving Inbound Calls
+
+Once Twilio is configured and the assistant has a phone number, inbound calls work automatically. When someone dials the assistant's number:
+
+1. The gateway resolves the assistant by phone number and forwards to the runtime
+2. A new voice session is created, keyed by the Twilio CallSid
+3. The LLM-driven orchestrator answers in receptionist mode — greeting the caller warmly and asking how it can help
+4. The conversation proceeds naturally, with ASK_GUARDIAN dispatches to consult the user when needed
+
+No additional configuration is needed beyond the standard Twilio setup (Steps 1-5 above). As long as `calls.enabled` is `true` and the phone number has been provisioned/assigned, inbound calls are handled automatically.
+
+### Guardian voice verification for inbound calls
+
+Optionally, the user can require callers to verify themselves by entering a six-digit code before the call proceeds. This is managed through the **channel guardian verification** system:
+
+1. The user initiates a verification challenge from the desktop UI for the `voice` channel
+2. A six-digit code is generated and shown to the user
+3. When the next inbound call arrives, the relay server detects the pending challenge and prompts the caller: "Please enter your six-digit verification code using your keypad, or speak the digits now."
+4. The caller enters the code via DTMF (keypad) or by speaking the digits
+5. If the code matches, a guardian binding is created and the call proceeds normally
+6. If verification fails after 3 attempts, the call ends with "Verification failed. Goodbye."
+
+This feature is separate from the outbound DTMF callee verification. It uses the `ChannelGuardianService` challenge system rather than the per-call verification config.
 
 ## Live Call Monitoring
 
@@ -427,12 +464,19 @@ The `context` field is powerful — use it to give the agent background that hel
 
 ### Things the AI voice agent handles well
 
+**Outbound calls:**
 - Making reservations and appointments
 - Checking business hours, availability, or pricing
 - Confirming or rescheduling existing appointments
 - Gathering information (store policies, product availability)
 - Simple customer service interactions
 - Leaving voicemails (it will speak the message if voicemail picks up)
+
+**Inbound calls:**
+- Answering as a receptionist and routing caller requests to the user via ASK_GUARDIAN
+- Taking messages when the user is unavailable
+- Answering questions the assistant already knows from memory/context
+- Screening calls with guardian voice verification
 
 ### Things to be aware of
 

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -40,7 +40,7 @@ When someone dials the assistant's Twilio phone number:
 1. Twilio sends a voice webhook to the gateway at `/webhooks/twilio/voice` (no `callSessionId` in the URL)
 2. The gateway resolves which assistant owns the dialed number via `resolveAssistantByPhoneNumber`, falling back to the standard routing chain (chat_id, user_id, default/reject). Unmapped numbers are rejected with TwiML `<Reject>`.
 3. The runtime creates a new session keyed by the Twilio CallSid (`createInboundVoiceSession`)
-4. Twilio opens a ConversationRelay WebSocket. The relay detects the call is inbound (no task) and optionally gates the call behind **guardian voice verification** if a pending challenge exists.
+4. Twilio opens a ConversationRelay WebSocket. The relay detects the call is inbound when `initiatedFromConversationId == null` and optionally gates the call behind **guardian voice verification** if a pending challenge exists.
 5. Once verified (or if no challenge is pending), the LLM orchestrator greets the caller in a receptionist style: "Hello, this is [user]'s assistant. How can I help you today?"
 6. The assistant converses naturally, using ASK_GUARDIAN to consult the user when needed, just like outbound calls.
 

--- a/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
@@ -67,6 +67,7 @@ Tell the user: "App created! Now let's configure the permissions it needs."
 > - `groups:history` — Read message history in private channels
 > - `im:read` — View direct message info
 > - `im:history` — Read direct message history
+> - `im:write` — Open and send direct messages
 > - `mpim:read` — View group DM info
 > - `mpim:history` — Read group DM history
 > - `users:read` — View user profiles

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -1,5 +1,5 @@
 import * as net from 'node:net';
-import { createVerificationChallenge, getGuardianBinding, revokeBinding as revokeGuardianBinding } from '../../runtime/channel-guardian-service.js';
+import { createVerificationChallenge, getGuardianBinding, getPendingChallenge, revokeBinding as revokeGuardianBinding, revokePendingChallenges } from '../../runtime/channel-guardian-service.js';
 import { createReadinessService, type ChannelReadinessService } from '../../runtime/channel-readiness-service.js';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
 import type {
@@ -67,6 +67,7 @@ export function handleGuardianVerification(
           guardianDisplayName = ext.displayName;
         }
       }
+      const hasPendingChallenge = getPendingChallenge(assistantId, channel) != null;
       ctx.send(socket, {
         type: 'guardian_verification_response',
         success: true,
@@ -77,9 +78,11 @@ export function handleGuardianVerification(
         channel,
         assistantId,
         guardianDeliveryChatId: binding?.guardianDeliveryChatId,
+        hasPendingChallenge,
       });
     } else if (msg.action === 'revoke') {
       revokeGuardianBinding(assistantId, channel);
+      revokePendingChallenges(assistantId, channel);
       ctx.send(socket, {
         type: 'guardian_verification_response',
         success: true,

--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -154,7 +154,7 @@ export function handleIngressInvite(
       }
 
       default: {
-        ctx.send(socket, { type: 'ingress_invite_response', success: false, error: `Unknown action: ${String((msg as Record<string, unknown>).action)}` });
+        ctx.send(socket, { type: 'ingress_invite_response', success: false, error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}` });
       }
     }
   } catch (err) {
@@ -263,7 +263,7 @@ export function handleIngressMember(
       }
 
       default: {
-        ctx.send(socket, { type: 'ingress_member_response', success: false, error: `Unknown action: ${String((msg as Record<string, unknown>).action)}` });
+        ctx.send(socket, { type: 'ingress_member_response', success: false, error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}` });
       }
     }
   } catch (err) {
@@ -344,7 +344,7 @@ export function handleInboxEscalation(
       }
 
       default: {
-        ctx.send(socket, { type: 'assistant_inbox_escalation_response', success: false, error: `Unknown action: ${String((msg as Record<string, unknown>).action)}` });
+        ctx.send(socket, { type: 'assistant_inbox_escalation_response', success: false, error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}` });
       }
     }
   } catch (err) {

--- a/assistant/src/daemon/handlers/dictation.ts
+++ b/assistant/src/daemon/handlers/dictation.ts
@@ -1,6 +1,5 @@
 import * as net from 'node:net';
-import { getConfig } from '../../config/loader.js';
-import { getFailoverProvider, listProviders } from '../../providers/registry.js';
+import { getConfiguredProvider } from '../../providers/provider-send-message.js';
 import type { DictationRequest } from '../ipc-protocol.js';
 import { log, defineHandlers, type HandlerContext } from './shared.js';
 
@@ -147,15 +146,14 @@ export async function handleDictationRequest(
     : msg.transcription; // command prompt already embeds the selected text and instruction
 
   try {
-    const config = getConfig();
-    if (!listProviders().includes(config.provider)) {
-      log.warn({ provider: config.provider }, 'Dictation: no provider available, returning raw transcription');
+    const provider = getConfiguredProvider();
+    if (!provider) {
+      log.warn('Dictation: no provider available, returning raw transcription');
       const fallbackText = mode === 'command' ? (msg.context.selectedText ?? msg.transcription) : msg.transcription;
       ctx.send(socket, { type: 'dictation_response', text: fallbackText, mode });
       return;
     }
 
-    const provider = getFailoverProvider(config.provider, config.providerOrder);
     const response = await provider.sendMessage(
       [{ role: 'user', content: [{ type: 'text', text: userText }] }],
       [], // no tools

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -3,8 +3,7 @@ import { v4 as uuid } from 'uuid';
 import { readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import * as conversationStore from '../../memory/conversation-store.js';
-import { getConfig } from '../../config/loader.js';
-import { getFailoverProvider, listProviders } from '../../providers/registry.js';
+import { getConfiguredProvider } from '../../providers/provider-send-message.js';
 import type { Provider } from '../../providers/types.js';
 import { classifyInteraction } from '../classifier.js';
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
@@ -172,10 +171,9 @@ export async function handleSuggestionRequest(
     }
 
     // Try LLM suggestion using the configured provider
-    const config = getConfig();
-    if (listProviders().includes(config.provider)) {
+    const provider = getConfiguredProvider();
+    if (provider) {
       try {
-        const provider = getFailoverProvider(config.provider, config.providerOrder);
         let promise = suggestionInFlight.get(m.id);
         if (!promise) {
           promise = generateSuggestion(provider, text);

--- a/assistant/src/daemon/ipc-contract/integrations.ts
+++ b/assistant/src/daemon/ipc-contract/integrations.ts
@@ -234,6 +234,8 @@ export interface GuardianVerificationResponse {
   guardianUsername?: string;
   /** Optional display name for the bound guardian (for UI display). */
   guardianDisplayName?: string;
+  /** Whether a pending verification challenge exists for this (assistantId, channel). Used by relay setup to detect active voice verification sessions. */
+  hasPendingChallenge?: boolean;
   error?: string;
 }
 

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -18,7 +18,7 @@ import {
 } from '../util/platform.js';
 import { initializeDb } from '../memory/db.js';
 import { rotateToolInvocations } from '../memory/tool-usage-store.js';
-import { initializeProviders, getFailoverProvider, listProviders } from '../providers/registry.js';
+import { initializeProviders, getFailoverProvider } from '../providers/registry.js';
 import { initializeTools } from '../tools/registry.js';
 import { loadConfig } from '../config/loader.js';
 import {
@@ -290,10 +290,12 @@ function loadDotEnv(): void {
 function createApprovalCopyGenerator(): ApprovalCopyGenerator {
   return async (context, options = {}) => {
     const config = loadConfig();
-    if (!listProviders().includes(config.provider)) {
+    let provider;
+    try {
+      provider = getFailoverProvider(config.provider, config.providerOrder);
+    } catch {
       return null;
     }
-    const provider = getFailoverProvider(config.provider, config.providerOrder);
 
     const fallbackText = options.fallbackText?.trim() || getFallbackMessage(context);
     const requiredKeywords = options.requiredKeywords?.map((kw) => kw.trim()).filter((kw) => kw.length > 0);

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -18,7 +18,7 @@ import {
 } from '../util/platform.js';
 import { initializeDb } from '../memory/db.js';
 import { rotateToolInvocations } from '../memory/tool-usage-store.js';
-import { initializeProviders, getFailoverProvider } from '../providers/registry.js';
+import { initializeProviders, getFailoverProvider, listProviders } from '../providers/registry.js';
 import { initializeTools } from '../tools/registry.js';
 import { loadConfig } from '../config/loader.js';
 import {

--- a/assistant/src/memory/channel-guardian-store.ts
+++ b/assistant/src/memory/channel-guardian-store.ts
@@ -257,6 +257,20 @@ export function createChallenge(params: {
   return rowToChallenge(row);
 }
 
+export function revokePendingChallenges(assistantId: string, channel: string): void {
+  const db = getDb();
+  db.update(channelGuardianVerificationChallenges)
+    .set({ status: 'revoked', updatedAt: Date.now() })
+    .where(
+      and(
+        eq(channelGuardianVerificationChallenges.assistantId, assistantId),
+        eq(channelGuardianVerificationChallenges.channel, channel),
+        eq(channelGuardianVerificationChallenges.status, 'pending'),
+      ),
+    )
+    .run();
+}
+
 export function findPendingChallengeByHash(
   assistantId: string,
   channel: string,
@@ -273,6 +287,33 @@ export function findPendingChallengeByHash(
         eq(channelGuardianVerificationChallenges.assistantId, assistantId),
         eq(channelGuardianVerificationChallenges.channel, channel),
         eq(channelGuardianVerificationChallenges.challengeHash, challengeHash),
+        eq(channelGuardianVerificationChallenges.status, 'pending'),
+        gt(channelGuardianVerificationChallenges.expiresAt, now),
+      ),
+    )
+    .get();
+
+  return row ? rowToChallenge(row) : null;
+}
+
+/**
+ * Find any pending (non-expired) challenge for a given (assistantId, channel).
+ * Used by relay setup to detect whether a voice verification session is active.
+ */
+export function findPendingChallengeForChannel(
+  assistantId: string,
+  channel: string,
+): VerificationChallenge | null {
+  const db = getDb();
+  const now = Date.now();
+
+  const row = db
+    .select()
+    .from(channelGuardianVerificationChallenges)
+    .where(
+      and(
+        eq(channelGuardianVerificationChallenges.assistantId, assistantId),
+        eq(channelGuardianVerificationChallenges.channel, channel),
         eq(channelGuardianVerificationChallenges.status, 'pending'),
         gt(channelGuardianVerificationChallenges.expiresAt, now),
       ),

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -571,6 +571,7 @@ export function initializeDb(): void {
   // Partial covering index for directItemSearch: the LIKE '%term%' pattern can't
   // seek a B-tree, but this index lets SQLite scan only active non-invalidated rows
   // and evaluate LIKE + return columns without touching the main table.
+  database.run(/*sql*/ `DROP INDEX IF EXISTS idx_memory_items_active_search`);
   database.run(/*sql*/ `
     CREATE INDEX IF NOT EXISTS idx_memory_items_active_search
     ON memory_items(status, invalid_at, last_seen_at DESC, subject, statement, id, kind, confidence, importance, first_seen_at, scope_id)

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -573,7 +573,7 @@ export function initializeDb(): void {
   // and evaluate LIKE + return columns without touching the main table.
   database.run(/*sql*/ `
     CREATE INDEX IF NOT EXISTS idx_memory_items_active_search
-    ON memory_items(last_seen_at DESC, subject, statement, id, kind, confidence, importance, first_seen_at, scope_id)
+    ON memory_items(status, invalid_at, last_seen_at DESC, subject, statement, id, kind, confidence, importance, first_seen_at, scope_id)
     WHERE status = 'active' AND invalid_at IS NULL
   `);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_target ON memory_embeddings(target_type, target_id)`);

--- a/assistant/src/memory/inbox-thread-store.ts
+++ b/assistant/src/memory/inbox-thread-store.ts
@@ -6,7 +6,7 @@
  * (unread counts, escalation state, last activity timestamps).
  */
 
-import { and, desc, eq, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { getDb } from './db.js';
 import { assistantInboxThreadState } from './schema.js';
 

--- a/assistant/src/messaging/style-analyzer.ts
+++ b/assistant/src/messaging/style-analyzer.ts
@@ -9,8 +9,7 @@
 import type { Message as ProviderMessage } from './provider-types.js';
 import type { Message, ToolDefinition } from '../providers/types.js';
 import { truncate } from '../util/truncate.js';
-import { getProvider } from '../providers/registry.js';
-import { getConfig } from '../config/loader.js';
+import { getConfiguredProvider } from '../providers/provider-send-message.js';
 
 export interface StylePattern {
   aspect: string;
@@ -118,8 +117,10 @@ export async function extractStylePatterns(
 
   const corpus = corpusEntries.map((e, i) => `--- Message ${i + 1} ---\n${e}`).join('\n\n');
 
-  const config = getConfig();
-  const provider = getProvider(config.provider);
+  const provider = getConfiguredProvider();
+  if (!provider) {
+    return { stylePatterns: [], contactObservations: [] };
+  }
   const promptMessages: Message[] = [{
     role: 'user',
     content: [{ type: 'text', text: `Analyze these ${corpusEntries.length} sent messages for writing style patterns:\n\n${corpus}` }],

--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -5,17 +5,31 @@
  */
 
 import type { Provider, ProviderResponse, Message, ContentBlock, ToolUseContent } from './types.js';
-import { getFailoverProvider, listProviders, initializeProviders } from './registry.js';
+import { getFailoverProvider, listProviders, initializeProviders, resolveProviderSelection } from './registry.js';
 import { getConfig } from '../config/loader.js';
+import { getLogger } from '../util/logger.js';
+
+export interface ConfiguredProviderResult {
+  provider: Provider;
+  configuredProviderName: string;
+  selectedProviderName: string;
+  usedFallbackPrimary: boolean;
+}
+
+const providerSelectionLog = getLogger('provider-selection');
+let fallbackWarningLogged = false;
 
 /**
- * Resolve the configured provider through the registry/failover path.
+ * Resolve the configured provider with full selection metadata.
  * If providers haven't been initialized yet (e.g. non-daemon code paths),
  * performs a one-shot `initializeProviders(getConfig())`.
  *
- * Returns `null` when the configured provider is unavailable.
+ * Uses fail-open selection: if `config.provider` is unavailable but
+ * alternates from `config.providerOrder` exist, selects the first available.
+ *
+ * Returns `null` when no providers are available at all.
  */
-export function getConfiguredProvider(): Provider | null {
+export function resolveConfiguredProvider(): ConfiguredProviderResult | null {
   const config = getConfig();
 
   if (listProviders().length === 0) {
@@ -26,16 +40,45 @@ export function getConfiguredProvider(): Provider | null {
     }
   }
 
-  if (!listProviders().includes(config.provider)) {
+  const providerOrder = Array.isArray(config.providerOrder) ? config.providerOrder : [];
+  const selection = resolveProviderSelection(config.provider, providerOrder);
+
+  if (!selection.selectedPrimary) {
     return null;
   }
 
+  if (selection.usedFallbackPrimary) {
+    const level = fallbackWarningLogged ? 'debug' : 'warn';
+    providerSelectionLog[level](
+      { configured: config.provider, selected: selection.selectedPrimary },
+      'Configured provider unavailable, using fallback',
+    );
+    fallbackWarningLogged = true;
+  }
+
   try {
-    const providerOrder = Array.isArray(config.providerOrder) ? config.providerOrder : [];
-    return getFailoverProvider(config.provider, providerOrder);
+    const provider = getFailoverProvider(config.provider, providerOrder);
+    return {
+      provider,
+      configuredProviderName: config.provider,
+      selectedProviderName: selection.selectedPrimary,
+      usedFallbackPrimary: selection.usedFallbackPrimary,
+    };
   } catch {
     return null;
   }
+}
+
+/**
+ * Resolve the configured provider through the registry/failover path.
+ * Thin wrapper around `resolveConfiguredProvider()` for callsites
+ * that only need the Provider instance.
+ *
+ * Returns `null` when no providers are available.
+ */
+export function getConfiguredProvider(): Provider | null {
+  const result = resolveConfiguredProvider();
+  return result?.provider ?? null;
 }
 
 /**

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -29,33 +29,74 @@ export function getProvider(name: string): Provider {
   return provider;
 }
 
+export interface ProviderSelection {
+  /** Ordered list of available provider names */
+  availableProviders: string[];
+  /** The selected (effective) primary provider name, or null if none available */
+  selectedPrimary: string | null;
+  /** Whether the effective primary differs from the requested primary */
+  usedFallbackPrimary: boolean;
+}
+
 /**
- * Build a provider that tries the primary provider first, then falls back to
- * others in the configured order. If providerOrder is empty or only contains
- * the primary, returns the primary provider directly (no wrapper overhead).
- * Caches the FailoverProvider instance so health state persists across calls.
+ * Resolve provider selection from requested primary and provider order.
+ * Dedupes [requestedPrimary, ...providerOrder], filtered to initialized providers.
+ * Returns null selectedPrimary when no providers are available.
  */
-export function getFailoverProvider(primaryName: string, providerOrder: string[]): Provider {
-  const primary = getProvider(primaryName);
+export function resolveProviderSelection(
+  requestedPrimary: string,
+  providerOrder: string[],
+): ProviderSelection {
+  const ordered: string[] = [];
+  const seen = new Set<string>();
 
-  // Build the ordered list: primary first, then remaining from providerOrder
-  const orderedProviders: Provider[] = [primary];
-  const seen = new Set<string>([primaryName]);
-
-  for (const name of providerOrder) {
+  for (const name of [requestedPrimary, ...providerOrder]) {
     if (seen.has(name)) continue;
-    const p = providers.get(name);
-    if (p) {
-      orderedProviders.push(p);
-      seen.add(name);
+    seen.add(name);
+    if (providers.has(name)) {
+      ordered.push(name);
     }
   }
 
-  if (orderedProviders.length === 1) {
-    return primary;
+  if (ordered.length === 0) {
+    return { availableProviders: [], selectedPrimary: null, usedFallbackPrimary: false };
   }
 
-  const cacheKey = `${primaryName}:${providerOrder.join(',')}`;
+  return {
+    availableProviders: ordered,
+    selectedPrimary: ordered[0],
+    usedFallbackPrimary: ordered[0] !== requestedPrimary,
+  };
+}
+
+/**
+ * Build a provider that tries the effective primary provider first, then falls
+ * back to others in the configured order. If the requested primary is not
+ * available, automatically selects the first available provider from the
+ * deduped [primaryName, ...providerOrder] list (fail-open).
+ *
+ * Throws ConfigError only when NO providers are available at all.
+ * Caches the FailoverProvider instance so health state persists across calls.
+ */
+export function getFailoverProvider(primaryName: string, providerOrder: string[]): Provider {
+  const selection = resolveProviderSelection(primaryName, providerOrder);
+
+  if (!selection.selectedPrimary) {
+    throw new ConfigError(
+      `No providers available. Requested: "${primaryName}". Registered: ${listProviders().join(", ") || "none"}`,
+    );
+  }
+
+  const orderedProviders: Provider[] = selection.availableProviders.map(
+    (name) => providers.get(name)!,
+  );
+
+  if (orderedProviders.length === 1) {
+    return orderedProviders[0];
+  }
+
+  // Cache key from effective ordered providers (not raw input strings)
+  const cacheKey = selection.availableProviders.join(',');
   if (cachedFailoverProvider && cachedFailoverKey === cacheKey) {
     return cachedFailoverProvider;
   }

--- a/assistant/src/runtime/approval-message-composer.ts
+++ b/assistant/src/runtime/approval-message-composer.ts
@@ -215,6 +215,11 @@ export function getFallbackMessage(context: ApprovalMessageContext): string {
       return `Verification failed. ${context.failureReason ?? 'Please try again.'}`;
 
     case 'guardian_verify_challenge_setup':
+      if (context.channel === 'voice') {
+        // Voice challenges use a six-digit numeric code that can be spoken aloud
+        const code = context.verifyCommand?.replace('/guardian_verify ', '') ?? 'the verification code';
+        return `To complete guardian verification, speak or enter the six-digit code: ${code}. This code expires in ${Math.round((context.ttlSeconds ?? 600) / 60)} minutes.`;
+      }
       return `To complete guardian verification, send ${context.verifyCommand ?? 'the verification command'} within ${context.ttlSeconds ?? 60} seconds.`;
 
     case 'guardian_verify_status_bound':

--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -12,14 +12,16 @@ import {
   createBinding,
   getActiveBinding,
   revokeBinding as storeRevokeBinding,
+  revokePendingChallenges as storeRevokePendingChallenges,
   createChallenge,
   findPendingChallengeByHash,
+  findPendingChallengeForChannel,
   consumeChallenge,
   getRateLimit,
   recordInvalidAttempt,
   resetRateLimit,
 } from '../memory/channel-guardian-store.js';
-import type { GuardianBinding } from '../memory/channel-guardian-store.js';
+import type { GuardianBinding, VerificationChallenge } from '../memory/channel-guardian-store.js';
 import { composeApprovalMessage } from './approval-message-composer.js';
 
 // ---------------------------------------------------------------------------
@@ -67,18 +69,32 @@ function hashSecret(secret: string): string {
 // ---------------------------------------------------------------------------
 
 /**
+ * Generate a six-digit numeric secret for voice channel challenges.
+ * Uses cryptographic randomness to pick a number in [100000, 999999].
+ */
+function generateVoiceSecret(): string {
+  const buf = randomBytes(4);
+  const num = buf.readUInt32BE(0);
+  // Map to the range [100000, 999999] (900000 possible values)
+  return String(100000 + (num % 900000));
+}
+
+/**
  * Create a new verification challenge for a guardian candidate.
  *
- * Generates a random secret, hashes it (SHA-256), and stores the
- * challenge record with a 10-minute TTL. The raw secret is returned
- * so it can be displayed to the user; only the hash is persisted.
+ * For voice channels, generates a six-digit numeric secret that can be
+ * spoken aloud. For all other channels, generates a 32-byte hex secret.
+ *
+ * Hashes the secret (SHA-256) and stores the challenge record with a
+ * 10-minute TTL. The raw secret is returned so it can be displayed to
+ * the user; only the hash is persisted.
  */
 export function createVerificationChallenge(
   assistantId: string,
   channel: string,
   sessionId?: string,
 ): CreateChallengeResult {
-  const secret = randomBytes(32).toString('hex');
+  const secret = channel === 'voice' ? generateVoiceSecret() : randomBytes(32).toString('hex');
   const challengeHash = hashSecret(secret);
   const challengeId = uuid();
   const expiresAt = Date.now() + CHALLENGE_TTL_MS;
@@ -102,6 +118,7 @@ export function createVerificationChallenge(
     ttlSeconds,
     instruction: composeApprovalMessage({
       scenario: 'guardian_verify_challenge_setup',
+      channel,
       verifyCommand,
       ttlSeconds,
     }),
@@ -235,4 +252,28 @@ export function revokeBinding(
   channel: string,
 ): boolean {
   return storeRevokeBinding(assistantId, channel);
+}
+
+/**
+ * Revoke all pending challenges for a given assistant and channel.
+ * Called when the user cancels verification so that stale challenges
+ * don't gate inbound calls.
+ */
+export function revokePendingChallenges(
+  assistantId: string,
+  channel: string,
+): void {
+  storeRevokePendingChallenges(assistantId, channel);
+}
+
+/**
+ * Look up a pending (non-expired) verification challenge for a given
+ * assistant and channel. Used by relay setup to detect whether an active
+ * voice verification session exists.
+ */
+export function getPendingChallenge(
+  assistantId: string,
+  channel: string,
+): VerificationChallenge | null {
+  return findPendingChallengeForChannel(assistantId, channel);
 }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -845,7 +845,7 @@ export class RuntimeHttpServer {
       // the Twilio signature) and reconstruct requests for the existing
       // Twilio route handlers.
       if (endpoint === 'internal/twilio/voice-webhook' && req.method === 'POST') {
-        const json = await req.json() as { params: Record<string, string>; originalUrl?: string };
+        const json = await req.json() as { params: Record<string, string>; originalUrl?: string; assistantId?: string };
         const formBody = new URLSearchParams(json.params).toString();
         // Reconstruct request URL: keep the original URL query string (callSessionId)
         const reconstructedUrl = json.originalUrl ?? req.url;
@@ -854,7 +854,7 @@ export class RuntimeHttpServer {
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
           body: formBody,
         });
-        return await handleVoiceWebhook(fakeReq);
+        return await handleVoiceWebhook(fakeReq, json.assistantId);
       }
 
       if (endpoint === 'internal/twilio/status' && req.method === 'POST') {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -700,6 +700,7 @@ export class RuntimeHttpServer {
         return Response.json({
           sessions: conversations.map((c) => {
             const binding = bindings.get(c.id);
+            const originChannel = parseChannelId(c.originChannel);
             return {
               id: c.id,
               title: c.title ?? 'Untitled',
@@ -714,6 +715,7 @@ export class RuntimeHttpServer {
                   username: binding.username,
                 },
               } : {}),
+              ...(originChannel ? { conversationOriginChannel: originChannel } : {}),
             };
           }),
           hasMore: offset + conversations.length < totalCount,

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -2000,9 +2000,25 @@ async function handleApprovalInterception(
                 assistantId,
               );
             }
+
+            return { handled: true, type: 'guardian_decision_applied' };
           }
 
-          return { handled: true, type: 'guardian_decision_applied' };
+          // Race condition: run was already resolved. Deliver stale notice.
+          try {
+            const staleText = await composeApprovalMessageGenerative({
+              scenario: 'approval_already_resolved',
+              channel: sourceChannel,
+            }, {}, approvalCopyGenerator);
+            await deliverChannelReply(replyCallbackUrl, {
+              chatId: externalChatId,
+              text: staleText,
+              assistantId,
+            }, bearerToken);
+          } catch (err) {
+            log.error({ err, conversationId: targetLegacyApproval.conversationId }, 'Failed to deliver stale guardian legacy fallback notice');
+          }
+          return { handled: true, type: 'stale_ignored' };
         }
 
         // No decision could be parsed — send a generic reminder to the guardian
@@ -2243,24 +2259,29 @@ async function handleApprovalInterception(
 
       const result = handleChannelDecision(conversationId, cbDecision, orchestrator);
 
-      // Schedule a background poll for run terminal state and deliver the reply.
-      // This handles the case where the original poll in
-      // processChannelMessageWithApprovals has already exited due to timeout.
-      // The claimRunDelivery guard ensures at-most-once delivery when both
-      // pollers race to terminal state.
-      if (result.applied && result.runId) {
-        schedulePostDecisionDelivery(
-          orchestrator,
-          result.runId,
-          conversationId,
-          externalChatId,
-          replyCallbackUrl,
-          bearerToken,
-          assistantId,
-        );
+      if (result.applied) {
+        // Schedule a background poll for run terminal state and deliver the reply.
+        // This handles the case where the original poll in
+        // processChannelMessageWithApprovals has already exited due to timeout.
+        // The claimRunDelivery guard ensures at-most-once delivery when both
+        // pollers race to terminal state.
+        if (result.runId) {
+          schedulePostDecisionDelivery(
+            orchestrator,
+            result.runId,
+            conversationId,
+            externalChatId,
+            replyCallbackUrl,
+            bearerToken,
+            assistantId,
+          );
+        }
+        return { handled: true, type: 'decision_applied' };
       }
 
-      return { handled: true, type: 'decision_applied' };
+      // Race condition: run was already resolved between the stale check
+      // above and the decision attempt.
+      return { handled: true, type: 'stale_ignored' };
     }
   }
 
@@ -2401,18 +2422,36 @@ async function handleApprovalInterception(
         }
       }
       const result = handleChannelDecision(conversationId, legacyDecision, orchestrator);
-      if (result.applied && result.runId) {
-        schedulePostDecisionDelivery(
-          orchestrator,
-          result.runId,
-          conversationId,
-          externalChatId,
-          replyCallbackUrl,
-          bearerToken,
-          assistantId,
-        );
+      if (result.applied) {
+        if (result.runId) {
+          schedulePostDecisionDelivery(
+            orchestrator,
+            result.runId,
+            conversationId,
+            externalChatId,
+            replyCallbackUrl,
+            bearerToken,
+            assistantId,
+          );
+        }
+        return { handled: true, type: 'decision_applied' };
       }
-      return { handled: true, type: 'decision_applied' };
+
+      // Race condition: run was already resolved.
+      try {
+        const staleText = await composeApprovalMessageGenerative({
+          scenario: 'approval_already_resolved',
+          channel: sourceChannel,
+        }, {}, approvalCopyGenerator);
+        await deliverChannelReply(replyCallbackUrl, {
+          chatId: externalChatId,
+          text: staleText,
+          assistantId,
+        }, bearerToken);
+      } catch (err) {
+        log.error({ err, conversationId }, 'Failed to deliver stale approval notice (legacy path)');
+      }
+      return { handled: true, type: 'stale_ignored' };
     }
   }
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -11,8 +11,7 @@ import {
 import * as conversationStore from '../../memory/conversation-store.js';
 import * as attachmentsStore from '../../memory/attachments-store.js';
 import { renderHistoryContent, mergeToolResults } from '../../daemon/handlers.js';
-import { getConfig } from '../../config/loader.js';
-import { getFailoverProvider, listProviders } from '../../providers/registry.js';
+import { getConfiguredProvider } from '../../providers/provider-send-message.js';
 import type { Provider } from '../../providers/types.js';
 import type {
   MessageProcessor,
@@ -313,10 +312,9 @@ export async function handleGetSuggestion(
     }
 
     // Try LLM suggestion using the configured provider
-    const config = getConfig();
-    if (listProviders().includes(config.provider)) {
+    const provider = getConfiguredProvider();
+    if (provider) {
       try {
-        const provider = getFailoverProvider(config.provider, config.providerOrder);
         // Deduplicate concurrent requests
         let promise = suggestionInFlight.get(msg.id);
         if (!promise) {

--- a/assistant/src/tools/credentials/post-connect-hooks.ts
+++ b/assistant/src/tools/credentials/post-connect-hooks.ts
@@ -1,0 +1,61 @@
+/**
+ * Post-connect hooks for OAuth2 services.
+ *
+ * This module decouples provider-specific post-connection side effects
+ * (e.g. sending a welcome DM after Slack OAuth) from the generic vault
+ * OAuth2 flow. Each hook is keyed by canonical service name and receives
+ * the raw token response so it can perform provider-specific actions.
+ */
+
+import { authTest, conversationsOpen, postMessage } from '../../messaging/providers/slack/client.js';
+import { getLogger } from '../../util/logger.js';
+
+const log = getLogger('post-connect-hooks');
+
+export interface PostConnectHookContext {
+  service: string;
+  rawTokenResponse: Record<string, unknown>;
+}
+
+type PostConnectHook = (ctx: PostConnectHookContext) => Promise<void>;
+
+// ---------------------------------------------------------------------------
+// Provider-specific hooks
+// ---------------------------------------------------------------------------
+
+async function slackWelcomeDM(ctx: PostConnectHookContext): Promise<void> {
+  const botToken = ctx.rawTokenResponse.access_token as string | undefined;
+  const authedUser = ctx.rawTokenResponse.authed_user as Record<string, unknown> | undefined;
+  const installingUserId = authedUser?.id as string | undefined;
+  if (!botToken || !installingUserId) return;
+
+  const identity = await authTest(botToken);
+  const dmChannel = await conversationsOpen(botToken, installingUserId);
+  const welcomeMsg =
+    `You have installed ${identity.user}, an AI Assistant, on ${identity.team}. ` +
+    `You can manage the assistant experience for this workspace by chatting with the assistant or from the Settings page.`;
+  await postMessage(botToken, dmChannel.channel.id, welcomeMsg);
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+const POST_CONNECT_HOOKS: Record<string, PostConnectHook> = {
+  'integration:slack': slackWelcomeDM,
+};
+
+/**
+ * Run the post-connect hook for a service, if one is registered.
+ * Failures are logged but never propagated -- they must not break the OAuth flow.
+ */
+export async function runPostConnectHook(ctx: PostConnectHookContext): Promise<void> {
+  const hook = POST_CONNECT_HOOKS[ctx.service];
+  if (!hook) return;
+
+  try {
+    await hook(ctx);
+  } catch (err) {
+    log.warn({ err, service: ctx.service }, 'Post-connect hook failed (non-fatal)');
+  }
+}

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -14,7 +14,7 @@ import { validatePolicyInput, toPolicyFromInput } from './policy-validate.js';
 import type { CredentialPolicyInput, CredentialInjectionTemplate } from './policy-types.js';
 import { credentialBroker } from './broker.js';
 import { startOAuth2Flow, type TokenEndpointAuthMethod } from '../../security/oauth2.js';
-import { authTest, conversationsOpen, postMessage } from '../../messaging/providers/slack/client.js';
+import { runPostConnectHook } from './post-connect-hooks.js';
 import { getConfig } from '../../config/loader.js';
 import { getLogger } from '../../util/logger.js';
 
@@ -661,24 +661,8 @@ class CredentialStoreTool implements Tool {
             }
           }
 
-          // Send a welcome DM for Slack connections
-          if (service === 'integration:slack') {
-            try {
-              const botToken = rawTokenResponse.access_token as string | undefined;
-              const authedUser = rawTokenResponse.authed_user as Record<string, unknown> | undefined;
-              const installingUserId = authedUser?.id as string | undefined;
-              if (botToken && installingUserId) {
-                const identity = await authTest(botToken);
-                const dmChannel = await conversationsOpen(botToken, installingUserId);
-                const welcomeMsg =
-                  `You have installed ${identity.user}, an AI Assistant, on ${identity.team}. ` +
-                  `You can manage the assistant experience for this workspace by chatting with the assistant or from the Settings page.`;
-                await postMessage(botToken, dmChannel.channel.id, welcomeMsg);
-              }
-            } catch (err) {
-              log.warn({ err }, 'Failed to send Slack welcome DM (non-fatal)');
-            }
-          }
+          // Run any provider-specific post-connect actions (e.g. Slack welcome DM)
+          await runPostConnectHook({ service, rawTokenResponse });
 
           return {
             content: `Successfully connected "${service}"${accountInfo ? ` as ${accountInfo}` : ''}. The service is now ready to use.`,

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -61,6 +61,7 @@ struct SettingsConnectTab: View {
             refreshBearerToken()
             store.refreshChannelGuardianStatus(channel: "telegram")
             store.refreshChannelGuardianStatus(channel: "sms")
+            store.refreshChannelGuardianStatus(channel: "voice")
             gatewayExpanded = store.ingressPublicBaseUrl.isEmpty
         }
         .onChange(of: store.ingressPublicBaseUrl) { _, newValue in
@@ -573,6 +574,9 @@ struct SettingsConnectTab: View {
                     value: store.twilioPhoneNumber ?? "",
                     valueFont: VFont.mono
                 )
+
+                Divider().background(VColor.surfaceBorder)
+                guardianStatusRow(channel: "voice")
             } else if store.twilioHasCredentials {
                 channelStatusRow(
                     label: "Credentials",
@@ -797,6 +801,11 @@ struct SettingsConnectTab: View {
                !displayName.isEmpty {
                 return displayName
             }
+        } else if channel == "voice" {
+            if let displayName = store.voiceGuardianDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !displayName.isEmpty {
+                return displayName
+            }
         }
         return identity
     }
@@ -816,11 +825,46 @@ struct SettingsConnectTab: View {
 
     @ViewBuilder
     private func guardianStatusRow(channel: String) -> some View {
-        let identity: String? = channel == "telegram" ? store.telegramGuardianIdentity : store.smsGuardianIdentity
-        let verified: Bool = channel == "telegram" ? store.telegramGuardianVerified : store.smsGuardianVerified
-        let inProgress: Bool = channel == "telegram" ? store.telegramGuardianVerificationInProgress : store.smsGuardianVerificationInProgress
-        let instruction: String? = channel == "telegram" ? store.telegramGuardianInstruction : store.smsGuardianInstruction
-        let error: String? = channel == "telegram" ? store.telegramGuardianError : store.smsGuardianError
+        let identity: String? = {
+            switch channel {
+            case "telegram": return store.telegramGuardianIdentity
+            case "sms": return store.smsGuardianIdentity
+            case "voice": return store.voiceGuardianIdentity
+            default: return nil
+            }
+        }()
+        let verified: Bool = {
+            switch channel {
+            case "telegram": return store.telegramGuardianVerified
+            case "sms": return store.smsGuardianVerified
+            case "voice": return store.voiceGuardianVerified
+            default: return false
+            }
+        }()
+        let inProgress: Bool = {
+            switch channel {
+            case "telegram": return store.telegramGuardianVerificationInProgress
+            case "sms": return store.smsGuardianVerificationInProgress
+            case "voice": return store.voiceGuardianVerificationInProgress
+            default: return false
+            }
+        }()
+        let instruction: String? = {
+            switch channel {
+            case "telegram": return store.telegramGuardianInstruction
+            case "sms": return store.smsGuardianInstruction
+            case "voice": return store.voiceGuardianInstruction
+            default: return nil
+            }
+        }()
+        let error: String? = {
+            switch channel {
+            case "telegram": return store.telegramGuardianError
+            case "sms": return store.smsGuardianError
+            case "voice": return store.voiceGuardianError
+            default: return nil
+            }
+        }()
         let primaryIdentity = guardianPrimaryIdentity(channel: channel, identity: identity)
         let secondaryIdentity = guardianSecondaryIdentity(primary: primaryIdentity, identity: identity)
         let telegramProfileURL: URL? = channel == "telegram"
@@ -910,6 +954,9 @@ struct SettingsConnectTab: View {
         if channel == "telegram" {
             let handle = store.telegramBotUsername.map { "@\($0)" } ?? "your bot"
             return "Message \(handle) with the below command within the next 10 minutes"
+        } else if channel == "voice" {
+            let number = store.twilioPhoneNumber ?? "your assistant"
+            return "Call \(number) and say the six-digit code below within the next 10 minutes"
         } else {
             let number = store.twilioPhoneNumber ?? "your assistant"
             return "Text \(number) with the below command within the next 10 minutes"
@@ -924,9 +971,28 @@ struct SettingsConnectTab: View {
         return String(instruction[range]).trimmingCharacters(in: CharacterSet(charactersIn: "`"))
     }
 
+    /// Extracts a six-digit verification code from voice-style instruction text.
+    /// Voice instructions use a format like "...six-digit code: 123456..." instead of the
+    /// `/guardian_verify <hex>` command used by Telegram and SMS channels.
+    private func extractVoiceGuardianCode(from instruction: String) -> String? {
+        guard let range = instruction.range(of: #"six-digit code:\s*(\d{6})"#, options: .regularExpression) else {
+            return nil
+        }
+        let match = String(instruction[range])
+        // Extract just the digits from "six-digit code: 123456"
+        guard let digitRange = match.range(of: #"\d{6}"#, options: .regularExpression) else {
+            return nil
+        }
+        return String(match[digitRange])
+    }
+
     @ViewBuilder
     private func guardianInstructionView(channel: String, instruction: String) -> some View {
-        let command = extractGuardianCommand(from: instruction)
+        // Voice uses a different instruction format ("six-digit code: 123456") vs
+        // Telegram/SMS which use "/guardian_verify <hex>".
+        let command: String? = channel == "voice"
+            ? extractVoiceGuardianCode(from: instruction)
+            : extractGuardianCommand(from: instruction)
         let isCopied = guardianCommandCopiedChannel == channel
 
         VStack(alignment: .leading, spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -115,6 +115,16 @@ public final class SettingsStore: ObservableObject {
     @Published var smsGuardianInstruction: String?
     @Published var smsGuardianError: String?
 
+    // MARK: - Channel Guardian State (Voice)
+
+    @Published var voiceGuardianIdentity: String?
+    @Published var voiceGuardianUsername: String?
+    @Published var voiceGuardianDisplayName: String?
+    @Published var voiceGuardianVerified: Bool = false
+    @Published var voiceGuardianVerificationInProgress: Bool = false
+    @Published var voiceGuardianInstruction: String?
+    @Published var voiceGuardianError: String?
+
     // MARK: - Email Integration State
 
     @Published var assistantEmail: String?
@@ -435,6 +445,23 @@ public final class SettingsStore: ObservableObject {
                 } else {
                     self.smsGuardianError = response.error
                 }
+            case "voice":
+                self.voiceGuardianVerificationInProgress = false
+                if response.success {
+                    self.voiceGuardianIdentity = response.guardianExternalUserId
+                    self.voiceGuardianUsername = Self.reflectedString(response, key: "guardianUsername")
+                    self.voiceGuardianDisplayName = Self.reflectedString(response, key: "guardianDisplayName")
+                    let isVerified = response.bound ?? false
+                    self.voiceGuardianVerified = isVerified
+                    if isVerified {
+                        self.voiceGuardianInstruction = nil
+                    } else if let instruction = response.instruction {
+                        self.voiceGuardianInstruction = instruction
+                    }
+                    self.voiceGuardianError = nil
+                } else {
+                    self.voiceGuardianError = response.error
+                }
             default:
                 break
             }
@@ -472,6 +499,7 @@ public final class SettingsStore: ObservableObject {
         // Refresh channel guardian status on init
         refreshChannelGuardianStatus(channel: "telegram")
         refreshChannelGuardianStatus(channel: "sms")
+        refreshChannelGuardianStatus(channel: "voice")
 
         // Ingress config is refreshed by onAppear in SettingsPanel,
         // not here, to avoid duplicate get requests whose
@@ -891,6 +919,10 @@ public final class SettingsStore: ObservableObject {
             smsGuardianVerificationInProgress = true
             smsGuardianError = nil
             smsGuardianInstruction = nil
+        case "voice":
+            voiceGuardianVerificationInProgress = true
+            voiceGuardianError = nil
+            voiceGuardianInstruction = nil
         default:
             return
         }
@@ -904,6 +936,9 @@ public final class SettingsStore: ObservableObject {
                 case "sms":
                     smsGuardianVerificationInProgress = false
                     smsGuardianError = "Daemon is not connected. Reconnect and try again."
+                case "voice":
+                    voiceGuardianVerificationInProgress = false
+                    voiceGuardianError = "Daemon is not connected. Reconnect and try again."
                 default:
                     break
                 }
@@ -922,6 +957,9 @@ public final class SettingsStore: ObservableObject {
             case "sms":
                 smsGuardianVerificationInProgress = false
                 smsGuardianError = "Failed to start verification. Try again."
+            case "voice":
+                voiceGuardianVerificationInProgress = false
+                voiceGuardianError = "Failed to start verification. Try again."
             default:
                 break
             }
@@ -938,6 +976,9 @@ public final class SettingsStore: ObservableObject {
         case "sms":
             smsGuardianVerificationInProgress = false
             smsGuardianInstruction = nil
+        case "voice":
+            voiceGuardianVerificationInProgress = false
+            voiceGuardianInstruction = nil
         default:
             break
         }
@@ -959,6 +1000,8 @@ public final class SettingsStore: ObservableObject {
             telegramGuardianInstruction = nil
         case "sms":
             smsGuardianInstruction = nil
+        case "voice":
+            voiceGuardianInstruction = nil
         default:
             break
         }
@@ -976,8 +1019,14 @@ public final class SettingsStore: ObservableObject {
         if let pendingGuardianChallengeChannel {
             return pendingGuardianChallengeChannel
         }
-        if telegramGuardianVerificationInProgress != smsGuardianVerificationInProgress {
-            return telegramGuardianVerificationInProgress ? "telegram" : "sms"
+        // Disambiguate when exactly one channel has verification in progress
+        let inProgressChannels = [
+            ("telegram", telegramGuardianVerificationInProgress),
+            ("sms", smsGuardianVerificationInProgress),
+            ("voice", voiceGuardianVerificationInProgress),
+        ].filter(\.1)
+        if inProgressChannels.count == 1 {
+            return inProgressChannels.first?.0
         }
         return nil
     }
@@ -995,6 +1044,8 @@ public final class SettingsStore: ObservableObject {
             telegramGuardianInstruction = nil
         case "sms":
             smsGuardianInstruction = nil
+        case "voice":
+            voiceGuardianInstruction = nil
         default:
             break
         }
@@ -1019,6 +1070,12 @@ public final class SettingsStore: ObservableObject {
                 if self.smsGuardianError == nil {
                     self.smsGuardianError = "Timed out waiting for verification instructions. Try again."
                 }
+            case "voice":
+                self.voiceGuardianVerificationInProgress = false
+                self.voiceGuardianInstruction = nil
+                if self.voiceGuardianError == nil {
+                    self.voiceGuardianError = "Timed out waiting for verification instructions. Try again."
+                }
             default:
                 break
             }
@@ -1028,7 +1085,7 @@ public final class SettingsStore: ObservableObject {
     }
 
     private func startGuardianStatusPolling(for channel: String) {
-        guard channel == "telegram" || channel == "sms" else { return }
+        guard channel == "telegram" || channel == "sms" || channel == "voice" else { return }
         stopGuardianStatusPolling(for: channel)
         guardianStatusPollingDeadlines[channel] = Date().addingTimeInterval(guardianStatusPollWindow)
         scheduleGuardianStatusPoll(for: channel, delay: guardianStatusPollInterval)

--- a/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
@@ -52,6 +52,12 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         XCTAssertFalse(store.smsGuardianVerificationInProgress)
         XCTAssertNil(store.smsGuardianInstruction)
         XCTAssertNil(store.smsGuardianError)
+
+        XCTAssertNil(store.voiceGuardianIdentity)
+        XCTAssertFalse(store.voiceGuardianVerified)
+        XCTAssertFalse(store.voiceGuardianVerificationInProgress)
+        XCTAssertNil(store.voiceGuardianInstruction)
+        XCTAssertNil(store.voiceGuardianError)
     }
 
     // MARK: - refreshChannelGuardianStatus
@@ -467,10 +473,13 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         // None of these should crash
         orphanStore.refreshChannelGuardianStatus(channel: "telegram")
         orphanStore.refreshChannelGuardianStatus(channel: "sms")
+        orphanStore.refreshChannelGuardianStatus(channel: "voice")
         orphanStore.startChannelGuardianVerification(channel: "telegram")
         orphanStore.startChannelGuardianVerification(channel: "sms")
+        orphanStore.startChannelGuardianVerification(channel: "voice")
         orphanStore.revokeChannelGuardian(channel: "telegram")
         orphanStore.revokeChannelGuardian(channel: "sms")
+        orphanStore.revokeChannelGuardian(channel: "voice")
     }
 
     // MARK: - Successful response clears previous error
@@ -524,17 +533,20 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
 
     // MARK: - Init sends status requests for both channels
 
-    func testInitSendsGuardianStatusRequestsForBothChannels() {
+    func testInitSendsGuardianStatusRequestsForAllChannels() {
         let guardianMessages = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
         let statusMessages = guardianMessages.filter { $0.action == "status" }
 
         let telegramStatus = statusMessages.filter { $0.channel == "telegram" }
         let smsStatus = statusMessages.filter { $0.channel == "sms" }
+        let voiceStatus = statusMessages.filter { $0.channel == "voice" }
 
         XCTAssertEqual(telegramStatus.count, 1)
         XCTAssertEqual(smsStatus.count, 1)
+        XCTAssertEqual(voiceStatus.count, 1)
         XCTAssertEqual(telegramStatus.first?.assistantId, testAssistantId)
         XCTAssertEqual(smsStatus.first?.assistantId, testAssistantId)
+        XCTAssertEqual(voiceStatus.first?.assistantId, testAssistantId)
     }
 
     func testStatusPollResponseDoesNotClearGuardianChallengePending() {
@@ -704,5 +716,132 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         // The SMS timeout should have fired, clearing the spinner and setting an error
         XCTAssertFalse(shortTimeoutStore.smsGuardianVerificationInProgress)
         XCTAssertEqual(shortTimeoutStore.smsGuardianError, "Timed out waiting for verification instructions. Try again.")
+    }
+
+    // MARK: - Voice Guardian Verification
+
+    func testStartVoiceVerificationSetsInProgressAndSendsChallenge() {
+        store.startChannelGuardianVerification(channel: "voice")
+
+        XCTAssertTrue(store.voiceGuardianVerificationInProgress)
+        XCTAssertNil(store.voiceGuardianError)
+
+        let guardianMessages = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
+        let challengeMessages = guardianMessages.filter { $0.action == "create_challenge" && $0.channel == "voice" }
+        XCTAssertEqual(challengeMessages.count, 1)
+        XCTAssertEqual(challengeMessages.first?.assistantId, testAssistantId)
+    }
+
+    func testSuccessfulStatusResponseUpdatesVoiceGuardianState() {
+        daemonClient.onGuardianVerificationResponse?(GuardianVerificationResponseMessage(
+            type: "guardian_verification_response",
+            success: true,
+            secret: nil,
+            instruction: nil,
+            bound: true,
+            guardianExternalUserId: "+15559876543",
+            channel: "voice",
+            assistantId: "self",
+            guardianDeliveryChatId: nil,
+            error: nil
+        ))
+
+        let predicate = NSPredicate { _, _ in self.store.voiceGuardianVerified }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(store.voiceGuardianIdentity, "+15559876543")
+        XCTAssertTrue(store.voiceGuardianVerified)
+        XCTAssertFalse(store.voiceGuardianVerificationInProgress)
+        XCTAssertNil(store.voiceGuardianError)
+    }
+
+    func testFailedResponseSetsVoiceError() {
+        store.voiceGuardianVerificationInProgress = true
+
+        daemonClient.onGuardianVerificationResponse?(GuardianVerificationResponseMessage(
+            type: "guardian_verification_response",
+            success: false,
+            secret: nil,
+            instruction: nil,
+            bound: nil,
+            guardianExternalUserId: nil,
+            channel: "voice",
+            assistantId: "self",
+            guardianDeliveryChatId: nil,
+            error: "Voice channel not configured"
+        ))
+
+        let predicate = NSPredicate { _, _ in !self.store.voiceGuardianVerificationInProgress }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertFalse(store.voiceGuardianVerificationInProgress)
+        XCTAssertEqual(store.voiceGuardianError, "Voice channel not configured")
+    }
+
+    func testRevokeVoiceGuardianSendsRevokeAction() {
+        store.revokeChannelGuardian(channel: "voice")
+
+        let guardianMessages = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
+        let revokeMessages = guardianMessages.filter { $0.action == "revoke" && $0.channel == "voice" }
+        XCTAssertEqual(revokeMessages.count, 1)
+        XCTAssertEqual(revokeMessages.first?.assistantId, testAssistantId)
+    }
+
+    func testRevokeVoiceGuardianClearsInstruction() {
+        store.voiceGuardianInstruction = "Call and say 123456"
+
+        store.revokeChannelGuardian(channel: "voice")
+
+        XCTAssertNil(store.voiceGuardianInstruction)
+    }
+
+    func testTimeoutClearsVoiceInstruction() {
+        sentMessages.removeAll()
+        let shortTimeoutStore = SettingsStore(
+            daemonClient: daemonClient,
+            guardianChallengeTimeoutDuration: 0.15,
+            guardianStatusPollInterval: 0.05,
+            guardianStatusPollWindow: 2.0
+        )
+
+        shortTimeoutStore.startChannelGuardianVerification(channel: "voice")
+
+        shortTimeoutStore.voiceGuardianInstruction = "Call and say 123456"
+
+        let predicate = NSPredicate { _, _ in
+            shortTimeoutStore.voiceGuardianError != nil
+        }
+        let timeoutExpectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [timeoutExpectation], timeout: 2.0)
+
+        XCTAssertNil(shortTimeoutStore.voiceGuardianInstruction)
+        XCTAssertFalse(shortTimeoutStore.voiceGuardianVerificationInProgress)
+    }
+
+    func testVoiceResponseDoesNotAffectTelegramOrSmsState() {
+        daemonClient.onGuardianVerificationResponse?(GuardianVerificationResponseMessage(
+            type: "guardian_verification_response",
+            success: true,
+            secret: nil,
+            instruction: nil,
+            bound: true,
+            guardianExternalUserId: "+15559876543",
+            channel: "voice",
+            assistantId: "self",
+            guardianDeliveryChatId: nil,
+            error: nil
+        ))
+
+        let predicate = NSPredicate { _, _ in self.store.voiceGuardianVerified }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        wait(for: [expectation], timeout: 2.0)
+
+        // Telegram and SMS should be unaffected
+        XCTAssertNil(store.telegramGuardianIdentity)
+        XCTAssertFalse(store.telegramGuardianVerified)
+        XCTAssertNil(store.smsGuardianIdentity)
+        XCTAssertFalse(store.smsGuardianVerified)
     }
 }

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -372,50 +372,55 @@ public final class ChatAttachmentManager: ObservableObject {
         }
 
         #if os(macOS)
-        // NSImage, tiffRepresentation, and NSBitmapImageRep are not thread-safe
-        // off the main thread. This method is nonisolated and called from
-        // Task.detached, so we must hop AppKit work onto the main thread.
-        let compressBlock = { () -> (Data, Bool) in
-            guard let image = NSImage(data: data),
-                  let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
-                return (data, false)
-            }
+        // Only NSImage/NSBitmapImageRep calls need the main thread; keep
+        // the CPU-heavy CGContext resize and encoding work off it.
 
-            let originalWidth = CGFloat(cgImage.width)
-            let originalHeight = CGFloat(cgImage.height)
-            guard originalWidth > 0 && originalHeight > 0 else {
-                return (data, false)
-            }
+        // Step 1 (AppKit – main thread): extract a CGImage from the raw data.
+        let extractBlock = { () -> CGImage? in
+            guard let image = NSImage(data: data) else { return nil }
+            return image.cgImage(forProposedRect: nil, context: nil, hints: nil)
+        }
+        guard let cgImage = Thread.isMainThread ? extractBlock() : DispatchQueue.main.sync(execute: extractBlock) else {
+            return (data, false)
+        }
 
-            // Calculate scale factor needed to reduce file size
-            // Rough heuristic: file size scales roughly with pixel count
-            let sizeReduction = Double(maxSize) / Double(data.count)
-            let pixelReduction = sqrt(sizeReduction * 0.85) // Target 85% of max for safety margin
-            let scale = min(CGFloat(pixelReduction), 1.0)
+        let originalWidth = CGFloat(cgImage.width)
+        let originalHeight = CGFloat(cgImage.height)
+        guard originalWidth > 0 && originalHeight > 0 else {
+            return (data, false)
+        }
 
-            let newWidth = Int(originalWidth * scale)
-            let newHeight = Int(originalHeight * scale)
+        // Step 2 (background): CoreGraphics resize – no AppKit required.
+        let sizeReduction = Double(maxSize) / Double(data.count)
+        let pixelReduction = sqrt(sizeReduction * 0.85) // Target 85% of max for safety margin
+        let scale = min(CGFloat(pixelReduction), 1.0)
 
-            guard let colorSpace = cgImage.colorSpace,
-                  let context = CGContext(
-                    data: nil,
-                    width: newWidth,
-                    height: newHeight,
-                    bitsPerComponent: 8,
-                    bytesPerRow: 0,
-                    space: colorSpace,
-                    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-                  ) else {
-                return (data, false)
-            }
+        let newWidth = Int(originalWidth * scale)
+        let newHeight = Int(originalHeight * scale)
 
-            context.interpolationQuality = .high
-            context.draw(cgImage, in: CGRect(x: 0, y: 0, width: newWidth, height: newHeight))
+        guard let colorSpace = cgImage.colorSpace,
+              let context = CGContext(
+                data: nil,
+                width: newWidth,
+                height: newHeight,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+              ) else {
+            return (data, false)
+        }
 
-            guard let scaledCGImage = context.makeImage() else {
-                return (data, false)
-            }
+        context.interpolationQuality = .high
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: newWidth, height: newHeight))
 
+        guard let scaledCGImage = context.makeImage() else {
+            return (data, false)
+        }
+
+        // Step 3 (AppKit – main thread): encode the scaled CGImage via
+        // NSImage/NSBitmapImageRep (tiffRepresentation is not thread-safe).
+        let encodeBlock = { () -> (Data, Bool) in
             let scaledImage = NSImage(cgImage: scaledCGImage, size: NSSize(width: newWidth, height: newHeight))
 
             // Try JPEG compression first (better for photos)
@@ -441,7 +446,7 @@ public final class ChatAttachmentManager: ObservableObject {
             log.warning("Failed to compress image to \(maxSize) bytes, final size: \(data.count)")
             return (data, false)
         }
-        return Thread.isMainThread ? compressBlock() : DispatchQueue.main.sync(execute: compressBlock)
+        return Thread.isMainThread ? encodeBlock() : DispatchQueue.main.sync(execute: encodeBlock)
 
         #elseif os(iOS)
         guard let image = UIImage(data: data) else {

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -372,70 +372,76 @@ public final class ChatAttachmentManager: ObservableObject {
         }
 
         #if os(macOS)
-        guard let image = NSImage(data: data),
-              let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
-            return (data, false)
-        }
-
-        let originalWidth = CGFloat(cgImage.width)
-        let originalHeight = CGFloat(cgImage.height)
-        guard originalWidth > 0 && originalHeight > 0 else {
-            return (data, false)
-        }
-
-        // Calculate scale factor needed to reduce file size
-        // Rough heuristic: file size scales roughly with pixel count
-        let sizeReduction = Double(maxSize) / Double(data.count)
-        let pixelReduction = sqrt(sizeReduction * 0.85) // Target 85% of max for safety margin
-        let scale = min(CGFloat(pixelReduction), 1.0)
-
-        let newWidth = Int(originalWidth * scale)
-        let newHeight = Int(originalHeight * scale)
-
-        guard let colorSpace = cgImage.colorSpace,
-              let context = CGContext(
-                data: nil,
-                width: newWidth,
-                height: newHeight,
-                bitsPerComponent: 8,
-                bytesPerRow: 0,
-                space: colorSpace,
-                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-              ) else {
-            return (data, false)
-        }
-
-        context.interpolationQuality = .high
-        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: newWidth, height: newHeight))
-
-        guard let scaledCGImage = context.makeImage() else {
-            return (data, false)
-        }
-
-        let scaledImage = NSImage(cgImage: scaledCGImage, size: NSSize(width: newWidth, height: newHeight))
-
-        // Try JPEG compression first (better for photos)
-        if let tiffData = scaledImage.tiffRepresentation,
-           let bitmap = NSBitmapImageRep(data: tiffData),
-           let jpeg = bitmap.representation(using: .jpeg, properties: [.compressionFactor: 0.75]) {
-            if jpeg.count <= maxSize {
-                log.info("Compressed image from \(data.count) to \(jpeg.count) bytes (JPEG, \(newWidth)×\(newHeight))")
-                return (jpeg, true)
+        // NSImage, tiffRepresentation, and NSBitmapImageRep are not thread-safe
+        // off the main thread. This method is nonisolated and called from
+        // Task.detached, so we must hop AppKit work onto the main thread.
+        let compressBlock = { () -> (Data, Bool) in
+            guard let image = NSImage(data: data),
+                  let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+                return (data, false)
             }
-        }
 
-        // Fallback: try PNG
-        if let tiffData = scaledImage.tiffRepresentation,
-           let bitmap = NSBitmapImageRep(data: tiffData),
-           let png = bitmap.representation(using: .png, properties: [:]) {
-            if png.count <= maxSize {
-                log.info("Compressed image from \(data.count) to \(png.count) bytes (PNG, \(newWidth)×\(newHeight))")
-                return (png, true)
+            let originalWidth = CGFloat(cgImage.width)
+            let originalHeight = CGFloat(cgImage.height)
+            guard originalWidth > 0 && originalHeight > 0 else {
+                return (data, false)
             }
-        }
 
-        log.warning("Failed to compress image to \(maxSize) bytes, final size: \(data.count)")
-        return (data, false)
+            // Calculate scale factor needed to reduce file size
+            // Rough heuristic: file size scales roughly with pixel count
+            let sizeReduction = Double(maxSize) / Double(data.count)
+            let pixelReduction = sqrt(sizeReduction * 0.85) // Target 85% of max for safety margin
+            let scale = min(CGFloat(pixelReduction), 1.0)
+
+            let newWidth = Int(originalWidth * scale)
+            let newHeight = Int(originalHeight * scale)
+
+            guard let colorSpace = cgImage.colorSpace,
+                  let context = CGContext(
+                    data: nil,
+                    width: newWidth,
+                    height: newHeight,
+                    bitsPerComponent: 8,
+                    bytesPerRow: 0,
+                    space: colorSpace,
+                    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+                  ) else {
+                return (data, false)
+            }
+
+            context.interpolationQuality = .high
+            context.draw(cgImage, in: CGRect(x: 0, y: 0, width: newWidth, height: newHeight))
+
+            guard let scaledCGImage = context.makeImage() else {
+                return (data, false)
+            }
+
+            let scaledImage = NSImage(cgImage: scaledCGImage, size: NSSize(width: newWidth, height: newHeight))
+
+            // Try JPEG compression first (better for photos)
+            if let tiffData = scaledImage.tiffRepresentation,
+               let bitmap = NSBitmapImageRep(data: tiffData),
+               let jpeg = bitmap.representation(using: .jpeg, properties: [.compressionFactor: 0.75]) {
+                if jpeg.count <= maxSize {
+                    log.info("Compressed image from \(data.count) to \(jpeg.count) bytes (JPEG, \(newWidth)×\(newHeight))")
+                    return (jpeg, true)
+                }
+            }
+
+            // Fallback: try PNG
+            if let tiffData = scaledImage.tiffRepresentation,
+               let bitmap = NSBitmapImageRep(data: tiffData),
+               let png = bitmap.representation(using: .png, properties: [:]) {
+                if png.count <= maxSize {
+                    log.info("Compressed image from \(data.count) to \(png.count) bytes (PNG, \(newWidth)×\(newHeight))")
+                    return (png, true)
+                }
+            }
+
+            log.warning("Failed to compress image to \(maxSize) bytes, final size: \(data.count)")
+            return (data, false)
+        }
+        return Thread.isMainThread ? compressBlock() : DispatchQueue.main.sync(execute: compressBlock)
 
         #elseif os(iOS)
         guard let image = UIImage(data: data) else {

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1897,9 +1897,11 @@ public struct IPCGuardianVerificationResponse: Codable, Sendable {
     public let guardianUsername: String?
     /// Optional display name for the bound guardian (for UI display).
     public let guardianDisplayName: String?
+    /// Whether a pending verification challenge exists for this (assistantId, channel). Used by relay setup to detect active voice verification sessions.
+    public let hasPendingChallenge: Bool?
     public let error: String?
 
-    public init(type: String, success: Bool, secret: String? = nil, instruction: String? = nil, bound: Bool? = nil, guardianExternalUserId: String? = nil, channel: String? = nil, assistantId: String? = nil, guardianDeliveryChatId: String? = nil, guardianUsername: String? = nil, guardianDisplayName: String? = nil, error: String? = nil) {
+    public init(type: String, success: Bool, secret: String? = nil, instruction: String? = nil, bound: Bool? = nil, guardianExternalUserId: String? = nil, channel: String? = nil, assistantId: String? = nil, guardianDeliveryChatId: String? = nil, guardianUsername: String? = nil, guardianDisplayName: String? = nil, hasPendingChallenge: Bool? = nil, error: String? = nil) {
         self.type = type
         self.success = success
         self.secret = secret
@@ -1911,6 +1913,7 @@ public struct IPCGuardianVerificationResponse: Codable, Sendable {
         self.guardianDeliveryChatId = guardianDeliveryChatId
         self.guardianUsername = guardianUsername
         self.guardianDisplayName = guardianDisplayName
+        self.hasPendingChallenge = hasPendingChallenge
         self.error = error
     }
 }

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -25,6 +25,7 @@ struct ConversationsListResponse: Decodable {
         let threadType: String?
         let source: String?
         let channelBinding: IPCChannelBinding?
+        let conversationOriginChannel: String?
     }
     let sessions: [Session]
     let hasMore: Bool?
@@ -411,7 +412,7 @@ final class HTTPTransport {
             do {
                 let decoded = try decoder.decode(ConversationsListResponse.self, from: data)
                 let sessions = decoded.sessions.map {
-                    IPCSessionListResponseSession(id: $0.id, title: $0.title, updatedAt: $0.updatedAt, threadType: $0.threadType, source: $0.source, channelBinding: $0.channelBinding)
+                    IPCSessionListResponseSession(id: $0.id, title: $0.title, updatedAt: $0.updatedAt, threadType: $0.threadType, source: $0.source, channelBinding: $0.channelBinding, conversationOriginChannel: $0.conversationOriginChannel)
                 }
                 onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: sessions, hasMore: decoded.hasMore)))
             } catch {

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -97,6 +97,30 @@ The `/deliver/telegram` endpoint requires bearer auth by default (fail-closed). 
 
 This ensures that misconfiguration cannot expose an unauthenticated public message-send surface. In production, always configure `RUNTIME_PROXY_BEARER_TOKEN`. The `GATEWAY_TELEGRAM_DELIVER_AUTH_BYPASS` flag is intended for local development only.
 
+## Voice Ingress — Inbound Calls (Twilio)
+
+The `/webhooks/twilio/voice` endpoint handles both outbound and inbound voice calls. For **outbound** calls (initiated by the assistant via `call_start`), the voice webhook URL includes a `callSessionId` query parameter that identifies the pre-created session. For **inbound** calls (someone dialing the assistant's Twilio phone number), no `callSessionId` is present — the gateway resolves the target assistant and the runtime creates a session on the fly.
+
+### Inbound voice routing
+
+When the voice webhook is called without a `callSessionId` query parameter, the gateway treats it as an inbound call and resolves the assistant using the same routing chain as SMS:
+
+1. **`resolveAssistantByPhoneNumber(config, To)`** — Reverse lookup of the inbound `To` number against `assistantPhoneNumbers`. If the dialed number matches an assistant's configured phone number, that assistant handles the call.
+2. **Fallback to `resolveAssistant(From, From)`** — If no phone number match is found, the standard routing chain is used: `chat_id` match, `user_id` match, then the unmapped policy.
+3. **TwiML Reject for unmapped** — When the unmapped policy is `reject` (and no route matches), the gateway returns `<Reject reason="rejected"/>` TwiML directly to Twilio. Twilio plays a busy signal and hangs up. The call is never forwarded to the runtime.
+4. **Forward with assistantId** — When routing succeeds, the gateway forwards the voice webhook to the runtime at `POST /v1/internal/twilio/voice-webhook` with a JSON body containing `{ params, originalUrl, assistantId }`. The runtime calls `createInboundVoiceSession()` to bootstrap a session keyed by CallSid, then returns TwiML pointing Twilio to the ConversationRelay WebSocket.
+
+### Inbound call lifecycle (gateway perspective)
+
+```
+Caller → Twilio → Gateway /webhooks/twilio/voice (no callSessionId)
+  → resolveAssistantByPhoneNumber(To) || resolveAssistant(From) || TwiML Reject
+  → forward to runtime /v1/internal/twilio/voice-webhook (JSON: { params, originalUrl, assistantId })
+  → runtime returns TwiML (ConversationRelay connect)
+  → Twilio opens WebSocket → Gateway /webhooks/twilio/relay → Runtime /v1/calls/relay
+  → RelayConnection detects inbound (task=null), optional guardian verification gate, then receptionist-style LLM greeting
+```
+
 ## SMS Ingress (Twilio)
 
 The `/webhooks/twilio/sms` endpoint receives inbound SMS messages from Twilio. On each request:

--- a/gateway/src/__tests__/twilio-webhooks.test.ts
+++ b/gateway/src/__tests__/twilio-webhooks.test.ts
@@ -179,11 +179,24 @@ describe("Twilio voice webhook", () => {
     expect(calledUrl).toContain("/v1/internal/twilio/voice-webhook");
   });
 
-  test("returns 502 when runtime is unreachable", async () => {
+  test("rejects unmapped inbound call with TwiML Reject when unmappedPolicy is reject", async () => {
+    const handler = createTwilioVoiceWebhookHandler(makeConfig());
+    const url = "http://localhost:7830/webhooks/twilio/voice";
+    const params = { CallSid: "CA123" };
+    const req = buildSignedRequest(url, params, AUTH_TOKEN);
+
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("<Reject");
+  });
+
+  test("returns 502 when runtime is unreachable (outbound call)", async () => {
     fetchMock = mock(async () => { throw new Error("Connection refused"); });
 
     const handler = createTwilioVoiceWebhookHandler(makeConfig());
-    const url = "http://localhost:7830/webhooks/twilio/voice";
+    // Use callSessionId to simulate an outbound call that bypasses routing
+    const url = "http://localhost:7830/webhooks/twilio/voice?callSessionId=sess-1";
     const params = { CallSid: "CA123" };
     const req = buildSignedRequest(url, params, AUTH_TOKEN);
 
@@ -341,9 +354,9 @@ describe("Twilio webhook signature with canonical ingress base URL", () => {
     const config = makeConfig({ ingressPublicBaseUrl: publicBaseUrl });
     const handler = createTwilioVoiceWebhookHandler(config);
 
-    // The local URL is different from the public URL
-    const localUrl = "http://localhost:7830/webhooks/twilio/voice";
-    const publicUrl = publicBaseUrl + "/webhooks/twilio/voice";
+    // Use callSessionId to bypass inbound routing — this test is about signature validation
+    const localUrl = "http://localhost:7830/webhooks/twilio/voice?callSessionId=sig-test";
+    const publicUrl = publicBaseUrl + "/webhooks/twilio/voice?callSessionId=sig-test";
     const params = { CallSid: "CA123" };
 
     // Sign against the PUBLIC URL (as Twilio would)
@@ -374,7 +387,8 @@ describe("Twilio webhook signature with canonical ingress base URL", () => {
     const config = makeConfig({ ingressPublicBaseUrl: publicBaseUrl });
     const handler = createTwilioVoiceWebhookHandler(config);
 
-    const localUrl = "http://localhost:7830/webhooks/twilio/voice";
+    // Use callSessionId to bypass inbound routing — this test is about signature validation
+    const localUrl = "http://localhost:7830/webhooks/twilio/voice?callSessionId=sig-test";
     const params = { CallSid: "CA123" };
 
     // Sign against the raw request URL — the raw URL is always included as
@@ -406,9 +420,10 @@ describe("Twilio webhook signature with canonical ingress base URL", () => {
     const config = makeConfig({ ingressPublicBaseUrl: staleConfiguredBase });
     const handler = createTwilioVoiceWebhookHandler(config);
 
-    const localUrl = "http://localhost:7830/webhooks/twilio/voice";
+    // Use callSessionId to bypass inbound routing — this test is about signature validation
+    const localUrl = "http://localhost:7830/webhooks/twilio/voice?callSessionId=sig-test";
     const forwardedBase = "https://fresh-tunnel.example.com";
-    const signedPublicUrl = `${forwardedBase}/webhooks/twilio/voice`;
+    const signedPublicUrl = `${forwardedBase}/webhooks/twilio/voice?callSessionId=sig-test`;
     const params = { CallSid: "CA123" };
     const req = buildSignedRequest(
       signedPublicUrl,

--- a/gateway/src/http/routes/twilio-voice-webhook.test.ts
+++ b/gateway/src/http/routes/twilio-voice-webhook.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Unit tests for the Twilio voice webhook gateway handler.
+ *
+ * Validates that:
+ * - Inbound calls (no callSessionId) resolve the assistant by "To" phone number
+ *   and forward the assistantId to the runtime.
+ * - When phone-number lookup misses, fallback routing (defaultAssistantId /
+ *   unmapped policy) is applied instead of silently forwarding with no assistant.
+ * - Outbound calls (callSessionId present) do not resolve or forward an assistantId.
+ * - Validation failures are propagated as responses.
+ */
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+let lastForwardedAssistantId: string | undefined;
+let lastForwardedParams: Record<string, string> | undefined;
+let _lastForwardedOriginalUrl: string | undefined;
+let forwardCalled = false;
+
+mock.module("../../runtime/client.js", () => ({
+  forwardTwilioVoiceWebhook: async (
+    _config: unknown,
+    params: Record<string, string>,
+    originalUrl: string,
+    assistantId?: string,
+  ) => {
+    lastForwardedParams = params;
+    _lastForwardedOriginalUrl = originalUrl;
+    lastForwardedAssistantId = assistantId;
+    forwardCalled = true;
+    return {
+      status: 200,
+      body: "<Response/>",
+      headers: { "Content-Type": "text/xml" },
+    };
+  },
+}));
+
+mock.module("../../twilio/validate-webhook.js", () => ({
+  validateTwilioWebhookRequest: async (req: Request) => {
+    const rawBody = await req.text();
+    const formData = new URLSearchParams(rawBody);
+    const params: Record<string, string> = {};
+    for (const [key, value] of formData.entries()) {
+      params[key] = value;
+    }
+    return { rawBody, params };
+  },
+}));
+
+mock.module("../../logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { createTwilioVoiceWebhookHandler } from "./twilio-voice-webhook.js";
+import type { GatewayConfig } from "../../config.js";
+
+// ── Test config ────────────────────────────────────────────────────────
+
+const baseConfig: GatewayConfig = {
+  assistantRuntimeBaseUrl: "http://127.0.0.1:7821",
+  defaultAssistantId: undefined,
+  gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+  logFile: { dir: undefined, retentionDays: 30 },
+  maxAttachmentBytes: 20 * 1024 * 1024,
+  maxAttachmentConcurrency: 3,
+  maxWebhookPayloadBytes: 1024 * 1024,
+  port: 7830,
+  routingEntries: [],
+  runtimeBearerToken: undefined,
+  runtimeGatewayOriginSecret: undefined,
+  runtimeInitialBackoffMs: 500,
+  runtimeMaxRetries: 2,
+  runtimeProxyBearerToken: undefined,
+  runtimeProxyEnabled: false,
+  runtimeProxyRequireAuth: true,
+  runtimeTimeoutMs: 30000,
+  shutdownDrainMs: 5000,
+  telegramApiBaseUrl: "https://api.telegram.org",
+  telegramBotToken: undefined,
+  telegramDeliverAuthBypass: false,
+  telegramInitialBackoffMs: 1000,
+  telegramMaxRetries: 3,
+  telegramTimeoutMs: 15000,
+  telegramWebhookSecret: undefined,
+  twilioAuthToken: "test-auth-token",
+  twilioAccountSid: "AC_test",
+  twilioPhoneNumber: "+15550001111",
+  assistantPhoneNumbers: {
+    "assistant-abc": "+15550001111",
+    "assistant-xyz": "+15550002222",
+  },
+  smsDeliverAuthBypass: false,
+  ingressPublicBaseUrl: undefined,
+  unmappedPolicy: "reject",
+  whatsappPhoneNumberId: undefined,
+  whatsappAccessToken: undefined,
+  whatsappAppSecret: undefined,
+  whatsappWebhookVerifyToken: undefined,
+  whatsappDeliverAuthBypass: false,
+  whatsappTimeoutMs: 15000,
+  whatsappMaxRetries: 3,
+  whatsappInitialBackoffMs: 1000,
+};
+
+function makeVoiceRequest(
+  params: Record<string, string>,
+  queryString = "",
+): Request {
+  const body = new URLSearchParams(params).toString();
+  return new Request(
+    `http://127.0.0.1:7830/webhooks/twilio/voice${queryString}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+    },
+  );
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe("twilio voice webhook handler", () => {
+  beforeEach(() => {
+    lastForwardedAssistantId = undefined;
+    lastForwardedParams = undefined;
+    _lastForwardedOriginalUrl = undefined;
+    forwardCalled = false;
+  });
+
+  test("inbound call resolves assistant by To number and forwards assistantId", async () => {
+    const handler = createTwilioVoiceWebhookHandler(baseConfig);
+    const req = makeVoiceRequest({
+      CallSid: "CA_inbound_1",
+      From: "+14155551234",
+      To: "+15550001111",
+    });
+
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    expect(lastForwardedAssistantId).toBe("assistant-abc");
+    expect(lastForwardedParams?.CallSid).toBe("CA_inbound_1");
+  });
+
+  test("inbound call with unknown To number is rejected when unmappedPolicy is reject", async () => {
+    const handler = createTwilioVoiceWebhookHandler(baseConfig);
+    const req = makeVoiceRequest({
+      CallSid: "CA_inbound_2",
+      From: "+14155551234",
+      To: "+19999999999",
+    });
+
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("<Reject");
+    expect(forwardCalled).toBe(false);
+  });
+
+  test("inbound call with unknown To number uses defaultAssistantId when unmappedPolicy is default", async () => {
+    const configWithDefault: GatewayConfig = {
+      ...baseConfig,
+      unmappedPolicy: "default",
+      defaultAssistantId: "fallback-assistant",
+    };
+    const handler = createTwilioVoiceWebhookHandler(configWithDefault);
+    const req = makeVoiceRequest({
+      CallSid: "CA_inbound_fallback",
+      From: "+14155551234",
+      To: "+19999999999",
+    });
+
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    expect(lastForwardedAssistantId).toBe("fallback-assistant");
+    expect(forwardCalled).toBe(true);
+  });
+
+  test("outbound call (callSessionId present) does not resolve assistant by phone", async () => {
+    const handler = createTwilioVoiceWebhookHandler(baseConfig);
+    const req = makeVoiceRequest(
+      {
+        CallSid: "CA_outbound_1",
+        From: "+15550001111",
+        To: "+14155559999",
+      },
+      "?callSessionId=existing-session-id",
+    );
+
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    expect(lastForwardedAssistantId).toBeUndefined();
+  });
+
+  test("empty callSessionId is treated as inbound (resolves assistant by To number)", async () => {
+    const handler = createTwilioVoiceWebhookHandler(baseConfig);
+    const req = makeVoiceRequest(
+      {
+        CallSid: "CA_empty_session",
+        From: "+14155551234",
+        To: "+15550001111",
+      },
+      "?callSessionId=",
+    );
+
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    expect(lastForwardedAssistantId).toBe("assistant-abc");
+    expect(lastForwardedParams?.CallSid).toBe("CA_empty_session");
+  });
+
+  test("inbound call resolves second assistant by To number", async () => {
+    const handler = createTwilioVoiceWebhookHandler(baseConfig);
+    const req = makeVoiceRequest({
+      CallSid: "CA_inbound_3",
+      From: "+14155551234",
+      To: "+15550002222",
+    });
+
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    expect(lastForwardedAssistantId).toBe("assistant-xyz");
+  });
+
+  test("inbound call without assistantPhoneNumbers config is rejected when unmappedPolicy is reject", async () => {
+    const configNoMapping = { ...baseConfig, assistantPhoneNumbers: undefined };
+    const handler = createTwilioVoiceWebhookHandler(configNoMapping);
+    const req = makeVoiceRequest({
+      CallSid: "CA_inbound_4",
+      From: "+14155551234",
+      To: "+15550001111",
+    });
+
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("<Reject");
+    expect(forwardCalled).toBe(false);
+  });
+
+  test("inbound call without assistantPhoneNumbers uses defaultAssistantId when unmappedPolicy is default", async () => {
+    const configNoMappingWithDefault: GatewayConfig = {
+      ...baseConfig,
+      assistantPhoneNumbers: undefined,
+      unmappedPolicy: "default",
+      defaultAssistantId: "fallback-assistant",
+    };
+    const handler = createTwilioVoiceWebhookHandler(configNoMappingWithDefault);
+    const req = makeVoiceRequest({
+      CallSid: "CA_inbound_5",
+      From: "+14155551234",
+      To: "+15550001111",
+    });
+
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    expect(lastForwardedAssistantId).toBe("fallback-assistant");
+    expect(forwardCalled).toBe(true);
+  });
+});

--- a/gateway/src/http/routes/twilio-voice-webhook.ts
+++ b/gateway/src/http/routes/twilio-voice-webhook.ts
@@ -1,9 +1,13 @@
 import type { GatewayConfig } from "../../config.js";
 import { getLogger } from "../../logger.js";
 import { forwardTwilioVoiceWebhook } from "../../runtime/client.js";
+import { resolveAssistant, resolveAssistantByPhoneNumber, isRejection } from "../../routing/resolve-assistant.js";
 import { validateTwilioWebhookRequest } from "../../twilio/validate-webhook.js";
 
 const log = getLogger("twilio-voice-webhook");
+
+/** TwiML that rejects the call — Twilio plays a busy signal and hangs up. */
+const REJECT_TWIML = '<?xml version="1.0" encoding="UTF-8"?><Response><Reject reason="rejected"/></Response>';
 
 export function createTwilioVoiceWebhookHandler(config: GatewayConfig) {
   return async (req: Request): Promise<Response> => {
@@ -13,8 +17,53 @@ export function createTwilioVoiceWebhookHandler(config: GatewayConfig) {
     const { params } = validation;
     log.info({ callSid: params.CallSid }, "Twilio voice webhook received");
 
+    // For inbound calls (no callSessionId in the URL), resolve the assistant
+    // by the "To" phone number, then fall through to the standard routing
+    // chain (defaultAssistantId / unmapped policy) — mirroring how the SMS
+    // webhook handles phone-number lookup misses.
+    const url = new URL(req.url);
+    const hasCallSessionId = !!url.searchParams.get("callSessionId");
+    let assistantId: string | undefined;
+
+    if (!hasCallSessionId) {
+      const phoneRouting = params.To
+        ? resolveAssistantByPhoneNumber(config, params.To)
+        : undefined;
+
+      if (phoneRouting && "assistantId" in phoneRouting) {
+        assistantId = phoneRouting.assistantId;
+        log.info({ assistantId, toNumber: params.To }, "Resolved assistant by phone number for inbound call");
+      } else {
+        // Phone-number lookup missed — fall through to standard routing so
+        // defaultAssistantId / unmapped policy is respected, instead of
+        // silently forwarding with no assistant ID.
+        const fallbackRouting = resolveAssistant(
+          config,
+          params.From || "",
+          params.From || "",
+        );
+
+        if (isRejection(fallbackRouting)) {
+          log.warn(
+            { from: params.From, to: params.To, reason: fallbackRouting.reason },
+            "Inbound voice call rejected by routing — no phone number match and unmapped policy rejects",
+          );
+          return new Response(REJECT_TWIML, {
+            status: 200,
+            headers: { "Content-Type": "text/xml" },
+          });
+        }
+
+        assistantId = fallbackRouting.assistantId;
+        log.info(
+          { assistantId, routeSource: fallbackRouting.routeSource, from: params.From },
+          "Resolved assistant via fallback routing for inbound call",
+        );
+      }
+    }
+
     try {
-      const runtimeResponse = await forwardTwilioVoiceWebhook(config, params, req.url);
+      const runtimeResponse = await forwardTwilioVoiceWebhook(config, params, req.url, assistantId);
       return new Response(runtimeResponse.body, {
         status: runtimeResponse.status,
         headers: runtimeResponse.headers,

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -247,18 +247,22 @@ export type TwilioForwardResponse = {
  * Forward a validated Twilio voice webhook payload to the runtime.
  * The gateway sends the parsed form params as JSON; the runtime's internal
  * endpoint reconstructs what it needs.
+ *
+ * For inbound calls, `assistantId` is resolved by the gateway from the "To"
+ * phone number and forwarded so the runtime knows which assistant to bootstrap.
  */
 export async function forwardTwilioVoiceWebhook(
   config: GatewayConfig,
   params: Record<string, string>,
   originalUrl: string,
+  assistantId?: string,
 ): Promise<TwilioForwardResponse> {
   const url = `${config.assistantRuntimeBaseUrl}/v1/internal/twilio/voice-webhook`;
 
   const response = await fetchImpl(url, {
     method: "POST",
     headers: runtimeHeaders(config, { "Content-Type": "application/json" }),
-    body: JSON.stringify({ params, originalUrl }),
+    body: JSON.stringify({ params, originalUrl, assistantId }),
     signal: AbortSignal.timeout(config.runtimeTimeoutMs),
   });
 

--- a/playwright/bun.lock
+++ b/playwright/bun.lock
@@ -1,0 +1,21 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "vellum-assistant-playwright",
+      "devDependencies": {
+        "@playwright/test": "^1.50.0",
+      },
+    },
+  },
+  "packages": {
+    "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
+
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
+
+    "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
+  }
+}

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "vellum-assistant-playwright",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.0"
+  }
+}

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 30_000,
+  retries: 0,
+  reporter: "list",
+  use: {
+    trace: "on-first-retry",
+  },
+});

--- a/playwright/tests/hello-world.spec.ts
+++ b/playwright/tests/hello-world.spec.ts
@@ -1,0 +1,5 @@
+import { test, expect } from "@playwright/test";
+
+test("hello world", async () => {
+  expect(true).toBe(true);
+});


### PR DESCRIPTION
## Summary

Addresses review feedback from Devin on PR #7940: the legacy guardian fallback path (no conversational engine injected) returned `guardian_decision_applied` even when `handleChannelDecision` returned `applied: false` (race with expiry sweep or concurrent callback).

### Changes

**Legacy guardian fallback path** (`channel-routes.ts:~2005`):
- Moved `return { type: 'guardian_decision_applied' }` inside the `if (result.applied)` block
- Added stale notice delivery + `stale_ignored` return when not applied

**Legacy standard fallback path** (`channel-routes.ts:~2431`):
- Same pattern — `decision_applied` was returned unconditionally
- Now returns `stale_ignored` with stale notice when not applied

**Standard callback path** (`channel-routes.ts:~2279`):
- Same fix for consistency — race between stale check and decision attempt

**Missing import fix** (`lifecycle.ts`):
- Added `listProviders` to the import from `providers/registry.js` (merge artifact)

All four `handleChannelDecision` call sites in the approval flow now correctly distinguish between applied and stale results.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
