### PR TITLE
Fix: only show rename for threads with sessionId

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -912,11 +912,13 @@ struct MainWindowView: View {
             } label: {
                 Label(thread.isPinned ? "Unpin" : "Pin to Top", systemImage: thread.isPinned ? "pin.slash" : "pin")
             }
-            Button {
-                renamingThreadId = thread.id
-                renameText = thread.title
-            } label: {
-                Label("Rename", systemImage: "pencil")
+            if thread.sessionId != nil {
+                Button {
+                    renamingThreadId = thread.id
+                    renameText = thread.title
+                } label: {
+                    Label("Rename", systemImage: "pencil")
+                }
             }
             if threadManager.visibleThreads.count > 1 {
                 Button {


### PR DESCRIPTION
Address Devin review feedback on #8346. Only show the Rename context menu option when the thread has a sessionId, ensuring the rename will always be persisted to the daemon.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
