### PR TITLE
fix: change private to internal for AppDelegate menubar properties

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -114,9 +114,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private var quickChatShortcutObserver: AnyCancellable?
     private weak var recordingViewModel: ChatViewModel?
     private var statusIconCancellable: AnyCancellable?
-    private var connectionStatusCancellable: AnyCancellable?
-    private var pulseTimer: Timer?
-    private var pulsePhase: CGFloat = 1.0
+    var connectionStatusCancellable: AnyCancellable?
+    var pulseTimer: Timer?
+    var pulsePhase: CGFloat = 1.0
     var cachedSkills: [SkillInfo] = []
     var refreshSkillsTask: Task<Void, Never>?
     var cachedApps: [AppItem] = []


### PR DESCRIPTION
## Summary
- Changed `connectionStatusCancellable`, `pulseTimer`, and `pulsePhase` from `private` to `internal` in `AppDelegate.swift`
- These properties are accessed from `AppDelegate+MenuBar.swift` (a separate file), so `private` causes compiler errors

## Test plan
- [ ] Run `./build.sh` from `clients/macos/` to confirm the build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
