### PR TITLE
M2: macOS native notification + deep link to thread

### DIFF
--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -146,6 +146,7 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
             requestId: request.id,
             callSessionId,
             title: guardianCopy.threadTitle,
+            questionText: request.questionText,
           } as ServerMessage);
         }
         updateDeliveryStatus(delivery.id, 'sent');

--- a/assistant/src/daemon/ipc-contract/work-items.ts
+++ b/assistant/src/daemon/ipc-contract/work-items.ts
@@ -221,4 +221,5 @@ export interface GuardianRequestThreadCreated {
   requestId: string;
   callSessionId: string;
   title: string;
+  questionText: string;
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -84,7 +84,19 @@ extension AppDelegate {
             options: []
         )
 
-        center.setNotificationCategories([activityCategory, toolConfirmationCategory, rideShotgunCategory, voiceResponseCategory, quickChatCategory])
+        let viewGuardianAction = UNNotificationAction(
+            identifier: "VIEW_GUARDIAN",
+            title: "View",
+            options: [.foreground]
+        )
+        let guardianRequestCategory = UNNotificationCategory(
+            identifier: "GUARDIAN_REQUEST",
+            actions: [viewGuardianAction],
+            intentIdentifiers: [],
+            options: []
+        )
+
+        center.setNotificationCategories([activityCategory, toolConfirmationCategory, rideShotgunCategory, voiceResponseCategory, quickChatCategory, guardianRequestCategory])
     }
 
     func registerBundledFonts() {
@@ -165,7 +177,17 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             let conversationId = response.notification.request.content.userInfo["conversationId"] as? String
             await MainActor.run {
                 guard !self.isAwaitingFirstLaunchReady else { return }
-                self.openQuickChatThread(conversationId: conversationId)
+                self.openConversationThread(conversationId: conversationId)
+            }
+            return
+        }
+
+        // Handle guardian request notifications — open the guardian thread in the main window
+        if categoryId == "GUARDIAN_REQUEST" {
+            let conversationId = response.notification.request.content.userInfo["conversationId"] as? String
+            await MainActor.run {
+                guard !self.isAwaitingFirstLaunchReady else { return }
+                self.openConversationThread(conversationId: conversationId)
             }
             return
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -402,9 +402,30 @@ extension AppDelegate {
         }
     }
 
+    func deliverGuardianRequestNotification(title: String, questionText: String, conversationId: String) {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = String(questionText.prefix(200))
+        content.sound = .default
+        content.categoryIdentifier = "GUARDIAN_REQUEST"
+        content.userInfo = ["conversationId": conversationId]
+
+        let request = UNNotificationRequest(
+            identifier: "guardian-request-\(conversationId)",
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error {
+                log.error("Failed to post guardian request notification: \(error.localizedDescription)")
+            }
+        }
+    }
+
     /// Opens the main window and navigates to the thread for the given conversation ID.
     /// Retries if the thread isn't populated yet (e.g., ThreadManager hasn't loaded it).
-    func openQuickChatThread(conversationId: String?) {
+    /// Used by Quick Chat, Guardian Request, and other notification deep links.
+    func openConversationThread(conversationId: String?) {
         showMainWindow()
         guard let conversationId else { return }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -685,10 +685,20 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 callSessionId: msg.callSessionId,
                 title: msg.title
             )
-            if let thread = self.mainWindow?.threadManager.threads.first(where: { $0.sessionId == msg.conversationId }) {
-                self.mainWindow?.threadManager.activeThreadId = thread.id
+            if NSApp.isActive {
+                // App is in foreground — select thread and show window immediately
+                if let thread = self.mainWindow?.threadManager.threads.first(where: { $0.sessionId == msg.conversationId }) {
+                    self.mainWindow?.threadManager.activeThreadId = thread.id
+                }
+                self.showMainWindow()
+            } else {
+                // App is backgrounded — post native notification
+                self.deliverGuardianRequestNotification(
+                    title: msg.title,
+                    questionText: msg.title,
+                    conversationId: msg.conversationId
+                )
             }
-            self.showMainWindow()
         }
 
         // Handle escalation: text_qa -> computer_use via computer_use_request_control

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -695,7 +695,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 // App is backgrounded — post native notification
                 self.deliverGuardianRequestNotification(
                     title: msg.title,
-                    questionText: msg.title,
+                    questionText: msg.questionText,
                     conversationId: msg.conversationId
                 )
             }

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1853,13 +1853,15 @@ public struct IPCGuardianRequestThreadCreated: Codable, Sendable {
     public let requestId: String
     public let callSessionId: String
     public let title: String
+    public let questionText: String
 
-    public init(type: String, conversationId: String, requestId: String, callSessionId: String, title: String) {
+    public init(type: String, conversationId: String, requestId: String, callSessionId: String, title: String, questionText: String) {
         self.type = type
         self.conversationId = conversationId
         self.requestId = requestId
         self.callSessionId = callSessionId
         self.title = title
+        self.questionText = questionText
     }
 }
 


### PR DESCRIPTION
Add native macOS notification for guardian requests when app is backgrounded, with deep link to open the correct thread on click. Generalizes thread opening helper for reuse across notification types. Part of #8110.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
