### PR TITLE
docs: update inbox documentation for always-on behavior (G-08)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3939,11 +3939,11 @@ The assistant inbox extends the guardian security model to support controlled cr
 
 The channel inbound handler (`channel-routes.ts`) enforces an access control layer between message receipt and agent processing:
 
-1. When `inbox_enabled` is true and the sender is not the guardian, the handler looks up the sender in `assistant_ingress_members` by `(sourceChannel, externalUserId)`.
-2. If no member record exists, the `inbox_default_policy` config determines behavior (allow, deny, or escalate).
-3. If a member exists, their individual `policy` field takes precedence.
+1. When `senderExternalUserId` is present and the sender is not the guardian, the handler looks up the sender in `assistant_ingress_members` by `(sourceChannel, externalUserId)`.
+2. If no member record exists, the message is denied (`not_a_member`).
+3. If a member exists, their individual `policy` field determines behavior (allow, deny, or escalate).
 
-Invite tokens are created via the `ingress_invite` IPC contract. Each token is SHA-256 hashed before storage — the raw token is returned exactly once at creation time. External users redeem invites by sending the token as a channel message, which creates a member record with the default policy.
+Invite tokens are created via the `ingress_invite` IPC contract. Each token is SHA-256 hashed before storage — the raw token is returned exactly once at creation time. External users redeem invites by sending the token as a channel message, which creates a member record with `allow` policy.
 
 #### Escalation Data Flow
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -292,13 +292,13 @@ The assistant inbox provides secure cross-user messaging, allowing external user
 
 ### Ingress Membership
 
-External users join through **invite tokens** — the owner creates an invite via the desktop UI or IPC, and the external user redeems the token by sending it as a channel message. Redemption auto-creates a **member** record with a configurable access policy:
+External users join through **invite tokens** — the owner creates an invite via the desktop UI or IPC, and the external user redeems the token by sending it as a channel message. Redemption auto-creates a **member** record with an access policy:
 
 - **`allow`** — Messages are processed normally through the agent pipeline.
 - **`deny`** — Messages are rejected with a refusal notice.
 - **`escalate`** — Messages are held for guardian (owner) approval before processing.
 
-The default policy for new members is controlled by the `inbox_default_policy` config. Members can be listed, updated, revoked, or blocked via the `ingress_member` IPC contract.
+Non-members (senders with no invite redemption) are denied by default. Members can be listed, updated, revoked, or blocked via the `ingress_member` IPC contract.
 
 ### Escalation Flow (Dual-Surface)
 


### PR DESCRIPTION
## Summary
- Update assistant/README.md to remove references to inbox config booleans and feature flags
- Update ARCHITECTURE.md to reflect that inbox/ACL/escalation are always active
- Remove language about enabling/disabling the inbox feature

Part of: assistant-to-human-interaction namespace (G-08, final task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
