### PR TITLE
feat: increase maxInputTokens from 180k to 200k

### DIFF
--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -16,7 +16,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   },
   contextWindow: {
     enabled: true,
-    maxInputTokens: 180000,
+    maxInputTokens: 200000,
     targetInputTokens: 110000,
     compactThreshold: 0.8,
     preserveRecentUserTurns: 8,


### PR DESCRIPTION
## Summary
- Bumps `maxInputTokens` default from 180,000 to 200,000 in context window config

## Test plan
- [ ] Verify assistant operates normally with the increased token limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
