### PR TITLE
fix: improve Gmail OAuth setup UX with auto-detection and clearer messaging

### DIFF
--- a/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
@@ -6,7 +6,7 @@ includes: ["browser", "public-ingress"]
 metadata: {"vellum": {"emoji": "\ud83d\udd11"}}
 ---
 
-You are helping your user set up Google Cloud OAuth credentials so Gmail and Google Calendar integrations can connect. You will automate the entire GCP setup via the browser while the user watches via screencast.
+You are helping your user set up Google Cloud OAuth credentials so Gmail and Google Calendar integrations can connect. You will automate the entire GCP setup via the browser while the user watches via screencast. The user's only manual action is signing in to their Google account — everything else is fully automated.
 
 ## Client Check
 
@@ -26,11 +26,13 @@ Use `ui_show` with `surface_type: "confirmation"` and this message:
 
 > **Set up Google Cloud for Gmail & Calendar**
 >
-> I'll create a Google Cloud project, enable the Gmail and Calendar APIs, configure OAuth, and download credentials — all automatically in the browser. You can watch everything via screencast.
+> Here's what will happen:
+> 1. **A browser opens** — you sign in to your Google account
+> 2. **I automate everything** — project creation, APIs, OAuth config, credentials
+> 3. **You enter credentials** from a downloaded file (secure prompt — I never see them)
+> 4. **You authorize Vellum** with one click
 >
-> After the automated setup, I'll ask you to securely enter the client ID and client secret from the downloaded credential file (I never see these values).
->
-> Ready to get started?
+> The whole thing takes 2-3 minutes. Ready?
 
 If the user declines, acknowledge and stop. No further confirmations are needed after this point.
 
@@ -39,8 +41,9 @@ If the user declines, acknowledge and stop. No further confirmations are needed 
 Use `browser_navigate` to go to `https://console.cloud.google.com/`.
 
 Take a `browser_screenshot` and `browser_snapshot` to check the page state:
-- **If a sign-in page appears:** Tell the user "Please sign in to your Google account in the browser window. Let me know when you're done." Wait for their confirmation, then re-check.
-- **If a CAPTCHA appears:** Tell the user "There's a CAPTCHA to solve. Please complete it in the browser window and let me know." Wait, then re-check.
+- **If a sign-in page appears:** Tell the user: "Please sign in to your Google account in the browser preview panel (or the Chrome window that just opened)." Then **auto-detect sign-in completion** by polling `browser_snapshot` every 5-10 seconds. Check if the current URL has moved away from `accounts.google.com` to `console.cloud.google.com`. Do NOT ask the user to "let me know when you're done" — detect it automatically. Once sign-in is detected, tell the user: "Signed in! Starting the automated setup now..."
+- **If already signed in** (URL is already `console.cloud.google.com`): Tell the user: "Already signed in — starting setup now..." and continue immediately.
+- **If a CAPTCHA appears:** The browser automation's built-in handoff will handle this. If it persists, tell the user: "There's a CAPTCHA in the browser — please complete it and I'll continue automatically."
 - **If the console dashboard loads:** Continue to Step 3.
 
 ## Step 3: Create or Select a Project
@@ -75,7 +78,7 @@ Take a `browser_screenshot` to show result. Tell the user: "APIs enabled!"
 
 ## Step 5: Configure OAuth Consent Screen
 
-Tell the user: "Configuring OAuth consent screen..."
+Tell the user: "Configuring OAuth consent screen — this is the longest step, but it's fully automated..."
 
 Navigate to `https://console.cloud.google.com/apis/credentials/consent?project=PROJECT_ID`.
 
@@ -121,15 +124,17 @@ Click "Create".
 
 ## Step 7: Download Credentials JSON
 
+Tell the user: "Almost done — downloading credentials..."
+
 After the credentials dialog appears, click the "Download JSON" button (it may say "DOWNLOAD JSON" or show a download icon).
 
 Use `browser_wait_for_download` to wait for the file to download.
 
-Tell the user: "Credentials downloaded! The file is at: `<path>`"
+Tell the user: "Credentials downloaded!"
 
 ## Step 8: Secure Credential Entry
 
-Tell the user to open the downloaded JSON file, then prompt for secure entry:
+Tell the user: "I've downloaded the credentials file. Please open it and enter the values below. I won't see what you type — these go directly to secure storage."
 
 ```
 credential_store prompt:

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -22,7 +22,7 @@ Gmail, Slack, and Telegram setup all require a publicly reachable URL for OAuth 
    - Then call `skill_load` with `skill: "google-oauth-setup"`.
    - Tell the user Gmail isn't connected yet and briefly explain what the setup involves, then use `ui_show` with `surface_type: "confirmation"` to ask for permission to start:
      - **message:** "Ready to set up Gmail?"
-     - **detail:** "I'll automate the entire setup in the browser — creating a Google Cloud project, enabling APIs, and configuring OAuth. It takes a few minutes and you can watch via screencast."
+     - **detail:** "I'll open a browser where you sign in to Google, then automate everything else — creating a project, enabling APIs, and connecting your account. Takes 2-3 minutes and you can watch in the browser preview panel."
      - **confirmLabel:** "Get Started"
      - **cancelLabel:** "Not Now"
    - If the user confirms, briefly acknowledge (e.g., "Setting up Gmail now...") and proceed with the setup guide. If they decline, acknowledge and let them know they can set it up later.

--- a/clients/Package.resolved
+++ b/clients/Package.resolved
@@ -1,6 +1,24 @@
 {
   "pins" : [
     {
+      "identity" : "ios-voice-processor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Picovoice/ios-voice-processor.git",
+      "state" : {
+        "revision" : "083c02aed9a890400d647fd357f8a505bf672f58",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "porcupine",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Picovoice/porcupine",
+      "state" : {
+        "revision" : "08829fb824adee8aec1eb96c235c59f6cabc144a",
+        "version" : "3.0.4"
+      }
+    },
+    {
       "identity" : "sparkle",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",


### PR DESCRIPTION
## Summary

- Rewrite `google-oauth-setup/SKILL.md` confirmation dialog with a clear 4-step numbered overview and 2-3 minute time estimate
- Auto-detect Google sign-in completion by polling `browser_snapshot` for URL changes instead of asking users to "let me know when you're done"
- Improve progress messaging throughout (longest step callout, "almost done" on credential download, clearer secure entry instructions)
- Update `messaging/SKILL.md` confirmation detail to set expectations that user signs in once and automation handles the rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
