### PR TITLE
fix: address review feedback on browser download cleanup bugs (PR #8091)

### DIFF
--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -441,6 +441,11 @@ class BrowserManager {
     this.pages.clear();
     this.rawPages.clear();
     this.snapshotMaps.clear();
+    this.downloads.clear();
+    for (const pending of this.pendingDownloads.values()) {
+      for (const waiter of pending) waiter.reject(new Error('Browser closed'));
+    }
+    this.pendingDownloads.clear();
 
     if (this.context) {
       // Remove the close listener before intentional close to avoid
@@ -785,12 +790,18 @@ class BrowserManager {
   }
 
   waitForDownload(sessionId: string, timeoutMs: number = 30_000): Promise<DownloadInfo> {
+    // Check if a download already completed for this session before enqueuing a waiter
+    const existing = this.downloads.get(sessionId);
+    if (existing && existing.length > 0) {
+      return Promise.resolve(existing[existing.length - 1]);
+    }
+
     return new Promise<DownloadInfo>((resolve, reject) => {
       const timer = setTimeout(() => {
         // Remove this waiter from the pending list
         const pending = this.pendingDownloads.get(sessionId);
         if (pending) {
-          const idx = pending.findIndex(w => w.resolve === resolve);
+          const idx = pending.findIndex(w => w.resolve === wrappedResolve);
           if (idx >= 0) pending.splice(idx, 1);
           if (pending.length === 0) this.pendingDownloads.delete(sessionId);
         }


### PR DESCRIPTION
Fixes 3 bugs identified in PR #8091 review:\n\n1. closeAllPages now cleans up downloads and rejects pending download waiters\n2. waitForDownload timeout handler uses correct wrappedResolve reference\n3. waitForDownload checks already-completed downloads before enqueueing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
