### PR TITLE
fix: clean up settled surface mutex entries to prevent memory leak

### DIFF
--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -140,7 +140,14 @@ export function createSurfaceMutex(): <T>(surfaceId: string, fn: () => T | Promi
     const prev = chains.get(surfaceId) ?? Promise.resolve();
     const next = prev.then(fn, fn);
     // Keep the chain alive but swallow errors so one failure doesn't block subsequent ops
-    chains.set(surfaceId, next.then(() => {}, () => {}));
+    const tail = next.then(() => {}, () => {});
+    chains.set(surfaceId, tail);
+    // Clean up the map entry once the queue settles to prevent unbounded growth
+    tail.then(() => {
+      if (chains.get(surfaceId) === tail) {
+        chains.delete(surfaceId);
+      }
+    });
     return next;
   };
 }


### PR DESCRIPTION
Delete surface mutex map entries when the promise chain settles and no new work is queued, preventing unbounded memory growth in long-lived sessions with many unique surface IDs. Addressed in followup to #8245.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
