### PR TITLE
fix: add AbortSignal support to tool implementations

### DIFF
--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -93,6 +93,10 @@ export async function executeBrowserNavigate(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  if (context.signal?.aborted) {
+    return { content: 'Error: operation was cancelled', isError: true };
+  }
+
   const parsedUrl = parseUrl(input.url);
   if (!parsedUrl) {
     return { content: 'Error: url is required and must be a valid HTTP(S) URL', isError: true };
@@ -316,6 +320,7 @@ export async function executeBrowserNavigate(
       if (challenge?.type === 'captcha') {
         log.info('CAPTCHA detected, waiting up to 5s for auto-resolve');
         for (let i = 0; i < 5; i++) {
+          if (context.signal?.aborted) break;
           await new Promise((r) => setTimeout(r, 1000));
           const still = await detectCaptchaChallenge(page);
           if (!still) {
@@ -797,6 +802,10 @@ export async function executeBrowserWaitFor(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  if (context.signal?.aborted) {
+    return { content: 'Error: operation was cancelled', isError: true };
+  }
+
   const selector = typeof input.selector === 'string' && input.selector ? input.selector : null;
   const text = typeof input.text === 'string' && input.text ? input.text : null;
   const duration = typeof input.duration === 'number' ? input.duration : null;

--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -63,6 +63,7 @@ type WebFetchRequestExecutor = (
 type ExecuteWebFetchOptions = {
   resolveHostAddresses?: ResolveHostAddresses;
   requestExecutor?: WebFetchRequestExecutor;
+  signal?: AbortSignal;
 };
 
 type NodeHttpResponseLike = {
@@ -451,6 +452,17 @@ export async function executeWebFetch(
     controller.abort();
   }, timeoutSeconds * 1000);
 
+  // Forward external cancellation signal to our controller
+  const externalSignal = options?.signal;
+  const onExternalAbort = () => controller.abort();
+  if (externalSignal) {
+    if (externalSignal.aborted) {
+      controller.abort();
+    } else {
+      externalSignal.addEventListener('abort', onExternalAbort, { once: true });
+    }
+  }
+
   try {
     log.debug({ url: safeRequestedUrl, timeoutSeconds, maxChars, startIndex, rawMode }, 'Fetching webpage');
 
@@ -651,6 +663,9 @@ export async function executeWebFetch(
     };
   } catch (err) {
     if (err instanceof Error && err.name === 'AbortError') {
+      if (externalSignal?.aborted) {
+        return { content: 'Error: web fetch was cancelled', isError: true };
+      }
       return { content: `Error: web fetch timed out after ${timeoutSeconds}s`, isError: true };
     }
 
@@ -659,6 +674,7 @@ export async function executeWebFetch(
     return { content: `Error: Web fetch failed: ${msg}`, isError: true };
   } finally {
     clearTimeout(timeoutHandle);
+    externalSignal?.removeEventListener('abort', onExternalAbort);
   }
 }
 
@@ -705,8 +721,8 @@ class WebFetchTool implements Tool {
     };
   }
 
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    return executeWebFetch(input);
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    return executeWebFetch(input, { signal: context.signal });
   }
 }
 

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -115,6 +115,7 @@ async function executeBraveSearch(
   offset: number,
   freshness: string | undefined,
   apiKey: string,
+  signal?: AbortSignal,
 ): Promise<ToolExecutionResult> {
   const params = new URLSearchParams({
     q: query,
@@ -136,6 +137,7 @@ async function executeBraveSearch(
         'Accept-Encoding': 'gzip',
         'X-Subscription-Token': apiKey,
       },
+      signal,
     });
 
     if (response.ok) {
@@ -170,6 +172,7 @@ async function executeBraveSearch(
 async function executePerplexitySearch(
   query: string,
   apiKey: string,
+  signal?: AbortSignal,
 ): Promise<ToolExecutionResult> {
   for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
     const response = await fetch(PERPLEXITY_API_URL, {
@@ -184,6 +187,7 @@ async function executePerplexitySearch(
           { role: 'user', content: query },
         ],
       }),
+      signal,
     });
 
     if (response.ok) {
@@ -249,7 +253,7 @@ class WebSearchTool implements Tool {
     };
   }
 
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
     const query = input.query;
     if (!query || typeof query !== 'string') {
       return { content: 'Error: query is required and must be a string', isError: true };
@@ -281,10 +285,10 @@ class WebSearchTool implements Tool {
         const count = typeof input.count === 'number' ? Math.min(20, Math.max(1, Math.round(input.count))) : 10;
         const offset = typeof input.offset === 'number' ? Math.min(9, Math.max(0, Math.round(input.offset))) : 0;
         const freshness = typeof input.freshness === 'string' ? input.freshness : undefined;
-        return await executeBraveSearch(query, count, offset, freshness, apiKey);
+        return await executeBraveSearch(query, count, offset, freshness, apiKey, context.signal);
       }
 
-      return await executePerplexitySearch(query, apiKey);
+      return await executePerplexitySearch(query, apiKey, context.signal);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.error({ err }, 'Web search failed');

--- a/assistant/src/tools/terminal/evaluate-typescript.ts
+++ b/assistant/src/tools/terminal/evaluate-typescript.ts
@@ -169,7 +169,7 @@ export class EvaluateTypescriptTool implements Tool {
     timeoutSec: number,
     timeoutMs: number,
     maxOutputChars: number,
-    _context: ToolContext,
+    context: ToolContext,
   ): Promise<EvalResult> {
     return new Promise<EvalResult>((resolve) => {
       const startTime = Date.now();
@@ -197,11 +197,24 @@ export class EvaluateTypescriptTool implements Tool {
         child.kill('SIGKILL');
       }, timeoutMs);
 
+      // Cooperative cancellation via AbortSignal
+      const onAbort = () => {
+        child.kill('SIGKILL');
+      };
+      if (context.signal) {
+        if (context.signal.aborted) {
+          child.kill('SIGKILL');
+        } else {
+          context.signal.addEventListener('abort', onAbort, { once: true });
+        }
+      }
+
       child.stdout.on('data', (data: Buffer) => stdoutChunks.push(data));
       child.stderr.on('data', (data: Buffer) => stderrChunks.push(data));
 
       child.on('close', (code) => {
         clearTimeout(timer);
+        context.signal?.removeEventListener('abort', onAbort);
         const durationMs = Date.now() - startTime;
 
         let stdout = Buffer.concat(stdoutChunks).toString();
@@ -251,6 +264,7 @@ export class EvaluateTypescriptTool implements Tool {
 
       child.on('error', (err) => {
         clearTimeout(timer);
+        context.signal?.removeEventListener('abort', onAbort);
         const durationMs = Date.now() - startTime;
         resolve({
           ok: false,


### PR DESCRIPTION
Audit and add AbortSignal checking to web_fetch, evaluate_typescript, web_search, and browser tool execute() methods for proper cancellation support.

- **web_fetch**: Forward context.signal to internal AbortController so external cancellation aborts in-flight HTTP requests
- **evaluate_typescript**: Add abort listener to kill child process on cancellation, matching the pattern in shell.ts
- **web_search**: Pass context.signal to Brave/Perplexity fetch calls for cancellation support
- **browser_navigate**: Check signal.aborted at entry and in CAPTCHA wait loop
- **browser_wait_for**: Check signal.aborted at entry

Shell (bash) and host_bash already had proper AbortSignal support.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
