### PR TITLE
fix: broadcast pairing approval to HTTP/SSE clients

### DIFF
--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -123,7 +123,9 @@ export class AssistantEventHub {
     for (const entry of snapshot) {
       if (!entry.active) continue;
       if (entry.filter.assistantId !== event.assistantId) continue;
-      if (entry.filter.sessionId != null && entry.filter.sessionId !== event.sessionId) continue;
+      // System events (no sessionId) match all subscribers; scoped events
+      // must match the subscriber's sessionId filter when present.
+      if (event.sessionId != null && entry.filter.sessionId != null && entry.filter.sessionId !== event.sessionId) continue;
       try {
         await entry.callback(event);
       } catch (err) {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -78,6 +78,8 @@ import { handleSubscribeAssistantEvents } from './routes/events-routes.js';
 import { consumeCallback, consumeCallbackError } from '../security/oauth-callback-registry.js';
 import { PairingStore } from '../daemon/pairing-store.js';
 import type { ServerMessage } from '../daemon/ipc-contract.js';
+import { assistantEventHub } from './assistant-event-hub.js';
+import { buildAssistantEvent } from './assistant-event.js';
 
 // Middleware
 import {
@@ -183,10 +185,19 @@ export class RuntimeHttpServer {
   }
 
   private get pairingContext(): PairingHandlerContext {
+    const ipcBroadcast = this.pairingBroadcast;
     return {
       pairingStore: this.pairingStore,
       bearerToken: this.bearerToken,
-      pairingBroadcast: this.pairingBroadcast,
+      pairingBroadcast: ipcBroadcast
+        ? (msg) => {
+            // Broadcast to IPC socket clients (local Unix socket)
+            ipcBroadcast(msg);
+            // Also publish to the event hub so HTTP/SSE clients (e.g. macOS
+            // app with localHttpEnabled) receive pairing approval requests.
+            void assistantEventHub.publish(buildAssistantEvent('self', msg));
+          }
+        : undefined,
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes pairing approval prompt never appearing on macOS when the app uses HTTP transport (`localHttpEnabled` flag or `.env` with `VELLUM_FLAG_LOCAL_HTTP_ENABLED=1`).

**Root cause:** The macOS app connects to the daemon via HTTP/SSE (not Unix domain socket) when `localHttpEnabled` is on. Pairing approval requests were only broadcast to IPC socket clients via `server.broadcast()`, so HTTP-connected clients never received the `pairing_approval_request` message.

## Changes

### `assistant/src/runtime/http-server.ts`
- The `pairingContext` getter now wraps the pairing broadcast callback to publish events to both IPC sockets AND the `AssistantEventHub` (with `assistantId: 'self'`), so SSE-connected clients receive pairing approval requests.

### `assistant/src/runtime/assistant-event-hub.ts`
- Modified the session filter in `publish()`: events without a `sessionId` (system events like pairing) now pass through to all matching subscribers regardless of their session filter. Previously, a subscriber with `sessionId: 'sess_A'` would reject events without a sessionId.

## Testing
- Build with `VELLUM_FLAG_LOCAL_HTTP_ENABLED=1 ./build.sh run`
- Show QR code, scan with iOS
- Mac should now show the pairing approval prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
