### PR TITLE
fix: move wake word callback outside lock and use dynamic frame length

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/PorcupineWakeWordEngine.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/PorcupineWakeWordEngine.swift
@@ -23,7 +23,7 @@ final class PorcupineWakeWordEngine: WakeWordEngine {
 
     private var binding: PorcupineBinding?
     private var frameBuffer: [Int16] = []
-    private let frameLength: Int = 512
+    private var frameLength: Int = 512
 
     /// Guards `binding` and `frameBuffer` for thread safety between
     /// the main thread (`start`/`stop`) and the audio thread (`processAudioFrame`).
@@ -107,10 +107,14 @@ final class PorcupineWakeWordEngine: WakeWordEngine {
             return
         }
 
-        // 7. Commit state
+        // 7. Query actual frame length from binding
+        let actualFrameLength = Int(newBinding.frameLength)
+
+        // 8. Commit state
         withLock {
             self.binding = newBinding
             self.frameBuffer = []
+            self.frameLength = actualFrameLength
             self.hasLoggedProcessError = false
         }
         isRunning = true
@@ -131,6 +135,7 @@ final class PorcupineWakeWordEngine: WakeWordEngine {
     // MARK: - Audio processing (audio thread)
 
     func processAudioFrame(_ frame: [Int16]) {
+        var shouldNotify = false
         withLock {
             guard binding != nil else { return }
             frameBuffer.append(contentsOf: frame)
@@ -142,7 +147,7 @@ final class PorcupineWakeWordEngine: WakeWordEngine {
                 do {
                     let keywordIndex = try binding!.process(pcm: chunk)
                     if keywordIndex >= 0 {
-                        onWakeWordDetected?(1.0)
+                        shouldNotify = true
                     }
                 } catch {
                     if !hasLoggedProcessError {
@@ -153,6 +158,9 @@ final class PorcupineWakeWordEngine: WakeWordEngine {
                     return
                 }
             }
+        }
+        if shouldNotify {
+            onWakeWordDetected?(1.0)
         }
     }
 


### PR DESCRIPTION
## Summary
- Move onWakeWordDetected callback invocation outside os_unfair_lock to prevent potential deadlock
- Use binding.frameLength instead of hardcoded 512 to match Porcupine's actual frame size
- Addresses review feedback from PR #8323

Part of #8262
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
