### PR TITLE
fix: add Swift lockfile paths to dependency scan trigger

### DIFF
--- a/.github/workflows/ci-dependency-scan.yaml
+++ b/.github/workflows/ci-dependency-scan.yaml
@@ -6,11 +6,13 @@ on:
     paths:
       - '**/bun.lock'
       - '**/package.json'
+      - '**/Package.resolved'
       - '.github/workflows/ci-dependency-scan.yaml'
   pull_request:
     paths:
       - '**/bun.lock'
       - '**/package.json'
+      - '**/Package.resolved'
       - '.github/workflows/ci-dependency-scan.yaml'
   schedule:
     # Run weekly on Monday at 08:00 UTC to catch newly disclosed vulnerabilities


### PR DESCRIPTION
Address review feedback on PR #8072: add **/Package.resolved to CI dependency scan path filters to cover Swift dependencies.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
