### PR TITLE
fix: make error message bubbles span full chat width

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -90,7 +90,7 @@ struct ChatBubble: View {
                         .offset(x: isUser ? -(24 + VSpacing.sm) : (24 + VSpacing.sm))
                 }
             }
-            .frame(maxWidth: 520, alignment: isUser ? .trailing : .leading)
+            .frame(maxWidth: message.isError ? .infinity : 520, alignment: isUser ? .trailing : .leading)
     }
 
     private var formattedTimestamp: String {


### PR DESCRIPTION
## Summary

- Error message bubbles in chat (e.g. "The request was interrupted") were constrained to `maxWidth: 520` like regular messages
- Changed `bubbleChrome` to use `maxWidth: .infinity` when `message.isError`, so error banners span the full width of the chat area

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
