### PR TITLE
fix: gate wake word coordinator by enabled setting and add logout teardown

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -362,6 +362,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             quickChatPanel = nil
             voiceInput?.stop()
             voiceInput = nil
+            wakeWordCoordinator = nil
             ambientAgent.teardown()
 
             if let observer = windowObserver {
@@ -474,6 +475,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         quickChatPanel = nil
         voiceInput?.stop()
         voiceInput = nil
+        wakeWordCoordinator = nil
         ambientAgent.teardown()
 
         if let observer = windowObserver {

--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
@@ -72,6 +72,9 @@ final class WakeWordCoordinator: ObservableObject {
     }
 
     private func handleWakeWordDetected() {
+        // Ignore if wake word is disabled in settings
+        guard UserDefaults.standard.bool(forKey: "wakeWordEnabled") else { return }
+
         // Ignore if voice mode is already active
         guard voiceModeManager.state == .off else {
             log.info("Wake word ignored — voice mode already active (state: \(String(describing: voiceModeManager.state)))")
@@ -128,13 +131,16 @@ final class WakeWordCoordinator: ObservableObject {
             .sink { [weak self] newState in
                 guard let self else { return }
                 if newState == .off {
-                    log.info("Voice mode deactivated — resuming wake word listening")
-                    if self.activatedViaWakeWord {
-                        WakeWordFeedback.playDeactivationChime()
-                        self.activationWindow.show(state: .listening)
-                        self.activatedViaWakeWord = false
+                    // Only resume monitoring if wake word is enabled in settings
+                    if UserDefaults.standard.bool(forKey: "wakeWordEnabled") {
+                        log.info("Voice mode deactivated — resuming wake word listening")
+                        if self.activatedViaWakeWord {
+                            WakeWordFeedback.playDeactivationChime()
+                            self.activationWindow.show(state: .listening)
+                            self.activatedViaWakeWord = false
+                        }
+                        self.audioMonitor.startMonitoring()
                     }
-                    self.audioMonitor.startMonitoring()
                 }
             }
     }


### PR DESCRIPTION
## Summary
- Check wakeWordEnabled before resuming monitoring or processing wake word
- Clean up wakeWordCoordinator on logout/retire paths

Addresses feedback on #8160. Part of #7992
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
