### PR TITLE
feat: add structured error serialization to logger

### DIFF
--- a/assistant/src/util/log-redact.ts
+++ b/assistant/src/util/log-redact.ts
@@ -107,15 +107,56 @@ function redactValue(value: unknown, depth: number): unknown {
 }
 
 // ---------------------------------------------------------------------------
+// Error serialization — extracts non-enumerable Error fields and cause chain
+// ---------------------------------------------------------------------------
+
+function serializeError(err: unknown, depth: number): unknown {
+  if (depth > 8 || err === null || err === undefined) return err;
+
+  if (!(err instanceof Error)) {
+    return err;
+  }
+
+  const serialized: Record<string, unknown> = {
+    name: err.name,
+    message: err.message,
+  };
+
+  // AssistantError and subclasses carry a structured ErrorCode
+  if ('code' in err && typeof (err as { code: unknown }).code === 'string') {
+    serialized.code = (err as { code: string }).code;
+  }
+
+  if (err.stack) {
+    serialized.stack = err.stack;
+  }
+
+  // Walk the cause chain recursively
+  if (err.cause !== undefined) {
+    serialized.cause = serializeError(err.cause, depth + 1);
+  }
+
+  // Preserve any additional enumerable properties (e.g. provider, statusCode, toolName)
+  for (const [key, val] of Object.entries(err)) {
+    if (!(key in serialized)) {
+      serialized[key] = val;
+    }
+  }
+
+  return serialized;
+}
+
+// ---------------------------------------------------------------------------
 // Pino serializers
 // ---------------------------------------------------------------------------
 
 /**
- * Pino serializer for the `err` binding — redacts secrets from error messages,
- * stacks, and any attached properties.
+ * Pino serializer for the `err` binding — extracts non-enumerable Error fields
+ * (name, message, stack), structured codes, and cause chains, then redacts
+ * secrets from the result.
  */
 function errSerializer(err: unknown): unknown {
-  return redactValue(err, 0);
+  return redactValue(serializeError(err, 0), 0);
 }
 
 /**


### PR DESCRIPTION
Add pino serializer for Error objects that captures name, message, code, cause chain, and stack trace for consistent error logging.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
