### PR TITLE
fix: add bounds validation for confidence/importance fields

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
@@ -7,11 +7,8 @@ import { memoryItems } from '../../../../memory/schema.js';
 import { enqueueMemoryJob } from '../../../../memory/jobs-store.js';
 import { extractStylePatterns } from '../../../../messaging/style-analyzer.js';
 import { truncate } from '../../../../util/truncate.js';
+import { clampUnitInterval } from '../../../../memory/validation.js';
 import { resolveProvider, withProviderToken, ok, err } from './shared.js';
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
-}
 
 function upsertMemoryItem(opts: {
   kind: string;
@@ -35,7 +32,7 @@ function upsertMemoryItem(opts: {
       .set({
         statement: opts.statement,
         status: 'active',
-        importance: Math.max(existing.importance ?? 0, opts.importance),
+        importance: clampUnitInterval(Math.max(existing.importance ?? 0, opts.importance)),
         lastSeenAt: now,
         verificationState: 'assistant_inferred',
       })
@@ -51,7 +48,7 @@ function upsertMemoryItem(opts: {
       statement: opts.statement,
       status: 'active',
       confidence: 0.8,
-      importance: opts.importance,
+      importance: clampUnitInterval(opts.importance),
       fingerprint,
       verificationState: 'assistant_inferred',
       scopeId: opts.scopeId,
@@ -90,7 +87,7 @@ export async function run(input: Record<string, unknown>, context: ToolContext):
 
       for (const pattern of result.stylePatterns) {
         const subject = `${provider.id} writing style: ${pattern.aspect}`;
-        const importance = clamp(pattern.importance ?? 0.65, 0.55, 0.85);
+        const importance = clampUnitInterval(Math.min(0.85, Math.max(0.55, pattern.importance ?? 0.65)));
         upsertMemoryItem({ kind: 'style', subject, statement: pattern.summary, importance, scopeId });
         savedCount++;
       }

--- a/assistant/src/memory/conflict-store.ts
+++ b/assistant/src/memory/conflict-store.ts
@@ -3,6 +3,7 @@ import { v4 as uuid } from 'uuid';
 import { getDb, getSqlite, rawAll } from './db.js';
 import { enqueueMemoryJob } from './jobs-store.js';
 import { memoryItemConflicts, memoryItems } from './schema.js';
+import { clampUnitInterval } from './validation.js';
 
 export type MemoryConflictRelationship =
   | 'contradiction'
@@ -319,7 +320,7 @@ export function applyConflictResolution(input: ApplyConflictResolutionInput): bo
           status: 'active',
           invalidAt: null,
           lastSeenAt: Math.max(existingItem.lastSeenAt, candidateItem.lastSeenAt, now),
-          confidence: Math.max(existingItem.confidence, candidateItem.confidence),
+          confidence: clampUnitInterval(Math.max(existingItem.confidence, candidateItem.confidence)),
         })
         .where(eq(memoryItems.id, existingItem.id))
         .run();

--- a/assistant/src/memory/contradiction-checker.ts
+++ b/assistant/src/memory/contradiction-checker.ts
@@ -9,6 +9,7 @@ import { createOrUpdatePendingConflict } from './conflict-store.js';
 import { getDb, getSqlite, rawAll } from './db.js';
 import { enqueueMemoryJob } from './jobs-store.js';
 import { memoryItems } from './schema.js';
+import { clampUnitInterval } from './validation.js';
 
 const log = getLogger('memory-contradiction-checker');
 
@@ -335,7 +336,7 @@ function handleRelationship(
           .set({
             statement: newItem.statement,
             lastSeenAt: Math.max(freshExisting.lastSeenAt, freshNew!.lastSeenAt),
-            confidence: Math.max(freshExisting.confidence, freshNew!.confidence),
+            confidence: clampUnitInterval(Math.max(freshExisting.confidence, freshNew!.confidence)),
           })
           .where(eq(memoryItems.id, existingItem.id))
           .run();

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -10,6 +10,7 @@ import { enqueueMemoryJob } from './jobs-store.js';
 import { extractTextFromStoredMessageContent } from './message-content.js';
 import { getDb } from './db.js';
 import { memoryItemConflicts, memoryItems, memoryItemSources, messages } from './schema.js';
+import { clampUnitInterval } from './validation.js';
 
 const log = getLogger('memory-items-extractor');
 
@@ -196,8 +197,8 @@ async function extractItemsWithLLM(
         if (!raw.subject || !raw.statement) continue;
         const subject = truncate(String(raw.subject), 80, '');
         const statement = truncate(String(raw.statement), 500, '');
-        const confidence = clamp(parseScore(raw.confidence, 0.5), 0, 1);
-        const importance = clamp(parseScore(raw.importance, 0.5), 0, 1);
+        const confidence = clampUnitInterval(parseScore(raw.confidence, 0.5));
+        const importance = clampUnitInterval(parseScore(raw.importance, 0.5));
         const fingerprint = computeMemoryFingerprint(scopeId, raw.kind, subject, statement);
         items.push({
           kind: raw.kind as MemoryItemKind,
@@ -284,8 +285,8 @@ export async function extractAndUpsertMemoryItemsForMessage(messageId: string, s
       db.update(memoryItems)
         .set({
           status: effectiveStatus,
-          confidence: Math.max(existing.confidence, item.confidence),
-          importance: Math.max(existing.importance ?? 0, item.importance),
+          confidence: clampUnitInterval(Math.max(existing.confidence, item.confidence)),
+          importance: clampUnitInterval(Math.max(existing.importance ?? 0, item.importance)),
           lastSeenAt: Math.max(existing.lastSeenAt, seenAt),
           verificationState: promotedState,
         })
@@ -436,10 +437,6 @@ function parseScore(value: unknown, fallback: number): number {
   if (value == null || value === '') return fallback;
   const n = Number(value);
   return Number.isFinite(n) ? n : fallback;
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
 }
 
 /** Returns true if the given memory item is the candidate in an unresolved conflict. */

--- a/assistant/src/memory/validation.ts
+++ b/assistant/src/memory/validation.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/**
+ * Unit interval [0, 1] — used for confidence and importance fields on memory items.
+ * Coerces out-of-range numbers to the nearest bound rather than rejecting,
+ * since LLM-generated values occasionally exceed the range.
+ */
+export const unitInterval = z.number().transform((v) => Math.min(1, Math.max(0, v)));
+
+/** Zod schema for validating confidence/importance values on memory items. */
+export const memoryItemScores = z.object({
+  confidence: unitInterval,
+  importance: unitInterval,
+});
+
+/** Clamp a numeric value to [0, 1]. */
+export function clampUnitInterval(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -9,6 +9,7 @@ import { memoryItems } from '../../memory/schema.js';
 import { enqueueMemoryJob } from '../../memory/jobs-store.js';
 import { searchMemoryItems, formatRelativeTime } from '../../memory/retriever.js';
 import type { ScopePolicyOverride } from '../../memory/search/types.js';
+import { clampUnitInterval } from '../../memory/validation.js';
 import type { ToolExecutionResult } from '../types.js';
 
 const log = getLogger('memory-tools');


### PR DESCRIPTION
Add Zod validation to enforce 0-1 bounds on confidence and importance fields in memory items at the application layer.

- Create centralized `validation.ts` with `clampUnitInterval` helper and Zod schemas
- Apply bounds clamping in items-extractor.ts (LLM extraction + upsert paths)
- Apply bounds clamping in contradiction-checker.ts (merge confidence)
- Apply bounds clamping in conflict-store.ts (merge resolution)
- Apply bounds clamping in messaging-analyze-style.ts (style pattern importance)
- Replace local `clamp` helpers with centralized `clampUnitInterval`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
