### PR TITLE
Fix: reject non-emoji guardian titles from model output

### DIFF
--- a/assistant/src/calls/guardian-question-copy.ts
+++ b/assistant/src/calls/guardian-question-copy.ts
@@ -124,9 +124,8 @@ function parseGeneratedCopy(text: string): GuardianCopy | null {
     return null;
   }
 
-  // Reject titles that don't start with an emoji or that use the old "Guardian question:" prefix
-  const firstCodePoint = title.codePointAt(0) ?? 0;
-  if (firstCodePoint < 127 || /^guardian question:/i.test(title)) {
+  // Reject the old static prefix — the model is guided towards better titles but has final say
+  if (/^guardian question:/i.test(title)) {
     return null;
   }
 

--- a/assistant/src/calls/guardian-question-copy.ts
+++ b/assistant/src/calls/guardian-question-copy.ts
@@ -124,5 +124,11 @@ function parseGeneratedCopy(text: string): GuardianCopy | null {
     return null;
   }
 
+  // Reject titles that don't start with an emoji or that use the old "Guardian question:" prefix
+  const firstCodePoint = title.codePointAt(0) ?? 0;
+  if (firstCodePoint < 127 || /^guardian question:/i.test(title)) {
+    return null;
+  }
+
   return { threadTitle: title, initialMessage: message };
 }


### PR DESCRIPTION
Add validation in parseGeneratedCopy to reject titles that don't start with an emoji (code point < 127) or that use the old 'Guardian question:' prefix. Non-compliant model output now falls back to the deterministic copy instead of being accepted. Addresses review feedback on #8208.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
