### PR TITLE
M5: Dispatch path wiring + assistant copy

### DIFF
--- a/assistant/src/notifications/adapters/macos.ts
+++ b/assistant/src/notifications/adapters/macos.ts
@@ -12,7 +12,7 @@ import type { ServerMessage } from '../../daemon/ipc-contract.js';
 import type {
   NotificationChannel,
   ChannelAdapter,
-  PreparedDelivery,
+  ChannelDeliveryPayload,
   ChannelDestination,
   DeliveryResult,
 } from '../types.js';
@@ -30,25 +30,25 @@ export class MacOSAdapter implements ChannelAdapter {
     this.broadcast = broadcast;
   }
 
-  async send(delivery: PreparedDelivery, _destination: ChannelDestination): Promise<DeliveryResult> {
+  async send(payload: ChannelDeliveryPayload, _destination: ChannelDestination): Promise<DeliveryResult> {
     try {
       this.broadcast({
         type: 'notification_intent',
-        sourceEventName: delivery.sourceEventName,
-        title: delivery.title,
-        body: delivery.body,
-        deepLinkMetadata: delivery.deepLinkMetadata,
+        sourceEventName: payload.sourceEventName,
+        title: payload.copy.title,
+        body: payload.copy.body,
+        deepLinkMetadata: payload.deepLinkTarget,
       } as ServerMessage);
 
       log.info(
-        { sourceEventName: delivery.sourceEventName, title: delivery.title },
+        { sourceEventName: payload.sourceEventName, title: payload.copy.title },
         'macOS notification intent broadcast',
       );
 
       return { success: true };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      log.error({ err, sourceEventName: delivery.sourceEventName }, 'Failed to broadcast macOS notification intent');
+      log.error({ err, sourceEventName: payload.sourceEventName }, 'Failed to broadcast macOS notification intent');
       return { success: false, error: message };
     }
   }

--- a/assistant/src/notifications/adapters/telegram.ts
+++ b/assistant/src/notifications/adapters/telegram.ts
@@ -34,12 +34,11 @@ export class TelegramAdapter implements ChannelAdapter {
     const gatewayBase = getGatewayInternalBaseUrl();
     const deliverUrl = `${gatewayBase}/deliver/telegram`;
 
-    // Format copy for Telegram: bold title followed by body
-    const parts: string[] = [`<b>${escapeHtml(payload.copy.title)}</b>`, '', payload.copy.body];
+    // Format copy for Telegram as plain text (no parse_mode set on gateway side)
+    let messageText = payload.copy.title + '\n\n' + payload.copy.body;
     if (payload.copy.threadTitle) {
-      parts.push('', `Thread: ${payload.copy.threadTitle}`);
+      messageText += '\n\nThread: ' + payload.copy.threadTitle;
     }
-    const messageText = parts.join('\n');
 
     try {
       await deliverChannelReply(
@@ -63,12 +62,4 @@ export class TelegramAdapter implements ChannelAdapter {
       return { success: false, error: message };
     }
   }
-}
-
-/** Escape HTML special characters for Telegram's HTML parse mode. */
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
 }

--- a/assistant/src/notifications/adapters/telegram.ts
+++ b/assistant/src/notifications/adapters/telegram.ts
@@ -14,7 +14,7 @@ import { readHttpToken } from '../../util/platform.js';
 import type {
   NotificationChannel,
   ChannelAdapter,
-  PreparedDelivery,
+  ChannelDeliveryPayload,
   ChannelDestination,
   DeliveryResult,
 } from '../types.js';
@@ -24,17 +24,22 @@ const log = getLogger('notif-adapter-telegram');
 export class TelegramAdapter implements ChannelAdapter {
   readonly channel: NotificationChannel = 'telegram';
 
-  async send(delivery: PreparedDelivery, destination: ChannelDestination): Promise<DeliveryResult> {
+  async send(payload: ChannelDeliveryPayload, destination: ChannelDestination): Promise<DeliveryResult> {
     const chatId = destination.endpoint;
     if (!chatId) {
-      log.warn({ sourceEventName: delivery.sourceEventName }, 'Telegram destination has no chat ID — skipping');
+      log.warn({ sourceEventName: payload.sourceEventName }, 'Telegram destination has no chat ID — skipping');
       return { success: false, error: 'No chat ID configured for Telegram destination' };
     }
 
     const gatewayBase = getGatewayInternalBaseUrl();
     const deliverUrl = `${gatewayBase}/deliver/telegram`;
 
-    const messageText = `${delivery.title}\n\n${delivery.body}`;
+    // Format copy for Telegram: bold title followed by body
+    const parts: string[] = [`<b>${escapeHtml(payload.copy.title)}</b>`, '', payload.copy.body];
+    if (payload.copy.threadTitle) {
+      parts.push('', `Thread: ${payload.copy.threadTitle}`);
+    }
+    const messageText = parts.join('\n');
 
     try {
       await deliverChannelReply(
@@ -44,7 +49,7 @@ export class TelegramAdapter implements ChannelAdapter {
       );
 
       log.info(
-        { sourceEventName: delivery.sourceEventName, chatId },
+        { sourceEventName: payload.sourceEventName, chatId },
         'Telegram notification delivered',
       );
 
@@ -52,10 +57,18 @@ export class TelegramAdapter implements ChannelAdapter {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.error(
-        { err, sourceEventName: delivery.sourceEventName, chatId },
+        { err, sourceEventName: payload.sourceEventName, chatId },
         'Failed to deliver Telegram notification',
       );
       return { success: false, error: message };
     }
   }
+}
+
+/** Escape HTML special characters for Telegram's HTML parse mode. */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 }

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -99,28 +99,38 @@ export class NotificationBroadcaster {
       const deliveryId = uuid();
       const destinationLabel = destination.endpoint ?? channel;
 
-      // Use the persisted decision row ID for the FK; fall back to dedupeKey
-      // only if persistence failed (in which case the FK won't resolve, but we
-      // still record the delivery for debugging).
-      const decisionRowId = decision.persistedDecisionId ?? decision.dedupeKey;
+      // Only create a delivery audit record when we have a persisted decision ID
+      // for the FK. If decision persistence failed (persistedDecisionId is
+      // undefined), we still dispatch via the adapter but skip the delivery
+      // record — using dedupeKey would violate the FK constraint.
+      const hasPersistedDecision = decision.persistedDecisionId != null;
 
       try {
-        createDelivery({
-          id: deliveryId,
-          notificationDecisionId: decisionRowId,
-          assistantId: signal.assistantId,
-          channel,
-          destination: destinationLabel,
-          status: 'pending',
-          attempt: 1,
-          renderedTitle: copy.title,
-          renderedBody: copy.body,
-        });
+        if (hasPersistedDecision) {
+          createDelivery({
+            id: deliveryId,
+            notificationDecisionId: decision.persistedDecisionId,
+            assistantId: signal.assistantId,
+            channel,
+            destination: destinationLabel,
+            status: 'pending',
+            attempt: 1,
+            renderedTitle: copy.title,
+            renderedBody: copy.body,
+          });
+        } else {
+          log.warn(
+            { channel, signalId: signal.signalId },
+            'No persisted decision ID -- skipping delivery record creation',
+          );
+        }
 
         const adapterResult = await adapter.send(payload, destination);
 
         if (adapterResult.success) {
-          updateDeliveryStatus(deliveryId, 'sent');
+          if (hasPersistedDecision) {
+            updateDeliveryStatus(deliveryId, 'sent');
+          }
           results.push({
             channel,
             destination: destinationLabel,
@@ -128,7 +138,9 @@ export class NotificationBroadcaster {
             sentAt: Date.now(),
           });
         } else {
-          updateDeliveryStatus(deliveryId, 'failed', { message: adapterResult.error });
+          if (hasPersistedDecision) {
+            updateDeliveryStatus(deliveryId, 'failed', { message: adapterResult.error });
+          }
           results.push({
             channel,
             destination: destinationLabel,
@@ -140,10 +152,12 @@ export class NotificationBroadcaster {
         const errorMessage = err instanceof Error ? err.message : String(err);
         log.error({ err, channel, signalId: signal.signalId }, 'Unexpected error during channel delivery');
 
-        try {
-          updateDeliveryStatus(deliveryId, 'failed', { message: errorMessage });
-        } catch {
-          // Swallow -- the delivery record may not exist if createDelivery failed
+        if (hasPersistedDecision) {
+          try {
+            updateDeliveryStatus(deliveryId, 'failed', { message: errorMessage });
+          } catch {
+            // Swallow -- the delivery record may not exist if createDelivery failed
+          }
         }
 
         results.push({

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -99,10 +99,15 @@ export class NotificationBroadcaster {
       const deliveryId = uuid();
       const destinationLabel = destination.endpoint ?? channel;
 
+      // Use the persisted decision row ID for the FK; fall back to dedupeKey
+      // only if persistence failed (in which case the FK won't resolve, but we
+      // still record the delivery for debugging).
+      const decisionRowId = decision.persistedDecisionId ?? decision.dedupeKey;
+
       try {
         createDelivery({
           id: deliveryId,
-          notificationDecisionId: decision.dedupeKey,
+          notificationDecisionId: decisionRowId,
           assistantId: signal.assistantId,
           channel,
           destination: destinationLabel,

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -1,44 +1,30 @@
 /**
- * NotificationBroadcaster -- dispatches a notification to all selected
- * channels through their respective adapters.
+ * NotificationBroadcaster -- dispatches a notification decision to all
+ * selected channels through their respective adapters.
  *
- * For each channel the broadcaster:
+ * For each channel in the decision's selectedChannels:
  *   1. Resolves the destination via the destination-resolver
- *   2. Generates channel-specific copy via the copy-composer
+ *   2. Pulls rendered copy from the decision (or falls back to copy-composer)
  *   3. Dispatches through the channel adapter
  *   4. Records a delivery audit row in the deliveries-store
  */
 
 import { v4 as uuid } from 'uuid';
 import { getLogger } from '../util/logger.js';
-import { composeCopy } from './copy-composer.js';
+import { composeFallbackCopy } from './copy-composer.js';
 import { resolveDestinations } from './destination-resolver.js';
 import { createDelivery, updateDeliveryStatus } from './deliveries-store.js';
+import type { NotificationSignal } from './signal.js';
 import type {
   NotificationChannel,
+  NotificationDecision,
   NotificationDeliveryResult,
   ChannelAdapter,
+  ChannelDeliveryPayload,
+  RenderedChannelCopy,
 } from './types.js';
 
 const log = getLogger('notif-broadcaster');
-
-/**
- * Minimal envelope the broadcaster needs to dispatch a notification.
- * This replaces the old NotificationEnvelope which was tightly coupled
- * to the enum-based NotificationType.
- */
-export interface BroadcastEnvelope {
-  decisionId: string;
-  assistantId: string;
-  sourceEventName: string;
-  payload: Record<string, unknown>;
-  createdAt: number;
-}
-
-export interface BroadcastOptions {
-  /** Override the set of channels to deliver to (bypasses preference resolution). */
-  channels?: NotificationChannel[];
-}
 
 export class NotificationBroadcaster {
   private adapters: Map<NotificationChannel, ChannelAdapter>;
@@ -51,22 +37,29 @@ export class NotificationBroadcaster {
   }
 
   /**
-   * Broadcast a notification to the given set of channels.
+   * Broadcast a notification decision to all selected channels.
+   *
+   * The decision carries rendered copy per channel. When the decision was
+   * produced by the fallback path (fallbackUsed === true) and is missing
+   * copy for a channel, the copy-composer generates deterministic fallback copy.
    *
    * Returns an array of delivery results -- one per channel attempted.
    */
-  async broadcast(
-    envelope: BroadcastEnvelope,
-    enabledChannels: NotificationChannel[],
-    _options?: BroadcastOptions,
+  async broadcastDecision(
+    signal: NotificationSignal,
+    decision: NotificationDecision,
   ): Promise<NotificationDeliveryResult[]> {
-    const destinations = resolveDestinations(envelope.assistantId, enabledChannels);
+    const destinations = resolveDestinations(signal.assistantId, decision.selectedChannels);
+
+    // Pre-compute fallback copy in case any channel is missing rendered copy
+    let fallbackCopy: Partial<Record<NotificationChannel, RenderedChannelCopy>> | null = null;
+
     const results: NotificationDeliveryResult[] = [];
 
-    for (const channel of enabledChannels) {
+    for (const channel of decision.selectedChannels) {
       const adapter = this.adapters.get(channel);
       if (!adapter) {
-        log.warn({ channel, decisionId: envelope.decisionId }, 'No adapter registered for channel -- skipping');
+        log.warn({ channel, signalId: signal.signalId }, 'No adapter registered for channel -- skipping');
         results.push({
           channel,
           destination: '',
@@ -78,7 +71,7 @@ export class NotificationBroadcaster {
 
       const destination = destinations.get(channel);
       if (!destination) {
-        log.warn({ channel, decisionId: envelope.decisionId }, 'Could not resolve destination -- skipping');
+        log.warn({ channel, signalId: signal.signalId }, 'Could not resolve destination -- skipping');
         results.push({
           channel,
           destination: '',
@@ -88,25 +81,29 @@ export class NotificationBroadcaster {
         continue;
       }
 
-      const copy = composeCopy(envelope.sourceEventName, channel, envelope.payload);
-      const delivery = {
-        sourceEventName: envelope.sourceEventName,
-        title: copy.title,
-        body: copy.body,
-        threadTitle: copy.threadTitle,
-        threadSeedMessage: copy.threadSeedMessage,
-        deepLinkMetadata: envelope.payload as Record<string, unknown>,
+      // Pull rendered copy from the decision; fall back to copy-composer if missing
+      let copy = decision.renderedCopy[channel];
+      if (!copy) {
+        if (!fallbackCopy) {
+          fallbackCopy = composeFallbackCopy(signal, decision.selectedChannels);
+        }
+        copy = fallbackCopy[channel] ?? { title: 'Notification', body: signal.sourceEventName };
+      }
+
+      const payload: ChannelDeliveryPayload = {
+        sourceEventName: signal.sourceEventName,
+        copy,
+        deepLinkTarget: decision.deepLinkTarget,
       };
 
       const deliveryId = uuid();
       const destinationLabel = destination.endpoint ?? channel;
 
       try {
-        // Record a pending delivery row before attempting send
         createDelivery({
           id: deliveryId,
-          notificationDecisionId: envelope.decisionId,
-          assistantId: envelope.assistantId,
+          notificationDecisionId: decision.dedupeKey,
+          assistantId: signal.assistantId,
           channel,
           destination: destinationLabel,
           status: 'pending',
@@ -115,11 +112,10 @@ export class NotificationBroadcaster {
           renderedBody: copy.body,
         });
 
-        const adapterResult = await adapter.send(delivery, destination);
+        const adapterResult = await adapter.send(payload, destination);
 
         if (adapterResult.success) {
           updateDeliveryStatus(deliveryId, 'sent');
-
           results.push({
             channel,
             destination: destinationLabel,
@@ -127,10 +123,7 @@ export class NotificationBroadcaster {
             sentAt: Date.now(),
           });
         } else {
-          updateDeliveryStatus(deliveryId, 'failed', {
-            message: adapterResult.error,
-          });
-
+          updateDeliveryStatus(deliveryId, 'failed', { message: adapterResult.error });
           results.push({
             channel,
             destination: destinationLabel,
@@ -140,9 +133,8 @@ export class NotificationBroadcaster {
         }
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : String(err);
-        log.error({ err, channel, decisionId: envelope.decisionId }, 'Unexpected error during channel delivery');
+        log.error({ err, channel, signalId: signal.signalId }, 'Unexpected error during channel delivery');
 
-        // Best-effort update of the delivery row
         try {
           updateDeliveryStatus(deliveryId, 'failed', { message: errorMessage });
         } catch {

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -1,29 +1,25 @@
 /**
  * Deterministic, template-based copy generation for notification deliveries.
  *
+ * This is the fallback path used when the decision engine's LLM-generated
+ * copy is unavailable (fallbackUsed === true). It generates reasonable
+ * copy from the signal's sourceEventName, contextPayload, and attentionHints.
+ *
  * Each source event name has a set of fallback templates that interpolate
- * values from the event payload. Model-driven generation can be layered
- * on top later -- the deterministic path guarantees delivery reliability
- * even when the LLM is unavailable or slow.
+ * values from the context payload.
  */
 
-import type { NotificationChannel } from './types.js';
+import type { NotificationSignal } from './signal.js';
+import type { NotificationChannel, RenderedChannelCopy } from './types.js';
 
-export interface ComposedCopy {
-  title: string;
-  body: string;
-  threadTitle?: string;
-  threadSeedMessage?: string;
-}
-
-type CopyTemplate = (payload: Record<string, unknown>) => ComposedCopy;
+type CopyTemplate = (payload: Record<string, unknown>) => RenderedChannelCopy;
 
 function str(value: unknown, fallback: string): string {
   if (typeof value === 'string' && value.length > 0) return value;
   return fallback;
 }
 
-// Templates keyed by free-form sourceEventName strings instead of enum values.
+// Templates keyed by free-form sourceEventName strings.
 const TEMPLATES: Record<string, CopyTemplate> = {
   reminder_fired: (payload) => ({
     title: 'Reminder',
@@ -72,23 +68,41 @@ const TEMPLATES: Record<string, CopyTemplate> = {
 };
 
 /**
- * Generate notification copy for the given source event name, channel, and payload.
+ * Compose fallback notification copy for a signal when the decision
+ * engine's LLM path is unavailable.
  *
- * The `channel` parameter is accepted for future per-channel customisation
- * (e.g. shorter copy for push notifications) but is currently unused -- all
- * channels receive the same template output.
+ * Returns a map of channel -> RenderedChannelCopy for the requested channels.
+ * All channels currently receive the same template output; per-channel
+ * customisation can be layered on later.
  */
-export function composeCopy(
-  sourceEventName: string,
-  _channel: NotificationChannel,
-  payload: Record<string, unknown>,
-): ComposedCopy {
-  const template = TEMPLATES[sourceEventName];
-  if (!template) {
-    return {
-      title: 'Notification',
-      body: 'You have a new notification',
-    };
+export function composeFallbackCopy(
+  signal: NotificationSignal,
+  channels: NotificationChannel[],
+): Partial<Record<NotificationChannel, RenderedChannelCopy>> {
+  const template = TEMPLATES[signal.sourceEventName];
+
+  const baseCopy: RenderedChannelCopy = template
+    ? template(signal.contextPayload)
+    : buildGenericCopy(signal);
+
+  const result: Partial<Record<NotificationChannel, RenderedChannelCopy>> = {};
+  for (const ch of channels) {
+    result[ch] = { ...baseCopy };
   }
-  return template(payload);
+  return result;
+}
+
+/**
+ * Build generic copy when no template matches. Uses the signal's
+ * sourceEventName and attention hints to produce something reasonable.
+ */
+function buildGenericCopy(signal: NotificationSignal): RenderedChannelCopy {
+  const humanName = signal.sourceEventName.replace(/_/g, ' ');
+  const urgencyPrefix = signal.attentionHints.urgency === 'high' ? 'Urgent: ' : '';
+  const actionSuffix = signal.attentionHints.requiresAction ? ' — action required' : '';
+
+  return {
+    title: 'Notification',
+    body: `${urgencyPrefix}${humanName}${actionSuffix}`,
+  };
 }

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -264,7 +264,7 @@ export async function evaluateSignal(
   if (!provider) {
     log.warn('Configured provider unavailable for notification decision, using fallback');
     const decision = buildFallbackDecision(signal, availableChannels);
-    persistDecision(signal, decision);
+    decision.persistedDecisionId = persistDecision(signal, decision);
     return decision;
   }
 
@@ -277,7 +277,7 @@ export async function evaluateSignal(
     decision = buildFallbackDecision(signal, availableChannels);
   }
 
-  persistDecision(signal, decision);
+  decision.persistedDecisionId = persistDecision(signal, decision);
 
   if (options?.shadowMode ?? config.notifications.shadowMode) {
     log.info(
@@ -349,10 +349,11 @@ async function classifyWithLLM(
 
 // ── Persistence ────────────────────────────────────────────────────────
 
-function persistDecision(signal: NotificationSignal, decision: NotificationDecision): void {
+function persistDecision(signal: NotificationSignal, decision: NotificationDecision): string | undefined {
   try {
+    const decisionId = uuid();
     createDecision({
-      id: uuid(),
+      id: decisionId,
       notificationEventId: signal.signalId,
       shouldNotify: decision.shouldNotify,
       selectedChannels: decision.selectedChannels,
@@ -366,8 +367,10 @@ function persistDecision(signal: NotificationSignal, decision: NotificationDecis
         hasCopy: Object.keys(decision.renderedCopy).length > 0,
       },
     });
+    return decisionId;
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
     log.warn({ err: errMsg }, 'Failed to persist notification decision');
+    return undefined;
   }
 }

--- a/assistant/src/notifications/runtime-dispatch.ts
+++ b/assistant/src/notifications/runtime-dispatch.ts
@@ -1,0 +1,100 @@
+/**
+ * In-loop dispatch helper that wires the decision engine output to the
+ * broadcaster/adapters for end-to-end signal → decision → dispatch → delivery.
+ *
+ * Not a standalone service — called inline from the notification processing
+ * loop after the decision engine and deterministic checks have run.
+ */
+
+import { getConfig } from '../config/loader.js';
+import { getLogger } from '../util/logger.js';
+import type { NotificationBroadcaster } from './broadcaster.js';
+import type { NotificationSignal } from './signal.js';
+import type { NotificationDecision, NotificationDeliveryResult } from './types.js';
+
+const log = getLogger('notification-dispatch');
+
+export interface DispatchResult {
+  dispatched: boolean;
+  reason: string;
+  deliveryResults: NotificationDeliveryResult[];
+}
+
+/**
+ * Dispatch a notification decision through the broadcaster.
+ *
+ * Handles three early-exit cases before delegating to the broadcaster:
+ * 1. shouldNotify === false — the decision says not to notify
+ * 2. Shadow mode — decisions are logged but not actually dispatched
+ * 3. No selected channels — nothing to dispatch
+ */
+export async function dispatchDecision(
+  signal: NotificationSignal,
+  decision: NotificationDecision,
+  broadcaster: NotificationBroadcaster,
+): Promise<DispatchResult> {
+  // No-op when the decision engine says not to notify
+  if (!decision.shouldNotify) {
+    log.info(
+      { signalId: signal.signalId, reason: decision.reasoningSummary },
+      'Decision: do not notify',
+    );
+    return {
+      dispatched: false,
+      reason: 'Decision: shouldNotify=false',
+      deliveryResults: [],
+    };
+  }
+
+  // Shadow mode: log the decision but skip actual delivery
+  const config = getConfig();
+  if (config.notifications.shadowMode) {
+    log.info(
+      {
+        signalId: signal.signalId,
+        channels: decision.selectedChannels,
+        confidence: decision.confidence,
+        fallbackUsed: decision.fallbackUsed,
+      },
+      'Shadow mode: skipping dispatch (decision logged only)',
+    );
+    return {
+      dispatched: false,
+      reason: 'Shadow mode enabled — dispatch skipped',
+      deliveryResults: [],
+    };
+  }
+
+  // Guard against empty channel list
+  if (decision.selectedChannels.length === 0) {
+    log.info(
+      { signalId: signal.signalId },
+      'No channels selected in decision — nothing to dispatch',
+    );
+    return {
+      dispatched: false,
+      reason: 'No channels selected',
+      deliveryResults: [],
+    };
+  }
+
+  // Dispatch through the broadcaster
+  const deliveryResults = await broadcaster.broadcastDecision(signal, decision);
+
+  const sentCount = deliveryResults.filter((r) => r.status === 'sent').length;
+  log.info(
+    {
+      signalId: signal.signalId,
+      channels: decision.selectedChannels,
+      sentCount,
+      totalAttempted: deliveryResults.length,
+    },
+    'Dispatch complete',
+  );
+
+  return {
+    dispatched: true,
+    reason: `Dispatched to ${sentCount}/${deliveryResults.length} channels`,
+    deliveryResults,
+  };
+}

--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -71,4 +71,6 @@ export interface NotificationDecision {
   dedupeKey: string;
   confidence: number;
   fallbackUsed: boolean;
+  /** UUID of the persisted decision row (set after persistence in the decision engine). */
+  persistedDecisionId?: string;
 }

--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -22,16 +22,6 @@ export interface NotificationDeliveryResult {
 
 // -- Channel adapter interfaces -----------------------------------------------
 
-/** Copy rendered by the copy-composer for a single notification delivery. */
-export interface PreparedDelivery {
-  sourceEventName: string;
-  title: string;
-  body: string;
-  threadTitle?: string;
-  threadSeedMessage?: string;
-  deepLinkMetadata?: Record<string, unknown>;
-}
-
 /** Result returned by a channel adapter after attempting to send. */
 export interface DeliveryResult {
   success: boolean;
@@ -45,10 +35,20 @@ export interface ChannelDestination {
   metadata?: Record<string, unknown>;
 }
 
+/**
+ * Delivery payload assembled from the decision engine's rendered copy
+ * plus contextual fields the adapters need for formatting and routing.
+ */
+export interface ChannelDeliveryPayload {
+  sourceEventName: string;
+  copy: RenderedChannelCopy;
+  deepLinkTarget?: Record<string, unknown>;
+}
+
 /** Interface that each channel adapter must implement. */
 export interface ChannelAdapter {
   channel: NotificationChannel;
-  send(delivery: PreparedDelivery, destination: ChannelDestination): Promise<DeliveryResult>;
+  send(payload: ChannelDeliveryPayload, destination: ChannelDestination): Promise<DeliveryResult>;
 }
 
 // -- Decision engine output ---------------------------------------------------


### PR DESCRIPTION
Wire decision engine output to broadcaster and adapters. Create runtime-dispatch.ts helper, update broadcaster to accept decision-shaped input, update copy-composer as fallback, update macOS and Telegram adapters for decision-shaped copy. Closes #8288.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
