### PR TITLE
Fix: Delivery FK + Telegram plain text

### DIFF
--- a/assistant/src/notifications/adapters/telegram.ts
+++ b/assistant/src/notifications/adapters/telegram.ts
@@ -34,12 +34,11 @@ export class TelegramAdapter implements ChannelAdapter {
     const gatewayBase = getGatewayInternalBaseUrl();
     const deliverUrl = `${gatewayBase}/deliver/telegram`;
 
-    // Format copy for Telegram: bold title followed by body
-    const parts: string[] = [`<b>${escapeHtml(payload.copy.title)}</b>`, '', payload.copy.body];
+    // Format copy for Telegram as plain text (no parse_mode set on gateway side)
+    let messageText = payload.copy.title + '\n\n' + payload.copy.body;
     if (payload.copy.threadTitle) {
-      parts.push('', `Thread: ${payload.copy.threadTitle}`);
+      messageText += '\n\nThread: ' + payload.copy.threadTitle;
     }
-    const messageText = parts.join('\n');
 
     try {
       await deliverChannelReply(
@@ -63,12 +62,4 @@ export class TelegramAdapter implements ChannelAdapter {
       return { success: false, error: message };
     }
   }
-}
-
-/** Escape HTML special characters for Telegram's HTML parse mode. */
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
 }

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -99,10 +99,15 @@ export class NotificationBroadcaster {
       const deliveryId = uuid();
       const destinationLabel = destination.endpoint ?? channel;
 
+      // Use the persisted decision row ID for the FK; fall back to dedupeKey
+      // only if persistence failed (in which case the FK won't resolve, but we
+      // still record the delivery for debugging).
+      const decisionRowId = decision.persistedDecisionId ?? decision.dedupeKey;
+
       try {
         createDelivery({
           id: deliveryId,
-          notificationDecisionId: decision.dedupeKey,
+          notificationDecisionId: decisionRowId,
           assistantId: signal.assistantId,
           channel,
           destination: destinationLabel,

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -264,7 +264,7 @@ export async function evaluateSignal(
   if (!provider) {
     log.warn('Configured provider unavailable for notification decision, using fallback');
     const decision = buildFallbackDecision(signal, availableChannels);
-    persistDecision(signal, decision);
+    decision.persistedDecisionId = persistDecision(signal, decision);
     return decision;
   }
 
@@ -277,7 +277,7 @@ export async function evaluateSignal(
     decision = buildFallbackDecision(signal, availableChannels);
   }
 
-  persistDecision(signal, decision);
+  decision.persistedDecisionId = persistDecision(signal, decision);
 
   if (options?.shadowMode ?? config.notifications.shadowMode) {
     log.info(
@@ -349,10 +349,11 @@ async function classifyWithLLM(
 
 // ── Persistence ────────────────────────────────────────────────────────
 
-function persistDecision(signal: NotificationSignal, decision: NotificationDecision): void {
+function persistDecision(signal: NotificationSignal, decision: NotificationDecision): string | undefined {
   try {
+    const decisionId = uuid();
     createDecision({
-      id: uuid(),
+      id: decisionId,
       notificationEventId: signal.signalId,
       shouldNotify: decision.shouldNotify,
       selectedChannels: decision.selectedChannels,
@@ -366,8 +367,10 @@ function persistDecision(signal: NotificationSignal, decision: NotificationDecis
         hasCopy: Object.keys(decision.renderedCopy).length > 0,
       },
     });
+    return decisionId;
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
     log.warn({ err: errMsg }, 'Failed to persist notification decision');
+    return undefined;
   }
 }

--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -71,4 +71,6 @@ export interface NotificationDecision {
   dedupeKey: string;
   confidence: number;
   fallbackUsed: boolean;
+  /** UUID of the persisted decision row (set after persistence in the decision engine). */
+  persistedDecisionId?: string;
 }


### PR DESCRIPTION
Fix two review issues on #8330: (1) Use persisted decision row ID instead of dedupeKey for delivery FK, (2) Revert Telegram adapter to plain text formatting (remove HTML tags that displayed literally without parse_mode).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
