### PR TITLE
perf: add database indexes on memorySegments table

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -16,6 +16,7 @@ import {
   migrateGuardianActionTables,
   migrateBackfillInboxThreadStateFromBindings,
   migrateDropActiveSearchIndex,
+  migrateMemorySegmentsIndexes,
   validateMigrationState,
 } from './schema-migration.js';
 
@@ -1266,6 +1267,8 @@ export function initializeDb(): void {
   migrateGuardianActionTables(database);
 
   migrateMemoryFtsBackfill(database);
+
+  migrateMemorySegmentsIndexes(database);
 
   validateMigrationState(database);
 }

--- a/assistant/src/memory/migrations/016-memory-segments-indexes.ts
+++ b/assistant/src/memory/migrations/016-memory-segments-indexes.ts
@@ -1,0 +1,11 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Idempotent migration to ensure memory_segments has indexes on scope_id and
+ * conversation_id for faster lookups.  scope_id was already covered by
+ * db-init, but we include both here for completeness.
+ */
+export function migrateMemorySegmentsIndexes(database: DrizzleDb): void {
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_segments_scope_id ON memory_segments(scope_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_segments_conversation_id ON memory_segments(conversation_id)`);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -19,3 +19,4 @@ export { migrateCallSessionsAddInitiatedFrom } from './012-call-sessions-add-ini
 export { migrateGuardianActionTables } from './013-guardian-action-tables.js';
 export { migrateBackfillInboxThreadStateFromBindings } from './014-backfill-inbox-thread-state.js';
 export { migrateDropActiveSearchIndex } from './015-drop-active-search-index.js';
+export { migrateMemorySegmentsIndexes } from './016-memory-segments-indexes.js';

--- a/assistant/src/memory/schema-migration.ts
+++ b/assistant/src/memory/schema-migration.ts
@@ -19,4 +19,5 @@ export {
   migrateGuardianActionTables,
   migrateBackfillInboxThreadStateFromBindings,
   migrateDropActiveSearchIndex,
+  migrateMemorySegmentsIndexes,
 } from './migrations/index.js';

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, real, blob } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, integer, real, blob, index } from 'drizzle-orm/sqlite-core';
 
 export const conversations = sqliteTable('conversations', {
   id: text('id').primaryKey(),
@@ -58,7 +58,10 @@ export const memorySegments = sqliteTable('memory_segments', {
   contentHash: text('content_hash'),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
-});
+}, (table) => [
+  index('idx_memory_segments_scope_id').on(table.scopeId),
+  index('idx_memory_segments_conversation_id').on(table.conversationId),
+]);
 
 export const memoryItems = sqliteTable('memory_items', {
   id: text('id').primaryKey(),


### PR DESCRIPTION
Add indexes on scopeId and conversationId columns in memorySegments for faster lookups
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
