### PR TITLE
fix: make swarm retry backoff abortable via AbortSignal

### DIFF
--- a/assistant/src/swarm/orchestrator.ts
+++ b/assistant/src/swarm/orchestrator.ts
@@ -153,7 +153,7 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
       // Exponential backoff with ±25% jitter to prevent thundering herd
       const baseDelayMs = 1000 * Math.pow(2, retries - 1);
       const jitter = baseDelayMs * 0.25 * (2 * Math.random() - 1);
-      await new Promise((r) => setTimeout(r, baseDelayMs + jitter));
+      await abortableSleep(baseDelayMs + jitter, signal);
       if (signal?.aborted) break;
       result = await runWorkerTask({
         task,
@@ -318,6 +318,20 @@ function detectCycle(tasks: SwarmTaskNode[]): string[] | null {
     }
   }
   return null;
+}
+
+/** Resolves after `ms` milliseconds, or immediately if the signal fires first. */
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(done, ms);
+    signal?.addEventListener('abort', done, { once: true });
+    function done() {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', done);
+      resolve();
+    }
+  });
 }
 
 function buildMarkdownFallback(objective: string, results: SwarmTaskResult[]): string {


### PR DESCRIPTION
Address review feedback on PR #8045: make retry backoff sleep listen to AbortSignal so shutdown is responsive during failure conditions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
