### PR TITLE
fix: remove redundant conversation_id index on memory_segments

### DIFF
--- a/assistant/src/memory/migrations/016-memory-segments-indexes.ts
+++ b/assistant/src/memory/migrations/016-memory-segments-indexes.ts
@@ -1,11 +1,11 @@
 import type { DrizzleDb } from '../db-connection.js';
 
 /**
- * Idempotent migration to ensure memory_segments has indexes on scope_id and
- * conversation_id for faster lookups.  scope_id was already covered by
- * db-init, but we include both here for completeness.
+ * Idempotent migration to add a scope_id index on memory_segments.
+ * conversation_id is already covered by the composite index
+ * idx_memory_segments_conversation_created(conversation_id, created_at DESC)
+ * in db-init, so a standalone index is unnecessary.
  */
 export function migrateMemorySegmentsIndexes(database: DrizzleDb): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_segments_scope_id ON memory_segments(scope_id)`);
-  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_segments_conversation_id ON memory_segments(conversation_id)`);
 }


### PR DESCRIPTION
Remove redundant single-column conversation_id index that duplicates the access path of the existing composite index idx_memory_segments_conversation_created. Addressed in followup to #8230.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
