### PR TITLE
feat: add compound command detection for dangerous pipe chains

### DIFF
--- a/assistant/src/tools/terminal/parser.ts
+++ b/assistant/src/tools/terminal/parser.ts
@@ -36,6 +36,11 @@ export interface ParsedCommand {
 }
 
 const SHELL_PROGRAMS = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh', 'fish']);
+// Script interpreters that can execute arbitrary code from stdin — piping
+// untrusted data into these is as dangerous as piping into a shell.
+const SCRIPT_INTERPRETERS = new Set([
+  'python', 'python3', 'ruby', 'perl', 'node', 'deno', 'bun',
+]);
 const OPAQUE_PROGRAMS = new Set(['eval', 'source', 'alias']);
 const DANGEROUS_ENV_VARS = new Set([
   'LD_PRELOAD', 'LD_LIBRARY_PATH',
@@ -245,7 +250,7 @@ function detectDangerousPatterns(node: TSNode, segments: CommandSegment[]): Dang
   for (let i = 1; i < segments.length; i++) {
     if (segments[i].operator === '|') {
       const prog = segments[i].program;
-      if (SHELL_PROGRAMS.has(prog) || prog === 'eval' || prog === 'xargs') {
+      if (SHELL_PROGRAMS.has(prog) || prog === 'eval' || prog === 'xargs' || SCRIPT_INTERPRETERS.has(prog)) {
         patterns.push({
           type: 'pipe_to_shell',
           description: `Pipeline into ${prog}`,


### PR DESCRIPTION
Detects dangerous pipe patterns like curl|bash, wget|sh, curl|python and flags them as HIGH risk in the permissions checker.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
