### PR TITLE
fix: mock only sleep in provider error tests, keep real retry logic

### DIFF
--- a/assistant/src/__tests__/provider-error-scenarios.test.ts
+++ b/assistant/src/__tests__/provider-error-scenarios.test.ts
@@ -1,4 +1,7 @@
 import { describe, test, expect, mock } from 'bun:test';
+import { resolve } from 'node:path';
+
+const retryModulePath = resolve(import.meta.dir, '../util/retry.ts');
 
 mock.module('../util/logger.js', () => ({
   getLogger: () =>
@@ -6,59 +9,11 @@ mock.module('../util/logger.js', () => ({
   isDebug: () => false,
 }));
 
-// Re-export retry utilities with sleep as a no-op to avoid real backoff delays
+// Only mock sleep so retries complete instantly; keep real retry logic
 mock.module('../util/retry.js', () => {
-  const DEFAULT_MAX_RETRIES = 3;
-  const DEFAULT_BASE_DELAY_MS = 1000;
-
-  function computeRetryDelay(attempt: number, baseDelayMs = DEFAULT_BASE_DELAY_MS): number {
-    const cap = baseDelayMs * Math.pow(2, attempt);
-    const half = cap / 2;
-    return half + Math.random() * half;
-  }
-
-  function parseRetryAfterMs(value: string): number | undefined {
-    const seconds = Number(value);
-    if (!isNaN(seconds)) return seconds * 1000;
-    const dateMs = Date.parse(value);
-    if (!isNaN(dateMs)) return Math.max(0, dateMs - Date.now());
-    return undefined;
-  }
-
-  function getHttpRetryDelay(response: Response, attempt: number, baseDelayMs = DEFAULT_BASE_DELAY_MS): number {
-    const retryAfter = response.headers.get('retry-after');
-    if (retryAfter) {
-      const parsed = parseRetryAfterMs(retryAfter);
-      if (parsed !== undefined) return parsed;
-    }
-    const effectiveBase = attempt === 0 ? baseDelayMs * 2 : baseDelayMs;
-    return Math.max(baseDelayMs, computeRetryDelay(attempt, effectiveBase));
-  }
-
-  function isRetryableStatus(status: number): boolean {
-    return status === 429 || status >= 500;
-  }
-
-  function isRetryableNetworkError(error: unknown): boolean {
-    if (!(error instanceof Error)) return false;
-    const retryableCodes = new Set(['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'EPIPE']);
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code && retryableCodes.has(code)) return true;
-    if (error.cause instanceof Error) {
-      const causeCode = (error.cause as NodeJS.ErrnoException).code;
-      if (causeCode && retryableCodes.has(causeCode)) return true;
-    }
-    return false;
-  }
-
+  const real = require(retryModulePath);
   return {
-    DEFAULT_MAX_RETRIES,
-    DEFAULT_BASE_DELAY_MS,
-    computeRetryDelay,
-    parseRetryAfterMs,
-    getHttpRetryDelay,
-    isRetryableStatus,
-    isRetryableNetworkError,
+    ...real,
     sleep: () => Promise.resolve(),
   };
 });


### PR DESCRIPTION
Address review feedback on PR #8092: mock only the sleep function instead of the entire retry module, so tests exercise the production retry classification/backoff logic.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
