### PR TITLE
security: enforce file permissions on log files

### DIFF
--- a/assistant/src/util/logger.ts
+++ b/assistant/src/util/logger.ts
@@ -66,7 +66,7 @@ function buildRotatingLogger(config: LogFileConfig): pino.Logger {
 
   const today = formatDate(new Date());
   const filePath = logFilePathForDate(config.dir, new Date());
-  const fileStream = pino.destination({ dest: filePath, sync: false, mkdir: true });
+  const fileStream = pino.destination({ dest: filePath, sync: false, mkdir: true, mode: 0o600 });
 
   activeLogDate = today;
   activeLogFileConfig = config;
@@ -130,7 +130,7 @@ function getRootLogger(): pino.Logger {
     }
 
     try {
-      const fileStream = pino.destination({ dest: getLogPath(), sync: false, mkdir: true });
+      const fileStream = pino.destination({ dest: getLogPath(), sync: false, mkdir: true, mode: 0o600 });
 
       if (getDebugMode()) {
         const prettyStream = pinoPretty({ destination: 2 });

--- a/gateway/src/logger.ts
+++ b/gateway/src/logger.ts
@@ -63,7 +63,7 @@ function buildLogger(config: LogFileConfig | null): pino.Logger {
 
   const today = formatDate(new Date());
   const filePath = logFilePathForDate(config.dir, new Date());
-  const fileStream = pino.destination({ dest: filePath, sync: false, mkdir: true });
+  const fileStream = pino.destination({ dest: filePath, sync: false, mkdir: true, mode: 0o600 });
 
   activeLogDate = today;
   activeConfig = config;


### PR DESCRIPTION
Set 0o600 (owner read/write only) on pino log file destinations in both assistant and gateway to prevent sensitive data exposure.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
