### PR TITLE
fix: stop wake word engine when audio restart fails in handleConfigurationChange

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/AlwaysOnAudioMonitor.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/AlwaysOnAudioMonitor.swift
@@ -161,6 +161,7 @@ final class AlwaysOnAudioMonitor: ObservableObject {
             log.info("Audio monitoring restarted after configuration change")
         } catch {
             log.error("Failed to restart audio monitoring: \(error.localizedDescription)")
+            engine.stop()
             isListening = false
         }
     }


### PR DESCRIPTION
## Summary
- Add engine.stop() to handleConfigurationChange catch block to prevent resource leak

Addresses feedback on #8151. Part of #7992
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
