### PR TITLE
fix: widen 5xx regex to match parenthesized status codes

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -786,5 +786,7 @@ function isHttpStatusError(err: unknown): boolean {
   }
   // Fall back to message matching, but only for patterns that clearly
   // indicate an HTTP status code rather than arbitrary numbers.
-  return /\b429\b|(?:status|http)\s*(?:code\s*)?:?\s*5\d{2}\b/i.test(err.message);
+  // Matches: "status 503", "HTTP 500", "status code: 502", parenthesized
+  // codes like "(503)" from Gemini/Ollama, and bare "429" (rate-limit).
+  return /\b429\b|\(429\)|(?:status|http)\s*(?:code\s*)?:?\s*5\d{2}\b|\(5\d{2}\)/i.test(err.message);
 }


### PR DESCRIPTION
Addresses Codex review feedback on #8103. Expands the isHttpStatusError regex fallback to also match patterns like (503) and (429) used by Gemini/Ollama backends, while still avoiding false positives from bare dimension numbers like 512.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
