### PR TITLE
fix: wrap database migrations in transactions for rollback on failure

### DIFF
--- a/assistant/src/memory/schema-migration.ts
+++ b/assistant/src/memory/schema-migration.ts
@@ -248,10 +248,17 @@ export function migrateMemoryFtsBackfill(database: Db): void {
   const ftsCount = ftsCountRow?.c ?? 0;
   if (ftsCount > 0) return;
 
-  raw.exec(/*sql*/ `
-    INSERT INTO memory_segment_fts(segment_id, text)
-    SELECT id, text FROM memory_segments
-  `);
+  try {
+    raw.exec('BEGIN');
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_segment_fts(segment_id, text)
+      SELECT id, text FROM memory_segments
+    `);
+    raw.exec('COMMIT');
+  } catch (e) {
+    try { raw.exec('ROLLBACK'); } catch { /* no active transaction */ }
+    throw e;
+  }
 }
 
 /**
@@ -1163,52 +1170,61 @@ export function migrateCallSessionsAddInitiatedFrom(database: Db): void {
 export function migrateGuardianActionTables(database: Db): void {
   const raw = getSqliteFrom(database);
 
-  raw.exec(/*sql*/ `
-    CREATE TABLE IF NOT EXISTS guardian_action_requests (
-      id TEXT PRIMARY KEY,
-      assistant_id TEXT NOT NULL DEFAULT 'self',
-      kind TEXT NOT NULL,
-      source_channel TEXT NOT NULL,
-      source_conversation_id TEXT NOT NULL,
-      call_session_id TEXT NOT NULL REFERENCES call_sessions(id) ON DELETE CASCADE,
-      pending_question_id TEXT NOT NULL REFERENCES call_pending_questions(id) ON DELETE CASCADE,
-      question_text TEXT NOT NULL,
-      request_code TEXT NOT NULL,
-      status TEXT NOT NULL DEFAULT 'pending',
-      answer_text TEXT,
-      answered_by_channel TEXT,
-      answered_by_external_user_id TEXT,
-      answered_at INTEGER,
-      expires_at INTEGER NOT NULL,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
-    )
-  `);
+  try {
+    raw.exec('BEGIN');
 
-  raw.exec(/*sql*/ `
-    CREATE TABLE IF NOT EXISTS guardian_action_deliveries (
-      id TEXT PRIMARY KEY,
-      request_id TEXT NOT NULL REFERENCES guardian_action_requests(id) ON DELETE CASCADE,
-      destination_channel TEXT NOT NULL,
-      destination_conversation_id TEXT,
-      destination_chat_id TEXT,
-      destination_external_user_id TEXT,
-      status TEXT NOT NULL DEFAULT 'pending',
-      sent_at INTEGER,
-      responded_at INTEGER,
-      last_error TEXT,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
-    )
-  `);
+    raw.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS guardian_action_requests (
+        id TEXT PRIMARY KEY,
+        assistant_id TEXT NOT NULL DEFAULT 'self',
+        kind TEXT NOT NULL,
+        source_channel TEXT NOT NULL,
+        source_conversation_id TEXT NOT NULL,
+        call_session_id TEXT NOT NULL REFERENCES call_sessions(id) ON DELETE CASCADE,
+        pending_question_id TEXT NOT NULL REFERENCES call_pending_questions(id) ON DELETE CASCADE,
+        question_text TEXT NOT NULL,
+        request_code TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending',
+        answer_text TEXT,
+        answered_by_channel TEXT,
+        answered_by_external_user_id TEXT,
+        answered_at INTEGER,
+        expires_at INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
 
-  raw.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_action_requests_status ON guardian_action_requests(status)`);
-  raw.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_action_requests_call_session ON guardian_action_requests(call_session_id)`);
-  raw.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_action_requests_pending_question ON guardian_action_requests(pending_question_id)`);
-  raw.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_action_requests_request_code ON guardian_action_requests(request_code)`);
-  raw.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_action_deliveries_request_id ON guardian_action_deliveries(request_id)`);
-  raw.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_action_deliveries_status ON guardian_action_deliveries(status)`);
-  raw.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_action_deliveries_destination ON guardian_action_deliveries(destination_channel, destination_chat_id)`);
+    raw.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS guardian_action_deliveries (
+        id TEXT PRIMARY KEY,
+        request_id TEXT NOT NULL REFERENCES guardian_action_requests(id) ON DELETE CASCADE,
+        destination_channel TEXT NOT NULL,
+        destination_conversation_id TEXT,
+        destination_chat_id TEXT,
+        destination_external_user_id TEXT,
+        status TEXT NOT NULL DEFAULT 'pending',
+        sent_at INTEGER,
+        responded_at INTEGER,
+        last_error TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+
+    raw.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_action_requests_status ON guardian_action_requests(status)`);
+    raw.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_action_requests_call_session ON guardian_action_requests(call_session_id)`);
+    raw.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_action_requests_pending_question ON guardian_action_requests(pending_question_id)`);
+    raw.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_action_requests_request_code ON guardian_action_requests(request_code)`);
+    raw.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_action_deliveries_request_id ON guardian_action_deliveries(request_id)`);
+    raw.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_action_deliveries_status ON guardian_action_deliveries(status)`);
+    raw.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_action_deliveries_destination ON guardian_action_deliveries(destination_channel, destination_chat_id)`);
+
+    raw.exec('COMMIT');
+  } catch (e) {
+    try { raw.exec('ROLLBACK'); } catch { /* no active transaction */ }
+    throw e;
+  }
 }
 
 /**
@@ -1299,9 +1315,15 @@ export function migrateDropActiveSearchIndex(database: Db): void {
   ).get(checkpointKey);
   if (checkpoint) return;
 
-  raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_memory_items_active_search`);
-
-  raw.query(
-    `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,
-  ).run(checkpointKey, Date.now());
+  try {
+    raw.exec('BEGIN');
+    raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_memory_items_active_search`);
+    raw.query(
+      `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,
+    ).run(checkpointKey, Date.now());
+    raw.exec('COMMIT');
+  } catch (e) {
+    try { raw.exec('ROLLBACK'); } catch { /* no active transaction */ }
+    throw e;
+  }
 }


### PR DESCRIPTION
Wraps each migration in a transaction so failed migrations are rolled back instead of leaving the database in a partially-migrated state.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
