### PR TITLE
fix: fix sensitivity slider step and allow clearing Picovoice key

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/WakeWordSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WakeWordSettingsView.swift
@@ -113,7 +113,7 @@ struct WakeWordSettingsView: View {
                     .foregroundColor(VColor.textSecondary)
             }
 
-            VSlider(value: $wakeWordSensitivity, range: 0.0...1.0)
+            VSlider(value: $wakeWordSensitivity, range: 0.0...1.0, step: 0.1)
 
             Text("Higher values make detection more responsive but may increase false activations.")
                 .font(VFont.caption)
@@ -159,7 +159,10 @@ struct WakeWordSettingsView: View {
 
     private func savePicovoiceKey() {
         let trimmed = picovoiceKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        APIKeyManager.setKey(trimmed, for: "picovoice")
+        if trimmed.isEmpty {
+            APIKeyManager.deleteKey(for: "picovoice")
+        } else {
+            APIKeyManager.setKey(trimmed, for: "picovoice")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add step: 0.1 to VSlider so sensitivity can be set to intermediate values
- Allow clearing Picovoice key by deleting it when field is emptied

Addresses feedback on #8145. Part of #7992
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
