### PR TITLE
perf: tune SQLite pragmas for better performance

### DIFF
--- a/assistant/src/memory/db-connection.ts
+++ b/assistant/src/memory/db-connection.ts
@@ -14,8 +14,11 @@ export function getDb(): DrizzleDb {
     ensureDataDir();
     const sqlite = new Database(getDbPath());
     sqlite.exec('PRAGMA journal_mode=WAL');
+    sqlite.exec('PRAGMA synchronous=NORMAL');
     sqlite.exec('PRAGMA busy_timeout=5000');
     sqlite.exec('PRAGMA foreign_keys = ON');
+    sqlite.exec('PRAGMA cache_size=-256000');
+    sqlite.exec('PRAGMA temp_store=MEMORY');
     db = drizzle(sqlite, { schema });
   }
   return db;


### PR DESCRIPTION
Adds synchronous=NORMAL, cache_size=-256000 (256MB), and temp_store=MEMORY pragmas to reduce fsync overhead and keep temp data in RAM.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
