### PR TITLE
fix: add --require to Ruby per-interpreter value flags

### DIFF
--- a/assistant/src/tools/terminal/parser.ts
+++ b/assistant/src/tools/terminal/parser.ts
@@ -52,7 +52,7 @@ const STDIN_EXEC_FLAGS = new Set(['-c', '-e', '-']);
 const INTERPRETER_VALUE_FLAGS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
   ['python', new Set(['-W', '-X', '-Q'])],
   ['python3', new Set(['-W', '-X', '-Q'])],
-  ['ruby', new Set(['-r', '-I'])],
+  ['ruby', new Set(['-r', '--require', '-I'])],
   ['node', new Set(['-r', '--require', '--import', '--conditions'])],
   ['deno', new Set()],
   ['bun', new Set()],


### PR DESCRIPTION
Addresses Devin review feedback on #8165. Adds --require (long form of -r) to Ruby's per-interpreter value flags, which was dropped during migration from the shared set. Without it, echo payload | ruby --require json wouldn't be flagged as pipe_to_shell.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
