### PR TITLE
Fix: Per-event fallback dedupe key granularity

### DIFF
--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -169,7 +169,7 @@ function buildFallbackDecision(
       selectedChannels: [...availableChannels],
       reasoningSummary: 'Fallback: high urgency + requires action',
       renderedCopy: copy,
-      dedupeKey: `fallback:${signal.sourceEventName}:${signal.sourceSessionId}`,
+      dedupeKey: `fallback:${signal.sourceEventName}:${signal.sourceSessionId}:${signal.createdAt}`,
       confidence: 0.3,
       fallbackUsed: true,
     };
@@ -180,7 +180,7 @@ function buildFallbackDecision(
     selectedChannels: [],
     reasoningSummary: 'Fallback: suppressed (not high urgency + requires action)',
     renderedCopy: {},
-    dedupeKey: `fallback:${signal.sourceEventName}:${signal.sourceSessionId}`,
+    dedupeKey: `fallback:${signal.sourceEventName}:${signal.sourceSessionId}:${signal.createdAt}`,
     confidence: 0.3,
     fallbackUsed: true,
   };


### PR DESCRIPTION
Include signal createdAt in fallback dedupe key so genuinely different events in the same session get distinct keys while retries of the same signal are still deduplicated.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
