### PR TITLE
feat: add WakeWordCoordinator bridging wake word detection to voice mode (#7995)

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -43,7 +43,8 @@ final class VoiceInputManager {
     /// Used by `stopRecording()` to decide whether the overlay should stay visible.
     private var awaitingDaemonResponse = false
 
-    private var isRecording = false
+    /// Whether the microphone is currently recording for PTT/dictation.
+    private(set) var isRecording = false
     private var globalMonitor: Any?
     private var localMonitor: Any?
     private var globalKeyDownMonitor: Any?

--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Combine
+import os
+
+private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "WakeWordCoordinator")
+
+/// Bridges wake word detection (AlwaysOnAudioMonitor) to voice mode activation (VoiceModeManager).
+///
+/// On wake word detected: pauses the audio monitor, ensures a ChatViewModel is available,
+/// activates voice mode, and starts listening.
+/// On voice mode deactivation: resumes passive wake word listening.
+@MainActor
+final class WakeWordCoordinator: ObservableObject {
+
+    private let audioMonitor: AlwaysOnAudioMonitor
+    private let voiceModeManager: VoiceModeManager
+    private let threadManager: ThreadManager
+    private weak var voiceInputManager: VoiceInputManager?
+
+    /// When a wake word fires before the app is fully initialized,
+    /// we queue it and process once `markReady()` is called.
+    private var pendingWakeWord = false
+    private var isReady = false
+
+    private var stateCancellable: AnyCancellable?
+
+    init(
+        audioMonitor: AlwaysOnAudioMonitor,
+        voiceModeManager: VoiceModeManager,
+        threadManager: ThreadManager,
+        voiceInputManager: VoiceInputManager? = nil
+    ) {
+        self.audioMonitor = audioMonitor
+        self.voiceModeManager = voiceModeManager
+        self.threadManager = threadManager
+        self.voiceInputManager = voiceInputManager
+
+        setupWakeWordHandler()
+        observeVoiceModeState()
+    }
+
+    // MARK: - Readiness
+
+    /// Call once the app is fully initialized (daemon connected, UI ready).
+    /// Processes any wake word that fired before the app was ready.
+    func markReady() {
+        isReady = true
+        if pendingWakeWord {
+            pendingWakeWord = false
+            log.info("Processing queued wake word after app became ready")
+            handleWakeWordDetected()
+        }
+    }
+
+    // MARK: - Wake Word Handling
+
+    private func setupWakeWordHandler() {
+        audioMonitor.onWakeWordDetected = { [weak self] in
+            self?.onWakeWord()
+        }
+    }
+
+    private func onWakeWord() {
+        guard isReady else {
+            log.info("Wake word detected before app ready — queuing")
+            pendingWakeWord = true
+            return
+        }
+        handleWakeWordDetected()
+    }
+
+    private func handleWakeWordDetected() {
+        // Ignore if voice mode is already active
+        guard voiceModeManager.state == .off else {
+            log.info("Wake word ignored — voice mode already active (state: \(String(describing: voiceModeManager.state)))")
+            return
+        }
+
+        // Ignore if PTT dictation is currently recording
+        if let voiceInputManager, voiceInputManager.isRecording {
+            log.info("Wake word ignored — PTT dictation is active")
+            return
+        }
+
+        log.info("Wake word detected — activating voice mode")
+
+        // 1. Pause the audio monitor (stop keyword listening to free the mic)
+        audioMonitor.stopMonitoring()
+
+        // 2. Ensure we have an active ChatViewModel (create a new thread if needed)
+        let chatViewModel = ensureChatViewModel()
+
+        // 3. Activate voice mode and start listening
+        voiceModeManager.activate(chatViewModel: chatViewModel)
+        voiceModeManager.startListening()
+    }
+
+    /// Returns the active ChatViewModel, creating a new thread if none exists.
+    private func ensureChatViewModel() -> ChatViewModel {
+        if let existing = threadManager.activeViewModel {
+            return existing
+        }
+        // No active thread — create one, which sets it as active
+        threadManager.createThread()
+        // activeViewModel should now be set after createThread
+        return threadManager.activeViewModel!
+    }
+
+    // MARK: - Voice Mode State Observation
+
+    /// Watch VoiceModeManager.state — when it transitions to .off, resume the audio monitor.
+    private func observeVoiceModeState() {
+        stateCancellable = voiceModeManager.$state
+            .removeDuplicates()
+            .dropFirst() // skip the initial .off value
+            .sink { [weak self] newState in
+                guard let self else { return }
+                if newState == .off {
+                    log.info("Voice mode deactivated — resuming wake word listening")
+                    self.audioMonitor.startMonitoring()
+                }
+            }
+    }
+}


### PR DESCRIPTION
## Summary
- Create WakeWordCoordinator connecting AlwaysOnAudioMonitor to VoiceModeManager
- On wake word: pause monitor, activate voice mode, start listening
- On voice mode deactivation: resume passive wake word listening
- Handle edge cases (already in voice mode, PTT active, app not ready)

Part of #7992
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
