### PR TITLE
feat: M4 — macOS Approval Prompt UI

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -90,6 +90,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var mainWindow: MainWindow?
     var bundleConfirmationWindow: BundleConfirmationWindow?
     private var tasksWindow: TasksWindow?
+    private var pairingApprovalWindow: PairingApprovalWindow?
     /// Tracks file paths of .vellumapp bundles awaiting daemon responses (FIFO).
     /// Each call to sendOpenBundle appends a path; handleOpenBundleResponse
     /// pops the first entry so concurrent opens are correctly paired.
@@ -660,6 +661,17 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
         daemonClient.onOpenTasksWindow = { [weak self] in
             self?.showTasksWindow()
+        }
+
+        daemonClient.onPairingApprovalRequest = { [weak self] msg in
+            guard let self else { return }
+            if self.pairingApprovalWindow == nil {
+                self.pairingApprovalWindow = PairingApprovalWindow(daemonClient: self.daemonClient)
+            }
+            self.pairingApprovalWindow?.show(
+                pairingRequestId: msg.pairingRequestId,
+                deviceName: msg.deviceName
+            )
         }
 
         // Automatically surface threads created by scheduled task runs so

--- a/clients/macos/vellum-assistant/Features/Settings/PairingApprovalView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingApprovalView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+/// SwiftUI content for the pairing approval prompt.
+/// Shows the device name and three action buttons: Deny, Approve Once, Always Allow.
+struct PairingApprovalView: View {
+    let deviceName: String
+    let onDecision: (String) -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "iphone")
+                .font(.system(size: 40))
+                .foregroundStyle(.secondary)
+
+            Text("Pairing Request")
+                .font(.headline)
+
+            Text("\"\(deviceName)\" wants to pair with your Mac.")
+                .font(.body)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 12) {
+                Button("Deny") {
+                    onDecision("deny")
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Button("Approve Once") {
+                    onDecision("approve_once")
+                }
+
+                Button("Always Allow") {
+                    onDecision("always_allow")
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 340)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/PairingApprovalWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingApprovalWindow.swift
@@ -1,0 +1,60 @@
+import AppKit
+import SwiftUI
+import VellumAssistantShared
+
+/// Manages a floating NSWindow for pairing approval prompts.
+/// Follows the TasksWindow pattern — auto-centers, activates app, idempotent show/close.
+@MainActor
+final class PairingApprovalWindow {
+    private var window: NSWindow?
+    private let daemonClient: DaemonClient
+
+    init(daemonClient: DaemonClient) {
+        self.daemonClient = daemonClient
+    }
+
+    /// Show the pairing approval prompt for a specific device.
+    /// If a window is already showing, it is closed first (one prompt at a time).
+    func show(pairingRequestId: String, deviceName: String) {
+        // Close any existing prompt before showing a new one
+        close()
+
+        let view = PairingApprovalView(deviceName: deviceName) { [weak self] decision in
+            guard let self else { return }
+            try? self.daemonClient.sendPairingApprovalResponse(
+                pairingRequestId: pairingRequestId,
+                decision: decision
+            )
+            self.close()
+        }
+
+        let hostingController = NSHostingController(rootView: view)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 380, height: 200),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+
+        window.contentViewController = hostingController
+        window.title = "Pairing Request"
+        window.level = .floating
+        window.isReleasedWhenClosed = false
+        window.center()
+
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+
+        self.window = window
+    }
+
+    var isVisible: Bool {
+        window?.isVisible ?? false
+    }
+
+    func close() {
+        window?.close()
+        window = nil
+    }
+}

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -423,6 +423,15 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon wants us to open/focus the tasks window.
     public var onOpenTasksWindow: (() -> Void)?
 
+    /// Called when the daemon requests pairing approval from macOS.
+    public var onPairingApprovalRequest: ((PairingApprovalRequestMessage) -> Void)?
+
+    /// Called when the daemon sends the approved devices list.
+    public var onApprovedDevicesListResponse: ((ApprovedDevicesListResponseMessage) -> Void)?
+
+    /// Called when the daemon confirms a device removal.
+    public var onApprovedDeviceRemoveResponse: ((ApprovedDeviceRemoveResponseMessage) -> Void)?
+
     /// Called when a subagent is spawned.
     public var onSubagentSpawned: ((IPCSubagentSpawned) -> Void)?
 
@@ -1401,6 +1410,28 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             contentRestrictions: contentRestrictions,
             blockedToolCategories: blockedToolCategories
         ))
+    }
+
+    // MARK: - Pairing
+
+    /// Send the user's pairing approval decision.
+    public func sendPairingApprovalResponse(pairingRequestId: String, decision: String) throws {
+        try send(PairingApprovalResponseMessage(pairingRequestId: pairingRequestId, decision: decision))
+    }
+
+    /// Request the list of always-allowed devices.
+    public func sendApprovedDevicesList() throws {
+        try send(ApprovedDevicesListMessage())
+    }
+
+    /// Remove a device from the always-allow list.
+    public func sendApprovedDeviceRemove(hashedDeviceId: String) throws {
+        try send(ApprovedDeviceRemoveMessage(hashedDeviceId: hashedDeviceId))
+    }
+
+    /// Clear all approved devices.
+    public func sendApprovedDevicesClear() throws {
+        try send(ApprovedDevicesClearMessage())
     }
 
 }

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -254,6 +254,12 @@ extension DaemonClient {
             onAssistantInboxReplyResponse?(msg)
         case .assistantInboxEscalationResponse(let msg):
             onAssistantInboxEscalationResponse?(msg)
+        case .pairingApprovalRequest(let msg):
+            onPairingApprovalRequest?(msg)
+        case .approvedDevicesListResponse(let msg):
+            onApprovedDevicesListResponse?(msg)
+        case .approvedDeviceRemoveResponse(let msg):
+            onApprovedDeviceRemoveResponse?(msg)
         default:
             break
         }


### PR DESCRIPTION
## Summary
Adds the macOS-side pairing approval prompt UI and wiring. When an iOS device requests pairing, a native window appears with device name and approve/deny options.

## Changes
- **NEW** `PairingApprovalView.swift` — SwiftUI view with approve-once, always-allow, deny buttons
- **NEW** `PairingApprovalWindow.swift` — NSWindow wrapper for the approval prompt
- **MOD** `DaemonClient.swift` — Adds onPairingApprovalRequest callback
- **MOD** `DaemonMessageRouter.swift` — Routes pairing_approval_request to the new callback
- **MOD** `AppDelegate.swift` — Wires pairing approval request to show the approval window

## Stack
M4 of 9 — Simplify Pairing + Mac Approval
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
