### PR TITLE
Fix: Address review feedback on #8175

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
@@ -468,11 +468,6 @@ export async function preprocessForAsset(
       });
     }
 
-    // Atomically swap temp dir to durable path
-    await rm(framesDir, { recursive: true, force: true });
-    await mkdir(dirname(framesDir), { recursive: true });
-    await rename(tempDir, framesDir);
-
     const totalFrames = segments.reduce((sum, s) => sum + s.framePaths.length, 0);
     if (rawSegments.length > 0 && totalFrames === 0) {
       throw new Error(
@@ -480,6 +475,11 @@ export async function preprocessForAsset(
       );
     }
     onProgress?.(`Extracted ${totalFrames} total frames across ${segments.length} segments.\n`);
+
+    // Atomically swap temp dir to durable path
+    await rm(framesDir, { recursive: true, force: true });
+    await mkdir(dirname(framesDir), { recursive: true });
+    await rename(tempDir, framesDir);
 
     // Step 4: Subject registry
     onProgress?.('Building subject registry...\n');


### PR DESCRIPTION
Moves the totalFrames === 0 check to before the atomic rename so catch block cleanup targets the correct path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
