### PR TITLE
Fix: Address review feedback on #8161

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/services/reduce.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/reduce.ts
@@ -31,7 +31,7 @@ export interface ReduceOptions {
   query?: string;
   /** Optional system prompt for Claude. */
   systemPrompt?: string;
-  /** Model override. Defaults to claude-sonnet-4-6. */
+  /** Model override. When omitted, the configured provider's default is used. */
   model?: string;
 }
 
@@ -46,7 +46,6 @@ export interface ReduceResult {
 // Helpers
 // ---------------------------------------------------------------------------
 
-const DEFAULT_MODEL = 'claude-sonnet-4-6';
 const REDUCE_TIMEOUT_MS = 120_000;
 
 /**
@@ -124,8 +123,6 @@ async function sendToClaude(
     throw new Error('No LLM provider available. Please configure an API key.');
   }
 
-  const effectiveModel = model ?? DEFAULT_MODEL;
-
   const effectiveSystemPrompt = systemPrompt
     ?? 'You are an expert video analyst. You have been given structured analysis data extracted from a video. Answer the user\'s question based on this data. Be specific, reference timestamps when relevant, and provide clear, actionable insights.';
 
@@ -141,7 +138,7 @@ async function sendToClaude(
       [],
       effectiveSystemPrompt,
       {
-        config: { model: effectiveModel },
+        config: model ? { model } : {},
         signal,
       },
     );


### PR DESCRIPTION
Addresses review feedback from #8161: only sets explicit model override when caller provides one, otherwise lets the configured provider use its default model.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
