### PR TITLE
feat: add audit logging for blocked parental control attempts

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -81,6 +81,16 @@ export class ToolExecutor {
 
     // Reject tools blocked by parental control settings before any permission check.
     if (isToolBlocked(name)) {
+      log.warn(
+        {
+          toolName: name,
+          sessionId: context.sessionId,
+          conversationId: context.conversationId,
+          principal: context.principal,
+          reason: 'blocked_by_parental_controls',
+        },
+        'Parental control blocked tool invocation',
+      );
       const durationMs = Date.now() - startTime;
       emitLifecycleEvent(context, {
         type: 'permission_denied',


### PR DESCRIPTION
Adds structured audit logging when tool invocations are blocked by parental controls, recording tool name, user, and block reason.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
