### PR TITLE
fix: revert synchronous pragma to FULL for durability

### DIFF
--- a/assistant/src/memory/db-connection.ts
+++ b/assistant/src/memory/db-connection.ts
@@ -14,7 +14,7 @@ export function getDb(): DrizzleDb {
     ensureDataDir();
     const sqlite = new Database(getDbPath());
     sqlite.exec('PRAGMA journal_mode=WAL');
-    sqlite.exec('PRAGMA synchronous=NORMAL');
+    sqlite.exec('PRAGMA synchronous=FULL');
     sqlite.exec('PRAGMA busy_timeout=5000');
     sqlite.exec('PRAGMA foreign_keys = ON');
     sqlite.exec('PRAGMA cache_size=-256000');


### PR DESCRIPTION
Address review feedback on PR #8043: synchronous=NORMAL weakens durability in WAL mode. Revert to FULL to ensure committed transactions survive crashes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
