### PR TITLE
M2: Add rename option to macOS thread context menu UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -21,6 +21,8 @@ struct MainWindowView: View {
     @State private var isHoveredApp: String?
     @State private var requestedHomeBaseAtLaunch = false
     @State private var threadPendingDeletion: UUID?
+    @State private var renamingThreadId: UUID?
+    @State private var renameText: String = ""
     @State private var showAllThreads: Bool = false
     @State private var showAllScheduleThreads: Bool = false
     @State private var showAllApps: Bool = false
@@ -910,6 +912,12 @@ struct MainWindowView: View {
             } label: {
                 Label(thread.isPinned ? "Unpin" : "Pin to Top", systemImage: thread.isPinned ? "pin.slash" : "pin")
             }
+            Button {
+                renamingThreadId = thread.id
+                renameText = thread.title
+            } label: {
+                Label("Rename", systemImage: "pencil")
+            }
             if threadManager.visibleThreads.count > 1 {
                 Button {
                     threadManager.archiveThread(id: thread.id)
@@ -971,6 +979,28 @@ struct MainWindowView: View {
         .background(adaptiveColor(light: Moss._50, dark: Moss._950))
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         .clipped()
+        .alert("Rename Thread", isPresented: Binding(
+            get: { renamingThreadId != nil },
+            set: { if !$0 { renamingThreadId = nil } }
+        )) {
+            TextField("Title", text: $renameText)
+            Button("Cancel", role: .cancel) { renamingThreadId = nil }
+            Button("Save") {
+                if let id = renamingThreadId, !renameText.isEmpty {
+                    threadManager.updateThreadTitle(id: id, title: renameText)
+                    if let sessionId = threadManager.threads.first(where: { $0.id == id })?.sessionId {
+                        try? daemonClient.send(IPCSessionRenameRequest(
+                            type: "session_rename",
+                            sessionId: sessionId,
+                            title: renameText
+                        ))
+                    }
+                }
+                renamingThreadId = nil
+            }
+        } message: {
+            Text("Enter a new name for this thread")
+        }
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -912,11 +912,13 @@ struct MainWindowView: View {
             } label: {
                 Label(thread.isPinned ? "Unpin" : "Pin to Top", systemImage: thread.isPinned ? "pin.slash" : "pin")
             }
-            Button {
-                renamingThreadId = thread.id
-                renameText = thread.title
-            } label: {
-                Label("Rename", systemImage: "pencil")
+            if thread.sessionId != nil {
+                Button {
+                    renamingThreadId = thread.id
+                    renameText = thread.title
+                } label: {
+                    Label("Rename", systemImage: "pencil")
+                }
             }
             if threadManager.visibleThreads.count > 1 {
                 Button {


### PR DESCRIPTION
Add a Rename option to the right-click context menu on conversation threads. Shows a SwiftUI alert with a TextField for editing the title. Persists via session_rename IPC message to daemon. Part of #8334.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
