### PR TITLE
M3: Configurable keyboard shortcut

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -96,6 +96,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var galleryWindow: ComponentGalleryWindow?
     #endif
     private var windowObserver: Any?
+    private var quickChatShortcutObserver: AnyCancellable?
     private weak var recordingViewModel: ChatViewModel?
     private var statusIconCancellable: AnyCancellable?
     var cachedSkills: [SkillInfo] = []
@@ -344,6 +345,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 NSEvent.removeMonitor(quickChatMonitor)
                 self.quickChatMonitor = nil
             }
+            quickChatShortcutObserver?.cancel()
+            quickChatShortcutObserver = nil
             quickChatPanel?.dismiss()
             quickChatPanel = nil
             voiceInput?.stop()
@@ -449,6 +452,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             NSEvent.removeMonitor(quickChatMonitor)
             self.quickChatMonitor = nil
         }
+        quickChatShortcutObserver?.cancel()
+        quickChatShortcutObserver = nil
         quickChatPanel?.dismiss()
         quickChatPanel = nil
         voiceInput?.stop()
@@ -1045,9 +1050,32 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func setupQuickChatHotKey() {
+        registerQuickChatMonitor()
+
+        // Re-register the global hotkey whenever the user changes the shortcut
+        quickChatShortcutObserver = NotificationCenter.default
+            .publisher(for: UserDefaults.didChangeNotification)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.registerQuickChatMonitor()
+            }
+    }
+
+    /// Tears down the existing Quick Chat global monitor and registers a new
+    /// one based on the current `quickChatShortcut` UserDefaults value.
+    private func registerQuickChatMonitor() {
+        if let existing = quickChatMonitor {
+            NSEvent.removeMonitor(existing)
+            quickChatMonitor = nil
+        }
+
+        let shortcut = UserDefaults.standard.string(forKey: "quickChatShortcut") ?? "cmd+shift+space"
+        let (targetModifiers, targetKey) = ShortcutHelper.parseShortcut(shortcut)
+
         quickChatMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == [.command, .shift],
-                  event.charactersIgnoringModifiers == " " else { return }
+            let eventMods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            guard eventMods == targetModifiers,
+                  event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else { return }
             Task { @MainActor in
                 self?.showQuickChat()
             }
@@ -1417,6 +1445,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         if let monitor = quickChatMonitor {
             NSEvent.removeMonitor(monitor)
         }
+        quickChatShortcutObserver?.cancel()
         quickChatPanel?.dismiss()
         quickChatPanel = nil
         if let observer = windowObserver {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Appearance settings tab — theme selection and media embed configuration.
+/// Appearance settings tab — theme selection, keyboard shortcuts, and media embed configuration.
 struct SettingsAppearanceTab: View {
     @ObservedObject var store: SettingsStore
     @AppStorage("themePreference") private var themePreference: String = "system"
     @State private var newAllowlistDomain = ""
+    @State private var isRecordingShortcut = false
+    @State private var shortcutMonitor: Any?
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
@@ -38,6 +40,66 @@ struct SettingsAppearanceTab: View {
             }
             .padding(VSpacing.lg)
             .vCard(background: VColor.surfaceSubtle)
+
+            // KEYBOARD SHORTCUTS section
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("Keyboard Shortcuts")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                // Quick Chat (configurable)
+                HStack {
+                    Text("Quick Chat")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Spacer()
+                    Text(ShortcutHelper.displayString(for: store.quickChatShortcut))
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textPrimary)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(VColor.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.sm)
+                                .stroke(VColor.surfaceBorder, lineWidth: 1)
+                        )
+
+                    if isRecordingShortcut {
+                        VButton(label: "Press shortcut...", style: .tertiary) {
+                            stopRecording()
+                        }
+                    } else {
+                        VButton(label: "Record", style: .tertiary) {
+                            startRecording()
+                        }
+                    }
+                }
+
+                // Open Vellum (fixed, non-editable)
+                HStack {
+                    Text("Open Vellum")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Spacer()
+                    Text("\u{2318}\u{21E7}G")
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textMuted)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(VColor.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.sm)
+                                .stroke(VColor.surfaceBorder, lineWidth: 1)
+                        )
+                }
+            }
+            .padding(VSpacing.lg)
+            .vCard(background: VColor.surfaceSubtle)
+            .onDisappear {
+                stopRecording()
+            }
 
             // MEDIA EMBEDS section
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -118,4 +180,52 @@ struct SettingsAppearanceTab: View {
             .vCard(background: VColor.surfaceSubtle)
         }
     }
+
+    // MARK: - Shortcut Recording
+
+    private func startRecording() {
+        isRecordingShortcut = true
+        // Use local monitor so we capture key events while the settings window is focused
+        shortcutMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+
+            // Escape cancels recording without changing the shortcut
+            if event.keyCode == 53 {
+                stopRecording()
+                return nil
+            }
+
+            // Require at least one modifier key to form a valid global shortcut
+            let hasModifier = mods.contains(.command) || mods.contains(.control)
+                || mods.contains(.option)
+            guard hasModifier,
+                  let chars = event.charactersIgnoringModifiers, !chars.isEmpty else {
+                return nil
+            }
+
+            let shortcut = ShortcutHelper.shortcutString(
+                from: mods, key: chars, keyCode: event.keyCode
+            )
+            store.quickChatShortcut = shortcut
+            stopRecording()
+            return nil // consume the event
+        }
+    }
+
+    private func stopRecording() {
+        isRecordingShortcut = false
+        if let monitor = shortcutMonitor {
+            NSEvent.removeMonitor(monitor)
+            shortcutMonitor = nil
+        }
+    }
+}
+
+#Preview("Appearance Tab") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        SettingsAppearanceTab(store: SettingsStore())
+            .padding()
+    }
+    .frame(width: 500, height: 600)
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -59,6 +59,7 @@ public final class SettingsStore: ObservableObject {
 
     @Published var maxSteps: Double
     @Published var activityNotificationsEnabled: Bool
+    @Published var quickChatShortcut: String
 
     // MARK: - Media Embed Settings
 
@@ -243,6 +244,8 @@ public final class SettingsStore: ObservableObject {
         // Default to enabled for notifications
         self.activityNotificationsEnabled = UserDefaults.standard.object(forKey: "activityNotificationsEnabled") as? Bool ?? true
 
+        self.quickChatShortcut = UserDefaults.standard.string(forKey: "quickChatShortcut") ?? "cmd+shift+space"
+
         // Load media embed settings from workspace config
         let mediaSettings = Self.loadMediaEmbedSettings(from: configPath)
         self.mediaEmbedsEnabled = mediaSettings.enabled
@@ -278,6 +281,12 @@ public final class SettingsStore: ObservableObject {
             .dropFirst()
             .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
             .sink { value in UserDefaults.standard.set(value, forKey: "activityNotificationsEnabled") }
+            .store(in: &cancellables)
+
+        // Persist shortcut changes immediately so the hotkey re-registers without delay
+        $quickChatShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "quickChatShortcut") }
             .store(in: &cancellables)
 
         // Mirror DaemonClient's trust-rules-open flag so views can disable their buttons

--- a/clients/macos/vellum-assistant/Features/Settings/ShortcutHelper.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ShortcutHelper.swift
@@ -1,0 +1,111 @@
+import AppKit
+
+/// Utilities for converting between the string shortcut representation
+/// (e.g. "cmd+shift+space") and macOS modifier flags / display symbols.
+enum ShortcutHelper {
+
+    /// Converts a shortcut string like "cmd+shift+space" to a human-readable
+    /// display string like "Command Shift Space".
+    static func displayString(for shortcut: String) -> String {
+        let parts = shortcut.lowercased().split(separator: "+").map(String.init)
+        return parts.map { displayToken($0) }.joined()
+    }
+
+    /// Parses a shortcut string into modifier flags and a key string suitable
+    /// for matching against `NSEvent.charactersIgnoringModifiers`.
+    static func parseShortcut(_ shortcut: String) -> (NSEvent.ModifierFlags, String) {
+        let parts = shortcut.lowercased().split(separator: "+").map(String.init)
+        var modifiers: NSEvent.ModifierFlags = []
+        var key = ""
+
+        for part in parts {
+            switch part {
+            case "cmd", "command":
+                modifiers.insert(.command)
+            case "shift":
+                modifiers.insert(.shift)
+            case "opt", "alt", "option":
+                modifiers.insert(.option)
+            case "ctrl", "control":
+                modifiers.insert(.control)
+            default:
+                key = keyString(for: part)
+            }
+        }
+
+        return (modifiers, key)
+    }
+
+    /// Builds a shortcut string from modifier flags and a key code/characters,
+    /// as captured from an NSEvent during recording.
+    static func shortcutString(from modifiers: NSEvent.ModifierFlags, key: String, keyCode: UInt16) -> String {
+        var parts: [String] = []
+        if modifiers.contains(.control) { parts.append("ctrl") }
+        if modifiers.contains(.option) { parts.append("opt") }
+        if modifiers.contains(.shift) { parts.append("shift") }
+        if modifiers.contains(.command) { parts.append("cmd") }
+
+        let keyPart = keyName(for: key, keyCode: keyCode)
+        parts.append(keyPart)
+        return parts.joined(separator: "+")
+    }
+
+    // MARK: - Private
+
+    private static func displayToken(_ token: String) -> String {
+        switch token {
+        case "cmd", "command": return "\u{2318}"
+        case "shift": return "\u{21E7}"
+        case "opt", "alt", "option": return "\u{2325}"
+        case "ctrl", "control": return "\u{2303}"
+        case "space": return "Space"
+        case "return", "enter": return "\u{21A9}"
+        case "tab": return "\u{21E5}"
+        case "delete", "backspace": return "\u{232B}"
+        case "escape", "esc": return "\u{238B}"
+        case "up": return "\u{2191}"
+        case "down": return "\u{2193}"
+        case "left": return "\u{2190}"
+        case "right": return "\u{2192}"
+        default:
+            return token.uppercased()
+        }
+    }
+
+    /// Maps a token from the shortcut string to the value used for matching
+    /// against `NSEvent.charactersIgnoringModifiers`.
+    private static func keyString(for token: String) -> String {
+        switch token {
+        case "space": return " "
+        case "return", "enter": return "\r"
+        case "tab": return "\t"
+        case "escape", "esc": return "\u{1B}"
+        case "delete", "backspace": return "\u{7F}"
+        case "up": return String(Character(UnicodeScalar(NSUpArrowFunctionKey)!))
+        case "down": return String(Character(UnicodeScalar(NSDownArrowFunctionKey)!))
+        case "left": return String(Character(UnicodeScalar(NSLeftArrowFunctionKey)!))
+        case "right": return String(Character(UnicodeScalar(NSRightArrowFunctionKey)!))
+        default:
+            return token.lowercased()
+        }
+    }
+
+    /// Converts a captured key event back into the canonical token name
+    /// for the shortcut string format.
+    private static func keyName(for characters: String, keyCode: UInt16) -> String {
+        // Handle space explicitly (keyCode 49)
+        if keyCode == 49 || characters == " " { return "space" }
+        if characters == "\r" { return "return" }
+        if characters == "\t" { return "tab" }
+
+        // Single printable character
+        if characters.count == 1, let scalar = characters.unicodeScalars.first {
+            if scalar.value == NSUpArrowFunctionKey { return "up" }
+            if scalar.value == NSDownArrowFunctionKey { return "down" }
+            if scalar.value == NSLeftArrowFunctionKey { return "left" }
+            if scalar.value == NSRightArrowFunctionKey { return "right" }
+        }
+
+        return characters.lowercased()
+    }
+}


### PR DESCRIPTION
Makes the Quick Chat global shortcut user-configurable via Settings. Adds shortcut recorder UI, dynamic hotkey re-registration, and shortcut display helpers. Default remains Cmd+Shift+Space. Part of #8030.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
