### PR TITLE
fix(macos): resolve CI build errors in settings views

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -1183,9 +1183,8 @@ private struct ModelPickerItem: View {
     }
 }
 
-// MARK: - Environment Variables Sheet (Debug Only)
+// MARK: - Environment Variables Sheet
 
-#if DEBUG
 struct SettingsPanelEnvVarsSheet: View {
     let appEnvVars: [(String, String)]
     let daemonEnvVars: [(String, String)]
@@ -1243,7 +1242,6 @@ struct SettingsPanelEnvVarsSheet: View {
         }
     }
 }
-#endif
 
 struct SettingsPanel_Previews: PreviewProvider {
     static var previews: some View {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -106,9 +106,9 @@ struct SettingsConnectTab: View {
             return "arrow.trianglehead.2.counterclockwise"
         }
         switch store.vellumPlatformReachable {
-        case true: return "checkmark.circle.fill"
-        case false: return "xmark.circle.fill"
-        case nil: return "questionmark.circle"
+        case .some(true): return "checkmark.circle.fill"
+        case .some(false): return "xmark.circle.fill"
+        case .none: return "questionmark.circle"
         }
     }
 
@@ -117,9 +117,9 @@ struct SettingsConnectTab: View {
             return VColor.textMuted
         }
         switch store.vellumPlatformReachable {
-        case true: return VColor.success
-        case false: return VColor.error
-        case nil: return VColor.textMuted
+        case .some(true): return VColor.success
+        case .some(false): return VColor.error
+        case .none: return VColor.textMuted
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove `#if DEBUG` guard from `SettingsPanelEnvVarsSheet` so it compiles in release builds (already gated by dev mode at runtime)
- Use explicit `.some(true)`/`.some(false)`/`.none` patterns in `SettingsConnectTab` switch statements to satisfy the compiler's exhaustiveness checker

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22358705846

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
