### PR TITLE
fix: make guardian sweep test assertion meaningful

### DIFF
--- a/assistant/src/__tests__/guardian-action-sweep.test.ts
+++ b/assistant/src/__tests__/guardian-action-sweep.test.ts
@@ -190,7 +190,7 @@ describe('guardian-action-sweep', () => {
     expect(getPendingQuestion(session.id)).not.toBeNull();
   });
 
-  test('sweepExpiredGuardianActions sends external channel expiry notices for sent deliveries', () => {
+  test('sweepExpiredGuardianActions sends external channel expiry notices for sent deliveries', async () => {
     const convId = 'conv-sweep-4';
     ensureConversation(convId);
 
@@ -221,10 +221,11 @@ describe('guardian-action-sweep', () => {
 
     sweepExpiredGuardianActions('http://localhost:3000');
 
+    // Wait for the fire-and-forget async delivery to complete
+    await new Promise(resolve => setTimeout(resolve, 50));
+
     // The external delivery should trigger an HTTP POST to the gateway
-    // (async fire-and-forget, but we can check the mock was called)
-    // Since the delivery is async, check after a brief delay
-    expect(deliveredMessages.length).toBeGreaterThanOrEqual(0);
+    expect(deliveredMessages.length).toBeGreaterThanOrEqual(1);
   });
 
   test('sweepExpiredGuardianActions skips failed deliveries', () => {


### PR DESCRIPTION
Address review feedback on PR #8078: fix tautological assertion that always passed — make test async, await delivery, and assert >= 1.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
