### PR TITLE
fix: reset refresh timer and failure counter on QR retry

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -113,9 +113,11 @@ struct PairingQRCodeSheet: View {
 
             if registrationState == .failed && daemonClient != nil {
                 Button("Retry") {
+                    consecutiveRefreshFailures = 0
                     pairingRequestId = UUID().uuidString
                     pairingSecret = Self.generatePairingSecret()
                     registerWithDaemon()
+                    startRefreshTimer()
                 }
                 .buttonStyle(.bordered)
             }


### PR DESCRIPTION
## Summary
Resets `consecutiveRefreshFailures` to 0 and restarts the refresh timer when the user clicks Retry after a QR refresh failure. Without this, the QR would silently expire after 5 minutes and the next single failure would immediately re-trigger the error state.

Addresses feedback from PR #8248.

## Test plan
- [ ] Trigger 2 consecutive refresh failures to enter `.failed` state
- [ ] Click Retry — verify QR code reappears and refresh timer resumes
- [ ] Wait >4 minutes — verify QR auto-refreshes (timer is running)
- [ ] Trigger a single refresh failure after retry — verify it does NOT immediately re-enter `.failed` state (counter was reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
