### PR TITLE
perf: add database indexes on remaining tables

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -18,6 +18,7 @@ import {
   migrateDropActiveSearchIndex,
   migrateMemorySegmentsIndexes,
   migrateMemoryItemsIndexes,
+  migrateRemainingTableIndexes,
   validateMigrationState,
 } from './schema-migration.js';
 
@@ -1272,6 +1273,8 @@ export function initializeDb(): void {
   migrateMemorySegmentsIndexes(database);
 
   migrateMemoryItemsIndexes(database);
+
+  migrateRemainingTableIndexes(database);
 
   validateMigrationState(database);
 }

--- a/assistant/src/memory/migrations/018-remaining-table-indexes.ts
+++ b/assistant/src/memory/migrations/018-remaining-table-indexes.ts
@@ -1,0 +1,13 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Idempotent migration to add indexes on foreign-key and scope columns that
+ * lacked them.  messages.conversation_id is a FK used for ON DELETE CASCADE,
+ * so the index also speeds up cascading deletes.
+ */
+export function migrateRemainingTableIndexes(database: DrizzleDb): void {
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_item_conflicts_scope_id ON memory_item_conflicts(scope_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_summaries_scope_id ON memory_summaries(scope_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_messages_conversation_id ON messages(conversation_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_tool_invocations_conversation_id ON tool_invocations(conversation_id)`);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -21,3 +21,4 @@ export { migrateBackfillInboxThreadStateFromBindings } from './014-backfill-inbo
 export { migrateDropActiveSearchIndex } from './015-drop-active-search-index.js';
 export { migrateMemorySegmentsIndexes } from './016-memory-segments-indexes.js';
 export { migrateMemoryItemsIndexes } from './017-memory-items-indexes.js';
+export { migrateRemainingTableIndexes } from './018-remaining-table-indexes.js';

--- a/assistant/src/memory/schema-migration.ts
+++ b/assistant/src/memory/schema-migration.ts
@@ -21,4 +21,5 @@ export {
   migrateDropActiveSearchIndex,
   migrateMemorySegmentsIndexes,
   migrateMemoryItemsIndexes,
+  migrateRemainingTableIndexes,
 } from './migrations/index.js';

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -26,7 +26,9 @@ export const messages = sqliteTable('messages', {
   content: text('content').notNull(),
   createdAt: integer('created_at').notNull(),
   metadata: text('metadata'),
-});
+}, (table) => [
+  index('idx_messages_conversation_id').on(table.conversationId),
+]);
 
 export const toolInvocations = sqliteTable('tool_invocations', {
   id: text('id').primaryKey(),
@@ -40,7 +42,9 @@ export const toolInvocations = sqliteTable('tool_invocations', {
   riskLevel: text('risk_level').notNull(),
   durationMs: integer('duration_ms').notNull(),
   createdAt: integer('created_at').notNull(),
-});
+}, (table) => [
+  index('idx_tool_invocations_conversation_id').on(table.conversationId),
+]);
 
 export const memorySegments = sqliteTable('memory_segments', {
   id: text('id').primaryKey(),
@@ -113,7 +117,9 @@ export const memoryItemConflicts = sqliteTable('memory_item_conflicts', {
   resolvedAt: integer('resolved_at'),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
-});
+}, (table) => [
+  index('idx_memory_item_conflicts_scope_id').on(table.scopeId),
+]);
 
 export const memorySummaries = sqliteTable('memory_summaries', {
   id: text('id').primaryKey(),
@@ -127,7 +133,9 @@ export const memorySummaries = sqliteTable('memory_summaries', {
   endAt: integer('end_at').notNull(),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
-});
+}, (table) => [
+  index('idx_memory_summaries_scope_id').on(table.scopeId),
+]);
 
 export const memoryEmbeddings = sqliteTable('memory_embeddings', {
   id: text('id').primaryKey(),


### PR DESCRIPTION
Add indexes on memoryItemConflicts.scopeId, memorySummaries.scopeId, messages.conversationId, toolInvocations.conversationId
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
