### PR TITLE
fix(macos): use consistent paragraph style for placeholder height measurement

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -906,12 +906,14 @@ private final class CenteringClipView: NSClipView {
                let placeholder = textView.placeholderText,
                !placeholder.isEmpty {
                 let font = textView.font ?? NSFont.systemFont(ofSize: 13)
+                let paragraph = NSMutableParagraphStyle()
+                paragraph.lineBreakMode = .byTruncatingTail
                 let linePadding = textContainer.lineFragmentPadding
                 let availableWidth = max(0, textView.bounds.width - textView.textContainerInset.width * 2 - linePadding * 2)
                 let placeholderSize = (placeholder as NSString).boundingRect(
                     with: NSSize(width: availableWidth, height: .greatestFiniteMagnitude),
                     options: [.usesLineFragmentOrigin],
-                    attributes: [.font: font]
+                    attributes: [.font: font, .paragraphStyle: paragraph]
                 )
                 usedHeight = max(usedHeight, placeholderSize.height)
             }


### PR DESCRIPTION
## Summary
- Adds `.byTruncatingTail` paragraph style to placeholder height measurement in `CenteringClipView.constrainBoundsRect` to match the rendering style used in `ComposerNativeTextView.draw`
- Prevents inflated height calculation for long placeholders in narrow composers

## Addresses feedback from
https://github.com/vellum-ai/vellum-assistant/pull/7901#discussion_r2849231233
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
