### PR TITLE
fix(lint): resolve lint errors in influencer client

### DIFF
--- a/assistant/src/influencer/client.ts
+++ b/assistant/src/influencer/client.ts
@@ -46,7 +46,7 @@
  */
 
 import { extensionRelayServer } from '../browser-extension-relay/server.js';
-import type { ExtensionResponse } from '../browser-extension-relay/protocol.js';
+import type { ExtensionCommand, ExtensionResponse } from '../browser-extension-relay/protocol.js';
 import { readHttpToken } from '../util/platform.js';
 
 // ---------------------------------------------------------------------------
@@ -122,7 +122,7 @@ export interface InfluencerSearchResult {
 async function sendRelayCommand(command: Record<string, unknown>): Promise<ExtensionResponse> {
   const status = extensionRelayServer.getStatus();
   if (status.connected) {
-    return extensionRelayServer.sendCommand(command as any);
+    return extensionRelayServer.sendCommand(command as Omit<ExtensionCommand, 'id'>);
   }
 
   // Fall back to HTTP relay endpoint on the daemon
@@ -915,10 +915,10 @@ function matchesCriteria(
   profile: InfluencerProfile,
   criteria: InfluencerSearchCriteria,
 ): boolean {
-  if (criteria.minFollowers && profile.followers !== null) {
+  if (criteria.minFollowers && profile.followers != null) {
     if (profile.followers < criteria.minFollowers) return false;
   }
-  if (criteria.maxFollowers && profile.followers !== null) {
+  if (criteria.maxFollowers && profile.followers != null) {
     if (profile.followers > criteria.maxFollowers) return false;
   }
   if (criteria.verifiedOnly && !profile.isVerified) {
@@ -934,7 +934,7 @@ function scoreProfile(
   let score = 0;
 
   // Follower count scoring
-  if (profile.followers !== null) {
+  if (profile.followers != null) {
     if (profile.followers >= 1_000) score += 10;
     if (profile.followers >= 10_000) score += 20;
     if (profile.followers >= 100_000) score += 30;


### PR DESCRIPTION
## Summary
- Replace `as any` with proper `Omit<ExtensionCommand, 'id'>` type assertion in `sendRelayCommand`
- Replace `!== null` with `!= null` in `matchesCriteria` and `scoreProfile` to satisfy the no-restricted-syntax lint rule

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22358705846

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
