### PR TITLE
fix: forward audio buffers to WakeWordEngine and fix resource cleanup

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/AlwaysOnAudioMonitor.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/AlwaysOnAudioMonitor.swift
@@ -47,6 +47,9 @@ final class AlwaysOnAudioMonitor: ObservableObject {
         if let observer = configurationChangeObserver {
             NotificationCenter.default.removeObserver(observer)
         }
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        engine.stop()
     }
 
     // MARK: - Public API
@@ -100,14 +103,26 @@ final class AlwaysOnAudioMonitor: ObservableObject {
             onBus: 0,
             bufferSize: Self.bufferSize,
             format: hwFormat
-        ) { _, _ in
-            // Audio frames are captured here. The WakeWordEngine processes
-            // audio through its own pipeline once started. This tap keeps
-            // the audio engine active and the input node flowing.
+        ) { [weak self] buffer, _ in
+            guard let self else { return }
+            guard let floatData = buffer.floatChannelData else { return }
+            let frameLength = Int(buffer.frameLength)
+            // Convert Float32 PCM to Int16 for Porcupine
+            var int16Samples = [Int16](repeating: 0, count: frameLength)
+            for i in 0..<frameLength {
+                let sample = max(-1.0, min(1.0, floatData[0][i]))
+                int16Samples[i] = Int16(sample * Float(Int16.max))
+            }
+            self.engine.processAudioFrame(int16Samples)
         }
 
         audioEngine.prepare()
-        try audioEngine.start()
+        do {
+            try audioEngine.start()
+        } catch {
+            tearDownAudio()
+            throw error
+        }
     }
 
     private func tearDownAudio() {

--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordEngine.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordEngine.swift
@@ -15,4 +15,7 @@ protocol WakeWordEngine: AnyObject {
 
     /// Stop the detection engine and release resources.
     func stop()
+
+    /// Process a single frame of Int16 PCM audio samples.
+    func processAudioFrame(_ frame: [Int16])
 }


### PR DESCRIPTION
## Summary
- Forward audio tap buffers to WakeWordEngine via new processAudioFrame method (wake word detection was non-functional)
- Clean up audio tap when engine start fails (prevents crash on retry)
- Add proper resource cleanup in deinit

Addresses feedback on #8137. Part of #7992
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
