### PR TITLE
Fix: add questionText to guardian IPC for notification body

### DIFF
--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -146,6 +146,7 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
             requestId: request.id,
             callSessionId,
             title: guardianCopy.threadTitle,
+            questionText: request.questionText,
           } as ServerMessage);
         }
         updateDeliveryStatus(delivery.id, 'sent');

--- a/assistant/src/daemon/ipc-contract/work-items.ts
+++ b/assistant/src/daemon/ipc-contract/work-items.ts
@@ -221,4 +221,5 @@ export interface GuardianRequestThreadCreated {
   requestId: string;
   callSessionId: string;
   title: string;
+  questionText: string;
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -695,7 +695,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 // App is backgrounded — post native notification
                 self.deliverGuardianRequestNotification(
                     title: msg.title,
-                    questionText: msg.title,
+                    questionText: msg.questionText,
                     conversationId: msg.conversationId
                 )
             }

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1853,13 +1853,15 @@ public struct IPCGuardianRequestThreadCreated: Codable, Sendable {
     public let requestId: String
     public let callSessionId: String
     public let title: String
+    public let questionText: String
 
-    public init(type: String, conversationId: String, requestId: String, callSessionId: String, title: String) {
+    public init(type: String, conversationId: String, requestId: String, callSessionId: String, title: String, questionText: String) {
         self.type = type
         self.conversationId = conversationId
         self.requestId = requestId
         self.callSessionId = callSessionId
         self.title = title
+        self.questionText = questionText
     }
 }
 


### PR DESCRIPTION
Add questionText field to GuardianRequestThreadCreated IPC message so macOS notification body shows the actual question instead of duplicating the title. Addresses review feedback on #8147.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
