### PR TITLE
fix: use classified snapshot statement in contradiction update

### DIFF
--- a/assistant/src/memory/contradiction-checker.ts
+++ b/assistant/src/memory/contradiction-checker.ts
@@ -333,7 +333,7 @@ function handleRelationship(
         );
         db.update(memoryItems)
           .set({
-            statement: freshNew!.statement,
+            statement: newItem.statement,
             lastSeenAt: Math.max(freshExisting.lastSeenAt, freshNew!.lastSeenAt),
             confidence: Math.max(freshExisting.confidence, freshNew!.confidence),
           })


### PR DESCRIPTION
Addresses Codex review feedback on #8102. The update case now uses the classified snapshot statement (newItem.statement) instead of the fresh re-read (freshNew.statement) to prevent potential data corruption if another worker mutates the item between classification and transaction.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
