### PR TITLE
Fix: Guard notification table drops behind migration check

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -16,6 +16,7 @@ import {
   migrateGuardianActionTables,
   migrateBackfillInboxThreadStateFromBindings,
   migrateDropActiveSearchIndex,
+  migrateNotificationTablesSchema,
   validateMigrationState,
 } from './schema-migration.js';
 
@@ -1269,12 +1270,9 @@ export function initializeDb(): void {
 
   // ── Notification System ──────────────────────────────────────────────
 
-  // Migration: drop legacy tables from the old enum-based notification model.
-  // notification_deliveries must be dropped first (FK to notification_events).
-  // notification_preferences is fully removed (replaced by decision engine).
-  database.run(/*sql*/ `DROP TABLE IF EXISTS notification_deliveries`);
-  database.run(/*sql*/ `DROP TABLE IF EXISTS notification_events`);
-  database.run(/*sql*/ `DROP TABLE IF EXISTS notification_preferences`);
+  // Migration: drop legacy enum-based notification tables if old schema detected.
+  // Guarded behind a one-time check for the old `notification_type` column.
+  migrateNotificationTablesSchema(database);
 
   database.run(/*sql*/ `
     CREATE TABLE IF NOT EXISTS notification_events (

--- a/assistant/src/memory/migrations/016-notification-tables-schema-migration.ts
+++ b/assistant/src/memory/migrations/016-notification-tables-schema-migration.ts
@@ -1,0 +1,70 @@
+import { getSqliteFrom, type DrizzleDb } from '../db-connection.js';
+
+/**
+ * One-time migration: drop legacy enum-based notification tables so they can
+ * be recreated with the new signal-contract schema.
+ *
+ * Guard: only runs when the old `notification_type` column exists on the
+ * `notification_events` table (the old enum-based schema).  On fresh installs
+ * the table either doesn't exist yet or was created with the new schema, so
+ * CREATE TABLE IF NOT EXISTS in db-init handles idempotent creation.
+ *
+ * Drop order matters because of FK references:
+ *   notification_deliveries -> notification_events  (old schema FK)
+ *   notification_decisions  -> notification_events  (new schema FK, may exist from partial upgrade)
+ *   notification_events     (the table being rebuilt)
+ *   notification_preferences (fully removed, replaced by decision engine)
+ */
+export function migrateNotificationTablesSchema(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  const checkpointKey = 'migration_notification_tables_schema_v1';
+  const checkpoint = raw.query(
+    `SELECT 1 FROM memory_checkpoints WHERE key = ?`,
+  ).get(checkpointKey);
+  if (checkpoint) return;
+
+  // Check if the old schema is present: the legacy notification_events table
+  // had a `notification_type` column that the new schema does not.
+  const hasOldSchema = raw.query(
+    `SELECT COUNT(*) as cnt FROM pragma_table_info('notification_events') WHERE name = 'notification_type'`,
+  ).get() as { cnt: number } | undefined;
+
+  if (hasOldSchema && hasOldSchema.cnt > 0) {
+    try {
+      raw.exec('BEGIN');
+
+      // Drop in FK-safe order: children before parents
+      raw.exec(/*sql*/ `DROP TABLE IF EXISTS notification_deliveries`);
+      raw.exec(/*sql*/ `DROP TABLE IF EXISTS notification_decisions`);
+      raw.exec(/*sql*/ `DROP TABLE IF EXISTS notification_events`);
+      raw.exec(/*sql*/ `DROP TABLE IF EXISTS notification_preferences`);
+
+      raw.query(
+        `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,
+      ).run(checkpointKey, Date.now());
+
+      raw.exec('COMMIT');
+    } catch (e) {
+      try { raw.exec('ROLLBACK'); } catch { /* no active transaction */ }
+      throw e;
+    }
+  } else {
+    // No old schema detected (fresh install or already migrated).
+    // Still clean up notification_preferences if it exists, since we want
+    // to ensure it's removed regardless.
+    try {
+      raw.exec('BEGIN');
+
+      raw.exec(/*sql*/ `DROP TABLE IF EXISTS notification_preferences`);
+
+      raw.query(
+        `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,
+      ).run(checkpointKey, Date.now());
+
+      raw.exec('COMMIT');
+    } catch (e) {
+      try { raw.exec('ROLLBACK'); } catch { /* no active transaction */ }
+      throw e;
+    }
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -19,3 +19,4 @@ export { migrateCallSessionsAddInitiatedFrom } from './012-call-sessions-add-ini
 export { migrateGuardianActionTables } from './013-guardian-action-tables.js';
 export { migrateBackfillInboxThreadStateFromBindings } from './014-backfill-inbox-thread-state.js';
 export { migrateDropActiveSearchIndex } from './015-drop-active-search-index.js';
+export { migrateNotificationTablesSchema } from './016-notification-tables-schema-migration.js';

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -69,6 +69,11 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     version: 9,
     description: 'Drop old idx_memory_items_active_search so it can be recreated with updated covering columns',
   },
+  {
+    key: 'migration_notification_tables_schema_v1',
+    version: 10,
+    description: 'Drop legacy enum-based notification tables so they can be recreated with the new signal-contract schema',
+  },
 ];
 
 export interface MigrationValidationResult {

--- a/assistant/src/memory/schema-migration.ts
+++ b/assistant/src/memory/schema-migration.ts
@@ -19,4 +19,5 @@ export {
   migrateGuardianActionTables,
   migrateBackfillInboxThreadStateFromBindings,
   migrateDropActiveSearchIndex,
+  migrateNotificationTablesSchema,
 } from './migrations/index.js';


### PR DESCRIPTION
Both Codex and Devin flagged that DROP TABLE statements in db-init.ts run unconditionally on every startup. Guards the drops behind a check for the old notification_type column in notification_events. Only drops and recreates tables when migrating from the old enum-based schema. On normal startup, CREATE TABLE IF NOT EXISTS handles idempotent creation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
