### PR TITLE
fix: resolve CI type-check and lint errors

### DIFF
--- a/assistant/src/config/core-schema.ts
+++ b/assistant/src/config/core-schema.ts
@@ -223,8 +223,17 @@ const IngressBaseSchema = z.object({
       'ingress.publicBaseUrl must be an absolute URL starting with http:// or https://',
     )
     .default(''),
-  webhook: IngressWebhookConfigSchema.default({}),
-  rateLimit: IngressRateLimitConfigSchema.default({}),
+  webhook: IngressWebhookConfigSchema.default({
+    secret: '',
+    timeoutMs: 30_000,
+    maxRetries: 2,
+    initialBackoffMs: 500,
+    maxPayloadBytes: 1_048_576,
+  }),
+  rateLimit: IngressRateLimitConfigSchema.default({
+    maxRequestsPerMinute: 0,
+    maxRequestsPerHour: 0,
+  }),
   shutdownDrainMs: z
     .number({ error: 'ingress.shutdownDrainMs must be a number' })
     .int('ingress.shutdownDrainMs must be an integer')
@@ -233,7 +242,21 @@ const IngressBaseSchema = z.object({
 });
 
 export const IngressConfigSchema = IngressBaseSchema
-  .default({})
+  .default({
+    publicBaseUrl: '',
+    webhook: {
+      secret: '',
+      timeoutMs: 30_000,
+      maxRetries: 2,
+      initialBackoffMs: 500,
+      maxPayloadBytes: 1_048_576,
+    },
+    rateLimit: {
+      maxRequestsPerMinute: 0,
+      maxRequestsPerHour: 0,
+    },
+    shutdownDrainMs: 5_000,
+  })
   .transform((val) => ({
     ...val,
     // Backward compatibility: if `enabled` was never explicitly set (undefined),

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -266,6 +266,18 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   ingress: {
     enabled: undefined,
     publicBaseUrl: '',
+    webhook: {
+      secret: '',
+      timeoutMs: 30_000,
+      maxRetries: 2,
+      initialBackoffMs: 500,
+      maxPayloadBytes: 1_048_576,
+    },
+    rateLimit: {
+      maxRequestsPerMinute: 0,
+      maxRequestsPerHour: 0,
+    },
+    shutdownDrainMs: 5_000,
   },
   daemon: {
     startupSocketWaitMs: 5000,

--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -13,7 +13,7 @@ import { telegramBotMessagingProvider } from '../messaging/providers/telegram-bo
 import { smsMessagingProvider } from '../messaging/providers/sms/adapter.js';
 import { whatsappMessagingProvider } from '../messaging/providers/whatsapp/adapter.js';
 import { initWatcherEngine } from '../watcher/engine.js';
-import type { AssistantConfig } from '../config/loader.js';
+import type { AssistantConfig } from '../config/types.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('lifecycle');

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -9,7 +9,6 @@ import { memoryItems } from '../../memory/schema.js';
 import { enqueueMemoryJob } from '../../memory/jobs-store.js';
 import { searchMemoryItems, formatRelativeTime } from '../../memory/retriever.js';
 import type { ScopePolicyOverride } from '../../memory/search/types.js';
-import { clampUnitInterval } from '../../memory/validation.js';
 import type { ToolExecutionResult } from '../types.js';
 
 const log = getLogger('memory-tools');

--- a/assistant/src/util/log-redact.ts
+++ b/assistant/src/util/log-redact.ts
@@ -111,7 +111,7 @@ function redactValue(value: unknown, depth: number): unknown {
 // ---------------------------------------------------------------------------
 
 function serializeError(err: unknown, depth: number): unknown {
-  if (depth > 8 || err === null || err === undefined) return err;
+  if (depth > 8 || err == null) return err;
 
   if (!(err instanceof Error)) {
     return err;


### PR DESCRIPTION
## Summary
- Fix Zod 4 `.default({})` type errors in `IngressConfigSchema` by providing explicit default values matching the output type
- Fix `AssistantConfig` import in `providers-setup.ts` to use `types.js` (where it's actually exported) instead of `loader.js`
- Remove unused `clampUnitInterval` import and fix `=== null` lint violation

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22358705846

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
