### PR TITLE
fix: add database cleanup handler on process exit

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -16,7 +16,7 @@ import {
   migrateToWorkspaceLayout,
   removeSocketFile,
 } from '../util/platform.js';
-import { initializeDb } from '../memory/db.js';
+import { initializeDb, getSqlite } from '../memory/db.js';
 import { rotateToolInvocations } from '../memory/tool-usage-store.js';
 import { initializeProviders, getFailoverProvider } from '../providers/registry.js';
 import { initializeTools } from '../tools/registry.js';
@@ -783,6 +783,16 @@ export async function runDaemon(): Promise<void> {
     scheduler.stop();
     memoryWorker.stop();
     await qdrantManager.stop();
+
+    // Checkpoint WAL and close SQLite so no writes are lost on exit
+    try {
+      const sqlite = getSqlite();
+      sqlite.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+      sqlite.close();
+    } catch (err) {
+      log.warn({ err }, 'Database cleanup failed (non-fatal)');
+    }
+
     await Sentry.flush(2000);
     clearTimeout(forceTimer);
     cleanupPidFile();


### PR DESCRIPTION
Registers process exit and signal handlers to close the SQLite DB connection and checkpoint WAL, preventing data loss and WAL growth.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
