### PR TITLE
fix: add explicit self in PorcupineWakeWordEngine logger closure

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/PorcupineWakeWordEngine.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/PorcupineWakeWordEngine.swift
@@ -90,7 +90,7 @@ final class PorcupineWakeWordEngine: WakeWordEngine {
             // Treat keyword as an absolute path to a custom .ppn file
             keywordPath = keyword
         } else {
-            log.error("Keyword file not found: tried \(builtinPath) and absolute path \(keyword)")
+            log.error("Keyword file not found: tried \(builtinPath) and absolute path \(self.keyword)")
             return
         }
 


### PR DESCRIPTION
## Summary
- Fixes release build failure caused by missing `self.` prefix on `keyword` property reference inside `os.Logger` string interpolation (which creates an implicit closure context)
- The compiler is stricter about explicit capture semantics in release/universal binary builds

## Test plan
- [x] Reproduced failure locally with `swift build -c release --product vellum-assistant`
- [x] Verified build passes after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
