### PR TITLE
fix: reset activatedViaWakeWord flag on voice mode activation failure

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
@@ -85,7 +85,6 @@ final class WakeWordCoordinator: ObservableObject {
         }
 
         log.info("Wake word detected — activating voice mode")
-        activatedViaWakeWord = true
 
         // 1. Play activation chime and show visual indicator
         WakeWordFeedback.playActivationChime()
@@ -104,6 +103,7 @@ final class WakeWordCoordinator: ObservableObject {
             audioMonitor.startMonitoring()
             return
         }
+        activatedViaWakeWord = true
         voiceModeManager.startListening()
     }
 


### PR DESCRIPTION
## Summary
- Move activatedViaWakeWord assignment to after successful activation, preventing stale flag on failure

Addresses feedback on #8168. Part of #7992
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
