### PR TITLE
fix: restore null check for invalidAt in contradiction checker

### DIFF
--- a/assistant/src/memory/contradiction-checker.ts
+++ b/assistant/src/memory/contradiction-checker.ts
@@ -301,11 +301,11 @@ function handleRelationship(
     const freshExisting = db.select().from(memoryItems).where(eq(memoryItems.id, existingItem.id)).get();
     const freshNew = db.select().from(memoryItems).where(eq(memoryItems.id, newItem.id)).get();
 
-    if (!freshExisting || freshExisting.status !== 'active' || freshExisting.invalidAt !== undefined) {
+    if (!freshExisting || freshExisting.status !== 'active' || freshExisting.invalidAt != null) {
       log.debug({ existingId: existingItem.id }, 'Existing item no longer active — skipping');
       return false;
     }
-    if (!freshNew || (freshNew.status !== 'active' && result.relationship !== 'ambiguous_contradiction') || freshNew.invalidAt !== undefined) {
+    if (!freshNew || (freshNew.status !== 'active' && result.relationship !== 'ambiguous_contradiction') || freshNew.invalidAt != null) {
       log.debug({ newId: newItem.id }, 'New item no longer active — skipping');
       return false;
     }


### PR DESCRIPTION
Address review feedback on PR #8084: change invalidAt !== undefined back to != null since Drizzle/SQLite uses null for SQL NULL, not undefined. The strict !== undefined check caused handleRelationship to always return early, silently breaking all memory contradiction handling.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
