### PR TITLE
M3: Update pipeline stage types to preprocess/map/reduce

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/services/processing-pipeline.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/processing-pipeline.ts
@@ -2,7 +2,7 @@
  * Processing pipeline service.
  *
  * Orchestrates the full media processing pipeline with reliability features:
- * - Sequential stage execution: keyframe_extraction -> vision_analysis -> timeline_generation -> event_detection
+ * - Sequential stage execution: preprocess -> map -> reduce
  * - Stage-level retries with exponential backoff
  * - Resumability: checks processing_stages to find last completed stage
  * - Cancellation support: cooperative cancellation via asset status = 'cancelled'
@@ -27,10 +27,9 @@ import { computeRetryDelay, sleep } from '../../../../util/retry.js';
 // ---------------------------------------------------------------------------
 
 export type PipelineStageName =
-  | 'keyframe_extraction'
-  | 'vision_analysis'
-  | 'timeline_generation'
-  | 'event_detection';
+  | 'preprocess'
+  | 'map'
+  | 'reduce';
 
 export interface StageHandler {
   /** Execute the stage. Throw on failure. */
@@ -60,10 +59,9 @@ export interface PipelineResult {
 // ---------------------------------------------------------------------------
 
 const STAGE_ORDER: PipelineStageName[] = [
-  'keyframe_extraction',
-  'vision_analysis',
-  'timeline_generation',
-  'event_detection',
+  'preprocess',
+  'map',
+  'reduce',
 ];
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of #8012. Updates PipelineStageName and STAGE_ORDER from the old 4-stage model to the new 3-phase preprocess/map/reduce pipeline.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
