### PR TITLE
M4: In-loop decision step + deterministic checks (shadow mode)

### DIFF
--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -272,4 +272,9 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     memberAclEnabled: false,
     policyEnabled: false,
   },
+  notifications: {
+    enabled: false,
+    shadowMode: true,
+    decisionModel: 'claude-haiku-4-5-20251001',
+  },
 };

--- a/assistant/src/config/notifications-schema.ts
+++ b/assistant/src/config/notifications-schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const NotificationsConfigSchema = z.object({
+  enabled: z
+    .boolean({ error: 'notifications.enabled must be a boolean' })
+    .default(false),
+  shadowMode: z
+    .boolean({ error: 'notifications.shadowMode must be a boolean' })
+    .default(true),
+  decisionModel: z
+    .string({ error: 'notifications.decisionModel must be a string' })
+    .default('claude-haiku-4-5-20251001'),
+});
+
+export type NotificationsConfig = z.infer<typeof NotificationsConfigSchema>;

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -91,6 +91,13 @@ export type {
 } from './agent-schema.js';
 
 export {
+  NotificationsConfigSchema,
+} from './notifications-schema.js';
+export type {
+  NotificationsConfig,
+} from './notifications-schema.js';
+
+export {
   TimeoutConfigSchema,
   RateLimitConfigSchema,
   SecretDetectionConfigSchema,
@@ -125,6 +132,7 @@ import { CallsConfigSchema } from './calls-schema.js';
 import { SandboxConfigSchema } from './sandbox-schema.js';
 import { SkillsConfigSchema } from './skills-schema.js';
 import { AgentHeartbeatConfigSchema, SwarmConfigSchema, WorkspaceGitConfigSchema } from './agent-schema.js';
+import { NotificationsConfigSchema } from './notifications-schema.js';
 import {
   TimeoutConfigSchema,
   RateLimitConfigSchema,
@@ -431,6 +439,11 @@ export const AssistantConfigSchema = z.object({
     invitesEnabled: false,
     memberAclEnabled: false,
     policyEnabled: false,
+  }),
+  notifications: NotificationsConfigSchema.default({
+    enabled: false,
+    shadowMode: true,
+    decisionModel: 'claude-haiku-4-5-20251001',
   }),
 }).superRefine((config, ctx) => {
   if (config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -40,4 +40,5 @@ export type {
   SmsConfig,
   IngressConfig,
   AssistantInboxConfig,
+  NotificationsConfig,
 } from './schema.js';

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -169,7 +169,7 @@ function buildFallbackDecision(
       selectedChannels: [...availableChannels],
       reasoningSummary: 'Fallback: high urgency + requires action',
       renderedCopy: copy,
-      dedupeKey: `fallback:${signal.sourceEventName}:${signal.sourceSessionId}`,
+      dedupeKey: `fallback:${signal.sourceEventName}:${signal.sourceSessionId}:${signal.createdAt}`,
       confidence: 0.3,
       fallbackUsed: true,
     };
@@ -180,7 +180,7 @@ function buildFallbackDecision(
     selectedChannels: [],
     reasoningSummary: 'Fallback: suppressed (not high urgency + requires action)',
     renderedCopy: {},
-    dedupeKey: `fallback:${signal.sourceEventName}:${signal.sourceSessionId}`,
+    dedupeKey: `fallback:${signal.sourceEventName}:${signal.sourceSessionId}:${signal.createdAt}`,
     confidence: 0.3,
     fallbackUsed: true,
   };

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -1,0 +1,372 @@
+/**
+ * Notification decision engine.
+ *
+ * Evaluates a NotificationSignal against available channels and user
+ * preferences, producing a NotificationDecision that tells the broadcaster
+ * whether and how to notify the user. Uses the provider abstraction to
+ * call the LLM with forced tool_choice output, falling back to a
+ * deterministic heuristic when the model is unavailable or returns
+ * invalid output.
+ */
+
+import { v4 as uuid } from 'uuid';
+import { getConfig } from '../config/loader.js';
+import { getLogger } from '../util/logger.js';
+import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/provider-send-message.js';
+import { createDecision } from './decisions-store.js';
+import type { NotificationSignal } from './signal.js';
+import type { NotificationChannel, NotificationDecision, RenderedChannelCopy } from './types.js';
+
+const log = getLogger('notification-decision-engine');
+
+const DECISION_TIMEOUT_MS = 15_000;
+const PROMPT_VERSION = 'v1';
+
+// ── System prompt ──────────────────────────────────────────────────────
+
+function buildSystemPrompt(
+  availableChannels: NotificationChannel[],
+  preferenceContext?: string,
+): string {
+  const sections: string[] = [
+    `You are a notification routing engine. Given a signal describing an event, decide whether the user should be notified, on which channel(s), and compose the notification copy.`,
+    ``,
+    `Available notification channels: ${availableChannels.join(', ')}`,
+  ];
+
+  if (preferenceContext) {
+    sections.push(
+      ``,
+      `<user-preferences>`,
+      preferenceContext,
+      `</user-preferences>`,
+    );
+  }
+
+  sections.push(
+    ``,
+    `Guidelines:`,
+    `- Only notify when the signal genuinely warrants user attention.`,
+    `- Prefer fewer channels unless the signal is urgent.`,
+    `- For high-urgency signals that require action, notify on all available channels.`,
+    `- For low-urgency background events, suppress unless they match user preferences.`,
+    `- Keep notification copy concise and actionable.`,
+    `- Generate a stable dedupeKey derived from the signal context so duplicate signals can be suppressed.`,
+    ``,
+    `You MUST respond using the \`record_notification_decision\` tool. Do not respond with text.`,
+  );
+
+  return sections.join('\n');
+}
+
+// ── User prompt ────────────────────────────────────────────────────────
+
+function buildUserPrompt(signal: NotificationSignal): string {
+  const parts: string[] = [
+    `Signal ID: ${signal.signalId}`,
+    `Source event: ${signal.sourceEventName}`,
+    `Source channel: ${signal.sourceChannel}`,
+    `Urgency: ${signal.attentionHints.urgency}`,
+    `Requires action: ${signal.attentionHints.requiresAction}`,
+    `Is async background: ${signal.attentionHints.isAsyncBackground}`,
+    `User is viewing source now: ${signal.attentionHints.visibleInSourceNow}`,
+  ];
+
+  if (signal.attentionHints.deadlineAt) {
+    parts.push(`Deadline: ${new Date(signal.attentionHints.deadlineAt).toISOString()}`);
+  }
+
+  const payloadStr = JSON.stringify(signal.contextPayload);
+  if (payloadStr.length > 2) {
+    parts.push(``, `Context payload:`, payloadStr);
+  }
+
+  return `Evaluate this notification signal:\n\n${parts.join('\n')}`;
+}
+
+// ── Tool definition ────────────────────────────────────────────────────
+
+function buildDecisionTool(availableChannels: NotificationChannel[]) {
+  return {
+    name: 'record_notification_decision',
+    description: 'Record the notification routing decision for this signal',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        shouldNotify: {
+          type: 'boolean',
+          description: 'Whether the user should be notified about this signal',
+        },
+        selectedChannels: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: availableChannels,
+          },
+          description: 'Which channels to deliver the notification on',
+        },
+        reasoningSummary: {
+          type: 'string',
+          description: 'Brief explanation of why this routing decision was made',
+        },
+        renderedCopy: {
+          type: 'object',
+          description: 'Notification copy keyed by channel name',
+          properties: Object.fromEntries(
+            availableChannels.map((ch) => [
+              ch,
+              {
+                type: 'object',
+                properties: {
+                  title: { type: 'string', description: 'Short notification title' },
+                  body: { type: 'string', description: 'Notification body text' },
+                  threadTitle: { type: 'string', description: 'Optional thread title for grouped notifications' },
+                  threadSeedMessage: { type: 'string', description: 'Optional seed message for a new thread' },
+                },
+                required: ['title', 'body'],
+              },
+            ]),
+          ),
+        },
+        deepLinkTarget: {
+          type: 'object',
+          description: 'Optional deep link metadata for navigating to the source context',
+        },
+        dedupeKey: {
+          type: 'string',
+          description: 'A stable key derived from the signal to deduplicate repeated notifications for the same event',
+        },
+        confidence: {
+          type: 'number',
+          description: 'Confidence in the decision (0.0-1.0)',
+        },
+      },
+      required: ['shouldNotify', 'selectedChannels', 'reasoningSummary', 'renderedCopy', 'dedupeKey', 'confidence'],
+    },
+  };
+}
+
+// ── Deterministic fallback ─────────────────────────────────────────────
+
+function buildFallbackDecision(
+  signal: NotificationSignal,
+  availableChannels: NotificationChannel[],
+): NotificationDecision {
+  const isHighUrgencyAction =
+    signal.attentionHints.urgency === 'high' && signal.attentionHints.requiresAction;
+
+  if (isHighUrgencyAction) {
+    const copy: Partial<Record<NotificationChannel, RenderedChannelCopy>> = {};
+    for (const ch of availableChannels) {
+      copy[ch] = {
+        title: signal.sourceEventName,
+        body: `Action required: ${signal.sourceEventName}`,
+      };
+    }
+
+    return {
+      shouldNotify: true,
+      selectedChannels: [...availableChannels],
+      reasoningSummary: 'Fallback: high urgency + requires action',
+      renderedCopy: copy,
+      dedupeKey: `${signal.sourceEventName}:${signal.signalId}`,
+      confidence: 0.3,
+      fallbackUsed: true,
+    };
+  }
+
+  return {
+    shouldNotify: false,
+    selectedChannels: [],
+    reasoningSummary: 'Fallback: suppressed (not high urgency + requires action)',
+    renderedCopy: {},
+    dedupeKey: `${signal.sourceEventName}:${signal.signalId}`,
+    confidence: 0.3,
+    fallbackUsed: true,
+  };
+}
+
+// ── Validation ─────────────────────────────────────────────────────────
+
+const VALID_CHANNELS = new Set<string>(['macos', 'telegram']);
+
+function validateDecisionOutput(
+  input: Record<string, unknown>,
+  availableChannels: NotificationChannel[],
+): NotificationDecision | null {
+  if (typeof input.shouldNotify !== 'boolean') return null;
+  if (typeof input.reasoningSummary !== 'string') return null;
+  if (typeof input.dedupeKey !== 'string') return null;
+
+  if (!Array.isArray(input.selectedChannels)) return null;
+  const validChannels = (input.selectedChannels as unknown[]).filter(
+    (ch): ch is NotificationChannel =>
+      typeof ch === 'string' && VALID_CHANNELS.has(ch) && availableChannels.includes(ch as NotificationChannel),
+  );
+
+  const confidence = typeof input.confidence === 'number'
+    ? Math.max(0, Math.min(1, input.confidence))
+    : 0.5;
+
+  // Validate renderedCopy
+  const renderedCopy: Partial<Record<NotificationChannel, RenderedChannelCopy>> = {};
+  if (input.renderedCopy && typeof input.renderedCopy === 'object') {
+    const copyObj = input.renderedCopy as Record<string, unknown>;
+    for (const ch of validChannels) {
+      const chCopy = copyObj[ch];
+      if (chCopy && typeof chCopy === 'object') {
+        const c = chCopy as Record<string, unknown>;
+        if (typeof c.title === 'string' && typeof c.body === 'string') {
+          renderedCopy[ch] = {
+            title: c.title,
+            body: c.body,
+            threadTitle: typeof c.threadTitle === 'string' ? c.threadTitle : undefined,
+            threadSeedMessage: typeof c.threadSeedMessage === 'string' ? c.threadSeedMessage : undefined,
+          };
+        }
+      }
+    }
+  }
+
+  const deepLinkTarget = input.deepLinkTarget && typeof input.deepLinkTarget === 'object'
+    ? input.deepLinkTarget as Record<string, unknown>
+    : undefined;
+
+  return {
+    shouldNotify: input.shouldNotify,
+    selectedChannels: validChannels,
+    reasoningSummary: input.reasoningSummary,
+    renderedCopy,
+    deepLinkTarget,
+    dedupeKey: input.dedupeKey,
+    confidence,
+    fallbackUsed: false,
+  };
+}
+
+// ── Core evaluation function ───────────────────────────────────────────
+
+export interface EvaluateSignalOptions {
+  shadowMode?: boolean;
+}
+
+export async function evaluateSignal(
+  signal: NotificationSignal,
+  availableChannels: NotificationChannel[],
+  preferenceContext?: string,
+  options?: EvaluateSignalOptions,
+): Promise<NotificationDecision> {
+  const config = getConfig();
+  const decisionModel = config.notifications.decisionModel;
+
+  const provider = getConfiguredProvider();
+  if (!provider) {
+    log.warn('Configured provider unavailable for notification decision, using fallback');
+    const decision = buildFallbackDecision(signal, availableChannels);
+    persistDecision(signal, decision);
+    return decision;
+  }
+
+  let decision: NotificationDecision;
+  try {
+    decision = await classifyWithLLM(signal, availableChannels, preferenceContext, decisionModel);
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    log.warn({ err: errMsg }, 'Notification decision LLM call failed, using fallback');
+    decision = buildFallbackDecision(signal, availableChannels);
+  }
+
+  persistDecision(signal, decision);
+
+  if (options?.shadowMode ?? config.notifications.shadowMode) {
+    log.info(
+      {
+        signalId: signal.signalId,
+        shouldNotify: decision.shouldNotify,
+        channels: decision.selectedChannels,
+        fallbackUsed: decision.fallbackUsed,
+        confidence: decision.confidence,
+      },
+      'Shadow mode: decision logged but not dispatched',
+    );
+  }
+
+  return decision;
+}
+
+// ── LLM classification ────────────────────────────────────────────────
+
+async function classifyWithLLM(
+  signal: NotificationSignal,
+  availableChannels: NotificationChannel[],
+  preferenceContext: string | undefined,
+  model: string,
+): Promise<NotificationDecision> {
+  const provider = getConfiguredProvider()!;
+  const { signal: abortSignal, cleanup } = createTimeout(DECISION_TIMEOUT_MS);
+
+  const systemPrompt = buildSystemPrompt(availableChannels, preferenceContext);
+  const prompt = buildUserPrompt(signal);
+  const tool = buildDecisionTool(availableChannels);
+
+  try {
+    const response = await provider.sendMessage(
+      [userMessage(prompt)],
+      [tool],
+      systemPrompt,
+      {
+        config: {
+          model,
+          max_tokens: 2048,
+          tool_choice: { type: 'tool' as const, name: 'record_notification_decision' },
+        },
+        signal: abortSignal,
+      },
+    );
+    cleanup();
+
+    const toolBlock = extractToolUse(response);
+    if (!toolBlock) {
+      log.warn('No tool_use block in notification decision response, using fallback');
+      return buildFallbackDecision(signal, availableChannels);
+    }
+
+    const validated = validateDecisionOutput(
+      toolBlock.input as Record<string, unknown>,
+      availableChannels,
+    );
+    if (!validated) {
+      log.warn('Invalid notification decision output from LLM, using fallback');
+      return buildFallbackDecision(signal, availableChannels);
+    }
+
+    return validated;
+  } finally {
+    cleanup();
+  }
+}
+
+// ── Persistence ────────────────────────────────────────────────────────
+
+function persistDecision(signal: NotificationSignal, decision: NotificationDecision): void {
+  try {
+    createDecision({
+      id: uuid(),
+      notificationEventId: signal.signalId,
+      shouldNotify: decision.shouldNotify,
+      selectedChannels: decision.selectedChannels,
+      reasoningSummary: decision.reasoningSummary,
+      confidence: decision.confidence,
+      fallbackUsed: decision.fallbackUsed,
+      promptVersion: PROMPT_VERSION,
+      validationResults: {
+        dedupeKey: decision.dedupeKey,
+        channelCount: decision.selectedChannels.length,
+        hasCopy: Object.keys(decision.renderedCopy).length > 0,
+      },
+    });
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    log.warn({ err: errMsg }, 'Failed to persist notification decision');
+  }
+}

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -169,7 +169,7 @@ function buildFallbackDecision(
       selectedChannels: [...availableChannels],
       reasoningSummary: 'Fallback: high urgency + requires action',
       renderedCopy: copy,
-      dedupeKey: `${signal.sourceEventName}:${signal.signalId}`,
+      dedupeKey: `fallback:${signal.sourceEventName}:${signal.sourceSessionId}`,
       confidence: 0.3,
       fallbackUsed: true,
     };
@@ -180,7 +180,7 @@ function buildFallbackDecision(
     selectedChannels: [],
     reasoningSummary: 'Fallback: suppressed (not high urgency + requires action)',
     renderedCopy: {},
-    dedupeKey: `${signal.sourceEventName}:${signal.signalId}`,
+    dedupeKey: `fallback:${signal.sourceEventName}:${signal.sourceSessionId}`,
     confidence: 0.3,
     fallbackUsed: true,
   };
@@ -199,10 +199,11 @@ function validateDecisionOutput(
   if (typeof input.dedupeKey !== 'string') return null;
 
   if (!Array.isArray(input.selectedChannels)) return null;
-  const validChannels = (input.selectedChannels as unknown[]).filter(
+  const validatedChannels = (input.selectedChannels as unknown[]).filter(
     (ch): ch is NotificationChannel =>
       typeof ch === 'string' && VALID_CHANNELS.has(ch) && availableChannels.includes(ch as NotificationChannel),
   );
+  const validChannels = [...new Set(validatedChannels)];
 
   const confidence = typeof input.confidence === 'number'
     ? Math.max(0, Math.min(1, input.confidence))

--- a/assistant/src/notifications/deterministic-checks.ts
+++ b/assistant/src/notifications/deterministic-checks.ts
@@ -1,0 +1,185 @@
+/**
+ * Deterministic pre-send gate checks for notification decisions.
+ *
+ * These checks run after the decision engine produces a NotificationDecision
+ * and before the broadcaster dispatches. They enforce hard invariants that
+ * the LLM cannot override: channel availability, source-active suppression,
+ * deduplication, and schema validity.
+ */
+
+import { and, eq } from 'drizzle-orm';
+import { getDb } from '../memory/db.js';
+import { notificationEvents } from '../memory/schema.js';
+import { getLogger } from '../util/logger.js';
+import type { NotificationSignal } from './signal.js';
+import type { NotificationChannel, NotificationDecision } from './types.js';
+
+const log = getLogger('notification-deterministic-checks');
+
+export interface CheckResult {
+  passed: boolean;
+  reason?: string;
+}
+
+export interface DeterministicCheckContext {
+  /** Channels that are currently connected and available for delivery. */
+  connectedChannels: NotificationChannel[];
+  /** Dedupe window in milliseconds. Events with the same dedupeKey within this window are suppressed. */
+  dedupeWindowMs?: number;
+}
+
+const DEFAULT_DEDUPE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * Run all deterministic pre-send checks against a decision.
+ * Returns passed=false if any check fails, with a reason describing
+ * which check blocked the notification.
+ */
+export async function runDeterministicChecks(
+  signal: NotificationSignal,
+  decision: NotificationDecision,
+  context: DeterministicCheckContext,
+): Promise<CheckResult> {
+  // Check 1: Decision schema validity (fail-closed)
+  const schemaCheck = checkDecisionSchema(decision);
+  if (!schemaCheck.passed) {
+    log.info({ signalId: signal.signalId, reason: schemaCheck.reason }, 'Deterministic check failed: schema');
+    return schemaCheck;
+  }
+
+  // Check 2: Source-active suppression
+  const sourceActiveCheck = checkSourceActiveSuppression(signal);
+  if (!sourceActiveCheck.passed) {
+    log.info({ signalId: signal.signalId, reason: sourceActiveCheck.reason }, 'Deterministic check failed: source active');
+    return sourceActiveCheck;
+  }
+
+  // Check 3: Channel availability
+  const channelCheck = checkChannelAvailability(decision, context.connectedChannels);
+  if (!channelCheck.passed) {
+    log.info({ signalId: signal.signalId, reason: channelCheck.reason }, 'Deterministic check failed: channel availability');
+    return channelCheck;
+  }
+
+  // Check 4: Dedupe
+  const dedupeCheck = checkDedupe(signal, decision, context.dedupeWindowMs ?? DEFAULT_DEDUPE_WINDOW_MS);
+  if (!dedupeCheck.passed) {
+    log.info({ signalId: signal.signalId, reason: dedupeCheck.reason }, 'Deterministic check failed: dedupe');
+    return dedupeCheck;
+  }
+
+  return { passed: true };
+}
+
+// ── Individual checks ──────────────────────────────────────────────────
+
+/**
+ * Fail-closed schema validation. If the decision is missing required
+ * fields or has invalid types, block the notification.
+ */
+function checkDecisionSchema(decision: NotificationDecision): CheckResult {
+  if (typeof decision.shouldNotify !== 'boolean') {
+    return { passed: false, reason: 'Invalid decision: shouldNotify is not a boolean' };
+  }
+  if (!Array.isArray(decision.selectedChannels)) {
+    return { passed: false, reason: 'Invalid decision: selectedChannels is not an array' };
+  }
+  if (typeof decision.reasoningSummary !== 'string') {
+    return { passed: false, reason: 'Invalid decision: reasoningSummary is not a string' };
+  }
+  if (typeof decision.dedupeKey !== 'string' || decision.dedupeKey.length === 0) {
+    return { passed: false, reason: 'Invalid decision: dedupeKey is missing or empty' };
+  }
+  if (typeof decision.confidence !== 'number' || !Number.isFinite(decision.confidence)) {
+    return { passed: false, reason: 'Invalid decision: confidence is not a finite number' };
+  }
+  return { passed: true };
+}
+
+/**
+ * If the user is already looking at the source context (visibleInSourceNow),
+ * suppress the notification to avoid redundant alerts.
+ */
+function checkSourceActiveSuppression(signal: NotificationSignal): CheckResult {
+  if (signal.attentionHints.visibleInSourceNow) {
+    return {
+      passed: false,
+      reason: 'Source-active suppression: user is already viewing the source context',
+    };
+  }
+  return { passed: true };
+}
+
+/**
+ * Verify that at least one of the selected channels is actually
+ * connected and available for delivery.
+ */
+function checkChannelAvailability(
+  decision: NotificationDecision,
+  connectedChannels: NotificationChannel[],
+): CheckResult {
+  if (!decision.shouldNotify) {
+    // Not notifying — channel availability is irrelevant
+    return { passed: true };
+  }
+
+  const connectedSet = new Set(connectedChannels);
+  const availableSelected = decision.selectedChannels.filter((ch) => connectedSet.has(ch));
+
+  if (availableSelected.length === 0) {
+    return {
+      passed: false,
+      reason: `Channel availability: none of the selected channels (${decision.selectedChannels.join(', ')}) are connected`,
+    };
+  }
+
+  return { passed: true };
+}
+
+/**
+ * Check if a signal with the same dedupeKey was already processed
+ * within the dedupe window. Uses the events-store table directly.
+ */
+function checkDedupe(
+  signal: NotificationSignal,
+  decision: NotificationDecision,
+  windowMs: number,
+): CheckResult {
+  if (!decision.dedupeKey) {
+    return { passed: true };
+  }
+
+  try {
+    const db = getDb();
+    const cutoff = Date.now() - windowMs;
+
+    const existing = db
+      .select({ id: notificationEvents.id })
+      .from(notificationEvents)
+      .where(
+        and(
+          eq(notificationEvents.assistantId, signal.assistantId),
+          eq(notificationEvents.dedupeKey, decision.dedupeKey),
+        ),
+      )
+      .all();
+
+    // Filter by created_at > cutoff (the events store already checked
+    // dedupe on insert, but this catches cases where the engine is
+    // re-evaluating a signal that was previously stored).
+    for (const row of existing) {
+      // The current signal's own event row should not count as a duplicate
+      if (row.id === signal.signalId) continue;
+      // If any other event with the same dedupeKey exists, suppress
+      return {
+        passed: false,
+        reason: `Dedupe: signal with dedupeKey "${decision.dedupeKey}" was already processed`,
+      };
+    }
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    log.warn({ err: errMsg }, 'Dedupe check failed, allowing notification through');
+  }
+
+  return { passed: true };
+}

--- a/assistant/src/notifications/deterministic-checks.ts
+++ b/assistant/src/notifications/deterministic-checks.ts
@@ -154,7 +154,7 @@ function checkDedupe(
     const cutoff = Date.now() - windowMs;
 
     const existing = db
-      .select({ id: notificationEvents.id })
+      .select({ id: notificationEvents.id, createdAt: notificationEvents.createdAt })
       .from(notificationEvents)
       .where(
         and(
@@ -170,7 +170,9 @@ function checkDedupe(
     for (const row of existing) {
       // The current signal's own event row should not count as a duplicate
       if (row.id === signal.signalId) continue;
-      // If any other event with the same dedupeKey exists, suppress
+      // Only consider events within the dedupe window
+      if (row.createdAt < cutoff) continue;
+      // If any other event with the same dedupeKey exists within the window, suppress
       return {
         passed: false,
         reason: `Dedupe: signal with dedupeKey "${decision.dedupeKey}" was already processed`,

--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -50,3 +50,25 @@ export interface ChannelAdapter {
   channel: NotificationChannel;
   send(delivery: PreparedDelivery, destination: ChannelDestination): Promise<DeliveryResult>;
 }
+
+// -- Decision engine output ---------------------------------------------------
+
+/** Rendered notification copy for a single channel. */
+export interface RenderedChannelCopy {
+  title: string;
+  body: string;
+  threadTitle?: string;
+  threadSeedMessage?: string;
+}
+
+/** Output produced by the notification decision engine for a given signal. */
+export interface NotificationDecision {
+  shouldNotify: boolean;
+  selectedChannels: NotificationChannel[];
+  reasoningSummary: string;
+  renderedCopy: Partial<Record<NotificationChannel, RenderedChannelCopy>>;
+  deepLinkTarget?: Record<string, unknown>;
+  dedupeKey: string;
+  confidence: number;
+  fallbackUsed: boolean;
+}


### PR DESCRIPTION
Add assistant-led notification decision engine that evaluates signals and produces routing decisions. Includes deterministic pre-send checks (channel availability, source-active suppression, dedupe). Runs in shadow mode by default (logs decisions to audit table but doesn't dispatch). Part of #8204.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
