### PR TITLE
fix: avoid QR flicker during refresh and register on daemon connect

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -131,6 +131,14 @@ struct PairingQRCodeSheet: View {
         .onDisappear {
             stopRefreshTimer()
         }
+        .onChange(of: daemonClient != nil) { _, isConnected in
+            // When the daemon connects after the sheet is already open,
+            // trigger registration so the user doesn't have to dismiss and reopen.
+            if isConnected, registrationState != .registered {
+                registerWithDaemon()
+                startRefreshTimer()
+            }
+        }
     }
 
     private func errorContent(_ message: String) -> some View {
@@ -154,9 +162,11 @@ struct PairingQRCodeSheet: View {
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: Self.refreshInterval)
                 guard !Task.isCancelled else { break }
-                pairingRequestId = UUID().uuidString
-                pairingSecret = Self.generatePairingSecret()
-                registerWithDaemon()
+                // Generate new credentials into locals so the old QR stays visible
+                // while the re-registration HTTP request is in-flight.
+                let newRequestId = UUID().uuidString
+                let newSecret = Self.generatePairingSecret()
+                await refreshRegistration(newRequestId: newRequestId, newSecret: newSecret)
             }
         }
     }
@@ -178,6 +188,41 @@ struct PairingQRCodeSheet: View {
             return
         }
 
+        let reqId = pairingRequestId
+        let secret = pairingSecret
+
+        Task {
+            let result = await performRegistrationRequest(port: port, requestId: reqId, secret: secret)
+            switch result {
+            case .success:
+                registrationState = .registered
+            case .failure(let error):
+                registrationState = .failed
+                registrationError = error
+            }
+        }
+    }
+
+    /// Re-register with new credentials without disrupting the visible QR code.
+    /// Only swaps pairingRequestId, pairingSecret, and registrationState atomically
+    /// once the HTTP 200 response comes back. On failure the old QR stays visible.
+    private func refreshRegistration(newRequestId: String, newSecret: String) async {
+        guard let port = daemonClient?.httpPort else { return }
+
+        let result = await performRegistrationRequest(port: port, requestId: newRequestId, secret: newSecret)
+        switch result {
+        case .success:
+            pairingRequestId = newRequestId
+            pairingSecret = newSecret
+            registrationState = .registered
+        case .failure:
+            // Keep the old QR visible; the next timer tick will retry.
+            break
+        }
+    }
+
+    /// Shared HTTP request logic for pairing registration.
+    private func performRegistrationRequest(port: Int, requestId: String, secret: String) async -> Result<Void, String> {
         let tokenPath = resolveHttpTokenPath()
         let bearerToken: String? = {
             guard let path = tokenPath else { return nil }
@@ -187,8 +232,8 @@ struct PairingQRCodeSheet: View {
         let url = URL(string: "http://localhost:\(port)/v1/pairing/register")!
 
         var body: [String: Any] = [
-            "pairingRequestId": pairingRequestId,
-            "pairingSecret": pairingSecret,
+            "pairingRequestId": requestId,
+            "pairingSecret": secret,
             "gatewayUrl": gatewayUrl,
         ]
         if let lan = localLanUrl {
@@ -196,9 +241,7 @@ struct PairingQRCodeSheet: View {
         }
 
         guard let jsonData = try? JSONSerialization.data(withJSONObject: body) else {
-            registrationState = .failed
-            registrationError = "Failed to serialize registration payload."
-            return
+            return .failure("Failed to serialize registration payload.")
         }
 
         var request = URLRequest(url: url)
@@ -209,20 +252,16 @@ struct PairingQRCodeSheet: View {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
 
-        Task {
-            do {
-                let (_, response) = try await URLSession.shared.data(for: request)
-                if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 {
-                    registrationState = .registered
-                } else {
-                    let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
-                    registrationState = .failed
-                    registrationError = "Registration failed (HTTP \(statusCode))."
-                }
-            } catch {
-                registrationState = .failed
-                registrationError = "Could not reach daemon: \(error.localizedDescription)"
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 {
+                return .success(())
+            } else {
+                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+                return .failure("Registration failed (HTTP \(statusCode)).")
             }
+        } catch {
+            return .failure("Could not reach daemon: \(error.localizedDescription)")
         }
     }
 


### PR DESCRIPTION
## Summary
Keeps old QR visible during re-registration by only swapping credentials atomically on HTTP 200 success. Adds .onChange(of: daemonClient) to trigger registration when daemon becomes available after sheet opens. Addresses feedback from PR #8199.

## Implementation
- **QR flicker fix:** Extracted HTTP request logic into a shared `performRegistrationRequest()` that returns a `Result`. The refresh timer path generates new credentials into local variables and calls a new `refreshRegistration()` method that only updates `@State` properties (`pairingRequestId`, `pairingSecret`, `registrationState`) atomically once the HTTP 200 response comes back. On failure, the old QR stays visible. The initial `registerWithDaemon()` still shows `.registering` state since there's no existing QR to preserve.
- **Daemon late-connect fix:** Added `.onChange(of: daemonClient != nil)` that calls `registerWithDaemon()` and starts the refresh timer when `daemonClient` transitions from nil to non-nil and `registrationState` is not already `.registered`.

## Test plan
- [ ] Open QR sheet, keep it open for 5+ minutes -- QR code should refresh without any flicker or spinner
- [ ] Open QR sheet before daemon connects -- should show error, then auto-register when daemon becomes available
- [ ] Dismiss and reopen sheet -- timer should restart cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
