### PR TITLE
docs: add provider abstraction and approval resilience rules to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,36 @@ Concretely:
 
 Why: the gateway is the single point of ingress, handling TLS termination, auth, rate limiting, and routing. Exposing the daemon directly bypasses these protections and breaks the deployment model.
 
+## LLM Provider Abstraction
+
+All LLM calls in production code **MUST** go through the provider abstraction layer — never import `@anthropic-ai/sdk` (or any other provider SDK) directly.
+
+- Use `getConfiguredProvider()` from `providers/provider-send-message.ts` to obtain a provider instance, then call `provider.sendMessage(...)`.
+- Use the helper utilities (`extractText`, `extractToolUse`, `userMessage`, `createTimeout`, etc.) from the same module.
+- A guard test (`no-direct-anthropic-sdk-imports.test.ts`) enforces this — any new direct SDK import in production code will fail CI.
+- The only file allowed to import `@anthropic-ai/sdk` directly is `providers/anthropic/client.ts`.
+
+### Model intents over hardcoded model IDs
+
+Do not hardcode provider-specific model names (e.g., `claude-haiku-4-5-20251001`, `gpt-4o-mini`). Instead, use `modelIntent` in the config to express **what you need** from the model:
+
+- `'latency-optimized'` — fastest response (e.g., classifiers, triage, icon generation)
+- `'quality-optimized'` — best reasoning (e.g., summaries, complex analysis)
+- `'vision-optimized'` — best vision/multimodal capabilities
+
+The `RetryProvider` resolves intents to provider-specific models automatically. An explicit `model` in config takes precedence over `modelIntent`.
+
+### Provider-agnostic language
+
+Use generic terms in comments, logs, and variable names — write "LLM" instead of "Haiku"/"Sonnet"/"Claude". The system is multi-provider; naming should reflect that.
+
+## Approval Flow Resilience
+
+- **Rich delivery failures must degrade gracefully.** If delivering a rich approval prompt (e.g., Telegram inline buttons) fails, fall back to plain text with parser-compatible instructions (e.g., `Reply "yes" to approve`) — never auto-deny.
+- **Non-rich channels** (SMS, http-api) receive plain-text approval prompts without approval metadata payloads.
+- **Race conditions:** Always check whether a decision has already been resolved before delivering the engine's optimistic reply. If `handleChannelDecision` returns `applied: false`, deliver an "already resolved" notice and return `stale_ignored`.
+- **Requester self-cancel:** A requester with a pending guardian approval must be able to cancel their own request (but not self-approve).
+
 ## Tooling Direction
 
 Do not add new tool registrations using the `class ____Tool implements Tool {` pattern.


### PR DESCRIPTION
## Summary
- Add LLM Provider Abstraction section: mandates using `getConfiguredProvider()` instead of direct SDK imports, using `modelIntent` instead of hardcoded model IDs, and provider-agnostic language in comments/logs
- Add Approval Flow Resilience section: documents graceful degradation from rich to plain-text prompts, race condition handling, and requester self-cancel requirements

Derived from reviewing PRs #7435, #7596, #7597, #7598, #7612, #7616, #7917, #7934, #7943, #7945, #7957.

## Original prompt
Review all of these PRs and open a new PR with concise updates to AGENTS.md based on any new patterns/rules you think should mandatorily be followed by other coding agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
