### PR TITLE
Close remaining channel-context attribution and ingress validation gaps

### DIFF
--- a/assistant/src/config/vellum-skills/chatgpt-import/tools/chatgpt-import.ts
+++ b/assistant/src/config/vellum-skills/chatgpt-import/tools/chatgpt-import.ts
@@ -100,9 +100,13 @@ export async function run(
     }
 
     const conversation = createConversation(conv.title);
+    const importChannelMetadata = {
+      userMessageChannel: 'macos',
+      assistantMessageChannel: 'macos',
+    } as const;
 
     for (const msg of conv.messages) {
-      addMessage(conversation.id, msg.role, JSON.stringify(msg.content));
+      addMessage(conversation.id, msg.role, JSON.stringify(msg.content), importChannelMetadata);
     }
 
     // Override timestamps to match ChatGPT originals

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -300,13 +300,11 @@ export async function handleSessionCreate(
     ctx.socketToSession.set(socket, conversation.id);
     const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
     const requestId = uuid();
-    const transportChannel = parseChannelId(msg.transport?.channelId);
-    if (transportChannel) {
-      session.setTurnChannelContext({
-        userMessageChannel: transportChannel,
-        assistantMessageChannel: transportChannel,
-      });
-    }
+    const transportChannel = parseChannelId(msg.transport?.channelId) ?? 'macos';
+    session.setTurnChannelContext({
+      userMessageChannel: transportChannel,
+      assistantMessageChannel: transportChannel,
+    });
     session.processMessage(msg.initialMessage, [], sendEvent, requestId).catch((err) => {
       const message = err instanceof Error ? err.message : String(err);
       log.error({ err, sessionId: conversation.id }, 'Error processing initial message');

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -129,8 +129,8 @@ export function addMessage(conversationId: string, role: string, content: string
   const db = getDb();
   const messageId = uuid();
   const metadataStr = metadata ? JSON.stringify(metadata) : undefined;
-  const userMessageChannel =
-    role === 'user' && metadata && isChannelId(metadata.userMessageChannel)
+  const originChannelCandidate =
+    metadata && isChannelId(metadata.userMessageChannel)
       ? metadata.userMessageChannel
       : null;
   // Wrap insert + updatedAt bump in a transaction so they're atomic.
@@ -151,9 +151,9 @@ export function addMessage(conversationId: string, role: string, content: string
       };
       db.transaction((tx) => {
         tx.insert(messages).values(values).run();
-        if (userMessageChannel) {
+        if (originChannelCandidate) {
           tx.update(conversations)
-            .set({ originChannel: userMessageChannel })
+            .set({ originChannel: originChannelCandidate })
             .where(and(eq(conversations.id, conversationId), isNull(conversations.originChannel)))
             .run();
         }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -149,9 +149,15 @@ export async function handleSendMessage(
   };
 
   const { conversationKey, content, attachmentIds } = body;
+  if (!body.sourceChannel || typeof body.sourceChannel !== 'string') {
+    return Response.json(
+      { error: 'sourceChannel is required' },
+      { status: 400 },
+    );
+  }
   const sourceChannel = parseChannelId(body.sourceChannel);
 
-  if (body.sourceChannel != null && !sourceChannel) {
+  if (!sourceChannel) {
     return Response.json(
       { error: `Invalid sourceChannel: ${body.sourceChannel}. Valid values: ${CHANNEL_IDS.join(', ')}` },
       { status: 400 },
@@ -209,7 +215,7 @@ export async function handleSendMessage(
       content ?? '',
       hasAttachments ? attachmentIds : undefined,
       undefined,
-      sourceChannel ?? undefined,
+      sourceChannel,
     );
     return Response.json({ accepted: true, messageId: result.messageId });
   } catch (err) {

--- a/assistant/src/runtime/routes/run-routes.ts
+++ b/assistant/src/runtime/routes/run-routes.ts
@@ -24,9 +24,12 @@ export async function handleCreateRun(
   };
 
   const { conversationKey, content, attachmentIds } = body;
+  if (!body.sourceChannel || typeof body.sourceChannel !== 'string') {
+    return Response.json({ error: 'sourceChannel is required' }, { status: 400 });
+  }
   const sourceChannel = parseChannelId(body.sourceChannel);
 
-  if (body.sourceChannel != null && !sourceChannel) {
+  if (!sourceChannel) {
     return Response.json(
       { error: `Invalid sourceChannel: ${body.sourceChannel}. Valid values: ${CHANNEL_IDS.join(', ')}` },
       { status: 400 },
@@ -67,7 +70,7 @@ export async function handleCreateRun(
       mapping.conversationId,
       content ?? '',
       hasAttachments ? attachmentIds : undefined,
-      sourceChannel ? { sourceChannel } : undefined,
+      { sourceChannel },
     );
     return Response.json({
       id: run.id,


### PR DESCRIPTION
## Summary
- set `conversationOriginChannel` from valid `userMessageChannel` metadata regardless of message role, so assistant-seeded threads can retain correct origin
- ensure `session_create.initialMessage` always has turn channel context (defaulting to `macos` when transport channel is absent)
- require canonical `sourceChannel` on runtime `POST /v1/messages` and `POST /v1/runs` to remove ambiguous attribution fallbacks
- stamp imported ChatGPT messages with canonical channel metadata so imported turns carry channel context

## Validation
- `cd assistant && bun install`
- `cd assistant && bunx tsc --noEmit` *(currently fails on latest main with pre-existing unrelated error: `src/daemon/lifecycle.ts(392,10): Cannot find name 'listProviders'`)*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
