### PR TITLE
fix: preserve Error name/message/stack in log redaction serializer

### DIFF
--- a/gateway/src/log-redact.ts
+++ b/gateway/src/log-redact.ts
@@ -87,11 +87,49 @@ function redactValue(value: unknown, depth: number): unknown {
 }
 
 // ---------------------------------------------------------------------------
+// Error serialization — extracts non-enumerable Error fields and cause chain
+// ---------------------------------------------------------------------------
+
+function serializeError(err: unknown, depth: number): unknown {
+  if (depth > 8 || err == null) return err;
+
+  if (!(err instanceof Error)) {
+    return err;
+  }
+
+  const serialized: Record<string, unknown> = {
+    name: err.name,
+    message: err.message,
+  };
+
+  if ("code" in err && typeof (err as { code: unknown }).code === "string") {
+    serialized.code = (err as { code: string }).code;
+  }
+
+  if (err.stack) {
+    serialized.stack = err.stack;
+  }
+
+  if (err.cause !== undefined) {
+    serialized.cause = serializeError(err.cause, depth + 1);
+  }
+
+  // Preserve any additional enumerable properties
+  for (const [key, val] of Object.entries(err)) {
+    if (!(key in serialized)) {
+      serialized[key] = val;
+    }
+  }
+
+  return serialized;
+}
+
+// ---------------------------------------------------------------------------
 // Pino serializers
 // ---------------------------------------------------------------------------
 
 export const logSerializers: Record<string, (value: unknown) => unknown> = {
-  err: (err) => redactValue(err, 0),
+  err: (err) => redactValue(serializeError(err, 0), 0),
   req: (req) => redactValue(req, 0),
   res: (res) => redactValue(res, 0),
 };


### PR DESCRIPTION
Use serializeError to extract non-enumerable Error fields (name, message, stack, code) before applying string redaction in gateway/src/log-redact.ts. Fixes regression where the gateway errSerializer was turning errors into empty objects because Object.entries skips non-enumerable Error properties. The assistant version already had this fix; this brings the gateway copy in sync. Addressed in followup to #8233.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
