### PR TITLE
fix: enforce Content-Length pre-check in pairing proxy

### DIFF
--- a/gateway/src/http/routes/pairing-proxy.ts
+++ b/gateway/src/http/routes/pairing-proxy.ts
@@ -69,16 +69,25 @@ export function createPairingProxyHandler(config: GatewayConfig) {
 
     const hasBody = req.method !== "GET" && req.method !== "HEAD";
 
-    // Payload size guard — reject oversized requests before buffering.
+    // Payload size guard — primary defense: reject via Content-Length before
+    // reading the body into memory. This is the main protection against
+    // oversized requests because Bun's Request.arrayBuffer() buffers the
+    // entire body with no streaming-limit API, so once we call it the
+    // memory is already allocated.
     if (hasBody) {
       const contentLength = req.headers.get("content-length");
-      if (contentLength && Number(contentLength) > MAX_PAIRING_PAYLOAD_BYTES) {
-        log.warn({ contentLength }, "Pairing proxy payload too large (content-length)");
-        return Response.json({ error: "Payload too large" }, { status: 413 });
+      if (contentLength) {
+        const declared = Number(contentLength);
+        if (declared > MAX_PAIRING_PAYLOAD_BYTES || Number.isNaN(declared)) {
+          log.warn({ contentLength }, "Pairing proxy payload too large (content-length)");
+          return Response.json({ error: "Payload too large" }, { status: 413 });
+        }
       }
     }
 
     const bodyBuffer = hasBody ? await req.arrayBuffer() : null;
+    // Belt-and-suspenders: verify actual size after read in case
+    // Content-Length was absent (chunked) or spoofed.
     if (bodyBuffer !== null) {
       if (bodyBuffer.byteLength > MAX_PAIRING_PAYLOAD_BYTES) {
         log.warn({ bodyLength: bodyBuffer.byteLength }, "Pairing proxy payload too large");


### PR DESCRIPTION
Adds Content-Length header pre-check to reject oversized pairing proxy requests before reading body into memory. The post-read byte length check remains as a secondary guard. Addresses feedback from PR #8188.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
