### PR TITLE
fix: add explicit self. for property captures in PorcupineWakeWordEngine

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/PorcupineWakeWordEngine.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/PorcupineWakeWordEngine.swift
@@ -83,14 +83,14 @@ final class PorcupineWakeWordEngine: WakeWordEngine {
         // 5. Keyword path
         let keywordPath: String
         let keywordDir = resourceURL.appendingPathComponent("porcupine-keywords")
-        let builtinPath = keywordDir.appendingPathComponent(keyword.lowercased() + "_mac.ppn").path
+        let builtinPath = keywordDir.appendingPathComponent(self.keyword.lowercased() + "_mac.ppn").path
         if FileManager.default.fileExists(atPath: builtinPath) {
             keywordPath = builtinPath
-        } else if keyword.hasPrefix("/") && FileManager.default.fileExists(atPath: keyword) {
+        } else if self.keyword.hasPrefix("/") && FileManager.default.fileExists(atPath: self.keyword) {
             // Treat keyword as an absolute path to a custom .ppn file
-            keywordPath = keyword
+            keywordPath = self.keyword
         } else {
-            log.error("Keyword file not found: tried \(builtinPath) and absolute path \(keyword)")
+            log.error("Keyword file not found: tried \(builtinPath) and absolute path \(self.keyword)")
             return
         }
 
@@ -100,7 +100,7 @@ final class PorcupineWakeWordEngine: WakeWordEngine {
                 accessKey: accessKey,
                 modelPath: modelPath,
                 keywordPaths: [keywordPath],
-                sensitivities: [sensitivity]
+                sensitivities: [self.sensitivity]
             )
         } catch {
             log.error("Failed to initialize Porcupine engine: \(error)")


### PR DESCRIPTION
## Summary
- Add explicit `self.` prefix for `keyword` and `sensitivity` property references in `PorcupineWakeWordEngine.start()`
- Swift strict concurrency requires explicit `self.` when capturing properties in closures — `os.Logger` string interpolation creates implicit closures

## Test plan
- [x] Verify the Swift compiler error about closure capture semantics is resolved
- [x] No functional change — only adds explicit `self.` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
