### PR TITLE
Fix: Address review feedback on #8154

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
@@ -201,6 +201,10 @@ export function createSegments(
   liveRanges: TimeRange[],
   segmentDuration: number,
 ): Array<{ id: string; startSeconds: number; endSeconds: number }> {
+  if (segmentDuration <= 0) {
+    throw new Error(`segmentDuration must be positive, got ${segmentDuration}`);
+  }
+
   const segments: Array<{ id: string; startSeconds: number; endSeconds: number }> = [];
   let segIndex = 0;
 
@@ -470,6 +474,11 @@ export async function preprocessForAsset(
     await rename(tempDir, framesDir);
 
     const totalFrames = segments.reduce((sum, s) => sum + s.framePaths.length, 0);
+    if (rawSegments.length > 0 && totalFrames === 0) {
+      throw new Error(
+        `All ${rawSegments.length} segment(s) failed frame extraction — zero usable frames produced.`,
+      );
+    }
     onProgress?.(`Extracted ${totalFrames} total frames across ${segments.length} segments.\n`);
 
     // Step 4: Subject registry


### PR DESCRIPTION
Addresses review feedback from #8154: rejects non-positive segment durations to prevent infinite loops, throws error when all segment extractions fail.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
