### PR TITLE
refactor: extract generic DB row mapper utility

### DIFF
--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -5,54 +5,49 @@ import { callSessions, callEvents, callPendingQuestions } from '../memory/schema
 import type { CallSession, CallEvent, CallPendingQuestion, CallEventType, CallStatus } from './types.js';
 import { validateTransition } from './call-state-machine.js';
 import { getLogger } from '../util/logger.js';
+import { createRowMapper, cast } from '../util/row-mapper.js';
 
 const log = getLogger('call-store');
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-function parseCallSession(row: typeof callSessions.$inferSelect): CallSession {
-  return {
-    id: row.id,
-    conversationId: row.conversationId,
-    provider: row.provider,
-    providerCallSid: row.providerCallSid,
-    fromNumber: row.fromNumber,
-    toNumber: row.toNumber,
-    task: row.task,
-    status: row.status as CallSession['status'],
-    callerIdentityMode: row.callerIdentityMode,
-    callerIdentitySource: row.callerIdentitySource,
-    assistantId: row.assistantId,
-    initiatedFromConversationId: row.initiatedFromConversationId,
-    startedAt: row.startedAt,
-    endedAt: row.endedAt,
-    lastError: row.lastError,
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
-  };
-}
+const parseCallSession = createRowMapper<typeof callSessions.$inferSelect, CallSession>({
+  id: 'id',
+  conversationId: 'conversationId',
+  provider: 'provider',
+  providerCallSid: 'providerCallSid',
+  fromNumber: 'fromNumber',
+  toNumber: 'toNumber',
+  task: 'task',
+  status: { from: 'status', transform: cast<CallSession['status']>() },
+  callerIdentityMode: 'callerIdentityMode',
+  callerIdentitySource: 'callerIdentitySource',
+  assistantId: 'assistantId',
+  initiatedFromConversationId: 'initiatedFromConversationId',
+  startedAt: 'startedAt',
+  endedAt: 'endedAt',
+  lastError: 'lastError',
+  createdAt: 'createdAt',
+  updatedAt: 'updatedAt',
+});
 
-function parseCallEvent(row: typeof callEvents.$inferSelect): CallEvent {
-  return {
-    id: row.id,
-    callSessionId: row.callSessionId,
-    eventType: row.eventType as CallEvent['eventType'],
-    payloadJson: row.payloadJson,
-    createdAt: row.createdAt,
-  };
-}
+const parseCallEvent = createRowMapper<typeof callEvents.$inferSelect, CallEvent>({
+  id: 'id',
+  callSessionId: 'callSessionId',
+  eventType: { from: 'eventType', transform: cast<CallEvent['eventType']>() },
+  payloadJson: 'payloadJson',
+  createdAt: 'createdAt',
+});
 
-function parsePendingQuestion(row: typeof callPendingQuestions.$inferSelect): CallPendingQuestion {
-  return {
-    id: row.id,
-    callSessionId: row.callSessionId,
-    questionText: row.questionText,
-    status: row.status as CallPendingQuestion['status'],
-    askedAt: row.askedAt,
-    answeredAt: row.answeredAt,
-    answerText: row.answerText,
-  };
-}
+const parsePendingQuestion = createRowMapper<typeof callPendingQuestions.$inferSelect, CallPendingQuestion>({
+  id: 'id',
+  callSessionId: 'callSessionId',
+  questionText: 'questionText',
+  status: { from: 'status', transform: cast<CallPendingQuestion['status']>() },
+  askedAt: 'askedAt',
+  answeredAt: 'answeredAt',
+  answerText: 'answerText',
+});
 
 // ── Call Sessions ────────────────────────────────────────────────────
 

--- a/assistant/src/tools/reminder/reminder-store.ts
+++ b/assistant/src/tools/reminder/reminder-store.ts
@@ -2,6 +2,7 @@ import { and, asc, eq, lte } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from '../../memory/db.js';
 import { reminders } from '../../memory/schema.js';
+import { createRowMapper, cast } from '../../util/row-mapper.js';
 
 export interface ReminderRow {
   id: string;
@@ -15,6 +16,19 @@ export interface ReminderRow {
   createdAt: number;
   updatedAt: number;
 }
+
+const parseRow = createRowMapper<typeof reminders.$inferSelect, ReminderRow>({
+  id: 'id',
+  label: 'label',
+  message: 'message',
+  fireAt: 'fireAt',
+  mode: { from: 'mode', transform: cast<ReminderRow['mode']>() },
+  status: { from: 'status', transform: cast<ReminderRow['status']>() },
+  firedAt: 'firedAt',
+  conversationId: 'conversationId',
+  createdAt: 'createdAt',
+  updatedAt: 'updatedAt',
+});
 
 export function insertReminder(params: {
   label: string;
@@ -130,19 +144,4 @@ export function setReminderConversationId(id: string, conversationId: string): v
     .set({ conversationId, updatedAt: Date.now() })
     .where(eq(reminders.id, id))
     .run();
-}
-
-function parseRow(row: typeof reminders.$inferSelect): ReminderRow {
-  return {
-    id: row.id,
-    label: row.label,
-    message: row.message,
-    fireAt: row.fireAt,
-    mode: row.mode as ReminderRow['mode'],
-    status: row.status as ReminderRow['status'],
-    firedAt: row.firedAt,
-    conversationId: row.conversationId,
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
-  };
 }

--- a/assistant/src/util/row-mapper.ts
+++ b/assistant/src/util/row-mapper.ts
@@ -1,0 +1,79 @@
+/**
+ * Generic DB row mapper — replaces repetitive parse* functions across store files.
+ *
+ * Each field in the schema is described by either a source column name (passthrough)
+ * or a transform descriptor. The mapper produces a function that converts a raw
+ * Drizzle row into a typed domain object.
+ */
+
+// A field descriptor is either a key of the source row (passthrough) or a transform.
+type FieldDescriptor<TRow, TOut> =
+  | (keyof TRow & string)
+  | { from: keyof TRow & string; transform: (value: TRow[keyof TRow]) => TOut };
+
+// The schema maps each output field to a field descriptor.
+type MapperSchema<TRow, TDomain> = {
+  [K in keyof TDomain]: FieldDescriptor<TRow, TDomain[K]>;
+};
+
+/**
+ * Create a row-to-domain mapper from a declarative schema.
+ *
+ * Usage:
+ * ```ts
+ * const parseReminder = createRowMapper<typeof reminders.$inferSelect, ReminderRow>({
+ *   id: 'id',
+ *   label: 'label',
+ *   mode: { from: 'mode', transform: (v) => v as ReminderRow['mode'] },
+ * });
+ * ```
+ */
+export function createRowMapper<TRow, TDomain>(
+  schema: MapperSchema<TRow, TDomain>,
+): (row: TRow) => TDomain {
+  const entries = Object.entries(schema) as Array<
+    [string, FieldDescriptor<TRow, unknown>]
+  >;
+
+  return (row: TRow): TDomain => {
+    const result = {} as Record<string, unknown>;
+    for (const [key, descriptor] of entries) {
+      if (typeof descriptor === 'string') {
+        result[key] = row[descriptor as keyof TRow];
+      } else {
+        const d = descriptor as { from: keyof TRow & string; transform: (value: TRow[keyof TRow]) => unknown };
+        result[key] = d.transform(row[d.from]);
+      }
+    }
+    return result as TDomain;
+  };
+}
+
+/** Convenience: cast a value to a narrower type (for string union columns). */
+export function cast<T>() {
+  return (value: unknown) => value as T;
+}
+
+/** Convenience: parse a JSON string column with a fallback value on parse failure. */
+export function parseJson<T>(fallback: T): (value: unknown) => T {
+  return (value: unknown): T => {
+    if (typeof value !== 'string' || !value) return fallback;
+    try {
+      return JSON.parse(value) as T;
+    } catch {
+      return fallback;
+    }
+  };
+}
+
+/** Convenience: parse a JSON string column, returning null on parse failure. */
+export function parseJsonNullable<T>(): (value: unknown) => T | null {
+  return (value: unknown): T | null => {
+    if (typeof value !== 'string' || !value) return null;
+    try {
+      return JSON.parse(value) as T;
+    } catch {
+      return null;
+    }
+  };
+}


### PR DESCRIPTION
Creates a reusable `createRowMapper` utility to replace repetitive parse functions across store files. Demonstrated on `call-store.ts` (3 parse functions) and `reminder-store.ts` (1 parse function) as proof of concept.

The utility supports:
- Direct field passthrough (most common case)
- Type casting via `cast<T>()` helper (for string union columns)
- JSON parsing via `parseJson()` and `parseJsonNullable()` helpers
- Field renaming via `{ from, transform }` descriptors

Remaining ~35 store files can be migrated incrementally.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
