### PR TITLE
M2: Background session and notification delivery

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -72,7 +72,19 @@ extension AppDelegate {
             options: []
         )
 
-        center.setNotificationCategories([activityCategory, toolConfirmationCategory, rideShotgunCategory, voiceResponseCategory])
+        let viewQuickChatAction = UNNotificationAction(
+            identifier: "VIEW_QUICK_CHAT",
+            title: "View in Chat",
+            options: .foreground
+        )
+        let quickChatCategory = UNNotificationCategory(
+            identifier: "QUICK_CHAT_RESPONSE",
+            actions: [viewQuickChatAction],
+            intentIdentifiers: [],
+            options: []
+        )
+
+        center.setNotificationCategories([activityCategory, toolConfirmationCategory, rideShotgunCategory, voiceResponseCategory, quickChatCategory])
     }
 
     func registerBundledFonts() {
@@ -144,6 +156,16 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             await MainActor.run {
                 guard !self.isAwaitingFirstLaunchReady else { return }
                 self.showMainWindow()
+            }
+            return
+        }
+
+        // Handle quick chat response notifications — open the thread in the main window
+        if categoryId == "QUICK_CHAT_RESPONSE" {
+            let conversationId = response.notification.request.content.userInfo["conversationId"] as? String
+            await MainActor.run {
+                guard !self.isAwaitingFirstLaunchReady else { return }
+                self.openQuickChatThread(conversationId: conversationId)
             }
             return
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -1,4 +1,5 @@
 import AppKit
+import UserNotifications
 import VellumAssistantShared
 import os
 
@@ -237,6 +238,174 @@ extension AppDelegate {
                 await session.run()
             }
         }
+    }
+
+    // MARK: - Background Session (Quick Chat)
+
+    /// Starts a background session that sends a message to the daemon without
+    /// showing any UI. When the assistant responds, a macOS notification is
+    /// delivered. Multiple background sessions can run concurrently.
+    func startBackgroundSession(task: String, source: String) {
+        let sessionTask = task.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !sessionTask.isEmpty else { return }
+
+        Task { @MainActor in
+            // Ensure daemon connection
+            if !daemonClient.isConnected {
+                log.info("Daemon not connected, attempting to connect before background session")
+                do {
+                    try await daemonClient.connect()
+                    self.setupAmbientAgent()
+                } catch {
+                    log.error("Failed to connect to daemon for background session: \(error.localizedDescription)")
+                    self.deliverQuickChatErrorNotification(task: sessionTask)
+                    return
+                }
+            }
+
+            // Subscribe to daemon stream before sending task_submit
+            let messageStream = self.daemonClient.subscribe()
+
+            // Send task_submit
+            let screenBounds = CGDisplayBounds(CGMainDisplayID())
+            do {
+                try self.daemonClient.send(TaskSubmitMessage(
+                    task: sessionTask,
+                    screenWidth: Int(screenBounds.width),
+                    screenHeight: Int(screenBounds.height),
+                    attachments: nil,
+                    source: source
+                ))
+            } catch {
+                log.error("Failed to send background task submit: \(error)")
+                return
+            }
+
+            // Wait for task_routed, then listen for the response
+            var routedMessage: TaskRoutedMessage?
+            for await message in messageStream {
+                if case .taskRouted(let routed) = message {
+                    routedMessage = routed
+                    break
+                }
+                if case .error(let err) = message {
+                    log.error("Background task routing failed: \(err.message, privacy: .private)")
+                    break
+                }
+            }
+
+            guard let routed = routedMessage else {
+                log.error("Background session: no routed message received")
+                return
+            }
+
+            let sessionId = routed.sessionId
+
+            // Create a thread in ThreadManager so the user can find it later
+            if let threadManager = self.mainWindow?.threadManager {
+                threadManager.createTaskRunThread(
+                    conversationId: sessionId,
+                    workItemId: "",
+                    title: String(sessionTask.prefix(50))
+                )
+            }
+
+            // Listen for the assistant response in the background
+            var accumulatedText = ""
+            for await message in messageStream {
+                switch message {
+                case .assistantTextDelta(let delta):
+                    accumulatedText += delta.text
+
+                case .messageComplete(let complete) where complete.sessionId == sessionId:
+                    let responseText = accumulatedText.isEmpty ? "(No response)" : accumulatedText
+                    self.deliverQuickChatNotification(
+                        responseText: responseText,
+                        conversationId: sessionId
+                    )
+                    return
+
+                case .generationHandoff(let handoff) where handoff.sessionId == sessionId:
+                    let responseText = accumulatedText.isEmpty ? "(No response)" : accumulatedText
+                    self.deliverQuickChatNotification(
+                        responseText: responseText,
+                        conversationId: sessionId
+                    )
+                    return
+
+                case .cuError(let error) where error.sessionId == sessionId:
+                    self.deliverQuickChatNotification(
+                        responseText: "Error: \(error.message)",
+                        conversationId: sessionId
+                    )
+                    return
+
+                case .sessionError(let error) where error.sessionId == sessionId:
+                    self.deliverQuickChatNotification(
+                        responseText: "Error: \(error.userMessage)",
+                        conversationId: sessionId
+                    )
+                    return
+
+                default:
+                    break
+                }
+            }
+        }
+    }
+
+    private func deliverQuickChatNotification(responseText: String, conversationId: String) {
+        let content = UNMutableNotificationContent()
+        content.title = "Quick Chat"
+        // Truncate long responses for the notification body
+        if responseText.count > 200 {
+            content.body = String(responseText.prefix(200)) + "..."
+        } else {
+            content.body = responseText
+        }
+        content.sound = .default
+        content.categoryIdentifier = "QUICK_CHAT_RESPONSE"
+        content.userInfo = ["conversationId": conversationId]
+
+        let request = UNNotificationRequest(
+            identifier: "quick-chat-\(conversationId)",
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error {
+                log.error("Failed to post quick chat notification: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func deliverQuickChatErrorNotification(task: String) {
+        let content = UNMutableNotificationContent()
+        content.title = "Quick Chat"
+        content.body = "Could not connect to the assistant. Please try again."
+        content.sound = .default
+
+        let request = UNNotificationRequest(
+            identifier: "quick-chat-error-\(UUID().uuidString)",
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error {
+                log.error("Failed to post quick chat error notification: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Opens the main window and navigates to the thread for the given conversation ID.
+    func openQuickChatThread(conversationId: String?) {
+        showMainWindow()
+        guard let conversationId,
+              let threadManager = mainWindow?.threadManager,
+              let thread = threadManager.threads.first(where: { $0.sessionId == conversationId }) else {
+            return
+        }
+        threadManager.activeThreadId = thread.id
     }
 
     func showDaemonConnectionError() {

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1061,8 +1061,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let panel = QuickChatPanel()
-        panel.onSubmit = { message in
-            print("[QuickChat] \(message)")
+        panel.onSubmit = { [weak self] message in
+            self?.startBackgroundSession(task: message, source: "quick_chat")
         }
         panel.show()
         quickChatPanel = panel


### PR DESCRIPTION
## Summary
- Wires Quick Chat panel submit callback to create background daemon sessions via `startBackgroundSession()`
- Messages are sent to new threads without showing ThinkingIndicatorWindow, TextResponseWindow, or SessionOverlayWindow
- When the assistant responds (or errors), a macOS notification is delivered via `UNUserNotificationCenter`
- Clicking the notification opens the corresponding thread in the main window
- Multiple background sessions can run concurrently (each spawns its own Task)
- Handles daemon connection failure gracefully with an error notification

## Test plan
- [ ] Open Quick Chat (Cmd+Shift+Space), type a message, press Enter
- [ ] Verify no UI windows appear (no thinking indicator, no overlay)
- [ ] Verify a macOS notification appears with the assistant's response
- [ ] Click the notification and verify the thread opens in the main window
- [ ] Test with daemon disconnected — verify error notification appears
- [ ] Send multiple Quick Chat messages rapidly — verify they all complete independently

Part of #8030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8038" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
