### PR TITLE
fix: prevent duplicate audio in AVAudioConverter and use ceil for buffer capacity

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/AlwaysOnAudioMonitor.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/AlwaysOnAudioMonitor.swift
@@ -118,7 +118,7 @@ final class AlwaysOnAudioMonitor: ObservableObject {
 
             // Resample hardware audio to 16kHz mono
             let frameCapacity = AVAudioFrameCount(
-                Double(buffer.frameLength) * targetFormat.sampleRate / hwFormat.sampleRate
+                ceil(Double(buffer.frameLength) * targetFormat.sampleRate / hwFormat.sampleRate)
             )
             guard let convertedBuffer = AVAudioPCMBuffer(
                 pcmFormat: targetFormat,
@@ -126,7 +126,13 @@ final class AlwaysOnAudioMonitor: ObservableObject {
             ) else { return }
 
             var error: NSError?
+            var inputConsumed = false
             let status = converter.convert(to: convertedBuffer, error: &error) { _, outStatus in
+                if inputConsumed {
+                    outStatus.pointee = .noDataNow
+                    return nil
+                }
+                inputConsumed = true
                 outStatus.pointee = .haveData
                 return buffer
             }


### PR DESCRIPTION
## Summary
- Fix AVAudioConverter input block to only provide data once (prevents duplicate audio frames)
- Use ceil() for frameCapacity calculation (prevents undersized output buffer)
- Addresses review feedback from PR #8326

Part of #8262
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
