### PR TITLE
fix: Quick Chat session isolation — filter text deltas by sessionId

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -281,7 +281,12 @@ extension AppDelegate {
                 return
             }
 
-            // Wait for task_routed, then listen for the response
+            // Wait for task_routed, then listen for the response.
+            // Known limitation: IPCTaskRouted has no correlation/requestId field, so if two
+            // background sessions are started nearly simultaneously, one could capture the
+            // other's sessionId. The same limitation exists in startSession(). Adding a
+            // requestId to the IPC contract would fix this but requires a coordinated
+            // TypeScript + Swift change.
             var routedMessage: TaskRoutedMessage?
             for await message in messageStream {
                 if case .taskRouted(let routed) = message {
@@ -314,7 +319,7 @@ extension AppDelegate {
             var accumulatedText = ""
             for await message in messageStream {
                 switch message {
-                case .assistantTextDelta(let delta):
+                case .assistantTextDelta(let delta) where delta.sessionId == sessionId || delta.sessionId == nil:
                     accumulatedText += delta.text
 
                 case .messageComplete(let complete) where complete.sessionId == sessionId:


### PR DESCRIPTION
Fixes assistantTextDelta accumulating text from all sessions instead of filtering by sessionId, causing garbled notifications during concurrent sessions. Documents known limitation with taskRouted correlation. Addresses review feedback from PRs #8038 and #8055.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
