### PR TITLE
fix: remove -S/--split-string from env value-flag skip list

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -67,7 +67,7 @@ const WRAPPER_PROGRAMS = new Set([
 // `env` flags that consume the next positional argument as their value.
 // Without this, `env -u curl echo` would incorrectly identify `curl` (the
 // value of -u) as the wrapped program instead of `echo`.
-const ENV_VALUE_FLAGS = new Set(['-u', '--unset', '-C', '--chdir', '-S', '--split-string']);
+const ENV_VALUE_FLAGS = new Set(['-u', '--unset', '-C', '--chdir']);
 
 /**
  * Given a segment whose program is a known wrapper, return the first
@@ -75,7 +75,7 @@ const ENV_VALUE_FLAGS = new Set(['-u', '--unset', '-C', '--chdir', '-S', '--spli
  * when no suitable argument is found.
  *
  * Handles `env` specially: skips `VAR=value` pairs and value-taking flags
- * like `-u NAME`, `-C DIR`, and `-S STRING`.
+ * like `-u NAME` and `-C DIR`.
  */
 function getWrappedProgram(seg: { program: string; args: string[] }): string | undefined {
   const isEnv = seg.program === 'env';


### PR DESCRIPTION
Addresses Codex review feedback on #8163. Removes -S and --split-string from ENV_VALUE_FLAGS since env -S's value IS the command to run, not just a flag value. Skipping it would create a security bypass where env -S curl wouldn't detect curl as the wrapped program.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
