### PR TITLE
feat: make global hotkey configurable in macOS client

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -63,6 +63,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
     var statusItem: NSStatusItem!
     private var hotKeyMonitor: Any?
+    private var lastRegisteredGlobalHotkey: String?
+    private var globalHotkeyObserver: AnyCancellable?
     private var escapeMonitor: Any?
     private var quickChatPanel: QuickChatPanel?
     private var quickChatMonitor: Any?
@@ -361,6 +363,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 NSEvent.removeMonitor(hotKeyMonitor)
                 self.hotKeyMonitor = nil
             }
+            lastRegisteredGlobalHotkey = nil
+            globalHotkeyObserver?.cancel()
+            globalHotkeyObserver = nil
             if let escapeMonitor {
                 NSEvent.removeMonitor(escapeMonitor)
                 self.escapeMonitor = nil
@@ -478,6 +483,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             NSEvent.removeMonitor(hotKeyMonitor)
             self.hotKeyMonitor = nil
         }
+        lastRegisteredGlobalHotkey = nil
+        globalHotkeyObserver?.cancel()
+        globalHotkeyObserver = nil
         if let escapeMonitor {
             NSEvent.removeMonitor(escapeMonitor)
             self.escapeMonitor = nil
@@ -1117,20 +1125,45 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Hotkey
 
     private func setupHotKey() {
+        registerGlobalHotkeyMonitor()
+
+        globalHotkeyObserver = NotificationCenter.default
+            .publisher(for: UserDefaults.didChangeNotification)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.registerGlobalHotkeyMonitor()
+            }
+    }
+
+    /// Tears down and re-registers the global "Open Vellum" hotkey based on
+    /// the current `globalHotkeyShortcut` UserDefaults value. Skips
+    /// re-registration if the shortcut hasn't changed.
+    private func registerGlobalHotkeyMonitor() {
+        let shortcut = UserDefaults.standard.string(forKey: "globalHotkeyShortcut") ?? "cmd+shift+g"
+
+        if shortcut == lastRegisteredGlobalHotkey { return }
+
+        if let existing = hotKeyMonitor {
+            NSEvent.removeMonitor(existing)
+            hotKeyMonitor = nil
+        }
+
+        let (targetModifiers, targetKey) = ShortcutHelper.parseShortcut(shortcut)
+
         // Use NSEvent global monitor instead of Carbon RegisterEventHotKey (HotKey package).
         // Carbon hotkeys consume the event globally, preventing other apps from seeing the
-        // keystroke. NSEvent.addGlobalMonitorForEvents observes without consuming, so Cmd+Shift+G
-        // still reaches the frontmost app.
+        // keystroke. NSEvent.addGlobalMonitorForEvents observes without consuming.
         hotKeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == [.command, .shift],
-                  event.charactersIgnoringModifiers?.lowercased() == "g" else { return }
+            let eventMods = event.modifierFlags.intersection(.deviceIndependentFlagsMask).subtracting(.numericPad)
+            guard eventMods == targetModifiers,
+                  event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else { return }
             Task { @MainActor in
-                // Don't create the main window while the first-launch
-                // readiness gate is in progress.
                 guard self?.isAwaitingFirstLaunchReady != true else { return }
                 self?.showMainWindow()
             }
         }
+
+        lastRegisteredGlobalHotkey = shortcut
     }
 
     private func setupQuickChatHotKey() {
@@ -1573,6 +1606,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         if let monitor = hotKeyMonitor {
             NSEvent.removeMonitor(monitor)
         }
+        globalHotkeyObserver?.cancel()
         if let monitor = escapeMonitor {
             NSEvent.removeMonitor(monitor)
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -6,7 +6,8 @@ struct SettingsAppearanceTab: View {
     @ObservedObject var store: SettingsStore
     @AppStorage("themePreference") private var themePreference: String = "system"
     @State private var newAllowlistDomain = ""
-    @State private var isRecordingShortcut = false
+    @State private var isRecordingQuickChat = false
+    @State private var isRecordingGlobalHotkey = false
     @State private var shortcutMonitor: Any?
     @State private var shortcutConflictWarning: String?
 
@@ -48,6 +49,36 @@ struct SettingsAppearanceTab: View {
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
 
+                // Open Vellum (configurable)
+                HStack {
+                    Text("Open Vellum")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Spacer()
+                    Text(ShortcutHelper.displayString(for: store.globalHotkeyShortcut))
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textPrimary)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(VColor.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.sm)
+                                .stroke(VColor.surfaceBorder, lineWidth: 1)
+                        )
+
+                    if isRecordingGlobalHotkey {
+                        VButton(label: "Press shortcut...", style: .tertiary) {
+                            stopRecording()
+                        }
+                    } else {
+                        VButton(label: "Record", style: .tertiary) {
+                            startRecording(for: .globalHotkey)
+                        }
+                        .disabled(isRecordingQuickChat)
+                    }
+                }
+
                 // Quick Chat (configurable)
                 HStack {
                     Text("Quick Chat")
@@ -66,14 +97,15 @@ struct SettingsAppearanceTab: View {
                                 .stroke(VColor.surfaceBorder, lineWidth: 1)
                         )
 
-                    if isRecordingShortcut {
+                    if isRecordingQuickChat {
                         VButton(label: "Press shortcut...", style: .tertiary) {
                             stopRecording()
                         }
                     } else {
                         VButton(label: "Record", style: .tertiary) {
-                            startRecording()
+                            startRecording(for: .quickChat)
                         }
+                        .disabled(isRecordingGlobalHotkey)
                     }
                 }
 
@@ -81,25 +113,6 @@ struct SettingsAppearanceTab: View {
                     Text(shortcutConflictWarning)
                         .font(VFont.caption)
                         .foregroundColor(VColor.warning)
-                }
-
-                // Open Vellum (fixed, non-editable)
-                HStack {
-                    Text("Open Vellum")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textSecondary)
-                    Spacer()
-                    Text("\u{2318}\u{21E7}G")
-                        .font(VFont.mono)
-                        .foregroundColor(VColor.textMuted)
-                        .padding(.horizontal, VSpacing.sm)
-                        .padding(.vertical, VSpacing.xs)
-                        .background(VColor.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.sm)
-                                .stroke(VColor.surfaceBorder, lineWidth: 1)
-                        )
                 }
             }
             .padding(VSpacing.lg)
@@ -190,23 +203,27 @@ struct SettingsAppearanceTab: View {
 
     // MARK: - Shortcut Recording
 
-    /// The fixed "Open Vellum" shortcut tokens for order-independent conflict detection.
-    private static let openVellumShortcutTokens = ShortcutHelper.normalizeShortcut("cmd+shift+g")
+    private enum ShortcutTarget {
+        case globalHotkey
+        case quickChat
+    }
 
-    private func startRecording() {
-        isRecordingShortcut = true
+    private func startRecording(for target: ShortcutTarget) {
+        switch target {
+        case .globalHotkey: isRecordingGlobalHotkey = true
+        case .quickChat: isRecordingQuickChat = true
+        }
         shortcutConflictWarning = nil
-        // Use local monitor so we capture key events while the settings window is focused
+
+        let currentTarget = target
         shortcutMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
 
-            // Escape cancels recording without changing the shortcut
             if event.keyCode == 53 {
                 stopRecording()
                 return nil
             }
 
-            // Require at least one modifier key to form a valid global shortcut
             let hasModifier = mods.contains(.command) || mods.contains(.control)
                 || mods.contains(.option)
             guard hasModifier,
@@ -217,23 +234,40 @@ struct SettingsAppearanceTab: View {
             let shortcut = ShortcutHelper.shortcutString(
                 from: mods, key: chars, keyCode: event.keyCode
             )
+            let normalized = ShortcutHelper.normalizeShortcut(shortcut)
 
-            // Check for conflict with the fixed "Open Vellum" shortcut
-            if ShortcutHelper.normalizeShortcut(shortcut) == Self.openVellumShortcutTokens {
-                shortcutConflictWarning = "This shortcut conflicts with the Open Vellum shortcut (\u{2318}\u{21E7}G). Choose a different shortcut."
+            // Check for conflict with the other shortcut
+            let otherShortcut: String
+            let otherLabel: String
+            switch currentTarget {
+            case .globalHotkey:
+                otherShortcut = store.quickChatShortcut
+                otherLabel = "Quick Chat"
+            case .quickChat:
+                otherShortcut = store.globalHotkeyShortcut
+                otherLabel = "Open Vellum"
+            }
+
+            if normalized == ShortcutHelper.normalizeShortcut(otherShortcut) {
+                let display = ShortcutHelper.displayString(for: otherShortcut)
+                shortcutConflictWarning = "This shortcut conflicts with \(otherLabel) (\(display)). Choose a different shortcut."
                 stopRecording()
                 return nil
             }
 
             shortcutConflictWarning = nil
-            store.quickChatShortcut = shortcut
+            switch currentTarget {
+            case .globalHotkey: store.globalHotkeyShortcut = shortcut
+            case .quickChat: store.quickChatShortcut = shortcut
+            }
             stopRecording()
-            return nil // consume the event
+            return nil
         }
     }
 
     private func stopRecording() {
-        isRecordingShortcut = false
+        isRecordingQuickChat = false
+        isRecordingGlobalHotkey = false
         if let monitor = shortcutMonitor {
             NSEvent.removeMonitor(monitor)
             shortcutMonitor = nil

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -60,6 +60,7 @@ public final class SettingsStore: ObservableObject {
     @Published var maxSteps: Double
     @Published var activityNotificationsEnabled: Bool
     @Published var quickChatShortcut: String
+    @Published var globalHotkeyShortcut: String
 
     // MARK: - Media Embed Settings
 
@@ -249,6 +250,7 @@ public final class SettingsStore: ObservableObject {
         self.activityNotificationsEnabled = UserDefaults.standard.object(forKey: "activityNotificationsEnabled") as? Bool ?? true
 
         self.quickChatShortcut = UserDefaults.standard.string(forKey: "quickChatShortcut") ?? "cmd+shift+space"
+        self.globalHotkeyShortcut = UserDefaults.standard.string(forKey: "globalHotkeyShortcut") ?? "cmd+shift+g"
 
         #if DEBUG
         self.isDevMode = UserDefaults.standard.object(forKey: "devModeEnabled") as? Bool ?? true
@@ -297,6 +299,11 @@ public final class SettingsStore: ObservableObject {
         $quickChatShortcut
             .dropFirst()
             .sink { value in UserDefaults.standard.set(value, forKey: "quickChatShortcut") }
+            .store(in: &cancellables)
+
+        $globalHotkeyShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "globalHotkeyShortcut") }
             .store(in: &cancellables)
 
         $isDevMode


### PR DESCRIPTION
Add keyboard shortcut settings UI, UserDefaults persistence, and dynamic re-registration. Defaults to Cmd+Shift+G.

## Changes

- **SettingsStore**: Added `globalHotkeyShortcut` published property with UserDefaults persistence (key: `globalHotkeyShortcut`, default: `cmd+shift+g`)
- **AppDelegate**: Refactored `setupHotKey()` to use the same dynamic re-registration pattern as Quick Chat — reads shortcut from UserDefaults, parses via `ShortcutHelper`, and re-registers the NSEvent monitor when the setting changes
- **SettingsAppearanceTab**: Made "Open Vellum" shortcut configurable with the same key-capture recording UI used for Quick Chat. Added bidirectional conflict detection between both shortcuts. Both Record buttons disable when the other is actively recording.

## Test plan
- [ ] Launch app, verify Cmd+Shift+G opens the main window (default behavior preserved)
- [ ] Open Settings > Appearance > Keyboard Shortcuts, verify "Open Vellum" shows the current shortcut
- [ ] Click Record on "Open Vellum", press a new shortcut (e.g. Cmd+Shift+V), verify it saves
- [ ] Verify the new shortcut opens the main window and old one no longer does
- [ ] Try setting Open Vellum to the same shortcut as Quick Chat — verify conflict warning
- [ ] Try setting Quick Chat to the same shortcut as Open Vellum — verify conflict warning
- [ ] Restart the app, verify the custom shortcut persists
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
