### PR TITLE
refactor: remove excessive any usage in test files

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -1,7 +1,6 @@
 // Smoke command (run all security test files together):
 // bun test src/__tests__/checker.test.ts src/__tests__/trust-store.test.ts src/__tests__/session-skill-tools.test.ts src/__tests__/skill-script-runner-host.test.ts
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, test, expect, beforeAll, beforeEach, afterEach, mock } from 'bun:test';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, symlinkSync, realpathSync } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
@@ -39,9 +38,16 @@ mock.module('../util/logger.js', () => ({
 
 // Mutable config object so tests can switch permissions.mode between
 // 'legacy', 'strict', and 'workspace' without re-registering the mock.
-const testConfig: Record<string, any> = {
-  permissions: { mode: 'legacy' as 'legacy' | 'strict' | 'workspace' },
-  skills: { load: { extraDirs: [] as string[] } },
+interface TestConfig {
+  permissions: { mode: 'legacy' | 'strict' | 'workspace' };
+  skills: { load: { extraDirs: string[] } };
+  sandbox: { enabled: boolean };
+  [key: string]: unknown;
+}
+
+const testConfig: TestConfig = {
+  permissions: { mode: 'legacy' },
+  skills: { load: { extraDirs: [] } },
   sandbox: { enabled: true },
 };
 
@@ -58,6 +64,7 @@ mock.module('../config/loader.js', () => ({
 
 import { classifyRisk, check, generateAllowlistOptions, generateScopeOptions, _resetLegacyDeprecationWarning } from '../permissions/checker.js';
 import { RiskLevel } from '../permissions/types.js';
+import type { TrustRule } from '../permissions/types.js';
 import { addRule, clearCache, findHighestPriorityRule } from '../permissions/trust-store.js';
 import { getDefaultRuleTemplates } from '../permissions/defaults.js';
 import { registerTool, getTool } from '../tools/registry.js';
@@ -2353,13 +2360,13 @@ describe('Permission Checker', () => {
       const trustDir = dirnameFn(trustPath);
       if (!existsSync(trustDir)) mkdirSyncFs(trustDir, { recursive: true });
 
-      let currentRules: any[] = [];
+      let currentRules: TrustRule[] = [];
       try {
         const raw = readFileSync(trustPath, 'utf-8');
         currentRules = JSON.parse(raw).rules ?? [];
       } catch { /* first run */ }
 
-      currentRules = currentRules.filter((r: any) => r.id !== opts.id);
+      currentRules = currentRules.filter((r: TrustRule) => r.id !== opts.id);
       currentRules.push({
         ...opts,
         createdAt: Date.now(),
@@ -2486,7 +2493,7 @@ describe('Permission Checker', () => {
         // Write the executionTarget field directly (addVersionBoundRule doesn't support it)
         const trustPath = join(checkerTestDir, 'protected', 'trust.json');
         const raw = JSON.parse((await import('node:fs')).readFileSync(trustPath, 'utf-8'));
-        const rule = raw.rules.find((r: any) => r.id === 'inv4-target-scoped');
+        const rule = raw.rules.find((r: TrustRule) => r.id === 'inv4-target-scoped');
         rule.executionTarget = '/usr/local/bin/node';
         (await import('node:fs')).writeFileSync(trustPath, JSON.stringify(raw, null, 2));
         clearCache();

--- a/assistant/src/__tests__/terminal-tools.test.ts
+++ b/assistant/src/__tests__/terminal-tools.test.ts
@@ -1,8 +1,10 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { mkdtempSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { Tool } from '../tools/types.js';
+import type { SandboxBackend } from '../tools/terminal/backends/types.js';
+import type { ShellOutputResult } from '../tools/shared/shell-output.js';
 
 // ── Mock modules ────────────────────────────────────────────────────────────
 
@@ -502,7 +504,7 @@ describe('wrapCommand', () => {
 describe('Native sandbox backend', () => {
   // We test NativeBackend directly rather than through wrapCommand to avoid
   // platform-dependent sandbox-exec/bwrap availability.
-  let NativeBackend: any;
+  let NativeBackend: new () => SandboxBackend;
 
   beforeEach(async () => {
     const mod = await import('../tools/terminal/backends/native.js');
@@ -546,8 +548,8 @@ describe('Native sandbox backend', () => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe('Docker sandbox backend', () => {
-  let DockerBackend: any;
-  let _resetDockerChecks: any;
+  let DockerBackend: new (sandboxRoot: string, config?: Record<string, unknown>, uid?: number, gid?: number) => SandboxBackend;
+  let _resetDockerChecks: () => void;
 
   const sandboxDir = join(testTmpDir, 'docker-sandbox');
 
@@ -628,7 +630,7 @@ describe('Docker sandbox backend', () => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe('Shell tool input validation', () => {
-  let shellTool: any;
+  let shellTool: Tool;
 
   beforeEach(async () => {
     const mod = await import('../tools/terminal/shell.js');
@@ -715,7 +717,7 @@ describe('Shell tool input validation', () => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe('formatShellOutput', () => {
-  let formatShellOutput: any;
+  let formatShellOutput: (stdout: string, stderr: string, code: number | null, timedOut: boolean, timeoutSec: number) => ShellOutputResult;
 
   beforeEach(async () => {
     const mod = await import('../tools/shared/shell-output.js');
@@ -775,7 +777,7 @@ describe('formatShellOutput', () => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe('EvaluateTypescriptTool input validation', () => {
-  let evalTool: any;
+  let evalTool: Tool;
 
   beforeEach(async () => {
     const mod = await import('../tools/terminal/evaluate-typescript.js');

--- a/assistant/src/__tests__/tool-executor-shell-integration.test.ts
+++ b/assistant/src/__tests__/tool-executor-shell-integration.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * Integration tests: ToolExecutor → real checker.js → real shell-identity → real tree-sitter parser.
  *
@@ -10,6 +9,7 @@
  */
 import { describe, test, expect, beforeAll, mock } from 'bun:test';
 import type { ToolContext } from '../tools/types.js';
+import type { AllowlistOption, ScopeOption } from '../permissions/types.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
 
 // ── Config mock ──────────────────────────────────────────────────────
@@ -133,16 +133,16 @@ function makeContext(overrides?: Partial<ToolContext>): ToolContext {
  * passed to the prompter by the executor, then allows the tool.
  */
 function makeCapturingPrompter() {
-  let capturedAllowlist: any[] | undefined;
-  let capturedScopes: any[] | undefined;
+  let capturedAllowlist: AllowlistOption[] | undefined;
+  let capturedScopes: ScopeOption[] | undefined;
 
   const prompter = {
     prompt: async (
       _toolName: string,
       _input: Record<string, unknown>,
       _riskLevel: string,
-      allowlistOptions: any[],
-      scopeOptions: any[],
+      allowlistOptions: AllowlistOption[],
+      scopeOptions: ScopeOption[],
     ) => {
       capturedAllowlist = allowlistOptions;
       capturedScopes = scopeOptions;
@@ -177,7 +177,7 @@ describe('ToolExecutor → real shell allowlist integration', () => {
     expect(allowlist).toBeDefined();
     expect(allowlist!.length).toBeGreaterThan(1);
 
-    const patterns = allowlist!.map((o: any) => o.pattern);
+    const patterns = allowlist!.map((o: AllowlistOption) => o.pattern);
 
     // Should contain the exact command
     expect(patterns).toContain('npm install express');
@@ -197,8 +197,8 @@ describe('ToolExecutor → real shell allowlist integration', () => {
     const scopes = getScopes();
     expect(scopes).toBeDefined();
     expect(scopes!.length).toBeGreaterThanOrEqual(2);
-    expect(scopes!.some((s: any) => s.scope === '/tmp/project')).toBe(true);
-    expect(scopes!.some((s: any) => s.scope === 'everywhere')).toBe(true);
+    expect(scopes!.some((s: ScopeOption) => s.scope === '/tmp/project')).toBe(true);
+    expect(scopes!.some((s: ScopeOption) => s.scope === 'everywhere')).toBe(true);
   });
 
   test('compound command produces only exact compound option (no action keys)', async () => {
@@ -226,7 +226,7 @@ describe('ToolExecutor → real shell allowlist integration', () => {
     expect(allowlist).toBeDefined();
     expect(allowlist!.length).toBeGreaterThan(1);
 
-    const patterns = allowlist!.map((o: any) => o.pattern);
+    const patterns = allowlist!.map((o: AllowlistOption) => o.pattern);
 
     // Should contain the full original command as the exact option
     expect(patterns).toContain('cd /repo && gh pr view 123');
@@ -250,7 +250,7 @@ describe('ToolExecutor → real shell allowlist integration', () => {
     expect(scopes).toBeDefined();
     expect(scopes!.length).toBeGreaterThanOrEqual(2);
 
-    const scopeValues = scopes!.map((s: any) => s.scope);
+    const scopeValues = scopes!.map((s: ScopeOption) => s.scope);
 
     // Project-scoped option
     expect(scopeValues).toContain('/Users/test/my-project');
@@ -276,7 +276,7 @@ describe('ToolExecutor → real shell allowlist integration', () => {
     expect(allowlist).toBeDefined();
     expect(allowlist!.length).toBeGreaterThan(1);
 
-    const patterns = allowlist!.map((o: any) => o.pattern);
+    const patterns = allowlist!.map((o: AllowlistOption) => o.pattern);
 
     // Should contain exact command and action keys
     expect(patterns).toContain('git status');

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -1,8 +1,7 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, test, expect, beforeEach, afterEach, afterAll, mock, spyOn } from 'bun:test';
-import type { ToolExecutionResult, Tool } from '../tools/types.js';
+import type { ToolExecutionResult, Tool, ToolLifecycleEvent, ToolPermissionPromptEvent } from '../tools/types.js';
 import { RiskLevel } from '../permissions/types.js';
-import type { PolicyContext } from '../permissions/types.js';
+import type { AllowlistOption, ScopeOption, PolicyContext, TrustRule } from '../permissions/types.js';
 
 const mockConfig = {
   provider: 'anthropic',
@@ -322,8 +321,8 @@ describe('ToolExecutor contextual rule creation', () => {
 
   function setupAddRuleSpy() {
     addRuleSpy = spyOn(trustStore, 'addRule').mockImplementation(
-      (tool: string, pattern: string, scope: string, decision = 'allow', priority = 100, options?: any) => {
-        return { id: 'spy-rule-id', tool, pattern, scope, decision, priority, createdAt: Date.now(), ...options } as any;
+      (tool: string, pattern: string, scope: string, decision = 'allow', priority = 100, options?: { allowHighRisk?: boolean; executionTarget?: string }) => {
+        return { id: 'spy-rule-id', tool, pattern, scope, decision, priority, createdAt: Date.now(), ...options } as TrustRule;
       },
     );
     return addRuleSpy;
@@ -508,8 +507,8 @@ describe('ToolExecutor strict mode + high-risk integration (PR 25)', () => {
 
   function setupAddRuleSpy() {
     addRuleSpy = spyOn(trustStore, 'addRule').mockImplementation(
-      (tool: string, pattern: string, scope: string, decision = 'allow', priority = 100, options?: any) => {
-        return { id: 'spy-rule-id', tool, pattern, scope, decision, priority, createdAt: Date.now(), ...options } as any;
+      (tool: string, pattern: string, scope: string, decision = 'allow', priority = 100, options?: { allowHighRisk?: boolean; executionTarget?: string }) => {
+        return { id: 'spy-rule-id', tool, pattern, scope, decision, priority, createdAt: Date.now(), ...options } as TrustRule;
       },
     );
     return addRuleSpy;
@@ -1481,8 +1480,8 @@ describe('ToolExecutor persistentDecisionsAllowed contract', () => {
 
   function setupAddRuleSpy() {
     addRuleSpy = spyOn(trustStore, 'addRule').mockImplementation(
-      (tool: string, pattern: string, scope: string, decision = 'allow', priority = 100, options?: any) => {
-        return { id: 'spy-rule-id', tool, pattern, scope, decision, priority, createdAt: Date.now(), ...options } as any;
+      (tool: string, pattern: string, scope: string, decision = 'allow', priority = 100, options?: { allowHighRisk?: boolean; executionTarget?: string }) => {
+        return { id: 'spy-rule-id', tool, pattern, scope, decision, priority, createdAt: Date.now(), ...options } as TrustRule;
       },
     );
     return addRuleSpy;
@@ -1534,14 +1533,14 @@ describe('ToolExecutor persistentDecisionsAllowed contract', () => {
   });
 
   test('persistentDecisionsAllowed: false is emitted in lifecycle event for proxied bash', async () => {
-    let capturedEvent: any;
+    let capturedEvent: ToolPermissionPromptEvent | undefined;
     const prompter = makePrompterWithDecision('allow');
     const executor = new ToolExecutor(prompter);
     const result = await executor.execute(
       'bash',
       { command: 'curl https://example.com', network_mode: 'proxied' },
       makeContext({
-        onToolLifecycleEvent: (event: any) => {
+        onToolLifecycleEvent: (event: ToolLifecycleEvent) => {
           if (event.type === 'permission_prompt') {
             capturedEvent = event;
           }
@@ -1551,18 +1550,18 @@ describe('ToolExecutor persistentDecisionsAllowed contract', () => {
 
     expect(result.isError).toBe(false);
     expect(capturedEvent).toBeDefined();
-    expect(capturedEvent.persistentDecisionsAllowed).toBe(false);
+    expect(capturedEvent!.persistentDecisionsAllowed).toBe(false);
   });
 
   test('persistentDecisionsAllowed: true is emitted in lifecycle event for non-proxied bash', async () => {
-    let capturedEvent: any;
+    let capturedEvent: ToolPermissionPromptEvent | undefined;
     const prompter = makePrompterWithDecision('allow');
     const executor = new ToolExecutor(prompter);
     const result = await executor.execute(
       'bash',
       { command: 'echo hello' },
       makeContext({
-        onToolLifecycleEvent: (event: any) => {
+        onToolLifecycleEvent: (event: ToolLifecycleEvent) => {
           if (event.type === 'permission_prompt') {
             capturedEvent = event;
           }
@@ -1572,7 +1571,7 @@ describe('ToolExecutor persistentDecisionsAllowed contract', () => {
 
     expect(result.isError).toBe(false);
     expect(capturedEvent).toBeDefined();
-    expect(capturedEvent.persistentDecisionsAllowed).toBe(true);
+    expect(capturedEvent!.persistentDecisionsAllowed).toBe(true);
   });
 
   test('persistentDecisionsAllowed is passed to prompter confirmation_request for proxied bash', async () => {
@@ -1580,8 +1579,8 @@ describe('ToolExecutor persistentDecisionsAllowed contract', () => {
     const prompter = {
       prompt: async (
         _toolName: string, _input: Record<string, unknown>, _riskLevel: string,
-        _allowlistOptions: any[], _scopeOptions: any[], _diff: any, _sandboxed: any,
-        _sessionId: any, _executionTarget: any, persistentDecisionsAllowed: any,
+        _allowlistOptions: AllowlistOption[], _scopeOptions: ScopeOption[], _diff: unknown, _sandboxed: unknown,
+        _sessionId: unknown, _executionTarget: unknown, persistentDecisionsAllowed: boolean | undefined,
       ) => {
         capturedPersistent = persistentDecisionsAllowed;
         return { decision: 'allow' as const };
@@ -1643,8 +1642,8 @@ describe('E2E: proxied bash activation vs proxy approval persistence', () => {
 
   function setupAddRuleSpy() {
     addRuleSpy = spyOn(trustStore, 'addRule').mockImplementation(
-      (tool: string, pattern: string, scope: string, decision = 'allow', priority = 100, options?: any) => {
-        return { id: 'spy-rule-id', tool, pattern, scope, decision, priority, createdAt: Date.now(), ...options } as any;
+      (tool: string, pattern: string, scope: string, decision = 'allow', priority = 100, options?: { allowHighRisk?: boolean; executionTarget?: string }) => {
+        return { id: 'spy-rule-id', tool, pattern, scope, decision, priority, createdAt: Date.now(), ...options } as TrustRule;
       },
     );
     return addRuleSpy;
@@ -1871,8 +1870,8 @@ describe('ToolExecutor persistent-allow lifecycle', () => {
 
   function setupAddRuleSpy() {
     addRuleSpy = spyOn(trustStore, 'addRule').mockImplementation(
-      (tool: string, pattern: string, scope: string, decision = 'allow', priority = 100, options?: any) => {
-        return { id: 'spy-rule-id', tool, pattern, scope, decision, priority, createdAt: Date.now(), ...options } as any;
+      (tool: string, pattern: string, scope: string, decision = 'allow', priority = 100, options?: { allowHighRisk?: boolean; executionTarget?: string }) => {
+        return { id: 'spy-rule-id', tool, pattern, scope, decision, priority, createdAt: Date.now(), ...options } as TrustRule;
       },
     );
     return addRuleSpy;
@@ -1954,12 +1953,12 @@ describe('integration regressions — prompt payload (PR 11)', () => {
   test('shell command prompt payload includes allowlist and scope options', async () => {
     checkResultOverride = { decision: 'prompt', reason: 'Medium risk: requires approval' };
 
-    let capturedAllowlist: any[] | undefined;
-    let capturedScopes: any[] | undefined;
+    let capturedAllowlist: AllowlistOption[] | undefined;
+    let capturedScopes: ScopeOption[] | undefined;
     const prompter = {
       prompt: async (
         _toolName: string, _input: Record<string, unknown>, _riskLevel: string,
-        allowlistOptions: any[], scopeOptions: any[],
+        allowlistOptions: AllowlistOption[], scopeOptions: ScopeOption[],
       ) => {
         capturedAllowlist = allowlistOptions;
         capturedScopes = scopeOptions;

--- a/assistant/src/__tests__/web-search.test.ts
+++ b/assistant/src/__tests__/web-search.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 
 // No mock.module calls — this test file uses its own inline executeWebSearch
@@ -45,7 +44,7 @@ describe('WebSearchTool', () => {
       globalThis.fetch = (async () => {
         fetchCalled = true;
         return new Response('{}', { status: 200 });
-      }) as any;
+      }) as typeof fetch;
 
       process.env.BRAVE_API_KEY = 'test-key';
 
@@ -74,7 +73,7 @@ describe('WebSearchTool', () => {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         });
-      }) as any;
+      }) as typeof fetch;
 
       await executeWebSearch({ query: 'test', count: 50 }, 'test-key', 'brave');
       expect(capturedUrl).toContain('count=20');
@@ -91,7 +90,7 @@ describe('WebSearchTool', () => {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         });
-      }) as any;
+      }) as typeof fetch;
 
       await executeWebSearch({ query: 'test', offset: 20 }, 'test-key', 'brave');
       expect(capturedUrl).toContain('offset=9');
@@ -105,7 +104,7 @@ describe('WebSearchTool', () => {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         });
-      }) as any;
+      }) as typeof fetch;
 
       await executeWebSearch({ query: 'test', freshness: 'pw' }, 'test-key', 'brave');
       expect(capturedUrl).toContain('freshness=pw');
@@ -119,7 +118,7 @@ describe('WebSearchTool', () => {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         });
-      }) as any;
+      }) as typeof fetch;
 
       await executeWebSearch({ query: 'test', freshness: 'invalid' }, 'test-key', 'brave');
       expect(capturedUrl).not.toContain('freshness');
@@ -142,7 +141,7 @@ describe('WebSearchTool', () => {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         })
-      ) as any;
+      ) as typeof fetch;
 
       const result = await executeWebSearch({ query: 'test' }, 'test-key', 'brave');
       expect(result.isError).toBe(false);
@@ -159,7 +158,7 @@ describe('WebSearchTool', () => {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         })
-      ) as any;
+      ) as typeof fetch;
 
       const result = await executeWebSearch({ query: 'noresults' }, 'test-key', 'brave');
       expect(result.isError).toBe(false);
@@ -172,7 +171,7 @@ describe('WebSearchTool', () => {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         })
-      ) as any;
+      ) as typeof fetch;
 
       const result = await executeWebSearch({ query: 'empty' }, 'test-key', 'brave');
       expect(result.isError).toBe(false);
@@ -182,7 +181,7 @@ describe('WebSearchTool', () => {
     test('handles 401 unauthorized', async () => {
       globalThis.fetch = (async () =>
         new Response('Unauthorized', { status: 401 })
-      ) as any;
+      ) as typeof fetch;
 
       const result = await executeWebSearch({ query: 'test' }, 'bad-key', 'brave');
       expect(result.isError).toBe(true);
@@ -200,7 +199,7 @@ describe('WebSearchTool', () => {
           JSON.stringify({ web: { results: [{ title: 'Result', url: 'https://example.com', description: 'Found it' }] } }),
           { status: 200, headers: { 'Content-Type': 'application/json' } },
         );
-      }) as any;
+      }) as typeof fetch;
 
       const result = await executeWebSearch({ query: 'test' }, 'test-key', 'brave');
       expect(result.isError).toBe(false);
@@ -211,7 +210,7 @@ describe('WebSearchTool', () => {
     test('returns error after exhausting 429 retries', async () => {
       globalThis.fetch = (async () =>
         new Response('Too Many Requests', { status: 429 })
-      ) as any;
+      ) as typeof fetch;
 
       const result = await executeWebSearch({ query: 'test' }, 'test-key', 'brave');
       expect(result.isError).toBe(true);
@@ -235,7 +234,7 @@ describe('WebSearchTool', () => {
           JSON.stringify({ web: { results: [] } }),
           { status: 200, headers: { 'Content-Type': 'application/json' } },
         );
-      }) as any;
+      }) as typeof fetch;
 
       const result = await executeWebSearch({ query: 'test' }, 'test-key', 'brave');
       expect(result.isError).toBe(false);
@@ -245,7 +244,7 @@ describe('WebSearchTool', () => {
     test('handles network errors', async () => {
       globalThis.fetch = (async () => {
         throw new Error('Network unreachable');
-      }) as any;
+      }) as typeof fetch;
 
       const result = await executeWebSearch({ query: 'test' }, 'test-key', 'brave');
       expect(result.isError).toBe(true);
@@ -254,7 +253,7 @@ describe('WebSearchTool', () => {
 
     test('sends correct headers', async () => {
       let capturedHeaders: Record<string, string> = {};
-      globalThis.fetch = (async (_url: string, init: any) => {
+      globalThis.fetch = (async (_url: string, init: RequestInit) => {
         capturedHeaders = Object.fromEntries(
           Object.entries(init.headers as Record<string, string>),
         );
@@ -262,7 +261,7 @@ describe('WebSearchTool', () => {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         });
-      }) as any;
+      }) as typeof fetch;
 
       await executeWebSearch({ query: 'test' }, 'my-api-key', 'brave');
       expect(capturedHeaders['X-Subscription-Token']).toBe('my-api-key');
@@ -288,7 +287,7 @@ describe('WebSearchTool', () => {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         })
-      ) as any;
+      ) as typeof fetch;
 
       const result = await executeWebSearch({ query: 'test' }, 'test-key', 'brave');
       expect(result.isError).toBe(false);
@@ -309,7 +308,7 @@ describe('WebSearchTool', () => {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         })
-      ) as any;
+      ) as typeof fetch;
 
       const result = await executeWebSearch({ query: 'test' }, 'pplx-key', 'perplexity');
       expect(result.isError).toBe(false);
@@ -328,7 +327,7 @@ describe('WebSearchTool', () => {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         })
-      ) as any;
+      ) as typeof fetch;
 
       const result = await executeWebSearch({ query: 'noresults' }, 'pplx-key', 'perplexity');
       expect(result.isError).toBe(false);
@@ -338,7 +337,7 @@ describe('WebSearchTool', () => {
     test('handles 401 unauthorized', async () => {
       globalThis.fetch = (async () =>
         new Response('Unauthorized', { status: 401 })
-      ) as any;
+      ) as typeof fetch;
 
       const result = await executeWebSearch({ query: 'test' }, 'bad-key', 'perplexity');
       expect(result.isError).toBe(true);
@@ -347,17 +346,17 @@ describe('WebSearchTool', () => {
 
     test('sends correct headers', async () => {
       let capturedHeaders: Record<string, string> = {};
-      let capturedBody: any;
-      globalThis.fetch = (async (_url: string, init: any) => {
+      let capturedBody: Record<string, unknown>;
+      globalThis.fetch = (async (_url: string, init: RequestInit) => {
         capturedHeaders = Object.fromEntries(
           Object.entries(init.headers as Record<string, string>),
         );
-        capturedBody = JSON.parse(init.body);
+        capturedBody = JSON.parse(init.body as string);
         return new Response(JSON.stringify({ choices: [{ message: { content: 'result' } }] }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         });
-      }) as any;
+      }) as typeof fetch;
 
       await executeWebSearch({ query: 'test query' }, 'pplx-my-key', 'perplexity');
       expect(capturedHeaders['Authorization']).toBe('Bearer pplx-my-key');
@@ -377,7 +376,7 @@ describe('WebSearchTool', () => {
           JSON.stringify({ choices: [{ message: { content: 'Found it' } }] }),
           { status: 200, headers: { 'Content-Type': 'application/json' } },
         );
-      }) as any;
+      }) as typeof fetch;
 
       const result = await executeWebSearch({ query: 'test' }, 'pplx-key', 'perplexity');
       expect(result.isError).toBe(false);
@@ -388,7 +387,7 @@ describe('WebSearchTool', () => {
     test('handles network errors', async () => {
       globalThis.fetch = (async () => {
         throw new Error('Network unreachable');
-      }) as any;
+      }) as typeof fetch;
 
       const result = await executeWebSearch({ query: 'test' }, 'pplx-key', 'perplexity');
       expect(result.isError).toBe(true);
@@ -396,6 +395,23 @@ describe('WebSearchTool', () => {
     });
   });
 });
+
+interface BraveSearchResult {
+  title: string;
+  url: string;
+  description?: string;
+  age?: string;
+  extra_snippets?: string[];
+}
+
+interface BraveSearchResponse {
+  web?: { results: BraveSearchResult[] };
+}
+
+interface PerplexityResponse {
+  choices?: Array<{ message: { content: string } }>;
+  citations?: string[];
+}
 
 /**
  * Helper that exercises the web search logic directly, bypassing module
@@ -461,7 +477,7 @@ async function executeBraveSearchHelper(
       });
 
       if (response.ok) {
-        const data = await response.json() as any;
+        const data = await response.json() as BraveSearchResponse;
         const results = data.web?.results ?? [];
 
         if (results.length === 0) {
@@ -536,7 +552,7 @@ async function executePerplexitySearchHelper(
       });
 
       if (response.ok) {
-        const data = await response.json() as any;
+        const data = await response.json() as PerplexityResponse;
         const content = data.choices?.[0]?.message?.content;
         if (!content) {
           return { content: `No results found for "${query}".`, isError: false };


### PR DESCRIPTION
Replace `: any` with proper types (`TrustRule[]`, `AllowlistOption`, `ScopeOption`, `ToolLifecycleEvent`, `Tool`, `SandboxBackend`, etc.) in web-search.test.ts, checker.test.ts, tool-executor.test.ts, tool-executor-shell-integration.test.ts, and terminal-tools.test.ts. Removes `eslint-disable @typescript-eslint/no-explicit-any` file-level directives from all five files.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
