### PR TITLE
feat: consolidate messages and runs to avoid 409 in web QA

### DIFF
--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Baseline tests for busy (409) rejection on both HTTP send endpoints:
+ * - POST /v1/runs
+ * - POST /v1/messages
+ *
+ * These tests verify the current behavior where a second send attempt
+ * on a busy session returns 409 with a descriptive error message.
+ */
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Session } from '../daemon/session.js';
+
+const testDir = realpathSync(mkdtempSync(join(tmpdir(), 'send-endpoint-busy-test-')));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    model: 'test',
+    provider: 'test',
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    secretDetection: { enabled: false },
+  }),
+}));
+
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
+import { RuntimeHttpServer } from '../runtime/http-server.js';
+import { RunOrchestrator } from '../runtime/run-orchestrator.js';
+import type { MessageProcessor } from '../runtime/http-types.js';
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try { rmSync(testDir, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+// ── Session / processor helpers ─────────────────────────────────────────────
+
+function makeHangingSession(): Session {
+  let processing = false;
+  return {
+    isProcessing: () => processing,
+    persistUserMessage: () => undefined as unknown as string,
+    memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
+    setChannelCapabilities: () => {},
+    setAssistantId: () => {},
+    setGuardianContext: () => {},
+    setCommandIntent: () => {},
+    setTurnChannelContext: () => {},
+    updateClient: () => {},
+    runAgentLoop: async () => {
+      processing = true;
+      await new Promise<void>(() => {}); // hangs forever
+    },
+    handleConfirmationResponse: () => {},
+    handleSecretResponse: () => {},
+  } as unknown as Session;
+}
+
+function makeCompletingSession(): Session {
+  let processing = false;
+  return {
+    isProcessing: () => processing,
+    persistUserMessage: () => undefined as unknown as string,
+    memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
+    setChannelCapabilities: () => {},
+    setAssistantId: () => {},
+    setGuardianContext: () => {},
+    setCommandIntent: () => {},
+    setTurnChannelContext: () => {},
+    updateClient: () => {},
+    runAgentLoop: async () => {
+      processing = true;
+      await new Promise((r) => setTimeout(r, 20));
+      processing = false;
+    },
+    handleConfirmationResponse: () => {},
+    handleSecretResponse: () => {},
+  } as unknown as Session;
+}
+
+/**
+ * Build a processMessage function that throws the busy error when
+ * `shouldBeBusy` returns true.
+ */
+function makeBusyAwareProcessor(shouldBeBusy: () => boolean): MessageProcessor {
+  return async () => {
+    if (shouldBeBusy()) {
+      throw new Error('Session is already processing a message');
+    }
+    return { messageId: 'msg-1' };
+  };
+}
+
+// ── Test infrastructure ─────────────────────────────────────────────────────
+
+const TEST_TOKEN = 'test-bearer-send-busy';
+const AUTH_HEADERS = { Authorization: `Bearer ${TEST_TOKEN}` };
+
+function cleanDb() {
+  const db = getDb();
+  db.run('DELETE FROM message_runs');
+  db.run('DELETE FROM messages');
+  db.run('DELETE FROM conversations');
+  db.run('DELETE FROM conversation_keys');
+}
+
+describe('send endpoint busy behavior — POST /v1/runs', () => {
+  let server: RuntimeHttpServer;
+  let port: number;
+
+  beforeEach(cleanDb);
+
+  async function startServer(sessionFactory: () => Session) {
+    port = 19000 + Math.floor(Math.random() * 1000);
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => sessionFactory(),
+      resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
+    });
+    server = new RuntimeHttpServer({ port, bearerToken: TEST_TOKEN, runOrchestrator: orchestrator });
+    await server.start();
+  }
+
+  async function stopServer() {
+    await server?.stop();
+  }
+
+  function runsUrl() {
+    return `http://127.0.0.1:${port}/v1/runs`;
+  }
+
+  test('returns 409 with descriptive error when session is busy', async () => {
+    const session = makeHangingSession();
+    await startServer(() => session);
+
+    // First run starts and hangs
+    const res1 = await fetch(runsUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({ conversationKey: 'conv-busy-run', content: 'First', sourceChannel: 'macos' }),
+    });
+    expect(res1.status).toBe(201);
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    // Second run should get 409
+    const res2 = await fetch(runsUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({ conversationKey: 'conv-busy-run', content: 'Second', sourceChannel: 'macos' }),
+    });
+    expect(res2.status).toBe(409);
+    const body = await res2.json() as { error: string };
+    expect(body.error).toContain('busy');
+
+    await stopServer();
+  });
+
+  test('returns 201 when session is not busy', async () => {
+    await startServer(() => makeCompletingSession());
+
+    const res = await fetch(runsUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({ conversationKey: 'conv-ok-run', content: 'Hello', sourceChannel: 'macos' }),
+    });
+    expect(res.status).toBe(201);
+
+    await stopServer();
+  });
+});
+
+describe('send endpoint busy behavior — POST /v1/messages', () => {
+  let server: RuntimeHttpServer;
+  let port: number;
+  let busyFlag: boolean;
+
+  beforeEach(() => {
+    cleanDb();
+    busyFlag = false;
+  });
+
+  async function startServer(opts?: { alwaysBusy?: boolean }) {
+    port = 19000 + Math.floor(Math.random() * 1000);
+    if (opts?.alwaysBusy) busyFlag = true;
+    const processor = makeBusyAwareProcessor(() => busyFlag);
+    server = new RuntimeHttpServer({
+      port,
+      bearerToken: TEST_TOKEN,
+      processMessage: processor,
+    });
+    await server.start();
+  }
+
+  async function stopServer() {
+    await server?.stop();
+  }
+
+  function messagesUrl() {
+    return `http://127.0.0.1:${port}/v1/messages`;
+  }
+
+  test('returns 409 with descriptive error when session is busy', async () => {
+    await startServer({ alwaysBusy: true });
+
+    const res = await fetch(messagesUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({ conversationKey: 'conv-busy-msg', content: 'Hello', sourceChannel: 'macos' }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('busy');
+
+    await stopServer();
+  });
+
+  test('returns 200 with accepted:true when session is not busy', async () => {
+    await startServer();
+
+    const res = await fetch(messagesUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({ conversationKey: 'conv-ok-msg', content: 'Hello', sourceChannel: 'macos' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { accepted: boolean; messageId: string };
+    expect(body.accepted).toBe(true);
+    expect(body.messageId).toBeDefined();
+
+    await stopServer();
+  });
+
+  test('returns 400 when sourceChannel is missing', async () => {
+    await startServer();
+
+    const res = await fetch(messagesUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({ conversationKey: 'conv-no-channel', content: 'Hello' }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('sourceChannel');
+
+    await stopServer();
+  });
+
+  test('returns 400 when conversationKey is missing', async () => {
+    await startServer();
+
+    const res = await fetch(messagesUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({ content: 'Hello', sourceChannel: 'macos' }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('conversationKey');
+
+    await stopServer();
+  });
+
+  test('returns 400 when content is empty', async () => {
+    await startServer();
+
+    const res = await fetch(messagesUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({ conversationKey: 'conv-empty', content: '', sourceChannel: 'macos' }),
+    });
+
+    expect(res.status).toBe(400);
+
+    await stopServer();
+  });
+});

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -1,10 +1,6 @@
 /**
- * Baseline tests for busy (409) rejection on both HTTP send endpoints:
- * - POST /v1/runs
- * - POST /v1/messages
- *
- * These tests verify the current behavior where a second send attempt
- * on a busy session returns 409 with a descriptive error message.
+ * Tests for busy behavior on POST /v1/runs — verifies that a second send
+ * attempt on a busy session queues the message instead of rejecting.
  */
 import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
 import { mkdtempSync, rmSync, realpathSync } from 'node:fs';
@@ -47,7 +43,6 @@ mock.module('../config/loader.js', () => ({
 import { initializeDb, getDb, resetDb } from '../memory/db.js';
 import { RuntimeHttpServer } from '../runtime/http-server.js';
 import { RunOrchestrator } from '../runtime/run-orchestrator.js';
-import type { MessageProcessor } from '../runtime/http-types.js';
 
 initializeDb();
 
@@ -108,19 +103,6 @@ function makeCompletingSession(): Session {
     handleConfirmationResponse: () => {},
     handleSecretResponse: () => {},
   } as unknown as Session;
-}
-
-/**
- * Build a processMessage function that throws the busy error when
- * `shouldBeBusy` returns true.
- */
-function makeBusyAwareProcessor(shouldBeBusy: () => boolean): MessageProcessor {
-  return async () => {
-    if (shouldBeBusy()) {
-      throw new Error('Session is already processing a message');
-    }
-    return { messageId: 'msg-1' };
-  };
 }
 
 // ── Test infrastructure ─────────────────────────────────────────────────────
@@ -205,113 +187,3 @@ describe('send endpoint busy behavior — POST /v1/runs', () => {
   });
 });
 
-describe('send endpoint busy behavior — POST /v1/messages', () => {
-  let server: RuntimeHttpServer;
-  let port: number;
-  let busyFlag: boolean;
-
-  beforeEach(() => {
-    cleanDb();
-    busyFlag = false;
-  });
-
-  async function startServer(opts?: { alwaysBusy?: boolean }) {
-    port = 19000 + Math.floor(Math.random() * 1000);
-    if (opts?.alwaysBusy) busyFlag = true;
-    const processor = makeBusyAwareProcessor(() => busyFlag);
-    server = new RuntimeHttpServer({
-      port,
-      bearerToken: TEST_TOKEN,
-      processMessage: processor,
-    });
-    await server.start();
-  }
-
-  async function stopServer() {
-    await server?.stop();
-  }
-
-  function messagesUrl() {
-    return `http://127.0.0.1:${port}/v1/messages`;
-  }
-
-  test('returns 409 with descriptive error when session is busy (legacy path)', async () => {
-    await startServer({ alwaysBusy: true });
-
-    const res = await fetch(messagesUrl(), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-      body: JSON.stringify({ conversationKey: 'conv-busy-msg', content: 'Hello', sourceChannel: 'macos' }),
-    });
-
-    expect(res.status).toBe(409);
-    const body = await res.json() as { error: string };
-    expect(body.error).toContain('busy');
-
-    await stopServer();
-  });
-
-  test('returns 200 with accepted:true and deprecation header', async () => {
-    await startServer();
-
-    const res = await fetch(messagesUrl(), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-      body: JSON.stringify({ conversationKey: 'conv-ok-msg', content: 'Hello', sourceChannel: 'macos' }),
-    });
-
-    expect(res.status).toBe(200);
-    const body = await res.json() as { accepted: boolean; messageId: string };
-    expect(body.accepted).toBe(true);
-    expect(body.messageId).toBeDefined();
-    expect(res.headers.get('Deprecation')).toBe('true');
-
-    await stopServer();
-  });
-
-  test('returns 400 when sourceChannel is missing', async () => {
-    await startServer();
-
-    const res = await fetch(messagesUrl(), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-      body: JSON.stringify({ conversationKey: 'conv-no-channel', content: 'Hello' }),
-    });
-
-    expect(res.status).toBe(400);
-    const body = await res.json() as { error: string };
-    expect(body.error).toContain('sourceChannel');
-
-    await stopServer();
-  });
-
-  test('returns 400 when conversationKey is missing', async () => {
-    await startServer();
-
-    const res = await fetch(messagesUrl(), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-      body: JSON.stringify({ content: 'Hello', sourceChannel: 'macos' }),
-    });
-
-    expect(res.status).toBe(400);
-    const body = await res.json() as { error: string };
-    expect(body.error).toContain('conversationKey');
-
-    await stopServer();
-  });
-
-  test('returns 400 when content is empty', async () => {
-    await startServer();
-
-    const res = await fetch(messagesUrl(), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-      body: JSON.stringify({ conversationKey: 'conv-empty', content: '', sourceChannel: 'macos' }),
-    });
-
-    expect(res.status).toBe(400);
-
-    await stopServer();
-  });
-});

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -235,7 +235,7 @@ describe('send endpoint busy behavior — POST /v1/messages', () => {
     return `http://127.0.0.1:${port}/v1/messages`;
   }
 
-  test('returns 409 with descriptive error when session is busy', async () => {
+  test('returns 409 with descriptive error when session is busy (legacy path)', async () => {
     await startServer({ alwaysBusy: true });
 
     const res = await fetch(messagesUrl(), {
@@ -251,7 +251,7 @@ describe('send endpoint busy behavior — POST /v1/messages', () => {
     await stopServer();
   });
 
-  test('returns 200 with accepted:true when session is not busy', async () => {
+  test('returns 200 with accepted:true and deprecation header', async () => {
     await startServer();
 
     const res = await fetch(messagesUrl(), {
@@ -264,6 +264,7 @@ describe('send endpoint busy behavior — POST /v1/messages', () => {
     const body = await res.json() as { accepted: boolean; messageId: string };
     expect(body.accepted).toBe(true);
     expect(body.messageId).toBeDefined();
+    expect(res.headers.get('Deprecation')).toBe('true');
 
     await stopServer();
   });

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -60,6 +60,7 @@ afterAll(() => {
 
 function makeHangingSession(): Session {
   let processing = false;
+  const queuedMessages: Array<{ onEvent: (msg: unknown) => void }> = [];
   return {
     isProcessing: () => processing,
     persistUserMessage: () => undefined as unknown as string,
@@ -74,6 +75,12 @@ function makeHangingSession(): Session {
       processing = true;
       await new Promise<void>(() => {}); // hangs forever
     },
+    enqueueMessage: (_content: string, _attachments: unknown[], onEvent: (msg: unknown) => void) => {
+      if (!processing) return { queued: false, requestId: 'req-1' };
+      queuedMessages.push({ onEvent });
+      return { queued: true, requestId: 'req-1' };
+    },
+    getQueueDepth: () => queuedMessages.length,
     handleConfirmationResponse: () => {},
     handleSecretResponse: () => {},
   } as unknown as Session;
@@ -96,6 +103,8 @@ function makeCompletingSession(): Session {
       await new Promise((r) => setTimeout(r, 20));
       processing = false;
     },
+    enqueueMessage: () => ({ queued: false, requestId: 'req-1' }),
+    getQueueDepth: () => 0,
     handleConfirmationResponse: () => {},
     handleSecretResponse: () => {},
   } as unknown as Session;
@@ -152,7 +161,7 @@ describe('send endpoint busy behavior — POST /v1/runs', () => {
     return `http://127.0.0.1:${port}/v1/runs`;
   }
 
-  test('returns 409 with descriptive error when session is busy', async () => {
+  test('returns 201 with queued status when session is busy', async () => {
     const session = makeHangingSession();
     await startServer(() => session);
 
@@ -163,18 +172,21 @@ describe('send endpoint busy behavior — POST /v1/runs', () => {
       body: JSON.stringify({ conversationKey: 'conv-busy-run', content: 'First', sourceChannel: 'macos' }),
     });
     expect(res1.status).toBe(201);
+    const body1 = await res1.json() as { status: string };
+    expect(body1.status).toBe('running');
 
     await new Promise((r) => setTimeout(r, 30));
 
-    // Second run should get 409
+    // Second run should be queued (not rejected)
     const res2 = await fetch(runsUrl(), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
       body: JSON.stringify({ conversationKey: 'conv-busy-run', content: 'Second', sourceChannel: 'macos' }),
     });
-    expect(res2.status).toBe(409);
-    const body = await res2.json() as { error: string };
-    expect(body.error).toContain('busy');
+    expect(res2.status).toBe(201);
+    const body2 = await res2.json() as { id: string; status: string };
+    expect(body2.status).toBe('queued');
+    expect(body2.id).toBeDefined();
 
     await stopServer();
   });

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -665,8 +665,6 @@ export async function runDaemon(): Promise<void> {
       bearerToken,
       processMessage: (conversationId, content, attachmentIds, options, sourceChannel) =>
         server.processMessage(conversationId, content, attachmentIds, options, sourceChannel),
-      persistAndProcessMessage: (conversationId, content, attachmentIds, options, sourceChannel) =>
-        server.persistAndProcessMessage(conversationId, content, attachmentIds, options, sourceChannel),
       runOrchestrator: server.createRunOrchestrator(),
       interfacesDir: getInterfacesDir(),
       approvalCopyGenerator: createApprovalCopyGenerator(),

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -32,8 +32,6 @@ import { ensureBlobDir, sweepStaleBlobs } from './ipc-blob-store.js';
 import { bootstrapHomeBaseAppLink } from '../home-base/bootstrap.js';
 import { SessionEvictor } from './session-evictor.js';
 import { getSubagentManager } from '../subagent/index.js';
-import { resolveSlash } from './session-slash.js';
-import { createUserMessage, createAssistantMessage } from '../agent/message-types.js';
 import { registerDaemonCallbacks } from '../work-items/work-item-runner.js';
 import { AuthManager } from './auth-manager.js';
 import { ConfigWatcher } from './config-watcher.js';
@@ -717,57 +715,10 @@ export class DaemonServer {
         }))
       : [];
 
-    const slashResult = resolveSlash(content);
-
-    if (slashResult.kind === 'unknown') {
-      const serverTurnCtx = session.getTurnChannelContext();
-      const serverChannelMeta = serverTurnCtx
-        ? { userMessageChannel: serverTurnCtx.userMessageChannel, assistantMessageChannel: serverTurnCtx.assistantMessageChannel }
-        : undefined;
-      const userMsg = createUserMessage(content, attachments);
-      const persisted = conversationStore.addMessage(
-        conversationId,
-        'user',
-        JSON.stringify(userMsg.content),
-        serverChannelMeta,
-      );
-      session.getMessages().push(userMsg);
-
-      if (serverTurnCtx) {
-        try {
-          conversationStore.setConversationOriginChannelIfUnset(conversationId, serverTurnCtx.userMessageChannel);
-        } catch (err) {
-          log.warn({ err, conversationId }, 'Failed to set origin channel (best-effort)');
-        }
-      }
-
-      const assistantMsg = createAssistantMessage(slashResult.message);
-      conversationStore.addMessage(
-        conversationId,
-        'assistant',
-        JSON.stringify(assistantMsg.content),
-        serverChannelMeta,
-      );
-      session.getMessages().push(assistantMsg);
-      return { messageId: persisted.id };
-    }
-
-    const resolvedContent = slashResult.content;
-
-    if (slashResult.kind === 'rewritten') {
-      (session as unknown as { preactivatedSkillIds?: string[] }).preactivatedSkillIds = [slashResult.skillId];
-    }
-
+    // Delegate to session.processMessage which handles slash resolution,
+    // message persistence, and the agent loop — the same path used by IPC.
     const requestId = crypto.randomUUID();
-    let messageId: string;
-    try {
-      messageId = session.persistUserMessage(resolvedContent, attachments, requestId);
-    } catch (err) {
-      (session as unknown as { preactivatedSkillIds?: string[] }).preactivatedSkillIds = undefined;
-      throw err;
-    }
-
-    await session.runAgentLoop(resolvedContent, messageId, () => {});
+    const messageId = await session.processMessage(content, attachments, () => {}, requestId);
 
     return { messageId };
   }

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -680,53 +680,6 @@ export class DaemonServer {
 
   // ── HTTP message processing ─────────────────────────────────────────
 
-  async persistAndProcessMessage(
-    conversationId: string,
-    content: string,
-    attachmentIds?: string[],
-    options?: SessionCreateOptions,
-    sourceChannel?: string,
-  ): Promise<{ messageId: string }> {
-    const ingressCheck = checkIngressForSecrets(content);
-    if (ingressCheck.blocked) {
-      throw new IngressBlockedError(ingressCheck.userNotice!, ingressCheck.detectedTypes);
-    }
-
-    const session = await this.getOrCreateSession(conversationId, undefined, true, options);
-
-    if (session.isProcessing()) {
-      throw new Error('Session is already processing a message');
-    }
-
-    session.setAssistantId(options?.assistantId ?? 'self');
-    session.setGuardianContext(options?.guardianContext ?? null);
-    session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
-    session.setCommandIntent(options?.commandIntent ?? null);
-    const resolvedChannel = resolveTurnChannel(sourceChannel, options?.transport?.channelId);
-    session.setTurnChannelContext({
-      userMessageChannel: resolvedChannel,
-      assistantMessageChannel: resolvedChannel,
-    });
-
-    const attachments = attachmentIds
-      ? attachmentsStore.getAttachmentsByIds(attachmentIds).map((a) => ({
-          id: a.id,
-          filename: a.originalFilename,
-          mimeType: a.mimeType,
-          data: a.dataBase64,
-        }))
-      : [];
-
-    const requestId = crypto.randomUUID();
-    const messageId = session.persistUserMessage(content, attachments, requestId);
-
-    session.runAgentLoop(content, messageId, () => {}).catch((err) => {
-      log.error({ err, conversationId }, 'Background agent loop failed');
-    });
-
-    return { messageId };
-  }
-
   async processMessage(
     conversationId: string,
     content: string,

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -613,6 +613,7 @@ export async function runAgentLoopImpl(
         status: 'warning',
       });
       onEvent({ type: 'generation_cancelled', sessionId: ctx.conversationId });
+      onEvent({ type: 'message_complete', sessionId: ctx.conversationId });
     } else {
       ctx.traceEmitter.emit('message_complete', 'Message processing complete', {
         requestId: reqId,
@@ -643,6 +644,7 @@ export async function runAgentLoopImpl(
         status: 'warning',
       });
       onEvent({ type: 'generation_cancelled', sessionId: ctx.conversationId });
+      onEvent({ type: 'message_complete', sessionId: ctx.conversationId });
     } else {
       const message = err instanceof Error ? err.message : String(err);
       const errorClass = err instanceof Error ? err.constructor.name : 'Error';
@@ -655,6 +657,7 @@ export async function runAgentLoopImpl(
       onEvent({ type: 'error', message: `Failed to process message: ${message}` });
       const classified = classifySessionError(err, errorCtx);
       onEvent(buildSessionErrorMessage(ctx.conversationId, classified));
+      onEvent({ type: 'message_complete', sessionId: ctx.conversationId });
       void getHookManager().trigger('on-error', {
         error: err instanceof Error ? err.name : 'Error',
         message,

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -191,6 +191,7 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
         attributes: { reason: 'persist_failure' },
       });
       next.onEvent({ type: 'error', message });
+      next.onEvent({ type: 'message_complete', sessionId: session.conversationId });
     }
     // Continue draining regardless of success/failure
     drainQueue(session);
@@ -220,6 +221,7 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
       attributes: { reason: 'persist_failure' },
     });
     next.onEvent({ type: 'error', message });
+    next.onEvent({ type: 'message_complete', sessionId: session.conversationId });
     // runAgentLoop never ran, so its finally block won't clear this
     session.preactivatedSkillIds = undefined;
     // Continue draining — don't strand remaining messages
@@ -238,6 +240,7 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, conversationId: session.conversationId, requestId: next.requestId }, 'Error processing queued message');
     next.onEvent({ type: 'error', message: `Failed to process queued message: ${message}` });
+    next.onEvent({ type: 'message_complete', sessionId: session.conversationId });
   });
 }
 

--- a/assistant/src/memory/runs-store.ts
+++ b/assistant/src/memory/runs-store.ts
@@ -15,7 +15,7 @@ import { messageRuns } from './schema.js';
 // Types
 // ---------------------------------------------------------------------------
 
-export type RunStatus = 'running' | 'needs_confirmation' | 'needs_secret' | 'completed' | 'failed';
+export type RunStatus = 'queued' | 'running' | 'needs_confirmation' | 'needs_secret' | 'completed' | 'failed';
 
 export interface PendingConfirmation {
   toolName: string;
@@ -97,6 +97,7 @@ function rowToRun(row: typeof messageRuns.$inferSelect): Run {
 export function createRun(
   conversationId: string,
   messageId?: string,
+  initialStatus: 'running' | 'queued' = 'running',
 ): Run {
   const db = getDb();
   const now = Date.now();
@@ -106,7 +107,7 @@ export function createRun(
     id,
     conversationId,
     messageId: messageId ?? null,
-    status: 'running' as const,
+    status: initialStatus,
     pendingConfirmation: null,
     pendingSecret: null,
     inputTokens: 0,
@@ -182,6 +183,15 @@ export function clearRunSecret(runId: string): void {
       pendingSecret: null,
       updatedAt: now,
     })
+    .where(eq(messageRuns.id, runId))
+    .run();
+}
+
+export function startRun(runId: string): void {
+  const db = getDb();
+  const now = Date.now();
+  db.update(messageRuns)
+    .set({ status: 'running', updatedAt: now })
     .where(eq(messageRuns.id, runId))
     .run();
 }
@@ -281,7 +291,7 @@ export function getPendingConfirmationsByConversation(conversationId: string): P
 export function failOrphanedRuns(): number {
   const db = getDb();
   const now = Date.now();
-  const activeStatuses = ['running', 'needs_confirmation', 'needs_secret'];
+  const activeStatuses = ['queued', 'running', 'needs_confirmation', 'needs_secret'];
 
   // Count first so we can report how many were recovered.
   const active = db.select({ id: messageRuns.id })

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -841,6 +841,7 @@ export class RuntimeHttpServer {
         return await handleSendMessage(req, {
           processMessage: this.processMessage,
           persistAndProcessMessage: this.persistAndProcessMessage,
+          runOrchestrator: this.runOrchestrator,
         });
       }
 

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -27,7 +27,6 @@ import type { RunOrchestrator } from './run-orchestrator.js';
 // Route handlers — grouped by domain
 import {
   handleListMessages,
-  handleSendMessage,
   handleGetSuggestion,
   handleSearchConversations,
 } from './routes/conversation-routes.js';
@@ -100,7 +99,6 @@ import {
 export type {
   RuntimeMessageSessionOptions,
   MessageProcessor,
-  NonBlockingMessageProcessor,
   RuntimeHttpServerOptions,
   RuntimeAttachmentMetadata,
   ApprovalCopyGenerator,
@@ -109,7 +107,6 @@ export type {
 
 import type {
   MessageProcessor,
-  NonBlockingMessageProcessor,
   RuntimeHttpServerOptions,
   ApprovalCopyGenerator,
   ApprovalConversationGenerator,
@@ -399,7 +396,6 @@ export class RuntimeHttpServer {
   private hostname: string;
   private bearerToken: string | undefined;
   private processMessage?: MessageProcessor;
-  private persistAndProcessMessage?: NonBlockingMessageProcessor;
   private runOrchestrator?: RunOrchestrator;
   private approvalCopyGenerator?: ApprovalCopyGenerator;
   private approvalConversationGenerator?: ApprovalConversationGenerator;
@@ -416,7 +412,6 @@ export class RuntimeHttpServer {
     this.hostname = options.hostname ?? DEFAULT_HOSTNAME;
     this.bearerToken = options.bearerToken;
     this.processMessage = options.processMessage;
-    this.persistAndProcessMessage = options.persistAndProcessMessage;
     this.runOrchestrator = options.runOrchestrator;
     this.approvalCopyGenerator = options.approvalCopyGenerator;
     this.approvalConversationGenerator = options.approvalConversationGenerator;
@@ -835,14 +830,6 @@ export class RuntimeHttpServer {
 
       if (endpoint === 'search' && req.method === 'GET') {
         return handleSearchConversations(url);
-      }
-
-      if (endpoint === 'messages' && req.method === 'POST') {
-        return await handleSendMessage(req, {
-          processMessage: this.processMessage,
-          persistAndProcessMessage: this.persistAndProcessMessage,
-          runOrchestrator: this.runOrchestrator,
-        });
       }
 
       if (endpoint === 'attachments' && req.method === 'POST') {

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -71,19 +71,6 @@ export type MessageProcessor = (
   sourceChannel?: ChannelId,
 ) => Promise<{ messageId: string }>;
 
-/**
- * Non-blocking message processor that persists the user message and
- * starts the agent loop in the background, returning the messageId
- * immediately.
- */
-export type NonBlockingMessageProcessor = (
-  conversationId: string,
-  content: string,
-  attachmentIds?: string[],
-  options?: RuntimeMessageSessionOptions,
-  sourceChannel?: ChannelId,
-) => Promise<{ messageId: string }>;
-
 export interface RuntimeHttpServerOptions {
   port?: number;
   /** Hostname / IP to bind to. Defaults to '127.0.0.1' (loopback-only). */
@@ -91,8 +78,6 @@ export interface RuntimeHttpServerOptions {
   /** Bearer token required on every request (except health checks). */
   bearerToken?: string;
   processMessage?: MessageProcessor;
-  /** Non-blocking processor for POST /messages (persists + fires agent loop). */
-  persistAndProcessMessage?: NonBlockingMessageProcessor;
   /** Run orchestrator for the approval-flow run endpoints. */
   runOrchestrator?: RunOrchestrator;
   /** Root directory for interface files on disk. */

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -18,6 +18,7 @@ import type {
   RuntimeMessagePayload,
 } from '../http-types.js';
 import { getLogger } from '../../util/logger.js';
+import type { RunOrchestrator } from '../run-orchestrator.js';
 import { parseSendRequest, isValidationError } from './send-validation.js';
 
 const log = getLogger('runtime-http');
@@ -135,11 +136,16 @@ export function handleListMessages(
   return Response.json({ messages });
 }
 
+/**
+ * @deprecated Use POST /v1/runs instead. This endpoint is a compatibility
+ * shim that routes through the same submit/queue path as POST /v1/runs.
+ */
 export async function handleSendMessage(
   req: Request,
   deps: {
     processMessage?: MessageProcessor;
     persistAndProcessMessage?: NonBlockingMessageProcessor;
+    runOrchestrator?: RunOrchestrator;
   },
 ): Promise<Response> {
   const parsed = await parseSendRequest(req);
@@ -147,8 +153,31 @@ export async function handleSendMessage(
 
   const { conversationKey, conversationId, content, attachmentIds, sourceChannel } = parsed;
 
-  log.info({ endpoint: 'POST /v1/messages', conversationKey }, 'Send attempt');
+  log.warn({ endpoint: 'POST /v1/messages', conversationKey }, 'Deprecated endpoint — use POST /v1/runs');
 
+  // When the run orchestrator is available, route through it so both
+  // endpoints share the same submit/queue path.
+  if (deps.runOrchestrator) {
+    const run = await deps.runOrchestrator.startRun(
+      conversationId,
+      content,
+      attachmentIds,
+      { sourceChannel },
+    );
+    return new Response(
+      JSON.stringify({ accepted: true, messageId: run.messageId }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Deprecation': 'true',
+          'X-Deprecation-Notice': 'POST /v1/messages is deprecated. Use POST /v1/runs instead.',
+        },
+      },
+    );
+  }
+
+  // Fallback: use legacy processMessage path
   const processor = deps.persistAndProcessMessage ?? deps.processMessage;
   if (!processor) {
     return Response.json({ error: 'Message processing not configured' }, { status: 503 });
@@ -162,7 +191,17 @@ export async function handleSendMessage(
       undefined,
       sourceChannel,
     );
-    return Response.json({ accepted: true, messageId: result.messageId });
+    return new Response(
+      JSON.stringify({ accepted: true, messageId: result.messageId }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Deprecation': 'true',
+          'X-Deprecation-Notice': 'POST /v1/messages is deprecated. Use POST /v1/runs instead.',
+        },
+      },
+    );
   } catch (err) {
     if (err instanceof Error && err.message === 'Session is already processing a message') {
       log.warn({ endpoint: 'POST /v1/messages', conversationKey }, 'Send rejected — session busy');

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -12,14 +12,10 @@ import { renderHistoryContent, mergeToolResults } from '../../daemon/handlers.js
 import { getConfiguredProvider } from '../../providers/provider-send-message.js';
 import type { Provider } from '../../providers/types.js';
 import type {
-  MessageProcessor,
-  NonBlockingMessageProcessor,
   RuntimeAttachmentMetadata,
   RuntimeMessagePayload,
 } from '../http-types.js';
 import { getLogger } from '../../util/logger.js';
-import type { RunOrchestrator } from '../run-orchestrator.js';
-import { parseSendRequest, isValidationError } from './send-validation.js';
 
 const log = getLogger('runtime-http');
 const SUGGESTION_CACHE_MAX = 100;
@@ -136,83 +132,6 @@ export function handleListMessages(
   return Response.json({ messages });
 }
 
-/**
- * @deprecated Use POST /v1/runs instead. This endpoint is a compatibility
- * shim that routes through the same submit/queue path as POST /v1/runs.
- */
-export async function handleSendMessage(
-  req: Request,
-  deps: {
-    processMessage?: MessageProcessor;
-    persistAndProcessMessage?: NonBlockingMessageProcessor;
-    runOrchestrator?: RunOrchestrator;
-  },
-): Promise<Response> {
-  const parsed = await parseSendRequest(req);
-  if (isValidationError(parsed)) return parsed;
-
-  const { conversationKey, conversationId, content, attachmentIds, sourceChannel } = parsed;
-
-  log.warn({ endpoint: 'POST /v1/messages', conversationKey }, 'Deprecated endpoint — use POST /v1/runs');
-
-  // When the run orchestrator is available, route through it so both
-  // endpoints share the same submit/queue path.
-  if (deps.runOrchestrator) {
-    const run = await deps.runOrchestrator.startRun(
-      conversationId,
-      content,
-      attachmentIds,
-      { sourceChannel },
-    );
-    return new Response(
-      JSON.stringify({ accepted: true, messageId: run.messageId }),
-      {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-          'Deprecation': 'true',
-          'X-Deprecation-Notice': 'POST /v1/messages is deprecated. Use POST /v1/runs instead.',
-        },
-      },
-    );
-  }
-
-  // Fallback: use legacy processMessage path
-  const processor = deps.persistAndProcessMessage ?? deps.processMessage;
-  if (!processor) {
-    return Response.json({ error: 'Message processing not configured' }, { status: 503 });
-  }
-
-  try {
-    const result = await processor(
-      conversationId,
-      content,
-      attachmentIds,
-      undefined,
-      sourceChannel,
-    );
-    return new Response(
-      JSON.stringify({ accepted: true, messageId: result.messageId }),
-      {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-          'Deprecation': 'true',
-          'X-Deprecation-Notice': 'POST /v1/messages is deprecated. Use POST /v1/runs instead.',
-        },
-      },
-    );
-  } catch (err) {
-    if (err instanceof Error && err.message === 'Session is already processing a message') {
-      log.warn({ endpoint: 'POST /v1/messages', conversationKey }, 'Send rejected — session busy');
-      return Response.json(
-        { error: 'Session is busy processing another message. Please retry.' },
-        { status: 409 },
-      );
-    }
-    throw err;
-  }
-}
 
 async function generateLlmSuggestion(provider: Provider, assistantText: string): Promise<string | null> {
   const truncated = assistantText.length > 2000

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1,12 +1,10 @@
 /**
  * Route handlers for conversation messages and suggestions.
  */
-import { CHANNEL_IDS, parseChannelId } from '../../channels/types.js';
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import {
   getConversationByKey,
-  getOrCreateConversation,
 } from '../../memory/conversation-key-store.js';
 import * as conversationStore from '../../memory/conversation-store.js';
 import * as attachmentsStore from '../../memory/attachments-store.js';
@@ -20,6 +18,7 @@ import type {
   RuntimeMessagePayload,
 } from '../http-types.js';
 import { getLogger } from '../../util/logger.js';
+import { parseSendRequest, isValidationError } from './send-validation.js';
 
 const log = getLogger('runtime-http');
 const SUGGESTION_CACHE_MAX = 100;
@@ -143,68 +142,10 @@ export async function handleSendMessage(
     persistAndProcessMessage?: NonBlockingMessageProcessor;
   },
 ): Promise<Response> {
-  const body = await req.json() as {
-    conversationKey?: string;
-    content?: string;
-    attachmentIds?: string[];
-    sourceChannel?: string;
-  };
+  const parsed = await parseSendRequest(req);
+  if (isValidationError(parsed)) return parsed;
 
-  const { conversationKey, content, attachmentIds } = body;
-  if (!body.sourceChannel || typeof body.sourceChannel !== 'string') {
-    return Response.json(
-      { error: 'sourceChannel is required' },
-      { status: 400 },
-    );
-  }
-  const sourceChannel = parseChannelId(body.sourceChannel);
-
-  if (!sourceChannel) {
-    return Response.json(
-      { error: `Invalid sourceChannel: ${body.sourceChannel}. Valid values: ${CHANNEL_IDS.join(', ')}` },
-      { status: 400 },
-    );
-  }
-
-  if (!conversationKey) {
-    return Response.json(
-      { error: 'conversationKey is required' },
-      { status: 400 },
-    );
-  }
-
-  // Reject non-string content values (numbers, objects, etc.)
-  if (content != null && typeof content !== 'string') {
-    return Response.json(
-      { error: 'content must be a string' },
-      { status: 400 },
-    );
-  }
-
-  const trimmedContent = typeof content === 'string' ? content.trim() : '';
-  const hasAttachments = Array.isArray(attachmentIds) && attachmentIds.length > 0;
-
-  if (trimmedContent.length === 0 && !hasAttachments) {
-    return Response.json(
-      { error: 'content or attachmentIds is required' },
-      { status: 400 },
-    );
-  }
-
-  // Validate that all attachment IDs resolve
-  if (hasAttachments) {
-    const resolved = attachmentsStore.getAttachmentsByIds(attachmentIds);
-    if (resolved.length !== attachmentIds.length) {
-      const resolvedIds = new Set(resolved.map((a) => a.id));
-      const missing = attachmentIds.filter((id) => !resolvedIds.has(id));
-      return Response.json(
-        { error: `Attachment IDs not found: ${missing.join(', ')}` },
-        { status: 400 },
-      );
-    }
-  }
-
-  const mapping = getOrCreateConversation(conversationKey);
+  const { conversationKey, conversationId, content, attachmentIds, sourceChannel } = parsed;
 
   log.info({ endpoint: 'POST /v1/messages', conversationKey }, 'Send attempt');
 
@@ -215,9 +156,9 @@ export async function handleSendMessage(
 
   try {
     const result = await processor(
-      mapping.conversationId,
-      content ?? '',
-      hasAttachments ? attachmentIds : undefined,
+      conversationId,
+      content,
+      attachmentIds,
       undefined,
       sourceChannel,
     );

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -19,7 +19,9 @@ import type {
   RuntimeAttachmentMetadata,
   RuntimeMessagePayload,
 } from '../http-types.js';
+import { getLogger } from '../../util/logger.js';
 
+const log = getLogger('runtime-http');
 const SUGGESTION_CACHE_MAX = 100;
 
 function getInterfaceFilesWithMtimes(interfacesDir: string | null): Array<{ path: string; mtimeMs: number }> {
@@ -204,6 +206,8 @@ export async function handleSendMessage(
 
   const mapping = getOrCreateConversation(conversationKey);
 
+  log.info({ endpoint: 'POST /v1/messages', conversationKey }, 'Send attempt');
+
   const processor = deps.persistAndProcessMessage ?? deps.processMessage;
   if (!processor) {
     return Response.json({ error: 'Message processing not configured' }, { status: 503 });
@@ -220,6 +224,7 @@ export async function handleSendMessage(
     return Response.json({ accepted: true, messageId: result.messageId });
   } catch (err) {
     if (err instanceof Error && err.message === 'Session is already processing a message') {
+      log.warn({ endpoint: 'POST /v1/messages', conversationKey }, 'Send rejected — session busy');
       return Response.json(
         { error: 'Session is busy processing another message. Please retry.' },
         { status: 409 },
@@ -295,7 +300,6 @@ export async function handleGetSuggestion(
   }
 
   const { suggestionCache, suggestionInFlight } = deps;
-  const log = (await import('../../util/logger.js')).getLogger('runtime-http');
 
   // Walk backwards to find the last assistant message with text content
   for (let i = rawMessages.length - 1; i >= 0; i--) {

--- a/assistant/src/runtime/routes/run-routes.ts
+++ b/assistant/src/runtime/routes/run-routes.ts
@@ -1,14 +1,12 @@
 /**
  * Route handlers for run creation, status, decisions, and trust rules.
  */
-import { getOrCreateConversation } from '../../memory/conversation-key-store.js';
-import * as attachmentsStore from '../../memory/attachments-store.js';
 import * as runsStore from '../../memory/runs-store.js';
-import { CHANNEL_IDS, parseChannelId } from '../../channels/types.js';
 import { addRule } from '../../permissions/trust-store.js';
 import { getTool } from '../../tools/registry.js';
 import { getLogger } from '../../util/logger.js';
 import type { RunOrchestrator } from '../run-orchestrator.js';
+import { parseSendRequest, isValidationError } from './send-validation.js';
 
 const log = getLogger('runtime-http');
 
@@ -16,62 +14,18 @@ export async function handleCreateRun(
   req: Request,
   runOrchestrator: RunOrchestrator,
 ): Promise<Response> {
-  const body = await req.json() as {
-    conversationKey?: string;
-    content?: string;
-    attachmentIds?: string[];
-    sourceChannel?: string;
-  };
+  const parsed = await parseSendRequest(req);
+  if (isValidationError(parsed)) return parsed;
 
-  const { conversationKey, content, attachmentIds } = body;
-  if (!body.sourceChannel || typeof body.sourceChannel !== 'string') {
-    return Response.json({ error: 'sourceChannel is required' }, { status: 400 });
-  }
-  const sourceChannel = parseChannelId(body.sourceChannel);
-
-  if (!sourceChannel) {
-    return Response.json(
-      { error: `Invalid sourceChannel: ${body.sourceChannel}. Valid values: ${CHANNEL_IDS.join(', ')}` },
-      { status: 400 },
-    );
-  }
-
-  if (!conversationKey) {
-    return Response.json({ error: 'conversationKey is required' }, { status: 400 });
-  }
-
-  if (content != null && typeof content !== 'string') {
-    return Response.json({ error: 'content must be a string' }, { status: 400 });
-  }
-
-  const trimmedContent = typeof content === 'string' ? content.trim() : '';
-  const hasAttachments = Array.isArray(attachmentIds) && attachmentIds.length > 0;
-
-  if (trimmedContent.length === 0 && !hasAttachments) {
-    return Response.json({ error: 'content or attachmentIds is required' }, { status: 400 });
-  }
-
-  if (hasAttachments) {
-    const resolved = attachmentsStore.getAttachmentsByIds(attachmentIds);
-    if (resolved.length !== attachmentIds.length) {
-      const resolvedIds = new Set(resolved.map((a) => a.id));
-      const missing = attachmentIds.filter((id) => !resolvedIds.has(id));
-      return Response.json(
-        { error: `Attachment IDs not found: ${missing.join(', ')}` },
-        { status: 400 },
-      );
-    }
-  }
-
-  const mapping = getOrCreateConversation(conversationKey);
+  const { conversationKey, conversationId, content, attachmentIds, sourceChannel } = parsed;
 
   log.info({ endpoint: 'POST /v1/runs', conversationKey }, 'Send attempt');
 
   try {
     const run = await runOrchestrator.startRun(
-      mapping.conversationId,
-      content ?? '',
-      hasAttachments ? attachmentIds : undefined,
+      conversationId,
+      content,
+      attachmentIds,
       { sourceChannel },
     );
     return Response.json({

--- a/assistant/src/runtime/routes/run-routes.ts
+++ b/assistant/src/runtime/routes/run-routes.ts
@@ -21,29 +21,18 @@ export async function handleCreateRun(
 
   log.info({ endpoint: 'POST /v1/runs', conversationKey }, 'Send attempt');
 
-  try {
-    const run = await runOrchestrator.startRun(
-      conversationId,
-      content,
-      attachmentIds,
-      { sourceChannel },
-    );
-    return Response.json({
-      id: run.id,
-      status: run.status,
-      messageId: run.messageId,
-      createdAt: new Date(run.createdAt).toISOString(),
-    }, { status: 201 });
-  } catch (err) {
-    if (err instanceof Error && err.message === 'Session is already processing a message') {
-      log.warn({ endpoint: 'POST /v1/runs', conversationKey }, 'Send rejected — session busy');
-      return Response.json(
-        { error: 'Session is busy processing another message. Please retry.' },
-        { status: 409 },
-      );
-    }
-    throw err;
-  }
+  const run = await runOrchestrator.startRun(
+    conversationId,
+    content,
+    attachmentIds,
+    { sourceChannel },
+  );
+  return Response.json({
+    id: run.id,
+    status: run.status,
+    messageId: run.messageId,
+    createdAt: new Date(run.createdAt).toISOString(),
+  }, { status: 201 });
 }
 
 export function handleGetRun(

--- a/assistant/src/runtime/routes/run-routes.ts
+++ b/assistant/src/runtime/routes/run-routes.ts
@@ -65,6 +65,8 @@ export async function handleCreateRun(
 
   const mapping = getOrCreateConversation(conversationKey);
 
+  log.info({ endpoint: 'POST /v1/runs', conversationKey }, 'Send attempt');
+
   try {
     const run = await runOrchestrator.startRun(
       mapping.conversationId,
@@ -80,6 +82,7 @@ export async function handleCreateRun(
     }, { status: 201 });
   } catch (err) {
     if (err instanceof Error && err.message === 'Session is already processing a message') {
+      log.warn({ endpoint: 'POST /v1/runs', conversationKey }, 'Send rejected — session busy');
       return Response.json(
         { error: 'Session is busy processing another message. Please retry.' },
         { status: 409 },

--- a/assistant/src/runtime/routes/send-validation.ts
+++ b/assistant/src/runtime/routes/send-validation.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared request parsing and validation for HTTP send endpoints
+ * (POST /v1/runs and POST /v1/messages).
+ *
+ * Both endpoints accept the same body shape and apply the same
+ * validation rules. This module extracts that logic so each handler
+ * only implements the submission/response contract that differs.
+ */
+import type { ChannelId } from '../../channels/types.js';
+import { CHANNEL_IDS, parseChannelId } from '../../channels/types.js';
+import { getOrCreateConversation } from '../../memory/conversation-key-store.js';
+import * as attachmentsStore from '../../memory/attachments-store.js';
+
+export interface ValidatedSendRequest {
+  conversationKey: string;
+  conversationId: string;
+  content: string;
+  attachmentIds: string[] | undefined;
+  sourceChannel: ChannelId;
+}
+
+/**
+ * Parse and validate a send request body.
+ * Returns a `ValidatedSendRequest` on success, or a `Response` (4xx) on failure.
+ */
+export async function parseSendRequest(
+  req: Request,
+): Promise<ValidatedSendRequest | Response> {
+  const body = await req.json() as {
+    conversationKey?: string;
+    content?: string;
+    attachmentIds?: string[];
+    sourceChannel?: string;
+  };
+
+  const { conversationKey, content, attachmentIds } = body;
+
+  if (!body.sourceChannel || typeof body.sourceChannel !== 'string') {
+    return Response.json({ error: 'sourceChannel is required' }, { status: 400 });
+  }
+  const sourceChannel = parseChannelId(body.sourceChannel);
+  if (!sourceChannel) {
+    return Response.json(
+      { error: `Invalid sourceChannel: ${body.sourceChannel}. Valid values: ${CHANNEL_IDS.join(', ')}` },
+      { status: 400 },
+    );
+  }
+
+  if (!conversationKey) {
+    return Response.json({ error: 'conversationKey is required' }, { status: 400 });
+  }
+
+  if (content != null && typeof content !== 'string') {
+    return Response.json({ error: 'content must be a string' }, { status: 400 });
+  }
+
+  const trimmedContent = typeof content === 'string' ? content.trim() : '';
+  const hasAttachments = Array.isArray(attachmentIds) && attachmentIds.length > 0;
+
+  if (trimmedContent.length === 0 && !hasAttachments) {
+    return Response.json({ error: 'content or attachmentIds is required' }, { status: 400 });
+  }
+
+  if (hasAttachments) {
+    const resolved = attachmentsStore.getAttachmentsByIds(attachmentIds);
+    if (resolved.length !== attachmentIds.length) {
+      const resolvedIds = new Set(resolved.map((a) => a.id));
+      const missing = attachmentIds.filter((id) => !resolvedIds.has(id));
+      return Response.json(
+        { error: `Attachment IDs not found: ${missing.join(', ')}` },
+        { status: 400 },
+      );
+    }
+  }
+
+  const mapping = getOrCreateConversation(conversationKey);
+
+  return {
+    conversationKey,
+    conversationId: mapping.conversationId,
+    content: content ?? '',
+    attachmentIds: hasAttachments ? attachmentIds : undefined,
+    sourceChannel,
+  };
+}
+
+/** Type guard: returns true if `parseSendRequest` returned a validation error Response. */
+export function isValidationError(result: ValidatedSendRequest | Response): result is Response {
+  return result instanceof Response;
+}

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -141,8 +141,11 @@ export class RunOrchestrator {
 
     const session = await this.deps.getOrCreateSession(conversationId, transport);
 
+    // When the session is busy, enqueue the message and return a queued run
+    // instead of rejecting with a 409. The message will be processed when the
+    // current agent loop completes and drains the queue.
     if (session.isProcessing()) {
-      throw new Error('Session is already processing a message');
+      return this.enqueueRun(session, conversationId, content, attachmentIds, options);
     }
 
     // Determine the correct strictSideEffects value for this run:
@@ -285,6 +288,94 @@ export class RunOrchestrator {
         cleanup();
       }
     })();
+
+    return run;
+  }
+
+  /**
+   * Enqueue a message on a busy session and return a run with `queued` status.
+   * When the queue drains, the onEvent callback transitions the run through
+   * its lifecycle (queued → running → completed/failed).
+   */
+  private enqueueRun(
+    session: Session,
+    conversationId: string,
+    content: string,
+    attachmentIds?: string[],
+    options?: RunStartOptions,
+  ): Run {
+    const run = runsStore.createRun(conversationId, undefined, 'queued');
+    const requestId = crypto.randomUUID();
+
+    const attachments = attachmentIds
+      ? this.deps.resolveAttachments(attachmentIds)
+      : [];
+
+    const sourceChannel = options?.sourceChannel ?? 'macos';
+
+    // Serialized publish chain so hub subscribers observe events in order.
+    let hubChain: Promise<void> = Promise.resolve();
+    const publishToHub = (msg: ServerMessage): void => {
+      const msgRecord = msg as unknown as Record<string, unknown>;
+      const msgSessionId =
+        'sessionId' in msg && typeof msgRecord.sessionId === 'string'
+          ? (msgRecord.sessionId as string)
+          : undefined;
+      const resolvedSessionId = msgSessionId ?? conversationId;
+      const event = buildAssistantEvent('self', msg, resolvedSessionId);
+      hubChain = (async () => {
+        await hubChain;
+        try {
+          await assistantEventHub.publish(event);
+        } catch (err) {
+          log.warn({ err }, 'assistant-events hub subscriber threw during queued run');
+        }
+      })();
+    };
+
+    let lastError: string | null = null;
+    const onEvent = (msg: ServerMessage) => {
+      if (msg.type === 'message_dequeued') {
+        runsStore.startRun(run.id);
+      } else if (msg.type === 'error') {
+        lastError = msg.message;
+      } else if (msg.type === 'session_error') {
+        lastError = msg.userMessage;
+      } else if (msg.type === 'message_complete') {
+        if (lastError) {
+          runsStore.failRun(run.id, lastError);
+        } else {
+          runsStore.completeRun(run.id);
+        }
+      }
+      publishToHub(msg);
+    };
+
+    const channelMetadata = {
+      userMessageChannel: sourceChannel,
+      assistantMessageChannel: sourceChannel,
+    };
+
+    const result = session.enqueueMessage(
+      content,
+      attachments,
+      onEvent,
+      requestId,
+      undefined,
+      undefined,
+      channelMetadata,
+    );
+
+    if (result.rejected) {
+      // Queue is full — fail the run immediately
+      runsStore.failRun(run.id, 'Message queue is full');
+      log.warn({ runId: run.id, conversationId }, 'Queued run rejected — queue full');
+    } else {
+      log.info(
+        { runId: run.id, conversationId, queuePosition: session.getQueueDepth() },
+        'Run queued (session busy)',
+      );
+    }
 
     return run;
   }

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -313,6 +313,10 @@ export class RunOrchestrator {
 
     const sourceChannel = options?.sourceChannel ?? 'macos';
 
+    // Pre-compute per-run options to apply when the message is dequeued
+    const strictSideEffects = options?.forceStrictSideEffects
+      ?? this.deps.deriveDefaultStrictSideEffects(conversationId);
+
     // Serialized publish chain so hub subscribers observe events in order.
     let hubChain: Promise<void> = Promise.resolve();
     const publishToHub = (msg: ServerMessage): void => {
@@ -333,21 +337,80 @@ export class RunOrchestrator {
       })();
     };
 
+    const cleanup = () => {
+      this.pending.delete(run.id);
+      session.setChannelCapabilities(null);
+      session.setGuardianContext(null);
+      session.setCommandIntent(null);
+      session.setAssistantId('self');
+      session.updateClient(() => {}, true);
+    };
+
     let lastError: string | null = null;
+    let finalized = false;
+    const finalizeRun = () => {
+      if (finalized) return;
+      finalized = true;
+      if (lastError) {
+        runsStore.failRun(run.id, lastError);
+      } else {
+        runsStore.completeRun(run.id);
+      }
+      cleanup();
+    };
+
     const onEvent = (msg: ServerMessage) => {
       if (msg.type === 'message_dequeued') {
         runsStore.startRun(run.id);
+
+        // Apply per-run session options deferred from enqueue time
+        session.memoryPolicy = { ...session.memoryPolicy, strictSideEffects };
+        session.setAssistantId(options?.assistantId ?? 'self');
+        session.setGuardianContext(options?.guardianContext ?? null);
+        session.setCommandIntent(options?.commandIntent ?? null);
+        session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
+
+        // Wire confirmation/secret tracking so queued runs can be polled
+        session.updateClient((clientMsg: ServerMessage) => {
+          if (clientMsg.type === 'confirmation_request') {
+            runsStore.setRunConfirmation(run.id, {
+              toolName: clientMsg.toolName,
+              toolUseId: clientMsg.requestId,
+              input: clientMsg.input,
+              riskLevel: clientMsg.riskLevel,
+              executionTarget: clientMsg.executionTarget,
+              allowlistOptions: clientMsg.allowlistOptions,
+              scopeOptions: clientMsg.scopeOptions,
+              persistentDecisionsAllowed: clientMsg.persistentDecisionsAllowed,
+            });
+            this.pending.set(run.id, { prompterRequestId: clientMsg.requestId, session });
+          } else if (clientMsg.type === 'secret_request') {
+            runsStore.setRunSecret(run.id, {
+              requestId: clientMsg.requestId,
+              service: clientMsg.service,
+              field: clientMsg.field,
+              label: clientMsg.label,
+              description: clientMsg.description,
+              placeholder: clientMsg.placeholder,
+              purpose: clientMsg.purpose,
+              allowOneTimeSend: clientMsg.allowOneTimeSend,
+            });
+            this.pending.set(run.id, { prompterRequestId: clientMsg.requestId, session });
+          }
+          publishToHub(clientMsg);
+        });
       } else if (msg.type === 'error') {
         lastError = msg.message;
       } else if (msg.type === 'session_error') {
         lastError = msg.userMessage;
-      } else if (msg.type === 'message_complete') {
-        if (lastError) {
-          runsStore.failRun(run.id, lastError);
-        } else {
-          runsStore.completeRun(run.id);
-        }
+      } else if (msg.type === 'generation_cancelled') {
+        lastError = lastError ?? 'Generation cancelled';
       }
+
+      if (msg.type === 'message_complete') {
+        finalizeRun();
+      }
+
       publishToHub(msg);
     };
 
@@ -367,15 +430,16 @@ export class RunOrchestrator {
     );
 
     if (result.rejected) {
-      // Queue is full — fail the run immediately
       runsStore.failRun(run.id, 'Message queue is full');
       log.warn({ runId: run.id, conversationId }, 'Queued run rejected — queue full');
-    } else {
-      log.info(
-        { runId: run.id, conversationId, queuePosition: session.getQueueDepth() },
-        'Run queued (session busy)',
-      );
+      // Return fresh copy reflecting the failed status
+      return runsStore.getRun(run.id)!;
     }
+
+    log.info(
+      { runId: run.id, conversationId, queuePosition: session.getQueueDepth() },
+      'Run queued (session busy)',
+    );
 
     return run;
   }


### PR DESCRIPTION
## Summary

Consolidates the HTTP send endpoints to eliminate 409 busy rejections during web QA. All send paths now use queue-first behavior instead of rejecting when the session is busy.

- **PR 1**: Baseline tests and structured telemetry for send endpoint busy behavior
- **PR 2**: Extracted shared `parseSendRequest()` validation used by both send endpoints
- **PR 3**: Replaced 409 busy rejection with queue behavior on `POST /v1/runs` — adds `queued` run status and `enqueueRun()` on RunOrchestrator
- **PR 4**: Routed `POST /v1/messages` through RunOrchestrator with deprecation headers (compatibility shim)
- **PR 5**: Removed `POST /v1/messages` send endpoint, `NonBlockingMessageProcessor` type, and `persistAndProcessMessage` plumbing. `GET /v1/messages` (history) retained.
- **PR 6**: Converged `DaemonServer.processMessage` onto `session.processMessage()` — the same core used by IPC — eliminating duplicated slash resolution and fixing a subtle bug where the server path called `resolveSlash()` without `SlashContext`

### Key behavior change

When `POST /v1/runs` is called while the session is busy, it now returns `201` with `status: "queued"` instead of `409`. The queued message is processed when the current agent loop completes.

Linear: https://linear.app/vellum/issue/JARVIS-40/consolidate-messages-and-run-to-avoid-409-in-web-qa

## Test plan

- [x] `bun test src/__tests__/send-endpoint-busy.test.ts` — queue behavior verified
- [x] `bun test src/__tests__/run-orchestrator.test.ts` — orchestrator tests pass
- [ ] Manual QA: send messages while session is busy, verify queued behavior instead of 409
- [ ] Manual QA: verify `GET /v1/messages` history endpoint still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
