### PR TITLE
fix: add exponential backoff with jitter to swarm worker retries

### DIFF
--- a/assistant/src/swarm/orchestrator.ts
+++ b/assistant/src/swarm/orchestrator.ts
@@ -144,6 +144,11 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
     let retries = 0;
     while (result.status === 'failed' && retries < limits.maxRetriesPerTask && !signal?.aborted) {
       retries++;
+      // Exponential backoff with ±25% jitter to prevent thundering herd
+      const baseDelayMs = 1000 * Math.pow(2, retries - 1);
+      const jitter = baseDelayMs * 0.25 * (2 * Math.random() - 1);
+      await new Promise((r) => setTimeout(r, baseDelayMs + jitter));
+      if (signal?.aborted) break;
       result = await runWorkerTask({
         task,
         upstreamContext: plan.objective,


### PR DESCRIPTION
Replaces fixed retry delays with exponential backoff plus random jitter to prevent thundering herd in concurrent worker retries.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
