### PR TITLE
M1: Create concurrency pool + cost tracker services

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/__tests__/concurrency-pool.test.ts
+++ b/assistant/src/config/bundled-skills/media-processing/__tests__/concurrency-pool.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'bun:test';
+import { ConcurrencyPool } from '../services/concurrency-pool.js';
+
+describe('ConcurrencyPool', () => {
+  it('allows up to maxConcurrency tasks to run simultaneously', async () => {
+    const pool = new ConcurrencyPool(2);
+
+    await pool.acquire();
+    await pool.acquire();
+
+    expect(pool.activeCount).toBe(2);
+    expect(pool.waitingCount).toBe(0);
+
+    // Third acquire should not resolve immediately
+    let thirdResolved = false;
+    const thirdPromise = pool.acquire().then(() => {
+      thirdResolved = true;
+    });
+
+    // Yield the microtask queue so the promise chain can settle if it were going to
+    await Promise.resolve();
+    expect(thirdResolved).toBe(false);
+    expect(pool.waitingCount).toBe(1);
+
+    // Release one slot — third should now resolve
+    pool.release();
+    await thirdPromise;
+    expect(thirdResolved).toBe(true);
+    expect(pool.activeCount).toBe(2);
+    expect(pool.waitingCount).toBe(0);
+  });
+
+  it('releases slots on error so the pool does not leak', async () => {
+    const pool = new ConcurrencyPool(1);
+
+    const runTask = async () => {
+      await pool.acquire();
+      try {
+        throw new Error('simulated failure');
+      } finally {
+        pool.release();
+      }
+    };
+
+    // First task errors and releases its slot
+    await expect(runTask()).rejects.toThrow('simulated failure');
+    expect(pool.activeCount).toBe(0);
+
+    // Pool should still be usable after the error
+    await pool.acquire();
+    expect(pool.activeCount).toBe(1);
+    pool.release();
+  });
+
+  it('rejects maxConcurrency less than 1', () => {
+    expect(() => new ConcurrencyPool(0)).toThrow('maxConcurrency must be at least 1');
+  });
+
+  it('defaults to maxConcurrency of 10', async () => {
+    const pool = new ConcurrencyPool();
+
+    // Acquire 10 slots — all should resolve immediately
+    for (let i = 0; i < 10; i++) {
+      await pool.acquire();
+    }
+    expect(pool.activeCount).toBe(10);
+
+    // 11th should queue
+    let eleventhResolved = false;
+    pool.acquire().then(() => {
+      eleventhResolved = true;
+    });
+    await Promise.resolve();
+    expect(eleventhResolved).toBe(false);
+    expect(pool.waitingCount).toBe(1);
+  });
+});

--- a/assistant/src/config/bundled-skills/media-processing/__tests__/cost-tracker.test.ts
+++ b/assistant/src/config/bundled-skills/media-processing/__tests__/cost-tracker.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'bun:test';
+import { CostTracker } from '../services/cost-tracker.js';
+
+describe('CostTracker', () => {
+  it('accumulates costs across multiple segments', () => {
+    const tracker = new CostTracker();
+
+    tracker.record({
+      segmentId: 'seg-001',
+      model: 'gemini-2.5-flash',
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+    });
+
+    tracker.record({
+      segmentId: 'seg-002',
+      model: 'gemini-2.5-flash',
+      inputTokens: 0,
+      outputTokens: 1_000_000,
+    });
+
+    const summary = tracker.getSummary();
+    expect(summary.segmentCount).toBe(2);
+    expect(summary.totalInputTokens).toBe(1_000_000);
+    expect(summary.totalOutputTokens).toBe(1_000_000);
+    // $0.15 for 1M input + $0.60 for 1M output = $0.75
+    expect(summary.totalEstimatedUSD).toBeCloseTo(0.75, 6);
+  });
+
+  it('computes per-entry costs using Gemini 2.5 Flash pricing', () => {
+    const tracker = new CostTracker();
+
+    const entry = tracker.record({
+      segmentId: 'seg-010',
+      model: 'gemini-2.5-flash',
+      inputTokens: 200_000,
+      outputTokens: 50_000,
+    });
+
+    // Input: 200k * ($0.15 / 1M) = $0.03
+    // Output: 50k * ($0.60 / 1M) = $0.03
+    // Total: $0.06
+    expect(entry.estimatedUSD).toBeCloseTo(0.06, 6);
+    expect(entry.segmentId).toBe('seg-010');
+    expect(entry.model).toBe('gemini-2.5-flash');
+  });
+
+  it('returns an empty summary when no entries have been recorded', () => {
+    const tracker = new CostTracker();
+    const summary = tracker.getSummary();
+
+    expect(summary.segmentCount).toBe(0);
+    expect(summary.totalInputTokens).toBe(0);
+    expect(summary.totalOutputTokens).toBe(0);
+    expect(summary.totalEstimatedUSD).toBe(0);
+    expect(summary.entries).toHaveLength(0);
+  });
+
+  it('preserves entry order in summary', () => {
+    const tracker = new CostTracker();
+
+    tracker.record({ segmentId: 'a', model: 'm', inputTokens: 100, outputTokens: 200 });
+    tracker.record({ segmentId: 'b', model: 'm', inputTokens: 300, outputTokens: 400 });
+    tracker.record({ segmentId: 'c', model: 'm', inputTokens: 500, outputTokens: 600 });
+
+    const ids = tracker.getSummary().entries.map((e) => e.segmentId);
+    expect(ids).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/assistant/src/config/bundled-skills/media-processing/services/concurrency-pool.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/concurrency-pool.ts
@@ -1,0 +1,55 @@
+/**
+ * Semaphore-based concurrency limiter for parallel segment processing.
+ *
+ * Limits how many async operations can run simultaneously to avoid
+ * overwhelming API rate limits or exhausting system resources.
+ */
+
+export class ConcurrencyPool {
+  private running = 0;
+  private queue: Array<() => void> = [];
+
+  constructor(private readonly maxConcurrency: number = 10) {
+    if (maxConcurrency < 1) {
+      throw new Error('maxConcurrency must be at least 1');
+    }
+  }
+
+  /**
+   * Acquire a slot in the pool. Resolves immediately if a slot is available,
+   * otherwise waits until one is freed via `release()`.
+   */
+  acquire(): Promise<void> {
+    if (this.running < this.maxConcurrency) {
+      this.running++;
+      return Promise.resolve();
+    }
+
+    return new Promise<void>((resolve) => {
+      this.queue.push(resolve);
+    });
+  }
+
+  /**
+   * Release a slot back to the pool, allowing the next queued caller to proceed.
+   */
+  release(): void {
+    const next = this.queue.shift();
+    if (next) {
+      // Hand the slot directly to the next waiter (running count stays the same)
+      next();
+    } else {
+      this.running--;
+    }
+  }
+
+  /** Number of slots currently in use. */
+  get activeCount(): number {
+    return this.running;
+  }
+
+  /** Number of callers waiting for a slot. */
+  get waitingCount(): number {
+    return this.queue.length;
+  }
+}

--- a/assistant/src/config/bundled-skills/media-processing/services/cost-tracker.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/cost-tracker.ts
@@ -1,0 +1,94 @@
+/**
+ * Tracks token usage and estimated costs across video segment processing.
+ *
+ * Uses Gemini 2.5 Flash pricing for cost estimation:
+ *   - Input:  $0.15 per 1M tokens (for context <= 200k tokens)
+ *   - Output: $0.60 per 1M tokens (for context <= 200k tokens)
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SegmentCostEntry {
+  segmentId: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  estimatedUSD: number;
+}
+
+export interface CostSummary {
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalEstimatedUSD: number;
+  segmentCount: number;
+  entries: ReadonlyArray<SegmentCostEntry>;
+}
+
+// ---------------------------------------------------------------------------
+// Pricing (per token)
+// ---------------------------------------------------------------------------
+
+/** Gemini 2.5 Flash: $0.15 / 1M input tokens (<=200k context) */
+const INPUT_COST_PER_TOKEN = 0.15 / 1_000_000;
+
+/** Gemini 2.5 Flash: $0.60 / 1M output tokens (<=200k context) */
+const OUTPUT_COST_PER_TOKEN = 0.60 / 1_000_000;
+
+// ---------------------------------------------------------------------------
+// CostTracker
+// ---------------------------------------------------------------------------
+
+export class CostTracker {
+  private entries: SegmentCostEntry[] = [];
+
+  /**
+   * Record token usage for a processed segment. Automatically computes
+   * estimated cost using Gemini 2.5 Flash pricing.
+   */
+  record(params: {
+    segmentId: string;
+    model: string;
+    inputTokens: number;
+    outputTokens: number;
+  }): SegmentCostEntry {
+    const estimatedUSD =
+      params.inputTokens * INPUT_COST_PER_TOKEN +
+      params.outputTokens * OUTPUT_COST_PER_TOKEN;
+
+    const entry: SegmentCostEntry = {
+      segmentId: params.segmentId,
+      model: params.model,
+      inputTokens: params.inputTokens,
+      outputTokens: params.outputTokens,
+      estimatedUSD,
+    };
+
+    this.entries.push(entry);
+    return entry;
+  }
+
+  /**
+   * Return aggregate totals and the full list of per-segment entries.
+   */
+  getSummary(): CostSummary {
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+    let totalEstimatedUSD = 0;
+
+    for (const e of this.entries) {
+      totalInputTokens += e.inputTokens;
+      totalOutputTokens += e.outputTokens;
+      totalEstimatedUSD += e.estimatedUSD;
+    }
+
+    return {
+      totalInputTokens,
+      totalOutputTokens,
+      totalEstimatedUSD,
+      segmentCount: this.entries.length,
+      entries: this.entries,
+    };
+  }
+}


### PR DESCRIPTION
Part of #8012. Adds semaphore-based concurrency pool and token cost tracker for the new video pipeline map phase. Includes unit tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
