### PR TITLE
refactor: consolidate gateway transport hints into shared constants

### DIFF
--- a/gateway/src/__tests__/reply-path.test.ts
+++ b/gateway/src/__tests__/reply-path.test.ts
@@ -3,7 +3,7 @@ import {
   buildTelegramTransportMetadata,
   TELEGRAM_CHANNEL_TRANSPORT_HINTS,
   TELEGRAM_CHANNEL_TRANSPORT_UX_BRIEF,
-} from "../http/routes/telegram-webhook.js";
+} from "../channels/transport-hints.js";
 import { splitText } from "../telegram/send.js";
 
 describe("splitText", () => {

--- a/gateway/src/channels/transport-hints.ts
+++ b/gateway/src/channels/transport-hints.ts
@@ -1,0 +1,47 @@
+export const TELEGRAM_CHANNEL_TRANSPORT_HINTS = [
+  "chat-first-medium",
+  "channel-safe-onboarding",
+  "defer-dashboard-only-tasks",
+] as const;
+export const TELEGRAM_CHANNEL_TRANSPORT_UX_BRIEF =
+  "Telegram is chat-only. Complete channel-safe steps in-channel and defer dashboard-only Home Base tasks to desktop.";
+
+export function buildTelegramTransportMetadata(): { hints: string[]; uxBrief: string } {
+  return {
+    hints: [...TELEGRAM_CHANNEL_TRANSPORT_HINTS],
+    uxBrief: TELEGRAM_CHANNEL_TRANSPORT_UX_BRIEF,
+  };
+}
+
+export const SMS_CHANNEL_TRANSPORT_HINTS = [
+  "chat-first-medium",
+  "channel-safe-onboarding",
+  "defer-dashboard-only-tasks",
+  "sms-character-limits",
+] as const;
+export const SMS_CHANNEL_TRANSPORT_UX_BRIEF =
+  "SMS is text-only with carrier-imposed message length limits. Keep responses concise and defer rich-media tasks to desktop.";
+
+export function buildSmsTransportMetadata(): { hints: string[]; uxBrief: string } {
+  return {
+    hints: [...SMS_CHANNEL_TRANSPORT_HINTS],
+    uxBrief: SMS_CHANNEL_TRANSPORT_UX_BRIEF,
+  };
+}
+
+export const WHATSAPP_CHANNEL_TRANSPORT_HINTS = [
+  "chat-first-medium",
+  "channel-safe-onboarding",
+  "defer-dashboard-only-tasks",
+  "whatsapp-formatting",
+] as const;
+
+export const WHATSAPP_CHANNEL_TRANSPORT_UX_BRIEF =
+  "WhatsApp is a mobile messaging channel. Keep responses concise and use plain text; avoid markdown tables and complex formatting.";
+
+export function buildWhatsAppTransportMetadata(): { hints: string[]; uxBrief: string } {
+  return {
+    hints: [...WHATSAPP_CHANNEL_TRANSPORT_HINTS],
+    uxBrief: WHATSAPP_CHANNEL_TRANSPORT_UX_BRIEF,
+  };
+}

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -1,3 +1,4 @@
+import { buildTelegramTransportMetadata } from "../../channels/transport-hints.js";
 import type { GatewayConfig } from "../../config.js";
 import { DedupCache } from "../../dedup-cache.js";
 import { handleInbound } from "../../handlers/handle-inbound.js";
@@ -11,21 +12,6 @@ import { sendTelegramReply } from "../../telegram/send.js";
 import { verifyWebhookSecret } from "../../telegram/verify.js";
 
 const log = getLogger("telegram-webhook");
-
-export const TELEGRAM_CHANNEL_TRANSPORT_HINTS = [
-  "chat-first-medium",
-  "channel-safe-onboarding",
-  "defer-dashboard-only-tasks",
-] as const;
-export const TELEGRAM_CHANNEL_TRANSPORT_UX_BRIEF =
-  "Telegram is chat-only. Complete channel-safe steps in-channel and defer dashboard-only Home Base tasks to desktop.";
-
-export function buildTelegramTransportMetadata(): { hints: string[]; uxBrief: string } {
-  return {
-    hints: [...TELEGRAM_CHANNEL_TRANSPORT_HINTS],
-    uxBrief: TELEGRAM_CHANNEL_TRANSPORT_UX_BRIEF,
-  };
-}
 
 /**
  * Parse `/start` or `/start <payload>` from Telegram message content.

--- a/gateway/src/http/routes/twilio-sms-webhook.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.ts
@@ -1,3 +1,4 @@
+import { buildSmsTransportMetadata } from "../../channels/transport-hints.js";
 import type { GatewayConfig } from "../../config.js";
 import { StringDedupCache } from "../../dedup-cache.js";
 import { handleInbound } from "../../handlers/handle-inbound.js";
@@ -50,22 +51,6 @@ function shouldSendRejectionNotice(phoneNumber: string): boolean {
   }
   rejectionNoticeTimestamps.set(phoneNumber, now);
   return true;
-}
-
-export const SMS_CHANNEL_TRANSPORT_HINTS = [
-  "chat-first-medium",
-  "channel-safe-onboarding",
-  "defer-dashboard-only-tasks",
-  "sms-character-limits",
-] as const;
-export const SMS_CHANNEL_TRANSPORT_UX_BRIEF =
-  "SMS is text-only with carrier-imposed message length limits. Keep responses concise and defer rich-media tasks to desktop.";
-
-export function buildSmsTransportMetadata(): { hints: string[]; uxBrief: string } {
-  return {
-    hints: [...SMS_CHANNEL_TRANSPORT_HINTS],
-    uxBrief: SMS_CHANNEL_TRANSPORT_UX_BRIEF,
-  };
 }
 
 function normalizeSmsPayload(

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -1,3 +1,4 @@
+import { buildWhatsAppTransportMetadata } from "../../channels/transport-hints.js";
 import type { GatewayConfig } from "../../config.js";
 import { StringDedupCache } from "../../dedup-cache.js";
 import { handleInbound } from "../../handlers/handle-inbound.js";
@@ -47,23 +48,6 @@ function shouldSendRejectionNotice(senderId: string): boolean {
   }
   rejectionNoticeTimestamps.set(senderId, now);
   return true;
-}
-
-export const WHATSAPP_CHANNEL_TRANSPORT_HINTS = [
-  "chat-first-medium",
-  "channel-safe-onboarding",
-  "defer-dashboard-only-tasks",
-  "whatsapp-formatting",
-] as const;
-
-export const WHATSAPP_CHANNEL_TRANSPORT_UX_BRIEF =
-  "WhatsApp is a mobile messaging channel. Keep responses concise and use plain text; avoid markdown tables and complex formatting.";
-
-export function buildWhatsAppTransportMetadata(): { hints: string[]; uxBrief: string } {
-  return {
-    hints: [...WHATSAPP_CHANNEL_TRANSPORT_HINTS],
-    uxBrief: WHATSAPP_CHANNEL_TRANSPORT_UX_BRIEF,
-  };
 }
 
 export function createWhatsAppWebhookHandler(config: GatewayConfig) {


### PR DESCRIPTION
Moves TELEGRAM_CHANNEL_TRANSPORT_HINTS, SMS_CHANNEL_TRANSPORT_HINTS, WHATSAPP_CHANNEL_TRANSPORT_HINTS into a shared constants file.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
