### PR TITLE
feat: add Quick Input bar (Cmd+/)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -108,6 +108,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var thinkingWindow: ThinkingIndicatorWindow?
     private var quickInputWindow: QuickInputWindow?
     private var quickInputHotKeyRef: EventHotKeyRef?
+    private var quickInputEventHandlerRef: EventHandlerRef?
     public let services = AppServices()
     private let assistantCli = AssistantCli()
     public let updateManager = UpdateManager()
@@ -1157,7 +1158,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private func registerQuickInputMonitor() {
         // Install Carbon event handler for hotkey events
         var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
-        InstallEventHandler(GetApplicationEventTarget(), quickInputHotKeyHandler, 1, &eventType, nil, nil)
+        var handlerRef: EventHandlerRef?
+        InstallEventHandler(GetApplicationEventTarget(), quickInputHotKeyHandler, 1, &eventType, nil, &handlerRef)
+        quickInputEventHandlerRef = handlerRef
 
         // Register Cmd+/ (keyCode 44) as a system-wide hotkey
         let hotKeyID = EventHotKeyID(signature: OSType(0x564C_4D51), id: 1) // "VLMQ"
@@ -1178,11 +1181,15 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// Removes the Carbon hotkey registration.
+    /// Removes the Carbon hotkey and event handler registrations.
     private func tearDownQuickInputMonitors() {
         if let ref = quickInputHotKeyRef {
             UnregisterEventHotKey(ref)
             quickInputHotKeyRef = nil
+        }
+        if let ref = quickInputEventHandlerRef {
+            RemoveEventHandler(ref)
+            quickInputEventHandlerRef = nil
         }
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Carbon
 import VellumAssistantShared
 import Combine
 import CoreText
@@ -54,6 +55,35 @@ enum InteractionType {
     case textQA
 }
 
+/// Carbon event handler for the Quick Input hotkey (Cmd+/).
+/// Must be a free function because Carbon callbacks are C function pointers.
+private func quickInputHotKeyHandler(
+    _: EventHandlerCallRef?,
+    event: EventRef?,
+    _: UnsafeMutableRawPointer?
+) -> OSStatus {
+    guard let event else { return OSStatus(eventNotHandledErr) }
+
+    var hotKeyID = EventHotKeyID()
+    let status = GetEventParameter(
+        event,
+        EventParamName(kEventParamDirectObject),
+        EventParamType(typeEventHotKeyID),
+        nil,
+        MemoryLayout<EventHotKeyID>.size,
+        nil,
+        &hotKeyID
+    )
+    guard status == noErr, hotKeyID.id == 1 else { return OSStatus(eventNotHandledErr) }
+
+    Task { @MainActor in
+        guard let appDelegate = AppDelegate.shared,
+              !appDelegate.isAwaitingFirstLaunchReady else { return }
+        appDelegate.toggleQuickInput()
+    }
+    return noErr
+}
+
 @MainActor
 public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Shared reference — `NSApp.delegate as? AppDelegate` fails under
@@ -76,6 +106,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private var wakeWordCoordinator: WakeWordCoordinator?
     private var voiceTranscriptionWindow: VoiceTranscriptionWindow?
     var thinkingWindow: ThinkingIndicatorWindow?
+    private var quickInputWindow: QuickInputWindow?
+    private var quickInputHotKeyRef: EventHotKeyRef?
     public let services = AppServices()
     private let assistantCli = AssistantCli()
     public let updateManager = UpdateManager()
@@ -357,6 +389,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 NSEvent.removeMonitor(hotKeyMonitor)
                 self.hotKeyMonitor = nil
             }
+            self.tearDownQuickInputMonitors()
+            quickInputWindow?.dismiss()
+            quickInputWindow = nil
             lastRegisteredGlobalHotkey = nil
             globalHotkeyObserver?.cancel()
             globalHotkeyObserver = nil
@@ -464,6 +499,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             NSEvent.removeMonitor(hotKeyMonitor)
             self.hotKeyMonitor = nil
         }
+        tearDownQuickInputMonitors()
+        quickInputWindow?.dismiss()
+        quickInputWindow = nil
         lastRegisteredGlobalHotkey = nil
         globalHotkeyObserver?.cancel()
         globalHotkeyObserver = nil
@@ -1104,6 +1142,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func setupHotKey() {
         registerGlobalHotkeyMonitor()
+        registerQuickInputMonitor()
 
         globalHotkeyObserver = NotificationCenter.default
             .publisher(for: UserDefaults.didChangeNotification)
@@ -1111,6 +1150,64 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             .sink { [weak self] _ in
                 self?.registerGlobalHotkeyMonitor()
             }
+    }
+
+    /// Registers a Carbon hotkey (Cmd+/) that intercepts system-wide,
+    /// before the frontmost app's menu system can consume it.
+    private func registerQuickInputMonitor() {
+        // Install Carbon event handler for hotkey events
+        var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
+        InstallEventHandler(GetApplicationEventTarget(), quickInputHotKeyHandler, 1, &eventType, nil, nil)
+
+        // Register Cmd+/ (keyCode 44) as a system-wide hotkey
+        let hotKeyID = EventHotKeyID(signature: OSType(0x564C_4D51), id: 1) // "VLMQ"
+        var hotKeyRef: EventHotKeyRef?
+        let status = RegisterEventHotKey(
+            UInt32(kVK_ANSI_Slash),
+            UInt32(cmdKey),
+            hotKeyID,
+            GetApplicationEventTarget(),
+            0,
+            &hotKeyRef
+        )
+        if status == noErr {
+            quickInputHotKeyRef = hotKeyRef
+            log.info("Quick Input: Carbon hotkey Cmd+/ registered successfully")
+        } else {
+            log.error("Quick Input: Failed to register Carbon hotkey, status: \(status)")
+        }
+    }
+
+    /// Removes the Carbon hotkey registration.
+    private func tearDownQuickInputMonitors() {
+        if let ref = quickInputHotKeyRef {
+            UnregisterEventHotKey(ref)
+            quickInputHotKeyRef = nil
+        }
+    }
+
+    func toggleQuickInput() {
+        if let window = quickInputWindow, window.isVisible {
+            window.dismiss()
+            return
+        }
+
+        let window = QuickInputWindow()
+        window.onSubmit = { [weak self] message in
+            self?.handleQuickInputSubmit(message)
+        }
+        window.show()
+        quickInputWindow = window
+    }
+
+    private func handleQuickInputSubmit(_ message: String) {
+        showMainWindow()
+        guard let mainWindow else { return }
+        mainWindow.threadManager.createThread()
+        if let viewModel = mainWindow.activeViewModel {
+            viewModel.inputText = message
+            viewModel.sendMessage()
+        }
     }
 
     /// Tears down and re-registers the global "Open Vellum" hotkey based on
@@ -1514,6 +1611,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         if let monitor = hotKeyMonitor {
             NSEvent.removeMonitor(monitor)
         }
+        tearDownQuickInputMonitors()
         globalHotkeyObserver?.cancel()
         if let monitor = escapeMonitor {
             NSEvent.removeMonitor(monitor)

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputView.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputView.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct QuickInputView: View {
+    let onSubmit: (String) -> Void
+    let onDismiss: () -> Void
+
+    @State private var text = ""
+    @FocusState private var isFocused: Bool
+
+    private let panelWidth: CGFloat = 500
+
+    var body: some View {
+        HStack(spacing: VSpacing.sm) {
+            TextField("Send a message...", text: $text)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .textFieldStyle(.plain)
+                .focused($isFocused)
+                .onSubmit {
+                    submit()
+                }
+                .onKeyPress(.escape) {
+                    onDismiss()
+                    return .handled
+                }
+
+            Button(action: submit) {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 20))
+                    .foregroundColor(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        ? VColor.textMuted
+                        : VColor.sendButton)
+            }
+            .buttonStyle(.plain)
+            .disabled(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            .accessibilityLabel("Send message")
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.md)
+        .frame(width: panelWidth)
+        .background(
+            VisualEffectBlur(material: .hudWindow, blendingMode: .behindWindow)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .onAppear {
+            isFocused = true
+        }
+    }
+
+    private func submit() {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        onSubmit(trimmed)
+    }
+}
+
+// MARK: - NSVisualEffectView wrapper
+
+struct VisualEffectBlur: NSViewRepresentable {
+    let material: NSVisualEffectView.Material
+    let blendingMode: NSVisualEffectView.BlendingMode
+
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = material
+        view.blendingMode = blendingMode
+        view.state = .active
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {
+        nsView.material = material
+        nsView.blendingMode = blendingMode
+    }
+}
+
+#Preview("QuickInputView") {
+    ZStack {
+        Color.black.opacity(0.5).ignoresSafeArea()
+        QuickInputView(
+            onSubmit: { message in
+                print("Submitted: \(message)")
+            },
+            onDismiss: {
+                print("Dismissed")
+            }
+        )
+    }
+    .frame(width: 600, height: 200)
+}

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
@@ -34,7 +34,7 @@ final class QuickInputWindow {
         let view = QuickInputView(
             onSubmit: { [weak self] message in
                 self?.onSubmit?(message)
-                self?.dismiss()
+                self?.dismiss(restorePreviousApp: false)
             },
             onDismiss: { [weak self] in
                 self?.dismiss()
@@ -89,7 +89,7 @@ final class QuickInputWindow {
         self.panel = panel
     }
 
-    func dismiss() {
+    func dismiss(restorePreviousApp: Bool = true) {
         if let resignObserver {
             NotificationCenter.default.removeObserver(resignObserver)
         }
@@ -97,7 +97,7 @@ final class QuickInputWindow {
 
         guard let panel else { return }
 
-        let appToRestore = previousApp
+        let appToRestore = restorePreviousApp ? previousApp : nil
         previousApp = nil
 
         NSAnimationContext.runAnimationGroup({ context in
@@ -118,7 +118,12 @@ final class QuickInputWindow {
     // MARK: - Private
 
     private func centerOnScreen(_ panel: NSPanel) {
-        let screen = NSScreen.main ?? NSScreen.screens.first
+        // Use the screen containing the mouse cursor so the panel appears
+        // on the active display, even when triggered from another app.
+        let mouseLocation = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first(where: { $0.frame.contains(mouseLocation) })
+            ?? NSScreen.main
+            ?? NSScreen.screens.first
         guard let screenFrame = screen?.visibleFrame else { return }
 
         if let fittingSize = panel.contentView?.fittingSize {

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
@@ -75,14 +75,15 @@ final class QuickInputWindow {
             panel.animator().alphaValue = 1
         }
 
-        // Dismiss when the panel loses focus
+        // Dismiss when the panel loses focus. Don't restore the previous
+        // app — the user clicked elsewhere, so that app already has focus.
         resignObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didResignKeyNotification,
             object: panel,
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor in
-                self?.dismiss()
+                self?.dismiss(restorePreviousApp: false)
             }
         }
 

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
@@ -1,0 +1,138 @@
+import AppKit
+import SwiftUI
+import VellumAssistantShared
+
+/// Borderless NSPanel subclass that can become key window.
+/// Without this override, borderless windows refuse key status
+/// and SwiftUI TextField won't accept keyboard input.
+private class KeyablePanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+}
+
+/// A borderless, floating NSPanel that hosts the Quick Input text field.
+/// Appears centered on the active screen, slightly above center (Spotlight-style).
+/// Dismisses itself when it resigns key window status.
+@MainActor
+final class QuickInputWindow {
+    private var panel: NSPanel?
+    private var resignObserver: Any?
+    private var previousApp: NSRunningApplication?
+
+    /// Callback invoked when the user submits a message.
+    var onSubmit: ((String) -> Void)?
+
+    func show() {
+        // Remember the frontmost app so we can restore focus on dismiss
+        previousApp = NSWorkspace.shared.frontmostApplication
+
+        if let existing = panel {
+            existing.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let view = QuickInputView(
+            onSubmit: { [weak self] message in
+                self?.onSubmit?(message)
+                self?.dismiss()
+            },
+            onDismiss: { [weak self] in
+                self?.dismiss()
+            }
+        )
+
+        let hostingController = NSHostingController(rootView: view)
+
+        let panel = KeyablePanel(
+            contentRect: NSRect(x: 0, y: 0, width: 500, height: 48),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        panel.contentViewController = hostingController
+        panel.level = .floating
+        panel.isMovableByWindowBackground = true
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.isReleasedWhenClosed = false
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = true
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+        // Center horizontally, ~1/3 from top vertically (Spotlight-style)
+        centerOnScreen(panel)
+
+        // Animate in
+        panel.alphaValue = 0
+        panel.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = VAnimation.durationFast
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            panel.animator().alphaValue = 1
+        }
+
+        // Dismiss when the panel loses focus
+        resignObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResignKeyNotification,
+            object: panel,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.dismiss()
+            }
+        }
+
+        self.panel = panel
+    }
+
+    func dismiss() {
+        if let resignObserver {
+            NotificationCenter.default.removeObserver(resignObserver)
+        }
+        resignObserver = nil
+
+        guard let panel else { return }
+
+        let appToRestore = previousApp
+        previousApp = nil
+
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = VAnimation.durationFast
+            context.timingFunction = CAMediaTimingFunction(name: .easeIn)
+            panel.animator().alphaValue = 0
+        }, completionHandler: { [weak self] in
+            panel.close()
+            self?.panel = nil
+            appToRestore?.activate()
+        })
+    }
+
+    var isVisible: Bool {
+        panel?.isVisible ?? false
+    }
+
+    // MARK: - Private
+
+    private func centerOnScreen(_ panel: NSPanel) {
+        let screen = NSScreen.main ?? NSScreen.screens.first
+        guard let screenFrame = screen?.visibleFrame else { return }
+
+        if let fittingSize = panel.contentView?.fittingSize {
+            let width = max(fittingSize.width, 500)
+            let height = fittingSize.height
+            let x = screenFrame.midX - width / 2
+            // Position ~1/3 from top (like Spotlight)
+            let y = screenFrame.midY + screenFrame.height * 0.15
+            panel.setFrame(
+                NSRect(x: x, y: y, width: width, height: height),
+                display: true
+            )
+        } else {
+            panel.center()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a floating Spotlight-style Quick Input bar triggered by Cmd+/ system-wide
- Uses Carbon `RegisterEventHotKey` to intercept the shortcut before any app can consume it
- On submit: opens main window, creates a new thread, and sends the typed message

## Files
- **New:** `Features/QuickInput/QuickInputView.swift` — SwiftUI text field with send button
- **New:** `Features/QuickInput/QuickInputWindow.swift` — Floating borderless NSPanel (Spotlight-style positioning)
- **Modified:** `App/AppDelegate.swift` — Carbon hotkey registration, toggle/submit handlers, cleanup in logout/retire/terminate paths

## Test plan
- [ ] `./build.sh` compiles
- [ ] From any app, press Cmd+/ — floating input bar appears centered on screen
- [ ] Type a message, press Return — main window opens with new thread containing the message
- [ ] Press Cmd+/ again or Escape — input bar dismisses
- [ ] Click away from the input bar — it auto-dismisses
- [ ] Verify Cmd+/ works even from apps that bind it (e.g. Xcode, VS Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
