### PR TITLE
M5: Create Reduce service + rewrite query-media-events tool

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/TOOLS.json
+++ b/assistant/src/config/bundled-skills/media-processing/TOOLS.json
@@ -184,23 +184,31 @@
       "execution_target": "host"
     },
     {
-      "name": "query_media_events",
-      "description": "Query media events using natural language. Parses the query into structured filters (event type, count, confidence threshold, time range) and retrieves matching events ranked by confidence. Supports domain-specific keyword mapping (e.g., 'turnovers' → eventType='turnover').",
+      "name": "query_media",
+      "description": "Query video analysis data using natural language. Sends map output (from analyze_keyframes) to Claude for intelligent analysis and Q&A. Supports arbitrary questions about video content — Claude reads the full structured analysis and answers based on the data.",
       "category": "media",
       "risk": "low",
       "input_schema": {
         "type": "object",
         "properties": {
-          "query": {
-            "type": "string",
-            "description": "Natural language query describing the events to find (e.g., 'top 5 turnovers', 'high confidence goals in the first half')"
-          },
           "asset_id": {
             "type": "string",
-            "description": "ID of the media asset to search within"
+            "description": "ID of the media asset to query"
+          },
+          "query": {
+            "type": "string",
+            "description": "Natural language query about the video data (e.g., 'What happens at the 5 minute mark?', 'Summarize the key events', 'Are there any scoring plays?')"
+          },
+          "system_prompt": {
+            "type": "string",
+            "description": "Optional system prompt for Claude to customize analysis behavior"
+          },
+          "model": {
+            "type": "string",
+            "description": "LLM model to use for analysis. Default: 'claude-sonnet-4-6'"
           }
         },
-        "required": ["query", "asset_id"]
+        "required": ["asset_id", "query"]
       },
       "executor": "tools/query-media-events.ts",
       "execution_target": "host"

--- a/assistant/src/config/bundled-skills/media-processing/services/reduce.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/reduce.ts
@@ -1,0 +1,199 @@
+/**
+ * Reduce service — sends Map output to Claude as text-only for analysis.
+ *
+ * Two modes:
+ * - One-shot merge: assembles all Map results into a single document,
+ *   sends to Claude with the provided system prompt for analysis.
+ * - Interactive Q&A: loads existing map output + user query, sends to
+ *   Claude, returns the answer.
+ *
+ * Uses the existing provider infrastructure (getConfiguredProvider) so
+ * it works with whatever LLM provider is configured.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { getMediaAssetById } from '../../../../memory/media-store.js';
+import {
+  getConfiguredProvider,
+  createTimeout,
+  extractAllText,
+  userMessage,
+} from '../../../../providers/provider-send-message.js';
+import type { MapOutput } from './gemini-map.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ReduceOptions {
+  /** Natural language query about the video data. */
+  query: string;
+  /** Optional system prompt for Claude. */
+  systemPrompt?: string;
+  /** Model override. Defaults to claude-sonnet-4-6. */
+  model?: string;
+}
+
+export interface ReduceResult {
+  answer: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MODEL = 'claude-sonnet-4-6';
+const REDUCE_TIMEOUT_MS = 120_000;
+
+/**
+ * Load map-output.json for an asset from its pipeline directory.
+ */
+async function loadMapOutput(assetId: string): Promise<MapOutput> {
+  const asset = getMediaAssetById(assetId);
+  if (!asset) {
+    throw new Error(`Media asset not found: ${assetId}`);
+  }
+
+  const pipelineDir = join(dirname(asset.filePath), 'pipeline', assetId);
+  const mapOutputPath = join(pipelineDir, 'map-output.json');
+
+  let raw: string;
+  try {
+    raw = await readFile(mapOutputPath, 'utf-8');
+  } catch {
+    throw new Error(
+      'No map output found. Run analyze_keyframes first to generate map-output.json.',
+    );
+  }
+
+  return JSON.parse(raw) as MapOutput;
+}
+
+/**
+ * Format map output segments into a text document for Claude.
+ * Strips image data — text only.
+ */
+function formatMapOutputAsText(mapOutput: MapOutput): string {
+  const lines: string[] = [];
+
+  lines.push(`Video Analysis Data (asset: ${mapOutput.assetId})`);
+  lines.push(`Model: ${mapOutput.model}`);
+  lines.push(`Segments analyzed: ${mapOutput.successCount}/${mapOutput.segmentCount}`);
+  if (mapOutput.failedCount > 0) {
+    lines.push(`Failed segments: ${mapOutput.failedCount}`);
+  }
+  if (mapOutput.skippedCount > 0) {
+    lines.push(`Skipped segments: ${mapOutput.skippedCount}`);
+  }
+  lines.push('');
+  lines.push('--- Segment Results ---');
+  lines.push('');
+
+  for (const segment of mapOutput.segments) {
+    const startMin = Math.floor(segment.startSeconds / 60);
+    const startSec = Math.floor(segment.startSeconds % 60);
+    const endMin = Math.floor(segment.endSeconds / 60);
+    const endSec = Math.floor(segment.endSeconds % 60);
+    const timeRange = `${startMin}:${String(startSec).padStart(2, '0')} - ${endMin}:${String(endSec).padStart(2, '0')}`;
+
+    lines.push(`[Segment ${segment.segmentId}] ${timeRange}`);
+    lines.push(JSON.stringify(segment.result, null, 2));
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Core: send to Claude via provider infrastructure
+// ---------------------------------------------------------------------------
+
+async function sendToClaude(
+  mapText: string,
+  query: string,
+  systemPrompt?: string,
+  model?: string,
+  onProgress?: (msg: string) => void,
+): Promise<ReduceResult> {
+  const provider = getConfiguredProvider();
+  if (!provider) {
+    throw new Error('No LLM provider available. Please configure an API key.');
+  }
+
+  const effectiveModel = model ?? DEFAULT_MODEL;
+
+  const effectiveSystemPrompt = systemPrompt
+    ?? 'You are an expert video analyst. You have been given structured analysis data extracted from a video. Answer the user\'s question based on this data. Be specific, reference timestamps when relevant, and provide clear, actionable insights.';
+
+  const userContent = `Here is the video analysis data:\n\n${mapText}\n\n---\n\nUser query: ${query}`;
+
+  onProgress?.('Sending map output to Claude for analysis...\n');
+
+  const { signal, cleanup } = createTimeout(REDUCE_TIMEOUT_MS);
+
+  try {
+    const response = await provider.sendMessage(
+      [userMessage(userContent)],
+      [],
+      effectiveSystemPrompt,
+      {
+        config: { model: effectiveModel },
+        signal,
+      },
+    );
+    cleanup();
+
+    const answer = extractAllText(response);
+
+    onProgress?.(`Reduce complete (${response.usage.inputTokens} input + ${response.usage.outputTokens} output tokens).\n`);
+
+    return {
+      answer,
+      model: response.model,
+      inputTokens: response.usage.inputTokens,
+      outputTokens: response.usage.outputTokens,
+    };
+  } finally {
+    cleanup();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * One-shot merge mode: load map output for an asset, send all data to
+ * Claude with a system prompt, and return the analysis.
+ */
+export async function reduceForAsset(
+  assetId: string,
+  options: ReduceOptions,
+  onProgress?: (msg: string) => void,
+): Promise<ReduceResult> {
+  const mapOutput = await loadMapOutput(assetId);
+
+  if (mapOutput.segments.length === 0) {
+    throw new Error('Map output contains no segments. Run analyze_keyframes first.');
+  }
+
+  const mapText = formatMapOutputAsText(mapOutput);
+  return sendToClaude(mapText, options.query, options.systemPrompt, options.model, onProgress);
+}
+
+/**
+ * Interactive Q&A mode: load existing map output + user query, send to
+ * Claude, return the answer. Functionally identical to reduceForAsset
+ * but named distinctly for clarity in call sites.
+ */
+export async function queryMapOutput(
+  assetId: string,
+  options: ReduceOptions,
+  onProgress?: (msg: string) => void,
+): Promise<ReduceResult> {
+  return reduceForAsset(assetId, options, onProgress);
+}

--- a/assistant/src/config/bundled-skills/media-processing/tools/query-media-events.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/query-media-events.ts
@@ -1,178 +1,20 @@
 /**
- * Natural language query tool for media events.
+ * Query media tool — sends natural language queries against video
+ * analysis data (map output) via Claude for intelligent answers.
  *
- * Accepts a free-text query and optional asset_id, parses the query into
- * structured filters via simple keyword matching, then delegates to the
- * generic retrieval service. Domain-specific keyword mappings live here;
- * the retrieval layer remains fully generic.
+ * Replaces the old keyword-matching approach with an LLM-powered
+ * reduce/query step that can answer arbitrary questions about the
+ * video content.
  */
 
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
-import { retrieveEvents, type RetrievalFilters } from '../services/retrieval-service.js';
-import { getTrackingProfile, type CapabilityTier } from '../../../../memory/media-store.js';
-import { getCapabilitiesByTier, getCapabilityByName } from '../services/capability-registry.js';
+import { reduceForAsset, type ReduceOptions, type ReduceResult } from '../services/reduce.js';
 
 // ---------------------------------------------------------------------------
-// NL query parsing
+// Exported function for job handler use (one-shot merge mode)
 // ---------------------------------------------------------------------------
 
-/** Maps domain-specific keywords to canonical event type labels. */
-const EVENT_TYPE_KEYWORDS: Record<string, string> = {
-  // Basketball
-  turnover: 'turnover',
-  turnovers: 'turnover',
-  steal: 'turnover',
-  steals: 'turnover',
-  // Soccer / football
-  goal: 'goal',
-  goals: 'goal',
-  score: 'goal',
-  scores: 'goal',
-  // Generic
-  highlight: 'highlight',
-  highlights: 'highlight',
-  scene_change: 'scene_change',
-  'scene change': 'scene_change',
-  'scene changes': 'scene_change',
-  foul: 'foul',
-  fouls: 'foul',
-  shot: 'shot',
-  shots: 'shot',
-  rebound: 'rebound',
-  rebounds: 'rebound',
-  assist: 'assist',
-  assists: 'assist',
-  block: 'block',
-  blocks: 'block',
-  transition: 'transition',
-  transitions: 'transition',
-  fast_break: 'fast_break',
-  'fast break': 'fast_break',
-  'fast breaks': 'fast_break',
-};
-
-/**
- * Extract a numeric limit from phrases like "top 5", "first 3", "last 10".
- * Returns undefined if no limit phrase is found.
- */
-function parseLimit(query: string): number | undefined {
-  const match = query.match(/(?:top|first|last|show|find|get)\s+(\d+)(?!\s*min)/i);
-  if (match) return parseInt(match[1], 10);
-  // Also match trailing "N events/moments"
-  const trailingMatch = query.match(/(\d+)\s+(?:events?|moments?|plays?|clips?)/i);
-  if (trailingMatch) return parseInt(trailingMatch[1], 10);
-  return undefined;
-}
-
-/**
- * Extract a confidence threshold from the query.
- */
-function parseConfidence(query: string): number | undefined {
-  const lower = query.toLowerCase();
-  if (lower.includes('high confidence') || lower.includes('very confident') || lower.includes('most confident')) {
-    return 0.8;
-  }
-  if (lower.includes('confident') || lower.includes('medium confidence')) {
-    return 0.5;
-  }
-  // Explicit threshold: "confidence > 0.7" or "confidence above 0.7"
-  const explicitMatch = lower.match(/confidence\s*(?:>|above|over|>=)\s*([\d.]+)/);
-  if (explicitMatch) return parseFloat(explicitMatch[1]);
-  return undefined;
-}
-
-/**
- * Extract a time range from the query (returns seconds).
- * Supports phrases like "first half", "second half", "first N minutes",
- * "last N minutes", "between M and N minutes".
- */
-function parseTimeRange(query: string): { startTimeMin?: number; startTimeMax?: number } {
-  const lower = query.toLowerCase();
-
-  // "first half" / "second half" — these are relative and require knowing
-  // total duration, which we don't have. Use reasonable game defaults:
-  // assume ~48 min game → 2880s, half = 1440s
-  if (lower.includes('first half')) {
-    return { startTimeMin: 0, startTimeMax: 1440 };
-  }
-  if (lower.includes('second half')) {
-    return { startTimeMin: 1440 };
-  }
-
-  // "first N minutes"
-  const firstNMin = lower.match(/first\s+(\d+)\s*min/);
-  if (firstNMin) {
-    return { startTimeMin: 0, startTimeMax: parseInt(firstNMin[1], 10) * 60 };
-  }
-
-  // "last N minutes"
-  // Without knowing total duration we can't compute this precisely,
-  // so we skip it and let the retrieval return all results.
-
-  // "between M and N minutes"
-  const betweenMatch = lower.match(/between\s+(\d+)\s*(?:and|to|-)\s*(\d+)\s*min/);
-  if (betweenMatch) {
-    return {
-      startTimeMin: parseInt(betweenMatch[1], 10) * 60,
-      startTimeMax: parseInt(betweenMatch[2], 10) * 60,
-    };
-  }
-
-  return {};
-}
-
-/**
- * Extract the event type from the query by matching known keywords.
- */
-function parseEventType(query: string): string | undefined {
-  const lower = query.toLowerCase();
-
-  // Check multi-word keywords first (longer matches win)
-  const multiWordKeys = Object.keys(EVENT_TYPE_KEYWORDS)
-    .filter((k) => k.includes(' ') || k.includes('_'))
-    .sort((a, b) => b.length - a.length);
-
-  for (const key of multiWordKeys) {
-    if (lower.includes(key)) return EVENT_TYPE_KEYWORDS[key];
-  }
-
-  // Check single-word keywords
-  const words = lower.replace(/[^\w\s]/g, '').split(/\s+/);
-  for (const word of words) {
-    if (EVENT_TYPE_KEYWORDS[word]) return EVENT_TYPE_KEYWORDS[word];
-  }
-
-  return undefined;
-}
-
-/**
- * Parse a natural language query into structured retrieval filters.
- */
-function parseQuery(query: string, assetId?: string): RetrievalFilters {
-  const eventType = parseEventType(query);
-  const limit = parseLimit(query);
-  const minConfidence = parseConfidence(query);
-  const timeRange = parseTimeRange(query);
-
-  return {
-    assetId,
-    eventType,
-    minConfidence,
-    limit: limit ?? 10,
-    sortBy: 'confidence',
-    ...timeRange,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Formatting
-// ---------------------------------------------------------------------------
-
-function formatTimestamp(seconds: number): string {
-  const mins = Math.floor(seconds / 60);
-  const secs = Math.floor(seconds % 60);
-  return `${mins}:${secs.toString().padStart(2, '0')}`;
-}
+export { reduceForAsset } from '../services/reduce.js';
 
 // ---------------------------------------------------------------------------
 // Tool entry point
@@ -180,121 +22,44 @@ function formatTimestamp(seconds: number): string {
 
 export async function run(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const assetId = input.asset_id as string | undefined;
+  if (!assetId) {
+    return { content: 'asset_id is required.', isError: true };
+  }
+
   const query = input.query as string | undefined;
   if (!query) {
     return { content: 'query is required.', isError: true };
   }
 
-  const assetId = input.asset_id as string | undefined;
-  if (!assetId) {
-    return { content: 'asset_id is required to scope the query to a specific media asset.', isError: true };
-  }
+  const systemPrompt = input.system_prompt as string | undefined;
+  const model = input.model as string | undefined;
 
-  const filters = parseQuery(query, assetId);
-
-  // Retrieve without limit so we can apply capability filtering first, then limit
-  const userLimit = filters.limit;
-  const result = retrieveEvents({ ...filters, limit: 0 });
-
-  // Determine which capabilities are allowed based on the tracking profile
-  const profile = getTrackingProfile(assetId);
-
-  let allowedEventTypes: Set<string> | null = null;
-  const tierForEventType = new Map<string, CapabilityTier>();
-
-  if (profile) {
-    // Use the explicit profile: only enabled capabilities pass
-    allowedEventTypes = new Set<string>();
-    for (const [capName, entry] of Object.entries(profile.capabilities)) {
-      if (entry.enabled) {
-        allowedEventTypes.add(capName);
-        tierForEventType.set(capName, entry.tier);
-      }
-    }
-  } else {
-    // No profile: default to 'ready' tier capabilities only
-    const readyCaps = getCapabilitiesByTier('ready');
-    if (readyCaps.length > 0) {
-      allowedEventTypes = new Set(readyCaps.map((c) => c.name));
-      for (const cap of readyCaps) {
-        tierForEventType.set(cap.name, 'ready');
-      }
-    }
-    // If no capabilities are registered at all, allow everything (pass null)
-  }
-
-  // Filter events by allowed capabilities, then apply the user-requested limit
-  let filteredEvents = result.events;
-  if (allowedEventTypes != null) {
-    filteredEvents = filteredEvents.filter((e) => allowedEventTypes!.has(e.eventType));
-  }
-  if (userLimit && filteredEvents.length > userLimit) {
-    filteredEvents = filteredEvents.slice(0, userLimit);
-  }
-
-  if (filteredEvents.length === 0) {
-    const parts = ['No matching events found'];
-    if (filters.eventType) parts.push(`for event type "${filters.eventType}"`);
-    if (filters.minConfidence) parts.push(`with confidence >= ${filters.minConfidence}`);
-    if (!profile) parts.push('(defaulting to ready-tier capabilities only)');
-    parts.push(`in asset ${assetId}.`);
-    return { content: parts.join(' '), isError: false };
-  }
-
-  const tierLabels: Record<string, string> = {
-    ready: '[Ready]',
-    beta: '[Beta]',
-    experimental: '[Experimental]',
+  const options: ReduceOptions = {
+    query,
+    systemPrompt,
+    model,
   };
 
-  const tierDisclaimers: Record<string, string> = {
-    beta: 'Beta results may have accuracy gaps.',
-    experimental: 'Experimental results are early-stage; expect noise.',
-  };
-
-  const eventSummaries = filteredEvents.map((e, i) => {
-    const tier = tierForEventType.get(e.eventType) ?? getCapabilityByName(e.eventType)?.tier;
-    const tierLabel = tier ? tierLabels[tier] ?? `[${tier}]` : '[Ready]';
-    const disclaimer = tier ? tierDisclaimers[tier] : undefined;
+  try {
+    const result: ReduceResult = await reduceForAsset(assetId, options, context.onOutput);
 
     return {
-      rank: i + 1,
-      id: e.id,
-      eventType: e.eventType,
-      tierLabel,
-      ...(disclaimer ? { confidenceDisclaimer: disclaimer } : {}),
-      timeRange: `${formatTimestamp(e.startTime)} – ${formatTimestamp(e.endTime)}`,
-      startTime: e.startTime,
-      endTime: e.endTime,
-      confidence: Math.round(e.confidence * 100) / 100,
-      reasons: e.reasons,
-      metadata: e.metadata,
+      content: JSON.stringify({
+        query,
+        answer: result.answer,
+        model: result.model,
+        usage: {
+          inputTokens: result.inputTokens,
+          outputTokens: result.outputTokens,
+        },
+      }, null, 2),
+      isError: false,
     };
-  });
-
-  // Collect disclaimers for any non-ready tiers present in results
-  const activeTiers = new Set(eventSummaries.map((e) => e.tierLabel));
-  const disclaimers: string[] = [];
-  if (activeTiers.has('[Beta]')) disclaimers.push(tierDisclaimers.beta);
-  if (activeTiers.has('[Experimental]')) disclaimers.push(tierDisclaimers.experimental);
-
-  return {
-    content: JSON.stringify({
-      query,
-      parsedFilters: {
-        eventType: filters.eventType ?? null,
-        minConfidence: filters.minConfidence ?? null,
-        limit: filters.limit,
-        startTimeMin: filters.startTimeMin ?? null,
-        startTimeMax: filters.startTimeMax ?? null,
-      },
-      trackingProfile: profile ? 'custom' : 'default (ready tier only)',
-      ...(disclaimers.length > 0 ? { disclaimers } : {}),
-      totalResults: eventSummaries.length,
-      events: eventSummaries,
-    }, null, 2),
-    isError: false,
-  };
+  } catch (err) {
+    const msg = (err as Error).message;
+    return { content: msg, isError: true };
+  }
 }


### PR DESCRIPTION
Part of #8012. Adds Reduce service that sends map output to Claude as text-only for analysis/Q&A. Rewrites query-media-events tool with new schema supporting NL queries against video data.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
