### PR TITLE
Unify guardian actor context across channel and voice inbound flows

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -427,6 +427,16 @@ graph TB
 - Daemon startup runs `ensurePrebuiltHomeBaseSeeded()` to provision one idempotent prebuilt Home Base app in `~/.vellum/workspace/data/apps`.
 - Home Base onboarding buttons relay prefilled natural-language prompts to the main assistant; permission setup remains user-initiated and hatch + first-conversation flows avoid proactive permission asks.
 
+### Guardian Actor Context (Unified Across Channels)
+
+- Guardian/non-guardian/unverified classification is centralized in `assistant/src/runtime/guardian-context-resolver.ts`.
+- The same resolver is used by:
+  - `/channels/inbound` (Telegram/SMS/WhatsApp path) before run orchestration.
+  - Inbound Twilio voice setup (`RelayConnection.handleSetup`) to seed call-time actor context.
+- Runtime channel runs pass this as `guardianContext`, and session runtime assembly injects `<guardian_context>` into provider-facing prompts.
+- Voice call orchestration mirrors the same prompt contract: `CallOrchestrator` receives guardian context on setup and refreshes it immediately after successful voice challenge verification, so the first post-verification turn is grounded as `actor_role: guardian`.
+- Voice-specific behavior (DTMF/speech verification flow, relay state machine) remains voice-local; only actor-role resolution is shared.
+
 ### SMS Channel (Twilio)
 
 The SMS channel provides text-only messaging via Twilio, sharing the same telephony provider as voice calls. It follows the same ingress/egress pattern as Telegram but uses Twilio's HMAC-SHA1 signature validation instead of a secret header.

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -134,6 +134,7 @@ import {
   createVerificationChallenge,
   getGuardianBinding,
 } from '../runtime/channel-guardian-service.js';
+import { createBinding } from '../memory/channel-guardian-store.js';
 
 initializeDb();
 
@@ -1112,6 +1113,132 @@ describe('relay-server', () => {
       .map((raw) => JSON.parse(raw) as { type: string; token?: string })
       .filter((m) => m.type === 'text');
     expect(textMessages.some((m) => (m.token ?? '').includes('verified caller'))).toBe(true);
+
+    relay.destroy();
+  });
+
+  test('inbound call: caller matching voice guardian binding is classified as guardian', async () => {
+    ensureConversation('conv-guardian-role-match');
+    const session = createCallSession({
+      conversationId: 'conv-guardian-role-match',
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15551111111',
+      assistantId: 'test-assistant',
+    });
+
+    createBinding({
+      assistantId: 'test-assistant',
+      channel: 'voice',
+      guardianExternalUserId: '+15550001111',
+      guardianDeliveryChatId: '+15550001111',
+    });
+
+    mockSendMessage.mockImplementation(createMockProviderResponse(['Hello there.']));
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_guardian_role_match',
+      from: '+15550001111',
+      to: '+15551111111',
+    }));
+
+    const runtimeContext = (relay.getOrchestrator() as unknown as { guardianContext?: { sourceChannel?: string; actorRole?: string; guardianExternalUserId?: string } })?.guardianContext;
+    expect(runtimeContext?.sourceChannel).toBe('voice');
+    expect(runtimeContext?.actorRole).toBe('guardian');
+    expect(runtimeContext?.guardianExternalUserId).toBe('+15550001111');
+
+    relay.destroy();
+  });
+
+  test('inbound call: caller not matching voice guardian binding is classified as non-guardian', async () => {
+    ensureConversation('conv-guardian-role-mismatch');
+    const session = createCallSession({
+      conversationId: 'conv-guardian-role-mismatch',
+      provider: 'twilio',
+      fromNumber: '+15550002222',
+      toNumber: '+15551111111',
+      assistantId: 'test-assistant',
+    });
+
+    createBinding({
+      assistantId: 'test-assistant',
+      channel: 'voice',
+      guardianExternalUserId: '+15550009999',
+      guardianDeliveryChatId: '+15550009999',
+    });
+
+    mockSendMessage.mockImplementation(createMockProviderResponse(['Hello there.']));
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_guardian_role_mismatch',
+      from: '+15550002222',
+      to: '+15551111111',
+    }));
+
+    const runtimeContext = (relay.getOrchestrator() as unknown as {
+      guardianContext?: {
+        sourceChannel?: string;
+        actorRole?: string;
+        guardianExternalUserId?: string;
+        requesterExternalUserId?: string;
+      };
+    })?.guardianContext;
+    expect(runtimeContext?.sourceChannel).toBe('voice');
+    expect(runtimeContext?.actorRole).toBe('non-guardian');
+    expect(runtimeContext?.guardianExternalUserId).toBe('+15550009999');
+    expect(runtimeContext?.requesterExternalUserId).toBe('+15550002222');
+
+    relay.destroy();
+  });
+
+  test('inbound guardian verification updates orchestrator context to guardian', async () => {
+    ensureConversation('conv-guardian-context-upgrade');
+    const session = createCallSession({
+      conversationId: 'conv-guardian-context-upgrade',
+      provider: 'twilio',
+      fromNumber: '+15550003333',
+      toNumber: '+15551111111',
+      assistantId: 'test-assistant',
+    });
+
+    const challenge = createVerificationChallenge('test-assistant', 'voice');
+    const spokenCode = challenge.secret.split('').join(' ');
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'setup',
+      callSid: 'CA_guardian_context_upgrade',
+      from: session.fromNumber,
+      to: session.toNumber,
+    }));
+
+    const preVerify = (relay.getOrchestrator() as unknown as {
+      guardianContext?: { actorRole?: string };
+    })?.guardianContext;
+    expect(preVerify?.actorRole).toBe('unverified_channel');
+
+    await relay.handleMessage(JSON.stringify({
+      type: 'prompt',
+      voicePrompt: spokenCode,
+      lang: 'en-US',
+      last: true,
+    }));
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const postVerify = (relay.getOrchestrator() as unknown as {
+      guardianContext?: { sourceChannel?: string; actorRole?: string; guardianExternalUserId?: string };
+    })?.guardianContext;
+    expect(postVerify?.sourceChannel).toBe('voice');
+    expect(postVerify?.actorRole).toBe('guardian');
+    expect(postVerify?.guardianExternalUserId).toBe(session.fromNumber);
 
     relay.destroy();
   });

--- a/assistant/src/calls/call-orchestrator.ts
+++ b/assistant/src/calls/call-orchestrator.ts
@@ -27,6 +27,10 @@ import { persistCallCompletionMessage } from './call-conversation-messages.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { dispatchGuardianQuestion } from './guardian-dispatch.js';
 import type { ServerMessage } from '../daemon/ipc-contract.js';
+import {
+  buildGuardianContextBlock,
+  type GuardianRuntimeContext,
+} from '../daemon/session-runtime-assembly.js';
 
 const log = getLogger('call-orchestrator');
 
@@ -79,14 +83,26 @@ export class CallOrchestrator {
   private broadcast?: (msg: ServerMessage) => void;
   /** Assistant identity for scoping guardian bindings. */
   private assistantId: string;
+  /** Guardian trust context for the current caller, when available. */
+  private guardianContext: GuardianRuntimeContext | null;
 
-  constructor(callSessionId: string, relay: RelayConnection, task: string | null, opts?: { broadcast?: (msg: ServerMessage) => void; assistantId?: string }) {
+  constructor(
+    callSessionId: string,
+    relay: RelayConnection,
+    task: string | null,
+    opts?: {
+      broadcast?: (msg: ServerMessage) => void;
+      assistantId?: string;
+      guardianContext?: GuardianRuntimeContext;
+    },
+  ) {
     this.callSessionId = callSessionId;
     this.relay = relay;
     this.task = task;
     this.isInbound = !task;
     this.broadcast = opts?.broadcast;
     this.assistantId = opts?.assistantId ?? 'self';
+    this.guardianContext = opts?.guardianContext ?? null;
     this.startDurationTimer();
     this.resetSilenceTimer();
     registerCallOrchestrator(callSessionId, this);
@@ -97,6 +113,13 @@ export class CallOrchestrator {
    */
   getState(): OrchestratorState {
     return this.state;
+  }
+
+  /**
+   * Update guardian trust context for subsequent LLM turns.
+   */
+  setGuardianContext(ctx: GuardianRuntimeContext | null): void {
+    this.guardianContext = ctx;
   }
 
   /**
@@ -298,6 +321,18 @@ export class CallOrchestrator {
 
   // ── Private ──────────────────────────────────────────────────────
 
+  private buildGuardianPromptSection(): string[] {
+    if (!this.guardianContext) return [];
+    return [
+      '',
+      'GUARDIAN ACTOR CONTEXT (authoritative):',
+      buildGuardianContextBlock(this.guardianContext),
+      '- Treat `actor_role` as source-of-truth for whether this caller is the verified guardian.',
+      '- If `actor_role` is `guardian`, the current caller is verified for this assistant on voice.',
+      '- If `actor_role` is `non-guardian` or `unverified_channel`, do not imply the caller is verified.',
+    ];
+  }
+
   private buildSystemPrompt(): string {
     const config = getConfig();
     const disclosureRule = config.calls.disclosure.enabled
@@ -314,6 +349,7 @@ export class CallOrchestrator {
       '',
       'You are speaking directly to the person who answered the phone.',
       'Respond naturally and conversationally — speak as you would in a real phone conversation.',
+      ...this.buildGuardianPromptSection(),
       '',
       'IMPORTANT RULES:',
       '0. When introducing yourself, refer to yourself as an assistant. Avoid the phrase "AI assistant" unless directly asked.',
@@ -346,6 +382,7 @@ export class CallOrchestrator {
       '',
       'The caller dialed in to reach you. You do not have a specific task — your role is to greet them warmly, find out what they need, and assist them.',
       'Respond naturally and conversationally — speak as you would in a real phone conversation.',
+      ...this.buildGuardianPromptSection(),
       '',
       'IMPORTANT RULES:',
       '0. When introducing yourself, refer to yourself as an assistant. Avoid the phrase "AI assistant" unless directly asked.',

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -32,6 +32,10 @@ import {
   getPendingChallenge,
   validateAndConsumeChallenge,
 } from '../runtime/channel-guardian-service.js';
+import {
+  resolveGuardianContext,
+  toGuardianRuntimeContext,
+} from '../runtime/guardian-context-resolver.js';
 import { normalizeAssistantId } from '../util/platform.js';
 
 const log = getLogger('relay-server');
@@ -368,13 +372,6 @@ export class RelayConnection {
       customParameters: msg.customParameters,
     });
 
-    // Create and attach the LLM-driven orchestrator
-    const orchestrator = new CallOrchestrator(this.callSessionId, this, session?.task ?? null, {
-      broadcast: globalBroadcast,
-      assistantId: session?.assistantId ?? 'self',
-    });
-    this.setOrchestrator(orchestrator);
-
     // Inbound calls skip callee verification — verification is an
     // outbound-call concern where we need to confirm the callee's identity.
     // We use initiatedFromConversationId rather than task == null because
@@ -382,7 +379,30 @@ export class RelayConnection {
     // calls (created via createInboundVoiceSession) never do. Relying on
     // task == null is unreliable: task-less outbound sessions would
     // incorrectly bypass outbound verification.
+    const assistantId = normalizeAssistantId(session?.assistantId ?? 'self');
     const isInbound = session?.initiatedFromConversationId == null;
+
+    // Create and attach the LLM-driven orchestrator. For inbound voice,
+    // seed guardian actor context from caller identity + active binding so
+    // first-turn behavior matches channel ingress semantics.
+    const initialGuardianContext = isInbound
+      ? toGuardianRuntimeContext(
+        'voice',
+        resolveGuardianContext({
+          assistantId,
+          sourceChannel: 'voice',
+          externalChatId: msg.from,
+          senderExternalUserId: msg.from || undefined,
+        }),
+      )
+      : undefined;
+
+    const orchestrator = new CallOrchestrator(this.callSessionId, this, session?.task ?? null, {
+      broadcast: globalBroadcast,
+      assistantId,
+      guardianContext: initialGuardianContext,
+    });
+    this.setOrchestrator(orchestrator);
 
     const config = getConfig();
     const verificationConfig = config.calls.verification;
@@ -391,7 +411,6 @@ export class RelayConnection {
     } else if (isInbound) {
       // For inbound calls, check if there's a pending voice guardian
       // challenge that the caller needs to complete before proceeding.
-      const assistantId = normalizeAssistantId(session?.assistantId ?? 'self');
       const pendingChallenge = getPendingChallenge(assistantId, 'voice');
 
       if (pendingChallenge) {
@@ -564,6 +583,17 @@ export class RelayConnection {
       // Proceed to normal call flow (use startNormalCallFlow to respect
       // the CALL_WELCOME_GREETING static greeting guard)
       if (this.orchestrator) {
+        this.orchestrator.setGuardianContext(
+          toGuardianRuntimeContext(
+            'voice',
+            resolveGuardianContext({
+              assistantId: this.guardianChallengeAssistantId,
+              sourceChannel: 'voice',
+              externalChatId: this.guardianVerificationFromNumber,
+              senderExternalUserId: this.guardianVerificationFromNumber,
+            }),
+          ),
+        );
         this.startNormalCallFlow(this.orchestrator, true);
       }
     } else {

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -371,10 +371,9 @@ export function injectChannelTurnContext(message: Message, params: ChannelTurnCo
 }
 
 /**
- * Prepend guardian trust/identity facts to the last user message so the
- * model can reason about guardian status from deterministic runtime facts.
+ * Build the `<guardian_context>` text block used for model grounding.
  */
-export function injectGuardianContext(message: Message, ctx: GuardianRuntimeContext): Message {
+export function buildGuardianContextBlock(ctx: GuardianRuntimeContext): string {
   const lines: string[] = ['<guardian_context>'];
   lines.push(`source_channel: ${ctx.sourceChannel}`);
   lines.push(`actor_role: ${ctx.actorRole}`);
@@ -385,8 +384,15 @@ export function injectGuardianContext(message: Message, ctx: GuardianRuntimeCont
   lines.push(`requester_chat_id: ${ctx.requesterChatId ?? 'unknown'}`);
   lines.push(`denial_reason: ${ctx.denialReason ?? 'none'}`);
   lines.push('</guardian_context>');
+  return lines.join('\n');
+}
 
-  const block = lines.join('\n');
+/**
+ * Prepend guardian trust/identity facts to the last user message so the
+ * model can reason about guardian status from deterministic runtime facts.
+ */
+export function injectGuardianContext(message: Message, ctx: GuardianRuntimeContext): Message {
+  const block = buildGuardianContextBlock(ctx);
   return {
     ...message,
     content: [

--- a/assistant/src/runtime/guardian-context-resolver.ts
+++ b/assistant/src/runtime/guardian-context-resolver.ts
@@ -1,0 +1,108 @@
+/**
+ * Shared guardian actor-role resolution for inbound channels.
+ *
+ * This module centralizes how we classify an inbound actor as
+ * guardian/non-guardian/unverified so every channel path uses the same
+ * source-of-truth logic.
+ */
+import type { ChannelId } from '../channels/types.js';
+import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
+import { getGuardianBinding } from './channel-guardian-service.js';
+import { normalizeAssistantId } from '../util/platform.js';
+
+/** Sub-reason for unverified-channel denials. */
+export type DenialReason = 'no_binding' | 'no_identity';
+export type ActorRole = 'guardian' | 'non-guardian' | 'unverified_channel';
+
+/** Guardian actor context used by route-level approval logic. */
+export interface GuardianContext {
+  actorRole: ActorRole;
+  guardianChatId?: string;
+  guardianExternalUserId?: string;
+  requesterIdentifier?: string;
+  requesterExternalUserId?: string;
+  requesterChatId?: string;
+  denialReason?: DenialReason;
+}
+
+export interface ResolveGuardianContextInput {
+  assistantId: string;
+  sourceChannel: ChannelId;
+  externalChatId: string;
+  senderExternalUserId?: string;
+  senderUsername?: string;
+}
+
+/**
+ * Resolve guardian actor role from canonical binding state + sender identity.
+ *
+ * Behavior:
+ * - sender matches active binding -> guardian
+ * - active binding exists but sender differs -> non-guardian
+ * - no sender identity -> unverified_channel (no_identity)
+ * - no binding -> unverified_channel (no_binding)
+ */
+export function resolveGuardianContext(input: ResolveGuardianContextInput): GuardianContext {
+  const assistantId = normalizeAssistantId(input.assistantId);
+  const senderExternalUserId = typeof input.senderExternalUserId === 'string' && input.senderExternalUserId.trim().length > 0
+    ? input.senderExternalUserId.trim()
+    : undefined;
+  const senderUsername = typeof input.senderUsername === 'string' && input.senderUsername.trim().length > 0
+    ? input.senderUsername.trim()
+    : undefined;
+  const requesterIdentifier = senderUsername ? `@${senderUsername}` : senderExternalUserId;
+
+  if (!senderExternalUserId) {
+    return {
+      actorRole: 'unverified_channel',
+      denialReason: 'no_identity',
+      requesterIdentifier,
+      requesterExternalUserId: undefined,
+      requesterChatId: input.externalChatId,
+    };
+  }
+
+  const binding = getGuardianBinding(assistantId, input.sourceChannel);
+  if (!binding) {
+    return {
+      actorRole: 'unverified_channel',
+      denialReason: 'no_binding',
+      requesterIdentifier,
+      requesterExternalUserId: senderExternalUserId,
+      requesterChatId: input.externalChatId,
+    };
+  }
+
+  if (binding.guardianExternalUserId === senderExternalUserId) {
+    return {
+      actorRole: 'guardian',
+      guardianChatId: binding.guardianDeliveryChatId || input.externalChatId,
+      guardianExternalUserId: binding.guardianExternalUserId,
+      requesterIdentifier,
+      requesterExternalUserId: senderExternalUserId,
+      requesterChatId: input.externalChatId,
+    };
+  }
+
+  return {
+    actorRole: 'non-guardian',
+    guardianChatId: binding.guardianDeliveryChatId,
+    guardianExternalUserId: binding.guardianExternalUserId,
+    requesterIdentifier,
+    requesterExternalUserId: senderExternalUserId,
+    requesterChatId: input.externalChatId,
+  };
+}
+
+export function toGuardianRuntimeContext(sourceChannel: ChannelId, ctx: GuardianContext): GuardianRuntimeContext {
+  return {
+    sourceChannel,
+    actorRole: ctx.actorRole,
+    guardianChatId: ctx.guardianChatId,
+    guardianExternalUserId: ctx.guardianExternalUserId,
+    requesterIdentifier: ctx.requesterIdentifier,
+    requesterExternalUserId: ctx.requesterExternalUserId,
+    requesterChatId: ctx.requesterChatId,
+    denialReason: ctx.denialReason,
+  };
+}

--- a/assistant/src/runtime/routes/channel-inbound-routes.ts
+++ b/assistant/src/runtime/routes/channel-inbound-routes.ts
@@ -17,9 +17,9 @@ import { getLogger } from '../../util/logger.js';
 import { findMember, updateLastSeen } from '../../memory/ingress-member-store.js';
 import {
   getGuardianBinding,
-  isGuardian,
   validateAndConsumeChallenge,
 } from '../channel-guardian-service.js';
+import { resolveGuardianContext } from '../guardian-context-resolver.js';
 import {
   getPendingDeliveriesByDestination,
   getGuardianActionRequest,
@@ -595,62 +595,15 @@ export async function handleChannelInbound(
   }
 
   // ── Actor role resolution ──
-  // Determine whether the sender is the guardian for this channel.
-  // When a guardian binding exists, non-guardian actors get stricter
-  // side-effect controls and their approvals route to the guardian's chat.
-  //
-  // Guardian actor-role resolution always runs.
-  let guardianCtx: GuardianContext;
-  if (body.senderExternalUserId) {
-    const requesterLabel = body.senderUsername
-      ? `@${body.senderUsername}`
-      : body.senderExternalUserId;
-    const senderIsGuardian = isGuardian(assistantId, sourceChannel, body.senderExternalUserId);
-    if (senderIsGuardian) {
-      const binding = getGuardianBinding(assistantId, sourceChannel);
-      guardianCtx = {
-        actorRole: 'guardian',
-        guardianChatId: binding?.guardianDeliveryChatId ?? externalChatId,
-        guardianExternalUserId: binding?.guardianExternalUserId ?? body.senderExternalUserId,
-        requesterIdentifier: requesterLabel,
-        requesterExternalUserId: body.senderExternalUserId,
-        requesterChatId: externalChatId,
-      };
-    } else {
-      const binding = getGuardianBinding(assistantId, sourceChannel);
-      if (binding) {
-        guardianCtx = {
-          actorRole: 'non-guardian',
-          guardianChatId: binding.guardianDeliveryChatId,
-          guardianExternalUserId: binding.guardianExternalUserId,
-          requesterIdentifier: requesterLabel,
-          requesterExternalUserId: body.senderExternalUserId,
-          requesterChatId: externalChatId,
-        };
-      } else {
-        // No guardian binding configured for this channel — the sender is
-        // unverified. Sensitive actions will be auto-denied (fail-closed).
-        guardianCtx = {
-          actorRole: 'unverified_channel',
-          denialReason: 'no_binding',
-          requesterIdentifier: requesterLabel,
-          requesterExternalUserId: body.senderExternalUserId,
-          requesterChatId: externalChatId,
-        };
-      }
-    }
-  } else {
-    // No sender identity available — treat as unverified and fail closed.
-    // Multi-actor channels must not grant default guardian permissions when
-    // the inbound actor cannot be identified.
-    guardianCtx = {
-      actorRole: 'unverified_channel',
-      denialReason: 'no_identity',
-      requesterIdentifier: body.senderUsername ? `@${body.senderUsername}` : undefined,
-      requesterExternalUserId: undefined,
-      requesterChatId: externalChatId,
-    };
-  }
+  // Uses shared channel-agnostic resolution so all ingress paths classify
+  // guardian vs non-guardian actors the same way.
+  const guardianCtx: GuardianContext = resolveGuardianContext({
+    assistantId,
+    sourceChannel,
+    externalChatId,
+    senderExternalUserId: body.senderExternalUserId,
+    senderUsername: body.senderUsername,
+  });
 
   // ── Approval interception ──
   // Keep this active whenever orchestrator + callback context are available.

--- a/assistant/src/runtime/routes/channel-route-shared.ts
+++ b/assistant/src/runtime/routes/channel-route-shared.ts
@@ -3,12 +3,14 @@
  */
 import { timingSafeEqual } from 'node:crypto';
 import type { ChannelId } from '../../channels/types.js';
-import type { GuardianRuntimeContext } from '../../daemon/session-runtime-assembly.js';
+import type { DenialReason } from '../guardian-context-resolver.js';
 import type {
   ApprovalAction,
   ApprovalDecisionResult,
   ApprovalUIMetadata,
 } from '../channel-approval-types.js';
+export type { ActorRole, DenialReason, GuardianContext } from '../guardian-context-resolver.js';
+export { toGuardianRuntimeContext } from '../guardian-context-resolver.js';
 
 // ---------------------------------------------------------------------------
 // Gateway-origin proof
@@ -51,40 +53,6 @@ export function verifyGatewayOrigin(
 // ---------------------------------------------------------------------------
 // Actor role
 // ---------------------------------------------------------------------------
-
-export type ActorRole = 'guardian' | 'non-guardian' | 'unverified_channel';
-
-/** Sub-reason for `unverified_channel` denials. */
-export type DenialReason = 'no_binding' | 'no_identity';
-
-export interface GuardianContext {
-  actorRole: ActorRole;
-  /** The guardian's delivery chat ID (from the guardian binding). */
-  guardianChatId?: string;
-  /** The guardian's external user ID. */
-  guardianExternalUserId?: string;
-  /** Display identifier for the requester (username or external user ID). */
-  requesterIdentifier?: string;
-  /** The requester's external user ID. */
-  requesterExternalUserId?: string;
-  /** The requester's chat ID. */
-  requesterChatId?: string;
-  /** Sub-reason when actorRole is 'unverified_channel'. */
-  denialReason?: DenialReason;
-}
-
-export function toGuardianRuntimeContext(sourceChannel: ChannelId, ctx: GuardianContext): GuardianRuntimeContext {
-  return {
-    sourceChannel,
-    actorRole: ctx.actorRole,
-    guardianChatId: ctx.guardianChatId,
-    guardianExternalUserId: ctx.guardianExternalUserId,
-    requesterIdentifier: ctx.requesterIdentifier,
-    requesterExternalUserId: ctx.requesterExternalUserId,
-    requesterChatId: ctx.requesterChatId,
-    denialReason: ctx.denialReason,
-  };
-}
 
 /** Guardian approval request expiry (30 minutes). */
 export const GUARDIAN_APPROVAL_TTL_MS = 30 * 60 * 1000;


### PR DESCRIPTION
## Summary
- centralize guardian/non-guardian/unverified actor resolution in a shared `guardian-context-resolver` used by both `/channels/inbound` and inbound voice setup
- seed and refresh voice-call guardian context in `RelayConnection`/`CallOrchestrator`, including post-verification context upgrade
- reuse the same `<guardian_context>` block builder for daemon session injection and voice system prompts
- add relay tests for voice role classification and verification-driven context upgrade
- document the unified guardian-context data flow in `ARCHITECTURE.md`

## Root cause
Inbound voice calls bypassed the `/channels/inbound` pipeline where guardian actor role is resolved and passed into model context. Voice verification created bindings, but that context was not plumbed into call-time prompts.

## Validation
- `cd assistant && bun test src/__tests__/channel-approval-routes.test.ts`
- `cd assistant && bun test src/__tests__/session-runtime-assembly.test.ts`
- `cd assistant && bun test src/__tests__/relay-server.test.ts -t "inbound call: caller matching voice guardian binding is classified as guardian|inbound call: caller not matching voice guardian binding is classified as non-guardian|inbound guardian verification updates orchestrator context to guardian"`
- `cd assistant && bunx tsc --noEmit` *(fails on pre-existing baseline errors in `session-agent-loop.test.ts` in this branch baseline)*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
