### PR TITLE
fix: use AVAudioConverter for robust 16kHz resampling in AlwaysOnAudioMonitor

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/AlwaysOnAudioMonitor.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/AlwaysOnAudioMonitor.swift
@@ -96,9 +96,8 @@ final class AlwaysOnAudioMonitor: ObservableObject {
             throw AudioMonitorError.noInputChannels
         }
 
-        // Porcupine requires 16kHz mono Int16 PCM. Request 16kHz mono Float32 from
-        // AVAudioEngine (which handles resampling internally); the tap callback
-        // converts Float32 → Int16 before feeding the wake word engine.
+        // Porcupine requires 16kHz mono Int16 PCM. Use hardware format for the tap
+        // (avoids runtime assertions on some Macs) and resample in the callback.
         let targetFormat = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
             sampleRate: 16000,
@@ -106,15 +105,35 @@ final class AlwaysOnAudioMonitor: ObservableObject {
             interleaved: false
         )!
 
+        guard let converter = AVAudioConverter(from: hwFormat, to: targetFormat) else {
+            throw AudioMonitorError.converterCreationFailed
+        }
+
         inputNode.installTap(
             onBus: 0,
             bufferSize: Self.bufferSize,
-            format: targetFormat
+            format: hwFormat
         ) { [weak self] buffer, _ in
             guard let self else { return }
-            guard let floatData = buffer.floatChannelData else { return }
-            let frameLength = Int(buffer.frameLength)
-            // Convert Float32 PCM to Int16 for Porcupine
+
+            // Resample hardware audio to 16kHz mono
+            let frameCapacity = AVAudioFrameCount(
+                Double(buffer.frameLength) * targetFormat.sampleRate / hwFormat.sampleRate
+            )
+            guard let convertedBuffer = AVAudioPCMBuffer(
+                pcmFormat: targetFormat,
+                frameCapacity: frameCapacity
+            ) else { return }
+
+            var error: NSError?
+            let status = converter.convert(to: convertedBuffer, error: &error) { _, outStatus in
+                outStatus.pointee = .haveData
+                return buffer
+            }
+            guard status == .haveData || status == .inputRanDry else { return }
+
+            guard let floatData = convertedBuffer.floatChannelData else { return }
+            let frameLength = Int(convertedBuffer.frameLength)
             var int16Samples = [Int16](repeating: 0, count: frameLength)
             for i in 0..<frameLength {
                 let sample = max(-1.0, min(1.0, floatData[0][i]))
@@ -193,11 +212,14 @@ final class AlwaysOnAudioMonitor: ObservableObject {
 
 enum AudioMonitorError: LocalizedError {
     case noInputChannels
+    case converterCreationFailed
 
     var errorDescription: String? {
         switch self {
         case .noInputChannels:
             return "No audio input channels available — microphone may not be connected or permitted"
+        case .converterCreationFailed:
+            return "Failed to create audio format converter for 16kHz resampling"
         }
     }
 }


### PR DESCRIPTION
## Summary
- Changed audio tap to use hardware format (avoids runtime assertions on some Macs)
- Added AVAudioConverter to resample from hardware format to 16kHz mono
- Addresses review feedback from PR #8318

Part of #8262
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
