### PR TITLE
fix: align lastPairedAt type to Int matching generated IPC types

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ApprovedDevicesSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ApprovedDevicesSection.swift
@@ -69,8 +69,8 @@ struct ApprovedDevicesSection: View {
         }
     }
 
-    private func formattedDate(_ timestamp: Double) -> String {
-        let date = Date(timeIntervalSince1970: timestamp / 1000.0)
+    private func formattedDate(_ timestamp: Int) -> String {
+        let date = Date(timeIntervalSince1970: Double(timestamp) / 1000.0)
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .abbreviated
         return formatter.localizedString(for: date, relativeTo: Date())

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2775,7 +2775,7 @@ public struct ApprovedDevicesListResponseMessage: Decodable, Sendable {
     public struct Device: Decodable, Sendable {
         public let hashedDeviceId: String
         public let deviceName: String
-        public let lastPairedAt: Double
+        public let lastPairedAt: Int
     }
     public let devices: [Device]
 }


### PR DESCRIPTION
Changes lastPairedAt from Double to Int in hand-written ApprovedDevicesListResponseMessage.Device to match the auto-generated IPCContractGenerated.swift type.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
