### PR TITLE
M6: Conversational preference ingestion

### DIFF
--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -235,6 +235,29 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
   session.currentActiveSurfaceId = next.activeSurfaceId;
   session.currentPage = next.currentPage;
 
+  // Fire-and-forget: detect notification preferences in the queued message
+  // and persist any that are found, mirroring the logic in processMessage.
+  if (session.assistantId) {
+    const aid = session.assistantId;
+    extractPreferences(resolvedContent)
+      .then((result) => {
+        if (!result.detected) return;
+        for (const pref of result.preferences) {
+          createPreference({
+            assistantId: aid,
+            preferenceText: pref.preferenceText,
+            appliesWhen: pref.appliesWhen,
+            priority: pref.priority,
+          });
+        }
+        log.info({ count: result.preferences.length, conversationId: session.conversationId }, 'Persisted extracted notification preferences (queued)');
+      })
+      .catch((err) => {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        log.warn({ err: errMsg, conversationId: session.conversationId }, 'Background preference extraction failed (queued)');
+      });
+  }
+
   // Fire-and-forget: persistUserMessage set session.processing = true
   // so subsequent messages will still be enqueued.
   // runAgentLoop's finally block will call drainQueue when this run completes.

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -24,6 +24,8 @@ import {
 import { answerCall } from '../calls/call-domain.js';
 import { resolveSlash, type SlashContext } from './session-slash.js';
 import { getConfig } from '../config/loader.js';
+import { extractPreferences } from '../notifications/preference-extractor.js';
+import { createPreference } from '../notifications/preferences-store.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('session-process');
@@ -68,6 +70,8 @@ export interface ProcessSessionContext {
   readonly usageStats: UsageStats;
   /** Request-scoped skill IDs preactivated via slash resolution. */
   preactivatedSkillIds?: string[];
+  /** Assistant identity — used for scoping notification preferences. */
+  readonly assistantId?: string;
   persistUserMessage(content: string, attachments: UserMessageAttachment[], requestId?: string, metadata?: Record<string, unknown>): string;
   runAgentLoop(
     content: string,
@@ -373,6 +377,30 @@ export async function processMessage(
     // runAgentLoop never ran, so its finally block won't clear this
     session.preactivatedSkillIds = undefined;
     return '';
+  }
+
+  // Fire-and-forget: detect notification preferences in the user message
+  // and persist any that are found. Runs in the background so it doesn't
+  // block the main conversation flow.
+  if (session.assistantId) {
+    const aid = session.assistantId;
+    extractPreferences(resolvedContent)
+      .then((result) => {
+        if (!result.detected) return;
+        for (const pref of result.preferences) {
+          createPreference({
+            assistantId: aid,
+            preferenceText: pref.preferenceText,
+            appliesWhen: pref.appliesWhen,
+            priority: pref.priority,
+          });
+        }
+        log.info({ count: result.preferences.length, conversationId: session.conversationId }, 'Persisted extracted notification preferences');
+      })
+      .catch((err) => {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        log.warn({ err: errMsg, conversationId: session.conversationId }, 'Background preference extraction failed');
+      });
   }
 
   await session.runAgentLoop(resolvedContent, userMessageId, onEvent);

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -1275,6 +1275,21 @@ export function initializeDb(): void {
   migrateNotificationTablesSchema(database);
 
   database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS notification_preferences (
+      id TEXT PRIMARY KEY,
+      assistant_id TEXT NOT NULL,
+      preference_text TEXT NOT NULL,
+      applies_when_json TEXT NOT NULL DEFAULT '{}',
+      priority INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_notification_preferences_assistant_id ON notification_preferences(assistant_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_notification_preferences_assistant_priority ON notification_preferences(assistant_id, priority DESC)`);
+
+  database.run(/*sql*/ `
     CREATE TABLE IF NOT EXISTS notification_events (
       id TEXT PRIMARY KEY,
       assistant_id TEXT NOT NULL,

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -918,6 +918,16 @@ export const notificationDecisions = sqliteTable('notification_decisions', {
   createdAt: integer('created_at').notNull(),
 });
 
+export const notificationPreferences = sqliteTable('notification_preferences', {
+  id: text('id').primaryKey(),
+  assistantId: text('assistant_id').notNull(),
+  preferenceText: text('preference_text').notNull(),
+  appliesWhenJson: text('applies_when_json').notNull().default('{}'),
+  priority: integer('priority').notNull().default(0),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+});
+
 export const notificationDeliveries = sqliteTable('notification_deliveries', {
   id: text('id').primaryKey(),
   notificationDecisionId: text('notification_decision_id')

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -263,7 +263,17 @@ export async function evaluateSignal(
 
   // When no explicit preference context is provided, load the user's
   // stored notification preferences from the memory-backed store.
-  const resolvedPreferenceContext = preferenceContext ?? getPreferenceSummary(signal.assistantId) ?? undefined;
+  // Wrapped in try/catch so a DB failure doesn't break the decision path.
+  let resolvedPreferenceContext = preferenceContext;
+  if (resolvedPreferenceContext === undefined) {
+    try {
+      resolvedPreferenceContext = getPreferenceSummary(signal.assistantId) ?? undefined;
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      log.warn({ err: errMsg, assistantId: signal.assistantId }, 'Failed to load preference summary, proceeding without preferences');
+      resolvedPreferenceContext = undefined;
+    }
+  }
 
   const provider = getConfiguredProvider();
   if (!provider) {

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -14,6 +14,7 @@ import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/provider-send-message.js';
 import { createDecision } from './decisions-store.js';
+import { getPreferenceSummary } from './preference-summary.js';
 import type { NotificationSignal } from './signal.js';
 import type { NotificationChannel, NotificationDecision, RenderedChannelCopy } from './types.js';
 
@@ -260,6 +261,10 @@ export async function evaluateSignal(
   const config = getConfig();
   const decisionModel = config.notifications.decisionModel;
 
+  // When no explicit preference context is provided, load the user's
+  // stored notification preferences from the memory-backed store.
+  const resolvedPreferenceContext = preferenceContext ?? getPreferenceSummary(signal.assistantId) ?? undefined;
+
   const provider = getConfiguredProvider();
   if (!provider) {
     log.warn('Configured provider unavailable for notification decision, using fallback');
@@ -270,7 +275,7 @@ export async function evaluateSignal(
 
   let decision: NotificationDecision;
   try {
-    decision = await classifyWithLLM(signal, availableChannels, preferenceContext, decisionModel);
+    decision = await classifyWithLLM(signal, availableChannels, resolvedPreferenceContext, decisionModel);
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
     log.warn({ err: errMsg }, 'Notification decision LLM call failed, using fallback');

--- a/assistant/src/notifications/preference-extractor.ts
+++ b/assistant/src/notifications/preference-extractor.ts
@@ -1,0 +1,223 @@
+/**
+ * Preference extraction pipeline.
+ *
+ * Detects notification-related user statements in conversation messages
+ * and extracts structured preference data. Uses a small/fast model
+ * (haiku) with a focused prompt for lightweight detection + extraction.
+ *
+ * Examples of statements it should detect:
+ * - "Use Telegram for urgent alerts"
+ * - "Don't notify me on desktop during work calls"
+ * - "Weeknights after 10pm: only critical notifications"
+ */
+
+import { getConfig } from '../config/loader.js';
+import { getLogger } from '../util/logger.js';
+import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/provider-send-message.js';
+import type { AppliesWhenConditions } from './preferences-store.js';
+
+const log = getLogger('notification-preference-extractor');
+
+const EXTRACTION_TIMEOUT_MS = 10_000;
+
+// ── Extraction result ──────────────────────────────────────────────────
+
+export interface ExtractedPreference {
+  preferenceText: string;
+  appliesWhen: AppliesWhenConditions;
+  priority: number;
+}
+
+export interface ExtractionResult {
+  detected: boolean;
+  preferences: ExtractedPreference[];
+}
+
+// ── System prompt ──────────────────────────────────────────────────────
+
+const SYSTEM_PROMPT = `You are a notification preference detector. Given a user message from a conversation, determine if it contains any notification preferences or routing instructions.
+
+Notification preferences are statements about HOW, WHEN, or WHERE the user wants to receive notifications. Examples:
+- "Use Telegram for urgent alerts"
+- "Don't notify me on desktop during work calls"
+- "Weeknights after 10pm: only critical notifications"
+- "Send me everything on macOS"
+- "Only bug me for high priority stuff"
+- "Mute notifications between 11pm and 7am"
+- "I prefer Telegram over desktop notifications"
+
+If the message does NOT contain any notification preferences, respond with the tool setting detected=false and an empty preferences array.
+
+If it DOES contain preferences, extract each one as a separate entry with:
+- preferenceText: the natural language preference as stated
+- appliesWhen: structured conditions (timeRange, channels, urgencyLevels, contexts)
+- priority: 0 for general defaults, 1 for specific overrides, 2 for critical/urgent overrides
+
+You MUST respond using the \`extract_notification_preferences\` tool.`;
+
+// ── Tool definition ────────────────────────────────────────────────────
+
+const EXTRACTION_TOOL = {
+  name: 'extract_notification_preferences',
+  description: 'Extract notification preferences from a user message',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      detected: {
+        type: 'boolean',
+        description: 'Whether the message contains notification preferences',
+      },
+      preferences: {
+        type: 'array',
+        description: 'Array of extracted preferences (empty if detected=false)',
+        items: {
+          type: 'object',
+          properties: {
+            preferenceText: {
+              type: 'string',
+              description: 'The natural language preference as stated by the user',
+            },
+            appliesWhen: {
+              type: 'object',
+              description: 'Structured conditions for when this preference applies',
+              properties: {
+                timeRange: {
+                  type: 'object',
+                  properties: {
+                    after: { type: 'string', description: 'Start time in HH:MM format' },
+                    before: { type: 'string', description: 'End time in HH:MM format' },
+                  },
+                },
+                channels: {
+                  type: 'array',
+                  items: { type: 'string' },
+                  description: 'Channels this preference applies to (e.g. telegram, macos)',
+                },
+                urgencyLevels: {
+                  type: 'array',
+                  items: { type: 'string' },
+                  description: 'Urgency levels this preference applies to (e.g. low, medium, high, critical)',
+                },
+                contexts: {
+                  type: 'array',
+                  items: { type: 'string' },
+                  description: 'Situational contexts (e.g. work_calls, meetings, sleeping)',
+                },
+              },
+            },
+            priority: {
+              type: 'number',
+              description: 'Priority for conflict resolution: 0=general default, 1=specific override, 2=critical override',
+            },
+          },
+          required: ['preferenceText', 'appliesWhen', 'priority'],
+        },
+      },
+    },
+    required: ['detected', 'preferences'],
+  },
+};
+
+// ── Core extraction function ───────────────────────────────────────────
+
+export async function extractPreferences(message: string): Promise<ExtractionResult> {
+  const provider = getConfiguredProvider();
+  if (!provider) {
+    log.debug('No provider available for preference extraction');
+    return { detected: false, preferences: [] };
+  }
+
+  const config = getConfig();
+  const model = config.notifications.decisionModel;
+
+  const { signal, cleanup } = createTimeout(EXTRACTION_TIMEOUT_MS);
+
+  try {
+    const response = await provider.sendMessage(
+      [userMessage(message)],
+      [EXTRACTION_TOOL],
+      SYSTEM_PROMPT,
+      {
+        config: {
+          model,
+          max_tokens: 1024,
+          tool_choice: { type: 'tool' as const, name: 'extract_notification_preferences' },
+        },
+        signal,
+      },
+    );
+    cleanup();
+
+    const toolBlock = extractToolUse(response);
+    if (!toolBlock) {
+      log.debug('No tool_use block in preference extraction response');
+      return { detected: false, preferences: [] };
+    }
+
+    const input = toolBlock.input as Record<string, unknown>;
+    return validateExtractionOutput(input);
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    log.debug({ err: errMsg }, 'Preference extraction failed');
+    return { detected: false, preferences: [] };
+  } finally {
+    cleanup();
+  }
+}
+
+// ── Validation ─────────────────────────────────────────────────────────
+
+function validateExtractionOutput(input: Record<string, unknown>): ExtractionResult {
+  if (typeof input.detected !== 'boolean') {
+    return { detected: false, preferences: [] };
+  }
+
+  if (!input.detected || !Array.isArray(input.preferences)) {
+    return { detected: false, preferences: [] };
+  }
+
+  const preferences: ExtractedPreference[] = [];
+
+  for (const raw of input.preferences) {
+    if (typeof raw !== 'object' || raw === null) continue;
+    const p = raw as Record<string, unknown>;
+
+    if (typeof p.preferenceText !== 'string' || !p.preferenceText.trim()) continue;
+
+    const appliesWhen: AppliesWhenConditions = {};
+    if (p.appliesWhen && typeof p.appliesWhen === 'object') {
+      const aw = p.appliesWhen as Record<string, unknown>;
+      if (aw.timeRange && typeof aw.timeRange === 'object') {
+        const tr = aw.timeRange as Record<string, unknown>;
+        appliesWhen.timeRange = {
+          after: typeof tr.after === 'string' ? tr.after : undefined,
+          before: typeof tr.before === 'string' ? tr.before : undefined,
+        };
+      }
+      if (Array.isArray(aw.channels)) {
+        appliesWhen.channels = aw.channels.filter((c): c is string => typeof c === 'string');
+      }
+      if (Array.isArray(aw.urgencyLevels)) {
+        appliesWhen.urgencyLevels = aw.urgencyLevels.filter((u): u is string => typeof u === 'string');
+      }
+      if (Array.isArray(aw.contexts)) {
+        appliesWhen.contexts = aw.contexts.filter((c): c is string => typeof c === 'string');
+      }
+    }
+
+    const priority = typeof p.priority === 'number'
+      ? Math.max(0, Math.min(2, Math.round(p.priority)))
+      : 0;
+
+    preferences.push({
+      preferenceText: p.preferenceText.trim(),
+      appliesWhen,
+      priority,
+    });
+  }
+
+  return {
+    detected: preferences.length > 0,
+    preferences,
+  };
+}

--- a/assistant/src/notifications/preference-summary.ts
+++ b/assistant/src/notifications/preference-summary.ts
@@ -59,12 +59,12 @@ function sanitizePreferenceText(text: string): string {
 
 /**
  * Safely convert and sanitize a value to a string.
- * If the value is already a string, sanitizes it with sanitizePreferenceText.
- * If it's not a string, coerces it to a string without sanitization.
- * This handles legacy or manually inserted JSON that may contain non-string values.
+ * Coerces to string first (if needed) then sanitizes with sanitizePreferenceText.
+ * This ensures all values are sanitized regardless of their original type,
+ * preventing prompt injection via coerced types.
  */
 function safeString(value: unknown): string {
-  return typeof value === 'string' ? sanitizePreferenceText(value) : String(value ?? '');
+  return sanitizePreferenceText(typeof value === 'string' ? value : String(value ?? ''));
 }
 
 // ── Condition formatting ────────────────────────────────────────────────

--- a/assistant/src/notifications/preference-summary.ts
+++ b/assistant/src/notifications/preference-summary.ts
@@ -29,20 +29,32 @@ export function getPreferenceSummary(assistantId: string): string | null {
   ];
 
   for (const pref of preferences) {
+    const safeText = sanitizePreferenceText(pref.preferenceText);
     const conditionStr = formatConditions(pref.appliesWhenJson);
     const priorityLabel = pref.priority >= 2 ? 'CRITICAL' : pref.priority === 1 ? 'override' : 'default';
     const prefix = `[${priorityLabel}]`;
 
     if (conditionStr) {
-      lines.push(`${prefix} "${pref.preferenceText}" (when: ${conditionStr})`);
+      lines.push(`${prefix} "${safeText}" (when: ${conditionStr})`);
     } else {
-      lines.push(`${prefix} "${pref.preferenceText}"`);
+      lines.push(`${prefix} "${safeText}"`);
     }
   }
 
   log.debug({ count: preferences.length }, 'Built preference summary');
 
   return lines.join('\n');
+}
+
+// ── Text sanitization ───────────────────────────────────────────────────
+
+/**
+ * Strip XML/HTML-like tags from preference text to prevent prompt injection.
+ * Replaces angle brackets with harmless unicode equivalents so user-authored
+ * text cannot break the `<user-preferences>` framing in the system prompt.
+ */
+function sanitizePreferenceText(text: string): string {
+  return text.replace(/</g, '\uFF1C').replace(/>/g, '\uFF1E');
 }
 
 // ── Condition formatting ────────────────────────────────────────────────

--- a/assistant/src/notifications/preference-summary.ts
+++ b/assistant/src/notifications/preference-summary.ts
@@ -57,6 +57,16 @@ function sanitizePreferenceText(text: string): string {
   return text.replace(/</g, '\uFF1C').replace(/>/g, '\uFF1E');
 }
 
+/**
+ * Safely convert and sanitize a value to a string.
+ * If the value is already a string, sanitizes it with sanitizePreferenceText.
+ * If it's not a string, coerces it to a string without sanitization.
+ * This handles legacy or manually inserted JSON that may contain non-string values.
+ */
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? sanitizePreferenceText(value) : String(value ?? '');
+}
+
 // ── Condition formatting ────────────────────────────────────────────────
 
 function formatConditions(appliesWhenJson: string): string {
@@ -73,8 +83,8 @@ function formatConditions(appliesWhenJson: string): string {
   const parts: string[] = [];
 
   if (conditions.timeRange) {
-    const after = conditions.timeRange.after ? sanitizePreferenceText(conditions.timeRange.after) : '';
-    const before = conditions.timeRange.before ? sanitizePreferenceText(conditions.timeRange.before) : '';
+    const after = conditions.timeRange.after ? safeString(conditions.timeRange.after) : '';
+    const before = conditions.timeRange.before ? safeString(conditions.timeRange.before) : '';
     if (after && before) {
       parts.push(`${after}-${before}`);
     } else if (after) {
@@ -85,15 +95,15 @@ function formatConditions(appliesWhenJson: string): string {
   }
 
   if (conditions.channels && conditions.channels.length > 0) {
-    parts.push(`channels: ${conditions.channels.map(sanitizePreferenceText).join(', ')}`);
+    parts.push(`channels: ${conditions.channels.map(safeString).join(', ')}`);
   }
 
   if (conditions.urgencyLevels && conditions.urgencyLevels.length > 0) {
-    parts.push(`urgency: ${conditions.urgencyLevels.map(sanitizePreferenceText).join(', ')}`);
+    parts.push(`urgency: ${conditions.urgencyLevels.map(safeString).join(', ')}`);
   }
 
   if (conditions.contexts && conditions.contexts.length > 0) {
-    parts.push(`context: ${conditions.contexts.map(sanitizePreferenceText).join(', ')}`);
+    parts.push(`context: ${conditions.contexts.map(safeString).join(', ')}`);
   }
 
   return parts.join('; ');

--- a/assistant/src/notifications/preference-summary.ts
+++ b/assistant/src/notifications/preference-summary.ts
@@ -73,7 +73,8 @@ function formatConditions(appliesWhenJson: string): string {
   const parts: string[] = [];
 
   if (conditions.timeRange) {
-    const { after, before } = conditions.timeRange;
+    const after = conditions.timeRange.after ? sanitizePreferenceText(conditions.timeRange.after) : '';
+    const before = conditions.timeRange.before ? sanitizePreferenceText(conditions.timeRange.before) : '';
     if (after && before) {
       parts.push(`${after}-${before}`);
     } else if (after) {
@@ -84,15 +85,15 @@ function formatConditions(appliesWhenJson: string): string {
   }
 
   if (conditions.channels && conditions.channels.length > 0) {
-    parts.push(`channels: ${conditions.channels.join(', ')}`);
+    parts.push(`channels: ${conditions.channels.map(sanitizePreferenceText).join(', ')}`);
   }
 
   if (conditions.urgencyLevels && conditions.urgencyLevels.length > 0) {
-    parts.push(`urgency: ${conditions.urgencyLevels.join(', ')}`);
+    parts.push(`urgency: ${conditions.urgencyLevels.map(sanitizePreferenceText).join(', ')}`);
   }
 
   if (conditions.contexts && conditions.contexts.length > 0) {
-    parts.push(`context: ${conditions.contexts.join(', ')}`);
+    parts.push(`context: ${conditions.contexts.map(sanitizePreferenceText).join(', ')}`);
   }
 
   return parts.join('; ');

--- a/assistant/src/notifications/preference-summary.ts
+++ b/assistant/src/notifications/preference-summary.ts
@@ -1,0 +1,87 @@
+/**
+ * Preference summary retriever.
+ *
+ * Builds a compact "notification preference summary" string for inclusion
+ * in the decision engine's system prompt. Fetches all stored preferences
+ * for an assistant and merges them into a coherent block that the LLM
+ * can interpret when making routing decisions.
+ */
+
+import { getLogger } from '../util/logger.js';
+import { listPreferences } from './preferences-store.js';
+import type { AppliesWhenConditions } from './preferences-store.js';
+
+const log = getLogger('notification-preference-summary');
+
+/**
+ * Build a compact preference summary for inclusion in the decision engine
+ * system prompt. Returns null if no preferences are stored.
+ */
+export function getPreferenceSummary(assistantId: string): string | null {
+  const preferences = listPreferences(assistantId);
+
+  if (preferences.length === 0) {
+    return null;
+  }
+
+  const lines: string[] = [
+    'The user has set the following notification preferences (ordered by priority, highest first):',
+  ];
+
+  for (const pref of preferences) {
+    const conditionStr = formatConditions(pref.appliesWhenJson);
+    const priorityLabel = pref.priority >= 2 ? 'CRITICAL' : pref.priority === 1 ? 'override' : 'default';
+    const prefix = `[${priorityLabel}]`;
+
+    if (conditionStr) {
+      lines.push(`${prefix} "${pref.preferenceText}" (when: ${conditionStr})`);
+    } else {
+      lines.push(`${prefix} "${pref.preferenceText}"`);
+    }
+  }
+
+  log.debug({ count: preferences.length }, 'Built preference summary');
+
+  return lines.join('\n');
+}
+
+// ── Condition formatting ────────────────────────────────────────────────
+
+function formatConditions(appliesWhenJson: string): string {
+  let conditions: AppliesWhenConditions;
+  try {
+    conditions = JSON.parse(appliesWhenJson);
+  } catch {
+    return '';
+  }
+
+  // Skip empty condition objects
+  if (!conditions || typeof conditions !== 'object') return '';
+
+  const parts: string[] = [];
+
+  if (conditions.timeRange) {
+    const { after, before } = conditions.timeRange;
+    if (after && before) {
+      parts.push(`${after}-${before}`);
+    } else if (after) {
+      parts.push(`after ${after}`);
+    } else if (before) {
+      parts.push(`before ${before}`);
+    }
+  }
+
+  if (conditions.channels && conditions.channels.length > 0) {
+    parts.push(`channels: ${conditions.channels.join(', ')}`);
+  }
+
+  if (conditions.urgencyLevels && conditions.urgencyLevels.length > 0) {
+    parts.push(`urgency: ${conditions.urgencyLevels.join(', ')}`);
+  }
+
+  if (conditions.contexts && conditions.contexts.length > 0) {
+    parts.push(`context: ${conditions.contexts.join(', ')}`);
+  }
+
+  return parts.join('; ');
+}

--- a/assistant/src/notifications/preferences-store.ts
+++ b/assistant/src/notifications/preferences-store.ts
@@ -1,0 +1,142 @@
+/**
+ * CRUD operations for notification preferences.
+ *
+ * Each row stores a natural-language notification preference expressed by
+ * the user (e.g. "Use Telegram for urgent alerts"), along with structured
+ * conditions for when the preference applies and a priority for conflict
+ * resolution.
+ */
+
+import { and, desc, eq } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+import { getDb } from '../memory/db.js';
+import { notificationPreferences } from '../memory/schema.js';
+
+// ── Row type ────────────────────────────────────────────────────────────
+
+export interface NotificationPreferenceRow {
+  id: string;
+  assistantId: string;
+  preferenceText: string;
+  appliesWhenJson: string; // serialised JSON
+  priority: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+function rowToPreference(row: typeof notificationPreferences.$inferSelect): NotificationPreferenceRow {
+  return {
+    id: row.id,
+    assistantId: row.assistantId,
+    preferenceText: row.preferenceText,
+    appliesWhenJson: row.appliesWhenJson,
+    priority: row.priority,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+// ── Structured conditions type ──────────────────────────────────────────
+
+export interface AppliesWhenConditions {
+  timeRange?: { after?: string; before?: string }; // e.g. "22:00", "06:00"
+  channels?: string[];        // e.g. ["telegram", "macos"]
+  urgencyLevels?: string[];   // e.g. ["high", "critical"]
+  contexts?: string[];        // e.g. ["work_calls", "meetings"]
+  [key: string]: unknown;
+}
+
+// ── Create ──────────────────────────────────────────────────────────────
+
+export interface CreatePreferenceParams {
+  assistantId: string;
+  preferenceText: string;
+  appliesWhen?: AppliesWhenConditions;
+  priority?: number;
+}
+
+export function createPreference(params: CreatePreferenceParams): NotificationPreferenceRow {
+  const db = getDb();
+  const now = Date.now();
+
+  const row = {
+    id: uuid(),
+    assistantId: params.assistantId,
+    preferenceText: params.preferenceText,
+    appliesWhenJson: JSON.stringify(params.appliesWhen ?? {}),
+    priority: params.priority ?? 0,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  db.insert(notificationPreferences).values(row).run();
+
+  return row;
+}
+
+// ── List ────────────────────────────────────────────────────────────────
+
+export function listPreferences(assistantId: string): NotificationPreferenceRow[] {
+  const db = getDb();
+
+  const rows = db
+    .select()
+    .from(notificationPreferences)
+    .where(eq(notificationPreferences.assistantId, assistantId))
+    .orderBy(desc(notificationPreferences.priority))
+    .all();
+
+  return rows.map(rowToPreference);
+}
+
+// ── Update ──────────────────────────────────────────────────────────────
+
+export interface UpdatePreferenceParams {
+  preferenceText?: string;
+  appliesWhen?: AppliesWhenConditions;
+  priority?: number;
+}
+
+export function updatePreference(id: string, params: UpdatePreferenceParams): boolean {
+  const db = getDb();
+  const now = Date.now();
+
+  const updates: Record<string, unknown> = { updatedAt: now };
+  if (params.preferenceText !== undefined) updates.preferenceText = params.preferenceText;
+  if (params.appliesWhen !== undefined) updates.appliesWhenJson = JSON.stringify(params.appliesWhen);
+  if (params.priority !== undefined) updates.priority = params.priority;
+
+  const result = db
+    .update(notificationPreferences)
+    .set(updates)
+    .where(eq(notificationPreferences.id, id))
+    .run() as unknown as { changes?: number };
+
+  return (result.changes ?? 0) > 0;
+}
+
+// ── Delete ──────────────────────────────────────────────────────────────
+
+export function deletePreference(id: string): boolean {
+  const db = getDb();
+
+  const result = db
+    .delete(notificationPreferences)
+    .where(eq(notificationPreferences.id, id))
+    .run() as unknown as { changes?: number };
+
+  return (result.changes ?? 0) > 0;
+}
+
+// ── Get by ID ───────────────────────────────────────────────────────────
+
+export function getPreferenceById(id: string): NotificationPreferenceRow | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(notificationPreferences)
+    .where(eq(notificationPreferences.id, id))
+    .get();
+  if (!row) return null;
+  return rowToPreference(row);
+}


### PR DESCRIPTION
Add conversational notification preference system: preference extractor (LLM-powered detection), preferences store (Drizzle CRUD), preference summary retriever, and wire into decision engine. Users can set notification preferences naturally in conversation. Closes #8289.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8343" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
