### PR TITLE
fix: Quick Chat shortcut conflict detection and '+' key encoding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -190,8 +190,8 @@ struct SettingsAppearanceTab: View {
 
     // MARK: - Shortcut Recording
 
-    /// The fixed "Open Vellum" shortcut in normalized form for conflict detection.
-    private static let openVellumShortcut = "cmd+shift+g"
+    /// The fixed "Open Vellum" shortcut tokens for order-independent conflict detection.
+    private static let openVellumShortcutTokens = ShortcutHelper.normalizeShortcut("cmd+shift+g")
 
     private func startRecording() {
         isRecordingShortcut = true
@@ -219,7 +219,7 @@ struct SettingsAppearanceTab: View {
             )
 
             // Check for conflict with the fixed "Open Vellum" shortcut
-            if shortcut.lowercased() == Self.openVellumShortcut {
+            if ShortcutHelper.normalizeShortcut(shortcut) == Self.openVellumShortcutTokens {
                 shortcutConflictWarning = "This shortcut conflicts with the Open Vellum shortcut (\u{2318}\u{21E7}G). Choose a different shortcut."
                 stopRecording()
                 return nil

--- a/clients/macos/vellum-assistant/Features/Settings/ShortcutHelper.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ShortcutHelper.swift
@@ -30,6 +30,8 @@ enum ShortcutHelper {
                 modifiers.insert(.control)
             case "fn":
                 modifiers.insert(.function)
+            case "plus":
+                key = "+"
             default:
                 key = keyString(for: part)
             }
@@ -49,14 +51,22 @@ enum ShortcutHelper {
         if modifiers.contains(.command) { parts.append("cmd") }
 
         let keyPart = keyName(for: key, keyCode: keyCode)
-        parts.append(keyPart)
+        parts.append(keyPart == "+" ? "plus" : keyPart)
         return parts.joined(separator: "+")
+    }
+
+    /// Splits a shortcut string into a normalized set of tokens for
+    /// order-independent comparison (e.g. "shift+cmd+g" and "cmd+shift+g" both
+    /// produce {"shift", "cmd", "g"}).
+    static func normalizeShortcut(_ shortcut: String) -> Set<String> {
+        Set(shortcut.lowercased().split(separator: "+").map(String.init))
     }
 
     // MARK: - Private
 
     private static func displayToken(_ token: String) -> String {
         switch token {
+        case "plus": return "+"
         case "cmd", "command": return "\u{2318}"
         case "shift": return "\u{21E7}"
         case "opt", "alt", "option": return "\u{2325}"


### PR DESCRIPTION
Fixes: (1) Shortcut conflict detection broken due to modifier ordering mismatch — now uses set-based normalized comparison. (2) '+' key encoded as 'plus' to avoid delimiter ambiguity. Addresses review feedback from PRs #8040 and #8046.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
