### PR TITLE
fix: add input validation and handle cleanup in PorcupineBinding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/PorcupineBinding.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/PorcupineBinding.swift
@@ -185,6 +185,13 @@ final class PorcupineBinding {
         keywordPaths: [String],
         sensitivities: [Float]
     ) throws {
+        guard keywordPaths.count == sensitivities.count else {
+            throw PorcupineBindingError.invalidArgument(
+                "Number of keyword paths (\(keywordPaths.count)) does not match number of sensitivities (\(sensitivities.count))",
+                []
+            )
+        }
+
         // Build a C-compatible array of keyword path strings using strdup
         // (same pattern as the iOS binding)
         var cKeywordPaths = keywordPaths.map { UnsafePointer<CChar>(strdup($0)) }
@@ -205,6 +212,9 @@ final class PorcupineBinding {
             throw mapStatus(status, message: "pv_porcupine_init failed", stack: messageStack)
         }
 
+        // Release any previously-initialized engine before overwriting the handle
+        delete()
+
         self.handle = porcupineHandle
         Self.logger.info("Porcupine engine initialized with \(keywordPaths.count) keyword(s)")
     }
@@ -217,6 +227,13 @@ final class PorcupineBinding {
     func process(pcm: [Int16]) throws -> Int32 {
         guard let handle = self.handle else {
             throw PorcupineBindingError.invalidState("Porcupine not initialized", [])
+        }
+
+        guard pcm.count == Int(frameLength) else {
+            throw PorcupineBindingError.invalidArgument(
+                "PCM frame must contain exactly \(frameLength) samples, got \(pcm.count)",
+                []
+            )
         }
 
         var keywordIndex: Int32 = -1


### PR DESCRIPTION
## Summary
- Validate keywordPaths.count == sensitivities.count before C API call
- Validate pcm.count == frameLength before pv_porcupine_process call
- Call delete() before re-assigning handle to prevent resource leak on re-initialization
- Addresses review feedback from PR #8320

Part of #8262
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
