### PR TITLE
fix: update Gmail setup prompt to reflect automated flow

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -22,10 +22,10 @@ Gmail, Slack, and Telegram setup all require a publicly reachable URL for OAuth 
    - Then call `skill_load` with `skill: "google-oauth-setup"`.
    - Tell the user Gmail isn't connected yet and briefly explain what the setup involves, then use `ui_show` with `surface_type: "confirmation"` to ask for permission to start:
      - **message:** "Ready to set up Gmail?"
-     - **detail:** "I'll walk you through creating Google Cloud credentials and connecting your account. The process takes a few minutes, and I'll ask for your approval before each step."
+     - **detail:** "I'll automate the entire setup in the browser — creating a Google Cloud project, enabling APIs, and configuring OAuth. It takes a few minutes and you can watch via screencast."
      - **confirmLabel:** "Get Started"
      - **cancelLabel:** "Not Now"
-   - Wait for the user to confirm before proceeding with the setup guide. If they decline, acknowledge and let them know they can set it up later.
+   - If the user confirms, briefly acknowledge (e.g., "Setting up Gmail now...") and proceed with the setup guide. If they decline, acknowledge and let them know they can set it up later.
 3. **If the user provides a client_id directly in chat:** Call `credential_store` with `action: "oauth2_connect"`, `service: "gmail"`, and `client_id: "<their value>"`. Include `client_secret` too if they provide one. Everything else is auto-filled.
 
 ### Slack


### PR DESCRIPTION
## Summary

- Updated Gmail setup confirmation dialog detail text to accurately describe the automated browser-based flow instead of claiming per-step approvals
- Added instruction to show a brief acknowledgment (e.g., "Setting up Gmail now...") after user clicks Get Started, rather than silently proceeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
