### PR TITLE
Revert PR #8069 to restore deterministic approval fallback

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -289,7 +289,7 @@ describe('inbound callback metadata triggers decision handling', () => {
 // 3. Plain text triggers decision handling
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('inbound text decisions via conversational approval trigger decision handling', () => {
+describe('inbound text matching approval phrases triggers decision handling', () => {
   beforeEach(() => {
     createBinding({
       assistantId: 'self',
@@ -302,10 +302,6 @@ describe('inbound text decisions via conversational approval trigger decision ha
   test('text "approve" triggers approve_once decision', async () => {
     const orchestrator = makeMockOrchestrator();
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
-    const mockConversationGenerator = mock(async (_ctx: unknown) => ({
-      disposition: 'approve_once' as const,
-      replyText: 'Approved once.',
-    }));
 
     // Establish the conversation
     const initReq = makeInboundRequest({ content: 'init' });
@@ -321,10 +317,7 @@ describe('inbound text decisions via conversational approval trigger decision ha
 
     const req = makeInboundRequest({ content: 'approve' });
 
-    const res = await handleChannelInbound(
-      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
-      mockConversationGenerator,
-    );
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
     const body = await res.json() as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
@@ -337,10 +330,6 @@ describe('inbound text decisions via conversational approval trigger decision ha
   test('text "always" triggers approve_always decision', async () => {
     const orchestrator = makeMockOrchestrator();
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
-    const mockConversationGenerator = mock(async (_ctx: unknown) => ({
-      disposition: 'approve_always' as const,
-      replyText: 'Approved always.',
-    }));
 
     const initReq = makeInboundRequest({ content: 'init' });
     await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
@@ -355,10 +344,7 @@ describe('inbound text decisions via conversational approval trigger decision ha
 
     const req = makeInboundRequest({ content: 'always' });
 
-    const res = await handleChannelInbound(
-      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
-      mockConversationGenerator,
-    );
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
     const body = await res.json() as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
@@ -627,13 +613,9 @@ describe('callback run ID validation', () => {
     deliverSpy.mockRestore();
   });
 
-  test('single-pending conversational decision can apply without targetRunId', async () => {
+  test('plain-text decisions bypass run ID validation (no runId in result)', async () => {
     const orchestrator = makeMockOrchestrator();
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
-    const mockConversationGenerator = mock(async (_ctx: unknown) => ({
-      disposition: 'approve_once' as const,
-      replyText: 'Approved.',
-    }));
 
     // Establish the conversation
     const initReq = makeInboundRequest({ content: 'init' });
@@ -648,13 +630,10 @@ describe('callback run ID validation', () => {
     const run = createRun(conversationId!);
     setRunConfirmation(run.id, sampleConfirmation);
 
-    // With a single pending approval, targetRunId is optional for decision-bearing dispositions.
+    // Send plain text "yes" — no runId in the parsed result, so validation is skipped
     const req = makeInboundRequest({ content: 'yes' });
 
-    const res = await handleChannelInbound(
-      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
-      mockConversationGenerator,
-    );
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
     const body = await res.json() as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
@@ -911,13 +890,9 @@ describe('no immediate reply after approval decision', () => {
     deliverSpy.mockRestore();
   });
 
-  test('conversational decision delivers engine reply immediately', async () => {
+  test('plain-text decision also does not trigger immediate reply', async () => {
     const orchestrator = makeMockOrchestrator();
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
-    const mockConversationGenerator = mock(async (_ctx: unknown) => ({
-      disposition: 'approve_once' as const,
-      replyText: 'Done, approving this request.',
-    }));
 
     // Establish the conversation
     const initReq = makeInboundRequest({ content: 'init' });
@@ -936,14 +911,11 @@ describe('no immediate reply after approval decision', () => {
     // Send a plain-text approval
     const req = makeInboundRequest({ content: 'approve' });
 
-    const res = await handleChannelInbound(
-      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
-      mockConversationGenerator,
-    );
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
     const body = await res.json() as Record<string, unknown>;
 
     expect(body.approval).toBe('decision_applied');
-    expect(deliverSpy).toHaveBeenCalled();
+    expect(deliverSpy).not.toHaveBeenCalled();
 
     deliverSpy.mockRestore();
   });
@@ -1501,10 +1473,6 @@ describe('SMS channel approval decisions', () => {
   test('plain-text "yes" via SMS triggers approve_once decision', async () => {
     const orchestrator = makeMockOrchestrator();
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
-    const mockConversationGenerator = mock(async (_ctx: unknown) => ({
-      disposition: 'approve_once' as const,
-      replyText: 'Approved once.',
-    }));
 
     // Establish the conversation via SMS
     const initReq = makeSmsInboundRequest({ content: 'init' });
@@ -1519,10 +1487,7 @@ describe('SMS channel approval decisions', () => {
     setRunConfirmation(run.id, sampleConfirmation);
 
     const req = makeSmsInboundRequest({ content: 'yes' });
-    const res = await handleChannelInbound(
-      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
-      mockConversationGenerator,
-    );
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
     const body = await res.json() as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
@@ -1535,10 +1500,6 @@ describe('SMS channel approval decisions', () => {
   test('plain-text "no" via SMS triggers reject decision', async () => {
     const orchestrator = makeMockOrchestrator();
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
-    const mockConversationGenerator = mock(async (_ctx: unknown) => ({
-      disposition: 'reject' as const,
-      replyText: 'Denied.',
-    }));
 
     const initReq = makeSmsInboundRequest({ content: 'init' });
     await handleChannelInbound(initReq, noopProcessMessage, 'token', orchestrator);
@@ -1552,10 +1513,7 @@ describe('SMS channel approval decisions', () => {
     setRunConfirmation(run.id, sampleConfirmation);
 
     const req = makeSmsInboundRequest({ content: 'no' });
-    const res = await handleChannelInbound(
-      req, noopProcessMessage, 'token', orchestrator, 'self', undefined, undefined,
-      mockConversationGenerator,
-    );
+    const res = await handleChannelInbound(req, noopProcessMessage, 'token', orchestrator);
     const body = await res.json() as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -38,6 +38,7 @@ import {
   updateApprovalDecision,
 } from '../../memory/channel-guardian-store.js';
 import { deliverChannelReply, deliverApprovalPrompt } from '../gateway-client.js';
+import { parseApprovalDecision } from '../channel-approval-parser.js';
 import {
   getChannelApprovalPrompt,
   buildApprovalUIMetadata,
@@ -1822,9 +1823,137 @@ async function handleApprovalInterception(
         return { handled: true, type: 'stale_ignored' };
       }
 
-      // No conversation engine available for this guardian follow-up. Keep the
-      // request pending and send a status prompt.
+      // ── Legacy fallback when no conversational engine is available ──
+      // Use the deterministic parser to handle guardian plain-text so that
+      // simple yes/no replies still work when the engine is not injected.
       if (content && !approvalConversationGenerator) {
+        const legacyGuardianDecision = parseApprovalDecision(content);
+        if (legacyGuardianDecision) {
+          // Guardians cannot approve_always — downgrade to approve_once.
+          if (legacyGuardianDecision.action === 'approve_always') {
+            legacyGuardianDecision.action = 'approve_once';
+          }
+
+          // Resolve the target approval: when a [ref:<runId>] tag is
+          // present, look up the specific pending approval by that runId
+          // so the decision applies to the correct conversation even when
+          // multiple guardian approvals are pending.
+          let targetLegacyApproval = guardianApproval;
+          if (legacyGuardianDecision.runId) {
+            const resolvedByRun = getPendingApprovalByRunAndGuardianChat(
+              legacyGuardianDecision.runId,
+              sourceChannel,
+              externalChatId,
+              assistantId,
+            );
+            if (!resolvedByRun) {
+              // The referenced run doesn't match any pending guardian
+              // approval — it may have expired or already been resolved.
+              try {
+                const staleText = await composeApprovalMessageGenerative({
+                  scenario: 'guardian_disambiguation',
+                  channel: sourceChannel,
+                }, {}, approvalCopyGenerator);
+                await deliverChannelReply(replyCallbackUrl, {
+                  chatId: externalChatId,
+                  text: staleText,
+                  assistantId,
+                }, bearerToken);
+              } catch (err) {
+                log.error({ err, externalChatId }, 'Failed to deliver stale approval notice (legacy path)');
+              }
+              return { handled: true, type: 'stale_ignored' };
+            }
+            targetLegacyApproval = resolvedByRun;
+          }
+
+          // Re-validate guardian identity against the resolved target.
+          // The default guardianApproval was already checked, but a
+          // runId-resolved approval may belong to a different guardian.
+          if (senderExternalUserId !== targetLegacyApproval.guardianExternalUserId) {
+            log.warn(
+              { externalChatId, senderExternalUserId, expectedGuardian: targetLegacyApproval.guardianExternalUserId, runId: legacyGuardianDecision.runId },
+              'Guardian identity mismatch on legacy run-ref resolved target approval',
+            );
+            try {
+              const mismatchText = await composeApprovalMessageGenerative({
+                scenario: 'guardian_identity_mismatch',
+                channel: sourceChannel,
+              }, {}, approvalCopyGenerator);
+              await deliverChannelReply(replyCallbackUrl, {
+                chatId: externalChatId,
+                text: mismatchText,
+                assistantId,
+              }, bearerToken);
+            } catch (err) {
+              log.error({ err, externalChatId }, 'Failed to deliver guardian identity mismatch notice (legacy path)');
+            }
+            return { handled: true, type: 'guardian_decision_applied' };
+          }
+
+          const result = handleChannelDecision(
+            targetLegacyApproval.conversationId,
+            legacyGuardianDecision,
+            orchestrator,
+          );
+
+          if (result.applied) {
+            const approvalStatus = legacyGuardianDecision.action === 'reject' ? 'denied' as const : 'approved' as const;
+            updateApprovalDecision(targetLegacyApproval.id, {
+              status: approvalStatus,
+              decidedByExternalUserId: senderExternalUserId,
+            });
+
+            // Notify the requester's chat about the outcome
+            const outcomeText = await composeApprovalMessageGenerative({
+              scenario: 'guardian_decision_outcome',
+              decision: legacyGuardianDecision.action === 'reject' ? 'denied' : 'approved',
+              toolName: targetLegacyApproval.toolName,
+              channel: sourceChannel,
+            }, {}, approvalCopyGenerator);
+            try {
+              await deliverChannelReply(replyCallbackUrl, {
+                chatId: targetLegacyApproval.requesterChatId,
+                text: outcomeText,
+                assistantId,
+              }, bearerToken);
+            } catch (err) {
+              log.error({ err, conversationId: targetLegacyApproval.conversationId }, 'Failed to notify requester of guardian decision (legacy path)');
+            }
+
+            if (result.runId) {
+              schedulePostDecisionDelivery(
+                orchestrator,
+                result.runId,
+                targetLegacyApproval.conversationId,
+                targetLegacyApproval.requesterChatId,
+                replyCallbackUrl,
+                bearerToken,
+                assistantId,
+              );
+            }
+
+            return { handled: true, type: 'guardian_decision_applied' };
+          }
+
+          // Race condition: run was already resolved. Deliver stale notice.
+          try {
+            const staleText = await composeApprovalMessageGenerative({
+              scenario: 'approval_already_resolved',
+              channel: sourceChannel,
+            }, {}, approvalCopyGenerator);
+            await deliverChannelReply(replyCallbackUrl, {
+              chatId: externalChatId,
+              text: staleText,
+              assistantId,
+            }, bearerToken);
+          } catch (err) {
+            log.error({ err, conversationId: targetLegacyApproval.conversationId }, 'Failed to deliver stale guardian legacy fallback notice');
+          }
+          return { handled: true, type: 'stale_ignored' };
+        }
+
+        // No decision could be parsed — send a generic reminder to the guardian
         try {
           const reminderText = await composeApprovalMessageGenerative({
             scenario: 'reminder_prompt',
@@ -1837,7 +1966,7 @@ async function handleApprovalInterception(
             assistantId,
           }, bearerToken);
         } catch (err) {
-          log.error({ err, conversationId: guardianApproval.conversationId }, 'Failed to deliver guardian reminder when approval conversation engine is unavailable');
+          log.error({ err, conversationId: guardianApproval.conversationId }, 'Failed to deliver guardian reminder (legacy path)');
         }
         return { handled: true, type: 'assistant_turn' };
       }
@@ -2187,7 +2316,52 @@ async function handleApprovalInterception(
     return { handled: true, type: 'stale_ignored' };
   }
 
-  // No conversation engine decision was available —
+  // Fallback: no conversational generator available or no content — use
+  // the legacy deterministic path as a safety net. This preserves backward
+  // compatibility when the generator is not injected.
+  if (content) {
+    const legacyDecision = parseApprovalDecision(content);
+    if (legacyDecision) {
+      if (legacyDecision.runId) {
+        if (pending.length === 0 || pending[0].runId !== legacyDecision.runId) {
+          return { handled: true, type: 'stale_ignored' };
+        }
+      }
+      const result = handleChannelDecision(conversationId, legacyDecision, orchestrator);
+      if (result.applied) {
+        if (result.runId) {
+          schedulePostDecisionDelivery(
+            orchestrator,
+            result.runId,
+            conversationId,
+            externalChatId,
+            replyCallbackUrl,
+            bearerToken,
+            assistantId,
+          );
+        }
+        return { handled: true, type: 'decision_applied' };
+      }
+
+      // Race condition: run was already resolved.
+      try {
+        const staleText = await composeApprovalMessageGenerative({
+          scenario: 'approval_already_resolved',
+          channel: sourceChannel,
+        }, {}, approvalCopyGenerator);
+        await deliverChannelReply(replyCallbackUrl, {
+          chatId: externalChatId,
+          text: staleText,
+          assistantId,
+        }, bearerToken);
+      } catch (err) {
+        log.error({ err, conversationId }, 'Failed to deliver stale approval notice (legacy path)');
+      }
+      return { handled: true, type: 'stale_ignored' };
+    }
+  }
+
+  // No decision could be extracted and no conversational engine is available —
   // deliver a simple status reply rather than a reminder prompt.
   try {
     const statusText = await composeApprovalMessageGenerative({


### PR DESCRIPTION
## Summary
- revert PR #8069 (`ff26f1f4d884245ae671afba0f6d5b78319381f5`)
- restore deterministic plain-text fallback behavior in `handleApprovalInterception`
- restore prior approval route test expectations for deterministic fallback scenarios

## Validation
- `bun test src/__tests__/channel-approval-routes.test.ts` (assistant)

## Notes
- `bunx tsc --noEmit` on current `origin/main` fails due existing unrelated errors in `assistant/src/__tests__/session-agent-loop.test.ts`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
