### PR TITLE
fix: approved devices race condition and optimistic clear

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1243,18 +1243,18 @@ public final class SettingsStore: ObservableObject {
 
     func removeApprovedDevice(hashedDeviceId: String) {
         guard let daemonClient else { return }
-        daemonClient.onApprovedDeviceRemoveResponse = { [weak self] msg in
-            if msg.success {
-                self?.approvedDevices.removeAll { $0.hashedDeviceId == hashedDeviceId }
-            }
-        }
+        approvedDevices.removeAll { $0.hashedDeviceId == hashedDeviceId }
         try? daemonClient.sendApprovedDeviceRemove(hashedDeviceId: hashedDeviceId)
     }
 
     func clearAllApprovedDevices() {
         guard let daemonClient else { return }
-        try? daemonClient.sendApprovedDevicesClear()
-        approvedDevices = []
+        do {
+            try daemonClient.sendApprovedDevicesClear()
+            approvedDevices = []
+        } catch {
+            // IPC failed — don't clear local state
+        }
     }
 
     // MARK: - Override Resolution


### PR DESCRIPTION
Fixes two issues in approved devices management: (1) removeApprovedDevice now optimistically removes from local array to avoid race condition with rapid clicks. (2) clearAllApprovedDevices only clears local state if IPC send succeeds.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
