### PR TITLE
fix: limit half-open probes to single attempt and propagate CircuitBreakerOpenError

### DIFF
--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -2,7 +2,7 @@ import type { GatewayConfig } from "../config.js";
 import { getLogger } from "../logger.js";
 import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
 import type { RouteResult } from "../routing/types.js";
-import { forwardToRuntime } from "../runtime/client.js";
+import { forwardToRuntime, CircuitBreakerOpenError } from "../runtime/client.js";
 import type { RuntimeInboundResponse } from "../runtime/client.js";
 import type { GatewayInboundEventV1 } from "../types.js";
 
@@ -111,6 +111,11 @@ export async function handleInbound(
 
     return { forwarded: true, rejected: false, runtimeResponse: response };
   } catch (err) {
+    // Let CircuitBreakerOpenError propagate so webhook handlers can
+    // return 503 + Retry-After instead of 500, which would cause
+    // Telegram (and similar transports) to retry immediately.
+    if (err instanceof CircuitBreakerOpenError) throw err;
+
     log.error(
       { err, assistantId: routing.assistantId },
       "Failed to forward inbound event to runtime",

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -5,7 +5,7 @@ import { handleInbound } from "../../handlers/handle-inbound.js";
 import { getLogger } from "../../logger.js";
 import { RejectionRateLimiter } from "../../rejection-rate-limiter.js";
 import { resolveAssistant, isRejection } from "../../routing/resolve-assistant.js";
-import { AttachmentValidationError, resetConversation, uploadAttachment } from "../../runtime/client.js";
+import { AttachmentValidationError, CircuitBreakerOpenError, resetConversation, uploadAttachment } from "../../runtime/client.js";
 import { callTelegramApi } from "../../telegram/api.js";
 import { downloadTelegramFile } from "../../telegram/download.js";
 import { normalizeTelegramUpdate } from "../../telegram/normalize.js";
@@ -290,6 +290,13 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
           tlog.info({ status: "forwarded" }, "Forwarded /start to runtime");
         }
       } catch (err) {
+        if (err instanceof CircuitBreakerOpenError) {
+          acknowledgeCallbackQuery(normalized.message.callbackQueryId, "start_command_circuit_open");
+          return Response.json(
+            { error: "Service temporarily unavailable" },
+            { status: 503, headers: { "Retry-After": String(err.retryAfterSecs) } },
+          );
+        }
         tlog.error({ err, updateId: payload.update_id }, "Failed to process /start command");
         sendTelegramReply(
           config,
@@ -480,6 +487,14 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
         );
       }
     } catch (err) {
+      if (err instanceof CircuitBreakerOpenError) {
+        tlog.warn({ retryAfterSecs: err.retryAfterSecs }, "Circuit breaker open — returning 503");
+        if (isCallback) acknowledgeCallbackQuery(normalized.message.callbackQueryId, "circuit_open");
+        return Response.json(
+          { error: "Service temporarily unavailable" },
+          { status: 503, headers: { "Retry-After": String(err.retryAfterSecs) } },
+        );
+      }
       tlog.error({ err, updateId: payload.update_id }, "Failed to process inbound event");
       if (isCallback) acknowledgeCallbackQuery(normalized.message.callbackQueryId, "forward_exception");
       if (updateId !== undefined) dedupCache.unreserve(updateId);

--- a/gateway/src/http/routes/twilio-sms-webhook.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.ts
@@ -6,7 +6,7 @@ import { getLogger } from "../../logger.js";
 import { RejectionRateLimiter } from "../../rejection-rate-limiter.js";
 import { resolveAssistant, resolveAssistantByPhoneNumber, isRejection } from "../../routing/resolve-assistant.js";
 import type { RouteResult } from "../../routing/types.js";
-import { resetConversation } from "../../runtime/client.js";
+import { CircuitBreakerOpenError, resetConversation } from "../../runtime/client.js";
 import { sendSmsReply } from "../../twilio/send-sms.js";
 import { validateTwilioWebhookRequest } from "../../twilio/validate-webhook.js";
 import type { GatewayInboundEventV1 } from "../../types.js";
@@ -206,6 +206,13 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
       dedupCache.mark(messageSid);
       tlog.info({ status: "forwarded", messageSid }, "SMS forwarded to runtime");
     } catch (err) {
+      if (err instanceof CircuitBreakerOpenError) {
+        tlog.warn({ retryAfterSecs: err.retryAfterSecs }, "Circuit breaker open — returning 503");
+        return Response.json(
+          { error: "Service temporarily unavailable" },
+          { status: 503, headers: { "Retry-After": String(err.retryAfterSecs) } },
+        );
+      }
       tlog.error({ err, messageSid }, "Failed to process inbound SMS");
       dedupCache.unreserve(messageSid);
       return Response.json({ error: "Internal error" }, { status: 500 });

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -5,7 +5,7 @@ import { handleInbound } from "../../handlers/handle-inbound.js";
 import { getLogger } from "../../logger.js";
 import { RejectionRateLimiter } from "../../rejection-rate-limiter.js";
 import { resolveAssistant, isRejection } from "../../routing/resolve-assistant.js";
-import { resetConversation } from "../../runtime/client.js";
+import { CircuitBreakerOpenError, resetConversation } from "../../runtime/client.js";
 import { markWhatsAppMessageRead } from "../../whatsapp/api.js";
 import { normalizeWhatsAppWebhook } from "../../whatsapp/normalize.js";
 import { sendWhatsAppReply } from "../../whatsapp/send.js";
@@ -207,6 +207,13 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
         dedupCache.mark(whatsappMessageId);
         tlog.info({ status: "forwarded", whatsappMessageId }, "WhatsApp message forwarded to runtime");
       } catch (err) {
+        if (err instanceof CircuitBreakerOpenError) {
+          tlog.warn({ retryAfterSecs: err.retryAfterSecs }, "Circuit breaker open — returning 503");
+          return Response.json(
+            { error: "Service temporarily unavailable" },
+            { status: 503, headers: { "Retry-After": String(err.retryAfterSecs) } },
+          );
+        }
         tlog.error({ err, whatsappMessageId }, "Failed to process inbound WhatsApp message");
         dedupCache.unreserve(whatsappMessageId);
         hasFailure = true;

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -180,7 +180,7 @@ export async function forwardToRuntime(
   payload: RuntimeInboundPayload,
   options?: ForwardOptions,
 ): Promise<RuntimeInboundResponse> {
-  cbBeforeRequest();
+  const isHalfOpenProbe = cbBeforeRequest();
 
   const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/channels/inbound`;
 
@@ -191,7 +191,11 @@ export async function forwardToRuntime(
 
   let lastError: Error | null = null;
 
-  for (let attempt = 0; attempt <= config.runtimeMaxRetries; attempt++) {
+  // Half-open probes get a single attempt — retries would defeat the
+  // purpose of cautiously testing whether the runtime has recovered.
+  const maxRetries = isHalfOpenProbe ? 0 : config.runtimeMaxRetries;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
     if (attempt > 0) {
       const delay = config.runtimeInitialBackoffMs * Math.pow(2, attempt - 1);
       log.debug({ attempt, delay, assistantId }, "Retrying runtime forward");


### PR DESCRIPTION
Limit half-open circuit breaker probes to a single runtime attempt instead of full retry loop. Let CircuitBreakerOpenError propagate from handleInbound instead of swallowing it, so webhook handlers can return appropriate 503 responses with Retry-After headers instead of 500s that trigger immediate retries.

Also updated all webhook handlers (Telegram, WhatsApp, Twilio SMS) to catch CircuitBreakerOpenError and return 503 + Retry-After.

Addressed in followup to #8236.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
