### PR TITLE
M1: Backend generative guardian copy + emoji title

### DIFF
--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -115,9 +115,9 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
     // Create delivery rows and dispatch
     for (const dest of destinations) {
       if (dest.channel === 'macos') {
-        const guardianCopy = await guardianCopyPromise;
-
-        // Create a dedicated server-side conversation for the mac guardian thread
+        // Create conversation and delivery row synchronously so they exist
+        // before awaiting LLM copy — prevents a race where an external channel
+        // reply resolves the request before the macOS delivery is created.
         const macConvKey = `asst:${assistantId}:guardian:request:${request.id}`;
         const { conversationId: macConversationId } = getOrCreateConversation(macConvKey);
 
@@ -126,6 +126,9 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
           destinationChannel: 'macos',
           destinationConversationId: macConversationId,
         });
+
+        // Now await LLM-generated copy for the message content and thread title
+        const guardianCopy = await guardianCopyPromise;
 
         // Add the guardian question as the initial message in the thread
         addMessage(

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -24,6 +24,7 @@ import { addMessage } from '../memory/conversation-store.js';
 import type { CallPendingQuestion } from './types.js';
 import { readHttpToken } from '../util/platform.js';
 import type { ServerMessage } from '../daemon/ipc-contract.js';
+import { generateGuardianCopy } from './guardian-question-copy.js';
 
 const log = getLogger('guardian-dispatch');
 
@@ -104,6 +105,12 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
     // Mac (internal) delivery — always created
     destinations.push({ channel: 'macos' });
 
+    // Generate thread copy for the mac guardian thread (title + initial message)
+    const guardianCopy = await generateGuardianCopy(
+      pendingQuestion.questionText,
+      request.requestCode,
+    );
+
     // Create delivery rows and dispatch
     for (const dest of destinations) {
       if (dest.channel === 'macos') {
@@ -121,7 +128,7 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
         addMessage(
           macConversationId,
           'assistant',
-          JSON.stringify([{ type: 'text', text: `Your assistant needs your input during a phone call.\n\nQuestion: ${request.questionText}\n\nReply to this message with your answer.` }]),
+          JSON.stringify([{ type: 'text', text: guardianCopy.initialMessage }]),
           { userMessageChannel: 'voice', assistantMessageChannel: 'macos' },
         );
 
@@ -132,7 +139,7 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
             conversationId: macConversationId,
             requestId: request.id,
             callSessionId,
-            title: `Guardian question: ${pendingQuestion.questionText.slice(0, 80)}`,
+            title: guardianCopy.threadTitle,
           } as ServerMessage);
         }
         updateDeliveryStatus(delivery.id, 'sent');

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -105,8 +105,9 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
     // Mac (internal) delivery — always created
     destinations.push({ channel: 'macos' });
 
-    // Generate thread copy for the mac guardian thread (title + initial message)
-    const guardianCopy = await generateGuardianCopy(
+    // Start LLM copy generation concurrently — only awaited in the macOS branch
+    // so external channels (Telegram, SMS) dispatch without LLM latency.
+    const guardianCopyPromise = generateGuardianCopy(
       pendingQuestion.questionText,
       request.requestCode,
     );
@@ -114,6 +115,8 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
     // Create delivery rows and dispatch
     for (const dest of destinations) {
       if (dest.channel === 'macos') {
+        const guardianCopy = await guardianCopyPromise;
+
         // Create a dedicated server-side conversation for the mac guardian thread
         const macConvKey = `asst:${assistantId}:guardian:request:${request.id}`;
         const { conversationId: macConversationId } = getOrCreateConversation(macConvKey);

--- a/assistant/src/calls/guardian-question-copy.ts
+++ b/assistant/src/calls/guardian-question-copy.ts
@@ -1,0 +1,128 @@
+/**
+ * Generative copy for guardian question threads.
+ *
+ * Uses the configured provider to generate an attention-oriented emoji-prefixed
+ * thread title and a richer initial message. Falls back to deterministic copy
+ * when the provider is unavailable or generation fails/times out.
+ */
+
+import { getLogger } from '../util/logger.js';
+import {
+  resolveConfiguredProvider,
+  createTimeout,
+  extractText,
+  userMessage,
+} from '../providers/provider-send-message.js';
+
+const log = getLogger('guardian-question-copy');
+
+/** Timeout for the generative copy call (ms). */
+const GENERATION_TIMEOUT_MS = 5_000;
+
+export interface GuardianCopy {
+  threadTitle: string;
+  initialMessage: string;
+}
+
+/**
+ * Build deterministic fallback copy when generation is unavailable or fails.
+ */
+export function buildFallbackCopy(questionText: string): GuardianCopy {
+  return {
+    threadTitle: `\u26A0\uFE0F ${questionText.slice(0, 70)}`,
+    initialMessage: [
+      'Your assistant needs your input during a phone call.',
+      '',
+      `Question: ${questionText}`,
+      '',
+      'Reply to this message with your answer.',
+    ].join('\n'),
+  };
+}
+
+/**
+ * Generate guardian thread copy (title + initial message) via the configured
+ * LLM provider. Returns deterministic fallback when the provider is unavailable,
+ * generation times out, or any error occurs.
+ */
+export async function generateGuardianCopy(
+  questionText: string,
+  requestCode?: string,
+): Promise<GuardianCopy> {
+  const fallback = buildFallbackCopy(questionText);
+
+  // If no provider is configured, return fallback immediately
+  const resolved = resolveConfiguredProvider();
+  if (!resolved) {
+    log.debug('No provider available for guardian copy generation, using fallback');
+    return fallback;
+  }
+
+  const { signal, cleanup } = createTimeout(GENERATION_TIMEOUT_MS);
+
+  try {
+    const prompt = [
+      'Generate a thread title and initial message for a guardian question during a live phone call.',
+      '',
+      `Question: ${questionText}`,
+      ...(requestCode ? [`Reference code: ${requestCode}`] : []),
+      '',
+      'Requirements:',
+      '- TITLE: An emoji-prefixed, attention-oriented, concise title (under 80 characters). Do NOT start with "Guardian question:". Use a relevant warning or alert emoji.',
+      '- MESSAGE: A clear initial message that includes the question text, mentions this is a live phone call waiting for the user\'s input, and asks them to reply with their answer.',
+      '',
+      'Respond in exactly this format (no extra text):',
+      'TITLE: <your title>',
+      'MESSAGE: <your message>',
+    ].join('\n');
+
+    const response = await resolved.provider.sendMessage(
+      [userMessage(prompt)],
+      undefined,
+      undefined,
+      { signal, config: { modelIntent: 'latency-optimized' } },
+    );
+
+    const text = extractText(response);
+    const parsed = parseGeneratedCopy(text);
+
+    if (parsed) {
+      return parsed;
+    }
+
+    log.warn({ raw: text }, 'Failed to parse generated guardian copy, using fallback');
+    return fallback;
+  } catch (err) {
+    if (signal.aborted) {
+      log.warn('Guardian copy generation timed out, using fallback');
+    } else {
+      log.warn({ err }, 'Guardian copy generation failed, using fallback');
+    }
+    return fallback;
+  } finally {
+    cleanup();
+  }
+}
+
+/**
+ * Parse the structured TITLE/MESSAGE response from the model.
+ * Returns null if the format is not matched.
+ */
+function parseGeneratedCopy(text: string): GuardianCopy | null {
+  const titleMatch = text.match(/^TITLE:\s*(.+)/m);
+  const messageMatch = text.match(/^MESSAGE:\s*([\s\S]+)/m);
+
+  if (!titleMatch || !messageMatch) {
+    return null;
+  }
+
+  const title = titleMatch[1].trim();
+  const message = messageMatch[1].trim();
+
+  // Sanity checks: title must be non-empty and under 80 chars, message must be non-empty
+  if (!title || title.length > 80 || !message) {
+    return null;
+  }
+
+  return { threadTitle: title, initialMessage: message };
+}


### PR DESCRIPTION
Replace static guardian thread copy with model-generated copy (title + initial message) with robust fallback. Adds guardian-question-copy.ts module that uses the configured provider to generate attention-oriented emoji-prefixed titles and richer initial messages. Falls back to deterministic copy when provider is unavailable or generation fails. Part of #8110.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
