### PR TITLE
fix: Quick Chat toast panel leak and timer race condition

### DIFF
--- a/clients/macos/vellum-assistant/Features/QuickChat/QuickChatPanel.swift
+++ b/clients/macos/vellum-assistant/Features/QuickChat/QuickChatPanel.swift
@@ -110,6 +110,12 @@ final class QuickChatPanel {
 
     /// Shows a brief "Message sent" toast near the given frame, then auto-dismisses.
     private func showSentToast(near frame: NSRect) {
+        // Close any existing toast immediately to prevent timer races
+        if let existing = toastPanel {
+            existing.close()
+            toastPanel = nil
+        }
+
         let toastView = HStack(spacing: VSpacing.sm) {
             Image(systemName: "checkmark.circle.fill")
                 .foregroundColor(VColor.success)
@@ -163,16 +169,18 @@ final class QuickChatPanel {
 
         self.toastPanel = toast
 
-        // Auto-dismiss after 1.5 seconds
+        // Auto-dismiss after 1.5 seconds. Capture `toast` directly so it's
+        // always closed even if `self` (QuickChatPanel) is deallocated first.
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
-            guard let toast = self?.toastPanel else { return }
             NSAnimationContext.runAnimationGroup({ context in
                 context.duration = VAnimation.durationFast
                 context.timingFunction = CAMediaTimingFunction(name: .easeIn)
                 toast.animator().alphaValue = 0
             }, completionHandler: {
                 toast.close()
-                self?.toastPanel = nil
+                if self?.toastPanel === toast {
+                    self?.toastPanel = nil
+                }
             })
         }
     }


### PR DESCRIPTION
Fixes: (1) Toast leaked on screen when QuickChatPanel deallocated before auto-dismiss timer — now captures toast directly. (2) Closes existing toast before showing new one to prevent timer races. Addresses review feedback from PR #8046.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
