### PR TITLE
feat(macos): add secret dev mode toggle

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedTab.swift
@@ -19,11 +19,12 @@ struct SettingsAdvancedTab: View {
     @State private var remoteIdentity: RemoteIdentityInfo?
     @State private var flagStates: [(flag: FeatureFlag, enabled: Bool)] = []
 
-    #if DEBUG
+    @State private var devModeTapCount: Int = 0
+    @State private var devModeMessage: String?
+
     @State private var showingEnvVars = false
     @State private var appEnvVars: [(String, String)] = []
     @State private var daemonEnvVars: [(String, String)] = []
-    #endif
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
@@ -35,9 +36,9 @@ struct SettingsAdvancedTab: View {
             hatchNewAssistantSection
             featureFlagSection
 
-            #if DEBUG
-            developerSection
-            #endif
+            if store.isDevMode {
+                developerSection
+            }
         }
         .onAppear {
             lockfileAssistants = LockfileAssistant.loadAll()
@@ -87,14 +88,12 @@ struct SettingsAdvancedTab: View {
             .frame(minWidth: 260)
             .interactiveDismissDisabled()
         }
-        #if DEBUG
         .sheet(isPresented: $showingEnvVars) {
             SettingsPanelEnvVarsSheet(appEnvVars: appEnvVars, daemonEnvVars: daemonEnvVars)
         }
         .onDisappear {
             daemonClient?.onEnvVarsResponse = nil
         }
-        #endif
     }
 
     // MARK: - Assistant Info
@@ -107,9 +106,30 @@ struct SettingsAdvancedTab: View {
 
             if let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }) {
                 infoRow(label: "Assistant ID", value: assistant.assistantId, mono: true)
+                    .onTapGesture {
+                        devModeTapCount += 1
+                        if devModeTapCount >= 7 {
+                            store.toggleDevMode()
+                            devModeTapCount = 0
+                            devModeMessage = store.isDevMode
+                                ? "Dev mode enabled"
+                                : "Dev mode disabled"
+                            Task {
+                                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                                devModeMessage = nil
+                            }
+                        }
+                    }
 
                 let home = assistant.home
                 homeRow(home: home)
+            }
+
+            if let message = devModeMessage {
+                Text(message)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.accent)
+                    .transition(.opacity)
             }
 
             // Process status (child view observes @Published changes)
@@ -347,7 +367,7 @@ struct SettingsAdvancedTab: View {
 
     @ViewBuilder
     private var featureFlagSection: some View {
-        if FeatureFlagManager.shared.isEnabled(.featureFlagEditorEnabled) {
+        if store.isDevMode {
             VStack(alignment: .leading, spacing: VSpacing.md) {
                 Text("Feature Flags")
                     .font(VFont.sectionTitle)
@@ -371,9 +391,8 @@ struct SettingsAdvancedTab: View {
         }
     }
 
-    // MARK: - Developer (Debug Only)
+    // MARK: - Developer
 
-    #if DEBUG
     @ViewBuilder
     private var developerSection: some View {
         if daemonClient != nil {
@@ -413,7 +432,6 @@ struct SettingsAdvancedTab: View {
             .vCard(background: VColor.surfaceSubtle)
         }
     }
-    #endif
 }
 
 // MARK: - Daemon Status Rows

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -147,15 +147,17 @@ struct SettingsConnectTab: View {
                     .foregroundColor(VColor.error)
             }
 
-            Divider().background(VColor.surfaceBorder)
+            if store.isDevMode {
+                Divider().background(VColor.surfaceBorder)
 
-            channelStatusRow(
-                label: "Platform URL",
-                icon: "link",
-                iconColor: VColor.textMuted,
-                value: AuthService.shared.baseURL,
-                valueFont: VFont.mono
-            )
+                channelStatusRow(
+                    label: "Platform URL",
+                    icon: "link",
+                    iconColor: VColor.textMuted,
+                    value: AuthService.shared.baseURL,
+                    valueFont: VFont.mono
+                )
+            }
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -250,7 +250,11 @@ public final class SettingsStore: ObservableObject {
 
         self.quickChatShortcut = UserDefaults.standard.string(forKey: "quickChatShortcut") ?? "cmd+shift+space"
 
+        #if DEBUG
+        self.isDevMode = UserDefaults.standard.object(forKey: "devModeEnabled") as? Bool ?? true
+        #else
         self.isDevMode = UserDefaults.standard.bool(forKey: "devModeEnabled")
+        #endif
 
         // Load media embed settings from workspace config
         let mediaSettings = Self.loadMediaEmbedSettings(from: configPath)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -144,6 +144,10 @@ public final class SettingsStore: ObservableObject {
     @Published var gatewayLastChecked: Date?
     @Published var isCheckingGateway: Bool = false
 
+    // MARK: - Dev Mode
+
+    @Published var isDevMode: Bool
+
     // MARK: - Trust Rules Coordination
 
     /// Whether any settings surface currently has a trust rules sheet open.
@@ -246,6 +250,8 @@ public final class SettingsStore: ObservableObject {
 
         self.quickChatShortcut = UserDefaults.standard.string(forKey: "quickChatShortcut") ?? "cmd+shift+space"
 
+        self.isDevMode = UserDefaults.standard.bool(forKey: "devModeEnabled")
+
         // Load media embed settings from workspace config
         let mediaSettings = Self.loadMediaEmbedSettings(from: configPath)
         self.mediaEmbedsEnabled = mediaSettings.enabled
@@ -287,6 +293,11 @@ public final class SettingsStore: ObservableObject {
         $quickChatShortcut
             .dropFirst()
             .sink { value in UserDefaults.standard.set(value, forKey: "quickChatShortcut") }
+            .store(in: &cancellables)
+
+        $isDevMode
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "devModeEnabled") }
             .store(in: &cancellables)
 
         // Mirror DaemonClient's trust-rules-open flag so views can disable their buttons
@@ -1273,6 +1284,12 @@ public final class SettingsStore: ObservableObject {
     var lanPairingUrl: String? {
         guard let ip = LANIPHelper.currentLANAddress() else { return nil }
         return "http://\(ip):7830"
+    }
+
+    // MARK: - Dev Mode Actions
+
+    func toggleDevMode() {
+        isDevMode.toggle()
     }
 
     // MARK: - Model Actions


### PR DESCRIPTION
## Summary
- Adds a secret "dev mode" activated by tapping the Assistant ID 7 times in Settings > Advanced (like Android developer options)
- Dev mode state persists in UserDefaults via `SettingsStore.isDevMode`
- Gates Feature Flags editor, Developer (env vars) section, and Platform URL (Connect tab) behind dev mode
- Replaces `#if DEBUG` compile-time guard on developer section with runtime `store.isDevMode` check so it works in production builds

## Test plan
- [ ] Build the app and open Settings > Advanced
- [ ] Tap the Assistant ID text 7 times — confirm "Dev mode enabled" message appears
- [ ] Confirm Feature Flags section now appears in Advanced tab
- [ ] Confirm Developer section (env vars) now appears in Advanced tab
- [ ] Navigate to Settings > Connect — confirm Platform URL row now appears in the Vellum section
- [ ] Tap Assistant ID 7 more times — confirm "Dev mode disabled" and sections disappear
- [ ] Quit and relaunch — confirm dev mode state persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
