### PR TITLE
M1: Quick Chat floating panel UI

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -55,6 +55,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var statusItem: NSStatusItem!
     private var hotKeyMonitor: Any?
     private var escapeMonitor: Any?
+    private var quickChatPanel: QuickChatPanel?
+    private var quickChatMonitor: Any?
     var overlayWindow: SessionOverlayWindow?
     var currentSession: ComputerUseSession?
     var currentTextSession: TextSession?
@@ -191,6 +193,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         setupFileMenu()
         setupViewMenu()
         setupHotKey()
+        setupQuickChatHotKey()
         setupEscapeMonitor()
         setupVoiceInput()
         setupAmbientAgent()
@@ -337,6 +340,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 NSEvent.removeMonitor(escapeMonitor)
                 self.escapeMonitor = nil
             }
+            if let quickChatMonitor {
+                NSEvent.removeMonitor(quickChatMonitor)
+                self.quickChatMonitor = nil
+            }
+            quickChatPanel?.dismiss()
+            quickChatPanel = nil
             voiceInput?.stop()
             voiceInput = nil
             ambientAgent.teardown()
@@ -436,6 +445,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             NSEvent.removeMonitor(escapeMonitor)
             self.escapeMonitor = nil
         }
+        if let quickChatMonitor {
+            NSEvent.removeMonitor(quickChatMonitor)
+            self.quickChatMonitor = nil
+        }
+        quickChatPanel?.dismiss()
+        quickChatPanel = nil
         voiceInput?.stop()
         voiceInput = nil
         ambientAgent.teardown()
@@ -1029,6 +1044,30 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    private func setupQuickChatHotKey() {
+        quickChatMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == [.command, .shift],
+                  event.charactersIgnoringModifiers == " " else { return }
+            Task { @MainActor in
+                self?.showQuickChat()
+            }
+        }
+    }
+
+    func showQuickChat() {
+        if let existing = quickChatPanel, existing.isVisible {
+            existing.dismiss()
+            return
+        }
+
+        let panel = QuickChatPanel()
+        panel.onSubmit = { message in
+            print("[QuickChat] \(message)")
+        }
+        panel.show()
+        quickChatPanel = panel
+    }
+
     private func setupEscapeMonitor() {
         escapeMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
             if event.keyCode == 53 { // Escape
@@ -1375,6 +1414,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         if let monitor = escapeMonitor {
             NSEvent.removeMonitor(monitor)
         }
+        if let monitor = quickChatMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+        quickChatPanel?.dismiss()
+        quickChatPanel = nil
         if let observer = windowObserver {
             NotificationCenter.default.removeObserver(observer)
         }

--- a/clients/macos/vellum-assistant/Features/QuickChat/QuickChatPanel.swift
+++ b/clients/macos/vellum-assistant/Features/QuickChat/QuickChatPanel.swift
@@ -1,0 +1,108 @@
+import AppKit
+import SwiftUI
+import VellumAssistantShared
+
+/// A borderless, floating NSPanel that hosts the Quick Chat text editor.
+/// Appears centered on the active screen with a vibrancy/blur background.
+/// Dismisses itself when it resigns key window status.
+@MainActor
+final class QuickChatPanel {
+    private var panel: NSPanel?
+    private var resignObserver: Any?
+
+    /// Callback invoked when the user submits a message.
+    var onSubmit: ((String) -> Void)?
+
+    func show() {
+        if let existing = panel {
+            existing.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let view = QuickChatView(
+            onSubmit: { [weak self] message in
+                self?.onSubmit?(message)
+                self?.dismiss()
+            },
+            onDismiss: { [weak self] in
+                self?.dismiss()
+            }
+        )
+
+        let hostingController = NSHostingController(rootView: view)
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 60),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        panel.contentViewController = hostingController
+        panel.level = .floating
+        panel.isMovableByWindowBackground = true
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.isReleasedWhenClosed = false
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = true
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+        // Center on the active screen
+        centerOnScreen(panel)
+
+        // Become key so the text editor receives focus
+        panel.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+
+        // Dismiss when the panel loses focus
+        resignObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResignKeyNotification,
+            object: panel,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.dismiss()
+            }
+        }
+
+        self.panel = panel
+    }
+
+    func dismiss() {
+        if let resignObserver {
+            NotificationCenter.default.removeObserver(resignObserver)
+        }
+        resignObserver = nil
+        panel?.close()
+        panel = nil
+    }
+
+    var isVisible: Bool {
+        panel?.isVisible ?? false
+    }
+
+    // MARK: - Private
+
+    private func centerOnScreen(_ panel: NSPanel) {
+        let screen = NSScreen.main ?? NSScreen.screens.first
+        guard let screenFrame = screen?.visibleFrame else { return }
+
+        // Let the hosting controller size the panel to fit the content
+        if let fittingSize = panel.contentView?.fittingSize {
+            let width = max(fittingSize.width, 400)
+            let height = fittingSize.height
+            let x = screenFrame.midX - width / 2
+            // Position slightly above center (like Spotlight)
+            let y = screenFrame.midY + screenFrame.height * 0.1
+            panel.setFrame(
+                NSRect(x: x, y: y, width: width, height: height),
+                display: true
+            )
+        } else {
+            panel.center()
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/QuickChat/QuickChatView.swift
+++ b/clients/macos/vellum-assistant/Features/QuickChat/QuickChatView.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct QuickChatView: View {
+    let onSubmit: (String) -> Void
+    let onDismiss: () -> Void
+
+    @State private var text = ""
+    @FocusState private var isFocused: Bool
+
+    private let panelWidth: CGFloat = 400
+    private let minEditorHeight: CGFloat = 36
+    private let maxEditorHeight: CGFloat = 120
+
+    var body: some View {
+        VStack(spacing: 0) {
+            TextEditor(text: $text)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .scrollContentBackground(.hidden)
+                .padding(.horizontal, VSpacing.md)
+                .padding(.vertical, VSpacing.sm)
+                .frame(minHeight: minEditorHeight, maxHeight: maxEditorHeight)
+                .fixedSize(horizontal: false, vertical: true)
+                .focused($isFocused)
+                .overlay(alignment: .topLeading) {
+                    if text.isEmpty {
+                        Text("Type a message...")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textMuted)
+                            .padding(.horizontal, VSpacing.md + 5)
+                            .padding(.vertical, VSpacing.sm + 1)
+                            .allowsHitTesting(false)
+                    }
+                }
+                .onKeyPress(.return, modifiers: []) {
+                    submit()
+                    return .handled
+                }
+                .onKeyPress(.return, modifiers: .command) {
+                    text += "\n"
+                    return .handled
+                }
+                .onKeyPress(.escape) {
+                    onDismiss()
+                    return .handled
+                }
+        }
+        .frame(width: panelWidth)
+        .background(
+            VisualEffectBlur(material: .hudWindow, blendingMode: .behindWindow)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .onAppear {
+            isFocused = true
+        }
+    }
+
+    private func submit() {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        onSubmit(trimmed)
+    }
+}
+
+// MARK: - NSVisualEffectView wrapper
+
+struct VisualEffectBlur: NSViewRepresentable {
+    let material: NSVisualEffectView.Material
+    let blendingMode: NSVisualEffectView.BlendingMode
+
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = material
+        view.blendingMode = blendingMode
+        view.state = .active
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {
+        nsView.material = material
+        nsView.blendingMode = blendingMode
+    }
+}
+
+// MARK: - Preview
+
+#Preview("QuickChatView") {
+    ZStack {
+        Color.black.opacity(0.5).ignoresSafeArea()
+        QuickChatView(
+            onSubmit: { message in
+                print("Submitted: \(message)")
+            },
+            onDismiss: {
+                print("Dismissed")
+            }
+        )
+    }
+    .frame(width: 500, height: 300)
+}


### PR DESCRIPTION
## Summary
- Adds a Spotlight-style floating panel (QuickChatPanel) for quick message input
- NSPanel with vibrancy/blur background, borderless, floating level, centered on screen
- Multi-line SwiftUI text editor with Enter to send, Cmd+Enter for newline, Escape to dismiss
- Panel auto-dismisses when it loses focus (resigns key window)
- Registers Cmd+Shift+Space global hotkey via NSEvent monitor (same pattern as existing Cmd+Shift+G)
- onSubmit callback prints message for now (session creation wired in M2)
- Proper cleanup in logout, retire, and app termination flows

## Test plan
- [ ] Verify Cmd+Shift+Space opens the floating panel centered on screen
- [ ] Verify typing and pressing Enter sends (prints) the message and dismisses
- [ ] Verify Cmd+Enter inserts a newline
- [ ] Verify Escape dismisses without sending
- [ ] Verify clicking away (panel loses focus) dismisses the panel
- [ ] Verify panel has blur/vibrancy background and rounded corners

Part of #8030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
