### PR TITLE
Fix: Sanitize coerced safeString values

### DIFF
--- a/assistant/src/notifications/preference-summary.ts
+++ b/assistant/src/notifications/preference-summary.ts
@@ -59,12 +59,12 @@ function sanitizePreferenceText(text: string): string {
 
 /**
  * Safely convert and sanitize a value to a string.
- * If the value is already a string, sanitizes it with sanitizePreferenceText.
- * If it's not a string, coerces it to a string without sanitization.
- * This handles legacy or manually inserted JSON that may contain non-string values.
+ * Coerces to string first (if needed) then sanitizes with sanitizePreferenceText.
+ * This ensures all values are sanitized regardless of their original type,
+ * preventing prompt injection via coerced types.
  */
 function safeString(value: unknown): string {
-  return typeof value === 'string' ? sanitizePreferenceText(value) : String(value ?? '');
+  return sanitizePreferenceText(typeof value === 'string' ? value : String(value ?? ''));
 }
 
 // ── Condition formatting ────────────────────────────────────────────────


### PR DESCRIPTION
Always apply sanitizePreferenceText regardless of input type in safeString helper. Addresses feedback on #8353.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
