### PR TITLE
Fix: create macOS delivery row before awaiting LLM copy

### DIFF
--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -115,9 +115,9 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
     // Create delivery rows and dispatch
     for (const dest of destinations) {
       if (dest.channel === 'macos') {
-        const guardianCopy = await guardianCopyPromise;
-
-        // Create a dedicated server-side conversation for the mac guardian thread
+        // Create conversation and delivery row synchronously so they exist
+        // before awaiting LLM copy — prevents a race where an external channel
+        // reply resolves the request before the macOS delivery is created.
         const macConvKey = `asst:${assistantId}:guardian:request:${request.id}`;
         const { conversationId: macConversationId } = getOrCreateConversation(macConvKey);
 
@@ -126,6 +126,9 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
           destinationChannel: 'macos',
           destinationConversationId: macConversationId,
         });
+
+        // Now await LLM-generated copy for the message content and thread title
+        const guardianCopy = await guardianCopyPromise;
 
         // Add the guardian question as the initial message in the thread
         addMessage(


### PR DESCRIPTION
Move macOS conversation and delivery row creation before the LLM copy await to eliminate theoretical race where external reply could resolve the request before the macOS delivery exists. Addresses review feedback on #8122.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
