### PR TITLE
feat: integrate Picovoice Porcupine SDK and create WakeWordEngine protocol (#7993)

### DIFF
--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.0.0"),
+        .package(url: "https://github.com/Picovoice/porcupine", from: "3.0.0"),
     ],
     targets: [
         .target(
@@ -45,7 +46,11 @@ let package = Package(
         // iOS apps should depend only on VellumAssistantShared, not this target.
         .target(
             name: "VellumAssistantLib",
-            dependencies: ["VellumAssistantShared", "Sparkle"],
+            dependencies: [
+                "VellumAssistantShared",
+                "Sparkle",
+                .product(name: "Porcupine", package: "porcupine"),
+            ],
             path: "macos/vellum-assistant",
             exclude: ["Resources/Info.plist", "Resources/bg.png"],
             resources: [

--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/PorcupineWakeWordEngine.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/PorcupineWakeWordEngine.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Porcupine
+import os
+
+/// Wake word detection engine backed by Picovoice Porcupine.
+///
+/// Uses the built-in "porcupine" keyword for initial development; a custom
+/// "hey vellum" keyword can be swapped in later by changing the keyword enum.
+final class PorcupineWakeWordEngine: WakeWordEngine {
+    private let logger = Logger(subsystem: "com.vellum.vellum-assistant", category: "WakeWord")
+
+    private var porcupine: Porcupine?
+    private let sensitivity: Float32
+    private(set) var isRunning = false
+
+    var onWakeWordDetected: ((Float) -> Void)?
+
+    /// - Parameter sensitivity: Detection sensitivity in [0, 1]. Higher values
+    ///   reduce misses but increase false positives. Default 0.5.
+    init(sensitivity: Float32 = 0.5) {
+        self.sensitivity = sensitivity
+    }
+
+    func start() throws {
+        guard !isRunning else { return }
+
+        guard let accessKey = APIKeyManager.getKey(for: "picovoice") else {
+            logger.error("No Picovoice access key found in keychain")
+            throw WakeWordEngineError.missingAccessKey
+        }
+
+        do {
+            porcupine = try Porcupine(
+                accessKey: accessKey,
+                keyword: Porcupine.BuiltInKeyword.porcupine,
+                sensitivity: sensitivity
+            )
+            isRunning = true
+            logger.info("Porcupine wake word engine started (sensitivity: \(self.sensitivity))")
+        } catch {
+            logger.error("Failed to initialize Porcupine: \(error.localizedDescription)")
+            throw WakeWordEngineError.initializationFailed(error)
+        }
+    }
+
+    func stop() {
+        guard isRunning else { return }
+        porcupine?.delete()
+        porcupine = nil
+        isRunning = false
+        logger.info("Porcupine wake word engine stopped")
+    }
+
+    /// Process a single audio frame through Porcupine.
+    ///
+    /// Frames must contain exactly `Porcupine.frameLength` 16-bit PCM samples
+    /// at `Porcupine.sampleRate` Hz (typically 512 samples at 16 kHz).
+    ///
+    /// - Parameter frame: Array of 16-bit PCM audio samples.
+    func processAudioFrame(_ frame: [Int16]) {
+        guard isRunning, let porcupine = porcupine else { return }
+
+        do {
+            let keywordIndex = try porcupine.process(pcm: frame)
+            if keywordIndex >= 0 {
+                // Porcupine doesn't expose a per-detection confidence score;
+                // use the configured sensitivity as a proxy since detections
+                // that pass the threshold are considered high-confidence.
+                let confidence = sensitivity
+                logger.info("Wake word detected (confidence proxy: \(confidence))")
+                onWakeWordDetected?(confidence)
+            }
+        } catch {
+            logger.error("Porcupine processing error: \(error.localizedDescription)")
+        }
+    }
+
+    deinit {
+        stop()
+    }
+}
+
+enum WakeWordEngineError: Error, LocalizedError {
+    case missingAccessKey
+    case initializationFailed(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAccessKey:
+            return "Picovoice access key not found. Set it via APIKeyManager."
+        case .initializationFailed(let underlying):
+            return "Failed to initialize wake word engine: \(underlying.localizedDescription)"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add Picovoice Porcupine Swift SDK as SwiftPM dependency
- Create WakeWordEngine protocol for testable wake word detection
- Create PorcupineWakeWordEngine implementation wrapping Porcupine SDK
- Handle Picovoice access key via APIKeyManager

Part of #7992
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
