### PR TITLE
fix: remove Porcupine iOS-only SPM dep that breaks Xcode 26.2 build

### DIFF
--- a/clients/Package.resolved
+++ b/clients/Package.resolved
@@ -1,24 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "ios-voice-processor",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Picovoice/ios-voice-processor.git",
-      "state" : {
-        "revision" : "083c02aed9a890400d647fd357f8a505bf672f58",
-        "version" : "1.2.0"
-      }
-    },
-    {
-      "identity" : "porcupine",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Picovoice/porcupine",
-      "state" : {
-        "revision" : "08829fb824adee8aec1eb96c235c59f6cabc144a",
-        "version" : "3.0.4"
-      }
-    },
-    {
       "identity" : "sparkle",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",

--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -26,7 +26,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.0.0"),
-        .package(url: "https://github.com/Picovoice/porcupine", from: "3.0.0"),
+        // Porcupine removed — iOS-only SPM package breaks on Xcode 26.2.
+        // TODO: Re-add via C SDK wrapper (lib/mac/) for macOS wake word support.
     ],
     targets: [
         .target(
@@ -49,7 +50,7 @@ let package = Package(
             dependencies: [
                 "VellumAssistantShared",
                 "Sparkle",
-                .product(name: "Porcupine", package: "porcupine"),
+                // Porcupine dep removed — stub engine doesn't need it
             ],
             path: "macos/vellum-assistant",
             exclude: ["Resources/Info.plist", "Resources/bg.png"],

--- a/clients/macos/vellum-assistant/Features/Settings/WakeWordSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WakeWordSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import VellumAssistantShared
 
 /// Wake word settings tab — enable/disable wake word listening,
 /// configure Picovoice access key, sensitivity, and conversation timeout.

--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/PorcupineWakeWordEngine.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/PorcupineWakeWordEngine.swift
@@ -35,7 +35,7 @@ final class PorcupineWakeWordEngine: WakeWordEngine {
     }
 
     /// Feed a buffer of 16-bit PCM audio samples for wake word detection.
-    func process(pcm: [Int16]) {
+    func processAudioFrame(_ frame: [Int16]) {
         // Stub — real implementation will call Porcupine's process() here
     }
 }

--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import VellumAssistantShared
 import os
 
 private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "WakeWordCoordinator")
@@ -77,7 +78,7 @@ final class WakeWordCoordinator: ObservableObject {
 
         // Ignore if voice mode is already active
         guard voiceModeManager.state == .off else {
-            log.info("Wake word ignored — voice mode already active (state: \(String(describing: voiceModeManager.state)))")
+            log.info("Wake word ignored — voice mode already active (state: \(String(describing: self.voiceModeManager.state)))")
             return
         }
 


### PR DESCRIPTION
## Summary
- Remove Porcupine SPM dependency — it's iOS-only and its transitive `ios-voice-processor` dep uses `AVAudioSession` which is unavailable on macOS. Xcode 26.2 is now strict about platform availability.
- Fix missing `import VellumAssistantShared` in `WakeWordSettingsView` and `WakeWordCoordinator`
- Fix stale protocol conformance in `PorcupineWakeWordEngine` (`process(pcm:)` → `processAudioFrame(_:)`)
- Fix missing `self.` in closure in `WakeWordCoordinator`

The wake word engine remains a stub. Follow-up: integrate Porcupine via its C SDK (`lib/mac/`) instead of the iOS SPM package.

## Test plan
- [x] `./build.sh` succeeds on Xcode 26.2
- [ ] App launches and runs normally
- [ ] Wake word settings tab renders without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
