### PR TITLE
fix: always start daemon HTTP server for iOS pairing

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -193,6 +193,7 @@ export async function startLocalDaemon(): Promise<void> {
       for (const key of [
         "ANTHROPIC_API_KEY",
         "BASE_DATA_DIR",
+        "RUNTIME_HTTP_PORT",
         "VELLUM_DAEMON_TCP_PORT",
         "VELLUM_DAEMON_TCP_HOST",
         "VELLUM_DAEMON_SOCKET",

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -557,12 +557,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let assistant = loadAssistantFromLockfile()
 
-        // Ensure the daemon starts its runtime HTTP server so the app
-        // can communicate over HTTP instead of IPC.
-        if FeatureFlagManager.shared.isEnabled(.localHttpEnabled) {
-            if ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] == nil {
-                setenv("RUNTIME_HTTP_PORT", "7821", 0)
-            }
+        // Ensure the daemon starts its runtime HTTP server so the
+        // gateway can proxy iOS traffic to it.
+        if ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] == nil {
+            setenv("RUNTIME_HTTP_PORT", "7821", 0)
         }
 
         configureDaemonTransport(for: assistant)

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -602,10 +602,9 @@ final class AssistantCli {
                     env[key] = val
                 }
             }
-            // Forward RUNTIME_HTTP_PORT only when the localHttpEnabled flag
-            // is active, so the daemon doesn't start its HTTP server by default.
-            if FeatureFlagManager.shared.isEnabled(.localHttpEnabled),
-               let port = fullEnv["RUNTIME_HTTP_PORT"] ?? getenv("RUNTIME_HTTP_PORT").flatMap({ String(cString: $0) }) {
+            // Always forward RUNTIME_HTTP_PORT so the daemon starts its
+            // HTTP server — required for iOS pairing via the gateway.
+            if let port = fullEnv["RUNTIME_HTTP_PORT"] ?? getenv("RUNTIME_HTTP_PORT").flatMap({ String(cString: $0) }) {
                 env["RUNTIME_HTTP_PORT"] = port
             }
             proc.environment = env


### PR DESCRIPTION
## Summary

- The daemon HTTP server (port 7821) is required for iOS pairing — the gateway proxies all iOS traffic through it. Previously this was gated behind the `RUNTIME_HTTP_PORT` env var, which relied on a fragile `setenv` → `getenv` → subprocess forwarding chain from the macOS app. `ProcessInfo.processInfo.environment` is a frozen snapshot from launch time, so the env var often wasn't forwarded, causing the HTTP server to never start.
- The `setPairingBroadcast` callback was never wired up in `lifecycle.ts`, so even if the HTTP server started, `pairing_approval_request` IPC messages were silently dropped and never reached the macOS app.
- Token regeneration killed the daemon but showed no loading state, leaving users with a dead-end "daemon unreachable" error.

## Implementation

### Daemon always starts HTTP server (`env.ts`, `lifecycle.ts`)
- `getRuntimeHttpPort()` now defaults to `7821` instead of returning `undefined`
- Removed the `if (httpPort)` conditional guard — the HTTP server always starts
- This eliminates the dependency on env var forwarding from the macOS app

### Wire pairing broadcast (`lifecycle.ts`)
- Added `runtimeHttp.setPairingBroadcast((msg) => server.broadcast(msg))` after `setRelayBroadcast`
- Without this, the `if (ctx.pairingBroadcast)` check in `pairing-routes.ts` silently skipped sending IPC approval requests

### Token regeneration UX (`SettingsConnectTab.swift`)
- Added `isRegeneratingToken` state with spinner UI: "Restarting daemon with new token…"
- Polls the daemon's healthz endpoint for up to 30s before clearing the loading state
- Disables the QR button during regeneration to prevent stale QR codes

## Testing
- Build and launch macOS app: `./build.sh run`
- Verify port 7821 is listening: `lsof -iTCP:7821 -sTCP:LISTEN`
- Show QR code, scan with iOS, verify Mac approval prompt appears
- Regenerate token and verify spinner shows while daemon restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
