### PR TITLE
Fix: Scope run abort handles to originating run

### DIFF
--- a/assistant/src/__tests__/run-orchestrator.test.ts
+++ b/assistant/src/__tests__/run-orchestrator.test.ts
@@ -610,7 +610,11 @@ describe('run abort', () => {
     const conversation = createConversation('abort handle test');
     const session = {
       isProcessing: () => false,
-      persistUserMessage: () => undefined as unknown as string,
+      currentRequestId: undefined as string | undefined,
+      persistUserMessage: (_c: string, _a: unknown[], reqId: string) => {
+        session.currentRequestId = reqId;
+        return undefined as unknown as string;
+      },
       memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
       setChannelCapabilities: () => {},
       setAssistantId: () => {},
@@ -640,7 +644,11 @@ describe('run abort', () => {
 
     const session = {
       isProcessing: () => false,
-      persistUserMessage: () => undefined as unknown as string,
+      currentRequestId: undefined as string | undefined,
+      persistUserMessage: (_c: string, _a: unknown[], reqId: string) => {
+        session.currentRequestId = reqId;
+        return undefined as unknown as string;
+      },
       memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
       setChannelCapabilities: () => {},
       setAssistantId: () => {},
@@ -664,7 +672,7 @@ describe('run abort', () => {
 
     const handle = await orchestrator.startRun(conversation.id, 'Hello');
 
-    // Abort immediately
+    // Abort immediately — session still has same requestId
     handle.abort();
     expect(abortCalled).toBe(true);
 
@@ -675,5 +683,86 @@ describe('run abort', () => {
     // since the mock runAgentLoop resolves after 200ms regardless.
     const stored = orchestrator.getRun(handle.run.id);
     expect(stored).not.toBeNull();
+  });
+
+  test('stale abort handle is a no-op when session has moved to a new run', async () => {
+    const conversation = createConversation('stale abort test');
+    let abortCalled = false;
+
+    const session = {
+      isProcessing: () => false,
+      currentRequestId: undefined as string | undefined,
+      persistUserMessage: (_c: string, _a: unknown[], reqId: string) => {
+        session.currentRequestId = reqId;
+        return undefined as unknown as string;
+      },
+      memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
+      setChannelCapabilities: () => {},
+      setAssistantId: () => {},
+      setGuardianContext: () => {},
+      setCommandIntent: () => {},
+      setTurnChannelContext: () => {},
+      updateClient: () => {},
+      runAgentLoop: async () => {},
+      handleConfirmationResponse: () => {},
+      abort: () => { abortCalled = true; },
+    } as unknown as Session;
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
+    });
+
+    // Start first run and capture its handle
+    const handle1 = await orchestrator.startRun(conversation.id, 'First turn');
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Start second run — session's currentRequestId now belongs to run 2
+    const _handle2 = await orchestrator.startRun(conversation.id, 'Second turn');
+
+    // Attempt to abort using the stale handle from run 1.
+    // Since the session has moved to a new requestId, this should be a no-op.
+    handle1.abort();
+    expect(abortCalled).toBe(false);
+  });
+
+  test('abort works when session still has matching requestId', async () => {
+    const conversation = createConversation('matching abort test');
+    let abortCalled = false;
+
+    const session = {
+      isProcessing: () => false,
+      currentRequestId: undefined as string | undefined,
+      persistUserMessage: (_c: string, _a: unknown[], reqId: string) => {
+        session.currentRequestId = reqId;
+        return undefined as unknown as string;
+      },
+      memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
+      setChannelCapabilities: () => {},
+      setAssistantId: () => {},
+      setGuardianContext: () => {},
+      setCommandIntent: () => {},
+      setTurnChannelContext: () => {},
+      updateClient: () => {},
+      runAgentLoop: async () => {
+        // Keep the agent loop running so the session stays on this requestId
+        await new Promise((r) => setTimeout(r, 500));
+      },
+      handleConfirmationResponse: () => {},
+      abort: () => { abortCalled = true; },
+    } as unknown as Session;
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
+    });
+
+    const handle = await orchestrator.startRun(conversation.id, 'Hello');
+
+    // Abort while the session is still processing this run
+    handle.abort();
+    expect(abortCalled).toBe(true);
   });
 });

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -338,7 +338,15 @@ export class RunOrchestrator {
 
     return {
       run,
-      abort: () => session.abort(),
+      // Scope the abort to this specific run by capturing the requestId.
+      // If the session has moved on to a new turn (different currentRequestId),
+      // this abort is stale and becomes a no-op — preventing voice barge-in
+      // from cancelling unrelated turns.
+      abort: () => {
+        if (session.currentRequestId === requestId) {
+          session.abort();
+        }
+      },
     };
   }
 


### PR DESCRIPTION
Addresses feedback on #8222. The abort function returned by startRun() now captures the run's request ID and verifies the session is still processing that run before aborting. Stale abort handles become no-ops, preventing voice barge-in from cancelling unrelated turns.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
