### PR TITLE
fix: move FRAMEWORKS_DIR definition before Porcupine staleness check

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -40,6 +40,7 @@ APP_DIR="$SCRIPT_DIR/dist/$BUNDLE_DISPLAY_NAME.app"
 CONTENTS="$APP_DIR/Contents"
 MACOS_DIR="$CONTENTS/MacOS"
 RESOURCES_DIR="$CONTENTS/Resources"
+FRAMEWORKS_DIR="$CONTENTS/Frameworks"
 
 # Version (overridable via env for CI, defaults to Package.swift)
 if [ -z "${DISPLAY_VERSION:-}" ]; then
@@ -283,7 +284,6 @@ if [ -d "$PORCUPINE_CHECKOUT/lib/mac" ]; then
 fi
 
 # Ensure .app bundle structure exists
-FRAMEWORKS_DIR="$CONTENTS/Frameworks"
 mkdir -p "$MACOS_DIR" "$RESOURCES_DIR" "$FRAMEWORKS_DIR"
 
 if [ "$NEEDS_REBUILD" = true ]; then


### PR DESCRIPTION
## Summary
- Moved FRAMEWORKS_DIR assignment to the top of build.sh alongside other path definitions
- Fixes unbound variable error when Porcupine checkout exists (script uses set -u)
- Addresses review feedback from PR #8321

Part of #8262
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
