### PR TITLE
refactor: make ingress ACL enforcement always-on (G-02)

### DIFF
--- a/assistant/src/runtime/routes/channel-inbound-routes.ts
+++ b/assistant/src/runtime/routes/channel-inbound-routes.ts
@@ -12,7 +12,6 @@ import * as externalConversationStore from '../../memory/external-conversation-s
 import { getPendingConfirmationsByConversation } from '../../memory/runs-store.js';
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { IngressBlockedError } from '../../util/errors.js';
-import { getConfig } from '../../config/loader.js';
 import { getLogger } from '../../util/logger.js';
 import { findMember, updateLastSeen } from '../../memory/ingress-member-store.js';
 import {
@@ -186,12 +185,11 @@ export async function handleChannelInbound(
   }
 
   // ── Ingress ACL enforcement ──
-  const inboxConfig = getConfig().assistantInbox;
   // Track the resolved member so the escalate branch can reference it after
   // recordInbound (where we have a conversationId).
   let resolvedMember: ReturnType<typeof findMember> = null;
 
-  if (inboxConfig.enabled && inboxConfig.memberAclEnabled && body.senderExternalUserId) {
+  if (body.senderExternalUserId) {
     resolvedMember = findMember({
       sourceChannel,
       externalUserId: body.senderExternalUserId,


### PR DESCRIPTION
## Summary
- Remove getConfig().assistantInbox reads from channel-inbound-routes.ts
- Change ACL enforcement condition from feature-flag-gated to always-on when senderExternalUserId is present
- Keep all security logic (member lookup, status checks, policy enforcement) intact

Part of: assistant-to-human-interaction namespace (G-02)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
