### PR TITLE
refactor: replace as unknown as with type guards

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -217,7 +217,7 @@ export class RelayConnection {
         this.handleError(parsed);
         break;
       default:
-        log.warn({ callSessionId: this.callSessionId, type: (parsed as Record<string, unknown>).type }, 'Unknown relay message type');
+        log.warn({ callSessionId: this.callSessionId, type: (parsed as { type: unknown }).type }, 'Unknown relay message type');
     }
   }
 
@@ -678,7 +678,9 @@ export class RelayConnection {
       'Caller transcript received (final)',
     );
 
-    const speakerMetadata = extractPromptSpeakerMetadata(msg as unknown as Record<string, unknown>);
+    // Spread to widen the typed message into a plain record — extractPromptSpeakerMetadata
+    // probes for snake_case and nested property variants not on RelayPromptMessage.
+    const speakerMetadata = extractPromptSpeakerMetadata({ ...msg });
     const speaker = this.speakerIdentityTracker.identifySpeaker(speakerMetadata);
 
     // Record in conversation history

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -778,9 +778,15 @@ function isAbortError(err: unknown): boolean {
  * HTTP/API clients), then falls back to looking for "status <code>" patterns
  * in the message. This avoids false positives from dimension numbers like 512.
  */
+function getErrorStatusCode(err: Error): unknown {
+  if ('status' in err) return (err as { status: unknown }).status;
+  if ('statusCode' in err) return (err as { statusCode: unknown }).statusCode;
+  return undefined;
+}
+
 function isHttpStatusError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
-  const status = (err as Record<string, unknown>).status ?? (err as Record<string, unknown>).statusCode;
+  const status = getErrorStatusCode(err);
   if (typeof status === 'number') {
     return status === 429 || (status >= 500 && status < 600);
   }

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -2,6 +2,7 @@ import { and, asc, desc, eq, lte } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { Cron } from 'croner';
 import { getDb } from '../memory/db.js';
+import { rawChanges } from '../memory/raw-query.js';
 import { scheduleJobs, scheduleRuns } from '../memory/schema.js';
 import { computeNextRunAt as computeNextRunAtEngine, isValidScheduleExpression } from './recurrence-engine.js';
 import { getLogger } from '../util/logger.js';
@@ -189,8 +190,8 @@ export function updateSchedule(
 
 export function deleteSchedule(id: string): boolean {
   const db = getDb();
-  const result = db.delete(scheduleJobs).where(eq(scheduleJobs.id, id)).run() as unknown as { changes?: number };
-  return (result.changes ?? 0) > 0;
+  db.delete(scheduleJobs).where(eq(scheduleJobs.id, id)).run();
+  return rawChanges() > 0;
 }
 
 /**
@@ -244,13 +245,13 @@ export function claimDueSchedules(now: number): ScheduleJob[] {
       updates.nextRunAt = newNextRunAt!;
     }
 
-    const result = db
+    db
       .update(scheduleJobs)
       .set(updates)
       .where(and(eq(scheduleJobs.id, row.id), eq(scheduleJobs.nextRunAt, row.nextRunAt)))
-      .run() as unknown as { changes?: number };
+      .run();
 
-    if ((result.changes ?? 0) === 0) continue;
+    if (rawChanges() === 0) continue;
 
     claimed.push(parseJobRow({
       ...row,
@@ -359,7 +360,14 @@ export function formatLocalDate(timestamp: number): string {
 export function describeCronExpression(expr: string): string {
   try {
     const cron = new Cron(expr, { maxRuns: 0 });
-    const p = (cron as unknown as { _states: { pattern: {
+    // Access Croner internal state to extract the parsed cron pattern.
+    // This is fragile but necessary — Croner doesn't expose a public API for this.
+    const cronInternal = cron as Record<string, unknown>;
+    const states = cronInternal._states;
+    if (!states || typeof states !== 'object') return expr;
+    const p = (states as Record<string, unknown>).pattern;
+    if (!p || typeof p !== 'object') return expr;
+    const pattern = p as {
       minute: number[];
       hour: number[];
       day: number[];
@@ -367,18 +375,18 @@ export function describeCronExpression(expr: string): string {
       dayOfWeek: number[];
       starDOM: boolean;
       starDOW: boolean;
-    } } })._states.pattern;
+    };
 
-    const activeMinutes = p.minute.reduce<number[]>((acc, v, i) => { if (v) acc.push(i); return acc; }, []);
-    const activeHours = p.hour.reduce<number[]>((acc, v, i) => { if (v) acc.push(i); return acc; }, []);
-    const activeDays = p.day.reduce<number[]>((acc, v, i) => { if (v) acc.push(i + 1); return acc; }, []);
-    const activeDOW = p.dayOfWeek.reduce<number[]>((acc, v, i) => { if (v) acc.push(i); return acc; }, []);
-    const activeMonths = p.month.reduce<number[]>((acc, v, i) => { if (v) acc.push(i + 1); return acc; }, []);
+    const activeMinutes = pattern.minute.reduce<number[]>((acc, v, i) => { if (v) acc.push(i); return acc; }, []);
+    const activeHours = pattern.hour.reduce<number[]>((acc, v, i) => { if (v) acc.push(i); return acc; }, []);
+    const activeDays = pattern.day.reduce<number[]>((acc, v, i) => { if (v) acc.push(i + 1); return acc; }, []);
+    const activeDOW = pattern.dayOfWeek.reduce<number[]>((acc, v, i) => { if (v) acc.push(i); return acc; }, []);
+    const activeMonths = pattern.month.reduce<number[]>((acc, v, i) => { if (v) acc.push(i + 1); return acc; }, []);
 
     const allMinutes = activeMinutes.length === 60;
     const allHours = activeHours.length === 24;
-    const allDays = p.starDOM;
-    const allDOW = p.starDOW;
+    const allDays = pattern.starDOM;
+    const allDOW = pattern.starDOW;
     const allMonths = activeMonths.length === 12;
 
     const fixedMinute = activeMinutes.length === 1;


### PR DESCRIPTION
Replace unsafe type assertions with proper type guard functions and existing utilities:

- **relay-server.ts**: Replace `msg as unknown as Record<string, unknown>` with object spread (`{ ...msg }`) to safely widen the type for extractPromptSpeakerMetadata, and narrow the default branch cast from `Record<string, unknown>` to `{ type: unknown }`.
- **schedule-store.ts**: Replace `as unknown as { changes?: number }` casts on Drizzle `.run()` return values with the existing `rawChanges()` utility from raw-query.ts (designed exactly for this purpose). Replace the single `as unknown as` for Croner internals with runtime property checks that gracefully fall back to the raw expression.
- **retriever.ts**: Replace `err as Record<string, unknown>` with a `getErrorStatusCode()` helper that uses `in` narrowing to safely access `.status`/`.statusCode` on error objects.
- **db-connection.ts** and **retriever.ts** generic casts: Left as-is — the db-connection cast is already isolated in a documented accessor function, and the generic `T` construction casts are a fundamental TypeScript limitation (no type guard applies when constructing values for generic types).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
