### PR TITLE
fix: resolve CI failures blocking v0.3.7 release

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -1,8 +1,8 @@
 /**
  * Optional HTTP server that exposes the canonical runtime API.
  *
- * Runs in the same process as the daemon. Started only when
- * `RUNTIME_HTTP_PORT` is set (default: disabled).
+ * Runs in the same process as the daemon. Always started on the
+ * configured port (default: 7821).
  */
 
 import { existsSync, readFileSync } from 'node:fs';
@@ -77,6 +77,7 @@ import type { BrowserRelayWebSocketData } from '../browser-extension-relay/serve
 import { handleSubscribeAssistantEvents } from './routes/events-routes.js';
 import { consumeCallback, consumeCallbackError } from '../security/oauth-callback-registry.js';
 import { PairingStore } from '../daemon/pairing-store.js';
+import type { ServerMessage } from '../daemon/ipc-contract.js';
 
 // Middleware
 import {
@@ -152,7 +153,7 @@ export class RuntimeHttpServer {
   private retrySweepTimer: ReturnType<typeof setInterval> | null = null;
   private sweepInProgress = false;
   private pairingStore = new PairingStore();
-  private pairingBroadcast?: (msg: { type: string; [key: string]: unknown }) => void;
+  private pairingBroadcast?: (msg: ServerMessage) => void;
 
   constructor(options: RuntimeHttpServerOptions = {}) {
     this.port = options.port ?? DEFAULT_PORT;
@@ -177,7 +178,7 @@ export class RuntimeHttpServer {
   }
 
   /** Set a callback for broadcasting IPC messages (wired by daemon server). */
-  setPairingBroadcast(fn: (msg: { type: string; [key: string]: unknown }) => void): void {
+  setPairingBroadcast(fn: (msg: ServerMessage) => void): void {
     this.pairingBroadcast = fn;
   }
 

--- a/assistant/src/runtime/routes/pairing-routes.ts
+++ b/assistant/src/runtime/routes/pairing-routes.ts
@@ -9,13 +9,14 @@ import {
   refreshDevice,
   hashDeviceId,
 } from '../../daemon/approved-devices-store.js';
+import type { ServerMessage } from '../../daemon/ipc-contract.js';
 
 const log = getLogger('runtime-http');
 
 export interface PairingHandlerContext {
   pairingStore: PairingStore;
   bearerToken: string | undefined;
-  pairingBroadcast?: (msg: { type: string; [key: string]: unknown }) => void;
+  pairingBroadcast?: (msg: ServerMessage) => void;
 }
 
 /**

--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/PorcupineWakeWordEngine.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/PorcupineWakeWordEngine.swift
@@ -90,7 +90,7 @@ final class PorcupineWakeWordEngine: WakeWordEngine {
             // Treat keyword as an absolute path to a custom .ppn file
             keywordPath = keyword
         } else {
-            log.error("Keyword file not found: tried \(builtinPath) and absolute path \(keyword)")
+            log.error("Keyword file not found: tried \(builtinPath) and absolute path \(self.keyword)")
             return
         }
 

--- a/gateway/src/http/routes/whatsapp-deliver.test.ts
+++ b/gateway/src/http/routes/whatsapp-deliver.test.ts
@@ -275,7 +275,7 @@ describe("/deliver/whatsapp", () => {
 
   it("returns 502 when sendWhatsAppReply throws", async () => {
     // Override the mock to throw
-    const throwingMock = mock.module("../../whatsapp/send.js", () => ({
+    const _throwingMock = mock.module("../../whatsapp/send.js", () => ({
       sendWhatsAppReply: async () => {
         throw new Error("WhatsApp API failure");
       },
@@ -307,7 +307,7 @@ describe("/deliver/whatsapp", () => {
     expect(res.status).toBe(200);
 
     expect(sendWhatsAppReplyCalls).toHaveLength(1);
-    const [config, to, text] = sendWhatsAppReplyCalls[0] as [GatewayConfig, string, string];
+    const [_config, to, text] = sendWhatsAppReplyCalls[0] as [GatewayConfig, string, string];
     expect(to).toBe("+15559876543");
     expect(text).toBe("Test message");
   });


### PR DESCRIPTION
## Summary

Fixes three CI failures that caused the v0.3.7 release to fail:

1. **ci-assistant (TypeScript)**: `setPairingBroadcast` callback used loose `{ type: string; [key: string]: unknown }` type which isn't assignable to `ServerMessage`. Changed to use proper `ServerMessage` type.

2. **ci-gateway (Lint)**: Two unused variables in `whatsapp-deliver.test.ts` — prefixed with `_` per ESLint convention.

3. **build-macos (Swift)**: `PorcupineWakeWordEngine.swift` — missing explicit `self.` for `keyword` property reference in closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
