### PR TITLE
fix: reset activatedViaWakeWord flag outside wakeWordEnabled guard

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
@@ -137,10 +137,10 @@ final class WakeWordCoordinator: ObservableObject {
                         if self.activatedViaWakeWord {
                             WakeWordFeedback.playDeactivationChime()
                             self.activationWindow.show(state: .listening)
-                            self.activatedViaWakeWord = false
                         }
                         self.audioMonitor.startMonitoring()
                     }
+                    self.activatedViaWakeWord = false  // always reset, regardless of setting
                 }
             }
     }


### PR DESCRIPTION
## Summary
- Move activatedViaWakeWord reset outside wakeWordEnabled guard to prevent stale flag when setting changes mid-session

Addresses feedback on #8174. Part of #7992
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
