### PR TITLE
refactor: deduplicate isPlainObject into shared utility

### DIFF
--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -17,15 +17,12 @@ import {
   getPrebuiltHomeBasePreview,
   findSeededHomeBaseApp,
 } from '../home-base/prebuilt/seed.js';
+import { isPlainObject } from '../util/object.js';
 
 const log = getLogger('session-surfaces');
 
 const MAX_UNDO_DEPTH = 10;
 const TASK_PROGRESS_TEMPLATE_FIELDS = ['title', 'status', 'steps'] as const;
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value != null && !Array.isArray(value);
-}
 
 function normalizeCardShowData(input: Record<string, unknown>, rawData: Record<string, unknown>): CardSurfaceData {
   const normalized: Record<string, unknown> = { ...rawData };

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -15,6 +15,7 @@ import type { SecretPrompter } from '../permissions/secret-prompter.js';
 import { addRule, findHighestPriorityRule } from '../permissions/trust-store.js';
 import { generateAllowlistOptions, generateScopeOptions, normalizeWebFetchUrl } from '../permissions/checker.js';
 import { getLogger } from '../util/logger.js';
+import { isPlainObject } from '../util/object.js';
 
 const log = getLogger('session-tool-setup');
 import { getAllToolDefinitions } from '../tools/registry.js';
@@ -76,10 +77,6 @@ export function buildToolDefinitions(): ToolDefinition[] {
 }
 
 // ── DoorDash task_progress auto-update ────────────────────────────────
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value != null && !Array.isArray(value);
-}
 
 interface DoordashStep { label: string; status: string; detail?: string }
 

--- a/assistant/src/util/object.ts
+++ b/assistant/src/util/object.ts
@@ -1,0 +1,3 @@
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, existsSync, statSync, unlinkSync, renameSync, readFileSync, writeFileSync, readdirSync, chmodSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
+import { isPlainObject } from './object.js';
 /**
  * Stderr-only logger for migration code. Using the pino logger during
  * migration is unsafe because pino initialization calls ensureDataDir(),
@@ -364,10 +365,6 @@ export function migratePath(source: string, destination: string): void {
  * top-level keys from the legacy file into the workspace file so they are
  * not silently lost during upgrade.
  */
-function isPlainObject(v: unknown): v is Record<string, unknown> {
-  return v != null && typeof v === 'object' && !Array.isArray(v);
-}
-
 function mergeSkippedConfigKeys(legacyPath: string, workspacePath: string): void {
   if (!existsSync(legacyPath) || !existsSync(workspacePath)) return;
 


### PR DESCRIPTION
Move isPlainObject() to assistant/src/util/object.ts and replace three duplicated local definitions in platform.ts, session-surfaces.ts, and session-tool-setup.ts with imports.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
