### PR TITLE
Fix: Auto-deny tool confirmations for non-guardian voice turns

### DIFF
--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -423,6 +423,229 @@ describe('voice-session-bridge', () => {
     expect(capturedGuardianContext).toEqual(guardianCtx);
   });
 
+  test('auto-denies confirmation requests for non-guardian voice turns', async () => {
+    const conversation = createConversation('voice bridge auto-deny non-guardian test');
+
+    let clientHandler: (msg: ServerMessage) => void = () => {};
+    const handleConfirmationCalls: Array<{
+      requestId: string;
+      decision: string;
+      decisionContext?: string;
+    }> = [];
+
+    const session = {
+      isProcessing: () => false,
+      persistUserMessage: () => undefined as unknown as string,
+      memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
+      setChannelCapabilities: () => {},
+      setAssistantId: () => {},
+      setGuardianContext: () => {},
+      setCommandIntent: () => {},
+      setTurnChannelContext: () => {},
+      updateClient: (handler: (msg: ServerMessage) => void) => {
+        clientHandler = handler;
+      },
+      runAgentLoop: async () => {
+        // Simulate the prompter emitting a confirmation_request via the
+        // updateClient callback (this is how the real prompter works).
+        clientHandler({
+          type: 'confirmation_request',
+          requestId: 'req-voice-1',
+          toolName: 'host_bash',
+          input: { command: 'rm -rf /' },
+          riskLevel: 'high',
+          allowlistOptions: [],
+          scopeOptions: [],
+        } as ServerMessage);
+        // The auto-deny resolves the prompter immediately, so the agent loop
+        // can continue. In production the loop would continue; here we just
+        // return to simulate completion.
+      },
+      handleConfirmationResponse: (
+        requestId: string,
+        decision: string,
+        _selectedPattern?: string,
+        _selectedScope?: string,
+        decisionContext?: string,
+      ) => {
+        handleConfirmationCalls.push({ requestId, decision, decisionContext });
+      },
+      abort: () => {},
+    } as unknown as Session;
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
+    });
+    setVoiceBridgeOrchestrator(orchestrator);
+
+    await startVoiceTurn({
+      conversationId: conversation.id,
+      content: 'Delete everything',
+      guardianContext: {
+        sourceChannel: 'voice',
+        actorRole: 'non-guardian',
+        guardianExternalUserId: '+15550009999',
+        guardianChatId: '+15550009999',
+        requesterExternalUserId: '+15550002222',
+      },
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // The confirmation should have been auto-denied immediately
+    expect(handleConfirmationCalls.length).toBe(1);
+    expect(handleConfirmationCalls[0].requestId).toBe('req-voice-1');
+    expect(handleConfirmationCalls[0].decision).toBe('deny');
+    expect(handleConfirmationCalls[0].decisionContext).toContain('voice call');
+    expect(handleConfirmationCalls[0].decisionContext).toContain('host_bash');
+  });
+
+  test('auto-denies confirmation requests for unverified_channel voice turns', async () => {
+    const conversation = createConversation('voice bridge auto-deny unverified test');
+
+    let clientHandler: (msg: ServerMessage) => void = () => {};
+    const handleConfirmationCalls: Array<{
+      requestId: string;
+      decision: string;
+    }> = [];
+
+    const session = {
+      isProcessing: () => false,
+      persistUserMessage: () => undefined as unknown as string,
+      memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
+      setChannelCapabilities: () => {},
+      setAssistantId: () => {},
+      setGuardianContext: () => {},
+      setCommandIntent: () => {},
+      setTurnChannelContext: () => {},
+      updateClient: (handler: (msg: ServerMessage) => void) => {
+        clientHandler = handler;
+      },
+      runAgentLoop: async () => {
+        clientHandler({
+          type: 'confirmation_request',
+          requestId: 'req-voice-2',
+          toolName: 'network_request',
+          input: { url: 'https://evil.com' },
+          riskLevel: 'medium',
+          allowlistOptions: [],
+          scopeOptions: [],
+        } as ServerMessage);
+      },
+      handleConfirmationResponse: (
+        requestId: string,
+        decision: string,
+      ) => {
+        handleConfirmationCalls.push({ requestId, decision });
+      },
+      abort: () => {},
+    } as unknown as Session;
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
+    });
+    setVoiceBridgeOrchestrator(orchestrator);
+
+    await startVoiceTurn({
+      conversationId: conversation.id,
+      content: 'Make a request',
+      guardianContext: {
+        sourceChannel: 'voice',
+        actorRole: 'unverified_channel',
+        denialReason: 'no_binding',
+      },
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(handleConfirmationCalls.length).toBe(1);
+    expect(handleConfirmationCalls[0].requestId).toBe('req-voice-2');
+    expect(handleConfirmationCalls[0].decision).toBe('deny');
+  });
+
+  test('does NOT auto-deny confirmation requests for guardian voice turns', async () => {
+    const conversation = createConversation('voice bridge no-auto-deny guardian test');
+
+    let clientHandler: (msg: ServerMessage) => void = () => {};
+    const handleConfirmationCalls: Array<{
+      requestId: string;
+      decision: string;
+    }> = [];
+
+    const session = {
+      isProcessing: () => false,
+      persistUserMessage: () => undefined as unknown as string,
+      memoryPolicy: { scopeId: 'default', includeDefaultFallback: false, strictSideEffects: false },
+      setChannelCapabilities: () => {},
+      setAssistantId: () => {},
+      setGuardianContext: () => {},
+      setCommandIntent: () => {},
+      setTurnChannelContext: () => {},
+      updateClient: (handler: (msg: ServerMessage) => void) => {
+        clientHandler = handler;
+      },
+      runAgentLoop: async () => {
+        clientHandler({
+          type: 'confirmation_request',
+          requestId: 'req-voice-3',
+          toolName: 'host_bash',
+          input: { command: 'ls' },
+          riskLevel: 'low',
+          allowlistOptions: [],
+          scopeOptions: [],
+        } as ServerMessage);
+        // For guardian actors, the confirmation enters the normal
+        // pending state — it is NOT auto-denied. The runAgentLoop
+        // would normally block waiting for resolution. We just return
+        // to keep the test simple.
+      },
+      handleConfirmationResponse: (
+        requestId: string,
+        decision: string,
+      ) => {
+        handleConfirmationCalls.push({ requestId, decision });
+      },
+      abort: () => {},
+    } as unknown as Session;
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+      deriveDefaultStrictSideEffects: () => false,
+    });
+    setVoiceBridgeOrchestrator(orchestrator);
+
+    await startVoiceTurn({
+      conversationId: conversation.id,
+      content: 'List files',
+      guardianContext: {
+        sourceChannel: 'voice',
+        actorRole: 'guardian',
+        guardianExternalUserId: '+15550001111',
+        guardianChatId: '+15550001111',
+      },
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Guardian actors should NOT have auto-deny — confirmation enters
+    // the normal pending flow (stored in run store, not auto-denied).
+    expect(handleConfirmationCalls.length).toBe(0);
+  });
+
   test('pre-aborted signal triggers immediate abort', async () => {
     const conversation = createConversation('voice bridge pre-abort test');
     let abortCalled = false;

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -106,7 +106,7 @@ export async function startVoiceTurn(opts: VoiceTurnOptions): Promise<VoiceTurnH
       sourceChannel: 'voice',
       assistantId: opts.assistantId,
       guardianContext: opts.guardianContext,
-      ...(forceStrictSideEffects ? { forceStrictSideEffects } : {}),
+      ...(forceStrictSideEffects ? { forceStrictSideEffects, voiceAutoDenyConfirmations: true } : {}),
       turnChannelContext: {
         userMessageChannel: 'voice',
         assistantMessageChannel: 'voice',

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -120,6 +120,14 @@ export interface RunStartOptions {
    * Used by voice relay for streaming TTS token delivery.
    */
   eventSink?: VoiceRunEventSink;
+  /**
+   * When true, any confirmation_request from the prompter is immediately
+   * auto-denied instead of being stored for client polling. Used by the
+   * voice path when forceStrictSideEffects is active: the voice transport
+   * has no interactive approval UI, so without this flag the run would
+   * stall for the full permission timeout (300s by default).
+   */
+  voiceAutoDenyConfirmations?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -233,9 +241,33 @@ export class RunOrchestrator {
     // When the prompter sends one of these, we record it in the run store so
     // the client can poll and submit a decision/secret via the respective endpoint.
     // Do NOT set hasNoClient — run sessions have a client (the HTTP caller).
+    const autoDeny = options?.voiceAutoDenyConfirmations === true;
     let lastError: string | null = null;
     session.updateClient((msg: ServerMessage) => {
       if (msg.type === 'confirmation_request') {
+        if (autoDeny) {
+          // Voice path with strict side effects: immediately deny the
+          // confirmation request so the agent loop resumes without
+          // waiting for the full permission timeout (300s). The voice
+          // transport has no interactive approval UI, so polling would
+          // just stall. Security is preserved — the tool call is denied.
+          log.info(
+            { runId: run.id, toolName: msg.toolName },
+            'Auto-denying confirmation request for voice turn (forceStrictSideEffects)',
+          );
+          session.handleConfirmationResponse(
+            msg.requestId,
+            'deny',
+            undefined,
+            undefined,
+            `Permission denied for "${msg.toolName}": this voice call does not have interactive approval capabilities. Side-effect tools are not available for non-guardian voice callers. In your next assistant reply, explain briefly that this action requires guardian-level access and cannot be performed during this call.`,
+          );
+          // Still publish to hub for observability, but skip run-store
+          // bookkeeping since the confirmation is already resolved.
+          publishToHub(msg);
+          return;
+        }
+
         runsStore.setRunConfirmation(run.id, {
           toolName: msg.toolName,
           toolUseId: msg.requestId,


### PR DESCRIPTION
Addresses feedback on #8299. Non-guardian/unverified voice turns with forceStrictSideEffects now auto-deny tool confirmation requests immediately instead of waiting for the 300-second timeout. Security enforcement is preserved (non-guardian callers still can't invoke side-effect tools) while eliminating the usability stall.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
