### PR TITLE
fix: rebind menu bar connection observer after client replacement and fix pulse animation

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -17,8 +17,15 @@ extension AppDelegate {
             button.target = self
         }
 
-        // Start observing daemon connection state immediately so the icon
-        // reflects disconnected/connected before the main window opens.
+        rebindConnectionStatusObserver()
+    }
+
+    /// (Re-)subscribe to `daemonClient.$isConnected` so the menu bar icon
+    /// tracks the current daemon client. Called from `setupMenuBar()` and
+    /// again from `setupDaemonClient()` after transport reconfiguration,
+    /// which may replace the underlying `DaemonClient` instance.
+    func rebindConnectionStatusObserver() {
+        connectionStatusCancellable?.cancel()
         connectionStatusCancellable = daemonClient.$isConnected
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
@@ -117,12 +124,20 @@ extension AppDelegate {
         if status.shouldPulse {
             guard pulseTimer == nil else { return }
             pulsePhase = 1.0
+            pulseDirection = -1.0
             pulseTimer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { [weak self] _ in
                 Task { @MainActor in
                     guard let self, self.statusItem != nil, let button = self.statusItem.button else { return }
-                    // Triangle wave between 0.3 and 1.0 over ~1.4s (28 frames at 50ms)
-                    self.pulsePhase -= 0.05
-                    if self.pulsePhase <= 0.3 { self.pulsePhase = 1.0 }
+                    // Triangle wave: smoothly oscillate between 1.0 and 0.3,
+                    // reversing direction at each boundary to avoid abrupt jumps.
+                    self.pulsePhase += self.pulseDirection * 0.05
+                    if self.pulsePhase <= 0.3 {
+                        self.pulsePhase = 0.3
+                        self.pulseDirection = 1.0
+                    } else if self.pulsePhase >= 1.0 {
+                        self.pulsePhase = 1.0
+                        self.pulseDirection = -1.0
+                    }
                     self.configureMenuBarIcon(button)
                 }
             }
@@ -130,6 +145,7 @@ extension AppDelegate {
             pulseTimer?.invalidate()
             pulseTimer = nil
             pulsePhase = 1.0
+            pulseDirection = -1.0
         }
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -145,6 +145,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var connectionStatusCancellable: AnyCancellable?
     var pulseTimer: Timer?
     var pulsePhase: CGFloat = 1.0
+    var pulseDirection: CGFloat = -1.0
     var cachedSkills: [SkillInfo] = []
     var refreshSkillsTask: Task<Void, Never>?
     var cachedApps: [AppItem] = []
@@ -674,6 +675,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         configureDaemonTransport(for: assistant)
+
+        // Rebind the menu bar icon observer to the (potentially new) daemon client
+        // so status changes on the replacement client trigger icon updates.
+        rebindConnectionStatusObserver()
 
         // Show macOS notification when a reminder fires
         daemonClient.onReminderFired = { msg in


### PR DESCRIPTION
Extract connection status subscription into reusable `rebindConnectionStatusObserver()` method called from both `setupMenuBar()` and `setupDaemonClient()` (after `configureDaemonTransport`). This ensures the menu bar icon tracks the current daemon client even when the transport is reconfigured (e.g., switching assistants).

Fix pulse animation to use a smooth triangle wave (1.0 → 0.3 → 1.0) by tracking `pulseDirection` and reversing at boundaries, instead of the previous sawtooth pattern that jumped abruptly from 0.3 back to 1.0.

Addresses review feedback on #8237.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
