### PR TITLE
fix: read daemon timeouts without triggering loadConfig/migration side effects

### DIFF
--- a/assistant/src/daemon/daemon-control.ts
+++ b/assistant/src/daemon/daemon-control.ts
@@ -5,13 +5,50 @@ import {
   getSocketPath,
   getPidPath,
   getRootDir,
+  getWorkspaceConfigPath,
   removeSocketFile,
 } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 import { DaemonError } from '../util/errors.js';
-import { getConfig } from '../config/loader.js';
 
 const log = getLogger('lifecycle');
+
+const DAEMON_TIMEOUT_DEFAULTS = {
+  startupSocketWaitMs: 5000,
+  stopTimeoutMs: 5000,
+  sigkillGracePeriodMs: 2000,
+};
+
+/**
+ * Read daemon timeout values directly from the config JSON file, bypassing
+ * loadConfig() and its ensureMigratedDataDir()/ensureDataDir() side effects.
+ * Falls back to hardcoded defaults on any error (missing file, malformed JSON,
+ * unexpected shape) so daemon stop/start never fails due to config issues.
+ */
+function readDaemonTimeouts(): typeof DAEMON_TIMEOUT_DEFAULTS {
+  try {
+    const raw = JSON.parse(readFileSync(getWorkspaceConfigPath(), 'utf-8'));
+    if (raw.daemon && typeof raw.daemon === 'object') {
+      return {
+        startupSocketWaitMs:
+          typeof raw.daemon.startupSocketWaitMs === 'number'
+            ? raw.daemon.startupSocketWaitMs
+            : DAEMON_TIMEOUT_DEFAULTS.startupSocketWaitMs,
+        stopTimeoutMs:
+          typeof raw.daemon.stopTimeoutMs === 'number'
+            ? raw.daemon.stopTimeoutMs
+            : DAEMON_TIMEOUT_DEFAULTS.stopTimeoutMs,
+        sigkillGracePeriodMs:
+          typeof raw.daemon.sigkillGracePeriodMs === 'number'
+            ? raw.daemon.sigkillGracePeriodMs
+            : DAEMON_TIMEOUT_DEFAULTS.sigkillGracePeriodMs,
+      };
+    }
+  } catch {
+    // Missing file, malformed JSON, etc. — use defaults.
+  }
+  return { ...DAEMON_TIMEOUT_DEFAULTS };
+}
 
 function isProcessRunning(pid: number): boolean {
   try {
@@ -125,8 +162,8 @@ export async function startDaemon(): Promise<{
   writePid(pid);
 
   // Wait for socket to appear
-  const config = getConfig();
-  const maxWait = config.daemon.startupSocketWaitMs;
+  const timeouts = readDaemonTimeouts();
+  const maxWait = timeouts.startupSocketWaitMs;
   const interval = 100;
   let waited = 0;
   while (waited < maxWait) {
@@ -165,10 +202,10 @@ export async function stopDaemon(): Promise<StopResult> {
 
   process.kill(pid, 'SIGTERM');
 
-  const config = getConfig();
+  const timeouts = readDaemonTimeouts();
 
   // Wait for process to exit
-  const maxWait = config.daemon.stopTimeoutMs;
+  const maxWait = timeouts.stopTimeoutMs;
   const interval = 100;
   let waited = 0;
   while (waited < maxWait) {
@@ -190,7 +227,7 @@ export async function stopDaemon(): Promise<StopResult> {
   // Wait for the process to actually die after SIGKILL. Without this,
   // startDaemon() can race with the dying process's shutdown handler,
   // which removes the socket file and bricks the new daemon.
-  const killMaxWait = config.daemon.sigkillGracePeriodMs;
+  const killMaxWait = timeouts.sigkillGracePeriodMs;
   let killWaited = 0;
   while (killWaited < killMaxWait && isProcessRunning(pid)) {
     await new Promise((r) => setTimeout(r, 100));


### PR DESCRIPTION
Replace getConfig() calls in startDaemon/stopDaemon with a lightweight config reader that reads the raw JSON file directly, bypassing loadConfig() and its ensureMigratedDataDir() side effects. Prevents migration data loss in startDaemon and config-parse failures in stopDaemon. Addressed in followup to #8265.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
