### PR TITLE
Fix channel context propagation gaps across queue, runtime, and inbox

### DIFF
--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -477,7 +477,10 @@ async function executeDeny(
   }, bearerToken);
 
   // Store a system note about the denial in the conversation
-  addMessage(conversationId, 'assistant', denialText);
+  addMessage(conversationId, 'assistant', denialText, {
+    userMessageChannel: sourceChannel,
+    assistantMessageChannel: sourceChannel,
+  });
   updateThreadActivity(conversationId, 'outbound');
 
   log.info({ conversationId, approvalId: approval.id }, 'Denied escalation refusal sent');
@@ -504,7 +507,15 @@ export function handleAssistantInboxReply(
     }
 
     // Store the reply as an assistant message
-    const message = addMessage(conversationId, 'assistant', content);
+    const bindingChannel = isChannelId(binding.sourceChannel) ? binding.sourceChannel : null;
+    const message = addMessage(
+      conversationId,
+      'assistant',
+      content,
+      bindingChannel
+        ? { userMessageChannel: bindingChannel, assistantMessageChannel: bindingChannel }
+        : undefined,
+    );
 
     // Update thread activity timestamps (resets unread count, updates last_outbound_at)
     updateThreadActivity(conversationId, 'outbound');

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -83,7 +83,20 @@ export async function handleUserMessage(
       attributes: { source: 'user_message' },
     });
 
-    const result = session.enqueueMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId, msg.activeSurfaceId, msg.currentPage);
+    const ipcChannel = parseChannelId(msg.channel) ?? 'macos';
+    const queuedChannelMetadata = {
+      userMessageChannel: ipcChannel,
+      assistantMessageChannel: ipcChannel,
+    };
+    const result = session.enqueueMessage(
+      msg.content ?? '',
+      msg.attachments ?? [],
+      sendEvent,
+      requestId,
+      msg.activeSurfaceId,
+      msg.currentPage,
+      queuedChannelMetadata,
+    );
     if (result.rejected) {
       rlog.warn('Message rejected — queue is full');
       session.traceEmitter.emit('request_error', 'Message rejected — queue is full', {
@@ -117,7 +130,6 @@ export async function handleUserMessage(
     }
 
     rlog.info('Processing user message');
-    const ipcChannel = parseChannelId(msg.channel) ?? 'macos';
     session.setTurnChannelContext({
       userMessageChannel: ipcChannel,
       assistantMessageChannel: ipcChannel,
@@ -288,6 +300,13 @@ export async function handleSessionCreate(
     ctx.socketToSession.set(socket, conversation.id);
     const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
     const requestId = uuid();
+    const transportChannel = parseChannelId(msg.transport?.channelId);
+    if (transportChannel) {
+      session.setTurnChannelContext({
+        userMessageChannel: transportChannel,
+        assistantMessageChannel: transportChannel,
+      });
+    }
     session.processMessage(msg.initialMessage, [], sendEvent, requestId).catch((err) => {
       const message = err instanceof Error ? err.message : String(err);
       log.error({ err, sessionId: conversation.id }, 'Error processing initial message');

--- a/assistant/src/daemon/ipc-validate.ts
+++ b/assistant/src/daemon/ipc-validate.ts
@@ -104,6 +104,9 @@ const HIGH_RISK_VALIDATORS: Record<string, PropertyValidator> = {
       if (typeof transport.channelId !== 'string' || transport.channelId.trim().length === 0) {
         return 'session_create "transport.channelId" must be a non-empty string';
       }
+      if (!isChannelId(transport.channelId)) {
+        return 'session_create "transport.channelId" must be a valid channel ID';
+      }
       if (transport.uxBrief !== undefined && typeof transport.uxBrief !== 'string') {
         return 'session_create "transport.uxBrief" must be a string when present';
       }

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -15,7 +15,7 @@ import { IngressBlockedError } from '../util/errors.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import * as attachmentsStore from '../memory/attachments-store.js';
 import { Session, DEFAULT_MEMORY_POLICY, type SessionMemoryPolicy } from './session.js';
-import { parseChannelId } from '../channels/types.js';
+import { parseChannelId, type ChannelId } from '../channels/types.js';
 import { resolveChannelCapabilities } from './session-runtime-assembly.js';
 import { ComputerUseSession } from './computer-use-session.js';
 import {
@@ -52,6 +52,24 @@ function readPackageVersion(): string | undefined {
 }
 
 const daemonVersion = readPackageVersion();
+
+function resolveTurnChannel(sourceChannel?: string, transportChannelId?: string): ChannelId {
+  if (sourceChannel != null) {
+    const parsed = parseChannelId(sourceChannel);
+    if (!parsed) {
+      throw new Error(`Invalid sourceChannel: ${sourceChannel}`);
+    }
+    return parsed;
+  }
+  if (transportChannelId != null) {
+    const parsed = parseChannelId(transportChannelId);
+    if (!parsed) {
+      throw new Error(`Invalid transport.channelId: ${transportChannelId}`);
+    }
+    return parsed;
+  }
+  return 'macos';
+}
 
 export class DaemonServer {
   private server: net.Server | null = null;
@@ -684,7 +702,7 @@ export class DaemonServer {
     session.setGuardianContext(options?.guardianContext ?? null);
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
     session.setCommandIntent(options?.commandIntent ?? null);
-    const resolvedChannel = parseChannelId(sourceChannel) ?? parseChannelId(options?.transport?.channelId) ?? 'macos';
+    const resolvedChannel = resolveTurnChannel(sourceChannel, options?.transport?.channelId);
     session.setTurnChannelContext({
       userMessageChannel: resolvedChannel,
       assistantMessageChannel: resolvedChannel,
@@ -731,7 +749,7 @@ export class DaemonServer {
     session.setGuardianContext(options?.guardianContext ?? null);
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
     session.setCommandIntent(options?.commandIntent ?? null);
-    const resolvedChannel2 = parseChannelId(sourceChannel) ?? parseChannelId(options?.transport?.channelId) ?? 'macos';
+    const resolvedChannel2 = resolveTurnChannel(sourceChannel, options?.transport?.channelId);
     session.setTurnChannelContext({
       userMessageChannel: resolvedChannel2,
       assistantMessageChannel: resolvedChannel2,

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -56,6 +56,7 @@ export interface EventHandlerDeps {
   readonly reqId: string;
   readonly isFirstMessage: boolean;
   readonly rlog: pino.Logger;
+  readonly turnChannelContext: TurnChannelContext;
 }
 
 // ── Factory ──────────────────────────────────────────────────────────
@@ -272,10 +273,15 @@ export function handleMessageComplete(
         ...(result.contentBlocks ? { contentBlocks: result.contentBlocks } : {}),
       }),
     );
+    const toolResultMetadata = {
+      userMessageChannel: deps.turnChannelContext.userMessageChannel,
+      assistantMessageChannel: deps.turnChannelContext.assistantMessageChannel,
+    };
     conversationStore.addMessage(
       deps.ctx.conversationId,
       'user',
       JSON.stringify(toolResultBlocks),
+      toolResultMetadata,
     );
     for (const id of state.pendingToolResults.keys()) {
       state.persistedToolUseIds.add(id);
@@ -309,10 +315,10 @@ export function handleMessageComplete(
     } as unknown as ContentBlock);
   }
 
-  const turnCtx: TurnChannelContext | null = deps.ctx.getTurnChannelContext();
-  const assistantChannelMetadata = turnCtx
-    ? { userMessageChannel: turnCtx.userMessageChannel, assistantMessageChannel: turnCtx.assistantMessageChannel }
-    : undefined;
+  const assistantChannelMetadata = {
+    userMessageChannel: deps.turnChannelContext.userMessageChannel,
+    assistantMessageChannel: deps.turnChannelContext.assistantMessageChannel,
+  };
   const assistantMsg = conversationStore.addMessage(
     deps.ctx.conversationId,
     'assistant',

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -332,7 +332,14 @@ export async function runAgentLoopImpl(
 
     let preRunHistoryLength = runMessages.length;
 
-    const deps: EventHandlerDeps = { ctx, onEvent, reqId, isFirstMessage, rlog };
+    const deps: EventHandlerDeps = {
+      ctx,
+      onEvent,
+      reqId,
+      isFirstMessage,
+      rlog,
+      turnChannelContext: capturedTurnChannelContext,
+    };
     const eventHandler = (event: AgentEvent) => dispatchAgentEvent(state, deps, event);
 
     const onCheckpoint = (): CheckpointDecision => {
@@ -513,10 +520,15 @@ export async function runAgentLoopImpl(
           ...(result.contentBlocks ? { contentBlocks: result.contentBlocks } : {}),
         }),
       );
+      const toolResultMetadata = {
+        userMessageChannel: capturedTurnChannelContext.userMessageChannel,
+        assistantMessageChannel: capturedTurnChannelContext.assistantMessageChannel,
+      };
       conversationStore.addMessage(
         ctx.conversationId,
         'user',
         JSON.stringify(toolResultBlocks),
+        toolResultMetadata,
       );
       state.pendingToolResults.clear();
     }

--- a/assistant/src/daemon/session-messaging.ts
+++ b/assistant/src/daemon/session-messaging.ts
@@ -8,6 +8,7 @@
 import { v4 as uuid } from 'uuid';
 import type { Message } from '../providers/types.js';
 import type { TurnChannelContext } from '../channels/types.js';
+import { parseChannelId } from '../channels/types.js';
 import type { ServerMessage, UserMessageAttachment } from './ipc-protocol.js';
 import { createUserMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
@@ -29,6 +30,14 @@ export interface MessagingSessionContext {
   getTurnChannelContext(): TurnChannelContext | null;
 }
 
+function extractTurnChannelContext(metadata?: Record<string, unknown>): TurnChannelContext | null {
+  if (!metadata) return null;
+  const userMessageChannel = parseChannelId(metadata.userMessageChannel);
+  const assistantMessageChannel = parseChannelId(metadata.assistantMessageChannel);
+  if (!userMessageChannel || !assistantMessageChannel) return null;
+  return { userMessageChannel, assistantMessageChannel };
+}
+
 // ── enqueueMessage ───────────────────────────────────────────────────
 
 export function enqueueMessage(
@@ -45,7 +54,17 @@ export function enqueueMessage(
     return { queued: false, requestId };
   }
 
-  const pushed = ctx.queue.push({ content, attachments, requestId, onEvent, activeSurfaceId, currentPage, metadata });
+  const turnChannelContext = extractTurnChannelContext(metadata) ?? ctx.getTurnChannelContext() ?? undefined;
+  const pushed = ctx.queue.push({
+    content,
+    attachments,
+    requestId,
+    onEvent,
+    activeSurfaceId,
+    currentPage,
+    metadata,
+    turnChannelContext,
+  });
   if (!pushed) {
     return { queued: false, rejected: true, requestId };
   }
@@ -84,15 +103,14 @@ export function persistUserMessage(
   ctx.messages.push(userMessage);
 
   try {
-    const turnCtx = ctx.getTurnChannelContext();
-    const channelMetadata = turnCtx
-      ? { userMessageChannel: turnCtx.userMessageChannel, assistantMessageChannel: turnCtx.assistantMessageChannel }
-      : undefined;
-    // NOTE: When a message is queued and persisted later, turnCtx reflects the
-    // session's *current* channel context at persistence time, which may differ
-    // from the channel that was active when the user originally sent the message.
-    // A proper fix would capture channel context per queued request at enqueue time.
-    const mergedMetadata = (metadata || channelMetadata) ? { ...metadata, ...channelMetadata } : undefined;
+    const turnCtx = extractTurnChannelContext(metadata) ?? ctx.getTurnChannelContext();
+    const mergedMetadata = turnCtx
+      ? {
+          ...(metadata ?? {}),
+          userMessageChannel: turnCtx.userMessageChannel,
+          assistantMessageChannel: turnCtx.assistantMessageChannel,
+        }
+      : metadata;
 
     const persistedUserMessage = conversationStore.addMessage(
       ctx.conversationId,

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -8,6 +8,7 @@
 
 import type { Message } from '../providers/types.js';
 import type { TurnChannelContext } from '../channels/types.js';
+import { parseChannelId } from '../channels/types.js';
 import type { ServerMessage, UserMessageAttachment } from './ipc-protocol.js';
 import type { UsageStats } from './ipc-contract.js';
 import type { MessageQueue } from './session-queue-manager.js';
@@ -75,6 +76,23 @@ export interface ProcessSessionContext {
     options?: { skipPreMessageRollback?: boolean },
   ): Promise<void>;
   getTurnChannelContext(): TurnChannelContext | null;
+  setTurnChannelContext(ctx: TurnChannelContext): void;
+}
+
+function resolveQueuedTurnContext(
+  queued: { turnChannelContext?: TurnChannelContext; metadata?: Record<string, unknown> },
+  fallback: TurnChannelContext | null,
+): TurnChannelContext | null {
+  if (queued.turnChannelContext) return queued.turnChannelContext;
+  const metadata = queued.metadata;
+  if (metadata) {
+    const userMessageChannel = parseChannelId(metadata.userMessageChannel);
+    const assistantMessageChannel = parseChannelId(metadata.assistantMessageChannel);
+    if (userMessageChannel && assistantMessageChannel) {
+      return { userMessageChannel, assistantMessageChannel };
+    }
+  }
+  return fallback;
 }
 
 /** Build a SlashContext from the current session state and config. */
@@ -119,6 +137,11 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
     requestId: next.requestId,
   });
 
+  const queuedTurnCtx = resolveQueuedTurnContext(next, session.getTurnChannelContext());
+  if (queuedTurnCtx) {
+    session.setTurnChannelContext(queuedTurnCtx);
+  }
+
   // Resolve slash commands for queued messages
   const slashResult = resolveSlash(next.content, buildSlashContext(session));
 
@@ -127,9 +150,8 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
   // failed write never leaves an unpersisted message in memory.
   if (slashResult.kind === 'unknown') {
     try {
-      const drainTurnCtx = session.getTurnChannelContext();
-      const drainChannelMeta = drainTurnCtx
-        ? { userMessageChannel: drainTurnCtx.userMessageChannel, assistantMessageChannel: drainTurnCtx.assistantMessageChannel }
+      const drainChannelMeta = queuedTurnCtx
+        ? { userMessageChannel: queuedTurnCtx.userMessageChannel, assistantMessageChannel: queuedTurnCtx.assistantMessageChannel }
         : undefined;
       const userMsg = createUserMessage(next.content, next.attachments);
       conversationStore.addMessage(

--- a/assistant/src/daemon/session-queue-manager.ts
+++ b/assistant/src/daemon/session-queue-manager.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ServerMessage, UserMessageAttachment } from './ipc-protocol.js';
+import type { TurnChannelContext } from '../channels/types.js';
 
 export interface QueuedMessage {
   content: string;
@@ -15,6 +16,7 @@ export interface QueuedMessage {
   activeSurfaceId?: string;
   currentPage?: string;
   metadata?: Record<string, unknown>;
+  turnChannelContext?: TurnChannelContext;
 }
 
 export const MAX_QUEUE_DEPTH = 10;

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -6,6 +6,7 @@ import { getConfig } from '../config/loader.js';
 import { indexMessageNow } from './indexer.js';
 import { parseChannelId } from '../channels/types.js';
 import type { ChannelId } from '../channels/types.js';
+import { isChannelId } from '../channels/types.js';
 import { getLogger } from '../util/logger.js';
 import { deleteOrphanAttachments } from './attachments-store.js';
 
@@ -128,6 +129,10 @@ export function addMessage(conversationId: string, role: string, content: string
   const db = getDb();
   const messageId = uuid();
   const metadataStr = metadata ? JSON.stringify(metadata) : undefined;
+  const userMessageChannel =
+    role === 'user' && metadata && isChannelId(metadata.userMessageChannel)
+      ? metadata.userMessageChannel
+      : null;
   // Wrap insert + updatedAt bump in a transaction so they're atomic.
   // Retry on SQLITE_BUSY in case busy_timeout is exhausted under heavy contention.
   // Timestamp is recomputed each attempt so a late retry doesn't persist a stale updatedAt.
@@ -146,6 +151,12 @@ export function addMessage(conversationId: string, role: string, content: string
       };
       db.transaction((tx) => {
         tx.insert(messages).values(values).run();
+        if (userMessageChannel) {
+          tx.update(conversations)
+            .set({ originChannel: userMessageChannel })
+            .where(and(eq(conversations.id, conversationId), isNull(conversations.originChannel)))
+            .run();
+        }
         tx.update(conversations)
           .set({ updatedAt: now })
           .where(eq(conversations.id, conversationId))

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1,7 +1,7 @@
 /**
  * Route handlers for conversation messages and suggestions.
  */
-import { parseChannelId } from '../../channels/types.js';
+import { CHANNEL_IDS, parseChannelId } from '../../channels/types.js';
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import {
@@ -149,7 +149,14 @@ export async function handleSendMessage(
   };
 
   const { conversationKey, content, attachmentIds } = body;
-  const sourceChannel = parseChannelId(body.sourceChannel) ?? undefined;
+  const sourceChannel = parseChannelId(body.sourceChannel);
+
+  if (body.sourceChannel != null && !sourceChannel) {
+    return Response.json(
+      { error: `Invalid sourceChannel: ${body.sourceChannel}. Valid values: ${CHANNEL_IDS.join(', ')}` },
+      { status: 400 },
+    );
+  }
 
   if (!conversationKey) {
     return Response.json(
@@ -202,7 +209,7 @@ export async function handleSendMessage(
       content ?? '',
       hasAttachments ? attachmentIds : undefined,
       undefined,
-      sourceChannel,
+      sourceChannel ?? undefined,
     );
     return Response.json({ accepted: true, messageId: result.messageId });
   } catch (err) {

--- a/assistant/src/runtime/routes/run-routes.ts
+++ b/assistant/src/runtime/routes/run-routes.ts
@@ -4,6 +4,7 @@
 import { getOrCreateConversation } from '../../memory/conversation-key-store.js';
 import * as attachmentsStore from '../../memory/attachments-store.js';
 import * as runsStore from '../../memory/runs-store.js';
+import { CHANNEL_IDS, parseChannelId } from '../../channels/types.js';
 import { addRule } from '../../permissions/trust-store.js';
 import { getTool } from '../../tools/registry.js';
 import { getLogger } from '../../util/logger.js';
@@ -19,9 +20,18 @@ export async function handleCreateRun(
     conversationKey?: string;
     content?: string;
     attachmentIds?: string[];
+    sourceChannel?: string;
   };
 
   const { conversationKey, content, attachmentIds } = body;
+  const sourceChannel = parseChannelId(body.sourceChannel);
+
+  if (body.sourceChannel != null && !sourceChannel) {
+    return Response.json(
+      { error: `Invalid sourceChannel: ${body.sourceChannel}. Valid values: ${CHANNEL_IDS.join(', ')}` },
+      { status: 400 },
+    );
+  }
 
   if (!conversationKey) {
     return Response.json({ error: 'conversationKey is required' }, { status: 400 });
@@ -57,6 +67,7 @@ export async function handleCreateRun(
       mapping.conversationId,
       content ?? '',
       hasAttachments ? attachmentIds : undefined,
+      sourceChannel ? { sourceChannel } : undefined,
     );
     return Response.json({
       id: run.id,

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingIntroductionViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingIntroductionViewModel.swift
@@ -69,7 +69,7 @@ final class FirstMeetingIntroductionViewModel {
                 try self.daemonClient.send(SessionCreateMessage(
                     title: "First meeting",
                     maxResponseTokens: 220,
-                    transportChannelId: "desktop",
+                    transportChannelId: "macos",
                     transportHints: [
                         "onboarding-active",
                         "onboarding-phase:post_hatch",

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
@@ -76,7 +76,7 @@ final class InterviewViewModel {
                 try self.daemonClient.send(SessionCreateMessage(
                     title: "Getting to know you",
                     maxResponseTokens: 220,
-                    transportChannelId: "desktop",
+                    transportChannelId: "macos",
                     transportHints: hints,
                     transportUxBrief: "Onboarding conversation after hatch. Follow the channel playbook and update USER.md directly."
                 ))

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -48,6 +48,15 @@ final class HTTPTransport {
     let baseURL: String
     let bearerToken: String?
     private let conversationKey: String
+    private let sourceChannel: String
+
+    private static var defaultSourceChannel: String {
+        #if os(iOS)
+        return "ios"
+        #else
+        return "macos"
+        #endif
+    }
 
     /// Currently active SSE task.
     private var sseTask: Task<Void, Never>?
@@ -95,6 +104,7 @@ final class HTTPTransport {
         self.baseURL = baseURL.hasSuffix("/") ? String(baseURL.dropLast()) : baseURL
         self.bearerToken = bearerToken
         self.conversationKey = conversationKey
+        self.sourceChannel = Self.defaultSourceChannel
     }
 
     // MARK: - Connect (health check driven)
@@ -294,7 +304,10 @@ final class HTTPTransport {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         applyAuth(&request)
 
-        var body: [String: Any] = ["conversationKey": conversationKey]
+        var body: [String: Any] = [
+            "conversationKey": conversationKey,
+            "sourceChannel": sourceChannel
+        ]
         if let content, !content.isEmpty {
             body["content"] = content
         }


### PR DESCRIPTION
## Summary
- capture and persist per-message turn channel context through queued message lifecycle
- persist conversation origin channel from any user-message write path using valid metadata
- propagate channel metadata for inbox assistant replies/denials
- enforce canonical channel IDs in IPC session transport validation
- plumb `sourceChannel` through HTTP run creation and runtime route validation
- switch onboarding session transport channel IDs from `desktop` to `macos`
- harden daemon HTTP processing channel resolution to reject invalid explicit channels

## Validation
- `cd assistant && bunx tsc --noEmit`
- `bun test` is currently noisy/failing on latest main for unrelated baseline issues; did not use as merge gate here

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
