### PR TITLE
Fix: Address review feedback on #8150

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/services/concurrency-pool.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/concurrency-pool.ts
@@ -38,7 +38,7 @@ export class ConcurrencyPool {
     if (next) {
       // Hand the slot directly to the next waiter (running count stays the same)
       next();
-    } else {
+    } else if (this.running > 0) {
       this.running--;
     }
   }

--- a/assistant/src/config/bundled-skills/media-processing/services/cost-tracker.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/cost-tracker.ts
@@ -1,10 +1,11 @@
 /**
  * Tracks token usage and estimated costs across video segment processing.
  *
- * Uses Gemini 2.5 Flash pricing for cost estimation:
- *   - Input:  $0.15 per 1M tokens (for context <= 200k tokens)
- *   - Output: $0.60 per 1M tokens (for context <= 200k tokens)
+ * Cost estimation uses the shared pricing resolver from `assistant/src/util/pricing.ts`,
+ * which maintains a multi-provider pricing catalog including Gemini models.
  */
+
+import { resolvePricing } from '../../../../util/pricing.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -27,25 +28,17 @@ export interface CostSummary {
 }
 
 // ---------------------------------------------------------------------------
-// Pricing (per token)
-// ---------------------------------------------------------------------------
-
-/** Gemini 2.5 Flash: $0.15 / 1M input tokens (<=200k context) */
-const INPUT_COST_PER_TOKEN = 0.15 / 1_000_000;
-
-/** Gemini 2.5 Flash: $0.60 / 1M output tokens (<=200k context) */
-const OUTPUT_COST_PER_TOKEN = 0.60 / 1_000_000;
-
-// ---------------------------------------------------------------------------
 // CostTracker
 // ---------------------------------------------------------------------------
 
 export class CostTracker {
   private entries: SegmentCostEntry[] = [];
 
+  constructor(private readonly provider: string = 'gemini') {}
+
   /**
-   * Record token usage for a processed segment. Automatically computes
-   * estimated cost using Gemini 2.5 Flash pricing.
+   * Record token usage for a processed segment. Computes estimated cost
+   * via the shared pricing resolver.
    */
   record(params: {
     segmentId: string;
@@ -53,9 +46,8 @@ export class CostTracker {
     inputTokens: number;
     outputTokens: number;
   }): SegmentCostEntry {
-    const estimatedUSD =
-      params.inputTokens * INPUT_COST_PER_TOKEN +
-      params.outputTokens * OUTPUT_COST_PER_TOKEN;
+    const result = resolvePricing(this.provider, params.model, params.inputTokens, params.outputTokens);
+    const estimatedUSD = result.estimatedCostUsd ?? 0;
 
     const entry: SegmentCostEntry = {
       segmentId: params.segmentId,
@@ -88,7 +80,7 @@ export class CostTracker {
       totalOutputTokens,
       totalEstimatedUSD,
       segmentCount: this.entries.length,
-      entries: this.entries,
+      entries: [...this.entries],
     };
   }
 }


### PR DESCRIPTION
Addresses review feedback from #8150: guards release() against double-release, returns immutable snapshot from getSummary(), and uses shared pricing resolver instead of hardcoded rates.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
