### PR TITLE
M2: Add streamThinking config flag and filter thinking deltas

### DIFF
--- a/assistant/src/config/core-schema.ts
+++ b/assistant/src/config/core-schema.ts
@@ -103,6 +103,9 @@ export const ThinkingConfigSchema = z.object({
     .int('thinking.budgetTokens must be an integer')
     .positive('thinking.budgetTokens must be a positive integer')
     .default(10000),
+  streamThinking: z
+    .boolean({ error: 'thinking.streamThinking must be a boolean' })
+    .default(false),
 });
 
 export const ContextWindowConfigSchema = z.object({

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -12,6 +12,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   thinking: {
     enabled: false,
     budgetTokens: 10000,
+    streamThinking: false,
   },
   contextWindow: {
     enabled: true,

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -121,6 +121,7 @@ export function handleThinkingDelta(
   deps: EventHandlerDeps,
   event: Extract<AgentEvent, { type: 'thinking_delta' }>,
 ): void {
+  if (!deps.ctx.streamThinking) return;
   emitLlmCallStartedIfNeeded(state, deps);
   deps.onEvent({ type: 'assistant_thinking_delta', thinking: event.thinking });
 }

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -116,6 +116,7 @@ export interface AgentLoopSessionContext {
   lastAttachmentWarnings: string[];
 
   hasNoClient: boolean;
+  readonly streamThinking: boolean;
   readonly prompter: PermissionPrompter;
   readonly queue: MessageQueue;
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -141,6 +141,7 @@ export class Session {
   /** @internal */ workspaceTopLevelDirty = true;
   public readonly traceEmitter: TraceEmitter;
   public memoryPolicy: SessionMemoryPolicy;
+  /** @internal */ streamThinking: boolean;
   /** @internal */ turnCount = 0;
   public lastAssistantAttachments: AssistantAttachmentDraft[] = [];
   public lastAttachmentWarnings: string[] = [];
@@ -195,6 +196,7 @@ export class Session {
     );
 
     const config = getConfig();
+    this.streamThinking = config.thinking.streamThinking ?? false;
     const resolveTools = createResolveToolsCallback(toolDefs, this);
 
     this.agentLoop = new AgentLoop(


### PR DESCRIPTION
Adds a streamThinking boolean to ThinkingConfig (default: false). When disabled, thinking deltas are suppressed in handleThinkingDelta before they reach the client. Part of #8200.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
