### PR TITLE
refactor: create centralized env var registry

### DIFF
--- a/assistant/src/config/env-registry.ts
+++ b/assistant/src/config/env-registry.ts
@@ -1,0 +1,172 @@
+/**
+ * Centralized environment variable registry.
+ *
+ * This module documents every VELLUM_* and related env var with its type,
+ * default, and description, and exports typed accessor functions for each.
+ *
+ * IMPORTANT: This module has NO internal imports (no logger, no platform
+ * utilities) so it can be safely imported from bootstrap-level code like
+ * util/platform.ts and util/logger.ts without circular dependencies.
+ *
+ * Higher-level env vars that depend on the logger or config system live in
+ * config/env.ts, which re-exports selected accessors from this module.
+ */
+
+// ── Helpers (dependency-free) ────────────────────────────────────────────────
+
+function str(name: string): string | undefined {
+  const v = process.env[name]?.trim();
+  return v || undefined;
+}
+
+function flag(name: string): boolean {
+  const raw = str(name);
+  return raw === 'true' || raw === '1';
+}
+
+function flagTriState(name: string): boolean | undefined {
+  const raw = str(name);
+  if (raw === 'true' || raw === '1') return true;
+  if (raw === 'false' || raw === '0') return false;
+  return undefined;
+}
+
+function int(name: string, fallback: number): number;
+function int(name: string): number | undefined;
+function int(name: string, fallback?: number): number | undefined {
+  const raw = str(name);
+  if (!raw) return fallback;
+  const n = parseInt(raw, 10);
+  if (isNaN(n)) return fallback;
+  return n;
+}
+
+// ── Registry ─────────────────────────────────────────────────────────────────
+// Each entry documents the env var name, type, default, and purpose.
+
+/**
+ * BASE_DATA_DIR — string, default: os.homedir()
+ * Overrides the home directory used as the base for ~/.vellum and lockfiles.
+ * Primarily used in tests to isolate filesystem state.
+ */
+export function getBaseDataDir(): string | undefined {
+  return str('BASE_DATA_DIR');
+}
+
+/**
+ * VELLUM_DAEMON_SOCKET — string, default: ~/.vellum/vellum.sock
+ * Overrides the Unix domain socket path for daemon IPC.
+ * Supports ~ expansion.
+ */
+export function getDaemonSocket(): string | undefined {
+  return str('VELLUM_DAEMON_SOCKET');
+}
+
+/**
+ * VELLUM_DAEMON_TCP_PORT — number, default: 8765
+ * TCP port for the daemon's TCP listener (used by iOS clients).
+ */
+export function getDaemonTcpPort(): number {
+  const raw = str('VELLUM_DAEMON_TCP_PORT');
+  if (raw) {
+    const port = parseInt(raw, 10);
+    if (!isNaN(port) && port > 0 && port <= 65535) return port;
+  }
+  return 8765;
+}
+
+/**
+ * VELLUM_DAEMON_TCP_ENABLED — boolean tri-state, default: undefined (falls back to flag file)
+ * Whether the daemon TCP listener should be active.
+ * 'true'/'1' → on, 'false'/'0' → off, unset → check flag file.
+ */
+export function getDaemonTcpEnabled(): boolean | undefined {
+  return flagTriState('VELLUM_DAEMON_TCP_ENABLED');
+}
+
+/**
+ * VELLUM_DAEMON_TCP_HOST — string, default: context-dependent (127.0.0.1 or 0.0.0.0)
+ * Hostname/address for the TCP listener. When unset, platform.ts resolves
+ * based on whether iOS pairing is enabled.
+ */
+export function getDaemonTcpHost(): string | undefined {
+  return str('VELLUM_DAEMON_TCP_HOST');
+}
+
+/**
+ * VELLUM_DAEMON_IOS_PAIRING — boolean tri-state, default: undefined (falls back to flag file)
+ * Whether iOS pairing mode is enabled. When on, TCP binds to 0.0.0.0.
+ * 'true'/'1' → on, 'false'/'0' → off, unset → check flag file.
+ */
+export function getDaemonIosPairing(): boolean | undefined {
+  return flagTriState('VELLUM_DAEMON_IOS_PAIRING');
+}
+
+/**
+ * VELLUM_DEBUG — boolean, default: false
+ * Enables debug-level logging and verbose output.
+ */
+export function getDebugMode(): boolean {
+  return flag('VELLUM_DEBUG');
+}
+
+/**
+ * VELLUM_LOG_STDERR — boolean, default: false
+ * Forces logger output to stderr instead of log files.
+ */
+export function getLogStderr(): boolean {
+  return flag('VELLUM_LOG_STDERR');
+}
+
+/**
+ * DEBUG_STDOUT_LOGS — boolean, default: false
+ * Enables additional log output to stdout (alongside file logging).
+ */
+export function getDebugStdoutLogs(): boolean {
+  return flag('DEBUG_STDOUT_LOGS');
+}
+
+/**
+ * VELLUM_ENABLE_MONITORING — boolean, default: false
+ * Enables monitoring/telemetry (Logfire, etc.).
+ */
+export function getEnableMonitoring(): boolean {
+  return flag('VELLUM_ENABLE_MONITORING');
+}
+
+// ── Known env var names ──────────────────────────────────────────────────────
+
+/**
+ * Complete set of recognized VELLUM_* env var names. Used by validateEnvVars()
+ * to warn about typos or unrecognized variables.
+ */
+const KNOWN_VELLUM_VARS = new Set([
+  'VELLUM_DAEMON_SOCKET',
+  'VELLUM_DAEMON_TCP_PORT',
+  'VELLUM_DAEMON_TCP_ENABLED',
+  'VELLUM_DAEMON_TCP_HOST',
+  'VELLUM_DAEMON_IOS_PAIRING',
+  'VELLUM_DEBUG',
+  'VELLUM_LOG_STDERR',
+  'VELLUM_ENABLE_MONITORING',
+  'VELLUM_HOOK_EVENT',
+  'VELLUM_HOOK_NAME',
+]);
+
+/**
+ * Check all VELLUM_* env vars and return warnings for any unrecognized ones.
+ * Returns an array of warning messages (empty if all vars are recognized).
+ *
+ * This is intentionally a pure function that returns strings rather than
+ * logging directly, so it can be called from bootstrap code before the
+ * logger is initialized.
+ */
+export function checkUnrecognizedEnvVars(): string[] {
+  const warnings: string[] = [];
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith('VELLUM_') && !KNOWN_VELLUM_VARS.has(key)) {
+      warnings.push(`Unrecognized environment variable: ${key}`);
+    }
+  }
+  return warnings;
+}

--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -8,14 +8,14 @@
  * - Fail-fast validation via validateEnv() at startup
  * - Shared derived values (e.g. gateway base URL) instead of duplicated logic
  *
- * Variables NOT centralized here (must resolve before this module loads):
- * - BASE_DATA_DIR, VELLUM_DAEMON_* — bootstrap/platform layer (util/platform.ts)
- * - VELLUM_DEBUG, BUN_TEST, NODE_ENV log flags — logger init (util/logger.ts)
- * - APP_VERSION — compile-time embedding (version.ts)
- * - __EVAL_INPUT_JSON, __SKILL_*_JSON — internal sandbox IPC
+ * Bootstrap-level env vars (BASE_DATA_DIR, VELLUM_DAEMON_*, VELLUM_DEBUG,
+ * VELLUM_LOG_STDERR, DEBUG_STDOUT_LOGS) are defined in config/env-registry.ts
+ * which has no internal dependencies and can be imported from platform/logger
+ * without circular imports.
  */
 
 import { getLogger } from '../util/logger.js';
+import { getEnableMonitoring, checkUnrecognizedEnvVars } from './env-registry.js';
 
 const log = getLogger('env');
 
@@ -134,7 +134,7 @@ export function getLogfireToken(): string | undefined {
 }
 
 export function isMonitoringEnabled(): boolean {
-  return flag('VELLUM_ENABLE_MONITORING');
+  return getEnableMonitoring();
 }
 
 export function getSentryDsn(): string | undefined {
@@ -173,5 +173,9 @@ export function validateEnv(): void {
 
   if (getTwilioWssBaseUrl()) {
     log.warn('TWILIO_WSS_BASE_URL env var is deprecated. Relay URL is now derived from ingress.publicBaseUrl.');
+  }
+
+  for (const warning of checkUnrecognizedEnvVars()) {
+    log.warn(warning);
   }
 }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -19,6 +19,7 @@ import {
   isHttpAuthDisabled,
   getRuntimeGatewayOriginSecret,
 } from '../config/env.js';
+import { getBaseDataDir } from '../config/env-registry.js';
 import { TwilioConversationRelayProvider } from '../calls/twilio-provider.js';
 import { loadConfig } from '../config/loader.js';
 import { getPublicBaseUrl } from '../inbound/public-ingress-urls.js';
@@ -169,7 +170,7 @@ interface DiskSpaceInfo {
 
 function getDiskSpaceInfo(): DiskSpaceInfo | null {
   try {
-    const baseDataDir = process.env.BASE_DATA_DIR?.trim();
+    const baseDataDir = getBaseDataDir();
     const diskPath = baseDataDir && existsSync(baseDataDir) ? baseDataDir : '/';
     const stats = statfsSync(diskPath);
     const totalBytes = stats.bsize * stats.blocks;

--- a/assistant/src/util/logger.ts
+++ b/assistant/src/util/logger.ts
@@ -5,6 +5,7 @@ import pino from 'pino';
 import pinoPretty from 'pino-pretty';
 import { logSerializers } from './log-redact.js';
 import { getLogPath } from './platform.js';
+import { getDebugMode, getLogStderr, getDebugStdoutLogs } from '../config/env-registry.js';
 
 export type LogFileConfig = {
   dir: string | undefined;
@@ -70,9 +71,9 @@ function buildRotatingLogger(config: LogFileConfig): pino.Logger {
   activeLogDate = today;
   activeLogFileConfig = config;
 
-  const level = process.env.VELLUM_DEBUG === '1' ? 'debug' : 'info';
+  const level = getDebugMode() ? 'debug' : 'info';
 
-  if (process.env.VELLUM_DEBUG === '1') {
+  if (getDebugMode()) {
     const prettyStream = pinoPretty({ destination: 2 });
     return pino(
       { name: 'assistant', level, serializers: logSerializers },
@@ -119,10 +120,10 @@ function getRootLogger(): pino.Logger {
     const forceStderr =
       process.env.BUN_TEST === '1'
       || process.env.NODE_ENV === 'test'
-      || process.env.VELLUM_LOG_STDERR === '1';
+      || getLogStderr();
     if (forceStderr) {
       rootLogger = pino(
-        { level: process.env.VELLUM_DEBUG === '1' ? 'debug' : 'info', serializers: logSerializers },
+        { level: getDebugMode() ? 'debug' : 'info', serializers: logSerializers },
         pino.destination(2),
       );
       return rootLogger;
@@ -131,14 +132,14 @@ function getRootLogger(): pino.Logger {
     try {
       const fileStream = pino.destination({ dest: getLogPath(), sync: false, mkdir: true });
 
-      if (process.env.VELLUM_DEBUG === '1') {
+      if (getDebugMode()) {
         const prettyStream = pinoPretty({ destination: 2 });
         const multi = pino.multistream([
           { stream: fileStream, level: 'info' as const },
           { stream: prettyStream, level: 'debug' as const },
         ]);
         rootLogger = pino({ level: 'debug', serializers: logSerializers }, multi);
-      } else if (process.env.DEBUG_STDOUT_LOGS === '1') {
+      } else if (getDebugStdoutLogs()) {
         rootLogger = pino(
           { level: 'info', serializers: logSerializers },
           pino.multistream([
@@ -150,7 +151,7 @@ function getRootLogger(): pino.Logger {
         rootLogger = pino({ level: 'info', serializers: logSerializers }, fileStream);
       }
     } catch {
-      rootLogger = pino({ level: process.env.VELLUM_DEBUG === '1' ? 'debug' : 'info', serializers: logSerializers }, pinoPretty({ destination: 2 }));
+      rootLogger = pino({ level: getDebugMode() ? 'debug' : 'info', serializers: logSerializers }, pinoPretty({ destination: 2 }));
     }
   }
   return rootLogger;
@@ -158,7 +159,7 @@ function getRootLogger(): pino.Logger {
 
 /** Returns true when VELLUM_DEBUG=1 is set. */
 export function isDebug(): boolean {
-  return process.env.VELLUM_DEBUG === '1';
+  return getDebugMode();
 }
 
 /**

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -2,6 +2,14 @@ import { mkdirSync, existsSync, statSync, unlinkSync, renameSync, readFileSync, 
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { isPlainObject } from './object.js';
+import {
+  getBaseDataDir,
+  getDaemonSocket,
+  getDaemonTcpPort,
+  getDaemonTcpEnabled,
+  getDaemonTcpHost,
+  getDaemonIosPairing,
+} from '../config/env-registry.js';
 /**
  * Stderr-only logger for migration code. Using the pino logger during
  * migration is unsafe because pino initialization calls ensureDataDir(),
@@ -53,7 +61,7 @@ export function getClipboardCommand(): string | null {
  * Returns null if neither file exists or both are malformed.
  */
 export function readLockfile(): Record<string, unknown> | null {
-  const base = process.env.BASE_DATA_DIR?.trim() || homedir();
+  const base = getBaseDataDir() || homedir();
   const candidates = [
     join(base, '.vellum.lock.json'),
     join(base, '.vellum.lockfile.json'),
@@ -105,7 +113,7 @@ export function normalizeAssistantId(assistantId: string): string {
  * Respects BASE_DATA_DIR for non-standard home directories.
  */
 export function writeLockfile(data: Record<string, unknown>): void {
-  const base = process.env.BASE_DATA_DIR?.trim() || homedir();
+  const base = getBaseDataDir() || homedir();
   writeFileSync(join(base, '.vellum.lock.json'), JSON.stringify(data, null, 2) + '\n');
 }
 
@@ -114,7 +122,7 @@ export function writeLockfile(data: Record<string, unknown>): void {
  * files, skills) and runtime files (socket, PID) live here.
  */
 export function getRootDir(): string {
-  return join(process.env.BASE_DATA_DIR?.trim() || homedir(), '.vellum');
+  return join(getBaseDataDir() || homedir(), '.vellum');
 }
 
 /**
@@ -155,7 +163,7 @@ export function getInterfacesDir(): string {
 }
 
 export function getSocketPath(): string {
-  const override = process.env.VELLUM_DAEMON_SOCKET?.trim();
+  const override = getDaemonSocket();
   if (override) {
     return expandHomePath(override);
   }
@@ -171,12 +179,7 @@ export function getSessionTokenPath(): string {
  * Reads VELLUM_DAEMON_TCP_PORT env var; defaults to 8765.
  */
 export function getTCPPort(): number {
-  const override = process.env.VELLUM_DAEMON_TCP_PORT?.trim();
-  if (override) {
-    const port = parseInt(override, 10);
-    if (!isNaN(port) && port > 0 && port <= 65535) return port;
-  }
-  return 8765;
+  return getDaemonTcpPort();
 }
 
 /**
@@ -191,9 +194,8 @@ export function getTCPPort(): number {
  * The macOS CLI (AssistantCli) also sets the env var for bundled-binary deployments.
  */
 export function isTCPEnabled(): boolean {
-  const override = process.env.VELLUM_DAEMON_TCP_ENABLED?.trim();
-  if (override === 'true' || override === '1') return true;
-  if (override === 'false' || override === '0') return false;
+  const envValue = getDaemonTcpEnabled();
+  if (envValue !== undefined) return envValue;
   return existsSync(join(getRootDir(), 'tcp-enabled'));
 }
 
@@ -205,7 +207,7 @@ export function isTCPEnabled(): boolean {
  *   3. Default: '127.0.0.1' (localhost only)
  */
 export function getTCPHost(): string {
-  const override = process.env.VELLUM_DAEMON_TCP_HOST?.trim();
+  const override = getDaemonTcpHost();
   if (override) return override;
   if (isIOSPairingEnabled()) return '0.0.0.0';
   return '127.0.0.1';
@@ -226,9 +228,8 @@ export function getTCPHost(): string {
  * access without exposing the daemon to the LAN.
  */
 export function isIOSPairingEnabled(): boolean {
-  const override = process.env.VELLUM_DAEMON_IOS_PAIRING?.trim();
-  if (override === 'true' || override === '1') return true;
-  if (override === 'false' || override === '0') return false;
+  const envValue = getDaemonIosPairing();
+  if (envValue !== undefined) return envValue;
   return existsSync(join(getRootDir(), 'ios-pairing-enabled'));
 }
 


### PR DESCRIPTION
Create config/env-registry.ts with typed accessors for all VELLUM_* and bootstrap-level env vars (BASE_DATA_DIR, VELLUM_DAEMON_*, VELLUM_DEBUG, VELLUM_LOG_STDERR, DEBUG_STDOUT_LOGS). Migrate scattered process.env reads in util/platform.ts, util/logger.ts, and runtime/http-server.ts to use the registry. Add unrecognized VELLUM_* env var warnings at startup via validateEnv().
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
