### PR TITLE
fix: promote sed and awk from LOW to MEDIUM risk

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -33,7 +33,7 @@ const LOW_RISK_PROGRAMS = new Set([
   'man', 'help', 'info',
   'env', 'printenv', 'set',
   'diff', 'sort', 'uniq', 'cut', 'tr', 'tee', 'xargs',
-  'jq', 'yq', 'sed', 'awk',
+  'jq', 'yq',
   'curl', 'wget', 'http', 'dig', 'nslookup', 'ping',
   'tree', 'du', 'df',
 ]);
@@ -307,7 +307,8 @@ export async function classifyRisk(toolName: string, input: Record<string, unkno
         continue;
       }
 
-      if (prog === 'chmod' || prog === 'chown' || prog === 'chgrp') {
+      if (prog === 'chmod' || prog === 'chown' || prog === 'chgrp'
+        || prog === 'sed' || prog === 'awk') {
         maxRisk = RiskLevel.Medium;
         continue;
       }


### PR DESCRIPTION
Moves sed and awk from LOW to MEDIUM risk classification since they can modify files and execute arbitrary expressions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
