### PR TITLE
fix: remove stale relayPort from storage when port field is cleared

### DIFF
--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -47,6 +47,8 @@ btnConnect.addEventListener('click', async () => {
     if (!isNaN(portNum) && portNum > 0 && portNum <= 65535) {
       storageUpdate.relayPort = portNum;
     }
+  } else {
+    await chrome.storage.local.remove('relayPort');
   }
   await chrome.storage.local.set(storageUpdate);
 


### PR DESCRIPTION
When a user clears the relay port input field in the Chrome extension popup, the previously-stored relayPort value should be removed from chrome.storage.local so that getRelayPort() in the worker correctly falls back to the default 7821. Previously, clearing the field left the stale value in storage, causing persistent connection to the old port.

Addresses review feedback on #8114 from both Codex and Devin.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
