### PR TITLE
feat: add 5-minute TTL for credential tokens in broker

### DIFF
--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -20,6 +20,9 @@ import { getLogger } from '../../util/logger.js';
 
 const log = getLogger('credential-broker');
 
+/** Tokens expire after 5 minutes to limit the window for using stale/revoked credentials. */
+const TOKEN_TTL_MS = 5 * 60 * 1000;
+
 /**
  * Credential broker that issues single-use tokens for policy-checked credential access.
  *
@@ -100,6 +103,11 @@ export class CredentialBroker {
     }
     if (token.consumed) {
       return { success: false, reason: 'Token already consumed' };
+    }
+    if (Date.now() - token.createdAt > TOKEN_TTL_MS) {
+      this.tokens.delete(tokenId);
+      log.info({ tokenId }, 'Token expired (TTL exceeded)');
+      return { success: false, reason: 'Token expired' };
     }
 
     token.consumed = true;
@@ -358,11 +366,12 @@ export class CredentialBroker {
     };
   }
 
-  /** Return the number of active (non-consumed, non-revoked) tokens. */
+  /** Return the number of active (non-consumed, non-revoked, non-expired) tokens. */
   get activeTokenCount(): number {
+    const now = Date.now();
     let count = 0;
     for (const token of this.tokens.values()) {
-      if (!token.consumed) count++;
+      if (!token.consumed && now - token.createdAt <= TOKEN_TTL_MS) count++;
     }
     return count;
   }


### PR DESCRIPTION
Adds a 5-minute TTL to cached credential tokens so stale/revoked tokens are automatically re-fetched.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
