### PR TITLE
fix: cancel pending restart task when mic becomes unavailable

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordErrorRecovery.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordErrorRecovery.swift
@@ -48,8 +48,10 @@ final class WakeWordErrorRecovery: ObservableObject {
 
     /// Call when the microphone becomes unavailable (e.g., disconnected or claimed by another app).
     func handleMicUnavailable() {
-        log.warning("Microphone unavailable, stopping engine")
+        restartTask?.cancel()
+        restartTask = nil
         engine.stop()
+        log.info("Mic unavailable — paused wake word engine")
         errorHistory.append((date: Date(), description: "Microphone unavailable"))
     }
 


### PR DESCRIPTION
## Summary
- Cancel pending restart task in handleMicUnavailable() to prevent false give-up during transient mic loss

Addresses feedback on #8141. Part of #7992
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
