### PR TITLE
fix: re-register QR pairing before TTL and handle missing daemon

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -17,7 +17,7 @@ struct PairingQRCodeSheet: View {
     @Environment(\.dismiss) var dismiss
 
     let gatewayUrl: String
-    let daemonClient: DaemonClient
+    let daemonClient: DaemonClient?
 
     @State private var hostId: String = ""
     @State private var pairingRequestId: String = UUID().uuidString
@@ -25,6 +25,10 @@ struct PairingQRCodeSheet: View {
     @State private var localLanUrl: String? = nil
     @State private var registrationState: RegistrationState = .idle
     @State private var registrationError: String? = nil
+    @State private var refreshTask: Task<Void, Never>? = nil
+
+    /// Re-register every 4 minutes to stay ahead of the 5-minute TTL.
+    private static let refreshInterval: UInt64 = 4 * 60 * 1_000_000_000
 
     enum RegistrationState {
         case idle, registering, registered, failed
@@ -45,54 +49,58 @@ struct PairingQRCodeSheet: View {
                 Button("Done") { dismiss() }
             }
 
-            switch registrationState {
-            case .idle, .registering:
-                VStack(spacing: VSpacing.sm) {
-                    ProgressView()
-                        .controlSize(.large)
-                    Text("Registering pairing request...")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textSecondary)
-                }
-                .frame(width: 220, height: 220)
+            if daemonClient == nil {
+                errorContent("Cannot generate QR code \u{2014} daemon not connected. Please wait for the daemon to start and try again.")
+            } else {
+                switch registrationState {
+                case .idle, .registering:
+                    VStack(spacing: VSpacing.sm) {
+                        ProgressView()
+                            .controlSize(.large)
+                        Text("Registering pairing request...")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                    .frame(width: 220, height: 220)
 
-            case .registered:
-                if let qrImage = generateQRImage() {
-                    Image(nsImage: qrImage)
-                        .resizable()
-                        .interpolation(.none)
-                        .scaledToFit()
-                        .frame(width: 220, height: 220)
-                        .padding(VSpacing.md)
-                        .background(Color.white)
-                        .cornerRadius(VRadius.md)
-                } else {
-                    errorContent("Failed to generate QR code.")
-                }
+                case .registered:
+                    if let qrImage = generateQRImage() {
+                        Image(nsImage: qrImage)
+                            .resizable()
+                            .interpolation(.none)
+                            .scaledToFit()
+                            .frame(width: 220, height: 220)
+                            .padding(VSpacing.md)
+                            .background(Color.white)
+                            .cornerRadius(VRadius.md)
+                    } else {
+                        errorContent("Failed to generate QR code.")
+                    }
 
-            case .failed:
-                errorContent(registrationError ?? "Could not register pairing request. Ensure the daemon is running.")
-            }
-
-            // State indicator
-            if canGenerateQR {
-                HStack(spacing: VSpacing.sm) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(VColor.success)
-                        .font(.system(size: 14))
-                    Text("Ready to pair with iOS")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.success)
+                case .failed:
+                    errorContent(registrationError ?? "Could not register pairing request. Ensure the daemon is running.")
                 }
 
-                if localLanUrl != nil {
-                    HStack(spacing: VSpacing.xs) {
-                        Image(systemName: "wifi")
-                            .foregroundColor(VColor.textMuted)
-                            .font(.system(size: 12))
-                        Text("LAN pairing available")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
+                // State indicator
+                if canGenerateQR {
+                    HStack(spacing: VSpacing.sm) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(VColor.success)
+                            .font(.system(size: 14))
+                        Text("Ready to pair with iOS")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.success)
+                    }
+
+                    if localLanUrl != nil {
+                        HStack(spacing: VSpacing.xs) {
+                            Image(systemName: "wifi")
+                                .foregroundColor(VColor.textMuted)
+                                .font(.system(size: 12))
+                            Text("LAN pairing available")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
                     }
                 }
             }
@@ -102,7 +110,7 @@ struct PairingQRCodeSheet: View {
                 .foregroundColor(VColor.textSecondary)
                 .multilineTextAlignment(.center)
 
-            if registrationState == .failed {
+            if registrationState == .failed && daemonClient != nil {
                 Button("Retry") {
                     pairingRequestId = UUID().uuidString
                     pairingSecret = Self.generatePairingSecret()
@@ -116,7 +124,12 @@ struct PairingQRCodeSheet: View {
         .onAppear {
             hostId = Self.computeHostId()
             localLanUrl = computeLocalLanUrl()
+            guard daemonClient != nil else { return }
             registerWithDaemon()
+            startRefreshTimer()
+        }
+        .onDisappear {
+            stopRefreshTimer()
         }
     }
 
@@ -133,13 +146,33 @@ struct PairingQRCodeSheet: View {
         .frame(width: 220, height: 220)
     }
 
+    // MARK: - Refresh Timer
+
+    private func startRefreshTimer() {
+        stopRefreshTimer()
+        refreshTask = Task { @MainActor in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: Self.refreshInterval)
+                guard !Task.isCancelled else { break }
+                pairingRequestId = UUID().uuidString
+                pairingSecret = Self.generatePairingSecret()
+                registerWithDaemon()
+            }
+        }
+    }
+
+    private func stopRefreshTimer() {
+        refreshTask?.cancel()
+        refreshTask = nil
+    }
+
     // MARK: - Registration
 
     private func registerWithDaemon() {
         registrationState = .registering
         registrationError = nil
 
-        guard let port = daemonClient.httpPort else {
+        guard let port = daemonClient?.httpPort else {
             registrationState = .failed
             registrationError = "Daemon HTTP server not running."
             return

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -88,12 +88,10 @@ struct SettingsConnectTab: View {
             Text("This will replace the current bearer token and restart the daemon. Any paired devices will need to reconnect.")
         }
         .sheet(isPresented: $showingPairingQR) {
-            if let client = daemonClient {
-                PairingQRCodeSheet(
-                    gatewayUrl: store.resolvedIosGatewayUrl,
-                    daemonClient: client
-                )
-            }
+            PairingQRCodeSheet(
+                gatewayUrl: store.resolvedIosGatewayUrl,
+                daemonClient: daemonClient
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
Adds a timer to re-register the pairing request before the 5-minute TTL expires, keeping the QR code valid while the sheet is open. Also shows an error when daemon client is unavailable instead of rendering an empty sheet.

## Implementation
- **TTL re-registration**: After initial registration succeeds, a `Task`-based loop fires every 4 minutes (before the 5-minute TTL). Each tick generates a new `pairingRequestId` and `pairingSecret`, re-registers with the daemon, and the QR code updates with the fresh values. The task is cancelled on sheet disappear.
- **Missing daemon client**: `PairingQRCodeSheet.daemonClient` is now optional (`DaemonClient?`). When nil, the sheet shows an explicit error message ("Cannot generate QR code — daemon not connected") instead of rendering nothing. `SettingsConnectTab` always passes through `daemonClient` (which may be nil) rather than conditionally rendering the sheet.

## Test plan
- [ ] Open the QR pairing sheet and keep it open for 5+ minutes — the QR code should refresh automatically before the TTL expires
- [ ] Open the QR sheet when the daemon is not running — should show an error message instead of an empty sheet
- [ ] Dismiss and reopen the sheet — timer should restart cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
