### PR TITLE
fix(macos): hide archive icon for last remaining thread

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -869,19 +869,21 @@ struct MainWindowView: View {
                     .buttonStyle(.plain)
                     .accessibilityLabel(thread.isPinned ? "Unpin \(thread.title)" : "Pin \(thread.title)")
 
-                    Button {
-                        threadPendingDeletion = thread.id
-                    } label: {
-                        Image(systemName: "archivebox")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundColor(VColor.textSecondary)
-                            .frame(width: 20, height: 20)
-                            .background(VColor.backgroundSubtle)
-                            .clipShape(Circle())
-                            .contentShape(Rectangle())
+                    if threadManager.visibleThreads.count > 1 {
+                        Button {
+                            threadPendingDeletion = thread.id
+                        } label: {
+                            Image(systemName: "archivebox")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundColor(VColor.textSecondary)
+                                .frame(width: 20, height: 20)
+                                .background(VColor.backgroundSubtle)
+                                .clipShape(Circle())
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Archive \(thread.title)")
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Archive \(thread.title)")
                 }
                 .padding(.trailing, VSpacing.xs)
             } else if thread.isPinned {
@@ -906,10 +908,12 @@ struct MainWindowView: View {
             } label: {
                 Label(thread.isPinned ? "Unpin" : "Pin to Top", systemImage: thread.isPinned ? "pin.slash" : "pin")
             }
-            Button {
-                threadManager.archiveThread(id: thread.id)
-            } label: {
-                Label("Archive", systemImage: "archivebox")
+            if threadManager.visibleThreads.count > 1 {
+                Button {
+                    threadManager.archiveThread(id: thread.id)
+                } label: {
+                    Label("Archive", systemImage: "archivebox")
+                }
             }
         }
         .onHover { hovering in


### PR DESCRIPTION
## Summary
- Hide archive button (hover overlay) when there's only 1 visible thread
- Hide "Archive" option from context menu when there's only 1 visible thread
- Prevents users from archiving their last thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
