### PR TITLE
Quick Chat — Spotlight-style Floating Composer

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -72,7 +72,19 @@ extension AppDelegate {
             options: []
         )
 
-        center.setNotificationCategories([activityCategory, toolConfirmationCategory, rideShotgunCategory, voiceResponseCategory])
+        let viewQuickChatAction = UNNotificationAction(
+            identifier: "VIEW_QUICK_CHAT",
+            title: "View in Chat",
+            options: .foreground
+        )
+        let quickChatCategory = UNNotificationCategory(
+            identifier: "QUICK_CHAT_RESPONSE",
+            actions: [viewQuickChatAction],
+            intentIdentifiers: [],
+            options: []
+        )
+
+        center.setNotificationCategories([activityCategory, toolConfirmationCategory, rideShotgunCategory, voiceResponseCategory, quickChatCategory])
     }
 
     func registerBundledFonts() {
@@ -144,6 +156,16 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             await MainActor.run {
                 guard !self.isAwaitingFirstLaunchReady else { return }
                 self.showMainWindow()
+            }
+            return
+        }
+
+        // Handle quick chat response notifications — open the thread in the main window
+        if categoryId == "QUICK_CHAT_RESPONSE" {
+            let conversationId = response.notification.request.content.userInfo["conversationId"] as? String
+            await MainActor.run {
+                guard !self.isAwaitingFirstLaunchReady else { return }
+                self.openQuickChatThread(conversationId: conversationId)
             }
             return
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -1,4 +1,5 @@
 import AppKit
+import UserNotifications
 import VellumAssistantShared
 import os
 
@@ -237,6 +238,174 @@ extension AppDelegate {
                 await session.run()
             }
         }
+    }
+
+    // MARK: - Background Session (Quick Chat)
+
+    /// Starts a background session that sends a message to the daemon without
+    /// showing any UI. When the assistant responds, a macOS notification is
+    /// delivered. Multiple background sessions can run concurrently.
+    func startBackgroundSession(task: String, source: String) {
+        let sessionTask = task.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !sessionTask.isEmpty else { return }
+
+        Task { @MainActor in
+            // Ensure daemon connection
+            if !daemonClient.isConnected {
+                log.info("Daemon not connected, attempting to connect before background session")
+                do {
+                    try await daemonClient.connect()
+                    self.setupAmbientAgent()
+                } catch {
+                    log.error("Failed to connect to daemon for background session: \(error.localizedDescription)")
+                    self.deliverQuickChatErrorNotification(task: sessionTask)
+                    return
+                }
+            }
+
+            // Subscribe to daemon stream before sending task_submit
+            let messageStream = self.daemonClient.subscribe()
+
+            // Send task_submit
+            let screenBounds = CGDisplayBounds(CGMainDisplayID())
+            do {
+                try self.daemonClient.send(TaskSubmitMessage(
+                    task: sessionTask,
+                    screenWidth: Int(screenBounds.width),
+                    screenHeight: Int(screenBounds.height),
+                    attachments: nil,
+                    source: source
+                ))
+            } catch {
+                log.error("Failed to send background task submit: \(error)")
+                return
+            }
+
+            // Wait for task_routed, then listen for the response
+            var routedMessage: TaskRoutedMessage?
+            for await message in messageStream {
+                if case .taskRouted(let routed) = message {
+                    routedMessage = routed
+                    break
+                }
+                if case .error(let err) = message {
+                    log.error("Background task routing failed: \(err.message, privacy: .private)")
+                    break
+                }
+            }
+
+            guard let routed = routedMessage else {
+                log.error("Background session: no routed message received")
+                return
+            }
+
+            let sessionId = routed.sessionId
+
+            // Create a thread in ThreadManager so the user can find it later
+            if let threadManager = self.mainWindow?.threadManager {
+                threadManager.createTaskRunThread(
+                    conversationId: sessionId,
+                    workItemId: "",
+                    title: String(sessionTask.prefix(50))
+                )
+            }
+
+            // Listen for the assistant response in the background
+            var accumulatedText = ""
+            for await message in messageStream {
+                switch message {
+                case .assistantTextDelta(let delta):
+                    accumulatedText += delta.text
+
+                case .messageComplete(let complete) where complete.sessionId == sessionId:
+                    let responseText = accumulatedText.isEmpty ? "(No response)" : accumulatedText
+                    self.deliverQuickChatNotification(
+                        responseText: responseText,
+                        conversationId: sessionId
+                    )
+                    return
+
+                case .generationHandoff(let handoff) where handoff.sessionId == sessionId:
+                    let responseText = accumulatedText.isEmpty ? "(No response)" : accumulatedText
+                    self.deliverQuickChatNotification(
+                        responseText: responseText,
+                        conversationId: sessionId
+                    )
+                    return
+
+                case .cuError(let error) where error.sessionId == sessionId:
+                    self.deliverQuickChatNotification(
+                        responseText: "Error: \(error.message)",
+                        conversationId: sessionId
+                    )
+                    return
+
+                case .sessionError(let error) where error.sessionId == sessionId:
+                    self.deliverQuickChatNotification(
+                        responseText: "Error: \(error.userMessage)",
+                        conversationId: sessionId
+                    )
+                    return
+
+                default:
+                    break
+                }
+            }
+        }
+    }
+
+    private func deliverQuickChatNotification(responseText: String, conversationId: String) {
+        let content = UNMutableNotificationContent()
+        content.title = "Quick Chat"
+        // Truncate long responses for the notification body
+        if responseText.count > 200 {
+            content.body = String(responseText.prefix(200)) + "..."
+        } else {
+            content.body = responseText
+        }
+        content.sound = .default
+        content.categoryIdentifier = "QUICK_CHAT_RESPONSE"
+        content.userInfo = ["conversationId": conversationId]
+
+        let request = UNNotificationRequest(
+            identifier: "quick-chat-\(conversationId)",
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error {
+                log.error("Failed to post quick chat notification: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func deliverQuickChatErrorNotification(task: String) {
+        let content = UNMutableNotificationContent()
+        content.title = "Quick Chat"
+        content.body = "Could not connect to the assistant. Please try again."
+        content.sound = .default
+
+        let request = UNNotificationRequest(
+            identifier: "quick-chat-error-\(UUID().uuidString)",
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error {
+                log.error("Failed to post quick chat error notification: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Opens the main window and navigates to the thread for the given conversation ID.
+    func openQuickChatThread(conversationId: String?) {
+        showMainWindow()
+        guard let conversationId,
+              let threadManager = mainWindow?.threadManager,
+              let thread = threadManager.threads.first(where: { $0.sessionId == conversationId }) else {
+            return
+        }
+        threadManager.activeThreadId = thread.id
     }
 
     func showDaemonConnectionError() {

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -55,6 +55,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var statusItem: NSStatusItem!
     private var hotKeyMonitor: Any?
     private var escapeMonitor: Any?
+    private var quickChatPanel: QuickChatPanel?
+    private var quickChatMonitor: Any?
     var overlayWindow: SessionOverlayWindow?
     var currentSession: ComputerUseSession?
     var currentTextSession: TextSession?
@@ -191,6 +193,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         setupFileMenu()
         setupViewMenu()
         setupHotKey()
+        setupQuickChatHotKey()
         setupEscapeMonitor()
         setupVoiceInput()
         setupAmbientAgent()
@@ -337,6 +340,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 NSEvent.removeMonitor(escapeMonitor)
                 self.escapeMonitor = nil
             }
+            if let quickChatMonitor {
+                NSEvent.removeMonitor(quickChatMonitor)
+                self.quickChatMonitor = nil
+            }
+            quickChatPanel?.dismiss()
+            quickChatPanel = nil
             voiceInput?.stop()
             voiceInput = nil
             ambientAgent.teardown()
@@ -436,6 +445,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             NSEvent.removeMonitor(escapeMonitor)
             self.escapeMonitor = nil
         }
+        if let quickChatMonitor {
+            NSEvent.removeMonitor(quickChatMonitor)
+            self.quickChatMonitor = nil
+        }
+        quickChatPanel?.dismiss()
+        quickChatPanel = nil
         voiceInput?.stop()
         voiceInput = nil
         ambientAgent.teardown()
@@ -1029,6 +1044,30 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    private func setupQuickChatHotKey() {
+        quickChatMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == [.command, .shift],
+                  event.charactersIgnoringModifiers == " " else { return }
+            Task { @MainActor in
+                self?.showQuickChat()
+            }
+        }
+    }
+
+    func showQuickChat() {
+        if let existing = quickChatPanel, existing.isVisible {
+            existing.dismiss()
+            return
+        }
+
+        let panel = QuickChatPanel()
+        panel.onSubmit = { message in
+            print("[QuickChat] \(message)")
+        }
+        panel.show()
+        quickChatPanel = panel
+    }
+
     private func setupEscapeMonitor() {
         escapeMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
             if event.keyCode == 53 { // Escape
@@ -1375,6 +1414,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         if let monitor = escapeMonitor {
             NSEvent.removeMonitor(monitor)
         }
+        if let monitor = quickChatMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+        quickChatPanel?.dismiss()
+        quickChatPanel = nil
         if let observer = windowObserver {
             NotificationCenter.default.removeObserver(observer)
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1061,8 +1061,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let panel = QuickChatPanel()
-        panel.onSubmit = { message in
-            print("[QuickChat] \(message)")
+        panel.onSubmit = { [weak self] message in
+            self?.startBackgroundSession(task: message, source: "quick_chat")
         }
         panel.show()
         quickChatPanel = panel

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -96,6 +96,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var galleryWindow: ComponentGalleryWindow?
     #endif
     private var windowObserver: Any?
+    private var quickChatShortcutObserver: AnyCancellable?
     private weak var recordingViewModel: ChatViewModel?
     private var statusIconCancellable: AnyCancellable?
     var cachedSkills: [SkillInfo] = []
@@ -344,6 +345,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 NSEvent.removeMonitor(quickChatMonitor)
                 self.quickChatMonitor = nil
             }
+            quickChatShortcutObserver?.cancel()
+            quickChatShortcutObserver = nil
             quickChatPanel?.dismiss()
             quickChatPanel = nil
             voiceInput?.stop()
@@ -449,6 +452,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             NSEvent.removeMonitor(quickChatMonitor)
             self.quickChatMonitor = nil
         }
+        quickChatShortcutObserver?.cancel()
+        quickChatShortcutObserver = nil
         quickChatPanel?.dismiss()
         quickChatPanel = nil
         voiceInput?.stop()
@@ -1045,9 +1050,32 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func setupQuickChatHotKey() {
+        registerQuickChatMonitor()
+
+        // Re-register the global hotkey whenever the user changes the shortcut
+        quickChatShortcutObserver = NotificationCenter.default
+            .publisher(for: UserDefaults.didChangeNotification)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.registerQuickChatMonitor()
+            }
+    }
+
+    /// Tears down the existing Quick Chat global monitor and registers a new
+    /// one based on the current `quickChatShortcut` UserDefaults value.
+    private func registerQuickChatMonitor() {
+        if let existing = quickChatMonitor {
+            NSEvent.removeMonitor(existing)
+            quickChatMonitor = nil
+        }
+
+        let shortcut = UserDefaults.standard.string(forKey: "quickChatShortcut") ?? "cmd+shift+space"
+        let (targetModifiers, targetKey) = ShortcutHelper.parseShortcut(shortcut)
+
         quickChatMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == [.command, .shift],
-                  event.charactersIgnoringModifiers == " " else { return }
+            let eventMods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            guard eventMods == targetModifiers,
+                  event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else { return }
             Task { @MainActor in
                 self?.showQuickChat()
             }
@@ -1417,6 +1445,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         if let monitor = quickChatMonitor {
             NSEvent.removeMonitor(monitor)
         }
+        quickChatShortcutObserver?.cancel()
         quickChatPanel?.dismiss()
         quickChatPanel = nil
         if let observer = windowObserver {

--- a/clients/macos/vellum-assistant/Features/QuickChat/QuickChatPanel.swift
+++ b/clients/macos/vellum-assistant/Features/QuickChat/QuickChatPanel.swift
@@ -8,6 +8,7 @@ import VellumAssistantShared
 @MainActor
 final class QuickChatPanel {
     private var panel: NSPanel?
+    private var toastPanel: NSPanel?
     private var resignObserver: Any?
 
     /// Callback invoked when the user submits a message.
@@ -23,7 +24,12 @@ final class QuickChatPanel {
         let view = QuickChatView(
             onSubmit: { [weak self] message in
                 self?.onSubmit?(message)
+                // Capture position before dismissing so the toast appears in the same spot
+                let panelFrame = self?.panel?.frame
                 self?.dismiss()
+                if let frame = panelFrame {
+                    self?.showSentToast(near: frame)
+                }
             },
             onDismiss: { [weak self] in
                 self?.dismiss()
@@ -53,9 +59,16 @@ final class QuickChatPanel {
         // Center on the active screen
         centerOnScreen(panel)
 
-        // Become key so the text editor receives focus
+        // Animate in: start transparent and slightly scaled down, then animate to full
+        panel.alphaValue = 0
         panel.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = VAnimation.durationFast
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            panel.animator().alphaValue = 1
+        }
 
         // Dismiss when the panel loses focus
         resignObserver = NotificationCenter.default.addObserver(
@@ -76,8 +89,17 @@ final class QuickChatPanel {
             NotificationCenter.default.removeObserver(resignObserver)
         }
         resignObserver = nil
-        panel?.close()
-        panel = nil
+
+        guard let panel else { return }
+        // Animate out: fade to transparent, then close
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = VAnimation.durationFast
+            context.timingFunction = CAMediaTimingFunction(name: .easeIn)
+            panel.animator().alphaValue = 0
+        }, completionHandler: { [weak self] in
+            panel.close()
+            self?.panel = nil
+        })
     }
 
     var isVisible: Bool {
@@ -85,6 +107,75 @@ final class QuickChatPanel {
     }
 
     // MARK: - Private
+
+    /// Shows a brief "Message sent" toast near the given frame, then auto-dismisses.
+    private func showSentToast(near frame: NSRect) {
+        let toastView = HStack(spacing: VSpacing.sm) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundColor(VColor.success)
+            Text("Message sent")
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.md)
+        .background(
+            VisualEffectBlur(material: .hudWindow, blendingMode: .behindWindow)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+
+        let hosting = NSHostingController(rootView: toastView)
+
+        let toast = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 180, height: 40),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        toast.contentViewController = hosting
+        toast.level = .floating
+        toast.titleVisibility = .hidden
+        toast.titlebarAppearsTransparent = true
+        toast.isReleasedWhenClosed = false
+        toast.backgroundColor = .clear
+        toast.isOpaque = false
+        toast.hasShadow = true
+        toast.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+        // Position just below where the Quick Chat panel was
+        if let fittingSize = toast.contentView?.fittingSize {
+            let x = frame.midX - fittingSize.width / 2
+            let y = frame.origin.y - fittingSize.height - 8
+            toast.setFrame(
+                NSRect(x: x, y: y, width: fittingSize.width, height: fittingSize.height),
+                display: true
+            )
+        }
+
+        toast.alphaValue = 0
+        toast.orderFrontRegardless()
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = VAnimation.durationFast
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            toast.animator().alphaValue = 1
+        }
+
+        self.toastPanel = toast
+
+        // Auto-dismiss after 1.5 seconds
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+            guard let toast = self?.toastPanel else { return }
+            NSAnimationContext.runAnimationGroup({ context in
+                context.duration = VAnimation.durationFast
+                context.timingFunction = CAMediaTimingFunction(name: .easeIn)
+                toast.animator().alphaValue = 0
+            }, completionHandler: {
+                toast.close()
+                self?.toastPanel = nil
+            })
+        }
+    }
 
     private func centerOnScreen(_ panel: NSPanel) {
         let screen = NSScreen.main ?? NSScreen.screens.first

--- a/clients/macos/vellum-assistant/Features/QuickChat/QuickChatPanel.swift
+++ b/clients/macos/vellum-assistant/Features/QuickChat/QuickChatPanel.swift
@@ -1,0 +1,108 @@
+import AppKit
+import SwiftUI
+import VellumAssistantShared
+
+/// A borderless, floating NSPanel that hosts the Quick Chat text editor.
+/// Appears centered on the active screen with a vibrancy/blur background.
+/// Dismisses itself when it resigns key window status.
+@MainActor
+final class QuickChatPanel {
+    private var panel: NSPanel?
+    private var resignObserver: Any?
+
+    /// Callback invoked when the user submits a message.
+    var onSubmit: ((String) -> Void)?
+
+    func show() {
+        if let existing = panel {
+            existing.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let view = QuickChatView(
+            onSubmit: { [weak self] message in
+                self?.onSubmit?(message)
+                self?.dismiss()
+            },
+            onDismiss: { [weak self] in
+                self?.dismiss()
+            }
+        )
+
+        let hostingController = NSHostingController(rootView: view)
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 60),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        panel.contentViewController = hostingController
+        panel.level = .floating
+        panel.isMovableByWindowBackground = true
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.isReleasedWhenClosed = false
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = true
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+        // Center on the active screen
+        centerOnScreen(panel)
+
+        // Become key so the text editor receives focus
+        panel.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+
+        // Dismiss when the panel loses focus
+        resignObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResignKeyNotification,
+            object: panel,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.dismiss()
+            }
+        }
+
+        self.panel = panel
+    }
+
+    func dismiss() {
+        if let resignObserver {
+            NotificationCenter.default.removeObserver(resignObserver)
+        }
+        resignObserver = nil
+        panel?.close()
+        panel = nil
+    }
+
+    var isVisible: Bool {
+        panel?.isVisible ?? false
+    }
+
+    // MARK: - Private
+
+    private func centerOnScreen(_ panel: NSPanel) {
+        let screen = NSScreen.main ?? NSScreen.screens.first
+        guard let screenFrame = screen?.visibleFrame else { return }
+
+        // Let the hosting controller size the panel to fit the content
+        if let fittingSize = panel.contentView?.fittingSize {
+            let width = max(fittingSize.width, 400)
+            let height = fittingSize.height
+            let x = screenFrame.midX - width / 2
+            // Position slightly above center (like Spotlight)
+            let y = screenFrame.midY + screenFrame.height * 0.1
+            panel.setFrame(
+                NSRect(x: x, y: y, width: width, height: height),
+                display: true
+            )
+        } else {
+            panel.center()
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/QuickChat/QuickChatView.swift
+++ b/clients/macos/vellum-assistant/Features/QuickChat/QuickChatView.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct QuickChatView: View {
+    let onSubmit: (String) -> Void
+    let onDismiss: () -> Void
+
+    @State private var text = ""
+    @FocusState private var isFocused: Bool
+
+    private let panelWidth: CGFloat = 400
+    private let minEditorHeight: CGFloat = 36
+    private let maxEditorHeight: CGFloat = 120
+
+    var body: some View {
+        VStack(spacing: 0) {
+            TextEditor(text: $text)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .scrollContentBackground(.hidden)
+                .padding(.horizontal, VSpacing.md)
+                .padding(.vertical, VSpacing.sm)
+                .frame(minHeight: minEditorHeight, maxHeight: maxEditorHeight)
+                .fixedSize(horizontal: false, vertical: true)
+                .focused($isFocused)
+                .overlay(alignment: .topLeading) {
+                    if text.isEmpty {
+                        Text("Type a message...")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textMuted)
+                            .padding(.horizontal, VSpacing.md + 5)
+                            .padding(.vertical, VSpacing.sm + 1)
+                            .allowsHitTesting(false)
+                    }
+                }
+                .onKeyPress(.return, modifiers: []) {
+                    submit()
+                    return .handled
+                }
+                .onKeyPress(.return, modifiers: .command) {
+                    text += "\n"
+                    return .handled
+                }
+                .onKeyPress(.escape) {
+                    onDismiss()
+                    return .handled
+                }
+        }
+        .frame(width: panelWidth)
+        .background(
+            VisualEffectBlur(material: .hudWindow, blendingMode: .behindWindow)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .onAppear {
+            isFocused = true
+        }
+    }
+
+    private func submit() {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        onSubmit(trimmed)
+    }
+}
+
+// MARK: - NSVisualEffectView wrapper
+
+struct VisualEffectBlur: NSViewRepresentable {
+    let material: NSVisualEffectView.Material
+    let blendingMode: NSVisualEffectView.BlendingMode
+
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = material
+        view.blendingMode = blendingMode
+        view.state = .active
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {
+        nsView.material = material
+        nsView.blendingMode = blendingMode
+    }
+}
+
+// MARK: - Preview
+
+#Preview("QuickChatView") {
+    ZStack {
+        Color.black.opacity(0.5).ignoresSafeArea()
+        QuickChatView(
+            onSubmit: { message in
+                print("Submitted: \(message)")
+            },
+            onDismiss: {
+                print("Dismissed")
+            }
+        )
+    }
+    .frame(width: 500, height: 300)
+}

--- a/clients/macos/vellum-assistant/Features/QuickChat/QuickChatView.swift
+++ b/clients/macos/vellum-assistant/Features/QuickChat/QuickChatView.swift
@@ -6,6 +6,7 @@ struct QuickChatView: View {
     let onDismiss: () -> Void
 
     @State private var text = ""
+    @State private var isPresented = false
     @FocusState private var isFocused: Bool
 
     private let panelWidth: CGFloat = 400
@@ -51,8 +52,12 @@ struct QuickChatView: View {
             VisualEffectBlur(material: .hudWindow, blendingMode: .behindWindow)
         )
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .scaleEffect(isPresented ? 1.0 : 0.95)
         .onAppear {
             isFocused = true
+            withAnimation(VAnimation.fast) {
+                isPresented = true
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Appearance settings tab — theme selection and media embed configuration.
+/// Appearance settings tab — theme selection, keyboard shortcuts, and media embed configuration.
 struct SettingsAppearanceTab: View {
     @ObservedObject var store: SettingsStore
     @AppStorage("themePreference") private var themePreference: String = "system"
     @State private var newAllowlistDomain = ""
+    @State private var isRecordingShortcut = false
+    @State private var shortcutMonitor: Any?
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
@@ -38,6 +40,66 @@ struct SettingsAppearanceTab: View {
             }
             .padding(VSpacing.lg)
             .vCard(background: VColor.surfaceSubtle)
+
+            // KEYBOARD SHORTCUTS section
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("Keyboard Shortcuts")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                // Quick Chat (configurable)
+                HStack {
+                    Text("Quick Chat")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Spacer()
+                    Text(ShortcutHelper.displayString(for: store.quickChatShortcut))
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textPrimary)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(VColor.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.sm)
+                                .stroke(VColor.surfaceBorder, lineWidth: 1)
+                        )
+
+                    if isRecordingShortcut {
+                        VButton(label: "Press shortcut...", style: .tertiary) {
+                            stopRecording()
+                        }
+                    } else {
+                        VButton(label: "Record", style: .tertiary) {
+                            startRecording()
+                        }
+                    }
+                }
+
+                // Open Vellum (fixed, non-editable)
+                HStack {
+                    Text("Open Vellum")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Spacer()
+                    Text("\u{2318}\u{21E7}G")
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textMuted)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(VColor.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.sm)
+                                .stroke(VColor.surfaceBorder, lineWidth: 1)
+                        )
+                }
+            }
+            .padding(VSpacing.lg)
+            .vCard(background: VColor.surfaceSubtle)
+            .onDisappear {
+                stopRecording()
+            }
 
             // MEDIA EMBEDS section
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -118,4 +180,52 @@ struct SettingsAppearanceTab: View {
             .vCard(background: VColor.surfaceSubtle)
         }
     }
+
+    // MARK: - Shortcut Recording
+
+    private func startRecording() {
+        isRecordingShortcut = true
+        // Use local monitor so we capture key events while the settings window is focused
+        shortcutMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+
+            // Escape cancels recording without changing the shortcut
+            if event.keyCode == 53 {
+                stopRecording()
+                return nil
+            }
+
+            // Require at least one modifier key to form a valid global shortcut
+            let hasModifier = mods.contains(.command) || mods.contains(.control)
+                || mods.contains(.option)
+            guard hasModifier,
+                  let chars = event.charactersIgnoringModifiers, !chars.isEmpty else {
+                return nil
+            }
+
+            let shortcut = ShortcutHelper.shortcutString(
+                from: mods, key: chars, keyCode: event.keyCode
+            )
+            store.quickChatShortcut = shortcut
+            stopRecording()
+            return nil // consume the event
+        }
+    }
+
+    private func stopRecording() {
+        isRecordingShortcut = false
+        if let monitor = shortcutMonitor {
+            NSEvent.removeMonitor(monitor)
+            shortcutMonitor = nil
+        }
+    }
+}
+
+#Preview("Appearance Tab") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        SettingsAppearanceTab(store: SettingsStore())
+            .padding()
+    }
+    .frame(width: 500, height: 600)
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -8,6 +8,7 @@ struct SettingsAppearanceTab: View {
     @State private var newAllowlistDomain = ""
     @State private var isRecordingShortcut = false
     @State private var shortcutMonitor: Any?
+    @State private var shortcutConflictWarning: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
@@ -74,6 +75,12 @@ struct SettingsAppearanceTab: View {
                             startRecording()
                         }
                     }
+                }
+
+                if let shortcutConflictWarning {
+                    Text(shortcutConflictWarning)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.warning)
                 }
 
                 // Open Vellum (fixed, non-editable)
@@ -183,8 +190,12 @@ struct SettingsAppearanceTab: View {
 
     // MARK: - Shortcut Recording
 
+    /// The fixed "Open Vellum" shortcut in normalized form for conflict detection.
+    private static let openVellumShortcut = "cmd+shift+g"
+
     private func startRecording() {
         isRecordingShortcut = true
+        shortcutConflictWarning = nil
         // Use local monitor so we capture key events while the settings window is focused
         shortcutMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
@@ -206,6 +217,15 @@ struct SettingsAppearanceTab: View {
             let shortcut = ShortcutHelper.shortcutString(
                 from: mods, key: chars, keyCode: event.keyCode
             )
+
+            // Check for conflict with the fixed "Open Vellum" shortcut
+            if shortcut.lowercased() == Self.openVellumShortcut {
+                shortcutConflictWarning = "This shortcut conflicts with the Open Vellum shortcut (\u{2318}\u{21E7}G). Choose a different shortcut."
+                stopRecording()
+                return nil
+            }
+
+            shortcutConflictWarning = nil
             store.quickChatShortcut = shortcut
             stopRecording()
             return nil // consume the event

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -59,6 +59,7 @@ public final class SettingsStore: ObservableObject {
 
     @Published var maxSteps: Double
     @Published var activityNotificationsEnabled: Bool
+    @Published var quickChatShortcut: String
 
     // MARK: - Media Embed Settings
 
@@ -243,6 +244,8 @@ public final class SettingsStore: ObservableObject {
         // Default to enabled for notifications
         self.activityNotificationsEnabled = UserDefaults.standard.object(forKey: "activityNotificationsEnabled") as? Bool ?? true
 
+        self.quickChatShortcut = UserDefaults.standard.string(forKey: "quickChatShortcut") ?? "cmd+shift+space"
+
         // Load media embed settings from workspace config
         let mediaSettings = Self.loadMediaEmbedSettings(from: configPath)
         self.mediaEmbedsEnabled = mediaSettings.enabled
@@ -278,6 +281,12 @@ public final class SettingsStore: ObservableObject {
             .dropFirst()
             .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
             .sink { value in UserDefaults.standard.set(value, forKey: "activityNotificationsEnabled") }
+            .store(in: &cancellables)
+
+        // Persist shortcut changes immediately so the hotkey re-registers without delay
+        $quickChatShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "quickChatShortcut") }
             .store(in: &cancellables)
 
         // Mirror DaemonClient's trust-rules-open flag so views can disable their buttons

--- a/clients/macos/vellum-assistant/Features/Settings/ShortcutHelper.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ShortcutHelper.swift
@@ -1,0 +1,111 @@
+import AppKit
+
+/// Utilities for converting between the string shortcut representation
+/// (e.g. "cmd+shift+space") and macOS modifier flags / display symbols.
+enum ShortcutHelper {
+
+    /// Converts a shortcut string like "cmd+shift+space" to a human-readable
+    /// display string like "Command Shift Space".
+    static func displayString(for shortcut: String) -> String {
+        let parts = shortcut.lowercased().split(separator: "+").map(String.init)
+        return parts.map { displayToken($0) }.joined()
+    }
+
+    /// Parses a shortcut string into modifier flags and a key string suitable
+    /// for matching against `NSEvent.charactersIgnoringModifiers`.
+    static func parseShortcut(_ shortcut: String) -> (NSEvent.ModifierFlags, String) {
+        let parts = shortcut.lowercased().split(separator: "+").map(String.init)
+        var modifiers: NSEvent.ModifierFlags = []
+        var key = ""
+
+        for part in parts {
+            switch part {
+            case "cmd", "command":
+                modifiers.insert(.command)
+            case "shift":
+                modifiers.insert(.shift)
+            case "opt", "alt", "option":
+                modifiers.insert(.option)
+            case "ctrl", "control":
+                modifiers.insert(.control)
+            default:
+                key = keyString(for: part)
+            }
+        }
+
+        return (modifiers, key)
+    }
+
+    /// Builds a shortcut string from modifier flags and a key code/characters,
+    /// as captured from an NSEvent during recording.
+    static func shortcutString(from modifiers: NSEvent.ModifierFlags, key: String, keyCode: UInt16) -> String {
+        var parts: [String] = []
+        if modifiers.contains(.control) { parts.append("ctrl") }
+        if modifiers.contains(.option) { parts.append("opt") }
+        if modifiers.contains(.shift) { parts.append("shift") }
+        if modifiers.contains(.command) { parts.append("cmd") }
+
+        let keyPart = keyName(for: key, keyCode: keyCode)
+        parts.append(keyPart)
+        return parts.joined(separator: "+")
+    }
+
+    // MARK: - Private
+
+    private static func displayToken(_ token: String) -> String {
+        switch token {
+        case "cmd", "command": return "\u{2318}"
+        case "shift": return "\u{21E7}"
+        case "opt", "alt", "option": return "\u{2325}"
+        case "ctrl", "control": return "\u{2303}"
+        case "space": return "Space"
+        case "return", "enter": return "\u{21A9}"
+        case "tab": return "\u{21E5}"
+        case "delete", "backspace": return "\u{232B}"
+        case "escape", "esc": return "\u{238B}"
+        case "up": return "\u{2191}"
+        case "down": return "\u{2193}"
+        case "left": return "\u{2190}"
+        case "right": return "\u{2192}"
+        default:
+            return token.uppercased()
+        }
+    }
+
+    /// Maps a token from the shortcut string to the value used for matching
+    /// against `NSEvent.charactersIgnoringModifiers`.
+    private static func keyString(for token: String) -> String {
+        switch token {
+        case "space": return " "
+        case "return", "enter": return "\r"
+        case "tab": return "\t"
+        case "escape", "esc": return "\u{1B}"
+        case "delete", "backspace": return "\u{7F}"
+        case "up": return String(Character(UnicodeScalar(NSUpArrowFunctionKey)!))
+        case "down": return String(Character(UnicodeScalar(NSDownArrowFunctionKey)!))
+        case "left": return String(Character(UnicodeScalar(NSLeftArrowFunctionKey)!))
+        case "right": return String(Character(UnicodeScalar(NSRightArrowFunctionKey)!))
+        default:
+            return token.lowercased()
+        }
+    }
+
+    /// Converts a captured key event back into the canonical token name
+    /// for the shortcut string format.
+    private static func keyName(for characters: String, keyCode: UInt16) -> String {
+        // Handle space explicitly (keyCode 49)
+        if keyCode == 49 || characters == " " { return "space" }
+        if characters == "\r" { return "return" }
+        if characters == "\t" { return "tab" }
+
+        // Single printable character
+        if characters.count == 1, let scalar = characters.unicodeScalars.first {
+            if scalar.value == NSUpArrowFunctionKey { return "up" }
+            if scalar.value == NSDownArrowFunctionKey { return "down" }
+            if scalar.value == NSLeftArrowFunctionKey { return "left" }
+            if scalar.value == NSRightArrowFunctionKey { return "right" }
+        }
+
+        return characters.lowercased()
+    }
+}


### PR DESCRIPTION
## Summary
Adds a lightweight, always-accessible floating input panel (Quick Chat) that lets users fire off a message to a new thread without opening the full app. Hit a configurable keyboard shortcut, type your message, hit Enter — the message goes to a new background thread and you get a notification when the assistant responds.

## Changes
- **Floating panel UI** — NSPanel with vibrancy background, multi-line composer input, Enter to send, Cmd+Enter for newline, Escape to dismiss
- **Background sessions** — Quick Chat messages create new threads that run in the background without showing any UI windows
- **Notification delivery** — macOS notifications when the assistant responds, click to open the thread
- **Configurable shortcut** — Default Cmd+Shift+Space, user can rebind via Settings > Appearance > Keyboard Shortcuts with a shortcut recorder
- **Polish** — Fade-in/scale animation, "Message sent" confirmation toast, shortcut conflict detection

## Milestone PRs (merged into feature branch)
- #8035: M1 — Quick Chat floating panel UI
- #8038: M2 — Background session and notification delivery
- #8040: M3 — Configurable keyboard shortcut
- #8046: M4 — Quick Chat polish

## Project issue
Closes #8030

## Test plan
- [ ] Press Cmd+Shift+Space — floating panel appears centered on screen
- [ ] Type a message and press Enter — panel dismisses, "Message sent" toast appears
- [ ] Notification appears when assistant responds
- [ ] Click notification — opens the thread in the main window
- [ ] Press Escape — panel dismisses without sending
- [ ] Cmd+Enter inserts a newline in the text editor
- [ ] Settings > Appearance > Keyboard Shortcuts — record a new shortcut
- [ ] Recording a conflicting shortcut (Cmd+Shift+G) shows a warning
- [ ] Quick Chat works while a foreground session is running

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
