### PR TITLE
refactor: remove assistant inbox feature flag from desktop UI (G-04)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -988,10 +988,8 @@ struct MainWindowView: View {
             SidebarNavRow(icon: "sparkles", label: "Skills", isActive: windowState.activePanel == .agent) {
                 windowState.togglePanel(.agent)
             }
-            if FeatureFlagManager.shared.isEnabled(.assistantInboxEnabled) {
-                SidebarNavRow(icon: "tray.fill", label: "Inbox", isActive: windowState.activePanel == .assistantInbox) {
-                    windowState.togglePanel(.assistantInbox)
-                }
+            SidebarNavRow(icon: "tray.fill", label: "Inbox", isActive: windowState.activePanel == .assistantInbox) {
+                windowState.togglePanel(.assistantInbox)
             }
 
             // Divider between nav items and threads
@@ -1102,10 +1100,8 @@ struct MainWindowView: View {
             SidebarNavRow(icon: "sparkles", label: "Skills", isActive: windowState.activePanel == .agent, isExpanded: false) {
                 windowState.togglePanel(.agent)
             }
-            if FeatureFlagManager.shared.isEnabled(.assistantInboxEnabled) {
-                SidebarNavRow(icon: "tray.fill", label: "Inbox", isActive: windowState.activePanel == .assistantInbox, isExpanded: false) {
-                    windowState.togglePanel(.assistantInbox)
-                }
+            SidebarNavRow(icon: "tray.fill", label: "Inbox", isActive: windowState.activePanel == .assistantInbox, isExpanded: false) {
+                windowState.togglePanel(.assistantInbox)
             }
 
             VColor.divider

--- a/clients/shared/Utilities/FeatureFlagManager.swift
+++ b/clients/shared/Utilities/FeatureFlagManager.swift
@@ -8,7 +8,6 @@ public enum FeatureFlag: String, CaseIterable {
     case featureFlagEditorEnabled = "feature_flag_editor_enabled"
     case hatchNewAssistantEnabled = "hatch_new_assistant_enabled"
     case localHttpEnabled = "local_http_enabled"
-    case assistantInboxEnabled = "assistant_inbox_enabled"
 
     public var displayName: String {
         switch self {
@@ -17,7 +16,6 @@ public enum FeatureFlag: String, CaseIterable {
         case .featureFlagEditorEnabled: return "Feature Flag Editor Enabled"
         case .hatchNewAssistantEnabled: return "Hatch New Assistant Enabled"
         case .localHttpEnabled: return "Local HTTP Enabled"
-        case .assistantInboxEnabled: return "Assistant Inbox Enabled"
         }
     }
 }


### PR DESCRIPTION
## Summary
- Remove FeatureFlagManager.isEnabled(.assistantInboxEnabled) checks from MainWindowView sidebar (both expanded and collapsed)
- Remove assistantInboxEnabled case from FeatureFlag enum
- Inbox sidebar nav is now always visible

Part of: assistant-to-human-interaction namespace (G-04)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
