### PR TITLE
Fix: Address review feedback on #8178

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/services/gemini-map.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/gemini-map.ts
@@ -91,6 +91,7 @@ function computeConfigHash(options: GeminiMapOptions): string {
     systemPrompt: options.systemPrompt,
     outputSchema: options.outputSchema,
     model: options.model ?? 'gemini-2.5-flash',
+    context: options.context,
   });
   return createHash('sha256').update(payload).digest('hex').slice(0, 8);
 }


### PR DESCRIPTION
Includes the context field in computeConfigHash to prevent stale cache hits when only context changes between runs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
