### PR TITLE
perf: add database indexes on memoryItems table

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -17,6 +17,7 @@ import {
   migrateBackfillInboxThreadStateFromBindings,
   migrateDropActiveSearchIndex,
   migrateMemorySegmentsIndexes,
+  migrateMemoryItemsIndexes,
   validateMigrationState,
 } from './schema-migration.js';
 
@@ -1269,6 +1270,8 @@ export function initializeDb(): void {
   migrateMemoryFtsBackfill(database);
 
   migrateMemorySegmentsIndexes(database);
+
+  migrateMemoryItemsIndexes(database);
 
   validateMigrationState(database);
 }

--- a/assistant/src/memory/migrations/017-memory-items-indexes.ts
+++ b/assistant/src/memory/migrations/017-memory-items-indexes.ts
@@ -1,0 +1,10 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Idempotent migration to add indexes on memory_items for scope_id and
+ * fingerprint — critical for duplicate detection and scope-filtered queries.
+ */
+export function migrateMemoryItemsIndexes(database: DrizzleDb): void {
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_items_scope_id ON memory_items(scope_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_items_fingerprint ON memory_items(fingerprint)`);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -20,3 +20,4 @@ export { migrateGuardianActionTables } from './013-guardian-action-tables.js';
 export { migrateBackfillInboxThreadStateFromBindings } from './014-backfill-inbox-thread-state.js';
 export { migrateDropActiveSearchIndex } from './015-drop-active-search-index.js';
 export { migrateMemorySegmentsIndexes } from './016-memory-segments-indexes.js';
+export { migrateMemoryItemsIndexes } from './017-memory-items-indexes.js';

--- a/assistant/src/memory/schema-migration.ts
+++ b/assistant/src/memory/schema-migration.ts
@@ -20,4 +20,5 @@ export {
   migrateBackfillInboxThreadStateFromBindings,
   migrateDropActiveSearchIndex,
   migrateMemorySegmentsIndexes,
+  migrateMemoryItemsIndexes,
 } from './migrations/index.js';

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -80,7 +80,10 @@ export const memoryItems = sqliteTable('memory_items', {
   lastUsedAt: integer('last_used_at'),
   validFrom: integer('valid_from'),
   invalidAt: integer('invalid_at'),
-});
+}, (table) => [
+  index('idx_memory_items_scope_id').on(table.scopeId),
+  index('idx_memory_items_fingerprint').on(table.fingerprint),
+]);
 
 export const memoryItemSources = sqliteTable('memory_item_sources', {
   memoryItemId: text('memory_item_id')


### PR DESCRIPTION
Add indexes on scopeId and fingerprint columns in memoryItems for faster duplicate detection and scope queries
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
