### PR TITLE
fix: promote curl and wget from LOW to MEDIUM risk

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -34,7 +34,7 @@ const LOW_RISK_PROGRAMS = new Set([
   'env', 'printenv', 'set',
   'diff', 'sort', 'uniq', 'cut', 'tr', 'tee', 'xargs',
   'jq', 'yq',
-  'curl', 'wget', 'http', 'dig', 'nslookup', 'ping',
+  'http', 'dig', 'nslookup', 'ping',
   'tree', 'du', 'df',
 ]);
 
@@ -309,6 +309,12 @@ export async function classifyRisk(toolName: string, input: Record<string, unkno
 
       if (prog === 'chmod' || prog === 'chown' || prog === 'chgrp'
         || prog === 'sed' || prog === 'awk') {
+        maxRisk = RiskLevel.Medium;
+        continue;
+      }
+
+      // curl/wget can download and execute arbitrary code from the internet
+      if (prog === 'curl' || prog === 'wget') {
         maxRisk = RiskLevel.Medium;
         continue;
       }


### PR DESCRIPTION
Moves curl and wget from LOW to MEDIUM risk classification since they can download and execute arbitrary code from the internet.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
