### PR TITLE
fix: remove redundant fingerprint index from memoryItems migration

### DIFF
--- a/assistant/src/memory/migrations/017-memory-items-indexes.ts
+++ b/assistant/src/memory/migrations/017-memory-items-indexes.ts
@@ -1,10 +1,12 @@
 import type { DrizzleDb } from '../db-connection.js';
 
 /**
- * Idempotent migration to add indexes on memory_items for scope_id and
- * fingerprint — critical for duplicate detection and scope-filtered queries.
+ * Idempotent migration to add an index on memory_items.scope_id for
+ * scope-filtered queries. The standalone fingerprint index is intentionally
+ * omitted — it's superseded by the compound unique index
+ * idx_memory_items_fingerprint_scope(fingerprint, scope_id), which already
+ * covers single-column lookups on fingerprint as its leading column.
  */
 export function migrateMemoryItemsIndexes(database: DrizzleDb): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_items_scope_id ON memory_items(scope_id)`);
-  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_items_fingerprint ON memory_items(fingerprint)`);
 }


### PR DESCRIPTION
Remove idx_memory_items_fingerprint from migration — it's redundant with the compound unique index idx_memory_items_fingerprint_scope and was being dropped/recreated on every startup. Keep only idx_memory_items_scope_id. Addressed in followup to #8244.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
