### PR TITLE
M4: Create Gemini Map service + rewrite analyze-keyframes tool

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/TOOLS.json
+++ b/assistant/src/config/bundled-skills/media-processing/TOOLS.json
@@ -97,7 +97,7 @@
     },
     {
       "name": "analyze_keyframes",
-      "description": "Analyze extracted keyframes using Claude VLM (vision language model). Groups frames into overlapping chunks and analyzes each chunk in a single multi-image API call, providing temporal context for better event detection. Supports resumability — skips already-analyzed frames.",
+      "description": "Map video segments through Gemini's structured output API for vision-based analysis. Reads frames from the preprocess manifest, sends each segment to Gemini with assistant-provided extraction instructions and a JSON Schema for guaranteed structured output. Supports concurrency pooling, cost tracking, resumability (skips segments with existing results), and automatic retries with exponential backoff.",
       "category": "media",
       "risk": "medium",
       "input_schema": {
@@ -105,28 +105,36 @@
         "properties": {
           "asset_id": {
             "type": "string",
-            "description": "ID of the media asset whose keyframes to analyze"
+            "description": "ID of the media asset whose segments to analyze"
           },
-          "analysis_type": {
+          "system_prompt": {
             "type": "string",
-            "description": "Type of analysis to perform. Default: 'scene_description'"
+            "description": "Assistant-provided extraction instructions for Gemini (e.g., what to look for in the frames)"
           },
-          "batch_size": {
-            "type": "number",
-            "description": "Number of keyframes to process per batch. Default: 10"
+          "output_schema": {
+            "type": "object",
+            "description": "JSON Schema for structured output — Gemini will enforce this schema on the response"
           },
-          "chunk_size": {
+          "context": {
+            "type": "object",
+            "description": "Additional context to include in the prompt (e.g., subject registry, domain-specific info)"
+          },
+          "model": {
+            "type": "string",
+            "description": "Gemini model to use. Default: 'gemini-2.5-flash'"
+          },
+          "concurrency": {
             "type": "number",
             "minimum": 1,
-            "description": "Number of frames per analysis chunk. Default: 10"
+            "description": "Maximum concurrent Gemini API requests. Default: 10"
           },
-          "overlap": {
+          "max_retries": {
             "type": "number",
             "minimum": 0,
-            "description": "Number of overlapping frames between adjacent chunks to avoid missing boundary events. Default: 2"
+            "description": "Maximum retry attempts per segment on failure. Default: 3"
           }
         },
-        "required": ["asset_id"]
+        "required": ["asset_id", "system_prompt", "output_schema"]
       },
       "executor": "tools/analyze-keyframes.ts",
       "execution_target": "host"

--- a/assistant/src/config/bundled-skills/media-processing/services/gemini-map.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/gemini-map.ts
@@ -1,0 +1,318 @@
+/**
+ * Gemini Map service — processes video segments through Gemini's structured
+ * output API for vision-based analysis with guaranteed valid JSON responses.
+ *
+ * Uses @google/genai SDK directly (not the GeminiProvider wrapper) to leverage
+ * responseMimeType, responseSchema, and usageMetadata for cost tracking.
+ */
+
+import { readFile, writeFile, mkdir, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { GoogleGenAI, ApiError } from '@google/genai';
+import { ConcurrencyPool } from './concurrency-pool.js';
+import { CostTracker, type CostSummary } from './cost-tracker.js';
+import { computeRetryDelay, sleep } from '../../../../util/retry.js';
+import type { Segment, SubjectRegistry } from './preprocess.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface GeminiMapOptions {
+  apiKey: string;
+  systemPrompt: string;
+  outputSchema: Record<string, unknown>;
+  context?: Record<string, unknown>;
+  model?: string;
+  concurrency?: number;
+  maxRetries?: number;
+}
+
+export interface SegmentMapResult {
+  segmentId: string;
+  startSeconds: number;
+  endSeconds: number;
+  result: unknown;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export interface MapOutput {
+  assetId: string;
+  model: string;
+  segmentCount: number;
+  successCount: number;
+  failedCount: number;
+  skippedCount: number;
+  costSummary: CostSummary;
+  segments: SegmentMapResult[];
+}
+
+type SegmentStatus = 'success' | 'failed' | 'skipped';
+
+interface SegmentProcessingResult {
+  segmentId: string;
+  status: SegmentStatus;
+  result?: SegmentMapResult;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MEDIA_TYPE_MAP: Record<string, string> = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  webp: 'image/webp',
+};
+
+function inferMediaType(filePath: string): string {
+  const ext = filePath.split('.').pop()?.toLowerCase() ?? 'jpg';
+  return MEDIA_TYPE_MAP[ext] ?? 'image/jpeg';
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core: process a single segment
+// ---------------------------------------------------------------------------
+
+async function processSegment(
+  client: GoogleGenAI,
+  segment: Segment,
+  options: GeminiMapOptions,
+): Promise<{ result: unknown; model: string; inputTokens: number; outputTokens: number }> {
+  // Read and encode frame images as base64 inline data parts
+  const parts: Array<Record<string, unknown>> = [];
+
+  for (const framePath of segment.framePaths) {
+    const imageData = await readFile(framePath);
+    const base64 = imageData.toString('base64');
+    const mimeType = inferMediaType(framePath);
+    parts.push({
+      inlineData: { mimeType, data: base64 },
+    });
+  }
+
+  // Add the text prompt part
+  let promptText = `Analyzing ${segment.framePaths.length} frames from video segment ${segment.id} (${segment.startSeconds.toFixed(1)}s - ${segment.endSeconds.toFixed(1)}s).`;
+
+  if (options.context) {
+    promptText += `\n\nAdditional context:\n${JSON.stringify(options.context, null, 2)}`;
+  }
+
+  parts.push({ text: promptText });
+
+  const model = options.model ?? 'gemini-2.5-flash';
+
+  const response = await client.models.generateContent({
+    model,
+    contents: [{ role: 'user' as const, parts: parts as never }],
+    config: {
+      systemInstruction: options.systemPrompt,
+      responseMimeType: 'application/json',
+      responseSchema: options.outputSchema as never,
+    },
+  });
+
+  // Extract response text (guaranteed JSON from responseMimeType)
+  const responseText = response.text ?? '{}';
+  const parsed = JSON.parse(responseText);
+
+  // Extract token usage from usageMetadata
+  const inputTokens = response.usageMetadata?.promptTokenCount ?? 0;
+  const outputTokens = response.usageMetadata?.candidatesTokenCount ?? 0;
+  const responseModel = response.modelVersion ?? model;
+
+  return { result: parsed, model: responseModel, inputTokens, outputTokens };
+}
+
+// ---------------------------------------------------------------------------
+// Process segment with retries
+// ---------------------------------------------------------------------------
+
+async function processSegmentWithRetry(
+  client: GoogleGenAI,
+  segment: Segment,
+  options: GeminiMapOptions,
+  maxRetries: number,
+  onProgress?: (msg: string) => void,
+): Promise<SegmentProcessingResult> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const { result, model, inputTokens, outputTokens } = await processSegment(client, segment, options);
+
+      return {
+        segmentId: segment.id,
+        status: 'success',
+        result: {
+          segmentId: segment.id,
+          startSeconds: segment.startSeconds,
+          endSeconds: segment.endSeconds,
+          result,
+          model,
+          inputTokens,
+          outputTokens,
+        },
+      };
+    } catch (err) {
+      // Handle Gemini safety blocks — not retryable
+      if (err instanceof ApiError) {
+        const message = err.message ?? '';
+        if (message.includes('SAFETY') || message.includes('safety')) {
+          onProgress?.(`  Segment ${segment.id}: blocked by safety filter, skipping.\n`);
+          return { segmentId: segment.id, status: 'skipped', error: 'Safety filter block' };
+        }
+
+        // 429 rate limits — retryable with backoff
+        if (err.status === 429 && attempt < maxRetries) {
+          const delay = computeRetryDelay(attempt);
+          onProgress?.(`  Segment ${segment.id}: rate limited, retrying in ${Math.round(delay)}ms (attempt ${attempt + 1}/${maxRetries})...\n`);
+          await sleep(delay);
+          continue;
+        }
+
+        // Other retryable errors (5xx)
+        if (err.status !== undefined && err.status >= 500 && attempt < maxRetries) {
+          const delay = computeRetryDelay(attempt);
+          onProgress?.(`  Segment ${segment.id}: server error (${err.status}), retrying in ${Math.round(delay)}ms...\n`);
+          await sleep(delay);
+          continue;
+        }
+      }
+
+      // Non-retryable or exhausted retries
+      if (attempt === maxRetries) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        onProgress?.(`  Segment ${segment.id}: failed after ${maxRetries + 1} attempts: ${errMsg}\n`);
+        return { segmentId: segment.id, status: 'failed', error: errMsg };
+      }
+
+      // Generic retry for unknown errors
+      const delay = computeRetryDelay(attempt);
+      await sleep(delay);
+    }
+  }
+
+  // Should not reach here, but TypeScript needs a return
+  return { segmentId: segment.id, status: 'failed', error: 'Exhausted retries' };
+}
+
+// ---------------------------------------------------------------------------
+// Main: mapSegments
+// ---------------------------------------------------------------------------
+
+export async function mapSegments(
+  assetId: string,
+  pipelineDir: string,
+  segments: Segment[],
+  options: GeminiMapOptions,
+  onProgress?: (msg: string) => void,
+): Promise<MapOutput> {
+  const model = options.model ?? 'gemini-2.5-flash';
+  const concurrency = options.concurrency ?? 10;
+  const maxRetries = options.maxRetries ?? 3;
+
+  const client = new GoogleGenAI({ apiKey: options.apiKey });
+  const pool = new ConcurrencyPool(concurrency);
+  const costTracker = new CostTracker();
+
+  const mapResultsDir = join(pipelineDir, 'map-results');
+  await mkdir(mapResultsDir, { recursive: true });
+
+  const results: SegmentMapResult[] = [];
+  let successCount = 0;
+  let failedCount = 0;
+  let skippedCount = 0;
+
+  onProgress?.(`Mapping ${segments.length} segments with ${model} (concurrency: ${concurrency})...\n`);
+
+  // Process all segments with concurrency limiting
+  const promises = segments.map(async (segment) => {
+    // Resumability: check for existing result file
+    const resultPath = join(mapResultsDir, `${segment.id}.json`);
+    if (await fileExists(resultPath)) {
+      try {
+        const existingData = await readFile(resultPath, 'utf-8');
+        const existing = JSON.parse(existingData) as SegmentMapResult;
+        results.push(existing);
+        successCount++;
+        costTracker.record({
+          segmentId: existing.segmentId,
+          model: existing.model,
+          inputTokens: existing.inputTokens,
+          outputTokens: existing.outputTokens,
+        });
+        onProgress?.(`  Segment ${segment.id}: loaded from cache.\n`);
+        return;
+      } catch {
+        // Corrupted cache file — reprocess
+      }
+    }
+
+    await pool.acquire();
+    try {
+      const processingResult = await processSegmentWithRetry(client, segment, options, maxRetries, onProgress);
+
+      if (processingResult.status === 'success' && processingResult.result) {
+        const segResult = processingResult.result as SegmentMapResult;
+        results.push(segResult);
+        successCount++;
+
+        costTracker.record({
+          segmentId: segResult.segmentId,
+          model: segResult.model,
+          inputTokens: segResult.inputTokens,
+          outputTokens: segResult.outputTokens,
+        });
+
+        // Write per-segment result to disk
+        await writeFile(resultPath, JSON.stringify(segResult, null, 2));
+
+        onProgress?.(`  Segment ${segment.id}: done (${segResult.inputTokens + segResult.outputTokens} tokens).\n`);
+      } else if (processingResult.status === 'skipped') {
+        skippedCount++;
+      } else {
+        failedCount++;
+      }
+    } finally {
+      pool.release();
+    }
+  });
+
+  await Promise.all(promises);
+
+  // Sort results by segment start time
+  results.sort((a, b) => a.startSeconds - b.startSeconds);
+
+  // Write merged output
+  const output: MapOutput = {
+    assetId,
+    model,
+    segmentCount: segments.length,
+    successCount,
+    failedCount,
+    skippedCount,
+    costSummary: costTracker.getSummary(),
+    segments: results,
+  };
+
+  const outputPath = join(pipelineDir, 'map-output.json');
+  await writeFile(outputPath, JSON.stringify(output, null, 2));
+
+  onProgress?.(`Map complete: ${successCount} succeeded, ${failedCount} failed, ${skippedCount} skipped.\n`);
+  onProgress?.(`Cost: $${output.costSummary.totalEstimatedUSD.toFixed(4)} (${output.costSummary.totalInputTokens} input + ${output.costSummary.totalOutputTokens} output tokens).\n`);
+
+  return output;
+}

--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -1,129 +1,36 @@
+import { join, dirname } from 'node:path';
 import { readFile } from 'node:fs/promises';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
-import { getConfiguredProvider, extractText, userMessageWithImages } from '../../../../providers/provider-send-message.js';
-import { initializeProviders } from '../../../../providers/registry.js';
-import { loadConfig, invalidateConfigCache } from '../../../../config/loader.js';
+import { getConfig } from '../../../../config/loader.js';
 import {
   getMediaAssetById,
-  getKeyframesForAsset,
-  getVisionOutputsForAsset,
-  insertVisionOutputsBatch,
-  createProcessingStage,
-  updateProcessingStage,
-  getProcessingStagesForAsset,
-  type MediaKeyframe,
-  type ProcessingStage,
 } from '../../../../memory/media-store.js';
+import { mapSegments, type MapOutput } from '../services/gemini-map.js';
+import type { PreprocessManifest } from '../services/preprocess.js';
 
-const CHUNKED_VLM_PROMPT = `You are analyzing a sequence of {N} consecutive video frames extracted at regular intervals from a video. The frames are in chronological order.
+// ---------------------------------------------------------------------------
+// Exported function for job handler use
+// ---------------------------------------------------------------------------
 
-For EACH frame, provide a JSON object with:
-- "frameIndex": the 0-based index within this chunk
-- "sceneDescription": concise description of the scene in this frame
-- "subjects": array of identifiable subjects/objects/people
-- "actions": array of actions or activities occurring
-- "context": environmental or situational context
-- "transitions": any notable changes from the previous frame (empty string for the first frame)
-
-Return a JSON array of these objects, one per frame. Return ONLY the JSON array, no additional text.`;
-
-function buildChunks(keyframes: MediaKeyframe[], chunkSize: number, overlap: number): MediaKeyframe[][] {
-  const chunks: MediaKeyframe[][] = [];
-  const step = Math.max(1, chunkSize - overlap);
-  for (let i = 0; i < keyframes.length; i += step) {
-    chunks.push(keyframes.slice(i, i + chunkSize));
-  }
-  return chunks;
+export interface MapSegmentsOptions {
+  systemPrompt: string;
+  outputSchema: Record<string, unknown>;
+  context?: Record<string, unknown>;
+  model?: string;
+  concurrency?: number;
+  maxRetries?: number;
 }
 
-async function analyzeChunk(
-  provider: import('../../../../providers/types.js').Provider,
-  chunk: MediaKeyframe[],
-): Promise<Array<{ keyframeId: string; output: Record<string, unknown>; confidence: number }>> {
-  const images: Array<{ base64: string; mediaType: string }> = [];
-
-  for (const keyframe of chunk) {
-    const imageData = await readFile(keyframe.filePath);
-    const base64 = imageData.toString('base64');
-    const ext = keyframe.filePath.split('.').pop()?.toLowerCase() ?? 'jpg';
-    const mediaTypeMap: Record<string, string> = {
-      jpg: 'image/jpeg',
-      jpeg: 'image/jpeg',
-      png: 'image/png',
-      gif: 'image/gif',
-      webp: 'image/webp',
-    };
-    const mediaType = mediaTypeMap[ext] ?? 'image/jpeg';
-    images.push({ base64, mediaType });
-  }
-
-  const prompt = CHUNKED_VLM_PROMPT.replace('{N}', String(chunk.length));
-
-  const response = await provider.sendMessage(
-    [userMessageWithImages(images, prompt)],
-    undefined,
-    undefined,
-    {
-      config: {
-        modelIntent: 'vision-optimized',
-        max_tokens: 4096,
-      },
-    },
-  );
-
-  const responseText = extractText(response);
-
-  let parsed: Array<Record<string, unknown>>;
-  try {
-    const jsonMatch = responseText.match(/```(?:json)?\s*([\s\S]*?)```/) ?? [null, responseText];
-    parsed = JSON.parse(jsonMatch[1]!.trim()) as Array<Record<string, unknown>>;
-  } catch {
-    // If parsing fails, return a single entry wrapping the raw text
-    parsed = chunk.map((_, idx) => ({
-      frameIndex: idx,
-      sceneDescription: idx === 0 ? responseText : '',
-      subjects: [],
-      actions: [],
-      context: '',
-      transitions: '',
-    }));
-  }
-
-  return chunk.map((keyframe, idx) => {
-    const entry = parsed[idx] ?? {
-      frameIndex: idx,
-      sceneDescription: '',
-      subjects: [],
-      actions: [],
-      context: '',
-      transitions: '',
-    };
-    // Add timestamp context
-    entry.timestamp = keyframe.timestamp;
-    return { keyframeId: keyframe.id, output: entry, confidence: 0.8 };
-  });
-}
-
-export async function analyzeKeyframesForAsset(
+export async function mapSegmentsForAsset(
   assetId: string,
-  analysisType?: string,
-  batchSize?: number,
+  options: MapSegmentsOptions,
   onProgress?: (msg: string) => void,
-  signal?: AbortSignal,
-  chunkSize?: number,
-  overlap?: number,
-): Promise<void> {
-  const type = analysisType ?? 'scene_description';
-  const batch = batchSize ?? 10;
+): Promise<MapOutput> {
+  const config = getConfig();
+  const apiKey = config.apiKeys.gemini;
 
-  if (batch <= 0) {
-    throw new Error('batch_size must be greater than 0.');
-  }
-  if (chunkSize !== undefined && chunkSize <= 0) {
-    throw new Error('chunk_size must be at least 1.');
-  }
-  if (overlap !== undefined && overlap < 0) {
-    throw new Error('overlap must be non-negative.');
+  if (!apiKey) {
+    throw new Error('No Gemini API key configured. Please set your Gemini API key to use keyframe analysis.');
   }
 
   const asset = getMediaAssetById(assetId);
@@ -131,132 +38,36 @@ export async function analyzeKeyframesForAsset(
     throw new Error(`Media asset not found: ${assetId}`);
   }
 
-  // Get all keyframes for this asset
-  const keyframes = getKeyframesForAsset(assetId);
-  if (keyframes.length === 0) {
-    throw new Error('No keyframes found for this asset. Run extract_keyframes first.');
-  }
+  // Load preprocess manifest
+  const pipelineDir = join(dirname(asset.filePath), 'pipeline', assetId);
+  const manifestPath = join(pipelineDir, 'manifest.json');
 
-  // Resumability: find already-analyzed keyframe IDs for this analysis type
-  const existingOutputs = getVisionOutputsForAsset(assetId, type);
-  const analyzedKeyframeIds = new Set(existingOutputs.map((o) => o.keyframeId));
-  const pendingKeyframes = keyframes.filter((kf) => !analyzedKeyframeIds.has(kf.id));
-
-  if (pendingKeyframes.length === 0) {
-    // Nothing to do — all keyframes already analyzed
-    return;
-  }
-
-  // Find or create the vision_analysis processing stage
-  let stage: ProcessingStage | undefined;
-  const existingStages = getProcessingStagesForAsset(assetId);
-  stage = existingStages.find((s) => s.stage === 'vision_analysis');
-  if (!stage) {
-    stage = createProcessingStage({ assetId, stage: 'vision_analysis' });
-  }
-
-  updateProcessingStage(stage.id, { status: 'running', startedAt: Date.now() });
-
-  // Use the same provider the main agent uses. If the provider registry
-  // was cleared or not yet initialized, force-reload the config from
-  // keychain/secure storage and re-initialize providers.
-  let provider = getConfiguredProvider();
-  if (!provider) {
-    invalidateConfigCache();
-    const freshConfig = loadConfig();
-    initializeProviders(freshConfig);
-    provider = getConfiguredProvider();
-  }
-  if (!provider) {
-    updateProcessingStage(stage.id, {
-      status: 'failed',
-      lastError: 'Configured provider unavailable',
-    });
-    throw new Error('No configured provider available. Check your provider settings in Settings → Integrations.');
-  }
-
-  const effectiveChunkSize = chunkSize ?? 10;
-  const effectiveOverlap = overlap ?? 2;
-
-  let analyzedCount = analyzedKeyframeIds.size;
-  const totalKeyframes = keyframes.length;
-
-  const chunks = buildChunks(pendingKeyframes, effectiveChunkSize, effectiveOverlap);
-
-  onProgress?.(`Analyzing ${pendingKeyframes.length} keyframes in ${chunks.length} chunks (${analyzedKeyframeIds.size} already done)...\n`);
-
-  let aborted = false;
-
+  let manifest: PreprocessManifest;
   try {
-    for (let chunkIdx = 0; chunkIdx < chunks.length; chunkIdx++) {
-      if (signal?.aborted) {
-        onProgress?.('Aborted.\n');
-        aborted = true;
-        break;
-      }
-
-      const chunk = chunks[chunkIdx]!;
-
-      try {
-        const chunkResults = await analyzeChunk(provider, chunk);
-
-        const batchResults: Array<{
-          assetId: string;
-          keyframeId: string;
-          analysisType: string;
-          output: Record<string, unknown>;
-          confidence?: number;
-        }> = [];
-
-        for (const result of chunkResults) {
-          // Overlap dedup: skip keyframes already inserted from a previous chunk
-          if (analyzedKeyframeIds.has(result.keyframeId)) {
-            continue;
-          }
-          analyzedKeyframeIds.add(result.keyframeId);
-          analyzedCount++;
-          batchResults.push({
-            assetId,
-            keyframeId: result.keyframeId,
-            analysisType: type,
-            output: result.output,
-            confidence: result.confidence,
-          });
-        }
-
-        if (batchResults.length > 0) {
-          insertVisionOutputsBatch(batchResults);
-        }
-      } catch (err) {
-        onProgress?.(`  Warning: failed to analyze chunk ${chunkIdx + 1}: ${(err as Error).message}\n`);
-      }
-
-      const progress = Math.round((analyzedCount / totalKeyframes) * 100);
-      updateProcessingStage(stage.id, { progress });
-
-      onProgress?.(`  Chunk ${chunkIdx + 1}/${chunks.length}: ${chunk.length} frames (${progress}% total)\n`);
-    }
-
-    if (aborted) {
-      throw new Error('Analysis aborted');
-    }
-
-    const finalProgress = Math.round((analyzedCount / totalKeyframes) * 100);
-    const isComplete = analyzedCount >= totalKeyframes;
-
-    updateProcessingStage(stage.id, {
-      status: isComplete ? 'completed' : 'running',
-      progress: finalProgress,
-      ...(isComplete ? { completedAt: Date.now() } : {}),
-    });
-  } catch (err) {
-    updateProcessingStage(stage.id, {
-      status: 'failed',
-      lastError: (err as Error).message.slice(0, 500),
-    });
-    throw err;
+    const raw = await readFile(manifestPath, 'utf-8');
+    manifest = JSON.parse(raw) as PreprocessManifest;
+  } catch {
+    throw new Error('No preprocess manifest found. Run extract_keyframes first.');
   }
+
+  if (manifest.segments.length === 0) {
+    throw new Error('No segments found in preprocess manifest. Run extract_keyframes first.');
+  }
+
+  return mapSegments(assetId, pipelineDir, manifest.segments, {
+    apiKey,
+    systemPrompt: options.systemPrompt,
+    outputSchema: options.outputSchema,
+    context: options.context,
+    model: options.model,
+    concurrency: options.concurrency,
+    maxRetries: options.maxRetries,
+  }, onProgress);
 }
+
+// ---------------------------------------------------------------------------
+// Tool entry point
+// ---------------------------------------------------------------------------
 
 export async function run(
   input: Record<string, unknown>,
@@ -267,73 +78,59 @@ export async function run(
     return { content: 'asset_id is required.', isError: true };
   }
 
-  const analysisType = (input.analysis_type as string) || 'scene_description';
-  const batchSize = (input.batch_size as number) ?? 10;
-  const chunkSizeInput = (input.chunk_size as number) ?? 10;
-  const overlapInput = (input.overlap as number) ?? 2;
-
-  // Validate: chunk_size must be at least 1, overlap must be non-negative
-  if (chunkSizeInput < 1) {
-    return { content: 'chunk_size must be at least 1.', isError: true };
+  const systemPrompt = input.system_prompt as string | undefined;
+  if (!systemPrompt) {
+    return { content: 'system_prompt is required.', isError: true };
   }
-  if (overlapInput < 0) {
-    return { content: 'overlap must be non-negative.', isError: true };
+
+  const outputSchema = input.output_schema as Record<string, unknown> | undefined;
+  if (!outputSchema) {
+    return { content: 'output_schema is required.', isError: true };
+  }
+
+  const contextObj = input.context as Record<string, unknown> | undefined;
+  const model = input.model as string | undefined;
+  const concurrency = input.concurrency as number | undefined;
+  const maxRetries = input.max_retries as number | undefined;
+
+  if (concurrency !== undefined && concurrency < 1) {
+    return { content: 'concurrency must be at least 1.', isError: true };
+  }
+  if (maxRetries !== undefined && maxRetries < 0) {
+    return { content: 'max_retries must be non-negative.', isError: true };
   }
 
   try {
-    // Check if all keyframes are already analyzed before calling the core function
-    const keyframes = getKeyframesForAsset(assetId);
-    const existingOutputs = getVisionOutputsForAsset(assetId, analysisType);
-    const analyzedKeyframeIds = new Set(existingOutputs.map((o) => o.keyframeId));
-    const pendingKeyframes = keyframes.filter((kf) => !analyzedKeyframeIds.has(kf.id));
-
-    if (keyframes.length > 0 && pendingKeyframes.length === 0) {
-      return {
-        content: JSON.stringify({
-          message: 'All keyframes already analyzed',
-          assetId,
-          analysisType,
-          totalKeyframes: keyframes.length,
-          alreadyAnalyzed: existingOutputs.length,
-        }, null, 2),
-        isError: false,
-      };
-    }
-
-    await analyzeKeyframesForAsset(assetId, analysisType, batchSize, context.onOutput, context.signal, chunkSizeInput, overlapInput);
-
-    // Gather final stats
-    const allKeyframes = getKeyframesForAsset(assetId);
-    const allOutputs = getVisionOutputsForAsset(assetId, analysisType);
-    const totalKeyframes = allKeyframes.length;
-    const analyzedCount = allOutputs.length;
-    const finalProgress = Math.round((analyzedCount / totalKeyframes) * 100);
-    const isComplete = analyzedCount >= totalKeyframes;
+    const output = await mapSegmentsForAsset(
+      assetId,
+      {
+        systemPrompt,
+        outputSchema,
+        context: contextObj,
+        model,
+        concurrency,
+        maxRetries,
+      },
+      context.onOutput,
+    );
 
     return {
       content: JSON.stringify({
-        message: `Vision analysis ${isComplete ? 'completed' : 'in progress'}`,
+        message: `Map ${output.failedCount === 0 ? 'completed' : 'completed with errors'}`,
         assetId,
-        analysisType,
-        totalKeyframes,
-        analyzedCount,
-        newlyAnalyzed: analyzedCount - analyzedKeyframeIds.size,
-        errorCount: pendingKeyframes.length - (analyzedCount - analyzedKeyframeIds.size),
-        progress: finalProgress,
+        model: output.model,
+        segmentCount: output.segmentCount,
+        successCount: output.successCount,
+        failedCount: output.failedCount,
+        skippedCount: output.skippedCount,
+        totalInputTokens: output.costSummary.totalInputTokens,
+        totalOutputTokens: output.costSummary.totalOutputTokens,
+        estimatedCostUSD: output.costSummary.totalEstimatedUSD,
       }, null, 2),
       isError: false,
     };
   } catch (err) {
     const msg = (err as Error).message;
-    // Preserve original error message format
-    if (
-      msg === 'batch_size must be greater than 0.' ||
-      msg.startsWith('Media asset not found:') ||
-      msg === 'No keyframes found for this asset. Run extract_keyframes first.' ||
-      msg === 'No configured provider available. Check your provider settings in Settings → Integrations.'
-    ) {
-      return { content: msg, isError: true };
-    }
-    return { content: `Vision analysis failed: ${(err as Error).message}`, isError: true };
+    return { content: msg, isError: true };
   }
 }


### PR DESCRIPTION
## Summary
- Adds `services/gemini-map.ts` — Gemini Map service using `@google/genai` SDK directly with `responseMimeType: 'application/json'` and `responseSchema` for guaranteed structured JSON output
- Rewrites `tools/analyze-keyframes.ts` to use the new Gemini Map service with per-segment processing, concurrency pooling (ConcurrencyPool), cost tracking (CostTracker), resumability, and retry logic with exponential backoff
- Updates `TOOLS.json` with new input schema (`system_prompt`, `output_schema`, `context`, `model`, `concurrency`, `max_retries`)

Part of #8012.

## Test plan
- [ ] Verify Gemini Map service processes segments with structured output schema enforcement
- [ ] Verify resumability — existing `map-results/<segmentId>.json` files are loaded from cache
- [ ] Verify concurrency limiting works correctly
- [ ] Verify retry logic with exponential backoff on 429/5xx errors
- [ ] Verify safety filter blocks are logged and skipped gracefully
- [ ] Verify cost tracking records token usage per segment
- [ ] Verify merged `map-output.json` is written correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
