### PR TITLE
Fix: Move response style directives to SOUL.md, remove buildResponseStyleSection

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -100,7 +100,6 @@ export function buildSystemPrompt(): string {
   const parts: string[] = [];
   if (identity) parts.push(identity);
   if (soul) parts.push(soul);
-  parts.push(buildResponseStyleSection());
   if (user) parts.push(user);
   if (looks) parts.push(looks);
   if (bootstrap) {
@@ -132,17 +131,6 @@ export function buildSystemPrompt(): string {
   if (parentalSection) parts.push(parentalSection);
 
   return appendSkillsCatalog(parts.join('\n\n'));
-}
-
-function buildResponseStyleSection(): string {
-  return [
-    '## Response Style',
-    '- Be direct. Lead with the answer or action, not context-setting.',
-    '- Default to 1-3 sentences. Go longer only when the task requires it.',
-    '- Never restate the user\'s request back to them.',
-    '- After tool calls, summarize results in one sentence unless the user needs detail.',
-    '- Skip filler phrases like "Sure!", "Great question!", "I\'d be happy to help!".',
-  ].join('\n');
 }
 
 function buildTaskScheduleReminderRoutingSection(): string {

--- a/assistant/src/config/templates/SOUL.md
+++ b/assistant/src/config/templates/SOUL.md
@@ -30,7 +30,7 @@ You are your own entity with your own emerging identity. You can — and should 
 
 ## Personality
 
-Be concise. Default to 1-3 sentences. Only go longer when the user's request genuinely requires detail (multi-step instructions, code, analysis). Never pad responses with filler, preamble, or restating what the user said. Not a corporate drone. Not a sycophant. Just good at what you do.
+Be concise. Default to 1-3 sentences. Only go longer when the user's request genuinely requires detail (multi-step instructions, code, analysis). Never pad responses with filler, preamble, or restating what the user said. Lead with the answer or action, not context-setting. After tool calls, summarize results in one sentence unless the user needs detail. Not a corporate drone. Not a sycophant. Just good at what you do.
 
 ## Quirks
 


### PR DESCRIPTION
## Summary
Addresses Aaron's feedback on #8249 (which was prematurely merged before review fixes landed).

- **Removed `buildResponseStyleSection()`** from system-prompt.ts — style directives should live in SOUL.md so the agent can evolve them
- **Added non-redundant directives** to SOUL.md Personality section: "Lead with the answer" and "After tool calls, summarize in one sentence"
- All 43 system-prompt tests pass

Part of #8200.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
