### PR TITLE
refactor: remove assistantInbox config schema, defaults, and types (G-01)

### DIFF
--- a/assistant/src/config/core-schema.ts
+++ b/assistant/src/config/core-schema.ts
@@ -270,21 +270,6 @@ export const DaemonConfigSchema = z.object({
     .default(30),
 });
 
-export const AssistantInboxConfigSchema = z.object({
-  enabled: z
-    .boolean({ error: 'assistantInbox.enabled must be a boolean' })
-    .default(false),
-  invitesEnabled: z
-    .boolean({ error: 'assistantInbox.invitesEnabled must be a boolean' })
-    .default(false),
-  memberAclEnabled: z
-    .boolean({ error: 'assistantInbox.memberAclEnabled must be a boolean' })
-    .default(false),
-  policyEnabled: z
-    .boolean({ error: 'assistantInbox.policyEnabled must be a boolean' })
-    .default(false),
-});
-
 export type TimeoutConfig = z.infer<typeof TimeoutConfigSchema>;
 export type RateLimitConfig = z.infer<typeof RateLimitConfigSchema>;
 export type SecretDetectionConfig = z.infer<typeof SecretDetectionConfigSchema>;
@@ -299,4 +284,3 @@ export type IngressWebhookConfig = z.infer<typeof IngressWebhookConfigSchema>;
 export type IngressRateLimitConfig = z.infer<typeof IngressRateLimitConfigSchema>;
 export type DaemonConfig = z.infer<typeof DaemonConfigSchema>;
 export type IngressConfig = z.infer<typeof IngressConfigSchema>;
-export type AssistantInboxConfig = z.infer<typeof AssistantInboxConfigSchema>;

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -273,10 +273,4 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     sigkillGracePeriodMs: 2000,
     titleGenerationMaxTokens: 30,
   },
-  assistantInbox: {
-    enabled: false,
-    invitesEnabled: false,
-    memberAclEnabled: false,
-    policyEnabled: false,
-  },
 };

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -105,7 +105,6 @@ export {
   IngressRateLimitConfigSchema,
   IngressConfigSchema,
   DaemonConfigSchema,
-  AssistantInboxConfigSchema,
 } from './core-schema.js';
 export type {
   TimeoutConfig,
@@ -122,7 +121,6 @@ export type {
   IngressRateLimitConfig,
   IngressConfig,
   DaemonConfig,
-  AssistantInboxConfig,
 } from './core-schema.js';
 
 // Imports for AssistantConfigSchema composition
@@ -144,7 +142,6 @@ import {
   SmsConfigSchema,
   IngressConfigSchema,
   DaemonConfigSchema,
-  AssistantInboxConfigSchema,
 } from './core-schema.js';
 
 const VALID_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama', 'fireworks', 'openrouter'] as const;
@@ -439,12 +436,6 @@ export const AssistantConfigSchema = z.object({
     stopTimeoutMs: 5000,
     sigkillGracePeriodMs: 2000,
     titleGenerationMaxTokens: 30,
-  }),
-  assistantInbox: AssistantInboxConfigSchema.default({
-    enabled: false,
-    invitesEnabled: false,
-    memberAclEnabled: false,
-    policyEnabled: false,
   }),
 }).superRefine((config, ctx) => {
   if (config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -40,5 +40,4 @@ export type {
   SmsConfig,
   IngressConfig,
   DaemonConfig,
-  AssistantInboxConfig,
 } from './schema.js';


### PR DESCRIPTION
## Summary
- Remove AssistantInboxConfigSchema and AssistantInboxConfig type from core-schema.ts
- Remove assistantInbox default values from defaults.ts
- Remove assistantInbox field from main config schema in schema.ts
- Clean up any imports of removed types

Part of: assistant-to-human-interaction namespace (G-01)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
