### PR TITLE
feat: M6 — macOS Approved Devices List UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ApprovedDevicesSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ApprovedDevicesSection.swift
@@ -7,7 +7,7 @@ import VellumAssistantShared
 @MainActor
 struct ApprovedDevicesSection: View {
     @ObservedObject var store: SettingsStore
-    @Binding var isExpanded: Bool
+    @State private var isExpanded: Bool = false
 
     var body: some View {
         VDisclosureSection(

--- a/clients/macos/vellum-assistant/Features/Settings/ApprovedDevicesSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ApprovedDevicesSection.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Displays always-allowed devices in the Connect tab.
+/// Each row shows device name + last paired time + a Remove button.
+/// Clear All button at bottom. Empty state: "No approved devices."
+@MainActor
+struct ApprovedDevicesSection: View {
+    @ObservedObject var store: SettingsStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack {
+                Text("Approved Devices")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+                Spacer()
+                if !store.approvedDevices.isEmpty {
+                    Button("Clear All") {
+                        store.clearAllApprovedDevices()
+                    }
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
+                    .buttonStyle(.borderless)
+                }
+            }
+
+            Text("Devices that have been granted \"Always Allow\" will pair automatically without prompting.")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+
+            if store.approvedDevices.isEmpty {
+                Text("No approved devices.")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textMuted)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, VSpacing.md)
+            } else {
+                ForEach(store.approvedDevices, id: \.hashedDeviceId) { device in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(device.deviceName)
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textPrimary)
+                            Text("Last paired: \(formattedDate(device.lastPairedAt))")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                        Spacer()
+                        Button("Remove") {
+                            store.removeApprovedDevice(hashedDeviceId: device.hashedDeviceId)
+                        }
+                        .font(VFont.caption)
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+                    .padding(.vertical, VSpacing.xs)
+                }
+            }
+        }
+        .padding(VSpacing.md)
+        .onAppear {
+            store.refreshApprovedDevices()
+        }
+    }
+
+    private func formattedDate(_ timestamp: Double) -> String {
+        let date = Date(timeIntervalSince1970: timestamp / 1000.0)
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/ApprovedDevicesSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ApprovedDevicesSection.swift
@@ -1,21 +1,58 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Displays always-allowed devices in the Connect tab.
+/// Displays always-allowed devices in a collapsible section of the Connect tab.
 /// Each row shows device name + last paired time + a Remove button.
 /// Clear All button at bottom. Empty state: "No approved devices."
 @MainActor
 struct ApprovedDevicesSection: View {
     @ObservedObject var store: SettingsStore
+    @Binding var isExpanded: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            HStack {
-                Text("Approved Devices")
-                    .font(VFont.sectionTitle)
-                    .foregroundColor(VColor.textPrimary)
-                Spacer()
-                if !store.approvedDevices.isEmpty {
+        VDisclosureSection(
+            title: "Approved Devices",
+            icon: "person.badge.shield.checkmark",
+            subtitle: !isExpanded && !store.approvedDevices.isEmpty
+                ? "\(store.approvedDevices.count) device\(store.approvedDevices.count == 1 ? "" : "s")"
+                : nil,
+            isExpanded: $isExpanded
+        ) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Text("Devices granted \"Always Allow\" pair automatically without prompting.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+
+                if store.approvedDevices.isEmpty {
+                    Text("No approved devices.")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textMuted)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.vertical, VSpacing.md)
+                } else {
+                    ForEach(store.approvedDevices, id: \.hashedDeviceId) { device in
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(device.deviceName)
+                                    .font(VFont.body)
+                                    .foregroundColor(VColor.textPrimary)
+                                Text("Last paired: \(formattedDate(device.lastPairedAt))")
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.textMuted)
+                            }
+                            Spacer()
+                            Button("Remove") {
+                                store.removeApprovedDevice(hashedDeviceId: device.hashedDeviceId)
+                            }
+                            .font(VFont.caption)
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                        }
+                        .padding(.vertical, VSpacing.xs)
+                    }
+
+                    Divider().background(VColor.surfaceBorder)
+
                     Button("Clear All") {
                         store.clearAllApprovedDevices()
                     }
@@ -24,41 +61,9 @@ struct ApprovedDevicesSection: View {
                     .buttonStyle(.borderless)
                 }
             }
-
-            Text("Devices that have been granted \"Always Allow\" will pair automatically without prompting.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
-
-            if store.approvedDevices.isEmpty {
-                Text("No approved devices.")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textMuted)
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .padding(.vertical, VSpacing.md)
-            } else {
-                ForEach(store.approvedDevices, id: \.hashedDeviceId) { device in
-                    HStack {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(device.deviceName)
-                                .font(VFont.body)
-                                .foregroundColor(VColor.textPrimary)
-                            Text("Last paired: \(formattedDate(device.lastPairedAt))")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textMuted)
-                        }
-                        Spacer()
-                        Button("Remove") {
-                            store.removeApprovedDevice(hashedDeviceId: device.hashedDeviceId)
-                        }
-                        .font(VFont.caption)
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-                    }
-                    .padding(.vertical, VSpacing.xs)
-                }
-            }
         }
-        .padding(VSpacing.md)
+        .padding(VSpacing.lg)
+        .vCard(background: VColor.surfaceSubtle)
         .onAppear {
             store.refreshApprovedDevices()
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -49,6 +49,7 @@ struct SettingsConnectTab: View {
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
             pairingSection
+            ApprovedDevicesSection(store: store)
             gatewaySection
             advancedSection
             diagnosticsSection

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1229,6 +1229,34 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
+    // MARK: - Approved Devices
+
+    @Published var approvedDevices: [ApprovedDevicesListResponseMessage.Device] = []
+
+    func refreshApprovedDevices() {
+        guard let daemonClient else { return }
+        daemonClient.onApprovedDevicesListResponse = { [weak self] msg in
+            self?.approvedDevices = msg.devices
+        }
+        try? daemonClient.sendApprovedDevicesList()
+    }
+
+    func removeApprovedDevice(hashedDeviceId: String) {
+        guard let daemonClient else { return }
+        daemonClient.onApprovedDeviceRemoveResponse = { [weak self] msg in
+            if msg.success {
+                self?.approvedDevices.removeAll { $0.hashedDeviceId == hashedDeviceId }
+            }
+        }
+        try? daemonClient.sendApprovedDeviceRemove(hashedDeviceId: hashedDeviceId)
+    }
+
+    func clearAllApprovedDevices() {
+        guard let daemonClient else { return }
+        try? daemonClient.sendApprovedDevicesClear()
+        approvedDevices = []
+    }
+
     // MARK: - Override Resolution
 
     /// Resolved gateway URL for iOS pairing — uses per-integration override if enabled, else global.


### PR DESCRIPTION
## Summary
Adds the Approved Devices section to the Connect tab, allowing users to view, remove, and clear paired devices.

## Changes
- **NEW** `ApprovedDevicesSection.swift` — SwiftUI section showing approved device list with remove/clear actions
- **MOD** `SettingsStore.swift` — Added `approvedDevices` published property and `refreshApprovedDevices()`, `removeApprovedDevice()`, `clearAllApprovedDevices()` methods
- **MOD** `SettingsConnectTab.swift` — Added `ApprovedDevicesSection(store: store)` between pairing and gateway sections

## Stack
M6 of 9 — Simplify Pairing + Mac Approval
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
