### PR TITLE
fix: skip deny on same-ID retry in PairingApprovalWindow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/PairingApprovalWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingApprovalWindow.swift
@@ -17,11 +17,18 @@ final class PairingApprovalWindow {
     }
 
     /// Show the pairing approval prompt for a specific device.
-    /// If a window is already showing, it is closed first (one prompt at a time).
-    /// Closing the previous window sends a deny for the superseded request.
+    /// If a window is already showing for a different request, it is closed first
+    /// (one prompt at a time) and a deny is sent for the superseded request.
+    /// If the same pairingRequestId is delivered again (daemon retry/rebroadcast),
+    /// the existing prompt is kept as-is — no deny is sent.
     func show(pairingRequestId: String, deviceName: String) {
+        // Same request ID redelivered (retry/rebroadcast) — keep current prompt.
+        if pairingRequestId == currentPairingRequestId, window != nil {
+            return
+        }
+
         // Close any existing prompt before showing a new one.
-        // This will send a deny for the previous request if unanswered.
+        // This will send a deny for the previous (different) request if unanswered.
         close()
 
         let view = PairingApprovalView(deviceName: deviceName) { [weak self] decision in


### PR DESCRIPTION
When show() is called with the same pairingRequestId (daemon retry/rebroadcast), skip the deny to prevent incorrectly marking the active request as denied. Only deny when a genuinely different request supersedes the current one. Addresses feedback from PR #8196.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
