### PR TITLE
fix: remove -I from interpreter value flags to fix Python conflict

### DIFF
--- a/assistant/src/tools/terminal/parser.ts
+++ b/assistant/src/tools/terminal/parser.ts
@@ -51,7 +51,6 @@ const STDIN_EXEC_FLAGS = new Set(['-c', '-e', '-']);
 const INTERPRETER_VALUE_FLAGS = new Set([
   '-W', '-X', '-Q',          // python
   '-r', '--require',         // node / ruby
-  '-I',                      // ruby
   '--import', '--conditions', // node
 ]);
 const OPAQUE_PROGRAMS = new Set(['eval', 'source', 'alias']);


### PR DESCRIPTION
Addresses Codex review feedback on #8136. Removes -I from INTERPRETER_VALUE_FLAGS since Python's -I is a standalone isolation flag (no value), not a value-taking flag like Ruby's -I. Having it in the shared set causes python -I script.py to be misclassified as stdin-exec mode.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
