### PR TITLE
M1: Reduce maxTokens default from 64000 to 16000

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -35,7 +35,7 @@ export type AgentEvent =
   | { type: 'usage'; inputTokens: number; outputTokens: number; cacheCreationInputTokens?: number; cacheReadInputTokens?: number; model: string; providerDurationMs: number; rawRequest?: unknown; rawResponse?: unknown };
 
 const DEFAULT_CONFIG: AgentLoopConfig = {
-  maxTokens: 64000,
+  maxTokens: 16000,
   maxToolUseTurns: 30,
 };
 

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -8,7 +8,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   apiKeys: {},
   webSearchProvider: 'perplexity',
   providerOrder: [],
-  maxTokens: 64000,
+  maxTokens: 16000,
   thinking: {
     enabled: false,
     budgetTokens: 10000,


### PR DESCRIPTION
Reduces the default maxTokens from 64000 to 16000 in both defaults.ts and the agent loop DEFAULT_CONFIG. This improves TTFT and encourages more concise responses. Part of #8200.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
