### PR TITLE
fix(swift): restore NWProtocolTCP on Unix socket, keep cancelled reconnect

### DIFF
--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -42,8 +42,8 @@ extension DaemonClient {
         if case .socket(let path) = config.transport {
             log.info("Connecting to daemon socket at \(path, privacy: .public)")
             endpoint = NWEndpoint.unix(path: path)
-            // Unix domain sockets use their own transport; do NOT layer TCP on top.
             parameters = NWParameters()
+            parameters.defaultProtocolStack.transportProtocol = NWProtocolTCP.Options()
         } else if case .tcp(let h, let p, let tls, _) = config.transport {
             log.info("Connecting to daemon at \(h, privacy: .private):\(p, privacy: .public) (tls=\(tls, privacy: .public))")
             endpoint = NWEndpoint.hostPort(host: NWEndpoint.Host(h), port: NWEndpoint.Port(integerLiteral: p))


### PR DESCRIPTION
## Summary

Restores `NWProtocolTCP.Options()` on the Unix domain socket transport in `DaemonConnection.swift`. This was incorrectly removed in #8325 — the TCP protocol options have been part of the IPC implementation since the original PR #499 and have worked in production for years.

The `.cancelled` state reconnect improvement from #8325 is preserved.

## Changes

- Restore `NWProtocolTCP.Options()` assignment for Unix socket connections
- Keep the `.cancelled` → `scheduleReconnect()` fix from #8325

## Why

Removing `NWProtocolTCP.Options()` from Unix sockets may cause IPC connection instability. The original implementation explicitly set TCP options even on Unix sockets, and this has been working reliably in production since the initial IPC implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
