### PR TITLE
Fix: relax title validation — reject old prefix only

### DIFF
--- a/assistant/src/calls/guardian-question-copy.ts
+++ b/assistant/src/calls/guardian-question-copy.ts
@@ -124,9 +124,8 @@ function parseGeneratedCopy(text: string): GuardianCopy | null {
     return null;
   }
 
-  // Reject titles that don't start with an emoji or that use the old "Guardian question:" prefix
-  const firstCodePoint = title.codePointAt(0) ?? 0;
-  if (firstCodePoint < 127 || /^guardian question:/i.test(title)) {
+  // Reject the old static prefix — the model is guided towards better titles but has final say
+  if (/^guardian question:/i.test(title)) {
     return null;
   }
 


### PR DESCRIPTION
Remove the emoji code point enforcement from parseGeneratedCopy. The model is guided towards emoji-prefixed titles via the prompt, but the format is ultimately the assistant's choice. Only the old 'Guardian question:' prefix is rejected to prevent regression.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
