### PR TITLE
Fix: validate conversation exists before renaming

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -358,6 +358,11 @@ export function handleSessionRename(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
+  const conversation = conversationStore.getConversation(msg.sessionId);
+  if (!conversation) {
+    ctx.send(socket, { type: 'error', message: `Session ${msg.sessionId} not found` });
+    return;
+  }
   conversationStore.updateConversationTitle(msg.sessionId, msg.title);
   ctx.send(socket, {
     type: 'session_title_updated',


### PR DESCRIPTION
Address Devin review feedback on #8338. Add existence check for conversation before updating title, matching the pattern used by handleSessionSwitch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
