### PR TITLE
feat: make daemon timeout values configurable

### DIFF
--- a/assistant/src/config/core-schema.ts
+++ b/assistant/src/config/core-schema.ts
@@ -247,6 +247,29 @@ export const IngressConfigSchema = IngressBaseSchema
     enabled: val.enabled ?? (val.publicBaseUrl ? true : undefined),
   }));
 
+export const DaemonConfigSchema = z.object({
+  startupSocketWaitMs: z
+    .number({ error: 'daemon.startupSocketWaitMs must be a number' })
+    .int('daemon.startupSocketWaitMs must be an integer')
+    .positive('daemon.startupSocketWaitMs must be a positive integer')
+    .default(5000),
+  stopTimeoutMs: z
+    .number({ error: 'daemon.stopTimeoutMs must be a number' })
+    .int('daemon.stopTimeoutMs must be an integer')
+    .positive('daemon.stopTimeoutMs must be a positive integer')
+    .default(5000),
+  sigkillGracePeriodMs: z
+    .number({ error: 'daemon.sigkillGracePeriodMs must be a number' })
+    .int('daemon.sigkillGracePeriodMs must be an integer')
+    .positive('daemon.sigkillGracePeriodMs must be a positive integer')
+    .default(2000),
+  titleGenerationMaxTokens: z
+    .number({ error: 'daemon.titleGenerationMaxTokens must be a number' })
+    .int('daemon.titleGenerationMaxTokens must be an integer')
+    .positive('daemon.titleGenerationMaxTokens must be a positive integer')
+    .default(30),
+});
+
 export const AssistantInboxConfigSchema = z.object({
   enabled: z
     .boolean({ error: 'assistantInbox.enabled must be a boolean' })
@@ -274,5 +297,6 @@ export type ModelPricingOverride = z.infer<typeof ModelPricingOverrideSchema>;
 export type SmsConfig = z.infer<typeof SmsConfigSchema>;
 export type IngressWebhookConfig = z.infer<typeof IngressWebhookConfigSchema>;
 export type IngressRateLimitConfig = z.infer<typeof IngressRateLimitConfigSchema>;
+export type DaemonConfig = z.infer<typeof DaemonConfigSchema>;
 export type IngressConfig = z.infer<typeof IngressConfigSchema>;
 export type AssistantInboxConfig = z.infer<typeof AssistantInboxConfigSchema>;

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -267,6 +267,12 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     enabled: undefined,
     publicBaseUrl: '',
   },
+  daemon: {
+    startupSocketWaitMs: 5000,
+    stopTimeoutMs: 5000,
+    sigkillGracePeriodMs: 2000,
+    titleGenerationMaxTokens: 30,
+  },
   assistantInbox: {
     enabled: false,
     invitesEnabled: false,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -104,6 +104,7 @@ export {
   IngressWebhookConfigSchema,
   IngressRateLimitConfigSchema,
   IngressConfigSchema,
+  DaemonConfigSchema,
   AssistantInboxConfigSchema,
 } from './core-schema.js';
 export type {
@@ -120,6 +121,7 @@ export type {
   IngressWebhookConfig,
   IngressRateLimitConfig,
   IngressConfig,
+  DaemonConfig,
   AssistantInboxConfig,
 } from './core-schema.js';
 
@@ -141,6 +143,7 @@ import {
   ModelPricingOverrideSchema,
   SmsConfigSchema,
   IngressConfigSchema,
+  DaemonConfigSchema,
   AssistantInboxConfigSchema,
 } from './core-schema.js';
 
@@ -430,6 +433,12 @@ export const AssistantConfigSchema = z.object({
     phoneNumber: '',
   }),
   ingress: IngressConfigSchema,
+  daemon: DaemonConfigSchema.default({
+    startupSocketWaitMs: 5000,
+    stopTimeoutMs: 5000,
+    sigkillGracePeriodMs: 2000,
+    titleGenerationMaxTokens: 30,
+  }),
   assistantInbox: AssistantInboxConfigSchema.default({
     enabled: false,
     invitesEnabled: false,

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -39,5 +39,6 @@ export type {
   CallerIdentityConfig,
   SmsConfig,
   IngressConfig,
+  DaemonConfig,
   AssistantInboxConfig,
 } from './schema.js';

--- a/assistant/src/daemon/daemon-control.ts
+++ b/assistant/src/daemon/daemon-control.ts
@@ -9,6 +9,7 @@ import {
 } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 import { DaemonError } from '../util/errors.js';
+import { getConfig } from '../config/loader.js';
 
 const log = getLogger('lifecycle');
 
@@ -124,7 +125,8 @@ export async function startDaemon(): Promise<{
   writePid(pid);
 
   // Wait for socket to appear
-  const maxWait = 5000;
+  const config = getConfig();
+  const maxWait = config.daemon.startupSocketWaitMs;
   const interval = 100;
   let waited = 0;
   while (waited < maxWait) {
@@ -146,7 +148,7 @@ export async function startDaemon(): Promise<{
   }
 
   throw new DaemonError(
-    'Daemon started but socket not available after 5 seconds',
+    `Daemon started but socket not available after ${maxWait}ms`,
   );
 }
 
@@ -163,8 +165,10 @@ export async function stopDaemon(): Promise<StopResult> {
 
   process.kill(pid, 'SIGTERM');
 
+  const config = getConfig();
+
   // Wait for process to exit
-  const maxWait = 5000;
+  const maxWait = config.daemon.stopTimeoutMs;
   const interval = 100;
   let waited = 0;
   while (waited < maxWait) {
@@ -186,7 +190,7 @@ export async function stopDaemon(): Promise<StopResult> {
   // Wait for the process to actually die after SIGKILL. Without this,
   // startDaemon() can race with the dying process's shutdown handler,
   // which removes the socket file and bricks the new daemon.
-  const killMaxWait = 2000;
+  const killMaxWait = config.daemon.sigkillGracePeriodMs;
   let killWaited = 0;
   while (killWaited < killMaxWait && isProcessRunning(pid)) {
     await new Promise((r) => setTimeout(r, 100));

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -712,6 +712,7 @@ async function generateTitle(
   onEvent: (msg: ServerMessage) => void,
   sessionSignal?: AbortSignal,
 ): Promise<void> {
+  const config = getConfig();
   const prompt = `Generate a very short title for this conversation. Rules: at most 5 words, at most 40 characters, no quotes.\n\nUser: ${truncate(userMessage, 200, '')}\nAssistant: ${truncate(assistantResponse, 200, '')}`;
   const signal = sessionSignal
     ? AbortSignal.any([sessionSignal, AbortSignal.timeout(10_000)])
@@ -720,7 +721,7 @@ async function generateTitle(
     [{ role: 'user', content: [{ type: 'text', text: prompt }] }],
     [],
     undefined,
-    { config: { max_tokens: 30 }, signal },
+    { config: { max_tokens: config.daemon.titleGenerationMaxTokens }, signal },
   );
 
   const textBlock = response.content.find((b) => b.type === 'text');


### PR DESCRIPTION
Add daemon config section with configurable startup wait, stop timeout, SIGKILL grace period, and title generation max_tokens.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
