### PR TITLE
fix: return immediately on aborted CAPTCHA wait instead of breaking

### DIFF
--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -320,7 +320,10 @@ export async function executeBrowserNavigate(
       if (challenge?.type === 'captcha') {
         log.info('CAPTCHA detected, waiting up to 5s for auto-resolve');
         for (let i = 0; i < 5; i++) {
-          if (context.signal?.aborted) break;
+          if (context.signal?.aborted) {
+            if (sender) updateBrowserStatus(context.sessionId, sender, 'idle');
+            return { content: 'Navigation cancelled.', isError: true };
+          }
           await new Promise((r) => setTimeout(r, 1000));
           const still = await detectCaptchaChallenge(page);
           if (!still) {


### PR DESCRIPTION
Change break to return in CAPTCHA auto-resolve abort check to prevent triggering handoff for cancelled tool calls. Addressed in followup to #8246.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
