### PR TITLE
fix: honor task cancellation in QRPairingSheet pairing flow

### DIFF
--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -300,7 +300,10 @@ struct QRPairingSheet: View {
                     handlePairingResponse(result, payload: payload, effectiveBaseURL: lanUrl)
                     return
                 }
-                // LAN failed, fall through to cloud gateway
+                // LAN failed — but if we were cancelled while waiting, stop here
+                // instead of falling through to the gateway path.
+                guard !Task.isCancelled else { return }
+                // Fall through to cloud gateway
             }
 
             // Cloud gateway
@@ -311,7 +314,7 @@ struct QRPairingSheet: View {
             )
             if let result = result {
                 handlePairingResponse(result, payload: payload, effectiveBaseURL: payload.gatewayURL)
-            } else {
+            } else if !Task.isCancelled {
                 await MainActor.run {
                     errorMessage = "Could not reach your Mac. Make sure the Vellum daemon is running."
                     phase = .error


### PR DESCRIPTION
Adds Task.isCancelled guards after LAN attempt fails to prevent falling through to gateway path when the sheet is dismissed. Addresses feedback from PR #8185.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
