### PR TITLE
fix: preserve statusCode fallback when status is undefined in getErrorStatusCode

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -779,7 +779,10 @@ function isAbortError(err: unknown): boolean {
  * in the message. This avoids false positives from dimension numbers like 512.
  */
 function getErrorStatusCode(err: Error): unknown {
-  if ('status' in err) return (err as { status: unknown }).status;
+  if ('status' in err) {
+    const status = (err as { status: unknown }).status;
+    if (status != null) return status;
+  }
   if ('statusCode' in err) return (err as { statusCode: unknown }).statusCode;
   return undefined;
 }


### PR DESCRIPTION
Fix getErrorStatusCode to fall through to statusCode when status property exists but is undefined/null. Restores the previous status ?? statusCode fallback behavior for retry handling. Addressed in followup to #8234.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
