### PR TITLE
refactor: use consistent pino logging throughout migration and startup code

### DIFF
--- a/assistant/src/migrations/log.ts
+++ b/assistant/src/migrations/log.ts
@@ -1,12 +1,23 @@
+import pino from 'pino';
+import { logSerializers } from '../util/log-redact.js';
+
 /**
- * Stderr-only logger for migration code. Using the pino logger during
- * migration is unsafe because pino initialization calls ensureDataDir(),
- * which pre-creates workspace destination directories and causes migration
- * moves to no-op.
+ * Standalone pino instance for migration code. This must NOT use getLogger()
+ * because that triggers ensureDataDir(), which pre-creates workspace
+ * destination directories and causes migration moves to no-op.
+ *
+ * Writes to stderr only — no log files that might not exist yet.
  */
+const migrationLogger: pino.Logger = pino(
+  { name: 'migration', level: 'info', serializers: logSerializers },
+  pino.destination(2),
+);
+
 export function migrationLog(level: 'info' | 'warn' | 'debug', msg: string, data?: Record<string, unknown>): void {
-  if (level === 'debug') return; // suppress debug-level migration noise
-  const prefix = level === 'warn' ? 'WARN' : 'INFO';
-  const extra = data ? ' ' + JSON.stringify(data) : '';
-  process.stderr.write(`[migration] ${prefix}: ${msg}${extra}\n`);
+  if (level === 'debug') return;
+  if (data) {
+    migrationLogger[level](data, msg);
+  } else {
+    migrationLogger[level](msg);
+  }
 }


### PR DESCRIPTION
Replace direct process.stderr.write calls in migration log.ts with a dedicated standalone pino instance that writes to stderr only. The migration logger uses its own pino instance (not getLogger()) to avoid triggering ensureDataDir() which would cause migration moves to no-op. Includes logSerializers for consistent secret redaction. Audited other startup code (daemon/main.ts, config/loader.ts, memory/db-init.ts) — they already use pino correctly or have intentional console.error fallbacks in crash handlers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
