### PR TITLE
fix: clear stale pairing overrides during v4 migration

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -181,6 +181,13 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         defaults.removeObject(forKey: "devLocalPairingEnabled")
         defaults.removeObject(forKey: "iosPairingUseOverride")
 
+        // Clear stale override values — the isOverrideEnabled gate was removed
+        // in M9, so any non-empty override now applies unconditionally. Users
+        // who had values typed in but the toggle OFF would have those stale
+        // values silently activate on upgrade.
+        defaults.removeObject(forKey: PairingConfiguration.gatewayOverrideKey)
+        defaults.removeObject(forKey: PairingConfiguration.tokenOverrideKey)
+
         // Mark migration as done
         defaults.set(true, forKey: Self.pairingV4MigrationKey)
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -131,6 +131,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         // renders EmptyView — we handle settings in the main window panel).
         UserDefaults.standard.removeObject(forKey: "NSWindow Frame com_apple_SwiftUI_Settings_window")
 
+        // Migration: clear stale pairing override values when the toggle was OFF.
+        // M9 removed the isOverrideEnabled gate — any non-empty override now
+        // applies unconditionally. Users who had override values typed in but
+        // the toggle OFF would have those stale values silently activate.
+        migratePairingOverridesIfNeeded()
+
         if let envPath = FeatureFlagManager.findRepoEnvFile() {
             FeatureFlagManager.shared.loadFromFile(at: envPath)
         }
@@ -585,6 +591,32 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         services.reconfigureDaemonClient(config: config)
 
         log.info("Configured HTTP transport for remote assistant \(assistant.assistantId) at \(runtimeUrl, privacy: .public)")
+    }
+
+    // MARK: - Pairing Override Migration
+
+    /// Key that tracks whether the pairing override migration has run.
+    private static let pairingOverrideMigrationKey = "pairing_override_migration_done"
+
+    /// Clears stale gateway/token override values when the old toggle was OFF
+    /// (or absent). Runs once; the flag persists across future launches.
+    private func migratePairingOverridesIfNeeded() {
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: Self.pairingOverrideMigrationKey) else { return }
+
+        // If the legacy toggle was off (false or absent), the user did not
+        // intend for overrides to be active. Clear them so they don't
+        // silently take effect now that the gate is removed.
+        let overrideWasEnabled = defaults.bool(forKey: "iosPairingUseOverride")
+        if !overrideWasEnabled {
+            defaults.removeObject(forKey: PairingConfiguration.gatewayOverrideKey)
+            defaults.removeObject(forKey: PairingConfiguration.tokenOverrideKey)
+        }
+
+        // Clean up the legacy toggle key itself — no longer used.
+        defaults.removeObject(forKey: "iosPairingUseOverride")
+
+        defaults.set(true, forKey: Self.pairingOverrideMigrationKey)
     }
 
     func setupDaemonClient() {

--- a/clients/macos/vellum-assistantTests/SettingsStoreOverrideResolutionTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreOverrideResolutionTests.swift
@@ -7,7 +7,6 @@ final class SettingsStoreOverrideResolutionTests: XCTestCase {
     // Each test manipulates UserDefaults keys that the override resolution
     // reads. Clean up after each test to avoid cross-contamination.
     override func tearDown() {
-        UserDefaults.standard.removeObject(forKey: "iosPairingUseOverride")
         UserDefaults.standard.removeObject(forKey: "iosPairingGatewayOverride")
         UserDefaults.standard.removeObject(forKey: "iosPairingTokenOverride")
         super.tearDown()
@@ -15,19 +14,7 @@ final class SettingsStoreOverrideResolutionTests: XCTestCase {
 
     // MARK: - iOS Gateway URL
 
-    func testIosGatewayReturnsGlobalWhenOverrideOff() {
-        UserDefaults.standard.set(false, forKey: "iosPairingUseOverride")
-        UserDefaults.standard.set("https://custom.example.com", forKey: "iosPairingGatewayOverride")
-
-        let store = SettingsStore()
-        // Simulate global URL being set via IPC response
-        store.ingressPublicBaseUrl = "https://global.example.com"
-
-        XCTAssertEqual(store.resolvedIosGatewayUrl, "https://global.example.com")
-    }
-
-    func testIosGatewayReturnsOverrideWhenOverrideOn() {
-        UserDefaults.standard.set(true, forKey: "iosPairingUseOverride")
+    func testIosGatewayReturnsOverrideWhenNonEmpty() {
         UserDefaults.standard.set("https://custom.example.com", forKey: "iosPairingGatewayOverride")
 
         let store = SettingsStore()
@@ -36,8 +23,7 @@ final class SettingsStoreOverrideResolutionTests: XCTestCase {
         XCTAssertEqual(store.resolvedIosGatewayUrl, "https://custom.example.com")
     }
 
-    func testIosGatewayFallsBackToGlobalWhenOverrideOnButEmpty() {
-        UserDefaults.standard.set(true, forKey: "iosPairingUseOverride")
+    func testIosGatewayFallsBackToGlobalWhenOverrideEmpty() {
         UserDefaults.standard.set("", forKey: "iosPairingGatewayOverride")
 
         let store = SettingsStore()
@@ -46,10 +32,17 @@ final class SettingsStoreOverrideResolutionTests: XCTestCase {
         XCTAssertEqual(store.resolvedIosGatewayUrl, "https://global.example.com")
     }
 
-    func testIosGatewayFallsBackToGlobalWhenOverrideOnAndWhitespaceOnly() {
-        UserDefaults.standard.set(true, forKey: "iosPairingUseOverride")
+    func testIosGatewayFallsBackToGlobalWhenOverrideWhitespaceOnly() {
         UserDefaults.standard.set("   ", forKey: "iosPairingGatewayOverride")
 
+        let store = SettingsStore()
+        store.ingressPublicBaseUrl = "https://global.example.com"
+
+        XCTAssertEqual(store.resolvedIosGatewayUrl, "https://global.example.com")
+    }
+
+    func testIosGatewayFallsBackToGlobalWhenOverrideAbsent() {
+        // No override key set at all
         let store = SettingsStore()
         store.ingressPublicBaseUrl = "https://global.example.com"
 


### PR DESCRIPTION
Clears stale iosPairingGatewayOverride and iosPairingTokenOverride values during upgrade migration on both iOS and macOS. Prevents stale override values from silently activating after the isOverrideEnabled gate was removed. Updates override resolution tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
