### PR TITLE
fix: prevent double dismiss of Quick Input panel on submit

### DIFF
--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
@@ -17,6 +17,7 @@ final class QuickInputWindow {
     private var panel: NSPanel?
     private var resignObserver: Any?
     private var previousApp: NSRunningApplication?
+    private var isDismissing = false
 
     /// Callback invoked when the user submits a message.
     var onSubmit: ((String) -> Void)?
@@ -91,12 +92,18 @@ final class QuickInputWindow {
     }
 
     func dismiss(restorePreviousApp: Bool = true) {
+        guard !isDismissing else { return }
+        isDismissing = true
+
         if let resignObserver {
             NotificationCenter.default.removeObserver(resignObserver)
         }
         resignObserver = nil
 
-        guard let panel else { return }
+        guard let panel else {
+            isDismissing = false
+            return
+        }
 
         let appToRestore = restorePreviousApp ? previousApp : nil
         previousApp = nil
@@ -108,6 +115,7 @@ final class QuickInputWindow {
         }, completionHandler: { [weak self] in
             panel.close()
             self?.panel = nil
+            self?.isDismissing = false
             appToRestore?.activate()
         })
     }


### PR DESCRIPTION
## Summary
- Add `isDismissing` flag to guard against re-entrant `dismiss()` calls
- On submit, `showMainWindow()` makes the panel resign key (firing the observer's dismiss), and the `onSubmit` closure also calls dismiss explicitly — without the guard, this causes double fade-out animation and double `panel.close()`

## Original prompt
Addresses review feedback from #8309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
