### PR TITLE
Fix: Complete sanitization + queued preference extraction

### DIFF
--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -235,6 +235,29 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
   session.currentActiveSurfaceId = next.activeSurfaceId;
   session.currentPage = next.currentPage;
 
+  // Fire-and-forget: detect notification preferences in the queued message
+  // and persist any that are found, mirroring the logic in processMessage.
+  if (session.assistantId) {
+    const aid = session.assistantId;
+    extractPreferences(resolvedContent)
+      .then((result) => {
+        if (!result.detected) return;
+        for (const pref of result.preferences) {
+          createPreference({
+            assistantId: aid,
+            preferenceText: pref.preferenceText,
+            appliesWhen: pref.appliesWhen,
+            priority: pref.priority,
+          });
+        }
+        log.info({ count: result.preferences.length, conversationId: session.conversationId }, 'Persisted extracted notification preferences (queued)');
+      })
+      .catch((err) => {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        log.warn({ err: errMsg, conversationId: session.conversationId }, 'Background preference extraction failed (queued)');
+      });
+  }
+
   // Fire-and-forget: persistUserMessage set session.processing = true
   // so subsequent messages will still be enqueued.
   // runAgentLoop's finally block will call drainQueue when this run completes.

--- a/assistant/src/notifications/preference-summary.ts
+++ b/assistant/src/notifications/preference-summary.ts
@@ -73,7 +73,8 @@ function formatConditions(appliesWhenJson: string): string {
   const parts: string[] = [];
 
   if (conditions.timeRange) {
-    const { after, before } = conditions.timeRange;
+    const after = conditions.timeRange.after ? sanitizePreferenceText(conditions.timeRange.after) : '';
+    const before = conditions.timeRange.before ? sanitizePreferenceText(conditions.timeRange.before) : '';
     if (after && before) {
       parts.push(`${after}-${before}`);
     } else if (after) {
@@ -84,15 +85,15 @@ function formatConditions(appliesWhenJson: string): string {
   }
 
   if (conditions.channels && conditions.channels.length > 0) {
-    parts.push(`channels: ${conditions.channels.join(', ')}`);
+    parts.push(`channels: ${conditions.channels.map(sanitizePreferenceText).join(', ')}`);
   }
 
   if (conditions.urgencyLevels && conditions.urgencyLevels.length > 0) {
-    parts.push(`urgency: ${conditions.urgencyLevels.join(', ')}`);
+    parts.push(`urgency: ${conditions.urgencyLevels.map(sanitizePreferenceText).join(', ')}`);
   }
 
   if (conditions.contexts && conditions.contexts.length > 0) {
-    parts.push(`context: ${conditions.contexts.join(', ')}`);
+    parts.push(`context: ${conditions.contexts.map(sanitizePreferenceText).join(', ')}`);
   }
 
   return parts.join('; ');


### PR DESCRIPTION
Fix two review issues on #8345: (1) Apply sanitization to all condition field values in formatConditions to close prompt injection vector, (2) Add preference extraction to queued message processing path so preferences are captured regardless of message timing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
