### PR TITLE
Handle 410s from auth

### DIFF
--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -23,11 +23,13 @@ public final class AuthManager {
     public var isSubmitting = false
     public var errorMessage: String?
 
-    private let authService = AuthService.shared
+    private let authService: AuthService
     private static let callbackScheme = "vellum-assistant"
     private var webAuthSession: ASWebAuthenticationSession?
 
-    public init() {}
+    public init(authService: AuthService = .shared) {
+        self.authService = authService
+    }
 
     public var isAuthenticated: Bool {
         if case .authenticated = state { return true }
@@ -60,6 +62,9 @@ public final class AuthManager {
             } else {
                 state = .unauthenticated
             }
+        } catch AuthServiceError.invalidSessionToken {
+            state = .unauthenticated
+            errorMessage = "Session expired. Please sign in again."
         } catch {
             log.error("Session check failed: \(error.localizedDescription)")
             state = .unauthenticated
@@ -153,6 +158,7 @@ public final class AuthManager {
         } catch {
             log.error("Logout request failed: \(error.localizedDescription)")
         }
+        // Always clear local session state, even if remote logout fails.
         await SessionTokenManager.deleteTokenAsync()
         state = .unauthenticated
         errorMessage = nil

--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -50,7 +50,7 @@ public final class AuthManager {
         state = .loading
         errorMessage = nil
 
-        guard await SessionTokenManager.getTokenAsync() != nil else {
+        guard await authService.hasSessionToken() else {
             state = .unauthenticated
             return
         }
@@ -159,7 +159,7 @@ public final class AuthManager {
             log.error("Logout request failed: \(error.localizedDescription)")
         }
         // Always clear local session state, even if remote logout fails.
-        await SessionTokenManager.deleteTokenAsync()
+        await authService.clearSessionToken()
         state = .unauthenticated
         errorMessage = nil
     }

--- a/clients/shared/App/Auth/AuthModels.swift
+++ b/clients/shared/App/Auth/AuthModels.swift
@@ -91,6 +91,7 @@ public enum AuthServiceError: LocalizedError {
     case networkError(Error)
     case decodingError(Error)
     case serverError(Int, [AllauthError])
+    case invalidSessionToken
     case noSessionToken
     case oidcDiscoveryFailed
     case oidcTokenExchangeFailed(String)
@@ -102,6 +103,7 @@ public enum AuthServiceError: LocalizedError {
         case .decodingError(let error): return "Failed to decode response: \(error.localizedDescription)"
         case .serverError(_, let errors):
             return errors.first?.message ?? "Server error"
+        case .invalidSessionToken: return "Session expired. Please sign in again."
         case .noSessionToken: return "No session token received"
         case .oidcDiscoveryFailed: return "Unable to fetch OIDC discovery document"
         case .oidcTokenExchangeFailed(let msg): return msg

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -5,7 +5,14 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 
 @MainActor
 public final class AuthService {
+    internal typealias RequestExecutor = (URLRequest) async throws -> (Data, URLResponse)
+
     public static let shared = AuthService()
+    private let requestExecutor: RequestExecutor
+    private let getSessionToken: () async -> String?
+    private let setSessionToken: (String) async -> Void
+    private let invalidateSessionToken: () async -> Void
+    private let baseURLOverride: String?
 
     private static let defaultBaseURL: String = {
         #if DEBUG && os(macOS)
@@ -16,6 +23,9 @@ public final class AuthService {
     }()
 
     public var baseURL: String {
+        if let baseURLOverride, !baseURLOverride.isEmpty {
+            return baseURLOverride
+        }
         #if DEBUG
         // Allow overriding the auth service URL via UserDefaults for development/testing.
         if let override = UserDefaults.standard.string(forKey: "authServiceBaseURL"), !override.isEmpty {
@@ -25,7 +35,35 @@ public final class AuthService {
         return Self.defaultBaseURL
     }
 
-    private init() {}
+    private init() {
+        self.baseURLOverride = nil
+        self.requestExecutor = { request in
+            try await URLSession.shared.data(for: request)
+        }
+        self.getSessionToken = {
+            await SessionTokenManager.getTokenAsync()
+        }
+        self.setSessionToken = { token in
+            await SessionTokenManager.setTokenAsync(token)
+        }
+        self.invalidateSessionToken = {
+            await SessionTokenManager.invalidateTokenAsync()
+        }
+    }
+
+    internal init(
+        baseURLOverride: String? = nil,
+        requestExecutor: @escaping RequestExecutor,
+        getSessionToken: @escaping () async -> String?,
+        setSessionToken: @escaping (String) async -> Void,
+        invalidateSessionToken: @escaping () async -> Void
+    ) {
+        self.baseURLOverride = baseURLOverride
+        self.requestExecutor = requestExecutor
+        self.getSessionToken = getSessionToken
+        self.setSessionToken = setSessionToken
+        self.invalidateSessionToken = invalidateSessionToken
+    }
 
     public func getConfig() async throws -> AllauthResponse<ConfigData> {
         try await request(path: "config", includeSessionToken: false)
@@ -122,7 +160,7 @@ public final class AuthService {
         urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        if includeSessionToken, let token = await SessionTokenManager.getTokenAsync() {
+        if includeSessionToken, let token = await getSessionToken() {
             urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
         }
 
@@ -137,7 +175,7 @@ public final class AuthService {
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await URLSession.shared.data(for: urlRequest)
+            (data, response) = try await requestExecutor(urlRequest)
         } catch {
             throw AuthServiceError.networkError(error)
         }
@@ -148,7 +186,7 @@ public final class AuthService {
         log.debug("Auth request \(method) \(path) -> \(statusCode)")
 
         if statusCode == 410 {
-            await SessionTokenManager.invalidateTokenAsync()
+            await invalidateSessionToken()
             throw AuthServiceError.invalidSessionToken
         }
 
@@ -162,7 +200,7 @@ public final class AuthService {
         }
 
         if let sessionToken = decoded.meta?.session_token {
-            await SessionTokenManager.setTokenAsync(sessionToken)
+            await setSessionToken(sessionToken)
         }
 
         return decoded

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -69,6 +69,14 @@ public final class AuthService {
         try await request(path: "config", includeSessionToken: false)
     }
 
+    public func hasSessionToken() async -> Bool {
+        await getSessionToken() != nil
+    }
+
+    public func clearSessionToken() async {
+        await invalidateSessionToken()
+    }
+
     public func getSession() async throws -> AllauthResponse<SessionData> {
         try await request(path: "auth/session", includeSessionToken: true)
     }

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -147,6 +147,11 @@ public final class AuthService {
 
         log.debug("Auth request \(method) \(path) -> \(statusCode)")
 
+        if statusCode == 410 {
+            await SessionTokenManager.invalidateTokenAsync()
+            throw AuthServiceError.invalidSessionToken
+        }
+
         let decoded: AllauthResponse<T>
         do {
             decoded = try JSONDecoder().decode(AllauthResponse<T>.self, from: data)

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -28,7 +28,7 @@ public final class AuthService {
     private init() {}
 
     public func getConfig() async throws -> AllauthResponse<ConfigData> {
-        try await request(path: "config", includeSessionToken: true)
+        try await request(path: "config", includeSessionToken: false)
     }
 
     public func getSession() async throws -> AllauthResponse<SessionData> {

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -28,15 +28,15 @@ public final class AuthService {
     private init() {}
 
     public func getConfig() async throws -> AllauthResponse<ConfigData> {
-        try await request(path: "config")
+        try await request(path: "config", includeSessionToken: true)
     }
 
     public func getSession() async throws -> AllauthResponse<SessionData> {
-        try await request(path: "auth/session")
+        try await request(path: "auth/session", includeSessionToken: true)
     }
 
     public func logout() async throws -> AllauthResponse<EmptyData> {
-        try await request(path: "auth/session", method: "DELETE")
+        try await request(path: "auth/session", method: "DELETE", includeSessionToken: true)
     }
 
     public func authenticateWithProviderToken(
@@ -55,7 +55,7 @@ public final class AuthService {
             "process": process,
             "token": token,
         ]
-        return try await request(path: "auth/provider/token", method: "POST", body: body)
+        return try await request(path: "auth/provider/token", method: "POST", body: body, includeSessionToken: true)
     }
 
     public func fetchOIDCDiscovery(url: String) async throws -> OIDCDiscovery {
@@ -109,6 +109,7 @@ public final class AuthService {
         path: String,
         method: String = "GET",
         body: Any? = nil,
+        includeSessionToken: Bool = true,
         headers: [String: String] = [:]
     ) async throws -> AllauthResponse<T> {
         let urlString = "\(baseURL)/_allauth/app/v1/\(path)"
@@ -121,7 +122,7 @@ public final class AuthService {
         urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        if let token = await SessionTokenManager.getTokenAsync() {
+        if includeSessionToken, let token = await SessionTokenManager.getTokenAsync() {
             urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
         }
 

--- a/clients/shared/App/Auth/SessionTokenManager.swift
+++ b/clients/shared/App/Auth/SessionTokenManager.swift
@@ -57,4 +57,9 @@ public enum SessionTokenManager {
             }
         }
     }
+
+    /// Invalidate a stale/expired session token from secure storage.
+    public static func invalidateTokenAsync() async {
+        await deleteTokenAsync()
+    }
 }

--- a/clients/shared/Tests/AuthFlowTests.swift
+++ b/clients/shared/Tests/AuthFlowTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+@testable import VellumAssistantShared
+
+private final class TokenBox {
+    var value: String?
+
+    init(_ value: String? = nil) {
+        self.value = value
+    }
+}
+
+@MainActor
+final class AuthFlowTests: XCTestCase {
+    func testGetConfigOmitsSessionTokenHeader() async throws {
+        let tokenBox = TokenBox("stale-token")
+        var capturedRequest: URLRequest?
+
+        let service = AuthService(
+            baseURLOverride: "https://auth.test",
+            requestExecutor: { request in
+                capturedRequest = request
+                return (
+                    #"{"status":200,"data":{"socialaccount":{"providers":[]}}}"#.data(using: .utf8)!,
+                    Self.makeHTTPResponse(for: request.url!, statusCode: 200)
+                )
+            },
+            getSessionToken: { tokenBox.value },
+            setSessionToken: { tokenBox.value = $0 },
+            invalidateSessionToken: { tokenBox.value = nil }
+        )
+
+        _ = try await service.getConfig()
+
+        XCTAssertEqual(capturedRequest?.url?.path, "/_allauth/app/v1/config")
+        XCTAssertNil(capturedRequest?.value(forHTTPHeaderField: "X-Session-Token"))
+    }
+
+    func testGetSessionIncludesSessionTokenHeader() async throws {
+        let tokenBox = TokenBox("session-123")
+        var capturedRequest: URLRequest?
+
+        let service = AuthService(
+            baseURLOverride: "https://auth.test",
+            requestExecutor: { request in
+                capturedRequest = request
+                return (
+                    #"{"status":200,"data":{"user":{"id":1,"email":"test@example.com"}}}"#.data(using: .utf8)!,
+                    Self.makeHTTPResponse(for: request.url!, statusCode: 200)
+                )
+            },
+            getSessionToken: { tokenBox.value },
+            setSessionToken: { tokenBox.value = $0 },
+            invalidateSessionToken: { tokenBox.value = nil }
+        )
+
+        _ = try await service.getSession()
+
+        XCTAssertEqual(capturedRequest?.url?.path, "/_allauth/app/v1/auth/session")
+        XCTAssertEqual(capturedRequest?.value(forHTTPHeaderField: "X-Session-Token"), "session-123")
+    }
+
+    func testGetSession410ClearsTokenAndThrowsInvalidSession() async throws {
+        let tokenBox = TokenBox("stale-token")
+
+        let service = AuthService(
+            baseURLOverride: "https://auth.test",
+            requestExecutor: { request in
+                (
+                    #"{"status":410}"#.data(using: .utf8)!,
+                    Self.makeHTTPResponse(for: request.url!, statusCode: 410)
+                )
+            },
+            getSessionToken: { tokenBox.value },
+            setSessionToken: { tokenBox.value = $0 },
+            invalidateSessionToken: { tokenBox.value = nil }
+        )
+
+        do {
+            _ = try await service.getSession()
+            XCTFail("Expected invalidSessionToken error")
+        } catch AuthServiceError.invalidSessionToken {
+            XCTAssertNil(tokenBox.value)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testAuthManagerCheckSessionSurfacesReauthPromptAfter410() async {
+        let tokenBox = TokenBox("stale-token")
+
+        let service = AuthService(
+            baseURLOverride: "https://auth.test",
+            requestExecutor: { request in
+                (
+                    #"{"status":410}"#.data(using: .utf8)!,
+                    Self.makeHTTPResponse(for: request.url!, statusCode: 410)
+                )
+            },
+            getSessionToken: { tokenBox.value },
+            setSessionToken: { tokenBox.value = $0 },
+            invalidateSessionToken: { tokenBox.value = nil }
+        )
+
+        let manager = AuthManager(authService: service)
+        await manager.checkSession()
+
+        Self.assertUnauthenticated(manager.state)
+        XCTAssertEqual(manager.errorMessage, "Session expired. Please sign in again.")
+        XCTAssertNil(tokenBox.value)
+    }
+
+    func testAuthManagerLogoutClearsTokenWhenRemoteLogoutFails() async {
+        let tokenBox = TokenBox("live-token")
+
+        let service = AuthService(
+            baseURLOverride: "https://auth.test",
+            requestExecutor: { _ in
+                throw URLError(.notConnectedToInternet)
+            },
+            getSessionToken: { tokenBox.value },
+            setSessionToken: { tokenBox.value = $0 },
+            invalidateSessionToken: { tokenBox.value = nil }
+        )
+
+        let manager = AuthManager(authService: service)
+        await manager.logout()
+
+        Self.assertUnauthenticated(manager.state)
+        XCTAssertNil(tokenBox.value)
+        XCTAssertNil(manager.errorMessage)
+    }
+
+    private static func makeHTTPResponse(for url: URL, statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+
+    private static func assertUnauthenticated(
+        _ state: AuthState,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        if case .unauthenticated = state {
+            return
+        }
+        XCTFail("Expected .unauthenticated state", file: file, line: line)
+    }
+}


### PR DESCRIPTION
We can see 410s from auth endpoints if
1. your session has legitimately expired
2. you change the platform URL you're targeting (e.g. local dev vs staging vs prod)

etc.

Some of the auth endpoints don't require auth in the first place, but will still 410 if provided with an invalid session token. This actually prevents you from logging in again.

Changes:
1. Stop passing auth token to `/config` API
2. Upon 410, clear token from keychain and prompt user to reauth
3. Logouts should always clear tokens from keychain


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
