### PR TITLE
fix: handle QR refresh failure and remove dead onChange

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -26,6 +26,7 @@ struct PairingQRCodeSheet: View {
     @State private var registrationState: RegistrationState = .idle
     @State private var registrationError: String? = nil
     @State private var refreshTask: Task<Void, Never>? = nil
+    @State private var consecutiveRefreshFailures: Int = 0
 
     /// Re-register every 4 minutes to stay ahead of the 5-minute TTL.
     private static let refreshInterval: UInt64 = 4 * 60 * 1_000_000_000
@@ -131,14 +132,6 @@ struct PairingQRCodeSheet: View {
         .onDisappear {
             stopRefreshTimer()
         }
-        .onChange(of: daemonClient != nil) { _, isConnected in
-            // When the daemon connects after the sheet is already open,
-            // trigger registration so the user doesn't have to dismiss and reopen.
-            if isConnected, registrationState != .registered {
-                registerWithDaemon()
-                startRefreshTimer()
-            }
-        }
     }
 
     private func errorContent(_ message: String) -> some View {
@@ -215,9 +208,15 @@ struct PairingQRCodeSheet: View {
             pairingRequestId = newRequestId
             pairingSecret = newSecret
             registrationState = .registered
+            consecutiveRefreshFailures = 0
         case .failure:
-            // Keep the old QR visible; the next timer tick will retry.
-            break
+            consecutiveRefreshFailures += 1
+            if consecutiveRefreshFailures >= 2 {
+                registrationState = .failed
+                registrationError = "Re-registration failed. Close and reopen to try again."
+                stopRefreshTimer()
+            }
+            // On first failure, keep old QR visible; the next timer tick will retry.
         }
     }
 


### PR DESCRIPTION
## Summary
Shows error state after 2 consecutive refresh registration failures instead of silently leaving a stale QR. Removes dead `.onChange(of: daemonClient != nil)` since `daemonClient` is always non-nil in production. Addresses feedback from PR #8227.

## Implementation

**Refresh failure handling:** Added a `@State private var consecutiveRefreshFailures: Int = 0` counter. On each successful refresh, the counter resets to 0. On failure, it increments. After 2 consecutive failures, the sheet transitions to `.failed` state with a user-visible error message ("Re-registration failed. Close and reopen to try again.") and stops the refresh timer. A single transient failure is tolerated — the next 4-minute timer tick retries automatically.

**Dead onChange removal:** The `.onChange(of: daemonClient != nil)` block was dead code because `daemonClient` is always non-nil in the production view hierarchy (`MainWindowView` -> `SettingsPanel` -> `SettingsConnectTab` all pass a non-optional `DaemonClient`). The nil-daemon error state is already handled at `onAppear` time.

## Files Changed
- `clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift` — Added consecutive failure counter with threshold-based error state; removed dead `.onChange` block.

## Testing
1. Build the macOS app and open Settings > Connect > Show QR Code
2. Verify QR code displays and refreshes normally when daemon is running
3. To test failure path: stop the daemon while the sheet is open; after ~8 minutes (2 refresh cycles), the sheet should show the error state instead of a stale QR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
