### PR TITLE
fix: separate iOS override migration and guard macOS cleanup

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -90,6 +90,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // the new approval flow. Runs once; the flag persists across future launches.
         migrateToPairingV4IfNeeded()
 
+        // Separate migration: clear stale override values when the old toggle was OFF.
+        // This runs independently of the v4 migration so users who already completed
+        // v4 migration still get the override cleanup.
+        migratePairingOverridesIfNeeded()
+
         // Initial connect is handled by SceneDelegate.sceneWillEnterForeground, which fires
         // during launch and on every background→foreground transition. Calling connect() here
         // too would race with the scene's connect() since isConnected is false while in-flight.
@@ -181,13 +186,6 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         defaults.removeObject(forKey: "devLocalPairingEnabled")
         defaults.removeObject(forKey: "iosPairingUseOverride")
 
-        // Clear stale override values — the isOverrideEnabled gate was removed
-        // in M9, so any non-empty override now applies unconditionally. Users
-        // who had values typed in but the toggle OFF would have those stale
-        // values silently activate on upgrade.
-        defaults.removeObject(forKey: PairingConfiguration.gatewayOverrideKey)
-        defaults.removeObject(forKey: PairingConfiguration.tokenOverrideKey)
-
         // Mark migration as done
         defaults.set(true, forKey: Self.pairingV4MigrationKey)
 
@@ -195,6 +193,36 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         clientProvider.rebuildClient()
 
         log.info("v4 pairing migration complete — legacy pairing state cleared")
+    }
+
+    // MARK: - Pairing Override Migration
+
+    /// Key that tracks whether the pairing override migration has run.
+    private static let pairingOverrideMigrationKey = "pairing_override_migration_done"
+
+    /// Clears stale gateway/token override values when the old toggle was OFF.
+    /// Runs once; the flag persists across future launches.
+    ///
+    /// This is separate from the v4 migration so users who already completed
+    /// v4 migration still get the override cleanup.
+    private func migratePairingOverridesIfNeeded() {
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: Self.pairingOverrideMigrationKey) else { return }
+
+        // Only clean up when the legacy toggle key is actually present.
+        // After M9 the toggle is no longer persisted, so absence means
+        // the user may have intentionally set overrides post-M9.
+        if defaults.object(forKey: "iosPairingUseOverride") != nil {
+            let overrideWasEnabled = defaults.bool(forKey: "iosPairingUseOverride")
+            if !overrideWasEnabled {
+                defaults.removeObject(forKey: PairingConfiguration.gatewayOverrideKey)
+                defaults.removeObject(forKey: PairingConfiguration.tokenOverrideKey)
+            }
+            // Clean up the legacy toggle key itself — no longer used.
+            defaults.removeObject(forKey: "iosPairingUseOverride")
+        }
+
+        defaults.set(true, forKey: Self.pairingOverrideMigrationKey)
     }
 
     func application(

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -600,23 +600,28 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Key that tracks whether the pairing override migration has run.
     private static let pairingOverrideMigrationKey = "pairing_override_migration_done"
 
-    /// Clears stale gateway/token override values when the old toggle was OFF
-    /// (or absent). Runs once; the flag persists across future launches.
+    /// Clears stale gateway/token override values when the old toggle was OFF.
+    /// Runs once; the flag persists across future launches.
+    ///
+    /// Only acts when the legacy `iosPairingUseOverride` key is actually present.
+    /// After M9 the toggle is no longer persisted, so absence means the user
+    /// may have intentionally set overrides post-M9 — skip cleanup to preserve them.
     private func migratePairingOverridesIfNeeded() {
         let defaults = UserDefaults.standard
         guard !defaults.bool(forKey: Self.pairingOverrideMigrationKey) else { return }
 
-        // If the legacy toggle was off (false or absent), the user did not
-        // intend for overrides to be active. Clear them so they don't
-        // silently take effect now that the gate is removed.
-        let overrideWasEnabled = defaults.bool(forKey: "iosPairingUseOverride")
-        if !overrideWasEnabled {
-            defaults.removeObject(forKey: PairingConfiguration.gatewayOverrideKey)
-            defaults.removeObject(forKey: PairingConfiguration.tokenOverrideKey)
+        // Only clean up when the legacy toggle key is actually present.
+        // After M9 the toggle is no longer persisted, so absence means
+        // the user may have intentionally set overrides post-M9.
+        if defaults.object(forKey: "iosPairingUseOverride") != nil {
+            let overrideWasEnabled = defaults.bool(forKey: "iosPairingUseOverride")
+            if !overrideWasEnabled {
+                defaults.removeObject(forKey: PairingConfiguration.gatewayOverrideKey)
+                defaults.removeObject(forKey: PairingConfiguration.tokenOverrideKey)
+            }
+            // Clean up the legacy toggle key itself — no longer used.
+            defaults.removeObject(forKey: "iosPairingUseOverride")
         }
-
-        // Clean up the legacy toggle key itself — no longer used.
-        defaults.removeObject(forKey: "iosPairingUseOverride")
 
         defaults.set(true, forKey: Self.pairingOverrideMigrationKey)
     }


### PR DESCRIPTION
## Summary

- **iOS:** Moves override cleanup into its own `migratePairingOverridesIfNeeded()` with a separate migration key (`pairing_override_migration_done`), so existing v4-migrated users still get cleanup. The override cleanup was previously inside `migrateToPairingV4IfNeeded()`, which is gated by `pairing_v4_migration_done` — users who already completed the v4 migration would never reach the new cleanup lines.
- **macOS:** Only runs cleanup when the legacy `iosPairingUseOverride` key is actually present in UserDefaults. After M9 the toggle is no longer persisted, so absence means the user may have intentionally set overrides post-M9 — treating absence as "toggle OFF" would incorrectly wipe those values.

Addresses feedback from PR #8197.

## Test plan

- [ ] Verify iOS users who already completed v4 migration get override cleanup on next launch
- [ ] Verify macOS users with intentional post-M9 overrides (no legacy toggle key) keep their values
- [ ] Verify macOS users with legacy toggle key set to OFF get overrides cleaned up
- [ ] Verify both migrations only run once (check for migration keys in UserDefaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
