### PR TITLE
fix: propagate AbortSignal through permission checking

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -304,7 +304,9 @@ async function buildCommandCandidates(toolName: string, input: Record<string, un
   return [...new Set(candidates)];
 }
 
-export async function classifyRisk(toolName: string, input: Record<string, unknown>, workingDir?: string, preParsed?: ParsedCommand, manifestOverride?: ManifestOverride): Promise<RiskLevel> {
+export async function classifyRisk(toolName: string, input: Record<string, unknown>, workingDir?: string, preParsed?: ParsedCommand, manifestOverride?: ManifestOverride, signal?: AbortSignal): Promise<RiskLevel> {
+  if (signal?.aborted) throw new Error('Cancelled');
+
   // Check cache first (skip when preParsed is provided since caller already
   // parsed and we'd just be duplicating the key computation cost).
   const cacheKey = preParsed ? null : riskCacheKey(toolName, input);
@@ -462,7 +464,10 @@ export async function check(
   workingDir: string,
   policyContext?: PolicyContext,
   manifestOverride?: ManifestOverride,
+  signal?: AbortSignal,
 ): Promise<PermissionCheckResult> {
+  if (signal?.aborted) throw new Error('Cancelled');
+
   // For shell tools, parse once and share the result to avoid duplicate tree-sitter work.
   let shellParsed: ParsedCommand | undefined;
   if (toolName === 'bash' || toolName === 'host_bash') {
@@ -472,7 +477,7 @@ export async function check(
     }
   }
 
-  const risk = await classifyRisk(toolName, input, workingDir, shellParsed, manifestOverride);
+  const risk = await classifyRisk(toolName, input, workingDir, shellParsed, manifestOverride, signal);
 
   // Build command string candidates for rule matching
   const commandCandidates = await buildCommandCandidates(toolName, input, workingDir, shellParsed);
@@ -602,7 +607,8 @@ function friendlyHostname(url: URL): string {
   return url.hostname.replace(/^www\./, '');
 }
 
-export async function generateAllowlistOptions(toolName: string, input: Record<string, unknown>): Promise<AllowlistOption[]> {
+export async function generateAllowlistOptions(toolName: string, input: Record<string, unknown>, signal?: AbortSignal): Promise<AllowlistOption[]> {
+  if (signal?.aborted) throw new Error('Cancelled');
   if (toolName === 'bash' || toolName === 'host_bash') {
     const command = ((input.command as string) ?? '').trim();
     return buildShellAllowlistOptions(command);

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -43,12 +43,15 @@ export class PermissionPrompter {
     sessionId?: string,
     executionTarget?: ExecutionTarget,
     persistentDecisionsAllowed?: boolean,
+    signal?: AbortSignal,
   ): Promise<{
     decision: UserDecision;
     selectedPattern?: string;
     selectedScope?: string;
     decisionContext?: string;
   }> {
+    if (signal?.aborted) return { decision: 'deny' };
+
     const requestId = uuid();
 
     return new Promise((resolve, reject) => {
@@ -60,6 +63,17 @@ export class PermissionPrompter {
       }, timeoutMs);
 
       this.pending.set(requestId, { resolve, reject, timer });
+
+      if (signal) {
+        const onAbort = () => {
+          if (this.pending.has(requestId)) {
+            clearTimeout(timer);
+            this.pending.delete(requestId);
+            resolve({ decision: 'deny' });
+          }
+        };
+        signal.addEventListener('abort', onAbort, { once: true });
+      }
 
       this.sendToClient({
         type: 'confirmation_request',

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -186,14 +186,14 @@ export class ToolExecutor {
 
     try {
       // Check permissions
-      const risk = await classifyRisk(name, input, context.workingDir);
+      const risk = await classifyRisk(name, input, context.workingDir, undefined, undefined, context.signal);
       riskLevel = risk;
 
       // Build principal context from tool metadata so policy rules can
       // distinguish skill-provided tools from core built-ins. Also includes
       // ephemeral rules when executing within a task run.
       const policyContext = buildPolicyContext(tool, context);
-      const result = await check(name, input, context.workingDir, policyContext);
+      const result = await check(name, input, context.workingDir, policyContext, undefined, context.signal);
 
       // Private threads force prompting for side-effect tools even when a
       // trust/allow rule would auto-allow. Deny decisions are preserved —
@@ -255,7 +255,7 @@ export class ToolExecutor {
         }
 
         // Need user approval
-        const allowlistOptions = await generateAllowlistOptions(name, input);
+        const allowlistOptions = await generateAllowlistOptions(name, input, context.signal);
         const scopeOptions = generateScopeOptions(context.workingDir, name);
 
         // Compute preview diff for file tools so the user sees what will change
@@ -313,6 +313,7 @@ export class ToolExecutor {
           context.conversationId,
           executionTarget,
           persistentDecisionsAllowed,
+          context.signal,
         );
 
         decision = response.decision;
@@ -632,6 +633,7 @@ export class ToolExecutor {
               context.conversationId,
               executionTarget,
               false, // no persistent decisions
+              context.signal,
             );
 
             if (response.decision === 'deny' || response.decision === 'always_deny') {


### PR DESCRIPTION
Add signal parameter to classifyRisk, check, prompt, and generateAllowlistOptions so cancellation propagates through permission checks.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
