### PR TITLE
refactor: remove remaining IPC handler feature-flag checks (G-03)

### DIFF
--- a/assistant/src/runtime/routes/channel-inbound-routes.ts
+++ b/assistant/src/runtime/routes/channel-inbound-routes.ts
@@ -12,7 +12,6 @@ import * as externalConversationStore from '../../memory/external-conversation-s
 import { getPendingConfirmationsByConversation } from '../../memory/runs-store.js';
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { IngressBlockedError } from '../../util/errors.js';
-import { getConfig } from '../../config/loader.js';
 import { getLogger } from '../../util/logger.js';
 import { findMember, updateLastSeen } from '../../memory/ingress-member-store.js';
 import {
@@ -186,12 +185,11 @@ export async function handleChannelInbound(
   }
 
   // ── Ingress ACL enforcement ──
-  const inboxConfig = getConfig().assistantInbox;
   // Track the resolved member so the escalate branch can reference it after
   // recordInbound (where we have a conversationId).
   let resolvedMember: ReturnType<typeof findMember> = null;
 
-  if (inboxConfig.enabled && inboxConfig.memberAclEnabled && body.senderExternalUserId) {
+  if (body.senderExternalUserId) {
     resolvedMember = findMember({
       sourceChannel,
       externalUserId: body.senderExternalUserId,


### PR DESCRIPTION
## Summary
- Remove `getConfig().assistantInbox` feature-flag check from `channel-inbound-routes.ts` ingress ACL enforcement
- ACL member lookup is now unconditional when `senderExternalUserId` is present (no longer gated behind `inboxConfig.enabled && inboxConfig.memberAclEnabled`)
- Remove unused `getConfig` import
- Verified all daemon IPC handlers in `config-inbox.ts` are already unconditionally registered (no feature-flag gating)
- Verified IPC contract and protocol files have no flag references

Part of: assistant-to-human-interaction namespace (G-03)

🤖 Generated with [Claude Code](https://claude.com/claude-code)