### PR TITLE
fix: remove iosPairingUseOverride deletion from v4 migration

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -184,7 +184,6 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
         // Clear dev pairing keys
         defaults.removeObject(forKey: "devLocalPairingEnabled")
-        defaults.removeObject(forKey: "iosPairingUseOverride")
 
         // Mark migration as done
         defaults.set(true, forKey: Self.pairingV4MigrationKey)


### PR DESCRIPTION
Removes the iosPairingUseOverride key deletion from migrateToPairingV4IfNeeded() so that migratePairingOverridesIfNeeded() can read it. Without this fix, users who haven't yet completed the v4 migration would have the key deleted before the override migration could check it. Addresses feedback from PR #8225.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
