### PR TITLE
Fix: Update maxTokens Zod schema default from 64000 to 16000

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -74,7 +74,7 @@ describe('AssistantConfigSchema', () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.provider).toBe('anthropic');
     expect(result.model).toBe('claude-opus-4-6');
-    expect(result.maxTokens).toBe(64000);
+    expect(result.maxTokens).toBe(16000);
     expect(result.apiKeys).toEqual({});
     expect(result.thinking).toEqual({ enabled: false, budgetTokens: 10000 });
     expect(result.contextWindow).toEqual({
@@ -1193,7 +1193,7 @@ describe('loadConfig with schema validation', () => {
     const config = loadConfig();
     expect(config.provider).toBe('anthropic');
     expect(config.model).toBe('claude-opus-4-6');
-    expect(config.maxTokens).toBe(64000);
+    expect(config.maxTokens).toBe(16000);
     expect(config.thinking).toEqual({ enabled: false, budgetTokens: 10000 });
     expect(config.contextWindow).toEqual({
       enabled: true,
@@ -1215,7 +1215,7 @@ describe('loadConfig with schema validation', () => {
   test('falls back to default for invalid maxTokens', () => {
     writeConfig({ maxTokens: -100 });
     const config = loadConfig();
-    expect(config.maxTokens).toBe(64000);
+    expect(config.maxTokens).toBe(16000);
   });
 
   test('falls back to defaults for invalid nested values', () => {
@@ -1240,13 +1240,13 @@ describe('loadConfig with schema validation', () => {
     expect(config.model).toBe('gpt-4');
     expect(config.thinking.enabled).toBe(true);
     expect(config.thinking.budgetTokens).toBe(5000);
-    expect(config.maxTokens).toBe(64000);
+    expect(config.maxTokens).toBe(16000);
   });
 
   test('handles no config file', () => {
     const config = loadConfig();
     expect(config.provider).toBe('anthropic');
-    expect(config.maxTokens).toBe(64000);
+    expect(config.maxTokens).toBe(16000);
   });
 
   test('partial nested objects get defaults for missing fields', () => {

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -172,7 +172,7 @@ export const AssistantConfigSchema = z.object({
     .number({ error: 'maxTokens must be a number' })
     .int('maxTokens must be an integer')
     .positive('maxTokens must be a positive integer')
-    .default(64000),
+    .default(16000),
   thinking: ThinkingConfigSchema.default({
     enabled: false,
     budgetTokens: 10000,


### PR DESCRIPTION
Addresses feedback from #8217. The Zod schema default for maxTokens was still 64000, which is the authoritative default used by loadConfig(). Updates schema.ts and all test expectations to 16000. Part of #8200.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
