### PR TITLE
fix: Quick Chat notification thread selection with retry

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -398,14 +398,30 @@ extension AppDelegate {
     }
 
     /// Opens the main window and navigates to the thread for the given conversation ID.
+    /// Retries if the thread isn't populated yet (e.g., ThreadManager hasn't loaded it).
     func openQuickChatThread(conversationId: String?) {
         showMainWindow()
-        guard let conversationId,
-              let threadManager = mainWindow?.threadManager,
-              let thread = threadManager.threads.first(where: { $0.sessionId == conversationId }) else {
-            return
+        guard let conversationId else { return }
+
+        func trySelect() -> Bool {
+            guard let threadManager = mainWindow?.threadManager,
+                  let thread = threadManager.threads.first(where: { $0.sessionId == conversationId }) else {
+                return false
+            }
+            threadManager.activeThreadId = thread.id
+            return true
         }
-        threadManager.activeThreadId = thread.id
+
+        if trySelect() { return }
+
+        // Thread may not be loaded yet — retry up to 5 times with 500ms delay
+        Task { @MainActor in
+            for _ in 0..<5 {
+                try? await Task.sleep(nanoseconds: 500_000_000)
+                if trySelect() { return }
+            }
+            log.warning("Could not find thread for conversation \(conversationId) after retries")
+        }
     }
 
     func showDaemonConnectionError() {


### PR DESCRIPTION
Adds retry logic to openQuickChatThread so clicking a notification works even if the ThreadManager hasn't loaded the thread yet. Retries up to 5 times with 500ms delays. Addresses review feedback from PR #8038.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
