### PR TITLE
Add memory banner to component gallery with correct styling

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -686,17 +686,17 @@ struct ChatView: View {
     private var memoryDegradedBanner: some View {
         if isMemoryDegraded {
             HStack(spacing: VSpacing.sm) {
-                Image(systemName: "brain")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(VColor.warning)
                 Text("Memory is temporarily unavailable")
                     .font(VFont.caption)
-                    .foregroundColor(VColor.textSecondary)
+                    .foregroundStyle(VColor.textPrimary)
                 Spacer()
             }
-            .padding(.horizontal, VSpacing.lg)
-            .padding(.vertical, VSpacing.xs)
-            .background(VColor.surface)
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+            .background(Color(hex: 0xF5F3EB), in: RoundedRectangle(cornerRadius: VRadius.md))
+            .padding(.horizontal)
             .transition(.move(edge: .top).combined(with: .opacity))
         }
     }

--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -38,6 +38,33 @@ struct ChatGallerySection: View {
 
             Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
 
+            // MARK: - Status Banners
+            GallerySectionHeader(
+                title: "Status Banners",
+                description: "Inline status banners for degraded services (memory, connectivity)."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    Text("Memory unavailable")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    HStack(spacing: VSpacing.sm) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(VColor.warning)
+                        Text("Memory is temporarily unavailable")
+                            .font(VFont.caption)
+                            .foregroundStyle(VColor.textPrimary)
+                        Spacer()
+                    }
+                    .padding(.horizontal, VSpacing.md)
+                    .padding(.vertical, VSpacing.sm)
+                    .background(Color(hex: 0xF5F3EB), in: RoundedRectangle(cornerRadius: VRadius.md))
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
             // MARK: - Skill Invocation
             GallerySectionHeader(
                 title: "Skill Invocation",


### PR DESCRIPTION
## Summary
- Added memory degradation banner to ChatGallerySection under 'Status Banners'
- Updated banner to use warning triangle icon, VColor.warning, VColor.textPrimary, and #F5F3EB background
- Ensures consistent styling between the actual banner in ChatView and the gallery preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
