### PR TITLE
feat: add trivy container scan for gateway Docker image

### DIFF
--- a/.github/workflows/ci-gateway-image.yml
+++ b/.github/workflows/ci-gateway-image.yml
@@ -39,6 +39,14 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: vellum-gateway:ci-${{ github.event.pull_request.number || github.sha }}
+          format: table
+          exit-code: '1'
+          severity: HIGH,CRITICAL
+
       - name: Smoke check - container boots
         run: |
           docker run --rm -d --name gateway-smoke \


### PR DESCRIPTION
Adds aquasecurity/trivy-action to scan the gateway Docker image for HIGH and CRITICAL vulnerabilities in CI.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
