### PR TITLE
feat(macos): add Restart menu item to status bar menu

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -283,6 +283,11 @@ extension AppDelegate {
         menu.addItem(galleryItem)
         #endif
 
+        let restartItem = NSMenuItem(title: "Restart", action: #selector(performRestart), keyEquivalent: "")
+        restartItem.target = self
+        restartItem.image = NSImage(systemSymbolName: "arrow.clockwise", accessibilityDescription: nil)
+        menu.addItem(restartItem)
+
         menu.addItem(NSMenuItem.separator())
 
         let logoutItem = NSMenuItem(title: "Sign Out", action: #selector(performLogout), keyEquivalent: "")

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -379,6 +379,21 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         authWindow = window
     }
 
+    @objc func performRestart() {
+        // Stop daemon before relaunch
+        assistantCli.stop()
+
+        // Launch a fresh instance then quit
+        let bundleURL = Bundle.main.bundleURL
+        let config = NSWorkspace.OpenConfiguration()
+        config.createsNewApplicationInstance = true
+        NSWorkspace.shared.openApplication(at: bundleURL, configuration: config) { _, _ in
+            DispatchQueue.main.async {
+                NSApp.terminate(nil)
+            }
+        }
+    }
+
     @objc func performLogout() {
         Task {
             await authManager.logout()

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -380,15 +380,16 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc func performRestart() {
-        // Stop daemon before relaunch
-        assistantCli.stop()
-
-        // Launch a fresh instance then quit
         let bundleURL = Bundle.main.bundleURL
         let config = NSWorkspace.OpenConfiguration()
         config.createsNewApplicationInstance = true
-        NSWorkspace.shared.openApplication(at: bundleURL, configuration: config) { _, _ in
+        NSWorkspace.shared.openApplication(at: bundleURL, configuration: config) { [weak self] _, error in
+            if let error {
+                log.error("Restart failed — could not launch new instance: \(error.localizedDescription)")
+                return
+            }
             DispatchQueue.main.async {
+                self?.assistantCli.stop()
                 NSApp.terminate(nil)
             }
         }


### PR DESCRIPTION
## Summary
- Add `performRestart()` method to AppDelegate that stops the daemon, launches a fresh instance via NSWorkspace, and terminates the current one
- Add "Restart" menu item (with `arrow.clockwise` icon) to the status bar context menu, positioned before Sign Out

## Original prompt
Create a fresh branch from `origin/main` with the restart capability extracted from `feature/qa-video-automation`. The restart feature is ~16 lines across 2 files — a new `performRestart()` method and a menu item wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
