### PR TITLE
fix: dynamic overfetch multiplier in semantic search

### DIFF
--- a/assistant/src/memory/search/semantic.ts
+++ b/assistant/src/memory/search/semantic.ts
@@ -23,7 +23,9 @@ export async function semanticSearch(
   const qdrant = getQdrantClient();
 
   // Overfetch to account for items filtered out post-query (invalidated, excluded, etc.)
-  const fetchLimit = limit * 2;
+  // Use 3x when exclusions are active to ensure enough results survive filtering
+  const overfetchMultiplier = excludedMessageIds.length > 0 ? 3 : 2;
+  const fetchLimit = limit * overfetchMultiplier;
   const results = await qdrant.searchWithFilter(
     queryVector,
     fetchLimit,


### PR DESCRIPTION
Uses 3x overfetch when exclusions are active instead of hard-coded 2x, ensuring enough results survive filtering.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
