### PR TITLE
fix: send deny on PairingApprovalWindow close and supersede

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/PairingApprovalWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingApprovalWindow.swift
@@ -8,6 +8,9 @@ import VellumAssistantShared
 final class PairingApprovalWindow {
     private var window: NSWindow?
     private let daemonClient: DaemonClient
+    private var currentPairingRequestId: String?
+    private var responseSent: Bool = false
+    private var windowDelegate: WindowCloseDelegate?
 
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
@@ -15,12 +18,15 @@ final class PairingApprovalWindow {
 
     /// Show the pairing approval prompt for a specific device.
     /// If a window is already showing, it is closed first (one prompt at a time).
+    /// Closing the previous window sends a deny for the superseded request.
     func show(pairingRequestId: String, deviceName: String) {
-        // Close any existing prompt before showing a new one
+        // Close any existing prompt before showing a new one.
+        // This will send a deny for the previous request if unanswered.
         close()
 
         let view = PairingApprovalView(deviceName: deviceName) { [weak self] decision in
             guard let self else { return }
+            self.responseSent = true
             try? self.daemonClient.sendPairingApprovalResponse(
                 pairingRequestId: pairingRequestId,
                 decision: decision
@@ -43,10 +49,19 @@ final class PairingApprovalWindow {
         window.isReleasedWhenClosed = false
         window.center()
 
+        // Delegate catches X-button close and sends deny if no response was sent.
+        let delegate = WindowCloseDelegate { [weak self] in
+            self?.handleWindowClosed()
+        }
+        window.delegate = delegate
+        self.windowDelegate = delegate
+
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
 
         self.window = window
+        self.currentPairingRequestId = pairingRequestId
+        self.responseSent = false
     }
 
     var isVisible: Bool {
@@ -54,7 +69,45 @@ final class PairingApprovalWindow {
     }
 
     func close() {
+        denyIfNeeded()
         window?.close()
         window = nil
+        windowDelegate = nil
+    }
+
+    // MARK: - Private
+
+    /// Sends a deny for the current request if no explicit response has been sent yet.
+    private func denyIfNeeded() {
+        guard let requestId = currentPairingRequestId, !responseSent else { return }
+        responseSent = true
+        try? daemonClient.sendPairingApprovalResponse(
+            pairingRequestId: requestId,
+            decision: "deny"
+        )
+    }
+
+    /// Called by the window delegate when the user clicks the X button.
+    private func handleWindowClosed() {
+        denyIfNeeded()
+        window = nil
+        windowDelegate = nil
+    }
+}
+
+// MARK: - WindowCloseDelegate
+
+/// Lightweight NSWindowDelegate that forwards windowWillClose to a closure.
+private final class WindowCloseDelegate: NSObject, NSWindowDelegate {
+    private let onClose: @MainActor () -> Void
+
+    init(onClose: @escaping @MainActor () -> Void) {
+        self.onClose = onClose
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        MainActor.assumeIsolated {
+            onClose()
+        }
     }
 }


### PR DESCRIPTION
## Summary
When the pairing approval window is closed via the X button or superseded by a new request, sends a deny response to the daemon. Prevents iOS devices from hanging in pending state indefinitely.

## Implementation
- Added `currentPairingRequestId` and `responseSent` tracking properties to `PairingApprovalWindow`
- Added `WindowCloseDelegate` (a lightweight `NSWindowDelegate`) that fires `windowWillClose` when the user clicks X
- `denyIfNeeded()` checks if there is an unanswered request and sends a deny via `daemonClient.sendPairingApprovalResponse`
- `close()` now calls `denyIfNeeded()` before closing the window, handling the supersede case
- The `onDecision` closure sets `responseSent = true` before calling `close()`, preventing double-sends

## Key Technical Choices
- Used a separate `WindowCloseDelegate` NSObject subclass rather than conforming `PairingApprovalWindow` to `NSWindowDelegate`, because `NSWindowDelegate` requires `NSObject` inheritance and `PairingApprovalWindow` is a plain `final class`
- `MainActor.assumeIsolated` in the delegate's `windowWillClose` to bridge from AppKit's callback to the `@MainActor`-isolated closure
- `try?` on the deny call mirrors the existing pattern for the approve/deny buttons — failure is silent since there's no UI to show the error

## Files Changed
- **MOD** `clients/macos/vellum-assistant/Features/Settings/PairingApprovalWindow.swift` — Added deny-on-close and deny-on-supersede logic

## Testing
1. Show a pairing approval window, then click the X button — verify the daemon receives a deny response
2. Show a pairing approval window, then trigger a second pairing request — verify the first request gets denied
3. Click Approve/Deny/Always Allow buttons — verify they still work correctly and don't double-send

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
