### PR TITLE
Fix: avoid blocking external channel dispatch on LLM generation

### DIFF
--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -105,8 +105,9 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
     // Mac (internal) delivery — always created
     destinations.push({ channel: 'macos' });
 
-    // Generate thread copy for the mac guardian thread (title + initial message)
-    const guardianCopy = await generateGuardianCopy(
+    // Start LLM copy generation concurrently — only awaited in the macOS branch
+    // so external channels (Telegram, SMS) dispatch without LLM latency.
+    const guardianCopyPromise = generateGuardianCopy(
       pendingQuestion.questionText,
       request.requestCode,
     );
@@ -114,6 +115,8 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
     // Create delivery rows and dispatch
     for (const dest of destinations) {
       if (dest.channel === 'macos') {
+        const guardianCopy = await guardianCopyPromise;
+
         // Create a dedicated server-side conversation for the mac guardian thread
         const macConvKey = `asst:${assistantId}:guardian:request:${request.id}`;
         const { conversationId: macConversationId } = getOrCreateConversation(macConvKey);


### PR DESCRIPTION
Move generateGuardianCopy await into macOS branch so Telegram/SMS dispatch is not blocked by up to 5s LLM timeout. Addresses review feedback on #8117.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
