### PR TITLE
fix: wrap contradiction checker in SQLite transaction

### DIFF
--- a/assistant/src/memory/contradiction-checker.ts
+++ b/assistant/src/memory/contradiction-checker.ts
@@ -6,7 +6,7 @@ import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } fro
 import { areStatementsCoherent } from './conflict-intent.js';
 import { isConflictKindEligible, isStatementConflictEligible } from './conflict-policy.js';
 import { createOrUpdatePendingConflict } from './conflict-store.js';
-import { getDb, rawAll } from './db.js';
+import { getDb, getSqlite, rawAll } from './db.js';
 import { enqueueMemoryJob } from './jobs-store.js';
 import { memoryItems } from './schema.js';
 
@@ -93,7 +93,7 @@ export async function checkContradictions(newItemId: string): Promise<void> {
 
     try {
       const result = await classifyRelationship(existing, newItem);
-      await handleRelationship(result, existing, newItem);
+      handleRelationship(result, existing, newItem);
       // Only stop when the new item itself is invalidated (update case).
       // For contradiction, the old item is invalidated but the new item remains
       // active and should continue to be checked against remaining candidates.
@@ -274,82 +274,98 @@ async function classifyRelationship(
 
 /**
  * Handle the classified relationship between an existing and new memory item.
+ *
+ * Wrapped in a SQLite transaction so that multi-row mutations (e.g. invalidating
+ * the old item AND setting validFrom on the new one) are atomic. The transaction
+ * also re-verifies both items are still active before mutating, preventing a
+ * TOCTOU race when multiple workers process contradictions concurrently.
  */
-async function handleRelationship(
+function handleRelationship(
   result: ClassifyResult,
   existingItem: MemoryItemRow,
   newItem: MemoryItemRow,
-): Promise<void> {
-  const db = getDb();
-  const now = Date.now();
-
-  switch (result.relationship) {
-    case 'contradiction': {
-      // Invalidate the old item (don't delete for audit trail), set validFrom on new item
-      log.info(
-        { existingId: existingItem.id, newId: newItem.id, explanation: result.explanation },
-        'Contradiction detected — invalidating old item',
-      );
-      db.update(memoryItems)
-        .set({ invalidAt: now })
-        .where(eq(memoryItems.id, existingItem.id))
-        .run();
-      db.update(memoryItems)
-        .set({ validFrom: now })
-        .where(eq(memoryItems.id, newItem.id))
-        .run();
-      break;
-    }
-    case 'update': {
-      // Merge info — update old item's statement, bump lastSeenAt
-      log.debug(
-        { existingId: existingItem.id, newId: newItem.id, explanation: result.explanation },
-        'Update detected — merging into existing item',
-      );
-      db.update(memoryItems)
-        .set({
-          statement: newItem.statement,
-          lastSeenAt: Math.max(existingItem.lastSeenAt, newItem.lastSeenAt),
-          confidence: Math.max(existingItem.confidence, newItem.confidence),
-        })
-        .where(eq(memoryItems.id, existingItem.id))
-        .run();
-      // Re-embed the existing item so its vector matches the updated statement
-      enqueueMemoryJob('embed_item', { itemId: existingItem.id });
-      // Invalidate the new item since its content has been merged into the existing one
-      db.update(memoryItems)
-        .set({ invalidAt: now })
-        .where(eq(memoryItems.id, newItem.id))
-        .run();
-      break;
-    }
-    case 'complement': {
-      // Both items can coexist — no changes needed
-      log.debug(
-        { existingId: existingItem.id, newId: newItem.id, explanation: result.explanation },
-        'Complement detected — keeping both items',
-      );
-      break;
-    }
-    case 'ambiguous_contradiction': {
-      log.info(
-        { existingId: existingItem.id, newId: newItem.id, explanation: result.explanation },
-        'Ambiguous contradiction detected — gating candidate pending clarification',
-      );
-      db.update(memoryItems)
-        .set({ status: 'pending_clarification' })
-        .where(eq(memoryItems.id, newItem.id))
-        .run();
-      createOrUpdatePendingConflict({
-        scopeId: newItem.scopeId,
-        existingItemId: existingItem.id,
-        candidateItemId: newItem.id,
-        relationship: 'ambiguous_contradiction',
-        clarificationQuestion: buildClarificationQuestion(existingItem.statement, newItem.statement),
-      });
-      break;
-    }
+): void {
+  if (result.relationship === 'complement') {
+    log.debug(
+      { existingId: existingItem.id, newId: newItem.id, explanation: result.explanation },
+      'Complement detected — keeping both items',
+    );
+    return;
   }
+
+  getSqlite().transaction(() => {
+    const db = getDb();
+    const now = Date.now();
+
+    // Re-check both items inside the transaction to guard against concurrent mutations
+    const freshExisting = db.select().from(memoryItems).where(eq(memoryItems.id, existingItem.id)).get();
+    const freshNew = db.select().from(memoryItems).where(eq(memoryItems.id, newItem.id)).get();
+
+    if (!freshExisting || freshExisting.status !== 'active' || freshExisting.invalidAt !== null) {
+      log.debug({ existingId: existingItem.id }, 'Existing item no longer active — skipping');
+      return;
+    }
+    if (!freshNew || (freshNew.status !== 'active' && result.relationship !== 'ambiguous_contradiction') || freshNew.invalidAt !== null) {
+      log.debug({ newId: newItem.id }, 'New item no longer active — skipping');
+      return;
+    }
+
+    switch (result.relationship) {
+      case 'contradiction': {
+        log.info(
+          { existingId: existingItem.id, newId: newItem.id, explanation: result.explanation },
+          'Contradiction detected — invalidating old item',
+        );
+        db.update(memoryItems)
+          .set({ invalidAt: now })
+          .where(eq(memoryItems.id, existingItem.id))
+          .run();
+        db.update(memoryItems)
+          .set({ validFrom: now })
+          .where(eq(memoryItems.id, newItem.id))
+          .run();
+        break;
+      }
+      case 'update': {
+        log.debug(
+          { existingId: existingItem.id, newId: newItem.id, explanation: result.explanation },
+          'Update detected — merging into existing item',
+        );
+        db.update(memoryItems)
+          .set({
+            statement: newItem.statement,
+            lastSeenAt: Math.max(existingItem.lastSeenAt, newItem.lastSeenAt),
+            confidence: Math.max(existingItem.confidence, newItem.confidence),
+          })
+          .where(eq(memoryItems.id, existingItem.id))
+          .run();
+        enqueueMemoryJob('embed_item', { itemId: existingItem.id });
+        db.update(memoryItems)
+          .set({ invalidAt: now })
+          .where(eq(memoryItems.id, newItem.id))
+          .run();
+        break;
+      }
+      case 'ambiguous_contradiction': {
+        log.info(
+          { existingId: existingItem.id, newId: newItem.id, explanation: result.explanation },
+          'Ambiguous contradiction detected — gating candidate pending clarification',
+        );
+        db.update(memoryItems)
+          .set({ status: 'pending_clarification' })
+          .where(eq(memoryItems.id, newItem.id))
+          .run();
+        createOrUpdatePendingConflict({
+          scopeId: newItem.scopeId,
+          existingItemId: existingItem.id,
+          candidateItemId: newItem.id,
+          relationship: 'ambiguous_contradiction',
+          clarificationQuestion: buildClarificationQuestion(existingItem.statement, newItem.statement),
+        });
+        break;
+      }
+    }
+  })();
 }
 
 function escapeSqlLike(s: string): string {


### PR DESCRIPTION
Wraps candidate processing in contradiction-checker.ts in a SQLite transaction to prevent race conditions during concurrent contradiction checks.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
