### PR TITLE
fix: add retry loop to dynamic overfetch when quota not met

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -188,10 +188,19 @@ async function collectAndMergeCandidates(
       const estimatedFetch = exclusionRatio < 1
         ? Math.ceil((directLimit / (1 - exclusionRatio)) * 1.5)
         : MAX_FETCH;
-      const fetchSize = Math.min(Math.max(estimatedFetch, directLimit + 24), MAX_FETCH);
+      let fetchSize = Math.min(Math.max(estimatedFetch, directLimit + 24), MAX_FETCH);
 
-      const fetched = directItemSearch(query, fetchSize, scopeIds);
+      let fetched = directItemSearch(query, fetchSize, scopeIds);
       directItems = filterDirectItems(fetched).slice(0, directLimit);
+
+      // Retry loop: when the estimate under-fetched (uneven exclusion
+      // distribution), keep increasing fetchSize until quota is met or
+      // the DB is exhausted.
+      while (directItems.length < directLimit && fetched.length === fetchSize && fetchSize < MAX_FETCH) {
+        fetchSize = Math.min(fetchSize * 2, MAX_FETCH);
+        fetched = directItemSearch(query, fetchSize, scopeIds);
+        directItems = filterDirectItems(fetched).slice(0, directLimit);
+      }
     }
   } else {
     directItems = directItemSearch(query, directLimit, scopeIds);


### PR DESCRIPTION
Address review feedback on PR #8051: add a retry path when directItems < directLimit and more data may exist, up to MAX_FETCH.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
