### PR TITLE
Fix M1 feedback: channel readiness + dedupe normalization

### DIFF
--- a/assistant/src/daemon/handlers/notification-settings.ts
+++ b/assistant/src/daemon/handlers/notification-settings.ts
@@ -17,6 +17,7 @@ import {
   NOTIFICATION_DELIVERY_CLASS_MAP,
 } from '../../notifications/types.js';
 import type { NotificationChannel } from '../../notifications/types.js';
+import { getSecureKey } from '../../security/secure-keys.js';
 
 const SUPPORTED_CHANNELS: NotificationChannel[] = ['macos', 'telegram'];
 
@@ -31,11 +32,12 @@ function buildSettingsResponse(ctx: HandlerContext) {
     deliveryClass: NOTIFICATION_DELIVERY_CLASS_MAP[t],
   }));
 
-  // Channel readiness: for now, macos is always ready. Telegram readiness
-  // would require checking config; start with a simple placeholder.
   const channelReadiness = SUPPORTED_CHANNELS.map((ch) => ({
     channel: ch,
-    ready: ch === 'macos', // telegram readiness will be wired in a follow-up
+    ready: ch === 'macos'
+      || (ch === 'telegram'
+        && !!getSecureKey('credential:telegram:bot_token')
+        && !!getSecureKey('credential:telegram:webhook_secret')),
   }));
 
   return {

--- a/assistant/src/notifications/events-store.ts
+++ b/assistant/src/notifications/events-store.ts
@@ -61,15 +61,20 @@ export function createEvent(params: CreateEventParams): NotificationEventRow | n
   const db = getDb();
   const now = Date.now();
 
+  // Normalize empty strings to null so the falsy check below and the DB
+  // unique index stay in agreement (empty string is falsy in JS but would
+  // be stored as a non-null value in SQLite).
+  const normalizedDedupeKey = params.dedupeKey || null;
+
   // If there's a dedupe key, check for duplicates first
-  if (params.dedupeKey) {
+  if (normalizedDedupeKey) {
     const existing = db
       .select()
       .from(notificationEvents)
       .where(
         and(
           eq(notificationEvents.assistantId, params.assistantId),
-          eq(notificationEvents.dedupeKey, params.dedupeKey),
+          eq(notificationEvents.dedupeKey, normalizedDedupeKey),
         ),
       )
       .get();
@@ -86,7 +91,7 @@ export function createEvent(params: CreateEventParams): NotificationEventRow | n
     sourceEventId: params.sourceEventId,
     requiresAction: params.requiresAction ? 1 : 0,
     payloadJson: JSON.stringify(params.payload),
-    dedupeKey: params.dedupeKey ?? null,
+    dedupeKey: normalizedDedupeKey,
     createdAt: now,
     updatedAt: now,
   };


### PR DESCRIPTION
Address Codex review feedback on PR #8256: wire real Telegram integration readiness check instead of hardcoded false, and normalize empty dedupe keys to null to prevent unique constraint violations.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
