### PR TITLE
Fix: Increment llmRunVersion in destroy() before abort

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -618,6 +618,48 @@ describe('call-controller', () => {
     expect(() => controller.destroy()).not.toThrow();
   });
 
+  test('destroy: during active turn does not trigger post-turn side effects', async () => {
+    // Simulate a turn that completes after destroy() is called
+    mockStartVoiceTurn.mockImplementation(async (opts: { signal?: AbortSignal; onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      return new Promise((resolve) => {
+        const timeout = setTimeout(() => {
+          opts.onTextDelta('This is a long response');
+          opts.onComplete();
+          resolve({ runId: 'run-1', abort: () => {} });
+        }, 1000);
+
+        opts.signal?.addEventListener('abort', () => {
+          clearTimeout(timeout);
+          // The defensive abort listener in runTurn resolves turnComplete
+          opts.onComplete();
+          resolve({ runId: 'run-1', abort: () => {} });
+        }, { once: true });
+      });
+    });
+
+    const { relay, controller } = setupController();
+    const turnPromise = controller.handleCallerUtterance('Start speaking');
+
+    // Let the turn start
+    await new Promise((r) => setTimeout(r, 5));
+
+    // Destroy the controller while the turn is active
+    controller.destroy();
+
+    // Wait for the turn to settle
+    await turnPromise;
+
+    // Verify that NO spurious post-turn side effects occurred after destroy:
+    // - No final empty-string sendTextToken('', true) call after abort
+    // The only end marker should be from handleInterrupt, not from post-turn logic
+    const endMarkers = relay.sentTokens.filter((t) => t.token === '' && t.last === true);
+
+    // destroy() increments llmRunVersion, so isCurrentRun() returns false
+    // for the aborted turn, preventing post-turn side effects including
+    // the spurious relay.sendTextToken('', true) on line 418.
+    expect(endMarkers.length).toBe(0);
+  });
+
   // ── handleUserInstruction ─────────────────────────────────────────
 
   test('handleUserInstruction: injects instruction marker and triggers turn when idle', async () => {

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -263,6 +263,7 @@ export class CallController {
     if (this.durationWarningTimer) clearTimeout(this.durationWarningTimer);
     if (this.consultationTimer) clearTimeout(this.consultationTimer);
     if (this.durationEndTimer) { clearTimeout(this.durationEndTimer); this.durationEndTimer = null; }
+    this.llmRunVersion++;
     this.abortCurrentTurn();
     unregisterCallController(this.callSessionId);
     log.info({ callSessionId: this.callSessionId }, 'CallController destroyed');


### PR DESCRIPTION
Addresses feedback on #8280. Adds llmRunVersion++ to destroy() before abortCurrentTurn(), matching handleInterrupt() behavior. Prevents post-turn side effects from running on a destroyed controller.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
