### PR TITLE
fix: normalize assistantId in guardian verification to prevent mismatch

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -32,6 +32,7 @@ import {
   getPendingChallenge,
   validateAndConsumeChallenge,
 } from '../runtime/channel-guardian-service.js';
+import { normalizeAssistantId } from '../util/platform.js';
 
 const log = getLogger('relay-server');
 
@@ -390,7 +391,7 @@ export class RelayConnection {
     } else if (isInbound) {
       // For inbound calls, check if there's a pending voice guardian
       // challenge that the caller needs to complete before proceeding.
-      const assistantId = session?.assistantId ?? 'self';
+      const assistantId = normalizeAssistantId(session?.assistantId ?? 'self');
       const pendingChallenge = getPendingChallenge(assistantId, 'voice');
 
       if (pendingChallenge) {

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -6,6 +6,7 @@ import type {
   GuardianVerificationRequest,
   ChannelReadinessRequest,
 } from '../ipc-protocol.js';
+import { normalizeAssistantId } from '../../util/platform.js';
 import { log, defineHandlers, type HandlerContext } from './shared.js';
 
 // Lazy singleton — created on first use so module-load stays lightweight.
@@ -22,9 +23,9 @@ export function handleGuardianVerification(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
-  // Use the assistant ID from the request when available; fall back to
-  // 'self' for backward compatibility with single-assistant mode.
-  const assistantId = msg.assistantId ?? 'self';
+  // Normalize the assistant ID so challenges are always stored under the
+  // same key the inbound-call path will use for lookups (typically "self").
+  const assistantId = normalizeAssistantId(msg.assistantId ?? 'self');
   const channel = msg.channel ?? 'telegram';
 
   try {

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -72,6 +72,34 @@ export function readLockfile(): Record<string, unknown> | null {
 }
 
 /**
+ * Normalize an assistant ID to its canonical form for DB operations.
+ *
+ * The system uses "self" as the canonical single-tenant identifier
+ * (see migration 007-assistant-id-to-self). However, the desktop UI
+ * sends the real assistant ID (e.g., "vellum-true-eel") while the
+ * inbound call path resolves phone numbers to config keys (typically
+ * "self"). This function maps any known lockfile assistant ID to "self"
+ * so both sides use a consistent DB key.
+ */
+export function normalizeAssistantId(assistantId: string): string {
+  if (assistantId === 'self') return 'self';
+
+  try {
+    const lockData = readLockfile();
+    const assistants = lockData?.assistants as Array<Record<string, unknown>> | undefined;
+    if (assistants) {
+      for (const entry of assistants) {
+        if (entry.assistantId === assistantId) return 'self';
+      }
+    }
+  } catch {
+    // lockfile unreadable — return as-is
+  }
+
+  return assistantId;
+}
+
+/**
  * Write data to the primary lockfile (~/.vellum.lock.json).
  * Respects BASE_DATA_DIR for non-standard home directories.
  */


### PR DESCRIPTION
## Summary
- Guardian voice verification challenges were never matched on inbound calls because the challenge was stored under the real assistant ID (e.g., `vellum-true-eel`) but looked up with `"self"`
- Added `normalizeAssistantId()` utility in `platform.ts` that maps known lockfile assistant IDs to `"self"`, consistent with the DB convention from migration 007
- Applied normalization at both boundaries: challenge creation (`config-channels.ts`) and challenge lookup (`relay-server.ts`)

## Original prompt

Bug: Voice Guardian Verification Fails Due to `assistantId` Mismatch — the `assistantId` used to store challenges differs from the one used to look them up on inbound calls, so verification is never triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
