### PR TITLE
feat(macos): add Vellum section to Connect settings tab

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -86,7 +86,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private var onboardingWindow: OnboardingWindow?
     private var authWindow: NSWindow?
-    let authManager = AuthManager()
+    var authManager: AuthManager { services.authManager }
     var mainWindow: MainWindow?
     var bundleConfirmationWindow: BundleConfirmationWindow?
     private var tasksWindow: TasksWindow?

--- a/clients/macos/vellum-assistant/App/AppServices.swift
+++ b/clients/macos/vellum-assistant/App/AppServices.swift
@@ -5,6 +5,7 @@ import VellumAssistantShared
 @MainActor
 public final class AppServices {
     public private(set) var daemonClient: DaemonClient
+    public let authManager = AuthManager()
     public let ambientAgent = AmbientAgent()
     let surfaceManager = SurfaceManager()
     let browserPiPManager = BrowserPiPManager()

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -280,7 +280,7 @@ final class MainWindow {
             self.pendingWakeUpMessage = nil
         } : nil
 
-        let rootView = MainWindowView(threadManager: threadManager, appListManager: appListManager, zoomManager: zoomManager, traceStore: traceStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, windowState: windowState, documentManager: documentManager, avatarEvolutionState: avatarEvolutionState, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, onSendWakeUp: wakeUpCallback)
+        let rootView = MainWindowView(threadManager: threadManager, appListManager: appListManager, zoomManager: zoomManager, traceStore: traceStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, documentManager: documentManager, avatarEvolutionState: avatarEvolutionState, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, onSendWakeUp: wakeUpCallback)
         let hostingController = NonDraggableHostingController(rootView: rootView)
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -47,6 +47,7 @@ struct MainWindowView: View {
     let surfaceManager: SurfaceManager
     let ambientAgent: AmbientAgent
     let settingsStore: SettingsStore
+    let authManager: AuthManager
     @ObservedObject var documentManager: DocumentManager
     let avatarEvolutionState: AvatarEvolutionState?
     @State private var lastAppliedBootstrapTurn: Int = 0
@@ -60,7 +61,7 @@ struct MainWindowView: View {
     /// Whether the "coming alive" overlay is currently showing.
     @State private var showComingAlive: Bool
 
-    init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, windowState: MainWindowState, documentManager: DocumentManager, avatarEvolutionState: AvatarEvolutionState? = nil, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager = VoiceModeManager(), onSendWakeUp: (() -> Void)? = nil) {
+    init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, avatarEvolutionState: AvatarEvolutionState? = nil, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager = VoiceModeManager(), onSendWakeUp: (() -> Void)? = nil) {
         self.threadManager = threadManager
         self.appListManager = appListManager
         self.zoomManager = zoomManager
@@ -69,6 +70,7 @@ struct MainWindowView: View {
         self.surfaceManager = surfaceManager
         self.ambientAgent = ambientAgent
         self.settingsStore = settingsStore
+        self.authManager = authManager
         self.windowState = windowState
         self.documentManager = documentManager
         self.avatarEvolutionState = avatarEvolutionState

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -23,7 +23,7 @@ extension MainWindowView {
         case .chat:
             chatView
         case .settings:
-            SettingsPanel(onClose: { windowState.selection = nil }, store: settingsStore, daemonClient: daemonClient, threadManager: threadManager)
+            SettingsPanel(onClose: { windowState.selection = nil }, store: settingsStore, daemonClient: daemonClient, threadManager: threadManager, authManager: authManager)
         case .agent:
             AgentPanel(onClose: { windowState.selection = nil }, onInvokeSkill: { skill in
                 if threadManager.activeViewModel == nil {
@@ -422,7 +422,7 @@ extension MainWindowView {
     func fullWindowPanel(_ panel: SidePanelType) -> some View {
         switch panel {
         case .settings:
-            SettingsPanel(onClose: { windowState.dismissOverlay() }, store: settingsStore, daemonClient: daemonClient, threadManager: threadManager)
+            SettingsPanel(onClose: { windowState.dismissOverlay() }, store: settingsStore, daemonClient: daemonClient, threadManager: threadManager, authManager: authManager)
                 .background(adaptiveColor(light: Moss._50, dark: Moss._950))
         case .agent:
             AgentPanel(onClose: { windowState.dismissOverlay() }, onInvokeSkill: { skill in
@@ -903,7 +903,7 @@ struct DynamicWorkspaceWrapper: View {
 struct MainWindowView_Previews: PreviewProvider {
     static var previews: some View {
         let dc = DaemonClient()
-        MainWindowView(threadManager: ThreadManager(daemonClient: dc), appListManager: AppListManager(), zoomManager: ZoomManager(), traceStore: TraceStore(), daemonClient: dc, surfaceManager: SurfaceManager(), ambientAgent: AmbientAgent(), settingsStore: SettingsStore(daemonClient: dc), windowState: MainWindowState(), documentManager: DocumentManager())
+        MainWindowView(threadManager: ThreadManager(daemonClient: dc), appListManager: AppListManager(), zoomManager: ZoomManager(), traceStore: TraceStore(), daemonClient: dc, surfaceManager: SurfaceManager(), ambientAgent: AmbientAgent(), settingsStore: SettingsStore(daemonClient: dc), authManager: AuthManager(), windowState: MainWindowState(), documentManager: DocumentManager())
             .frame(width: 900, height: 600)
             .padding(.top, 36)
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -17,6 +17,7 @@ struct SettingsPanel: View {
     @ObservedObject var store: SettingsStore
     var daemonClient: DaemonClient?
     @ObservedObject var threadManager: ThreadManager
+    var authManager: AuthManager
 
     @State private var apiKeyText: String = ""
     @State private var braveKeyText: String = ""
@@ -174,7 +175,7 @@ struct SettingsPanel: View {
     private var selectedTabContent: some View {
         switch selectedTab {
         case .connect:
-            SettingsConnectTab(store: store, daemonClient: daemonClient)
+            SettingsConnectTab(store: store, daemonClient: daemonClient, authManager: authManager)
         case .integrations:
             integrationsContent
         case .trust:
@@ -1246,7 +1247,7 @@ struct SettingsPanel_Previews: PreviewProvider {
         let dc = DaemonClient()
         ZStack {
             VColor.background.ignoresSafeArea()
-            SettingsPanel(onClose: {}, store: SettingsStore(daemonClient: dc), threadManager: ThreadManager(daemonClient: dc))
+            SettingsPanel(onClose: {}, store: SettingsStore(daemonClient: dc), threadManager: ThreadManager(daemonClient: dc), authManager: AuthManager())
         }
         .frame(width: 600, height: 700)
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -9,6 +9,7 @@ import VellumAssistantShared
 struct SettingsConnectTab: View {
     @ObservedObject var store: SettingsStore
     var daemonClient: DaemonClient?
+    var authManager: AuthManager
 
     @State private var gatewayUrlText: String = ""
     @FocusState private var isGatewayUrlFocused: Bool
@@ -48,6 +49,7 @@ struct SettingsConnectTab: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
+            vellumSection
             pairingSection
             gatewaySection
             advancedSection
@@ -55,6 +57,7 @@ struct SettingsConnectTab: View {
             channelsSection
         }
         .onAppear {
+            Task { await authManager.checkSession() }
             store.refreshIngressConfig()
             store.refreshAssistantEmail()
             gatewayUrlText = store.ingressPublicBaseUrl
@@ -96,6 +99,68 @@ struct SettingsConnectTab: View {
                 isLocalOverride: PairingConfiguration.isOverrideEnabled
             )
         }
+    }
+
+    // MARK: - Vellum Section
+
+    private var vellumSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("Vellum")
+                .font(VFont.sectionTitle)
+                .foregroundColor(VColor.textPrimary)
+
+            if authManager.isLoading {
+                channelStatusRow(
+                    label: "Account",
+                    icon: "arrow.trianglehead.2.counterclockwise",
+                    iconColor: VColor.textMuted,
+                    value: "Checking..."
+                )
+            } else if let user = authManager.currentUser {
+                channelStatusRow(
+                    label: "Account",
+                    icon: "checkmark.circle.fill",
+                    iconColor: VColor.success,
+                    value: user.email ?? user.display ?? "Signed in",
+                    action: .init(label: "Log Out", style: .danger) {
+                        Task { await authManager.logout() }
+                    }
+                )
+            } else {
+                channelStatusRow(
+                    label: "Account",
+                    icon: "xmark.circle",
+                    iconColor: VColor.textMuted,
+                    value: "Not signed in",
+                    action: .init(
+                        label: authManager.isSubmitting ? "Signing in..." : "Log In",
+                        style: .primary,
+                        disabled: authManager.isSubmitting
+                    ) {
+                        Task { await authManager.startWorkOSLogin() }
+                    }
+                )
+            }
+
+            if let error = authManager.errorMessage {
+                Text(error)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
+            }
+
+            Divider().background(VColor.surfaceBorder)
+
+            channelStatusRow(
+                label: "Platform URL",
+                icon: "link",
+                iconColor: VColor.textMuted,
+                value: AuthService.shared.baseURL,
+                valueFont: VFont.mono
+            )
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard(background: VColor.surfaceSubtle)
     }
 
     // MARK: - Gateway Section

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -49,9 +49,9 @@ struct SettingsConnectTab: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
-            vellumSection
             pairingSection
             gatewaySection
+            vellumSection
             advancedSection
             diagnosticsSection
             channelsSection


### PR DESCRIPTION
## Summary
- Adds a "Vellum" section at the top of the macOS Connect settings tab showing authentication status (login/logout via WorkOS OIDC) and the current platform URL
- Moves `AuthManager` ownership into `AppServices` and threads it through the view hierarchy to `SettingsConnectTab`
- Uses existing `AuthManager`/`AuthService` shared infrastructure and existing `channelStatusRow` UI pattern

## Test plan
- [x] `./build.sh` compiles without errors
- [x] `./build.sh lint` passes strict concurrency
- [ ] Manual: open Settings > Connect, verify Vellum section appears at top
- [ ] Manual: click Log In, complete WorkOS flow, verify status updates to authenticated with email
- [ ] Manual: click Log Out, verify status returns to "Not signed in"
- [ ] Manual: verify Platform URL displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
