### PR TITLE
Fix: Preference extraction wiring + hardening

### DIFF
--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -24,6 +24,8 @@ import {
 import { answerCall } from '../calls/call-domain.js';
 import { resolveSlash, type SlashContext } from './session-slash.js';
 import { getConfig } from '../config/loader.js';
+import { extractPreferences } from '../notifications/preference-extractor.js';
+import { createPreference } from '../notifications/preferences-store.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('session-process');
@@ -68,6 +70,8 @@ export interface ProcessSessionContext {
   readonly usageStats: UsageStats;
   /** Request-scoped skill IDs preactivated via slash resolution. */
   preactivatedSkillIds?: string[];
+  /** Assistant identity — used for scoping notification preferences. */
+  readonly assistantId?: string;
   persistUserMessage(content: string, attachments: UserMessageAttachment[], requestId?: string, metadata?: Record<string, unknown>): string;
   runAgentLoop(
     content: string,
@@ -373,6 +377,30 @@ export async function processMessage(
     // runAgentLoop never ran, so its finally block won't clear this
     session.preactivatedSkillIds = undefined;
     return '';
+  }
+
+  // Fire-and-forget: detect notification preferences in the user message
+  // and persist any that are found. Runs in the background so it doesn't
+  // block the main conversation flow.
+  if (session.assistantId) {
+    const aid = session.assistantId;
+    extractPreferences(resolvedContent)
+      .then((result) => {
+        if (!result.detected) return;
+        for (const pref of result.preferences) {
+          createPreference({
+            assistantId: aid,
+            preferenceText: pref.preferenceText,
+            appliesWhen: pref.appliesWhen,
+            priority: pref.priority,
+          });
+        }
+        log.info({ count: result.preferences.length, conversationId: session.conversationId }, 'Persisted extracted notification preferences');
+      })
+      .catch((err) => {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        log.warn({ err: errMsg, conversationId: session.conversationId }, 'Background preference extraction failed');
+      });
   }
 
   await session.runAgentLoop(resolvedContent, userMessageId, onEvent);

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -263,7 +263,17 @@ export async function evaluateSignal(
 
   // When no explicit preference context is provided, load the user's
   // stored notification preferences from the memory-backed store.
-  const resolvedPreferenceContext = preferenceContext ?? getPreferenceSummary(signal.assistantId) ?? undefined;
+  // Wrapped in try/catch so a DB failure doesn't break the decision path.
+  let resolvedPreferenceContext = preferenceContext;
+  if (resolvedPreferenceContext === undefined) {
+    try {
+      resolvedPreferenceContext = getPreferenceSummary(signal.assistantId) ?? undefined;
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      log.warn({ err: errMsg, assistantId: signal.assistantId }, 'Failed to load preference summary, proceeding without preferences');
+      resolvedPreferenceContext = undefined;
+    }
+  }
 
   const provider = getConfiguredProvider();
   if (!provider) {

--- a/assistant/src/notifications/preference-summary.ts
+++ b/assistant/src/notifications/preference-summary.ts
@@ -29,20 +29,32 @@ export function getPreferenceSummary(assistantId: string): string | null {
   ];
 
   for (const pref of preferences) {
+    const safeText = sanitizePreferenceText(pref.preferenceText);
     const conditionStr = formatConditions(pref.appliesWhenJson);
     const priorityLabel = pref.priority >= 2 ? 'CRITICAL' : pref.priority === 1 ? 'override' : 'default';
     const prefix = `[${priorityLabel}]`;
 
     if (conditionStr) {
-      lines.push(`${prefix} "${pref.preferenceText}" (when: ${conditionStr})`);
+      lines.push(`${prefix} "${safeText}" (when: ${conditionStr})`);
     } else {
-      lines.push(`${prefix} "${pref.preferenceText}"`);
+      lines.push(`${prefix} "${safeText}"`);
     }
   }
 
   log.debug({ count: preferences.length }, 'Built preference summary');
 
   return lines.join('\n');
+}
+
+// ── Text sanitization ───────────────────────────────────────────────────
+
+/**
+ * Strip XML/HTML-like tags from preference text to prevent prompt injection.
+ * Replaces angle brackets with harmless unicode equivalents so user-authored
+ * text cannot break the `<user-preferences>` framing in the system prompt.
+ */
+function sanitizePreferenceText(text: string): string {
+  return text.replace(/</g, '\uFF1C').replace(/>/g, '\uFF1E');
 }
 
 // ── Condition formatting ────────────────────────────────────────────────


### PR DESCRIPTION
Fix three review issues on #8343: (1) Wire extractPreferences into conversation message handler so preferences are actually detected and stored, (2) Wrap getPreferenceSummary in try/catch for fail-open behavior in decision engine, (3) Sanitize preference text before prompt insertion to prevent injection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
