### PR TITLE
fix: only play deactivation feedback for wake-word-triggered sessions

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
@@ -21,6 +21,7 @@ final class WakeWordCoordinator: ObservableObject {
     /// we queue it and process once `markReady()` is called.
     private var pendingWakeWord = false
     private var isReady = false
+    private var activatedViaWakeWord = false
 
     private let activationWindow = WakeWordActivationWindow()
     private var stateCancellable: AnyCancellable?
@@ -84,6 +85,7 @@ final class WakeWordCoordinator: ObservableObject {
         }
 
         log.info("Wake word detected — activating voice mode")
+        activatedViaWakeWord = true
 
         // 1. Play activation chime and show visual indicator
         WakeWordFeedback.playActivationChime()
@@ -127,8 +129,11 @@ final class WakeWordCoordinator: ObservableObject {
                 guard let self else { return }
                 if newState == .off {
                     log.info("Voice mode deactivated — resuming wake word listening")
-                    WakeWordFeedback.playDeactivationChime()
-                    self.activationWindow.show(state: .listening)
+                    if self.activatedViaWakeWord {
+                        WakeWordFeedback.playDeactivationChime()
+                        self.activationWindow.show(state: .listening)
+                        self.activatedViaWakeWord = false
+                    }
                     self.audioMonitor.startMonitoring()
                 }
             }


### PR DESCRIPTION
## Summary
- Track activatedViaWakeWord flag to distinguish wake-word vs manual voice mode activation
- Only play deactivation chime and show indicator for wake-word-triggered sessions

Addresses feedback on #8157. Part of #7992
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
