### PR TITLE
Fix: Decision engine dedupe and channel validation issues

### DIFF
--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -169,7 +169,7 @@ function buildFallbackDecision(
       selectedChannels: [...availableChannels],
       reasoningSummary: 'Fallback: high urgency + requires action',
       renderedCopy: copy,
-      dedupeKey: `${signal.sourceEventName}:${signal.signalId}`,
+      dedupeKey: `fallback:${signal.sourceEventName}:${signal.sourceSessionId}`,
       confidence: 0.3,
       fallbackUsed: true,
     };
@@ -180,7 +180,7 @@ function buildFallbackDecision(
     selectedChannels: [],
     reasoningSummary: 'Fallback: suppressed (not high urgency + requires action)',
     renderedCopy: {},
-    dedupeKey: `${signal.sourceEventName}:${signal.signalId}`,
+    dedupeKey: `fallback:${signal.sourceEventName}:${signal.sourceSessionId}`,
     confidence: 0.3,
     fallbackUsed: true,
   };
@@ -199,10 +199,11 @@ function validateDecisionOutput(
   if (typeof input.dedupeKey !== 'string') return null;
 
   if (!Array.isArray(input.selectedChannels)) return null;
-  const validChannels = (input.selectedChannels as unknown[]).filter(
+  const validatedChannels = (input.selectedChannels as unknown[]).filter(
     (ch): ch is NotificationChannel =>
       typeof ch === 'string' && VALID_CHANNELS.has(ch) && availableChannels.includes(ch as NotificationChannel),
   );
+  const validChannels = [...new Set(validatedChannels)];
 
   const confidence = typeof input.confidence === 'number'
     ? Math.max(0, Math.min(1, input.confidence))

--- a/assistant/src/notifications/deterministic-checks.ts
+++ b/assistant/src/notifications/deterministic-checks.ts
@@ -154,7 +154,7 @@ function checkDedupe(
     const cutoff = Date.now() - windowMs;
 
     const existing = db
-      .select({ id: notificationEvents.id })
+      .select({ id: notificationEvents.id, createdAt: notificationEvents.createdAt })
       .from(notificationEvents)
       .where(
         and(
@@ -170,7 +170,9 @@ function checkDedupe(
     for (const row of existing) {
       // The current signal's own event row should not count as a duplicate
       if (row.id === signal.signalId) continue;
-      // If any other event with the same dedupeKey exists, suppress
+      // Only consider events within the dedupe window
+      if (row.createdAt < cutoff) continue;
+      // If any other event with the same dedupeKey exists within the window, suppress
       return {
         passed: false,
         reason: `Dedupe: signal with dedupeKey "${decision.dedupeKey}" was already processed`,


### PR DESCRIPTION
Address review feedback on M4 PR #8311: (1) Apply dedupe window cutoff in deterministic checks so deduplication is time-bounded, (2) Use stable identifiers in fallback dedupe key instead of unique signalId, (3) Deduplicate model-selected channels to prevent double-sends.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
