### PR TITLE
fix: roll back optimistic removal in removeApprovedDevice on IPC failure

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1243,8 +1243,14 @@ public final class SettingsStore: ObservableObject {
 
     func removeApprovedDevice(hashedDeviceId: String) {
         guard let daemonClient else { return }
+        let removed = approvedDevices.filter { $0.hashedDeviceId == hashedDeviceId }
         approvedDevices.removeAll { $0.hashedDeviceId == hashedDeviceId }
-        try? daemonClient.sendApprovedDeviceRemove(hashedDeviceId: hashedDeviceId)
+        do {
+            try daemonClient.sendApprovedDeviceRemove(hashedDeviceId: hashedDeviceId)
+        } catch {
+            // IPC failed — restore optimistically removed devices
+            approvedDevices.append(contentsOf: removed)
+        }
     }
 
     func clearAllApprovedDevices() {


### PR DESCRIPTION
Uses do/try/catch to restore the removed device to the local array if IPC send fails, matching the clearAllApprovedDevices pattern. Addresses feedback from PR #8190.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
