### PR TITLE
M3: Guardian Context and Side-Effect Policy Parity

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -190,7 +190,7 @@ function resetTables() {
 /**
  * Create a call session and a controller wired to a mock relay.
  */
-function setupController(task?: string) {
+function setupController(task?: string, opts?: { assistantId?: string; guardianContext?: import('../daemon/session-runtime-assembly.js').GuardianRuntimeContext }) {
   ensureConversation('conv-ctrl-test');
   const session = createCallSession({
     conversationId: 'conv-ctrl-test',
@@ -201,7 +201,10 @@ function setupController(task?: string) {
   });
   updateCallSession(session.id, { status: 'in_progress' });
   const relay = createMockRelay();
-  const controller = new CallController(session.id, relay as unknown as RelayConnection, task ?? null);
+  const controller = new CallController(session.id, relay as unknown as RelayConnection, task ?? null, {
+    assistantId: opts?.assistantId,
+    guardianContext: opts?.guardianContext,
+  });
   return { session, relay, controller };
 }
 
@@ -592,6 +595,102 @@ describe('call-controller', () => {
     await turnPromise;
 
     expect(controller.getState()).toBe('idle');
+
+    controller.destroy();
+  });
+
+  // ── Guardian context pass-through ──────────────────────────────────
+
+  test('handleCallerUtterance: passes guardian context to startVoiceTurn', async () => {
+    const guardianCtx = {
+      sourceChannel: 'voice' as const,
+      actorRole: 'non-guardian' as const,
+      guardianExternalUserId: '+15550009999',
+      guardianChatId: '+15550009999',
+      requesterExternalUserId: '+15550002222',
+    };
+
+    let capturedGuardianContext: unknown = undefined;
+    mockStartVoiceTurn.mockImplementation(async (opts: {
+      guardianContext?: unknown;
+      onTextDelta: (t: string) => void;
+      onComplete: () => void;
+    }) => {
+      capturedGuardianContext = opts.guardianContext;
+      opts.onTextDelta('Hello.');
+      opts.onComplete();
+      return { runId: 'run-gc', abort: () => {} };
+    });
+
+    const { controller } = setupController(undefined, { guardianContext: guardianCtx });
+
+    await controller.handleCallerUtterance('Hello');
+
+    expect(capturedGuardianContext).toEqual(guardianCtx);
+
+    controller.destroy();
+  });
+
+  test('handleCallerUtterance: passes assistantId to startVoiceTurn', async () => {
+    let capturedAssistantId: string | undefined;
+    mockStartVoiceTurn.mockImplementation(async (opts: {
+      assistantId?: string;
+      onTextDelta: (t: string) => void;
+      onComplete: () => void;
+    }) => {
+      capturedAssistantId = opts.assistantId;
+      opts.onTextDelta('Hello.');
+      opts.onComplete();
+      return { runId: 'run-aid', abort: () => {} };
+    });
+
+    const { controller } = setupController(undefined, { assistantId: 'my-assistant' });
+
+    await controller.handleCallerUtterance('Hello');
+
+    expect(capturedAssistantId).toBe('my-assistant');
+
+    controller.destroy();
+  });
+
+  test('setGuardianContext: subsequent turns use updated guardian context', async () => {
+    const initialCtx = {
+      sourceChannel: 'voice' as const,
+      actorRole: 'unverified_channel' as const,
+      denialReason: 'no_binding' as const,
+    };
+
+    const upgradedCtx = {
+      sourceChannel: 'voice' as const,
+      actorRole: 'guardian' as const,
+      guardianExternalUserId: '+15550003333',
+      guardianChatId: '+15550003333',
+    };
+
+    const capturedContexts: unknown[] = [];
+    mockStartVoiceTurn.mockImplementation(async (opts: {
+      guardianContext?: unknown;
+      onTextDelta: (t: string) => void;
+      onComplete: () => void;
+    }) => {
+      capturedContexts.push(opts.guardianContext);
+      opts.onTextDelta('Response.');
+      opts.onComplete();
+      return { runId: `run-${capturedContexts.length}`, abort: () => {} };
+    });
+
+    const { controller } = setupController(undefined, { guardianContext: initialCtx });
+
+    // First turn: unverified
+    await controller.handleCallerUtterance('Hello');
+    expect(capturedContexts[0]).toEqual(initialCtx);
+
+    // Simulate guardian verification succeeding
+    controller.setGuardianContext(upgradedCtx);
+
+    // Second turn: should use upgraded guardian context
+    await controller.handleCallerUtterance('I verified');
+    expect(capturedContexts[1]).toEqual(upgradedCtx);
 
     controller.destroy();
   });

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -263,8 +263,8 @@ describe('relay-server', () => {
     const connectedEvents = events.filter(e => e.eventType === 'call_connected');
     expect(connectedEvents.length).toBe(1);
 
-    // Verify orchestrator was created
-    expect(relay.getOrchestrator()).not.toBeNull();
+    // Verify controller was created
+    expect(relay.getController()).not.toBeNull();
 
     relay.destroy();
   });
@@ -815,11 +815,11 @@ describe('relay-server', () => {
       to: '+15552222222',
     }));
 
-    expect(relay.getOrchestrator()).not.toBeNull();
+    expect(relay.getController()).not.toBeNull();
 
     relay.destroy();
 
-    expect(relay.getOrchestrator()).toBeNull();
+    expect(relay.getController()).toBeNull();
   });
 
   test('destroy: can be called multiple times without error', () => {
@@ -1145,7 +1145,7 @@ describe('relay-server', () => {
       to: '+15551111111',
     }));
 
-    const runtimeContext = (relay.getOrchestrator() as unknown as { guardianContext?: { sourceChannel?: string; actorRole?: string; guardianExternalUserId?: string } })?.guardianContext;
+    const runtimeContext = (relay.getController() as unknown as { guardianContext?: { sourceChannel?: string; actorRole?: string; guardianExternalUserId?: string } })?.guardianContext;
     expect(runtimeContext?.sourceChannel).toBe('voice');
     expect(runtimeContext?.actorRole).toBe('guardian');
     expect(runtimeContext?.guardianExternalUserId).toBe('+15550001111');
@@ -1181,7 +1181,7 @@ describe('relay-server', () => {
       to: '+15551111111',
     }));
 
-    const runtimeContext = (relay.getOrchestrator() as unknown as {
+    const runtimeContext = (relay.getController() as unknown as {
       guardianContext?: {
         sourceChannel?: string;
         actorRole?: string;
@@ -1197,7 +1197,7 @@ describe('relay-server', () => {
     relay.destroy();
   });
 
-  test('inbound guardian verification updates orchestrator context to guardian', async () => {
+  test('inbound guardian verification updates controller context to guardian', async () => {
     ensureConversation('conv-guardian-context-upgrade');
     const session = createCallSession({
       conversationId: 'conv-guardian-context-upgrade',
@@ -1219,7 +1219,7 @@ describe('relay-server', () => {
       to: session.toNumber,
     }));
 
-    const preVerify = (relay.getOrchestrator() as unknown as {
+    const preVerify = (relay.getController() as unknown as {
       guardianContext?: { actorRole?: string };
     })?.guardianContext;
     expect(preVerify?.actorRole).toBe('unverified_channel');
@@ -1233,7 +1233,7 @@ describe('relay-server', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 10));
 
-    const postVerify = (relay.getOrchestrator() as unknown as {
+    const postVerify = (relay.getController() as unknown as {
       guardianContext?: { sourceChannel?: string; actorRole?: string; guardianExternalUserId?: string };
     })?.guardianContext;
     expect(postVerify?.sourceChannel).toBe('voice');

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -423,6 +423,229 @@ describe('voice-session-bridge', () => {
     expect(capturedGuardianContext).toEqual(guardianCtx);
   });
 
+  test('auto-denies confirmation requests for non-guardian voice turns', async () => {
+    const conversation = createConversation('voice bridge auto-deny non-guardian test');
+
+    let clientHandler: (msg: ServerMessage) => void = () => {};
+    const handleConfirmationCalls: Array<{
+      requestId: string;
+      decision: string;
+      decisionContext?: string;
+    }> = [];
+
+    const session = {
+      isProcessing: () => false,
+      persistUserMessage: () => undefined as unknown as string,
+      memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
+      setChannelCapabilities: () => {},
+      setAssistantId: () => {},
+      setGuardianContext: () => {},
+      setCommandIntent: () => {},
+      setTurnChannelContext: () => {},
+      updateClient: (handler: (msg: ServerMessage) => void) => {
+        clientHandler = handler;
+      },
+      runAgentLoop: async () => {
+        // Simulate the prompter emitting a confirmation_request via the
+        // updateClient callback (this is how the real prompter works).
+        clientHandler({
+          type: 'confirmation_request',
+          requestId: 'req-voice-1',
+          toolName: 'host_bash',
+          input: { command: 'rm -rf /' },
+          riskLevel: 'high',
+          allowlistOptions: [],
+          scopeOptions: [],
+        } as ServerMessage);
+        // The auto-deny resolves the prompter immediately, so the agent loop
+        // can continue. In production the loop would continue; here we just
+        // return to simulate completion.
+      },
+      handleConfirmationResponse: (
+        requestId: string,
+        decision: string,
+        _selectedPattern?: string,
+        _selectedScope?: string,
+        decisionContext?: string,
+      ) => {
+        handleConfirmationCalls.push({ requestId, decision, decisionContext });
+      },
+      abort: () => {},
+    } as unknown as Session;
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
+    });
+    setVoiceBridgeOrchestrator(orchestrator);
+
+    await startVoiceTurn({
+      conversationId: conversation.id,
+      content: 'Delete everything',
+      guardianContext: {
+        sourceChannel: 'voice',
+        actorRole: 'non-guardian',
+        guardianExternalUserId: '+15550009999',
+        guardianChatId: '+15550009999',
+        requesterExternalUserId: '+15550002222',
+      },
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // The confirmation should have been auto-denied immediately
+    expect(handleConfirmationCalls.length).toBe(1);
+    expect(handleConfirmationCalls[0].requestId).toBe('req-voice-1');
+    expect(handleConfirmationCalls[0].decision).toBe('deny');
+    expect(handleConfirmationCalls[0].decisionContext).toContain('voice call');
+    expect(handleConfirmationCalls[0].decisionContext).toContain('host_bash');
+  });
+
+  test('auto-denies confirmation requests for unverified_channel voice turns', async () => {
+    const conversation = createConversation('voice bridge auto-deny unverified test');
+
+    let clientHandler: (msg: ServerMessage) => void = () => {};
+    const handleConfirmationCalls: Array<{
+      requestId: string;
+      decision: string;
+    }> = [];
+
+    const session = {
+      isProcessing: () => false,
+      persistUserMessage: () => undefined as unknown as string,
+      memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
+      setChannelCapabilities: () => {},
+      setAssistantId: () => {},
+      setGuardianContext: () => {},
+      setCommandIntent: () => {},
+      setTurnChannelContext: () => {},
+      updateClient: (handler: (msg: ServerMessage) => void) => {
+        clientHandler = handler;
+      },
+      runAgentLoop: async () => {
+        clientHandler({
+          type: 'confirmation_request',
+          requestId: 'req-voice-2',
+          toolName: 'network_request',
+          input: { url: 'https://evil.com' },
+          riskLevel: 'medium',
+          allowlistOptions: [],
+          scopeOptions: [],
+        } as ServerMessage);
+      },
+      handleConfirmationResponse: (
+        requestId: string,
+        decision: string,
+      ) => {
+        handleConfirmationCalls.push({ requestId, decision });
+      },
+      abort: () => {},
+    } as unknown as Session;
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
+    });
+    setVoiceBridgeOrchestrator(orchestrator);
+
+    await startVoiceTurn({
+      conversationId: conversation.id,
+      content: 'Make a request',
+      guardianContext: {
+        sourceChannel: 'voice',
+        actorRole: 'unverified_channel',
+        denialReason: 'no_binding',
+      },
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(handleConfirmationCalls.length).toBe(1);
+    expect(handleConfirmationCalls[0].requestId).toBe('req-voice-2');
+    expect(handleConfirmationCalls[0].decision).toBe('deny');
+  });
+
+  test('does NOT auto-deny confirmation requests for guardian voice turns', async () => {
+    const conversation = createConversation('voice bridge no-auto-deny guardian test');
+
+    let clientHandler: (msg: ServerMessage) => void = () => {};
+    const handleConfirmationCalls: Array<{
+      requestId: string;
+      decision: string;
+    }> = [];
+
+    const session = {
+      isProcessing: () => false,
+      persistUserMessage: () => undefined as unknown as string,
+      memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
+      setChannelCapabilities: () => {},
+      setAssistantId: () => {},
+      setGuardianContext: () => {},
+      setCommandIntent: () => {},
+      setTurnChannelContext: () => {},
+      updateClient: (handler: (msg: ServerMessage) => void) => {
+        clientHandler = handler;
+      },
+      runAgentLoop: async () => {
+        clientHandler({
+          type: 'confirmation_request',
+          requestId: 'req-voice-3',
+          toolName: 'host_bash',
+          input: { command: 'ls' },
+          riskLevel: 'low',
+          allowlistOptions: [],
+          scopeOptions: [],
+        } as ServerMessage);
+        // For guardian actors, the confirmation enters the normal
+        // pending state — it is NOT auto-denied. The runAgentLoop
+        // would normally block waiting for resolution. We just return
+        // to keep the test simple.
+      },
+      handleConfirmationResponse: (
+        requestId: string,
+        decision: string,
+      ) => {
+        handleConfirmationCalls.push({ requestId, decision });
+      },
+      abort: () => {},
+    } as unknown as Session;
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
+    });
+    setVoiceBridgeOrchestrator(orchestrator);
+
+    await startVoiceTurn({
+      conversationId: conversation.id,
+      content: 'List files',
+      guardianContext: {
+        sourceChannel: 'voice',
+        actorRole: 'guardian',
+        guardianExternalUserId: '+15550001111',
+        guardianChatId: '+15550001111',
+      },
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Guardian actors should NOT have auto-deny — confirmation enters
+    // the normal pending flow (stored in run store, not auto-denied).
+    expect(handleConfirmationCalls.length).toBe(0);
+  });
+
   test('pre-aborted signal triggers immediate abort', async () => {
     const conversation = createConversation('voice bridge pre-abort test');
     let abortCalled = false;

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -229,6 +229,200 @@ describe('voice-session-bridge', () => {
     expect(abortCalled).toBe(true);
   });
 
+  test('startVoiceTurn passes turnChannelContext with voice channel', async () => {
+    const conversation = createConversation('voice bridge channel context test');
+    const events: ServerMessage[] = [
+      { type: 'message_complete', sessionId: conversation.id },
+    ];
+
+    let capturedTurnChannelContext: unknown = null;
+    const session = {
+      ...makeStreamingSession(events),
+      setTurnChannelContext: (ctx: unknown) => { capturedTurnChannelContext = ctx; },
+    } as unknown as Session;
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
+    });
+    setVoiceBridgeOrchestrator(orchestrator);
+
+    await startVoiceTurn({
+      conversationId: conversation.id,
+      content: 'Hello',
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(capturedTurnChannelContext).toEqual({
+      userMessageChannel: 'voice',
+      assistantMessageChannel: 'voice',
+    });
+  });
+
+  test('startVoiceTurn forces strict side effects for non-guardian actors', async () => {
+    const conversation = createConversation('voice bridge strict non-guardian test');
+    const events: ServerMessage[] = [
+      { type: 'message_complete', sessionId: conversation.id },
+    ];
+
+    let capturedStrictSideEffects: boolean | undefined;
+    const session = {
+      ...makeStreamingSession(events),
+      get memoryPolicy() { return { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false }; },
+      set memoryPolicy(val: Record<string, unknown>) { capturedStrictSideEffects = val.strictSideEffects as boolean; },
+    } as unknown as Session;
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
+    });
+    setVoiceBridgeOrchestrator(orchestrator);
+
+    await startVoiceTurn({
+      conversationId: conversation.id,
+      content: 'Hello',
+      guardianContext: {
+        sourceChannel: 'voice',
+        actorRole: 'non-guardian',
+        guardianExternalUserId: '+15550009999',
+        guardianChatId: '+15550009999',
+        requesterExternalUserId: '+15550002222',
+      },
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(capturedStrictSideEffects).toBe(true);
+  });
+
+  test('startVoiceTurn forces strict side effects for unverified_channel actors', async () => {
+    const conversation = createConversation('voice bridge strict unverified test');
+    const events: ServerMessage[] = [
+      { type: 'message_complete', sessionId: conversation.id },
+    ];
+
+    let capturedStrictSideEffects: boolean | undefined;
+    const session = {
+      ...makeStreamingSession(events),
+      get memoryPolicy() { return { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false }; },
+      set memoryPolicy(val: Record<string, unknown>) { capturedStrictSideEffects = val.strictSideEffects as boolean; },
+    } as unknown as Session;
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
+    });
+    setVoiceBridgeOrchestrator(orchestrator);
+
+    await startVoiceTurn({
+      conversationId: conversation.id,
+      content: 'Hello',
+      guardianContext: {
+        sourceChannel: 'voice',
+        actorRole: 'unverified_channel',
+        denialReason: 'no_binding',
+      },
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(capturedStrictSideEffects).toBe(true);
+  });
+
+  test('startVoiceTurn does not force strict side effects for guardian actors', async () => {
+    const conversation = createConversation('voice bridge strict guardian test');
+    const events: ServerMessage[] = [
+      { type: 'message_complete', sessionId: conversation.id },
+    ];
+
+    let capturedStrictSideEffects: boolean | undefined;
+    const session = {
+      ...makeStreamingSession(events),
+      get memoryPolicy() { return { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false }; },
+      set memoryPolicy(val: Record<string, unknown>) { capturedStrictSideEffects = val.strictSideEffects as boolean; },
+    } as unknown as Session;
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
+    });
+    setVoiceBridgeOrchestrator(orchestrator);
+
+    await startVoiceTurn({
+      conversationId: conversation.id,
+      content: 'Hello',
+      guardianContext: {
+        sourceChannel: 'voice',
+        actorRole: 'guardian',
+        guardianExternalUserId: '+15550001111',
+        guardianChatId: '+15550001111',
+      },
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Guardian actors use the derived default (false), not forced true
+    expect(capturedStrictSideEffects).toBe(false);
+  });
+
+  test('startVoiceTurn passes guardian context to the session', async () => {
+    const conversation = createConversation('voice bridge guardian context test');
+    const events: ServerMessage[] = [
+      { type: 'message_complete', sessionId: conversation.id },
+    ];
+
+    let capturedGuardianContext: unknown = null;
+    const session = {
+      ...makeStreamingSession(events),
+      setGuardianContext: (ctx: unknown) => { capturedGuardianContext = ctx; },
+    } as unknown as Session;
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
+    });
+    setVoiceBridgeOrchestrator(orchestrator);
+
+    const guardianCtx = {
+      sourceChannel: 'voice' as const,
+      actorRole: 'guardian' as const,
+      guardianExternalUserId: '+15550001111',
+      guardianChatId: '+15550001111',
+    };
+
+    await startVoiceTurn({
+      conversationId: conversation.id,
+      content: 'Hello',
+      assistantId: 'test-assistant',
+      guardianContext: guardianCtx,
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(capturedGuardianContext).toEqual(guardianCtx);
+  });
+
   test('pre-aborted signal triggers immediate abort', async () => {
     const conversation = createConversation('voice bridge pre-abort test');
     let abortCalled = false;

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -89,6 +89,15 @@ export async function startVoiceTurn(opts: VoiceTurnOptions): Promise<VoiceTurnH
     },
   };
 
+  // Derive forceStrictSideEffects from guardian context to match channel
+  // ingress behavior: non-guardian and unverified actors always get strict
+  // side effects so all side-effect tools trigger the confirmation flow.
+  const actorRole = opts.guardianContext?.actorRole;
+  const forceStrictSideEffects =
+    actorRole === 'non-guardian' || actorRole === 'unverified_channel'
+      ? true
+      : undefined;
+
   const { run, abort } = await orchestrator.startRun(
     opts.conversationId,
     opts.content,
@@ -97,6 +106,11 @@ export async function startVoiceTurn(opts: VoiceTurnOptions): Promise<VoiceTurnH
       sourceChannel: 'voice',
       assistantId: opts.assistantId,
       guardianContext: opts.guardianContext,
+      ...(forceStrictSideEffects ? { forceStrictSideEffects } : {}),
+      turnChannelContext: {
+        userMessageChannel: 'voice',
+        assistantMessageChannel: 'voice',
+      },
       eventSink,
     },
   );

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -106,7 +106,7 @@ export async function startVoiceTurn(opts: VoiceTurnOptions): Promise<VoiceTurnH
       sourceChannel: 'voice',
       assistantId: opts.assistantId,
       guardianContext: opts.guardianContext,
-      ...(forceStrictSideEffects ? { forceStrictSideEffects } : {}),
+      ...(forceStrictSideEffects ? { forceStrictSideEffects, voiceAutoDenyConfirmations: true } : {}),
       turnChannelContext: {
         userMessageChannel: 'voice',
         assistantMessageChannel: 'voice',

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -120,6 +120,14 @@ export interface RunStartOptions {
    * Used by voice relay for streaming TTS token delivery.
    */
   eventSink?: VoiceRunEventSink;
+  /**
+   * When true, any confirmation_request from the prompter is immediately
+   * auto-denied instead of being stored for client polling. Used by the
+   * voice path when forceStrictSideEffects is active: the voice transport
+   * has no interactive approval UI, so without this flag the run would
+   * stall for the full permission timeout (300s by default).
+   */
+  voiceAutoDenyConfirmations?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -233,9 +241,33 @@ export class RunOrchestrator {
     // When the prompter sends one of these, we record it in the run store so
     // the client can poll and submit a decision/secret via the respective endpoint.
     // Do NOT set hasNoClient — run sessions have a client (the HTTP caller).
+    const autoDeny = options?.voiceAutoDenyConfirmations === true;
     let lastError: string | null = null;
     session.updateClient((msg: ServerMessage) => {
       if (msg.type === 'confirmation_request') {
+        if (autoDeny) {
+          // Voice path with strict side effects: immediately deny the
+          // confirmation request so the agent loop resumes without
+          // waiting for the full permission timeout (300s). The voice
+          // transport has no interactive approval UI, so polling would
+          // just stall. Security is preserved — the tool call is denied.
+          log.info(
+            { runId: run.id, toolName: msg.toolName },
+            'Auto-denying confirmation request for voice turn (forceStrictSideEffects)',
+          );
+          session.handleConfirmationResponse(
+            msg.requestId,
+            'deny',
+            undefined,
+            undefined,
+            `Permission denied for "${msg.toolName}": this voice call does not have interactive approval capabilities. Side-effect tools are not available for non-guardian voice callers. In your next assistant reply, explain briefly that this action requires guardian-level access and cannot be performed during this call.`,
+          );
+          // Still publish to hub for observability, but skip run-store
+          // bookkeeping since the confirmation is already resolved.
+          publishToHub(msg);
+          return;
+        }
+
         runsStore.setRunConfirmation(run.id, {
           toolName: msg.toolName,
           toolUseId: msg.requestId,


### PR DESCRIPTION
Part of #8181. Ensures voice turns pass sourceChannel, turnChannelContext, assistantId, and guardianContext to the session loop. Applies strict-side-effects override for non-guardian/unverified actors on voice, matching channel ingress behavior. Preserves guardian role upgrades after verification.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
