### PR TITLE
M4: Quick Chat polish

### DIFF
--- a/clients/macos/vellum-assistant/Features/QuickChat/QuickChatPanel.swift
+++ b/clients/macos/vellum-assistant/Features/QuickChat/QuickChatPanel.swift
@@ -8,6 +8,7 @@ import VellumAssistantShared
 @MainActor
 final class QuickChatPanel {
     private var panel: NSPanel?
+    private var toastPanel: NSPanel?
     private var resignObserver: Any?
 
     /// Callback invoked when the user submits a message.
@@ -23,7 +24,12 @@ final class QuickChatPanel {
         let view = QuickChatView(
             onSubmit: { [weak self] message in
                 self?.onSubmit?(message)
+                // Capture position before dismissing so the toast appears in the same spot
+                let panelFrame = self?.panel?.frame
                 self?.dismiss()
+                if let frame = panelFrame {
+                    self?.showSentToast(near: frame)
+                }
             },
             onDismiss: { [weak self] in
                 self?.dismiss()
@@ -53,9 +59,16 @@ final class QuickChatPanel {
         // Center on the active screen
         centerOnScreen(panel)
 
-        // Become key so the text editor receives focus
+        // Animate in: start transparent and slightly scaled down, then animate to full
+        panel.alphaValue = 0
         panel.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = VAnimation.durationFast
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            panel.animator().alphaValue = 1
+        }
 
         // Dismiss when the panel loses focus
         resignObserver = NotificationCenter.default.addObserver(
@@ -76,8 +89,17 @@ final class QuickChatPanel {
             NotificationCenter.default.removeObserver(resignObserver)
         }
         resignObserver = nil
-        panel?.close()
-        panel = nil
+
+        guard let panel else { return }
+        // Animate out: fade to transparent, then close
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = VAnimation.durationFast
+            context.timingFunction = CAMediaTimingFunction(name: .easeIn)
+            panel.animator().alphaValue = 0
+        }, completionHandler: { [weak self] in
+            panel.close()
+            self?.panel = nil
+        })
     }
 
     var isVisible: Bool {
@@ -85,6 +107,75 @@ final class QuickChatPanel {
     }
 
     // MARK: - Private
+
+    /// Shows a brief "Message sent" toast near the given frame, then auto-dismisses.
+    private func showSentToast(near frame: NSRect) {
+        let toastView = HStack(spacing: VSpacing.sm) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundColor(VColor.success)
+            Text("Message sent")
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.md)
+        .background(
+            VisualEffectBlur(material: .hudWindow, blendingMode: .behindWindow)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+
+        let hosting = NSHostingController(rootView: toastView)
+
+        let toast = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 180, height: 40),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        toast.contentViewController = hosting
+        toast.level = .floating
+        toast.titleVisibility = .hidden
+        toast.titlebarAppearsTransparent = true
+        toast.isReleasedWhenClosed = false
+        toast.backgroundColor = .clear
+        toast.isOpaque = false
+        toast.hasShadow = true
+        toast.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+        // Position just below where the Quick Chat panel was
+        if let fittingSize = toast.contentView?.fittingSize {
+            let x = frame.midX - fittingSize.width / 2
+            let y = frame.origin.y - fittingSize.height - 8
+            toast.setFrame(
+                NSRect(x: x, y: y, width: fittingSize.width, height: fittingSize.height),
+                display: true
+            )
+        }
+
+        toast.alphaValue = 0
+        toast.orderFrontRegardless()
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = VAnimation.durationFast
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            toast.animator().alphaValue = 1
+        }
+
+        self.toastPanel = toast
+
+        // Auto-dismiss after 1.5 seconds
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+            guard let toast = self?.toastPanel else { return }
+            NSAnimationContext.runAnimationGroup({ context in
+                context.duration = VAnimation.durationFast
+                context.timingFunction = CAMediaTimingFunction(name: .easeIn)
+                toast.animator().alphaValue = 0
+            }, completionHandler: {
+                toast.close()
+                self?.toastPanel = nil
+            })
+        }
+    }
 
     private func centerOnScreen(_ panel: NSPanel) {
         let screen = NSScreen.main ?? NSScreen.screens.first

--- a/clients/macos/vellum-assistant/Features/QuickChat/QuickChatView.swift
+++ b/clients/macos/vellum-assistant/Features/QuickChat/QuickChatView.swift
@@ -6,6 +6,7 @@ struct QuickChatView: View {
     let onDismiss: () -> Void
 
     @State private var text = ""
+    @State private var isPresented = false
     @FocusState private var isFocused: Bool
 
     private let panelWidth: CGFloat = 400
@@ -51,8 +52,12 @@ struct QuickChatView: View {
             VisualEffectBlur(material: .hudWindow, blendingMode: .behindWindow)
         )
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .scaleEffect(isPresented ? 1.0 : 0.95)
         .onAppear {
             isFocused = true
+            withAnimation(VAnimation.fast) {
+                isPresented = true
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -8,6 +8,7 @@ struct SettingsAppearanceTab: View {
     @State private var newAllowlistDomain = ""
     @State private var isRecordingShortcut = false
     @State private var shortcutMonitor: Any?
+    @State private var shortcutConflictWarning: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
@@ -74,6 +75,12 @@ struct SettingsAppearanceTab: View {
                             startRecording()
                         }
                     }
+                }
+
+                if let shortcutConflictWarning {
+                    Text(shortcutConflictWarning)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.warning)
                 }
 
                 // Open Vellum (fixed, non-editable)
@@ -183,8 +190,12 @@ struct SettingsAppearanceTab: View {
 
     // MARK: - Shortcut Recording
 
+    /// The fixed "Open Vellum" shortcut in normalized form for conflict detection.
+    private static let openVellumShortcut = "cmd+shift+g"
+
     private func startRecording() {
         isRecordingShortcut = true
+        shortcutConflictWarning = nil
         // Use local monitor so we capture key events while the settings window is focused
         shortcutMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
@@ -206,6 +217,15 @@ struct SettingsAppearanceTab: View {
             let shortcut = ShortcutHelper.shortcutString(
                 from: mods, key: chars, keyCode: event.keyCode
             )
+
+            // Check for conflict with the fixed "Open Vellum" shortcut
+            if shortcut.lowercased() == Self.openVellumShortcut {
+                shortcutConflictWarning = "This shortcut conflicts with the Open Vellum shortcut (\u{2318}\u{21E7}G). Choose a different shortcut."
+                stopRecording()
+                return nil
+            }
+
+            shortcutConflictWarning = nil
             store.quickChatShortcut = shortcut
             stopRecording()
             return nil // consume the event


### PR DESCRIPTION
## Summary

- Added smooth appear/disappear animations to the Quick Chat panel (fade + scale using VAnimation.fast)
- Added a "Message sent" confirmation toast that appears below the panel position and auto-dismisses after 1.5 seconds
- Added shortcut conflict detection in the Settings shortcut recorder — warns if the recorded shortcut conflicts with the fixed "Open Vellum" shortcut (Cmd+Shift+G)
- Verified that Quick Chat background sessions work correctly alongside foreground sessions (no changes needed — already isolated by design)

Part of #8030.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
