### PR TITLE
feat: M1 — IPC Contract: Pairing Approval Messages

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -2879,3 +2879,59 @@ exports[`IPC message snapshots ServerMessage types assistant_inbox_reply_respons
   "type": "assistant_inbox_reply_response",
 }
 `;
+
+exports[`IPC message snapshots ClientMessage types pairing_approval_response serializes to expected JSON 1`] = `
+{
+  "decision": "approve_once",
+  "pairingRequestId": "pair-001",
+  "type": "pairing_approval_response",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types approved_devices_list serializes to expected JSON 1`] = `
+{
+  "type": "approved_devices_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types approved_device_remove serializes to expected JSON 1`] = `
+{
+  "hashedDeviceId": "hashed-device-001",
+  "type": "approved_device_remove",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types approved_devices_clear serializes to expected JSON 1`] = `
+{
+  "type": "approved_devices_clear",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types pairing_approval_request serializes to expected JSON 1`] = `
+{
+  "deviceId": "device-001",
+  "deviceName": "iPhone 15",
+  "pairingRequestId": "pair-001",
+  "type": "pairing_approval_request",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types approved_devices_list_response serializes to expected JSON 1`] = `
+{
+  "devices": [
+    {
+      "deviceName": "iPhone 15",
+      "hashedDeviceId": "hashed-device-001",
+      "lastPairedAt": 1700000000000,
+    },
+  ],
+  "type": "approved_devices_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types approved_device_remove_response serializes to expected JSON 1`] = `
+{
+  "success": true,
+  "type": "approved_device_remove_response",
+}
+`;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -647,6 +647,21 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     conversationId: 'conv-001',
     content: 'Hello from the assistant',
   },
+  pairing_approval_response: {
+    type: 'pairing_approval_response',
+    pairingRequestId: 'pair-001',
+    decision: 'approve_once',
+  },
+  approved_devices_list: {
+    type: 'approved_devices_list',
+  },
+  approved_device_remove: {
+    type: 'approved_device_remove',
+    hashedDeviceId: 'hashed-device-001',
+  },
+  approved_devices_clear: {
+    type: 'approved_devices_clear',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -1863,6 +1878,24 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     type: 'assistant_inbox_reply_response',
     success: true,
     messageId: 'msg-reply-001',
+  },
+  pairing_approval_request: {
+    type: 'pairing_approval_request',
+    pairingRequestId: 'pair-001',
+    deviceId: 'device-001',
+    deviceName: 'iPhone 15',
+  },
+  approved_devices_list_response: {
+    type: 'approved_devices_list_response',
+    devices: [{
+      hashedDeviceId: 'hashed-device-001',
+      deviceName: 'iPhone 15',
+      lastPairedAt: 1700000000000,
+    }],
+  },
+  approved_device_remove_response: {
+    type: 'approved_device_remove_response',
+    success: true,
   },
 };
 

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -26,6 +26,7 @@ export * from './ipc-contract/schedules.js';
 export * from './ipc-contract/diagnostics.js';
 export * from './ipc-contract/parental-control.js';
 export * from './ipc-contract/inbox.js';
+export * from './ipc-contract/pairing.js';
 
 // Import types needed for aggregate unions and SubagentEvent
 import type { AuthMessage, PingMessage, CancelRequest, DeleteQueuedMessage, ModelGetRequest, ModelSetRequest, ImageGenModelSetRequest, HistoryRequest, UndoRequest, RegenerateRequest, UsageRequest, SandboxSetRequest, SessionListRequest, SessionCreateRequest, SessionSwitchRequest, SessionsClearRequest, ConversationSearchRequest } from './ipc-contract/sessions.js';
@@ -62,6 +63,7 @@ import type { DiagnosticsExportResponse, EnvVarsResponse, IpcBlobProbeResult, Di
 import type { SchedulesList, ScheduleToggle, ScheduleRemove, ScheduleRunNow, RemindersList, ReminderCancel } from './ipc-contract/schedules.js';
 import type { ParentalControlGetRequest, ParentalControlVerifyPinRequest, ParentalControlSetPinRequest, ParentalControlUpdateRequest, ParentalControlGetResponse, ParentalControlVerifyPinResponse, ParentalControlSetPinResponse, ParentalControlUpdateResponse } from './ipc-contract/parental-control.js';
 import type { IngressInviteRequest, IngressMemberRequest, AssistantInboxRequest, AssistantInboxEscalationRequest, AssistantInboxReplyRequest, IngressInviteResponse, IngressMemberResponse, AssistantInboxResponse, AssistantInboxEscalationResponse, AssistantInboxReplyResponse } from './ipc-contract/inbox.js';
+import type { PairingApprovalResponse, ApprovedDevicesList, ApprovedDeviceRemove, ApprovedDevicesClear, PairingApprovalRequest, ApprovedDevicesListResponse, ApprovedDeviceRemoveResponse } from './ipc-contract/pairing.js';
 
 // === SubagentEvent — defined here because it references ServerMessage ===
 
@@ -203,7 +205,11 @@ export type ClientMessage =
   | IngressMemberRequest
   | AssistantInboxRequest
   | AssistantInboxEscalationRequest
-  | AssistantInboxReplyRequest;
+  | AssistantInboxReplyRequest
+  | PairingApprovalResponse
+  | ApprovedDevicesList
+  | ApprovedDeviceRemove
+  | ApprovedDevicesClear;
 
 // === Server → Client aggregate union ===
 
@@ -351,7 +357,10 @@ export type ServerMessage =
   | IngressMemberResponse
   | AssistantInboxResponse
   | AssistantInboxEscalationResponse
-  | AssistantInboxReplyResponse;
+  | AssistantInboxReplyResponse
+  | PairingApprovalRequest
+  | ApprovedDevicesListResponse
+  | ApprovedDeviceRemoveResponse;
 
 // === Contract schema ===
 

--- a/assistant/src/daemon/ipc-contract/pairing.ts
+++ b/assistant/src/daemon/ipc-contract/pairing.ts
@@ -1,0 +1,45 @@
+// Pairing approval and approved-device management types.
+
+// === Client → Server ===
+
+export interface PairingApprovalResponse {
+  type: 'pairing_approval_response';
+  pairingRequestId: string;
+  decision: 'approve_once' | 'always_allow' | 'deny';
+}
+
+export interface ApprovedDevicesList {
+  type: 'approved_devices_list';
+}
+
+export interface ApprovedDeviceRemove {
+  type: 'approved_device_remove';
+  hashedDeviceId: string;
+}
+
+export interface ApprovedDevicesClear {
+  type: 'approved_devices_clear';
+}
+
+// === Server → Client ===
+
+export interface PairingApprovalRequest {
+  type: 'pairing_approval_request';
+  pairingRequestId: string;
+  deviceId: string;
+  deviceName: string;
+}
+
+export interface ApprovedDevicesListResponse {
+  type: 'approved_devices_list_response';
+  devices: Array<{
+    hashedDeviceId: string;
+    deviceName: string;
+    lastPairedAt: number;
+  }>;
+}
+
+export interface ApprovedDeviceRemoveResponse {
+  type: 'approved_device_remove_response';
+  success: boolean;
+}

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -260,6 +260,64 @@ public struct IPCAppRestoreResponse: Codable, Sendable {
     }
 }
 
+public struct IPCApprovedDeviceRemove: Codable, Sendable {
+    public let type: String
+    public let hashedDeviceId: String
+
+    public init(type: String, hashedDeviceId: String) {
+        self.type = type
+        self.hashedDeviceId = hashedDeviceId
+    }
+}
+
+public struct IPCApprovedDeviceRemoveResponse: Codable, Sendable {
+    public let type: String
+    public let success: Bool
+
+    public init(type: String, success: Bool) {
+        self.type = type
+        self.success = success
+    }
+}
+
+public struct IPCApprovedDevicesClear: Codable, Sendable {
+    public let type: String
+
+    public init(type: String) {
+        self.type = type
+    }
+}
+
+public struct IPCApprovedDevicesList: Codable, Sendable {
+    public let type: String
+
+    public init(type: String) {
+        self.type = type
+    }
+}
+
+public struct IPCApprovedDevicesListResponse: Codable, Sendable {
+    public let type: String
+    public let devices: [IPCApprovedDevicesListResponseDevice]
+
+    public init(type: String, devices: [IPCApprovedDevicesListResponseDevice]) {
+        self.type = type
+        self.devices = devices
+    }
+}
+
+public struct IPCApprovedDevicesListResponseDevice: Codable, Sendable {
+    public let hashedDeviceId: String
+    public let deviceName: String
+    public let lastPairedAt: Int
+
+    public init(hashedDeviceId: String, deviceName: String, lastPairedAt: Int) {
+        self.hashedDeviceId = hashedDeviceId
+        self.deviceName = deviceName
+        self.lastPairedAt = lastPairedAt
+    }
+}
+
 public struct IPCAppsListRequest: Codable, Sendable {
     public let type: String
 
@@ -2769,6 +2827,32 @@ public struct IPCOpenUrl: Codable, Sendable {
         self.type = type
         self.url = url
         self.title = title
+    }
+}
+
+public struct IPCPairingApprovalRequest: Codable, Sendable {
+    public let type: String
+    public let pairingRequestId: String
+    public let deviceId: String
+    public let deviceName: String
+
+    public init(type: String, pairingRequestId: String, deviceId: String, deviceName: String) {
+        self.type = type
+        self.pairingRequestId = pairingRequestId
+        self.deviceId = deviceId
+        self.deviceName = deviceName
+    }
+}
+
+public struct IPCPairingApprovalResponse: Codable, Sendable {
+    public let type: String
+    public let pairingRequestId: String
+    public let decision: String
+
+    public init(type: String, pairingRequestId: String, decision: String) {
+        self.type = type
+        self.pairingRequestId = pairingRequestId
+        self.decision = decision
     }
 }
 

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2205,6 +2205,9 @@ public enum ServerMessage: Decodable, Sendable {
     case assistantInboxResponse(IPCAssistantInboxResponse)
     case assistantInboxReplyResponse(IPCAssistantInboxReplyResponse)
     case assistantInboxEscalationResponse(IPCAssistantInboxEscalationResponse)
+    case pairingApprovalRequest(PairingApprovalRequestMessage)
+    case approvedDevicesListResponse(ApprovedDevicesListResponseMessage)
+    case approvedDeviceRemoveResponse(ApprovedDeviceRemoveResponseMessage)
     case pong
     case unknown(String)
 
@@ -2601,6 +2604,15 @@ public enum ServerMessage: Decodable, Sendable {
         case "assistant_inbox_escalation_response":
             let message = try IPCAssistantInboxEscalationResponse(from: decoder)
             self = .assistantInboxEscalationResponse(message)
+        case "pairing_approval_request":
+            let message = try PairingApprovalRequestMessage(from: decoder)
+            self = .pairingApprovalRequest(message)
+        case "approved_devices_list_response":
+            let message = try ApprovedDevicesListResponseMessage(from: decoder)
+            self = .approvedDevicesListResponse(message)
+        case "approved_device_remove_response":
+            let message = try ApprovedDeviceRemoveResponseMessage(from: decoder)
+            self = .approvedDeviceRemoveResponse(message)
         case "pong":
             self = .pong
         default:
@@ -2747,6 +2759,66 @@ public struct SlotContentWire: Decodable, Sendable {
     public let type: String
     public let panel: String?
     public let surfaceId: String?
+}
+
+// MARK: - Pairing Messages
+
+/// Server → Client: daemon asks macOS to show a pairing approval prompt.
+public struct PairingApprovalRequestMessage: Decodable, Sendable {
+    public let pairingRequestId: String
+    public let deviceId: String
+    public let deviceName: String
+}
+
+/// Server → Client: list of always-allowed devices.
+public struct ApprovedDevicesListResponseMessage: Decodable, Sendable {
+    public struct Device: Decodable, Sendable {
+        public let hashedDeviceId: String
+        public let deviceName: String
+        public let lastPairedAt: Double
+    }
+    public let devices: [Device]
+}
+
+/// Server → Client: confirmation of device removal.
+public struct ApprovedDeviceRemoveResponseMessage: Decodable, Sendable {
+    public let success: Bool
+}
+
+/// Client → Server: Mac user's decision on a pairing request.
+public struct PairingApprovalResponseMessage: Encodable, Sendable {
+    public let type: String = "pairing_approval_response"
+    public let pairingRequestId: String
+    public let decision: String
+
+    public init(pairingRequestId: String, decision: String) {
+        self.pairingRequestId = pairingRequestId
+        self.decision = decision
+    }
+}
+
+/// Client → Server: request list of always-allowed devices.
+public struct ApprovedDevicesListMessage: Encodable, Sendable {
+    public let type: String = "approved_devices_list"
+
+    public init() {}
+}
+
+/// Client → Server: revoke a device's always-allow status.
+public struct ApprovedDeviceRemoveMessage: Encodable, Sendable {
+    public let type: String = "approved_device_remove"
+    public let hashedDeviceId: String
+
+    public init(hashedDeviceId: String) {
+        self.hashedDeviceId = hashedDeviceId
+    }
+}
+
+/// Client → Server: clear all approved devices.
+public struct ApprovedDevicesClearMessage: Encodable, Sendable {
+    public let type: String = "approved_devices_clear"
+
+    public init() {}
 }
 
 // MARK: - Work Item Helpers


### PR DESCRIPTION
## Summary
Adds the IPC contract types for pairing approval and approved-device management. This is the foundation for the v4 pairing flow.

## Changes
- **NEW** `assistant/src/daemon/ipc-contract/pairing.ts` — Domain file with client→server (approval response, device list/remove/clear) and server→client (approval request, list response, remove response) message types
- **MOD** `assistant/src/daemon/ipc-contract.ts` — Re-exports pairing module and adds types to ClientMessage/ServerMessage unions
- **MOD** `clients/shared/IPC/IPCMessages.swift` — Swift wrappers for pairing IPC messages
- **MOD** `clients/shared/IPC/Generated/IPCContractGenerated.swift` — Auto-generated Swift types from the updated contract
- **MOD** `assistant/src/__tests__/ipc-snapshot.test.ts` — Snapshot test coverage for new message types
- **MOD** `assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap` — Updated snapshots

## Stack
M1 of 9 — Simplify Pairing + Mac Approval
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
