### PR TITLE
fix: strip .numericPad from modifier flags in shortcut matching

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1094,7 +1094,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         let (targetModifiers, targetKey) = ShortcutHelper.parseShortcut(shortcut)
 
         quickChatMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            let eventMods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            let eventMods = event.modifierFlags.intersection(.deviceIndependentFlagsMask).subtracting(.numericPad)
             guard eventMods == targetModifiers,
                   event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else { return }
             Task { @MainActor in
@@ -1105,7 +1105,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         // Local monitor fires when the app itself is active (global monitor only
         // fires when other apps are frontmost). Return nil to consume the event.
         quickChatLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            let eventMods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            let eventMods = event.modifierFlags.intersection(.deviceIndependentFlagsMask).subtracting(.numericPad)
             guard eventMods == targetModifiers,
                   event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else { return event }
             Task { @MainActor in

--- a/clients/macos/vellum-assistant/Features/Settings/ShortcutHelper.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ShortcutHelper.swift
@@ -43,12 +43,15 @@ enum ShortcutHelper {
     /// Builds a shortcut string from modifier flags and a key code/characters,
     /// as captured from an NSEvent during recording.
     static func shortcutString(from modifiers: NSEvent.ModifierFlags, key: String, keyCode: UInt16) -> String {
+        // Strip .numericPad — macOS implicitly sets it on arrow key events and it
+        // shouldn't participate in shortcut matching.
+        let mods = modifiers.subtracting(.numericPad)
         var parts: [String] = []
-        if modifiers.contains(.function) { parts.append("fn") }
-        if modifiers.contains(.control) { parts.append("ctrl") }
-        if modifiers.contains(.option) { parts.append("opt") }
-        if modifiers.contains(.shift) { parts.append("shift") }
-        if modifiers.contains(.command) { parts.append("cmd") }
+        if mods.contains(.function) { parts.append("fn") }
+        if mods.contains(.control) { parts.append("ctrl") }
+        if mods.contains(.option) { parts.append("opt") }
+        if mods.contains(.shift) { parts.append("shift") }
+        if mods.contains(.command) { parts.append("cmd") }
 
         let keyPart = keyName(for: key, keyCode: keyCode)
         parts.append(keyPart == "+" ? "plus" : keyPart)


### PR DESCRIPTION
## Summary
- Strip `.numericPad` modifier flag in `ShortcutHelper.shortcutString()` and both event monitors in `registerQuickChatMonitor()`
- macOS implicitly sets `.numericPad` on arrow key events, causing shortcut matching to fail for arrow-key shortcuts

## Files changed
- `ShortcutHelper.swift` — strip `.numericPad` before checking modifier flags during recording
- `AppDelegate.swift` — strip `.numericPad` from event modifier flags in both global and local monitors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
