### PR TITLE
fix: use control char as sed delimiter to avoid regex conflicts in pre-commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -404,7 +404,7 @@ while IFS= read -r -d '' FILE; do
                     # on the same line (e.g. minified JSON) must not be masked.
                     STRIPPED="$CONTENT"
                     for sp in "${SAFE_LINE_PATTERNS[@]}"; do
-                        STRIPPED=$(printf '%s\n' "$STRIPPED" | sed -E "s|$sp||g" 2>/dev/null || printf '%s\n' "$STRIPPED")
+                        STRIPPED=$(printf '%s\n' "$STRIPPED" | sed -E "s"$'\x01'"$sp"$'\x01\x01'"g" 2>/dev/null || printf '%s\n' "$STRIPPED")
                     done
                     if ! printf '%s\n' "$STRIPPED" | grep -iE -- "$PATTERN" >/dev/null 2>&1; then
                         continue


### PR DESCRIPTION
Use SOH control character (\x01) as sed delimiter instead of | or / to avoid conflicts with both regex alternation and literal slashes in SAFE_LINE_PATTERNS.

Addresses feedback on #8026.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
