### PR TITLE
docs: align inbound direction docs with relay logic

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4158,7 +4158,7 @@ sequenceDiagram
     TwilioAPI->>Gateway: WebSocket /webhooks/twilio/relay
     Gateway->>WS: proxy WS to runtime /v1/calls/relay
     WS->>WS: setup message (callSid)
-    WS->>WS: detect isInbound (session.task == null)
+    WS->>WS: detect isInbound (`session.initiatedFromConversationId == null`)
 
     alt Pending voice guardian challenge exists
         WS->>GuardianSvc: getPendingChallenge(assistantId, 'voice')
@@ -4198,7 +4198,7 @@ sequenceDiagram
     end
 ```
 
-**Inbound vs. outbound detection**: The relay server determines call direction by checking `session.task`. Outbound calls always have a task (the user-provided objective). Inbound calls have `task == null` because the caller dialed in — the assistant's role is to greet and assist rather than execute a specific task.
+**Inbound vs. outbound detection**: The relay server determines call direction by checking `session.initiatedFromConversationId`. Outbound calls are initiated from an existing conversation (`initiatedFromConversationId` set). Inbound calls are bootstrapped from Twilio webhooks and therefore have `initiatedFromConversationId == null`.
 
 **Inbound system prompt**: The `CallOrchestrator.buildInboundSystemPrompt()` generates a receptionist-style prompt: "You are on a live phone call, answering an incoming call on behalf of [user]. The caller dialed in to reach you. You do not have a specific task -- your role is to greet them warmly, find out what they need, and assist them."
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -118,7 +118,7 @@ Caller → Twilio → Gateway /webhooks/twilio/voice (no callSessionId)
   → forward to runtime /v1/internal/twilio/voice-webhook (JSON: { params, originalUrl, assistantId })
   → runtime returns TwiML (ConversationRelay connect)
   → Twilio opens WebSocket → Gateway /webhooks/twilio/relay → Runtime /v1/calls/relay
-  → RelayConnection detects inbound (task=null), optional guardian verification gate, then receptionist-style LLM greeting
+  → RelayConnection detects inbound (`initiatedFromConversationId == null`), optional guardian verification gate, then receptionist-style LLM greeting
 ```
 
 ## SMS Ingress (Twilio)


### PR DESCRIPTION
## Summary
- update inbound direction wording in gateway and architecture docs to match runtime behavior

## Changes
- `gateway/README.md`: replace task-based inbound detection wording with `initiatedFromConversationId == null`
- `ARCHITECTURE.md`: update sequence and explanatory text to use the same canonical direction signal

## Why
- closes the remaining post-merge documentation gap for inbound voice flow and reduces future debugging/refactor confusion
