### PR TITLE
fix: gate conversation timeout to active sessions and clamp interval

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -503,12 +503,20 @@ final class VoiceModeManager: ObservableObject {
     }
 
     private func startConversationTimeout() {
+        // Don't start a timeout if there's no active voice session — in-flight
+        // async work (e.g. transcription) can set state to .idle after
+        // deactivate() has already cleared chatViewModel.
+        guard chatViewModel != nil else { return }
+
         conversationTimeoutTask?.cancel()
         conversationTimeoutTask = Task { [weak self] in
             let interval = self?.conversationTimeoutInterval ?? 30
-            try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+            // Clamp to a safe range before UInt64 conversion to avoid crash
+            // on negative or NaN values from misconfigured settings.
+            let clampedInterval = max(1.0, interval.isFinite ? interval : 30.0)
+            try? await Task.sleep(nanoseconds: UInt64(clampedInterval * 1_000_000_000))
             guard let self, !Task.isCancelled, self.state == .idle else { return }
-            log.info("Voice mode: conversation timeout after \(interval)s idle — auto-deactivating")
+            log.info("Voice mode: conversation timeout after \(clampedInterval)s idle — auto-deactivating")
             self.wasAutoDeactivated = true
             self.deactivate()
         }


### PR DESCRIPTION
## Summary
- Only start conversation timeout when voice session is active (chatViewModel != nil)
- Clamp timeout interval to prevent crash on negative/NaN values

Addresses feedback on #8140. Part of #7992
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
