### PR TITLE
feat(macos): add health check indicator to Platform URL row

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -57,6 +57,7 @@ struct SettingsConnectTab: View {
         }
         .onAppear {
             Task { await authManager.checkSession() }
+            Task { await store.checkVellumPlatform() }
             store.refreshIngressConfig()
             store.refreshAssistantEmail()
             gatewayUrlText = store.ingressPublicBaseUrl
@@ -99,6 +100,28 @@ struct SettingsConnectTab: View {
     }
 
     // MARK: - Vellum Section
+
+    private var platformHealthIcon: String {
+        if store.isCheckingVellumPlatform {
+            return "arrow.trianglehead.2.counterclockwise"
+        }
+        switch store.vellumPlatformReachable {
+        case true: return "checkmark.circle.fill"
+        case false: return "xmark.circle.fill"
+        case nil: return "questionmark.circle"
+        }
+    }
+
+    private var platformHealthIconColor: Color {
+        if store.isCheckingVellumPlatform {
+            return VColor.textMuted
+        }
+        switch store.vellumPlatformReachable {
+        case true: return VColor.success
+        case false: return VColor.error
+        case nil: return VColor.textMuted
+        }
+    }
 
     private var vellumSection: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -150,11 +173,12 @@ struct SettingsConnectTab: View {
 
                 channelStatusRow(
                     label: "Platform URL",
-                    icon: "link",
-                    iconColor: VColor.textMuted,
+                    icon: platformHealthIcon,
+                    iconColor: platformHealthIconColor,
                     value: AuthService.shared.baseURL,
                     valueFont: VFont.mono
                 )
+                .help(store.vellumPlatformError ?? "")
             }
         }
         .padding(VSpacing.lg)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -57,7 +57,7 @@ struct SettingsConnectTab: View {
         }
         .onAppear {
             Task { await authManager.checkSession() }
-            Task { await store.checkVellumPlatform() }
+            if store.isDevMode { Task { await store.checkVellumPlatform() } }
             store.refreshIngressConfig()
             store.refreshAssistantEmail()
             gatewayUrlText = store.ingressPublicBaseUrl

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -144,6 +144,10 @@ public final class SettingsStore: ObservableObject {
     @Published var gatewayLastChecked: Date?
     @Published var isCheckingGateway: Bool = false
 
+    @Published var vellumPlatformReachable: Bool?
+    @Published var vellumPlatformError: String?
+    @Published var isCheckingVellumPlatform: Bool = false
+
     // MARK: - Dev Mode
 
     @Published var isDevMode: Bool
@@ -1241,6 +1245,37 @@ public final class SettingsStore: ObservableObject {
             return false
         } catch {
             return false
+        }
+    }
+
+    // MARK: - Platform Health Check
+
+    func checkVellumPlatform() async {
+        isCheckingVellumPlatform = true
+        defer { isCheckingVellumPlatform = false }
+
+        let baseUrl = AuthService.shared.baseURL
+        let normalized = baseUrl.hasSuffix("/") ? String(baseUrl.dropLast()) : baseUrl
+        guard let url = URL(string: "\(normalized)/healthz") else {
+            vellumPlatformReachable = false
+            vellumPlatformError = "Invalid URL"
+            return
+        }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 5
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) {
+                vellumPlatformReachable = true
+                vellumPlatformError = nil
+            } else {
+                let code = (response as? HTTPURLResponse)?.statusCode ?? 0
+                vellumPlatformReachable = false
+                vellumPlatformError = "HTTP \(code)"
+            }
+        } catch {
+            vellumPlatformReachable = false
+            vellumPlatformError = error.localizedDescription
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds a health check against `<platformBaseURL>/healthz` triggered on Connect tab appear
- Replaces the static "link" icon on the Platform URL row with a dynamic status icon (green checkmark / red xmark / spinner)
- Shows error details on hover via `.help()` tooltip

## Test plan
- [ ] Open Settings > Connect with dev mode enabled
- [ ] Verify Platform URL row shows a status icon instead of the static link icon
- [ ] When platform is reachable, green checkmark appears
- [ ] When unreachable (e.g. bad URL), red xmark appears and hovering shows the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
