### PR TITLE
Remove remaining deterministic approval fallback paths

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -289,7 +289,7 @@ describe('inbound callback metadata triggers decision handling', () => {
 // 3. Plain text triggers decision handling
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('inbound text matching approval phrases triggers decision handling', () => {
+describe('inbound text decisions via conversational approval trigger decision handling', () => {
   beforeEach(() => {
     createBinding({
       assistantId: 'self',
@@ -302,6 +302,10 @@ describe('inbound text matching approval phrases triggers decision handling', ()
   test('text "approve" triggers approve_once decision', async () => {
     const orchestrator = makeMockOrchestrator();
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    const mockConversationGenerator = mock(async (_ctx: unknown) => ({
+      disposition: 'approve_once' as const,
+      replyText: 'Approved once.',
+    }));
 
     // Establish the conversation
     const initReq = makeInboundRequest({ content: 'init' });
@@ -317,7 +321,10 @@ describe('inbound text matching approval phrases triggers decision handling', ()
 
     const req = makeInboundRequest({ content: 'approve' });
 
-    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const res = await handleChannelInbound(
+      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
+      mockConversationGenerator,
+    );
     const body = await res.json() as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
@@ -330,6 +337,10 @@ describe('inbound text matching approval phrases triggers decision handling', ()
   test('text "always" triggers approve_always decision', async () => {
     const orchestrator = makeMockOrchestrator();
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    const mockConversationGenerator = mock(async (_ctx: unknown) => ({
+      disposition: 'approve_always' as const,
+      replyText: 'Approved always.',
+    }));
 
     const initReq = makeInboundRequest({ content: 'init' });
     await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
@@ -344,7 +355,10 @@ describe('inbound text matching approval phrases triggers decision handling', ()
 
     const req = makeInboundRequest({ content: 'always' });
 
-    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const res = await handleChannelInbound(
+      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
+      mockConversationGenerator,
+    );
     const body = await res.json() as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
@@ -613,9 +627,13 @@ describe('callback run ID validation', () => {
     deliverSpy.mockRestore();
   });
 
-  test('plain-text decisions bypass run ID validation (no runId in result)', async () => {
+  test('single-pending conversational decision can apply without targetRunId', async () => {
     const orchestrator = makeMockOrchestrator();
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    const mockConversationGenerator = mock(async (_ctx: unknown) => ({
+      disposition: 'approve_once' as const,
+      replyText: 'Approved.',
+    }));
 
     // Establish the conversation
     const initReq = makeInboundRequest({ content: 'init' });
@@ -630,10 +648,13 @@ describe('callback run ID validation', () => {
     const run = createRun(conversationId!);
     setRunConfirmation(run.id, sampleConfirmation);
 
-    // Send plain text "yes" — no runId in the parsed result, so validation is skipped
+    // With a single pending approval, targetRunId is optional for decision-bearing dispositions.
     const req = makeInboundRequest({ content: 'yes' });
 
-    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const res = await handleChannelInbound(
+      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
+      mockConversationGenerator,
+    );
     const body = await res.json() as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
@@ -890,9 +911,13 @@ describe('no immediate reply after approval decision', () => {
     deliverSpy.mockRestore();
   });
 
-  test('plain-text decision also does not trigger immediate reply', async () => {
+  test('conversational decision delivers engine reply immediately', async () => {
     const orchestrator = makeMockOrchestrator();
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    const mockConversationGenerator = mock(async (_ctx: unknown) => ({
+      disposition: 'approve_once' as const,
+      replyText: 'Done, approving this request.',
+    }));
 
     // Establish the conversation
     const initReq = makeInboundRequest({ content: 'init' });
@@ -911,11 +936,14 @@ describe('no immediate reply after approval decision', () => {
     // Send a plain-text approval
     const req = makeInboundRequest({ content: 'approve' });
 
-    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const res = await handleChannelInbound(
+      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
+      mockConversationGenerator,
+    );
     const body = await res.json() as Record<string, unknown>;
 
     expect(body.approval).toBe('decision_applied');
-    expect(deliverSpy).not.toHaveBeenCalled();
+    expect(deliverSpy).toHaveBeenCalled();
 
     deliverSpy.mockRestore();
   });
@@ -1473,6 +1501,10 @@ describe('SMS channel approval decisions', () => {
   test('plain-text "yes" via SMS triggers approve_once decision', async () => {
     const orchestrator = makeMockOrchestrator();
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    const mockConversationGenerator = mock(async (_ctx: unknown) => ({
+      disposition: 'approve_once' as const,
+      replyText: 'Approved once.',
+    }));
 
     // Establish the conversation via SMS
     const initReq = makeSmsInboundRequest({ content: 'init' });
@@ -1487,7 +1519,10 @@ describe('SMS channel approval decisions', () => {
     setRunConfirmation(run.id, sampleConfirmation);
 
     const req = makeSmsInboundRequest({ content: 'yes' });
-    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const res = await handleChannelInbound(
+      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
+      mockConversationGenerator,
+    );
     const body = await res.json() as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
@@ -1500,6 +1535,10 @@ describe('SMS channel approval decisions', () => {
   test('plain-text "no" via SMS triggers reject decision', async () => {
     const orchestrator = makeMockOrchestrator();
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    const mockConversationGenerator = mock(async (_ctx: unknown) => ({
+      disposition: 'reject' as const,
+      replyText: 'Denied.',
+    }));
 
     const initReq = makeSmsInboundRequest({ content: 'init' });
     await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
@@ -1513,7 +1552,10 @@ describe('SMS channel approval decisions', () => {
     setRunConfirmation(run.id, sampleConfirmation);
 
     const req = makeSmsInboundRequest({ content: 'no' });
-    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
+    const res = await handleChannelInbound(
+      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
+      mockConversationGenerator,
+    );
     const body = await res.json() as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -38,7 +38,6 @@ import {
   updateApprovalDecision,
 } from '../../memory/channel-guardian-store.js';
 import { deliverChannelReply, deliverApprovalPrompt } from '../gateway-client.js';
-import { parseApprovalDecision } from '../channel-approval-parser.js';
 import {
   getChannelApprovalPrompt,
   buildApprovalUIMetadata,
@@ -1823,137 +1822,9 @@ async function handleApprovalInterception(
         return { handled: true, type: 'stale_ignored' };
       }
 
-      // ── Legacy fallback when no conversational engine is available ──
-      // Use the deterministic parser to handle guardian plain-text so that
-      // simple yes/no replies still work when the engine is not injected.
+      // No conversation engine available for this guardian follow-up. Keep the
+      // request pending and send a status prompt.
       if (content && !approvalConversationGenerator) {
-        const legacyGuardianDecision = parseApprovalDecision(content);
-        if (legacyGuardianDecision) {
-          // Guardians cannot approve_always — downgrade to approve_once.
-          if (legacyGuardianDecision.action === 'approve_always') {
-            legacyGuardianDecision.action = 'approve_once';
-          }
-
-          // Resolve the target approval: when a [ref:<runId>] tag is
-          // present, look up the specific pending approval by that runId
-          // so the decision applies to the correct conversation even when
-          // multiple guardian approvals are pending.
-          let targetLegacyApproval = guardianApproval;
-          if (legacyGuardianDecision.runId) {
-            const resolvedByRun = getPendingApprovalByRunAndGuardianChat(
-              legacyGuardianDecision.runId,
-              sourceChannel,
-              externalChatId,
-              assistantId,
-            );
-            if (!resolvedByRun) {
-              // The referenced run doesn't match any pending guardian
-              // approval — it may have expired or already been resolved.
-              try {
-                const staleText = await composeApprovalMessageGenerative({
-                  scenario: 'guardian_disambiguation',
-                  channel: sourceChannel,
-                }, {}, approvalCopyGenerator);
-                await deliverChannelReply(replyCallbackUrl, {
-                  chatId: externalChatId,
-                  text: staleText,
-                  assistantId,
-                }, bearerToken);
-              } catch (err) {
-                log.error({ err, externalChatId }, 'Failed to deliver stale approval notice (legacy path)');
-              }
-              return { handled: true, type: 'stale_ignored' };
-            }
-            targetLegacyApproval = resolvedByRun;
-          }
-
-          // Re-validate guardian identity against the resolved target.
-          // The default guardianApproval was already checked, but a
-          // runId-resolved approval may belong to a different guardian.
-          if (senderExternalUserId !== targetLegacyApproval.guardianExternalUserId) {
-            log.warn(
-              { externalChatId, senderExternalUserId, expectedGuardian: targetLegacyApproval.guardianExternalUserId, runId: legacyGuardianDecision.runId },
-              'Guardian identity mismatch on legacy run-ref resolved target approval',
-            );
-            try {
-              const mismatchText = await composeApprovalMessageGenerative({
-                scenario: 'guardian_identity_mismatch',
-                channel: sourceChannel,
-              }, {}, approvalCopyGenerator);
-              await deliverChannelReply(replyCallbackUrl, {
-                chatId: externalChatId,
-                text: mismatchText,
-                assistantId,
-              }, bearerToken);
-            } catch (err) {
-              log.error({ err, externalChatId }, 'Failed to deliver guardian identity mismatch notice (legacy path)');
-            }
-            return { handled: true, type: 'guardian_decision_applied' };
-          }
-
-          const result = handleChannelDecision(
-            targetLegacyApproval.conversationId,
-            legacyGuardianDecision,
-            orchestrator,
-          );
-
-          if (result.applied) {
-            const approvalStatus = legacyGuardianDecision.action === 'reject' ? 'denied' as const : 'approved' as const;
-            updateApprovalDecision(targetLegacyApproval.id, {
-              status: approvalStatus,
-              decidedByExternalUserId: senderExternalUserId,
-            });
-
-            // Notify the requester's chat about the outcome
-            const outcomeText = await composeApprovalMessageGenerative({
-              scenario: 'guardian_decision_outcome',
-              decision: legacyGuardianDecision.action === 'reject' ? 'denied' : 'approved',
-              toolName: targetLegacyApproval.toolName,
-              channel: sourceChannel,
-            }, {}, approvalCopyGenerator);
-            try {
-              await deliverChannelReply(replyCallbackUrl, {
-                chatId: targetLegacyApproval.requesterChatId,
-                text: outcomeText,
-                assistantId,
-              }, bearerToken);
-            } catch (err) {
-              log.error({ err, conversationId: targetLegacyApproval.conversationId }, 'Failed to notify requester of guardian decision (legacy path)');
-            }
-
-            if (result.runId) {
-              schedulePostDecisionDelivery(
-                orchestrator,
-                result.runId,
-                targetLegacyApproval.conversationId,
-                targetLegacyApproval.requesterChatId,
-                replyCallbackUrl,
-                bearerToken,
-                assistantId,
-              );
-            }
-
-            return { handled: true, type: 'guardian_decision_applied' };
-          }
-
-          // Race condition: run was already resolved. Deliver stale notice.
-          try {
-            const staleText = await composeApprovalMessageGenerative({
-              scenario: 'approval_already_resolved',
-              channel: sourceChannel,
-            }, {}, approvalCopyGenerator);
-            await deliverChannelReply(replyCallbackUrl, {
-              chatId: externalChatId,
-              text: staleText,
-              assistantId,
-            }, bearerToken);
-          } catch (err) {
-            log.error({ err, conversationId: targetLegacyApproval.conversationId }, 'Failed to deliver stale guardian legacy fallback notice');
-          }
-          return { handled: true, type: 'stale_ignored' };
-        }
-
-        // No decision could be parsed — send a generic reminder to the guardian
         try {
           const reminderText = await composeApprovalMessageGenerative({
             scenario: 'reminder_prompt',
@@ -1966,7 +1837,7 @@ async function handleApprovalInterception(
             assistantId,
           }, bearerToken);
         } catch (err) {
-          log.error({ err, conversationId: guardianApproval.conversationId }, 'Failed to deliver guardian reminder (legacy path)');
+          log.error({ err, conversationId: guardianApproval.conversationId }, 'Failed to deliver guardian reminder when approval conversation engine is unavailable');
         }
         return { handled: true, type: 'assistant_turn' };
       }
@@ -2316,52 +2187,7 @@ async function handleApprovalInterception(
     return { handled: true, type: 'stale_ignored' };
   }
 
-  // Fallback: no conversational generator available or no content — use
-  // the legacy deterministic path as a safety net. This preserves backward
-  // compatibility when the generator is not injected.
-  if (content) {
-    const legacyDecision = parseApprovalDecision(content);
-    if (legacyDecision) {
-      if (legacyDecision.runId) {
-        if (pending.length === 0 || pending[0].runId !== legacyDecision.runId) {
-          return { handled: true, type: 'stale_ignored' };
-        }
-      }
-      const result = handleChannelDecision(conversationId, legacyDecision, orchestrator);
-      if (result.applied) {
-        if (result.runId) {
-          schedulePostDecisionDelivery(
-            orchestrator,
-            result.runId,
-            conversationId,
-            externalChatId,
-            replyCallbackUrl,
-            bearerToken,
-            assistantId,
-          );
-        }
-        return { handled: true, type: 'decision_applied' };
-      }
-
-      // Race condition: run was already resolved.
-      try {
-        const staleText = await composeApprovalMessageGenerative({
-          scenario: 'approval_already_resolved',
-          channel: sourceChannel,
-        }, {}, approvalCopyGenerator);
-        await deliverChannelReply(replyCallbackUrl, {
-          chatId: externalChatId,
-          text: staleText,
-          assistantId,
-        }, bearerToken);
-      } catch (err) {
-        log.error({ err, conversationId }, 'Failed to deliver stale approval notice (legacy path)');
-      }
-      return { handled: true, type: 'stale_ignored' };
-    }
-  }
-
-  // No decision could be extracted and no conversational engine is available —
+  // No conversation engine decision was available —
   // deliver a simple status reply rather than a reminder prompt.
   try {
     const statusText = await composeApprovalMessageGenerative({


### PR DESCRIPTION
## Summary
- remove legacy deterministic approval parsing fallbacks from `handleApprovalInterception` in `channel-routes`
- keep pending approvals conversational: when no approval conversation engine is injected, reply with pending-status copy and keep run pending
- update approval route tests that previously asserted legacy plain-text parser behavior to use conversational generator expectations

## Validation
- `bunx tsc --noEmit` (assistant)
- `bun test src/__tests__/channel-approval-routes.test.ts` (assistant)