### PR TITLE
fix: Quick Chat hotkey robustness — local monitor, arrow keys, cached re-registration

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -57,6 +57,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private var escapeMonitor: Any?
     private var quickChatPanel: QuickChatPanel?
     private var quickChatMonitor: Any?
+    private var quickChatLocalMonitor: Any?
+    private var lastRegisteredShortcut: String?
     var overlayWindow: SessionOverlayWindow?
     var currentSession: ComputerUseSession?
     var currentTextSession: TextSession?
@@ -345,6 +347,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 NSEvent.removeMonitor(quickChatMonitor)
                 self.quickChatMonitor = nil
             }
+            if let quickChatLocalMonitor {
+                NSEvent.removeMonitor(quickChatLocalMonitor)
+                self.quickChatLocalMonitor = nil
+            }
+            lastRegisteredShortcut = nil
             quickChatShortcutObserver?.cancel()
             quickChatShortcutObserver = nil
             quickChatPanel?.dismiss()
@@ -452,6 +459,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             NSEvent.removeMonitor(quickChatMonitor)
             self.quickChatMonitor = nil
         }
+        if let quickChatLocalMonitor {
+            NSEvent.removeMonitor(quickChatLocalMonitor)
+            self.quickChatLocalMonitor = nil
+        }
+        lastRegisteredShortcut = nil
         quickChatShortcutObserver?.cancel()
         quickChatShortcutObserver = nil
         quickChatPanel?.dismiss()
@@ -1061,15 +1073,24 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             }
     }
 
-    /// Tears down the existing Quick Chat global monitor and registers a new
-    /// one based on the current `quickChatShortcut` UserDefaults value.
+    /// Tears down the existing Quick Chat monitors and registers new ones
+    /// based on the current `quickChatShortcut` UserDefaults value.
+    /// Skips re-registration if the shortcut hasn't changed.
     private func registerQuickChatMonitor() {
+        let shortcut = UserDefaults.standard.string(forKey: "quickChatShortcut") ?? "cmd+shift+space"
+
+        // Skip re-registration when the shortcut hasn't changed
+        if shortcut == lastRegisteredShortcut { return }
+
         if let existing = quickChatMonitor {
             NSEvent.removeMonitor(existing)
             quickChatMonitor = nil
         }
+        if let existing = quickChatLocalMonitor {
+            NSEvent.removeMonitor(existing)
+            quickChatLocalMonitor = nil
+        }
 
-        let shortcut = UserDefaults.standard.string(forKey: "quickChatShortcut") ?? "cmd+shift+space"
         let (targetModifiers, targetKey) = ShortcutHelper.parseShortcut(shortcut)
 
         quickChatMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
@@ -1080,6 +1101,20 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.showQuickChat()
             }
         }
+
+        // Local monitor fires when the app itself is active (global monitor only
+        // fires when other apps are frontmost). Return nil to consume the event.
+        quickChatLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            let eventMods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            guard eventMods == targetModifiers,
+                  event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else { return event }
+            Task { @MainActor in
+                self?.showQuickChat()
+            }
+            return nil
+        }
+
+        lastRegisteredShortcut = shortcut
     }
 
     func showQuickChat() {
@@ -1443,6 +1478,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             NSEvent.removeMonitor(monitor)
         }
         if let monitor = quickChatMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+        if let monitor = quickChatLocalMonitor {
             NSEvent.removeMonitor(monitor)
         }
         quickChatShortcutObserver?.cancel()

--- a/clients/macos/vellum-assistant/Features/Settings/ShortcutHelper.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ShortcutHelper.swift
@@ -28,6 +28,8 @@ enum ShortcutHelper {
                 modifiers.insert(.option)
             case "ctrl", "control":
                 modifiers.insert(.control)
+            case "fn":
+                modifiers.insert(.function)
             default:
                 key = keyString(for: part)
             }
@@ -40,6 +42,7 @@ enum ShortcutHelper {
     /// as captured from an NSEvent during recording.
     static func shortcutString(from modifiers: NSEvent.ModifierFlags, key: String, keyCode: UInt16) -> String {
         var parts: [String] = []
+        if modifiers.contains(.function) { parts.append("fn") }
         if modifiers.contains(.control) { parts.append("ctrl") }
         if modifiers.contains(.option) { parts.append("opt") }
         if modifiers.contains(.shift) { parts.append("shift") }
@@ -58,6 +61,7 @@ enum ShortcutHelper {
         case "shift": return "\u{21E7}"
         case "opt", "alt", "option": return "\u{2325}"
         case "ctrl", "control": return "\u{2303}"
+        case "fn": return "Fn"
         case "space": return "Space"
         case "return", "enter": return "\u{21A9}"
         case "tab": return "\u{21E5}"


### PR DESCRIPTION
Fixes three hotkey issues: (1) Adds local event monitor so Quick Chat shortcut works when app is active. (2) Handles .function modifier flag for arrow key shortcuts. (3) Caches last registered shortcut to avoid excessive re-registration on every UserDefaults change. Addresses review feedback from PRs #8035 and #8040.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
