### PR TITLE
M3: Update AlwaysOnAudioMonitor for 16kHz mono format

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/AlwaysOnAudioMonitor.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/AlwaysOnAudioMonitor.swift
@@ -96,13 +96,20 @@ final class AlwaysOnAudioMonitor: ObservableObject {
             throw AudioMonitorError.noInputChannels
         }
 
-        // Install a tap using the hardware format for low-latency capture.
-        // The buffer is available for the WakeWordEngine to consume via its
-        // own internal processing (the engine's start() primes it for detection).
+        // Porcupine requires 16kHz mono Int16 PCM. Request 16kHz mono Float32 from
+        // AVAudioEngine (which handles resampling internally); the tap callback
+        // converts Float32 → Int16 before feeding the wake word engine.
+        let targetFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 16000,
+            channels: 1,
+            interleaved: false
+        )!
+
         inputNode.installTap(
             onBus: 0,
             bufferSize: Self.bufferSize,
-            format: hwFormat
+            format: targetFormat
         ) { [weak self] buffer, _ in
             guard let self else { return }
             guard let floatData = buffer.floatChannelData else { return }


### PR DESCRIPTION
## Summary
- Changed audio tap to request 16kHz mono Float32 format instead of hardware format
- AVAudioEngine handles resampling internally — no additional conversion needed
- Porcupine requires 16kHz mono Int16 PCM; existing Float32→Int16 conversion in the tap callback handles the final step

Closes #8266
Part of #8262
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
