### PR TITLE
M7: Producer migration (high-value first)

### DIFF
--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -11,6 +11,7 @@
 
 import { getLogger } from '../util/logger.js';
 import { getGatewayInternalBaseUrl } from '../config/env.js';
+import { emitNotificationSignal } from '../notifications/emit-signal.js';
 import { getActiveBinding } from '../memory/channel-guardian-store.js';
 import {
   createGuardianActionRequest,
@@ -73,6 +74,33 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
       { requestId: request.id, requestCode: request.requestCode, callSessionId },
       'Created guardian action request',
     );
+
+    // Emit notification signal through the unified pipeline (fire-and-forget).
+    // The existing guardian dispatch logic below handles the actual delivery
+    // to specific channels (telegram, sms, macos), so this signal is
+    // supplementary — it lets the decision engine log and potentially route
+    // to additional channels in the future.
+    void emitNotificationSignal({
+      sourceEventName: 'guardian.question',
+      sourceChannel: 'voice',
+      sourceSessionId: callSessionId,
+      assistantId,
+      attentionHints: {
+        requiresAction: true,
+        urgency: 'high',
+        deadlineAt: expiresAt,
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
+      contextPayload: {
+        requestId: request.id,
+        requestCode: request.requestCode,
+        callSessionId,
+        questionText: pendingQuestion.questionText,
+        pendingQuestionId: pendingQuestion.id,
+      },
+      dedupeKey: `guardian:${request.id}`,
+    });
 
     // Determine delivery destinations
     const destinations: Array<{

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -654,7 +654,6 @@ export async function runDaemon(): Promise<void> {
           scheduleId: schedule.id,
           name: schedule.name,
         },
-        dedupeKey: `schedule:${schedule.id}`,
       });
     },
     (notification) => {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -654,7 +654,7 @@ export async function runDaemon(): Promise<void> {
           scheduleId: schedule.id,
           name: schedule.name,
         },
-        dedupeKey: `schedule:${schedule.id}:${Date.now()}`,
+        dedupeKey: `schedule:${schedule.id}`,
       });
     },
     (notification) => {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -73,6 +73,7 @@ import { AgentHeartbeatService } from '../agent-heartbeat/agent-heartbeat-servic
 import { getEnrichmentService } from '../workspace/commit-message-enrichment-service.js';
 import { reconcileCallsOnStartup } from '../calls/call-recovery.js';
 import { TwilioConversationRelayProvider } from '../calls/twilio-provider.js';
+import { emitNotificationSignal, registerBroadcastFn } from '../notifications/emit-signal.js';
 
 const log = getLogger('lifecycle');
 
@@ -596,37 +597,112 @@ export async function runDaemon(): Promise<void> {
   registerMessagingProvider(smsMessagingProvider);
   registerMessagingProvider(whatsappMessagingProvider);
 
+  // Register the IPC broadcast function for the notification signal pipeline's
+  // macOS adapter so it can deliver notification_intent messages to desktop clients.
+  registerBroadcastFn((msg) => server.broadcast(msg));
+
   const scheduler = startScheduler(
     async (conversationId, message) => {
       await server.processMessage(conversationId, message);
     },
     (reminder) => {
+      // Legacy IPC broadcast for backward compatibility with desktop client UI
       server.broadcast({
         type: 'reminder_fired',
         reminderId: reminder.id,
         label: reminder.label,
         message: reminder.message,
       });
+      // Signal pipeline: fire-and-forget
+      void emitNotificationSignal({
+        sourceEventName: 'reminder.fired',
+        sourceChannel: 'scheduler',
+        sourceSessionId: reminder.id,
+        attentionHints: {
+          requiresAction: true,
+          urgency: 'high',
+          isAsyncBackground: false,
+          visibleInSourceNow: false,
+        },
+        contextPayload: {
+          reminderId: reminder.id,
+          label: reminder.label,
+          message: reminder.message,
+        },
+        dedupeKey: `reminder:${reminder.id}`,
+      });
     },
     (schedule) => {
+      // Legacy IPC broadcast for backward compatibility with desktop client UI
       server.broadcast({
         type: 'schedule_complete',
         scheduleId: schedule.id,
         name: schedule.name,
       });
+      // Signal pipeline: fire-and-forget
+      void emitNotificationSignal({
+        sourceEventName: 'schedule.complete',
+        sourceChannel: 'scheduler',
+        sourceSessionId: schedule.id,
+        attentionHints: {
+          requiresAction: false,
+          urgency: 'medium',
+          isAsyncBackground: true,
+          visibleInSourceNow: false,
+        },
+        contextPayload: {
+          scheduleId: schedule.id,
+          name: schedule.name,
+        },
+        dedupeKey: `schedule:${schedule.id}:${Date.now()}`,
+      });
     },
     (notification) => {
+      // Legacy IPC broadcast for backward compatibility with desktop client UI
       server.broadcast({
         type: 'watcher_notification',
         title: notification.title,
         body: notification.body,
       });
+      // Signal pipeline: fire-and-forget
+      void emitNotificationSignal({
+        sourceEventName: 'watcher.notification',
+        sourceChannel: 'watcher',
+        sourceSessionId: `watcher-${Date.now()}`,
+        attentionHints: {
+          requiresAction: false,
+          urgency: 'low',
+          isAsyncBackground: true,
+          visibleInSourceNow: false,
+        },
+        contextPayload: {
+          title: notification.title,
+          body: notification.body,
+        },
+      });
     },
     (params) => {
+      // Legacy IPC broadcast for backward compatibility with desktop client UI
       server.broadcast({
         type: 'watcher_escalation',
         title: params.title,
         body: params.body,
+      });
+      // Signal pipeline: fire-and-forget
+      void emitNotificationSignal({
+        sourceEventName: 'watcher.escalation',
+        sourceChannel: 'watcher',
+        sourceSessionId: `watcher-escalation-${Date.now()}`,
+        attentionHints: {
+          requiresAction: true,
+          urgency: 'high',
+          isAsyncBackground: false,
+          visibleInSourceNow: false,
+        },
+        contextPayload: {
+          title: params.title,
+          body: params.body,
+        },
       });
     },
   );

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -1,0 +1,176 @@
+/**
+ * Single entry point for all notification producers.
+ *
+ * emitNotificationSignal() creates a NotificationSignal, persists the event,
+ * runs it through the decision engine + deterministic checks + dispatch
+ * pipeline. Producers call this instead of directly broadcasting IPC
+ * messages or dispatching through the old patterns.
+ *
+ * Designed for fire-and-forget usage: errors are logged but never propagated
+ * to the caller. The returned promise resolves even on failure.
+ */
+
+import { v4 as uuid } from 'uuid';
+import { getConfig } from '../config/loader.js';
+import { getLogger } from '../util/logger.js';
+import { createEvent } from './events-store.js';
+import { evaluateSignal } from './decision-engine.js';
+import { runDeterministicChecks, type DeterministicCheckContext } from './deterministic-checks.js';
+import { dispatchDecision } from './runtime-dispatch.js';
+import { NotificationBroadcaster } from './broadcaster.js';
+import { MacOSAdapter, type BroadcastFn } from './adapters/macos.js';
+import { TelegramAdapter } from './adapters/telegram.js';
+import type { NotificationSignal, AttentionHints } from './signal.js';
+import type { NotificationChannel } from './types.js';
+
+const log = getLogger('emit-signal');
+
+// ── Broadcaster singleton ──────────────────────────────────────────────
+
+let broadcasterInstance: NotificationBroadcaster | null = null;
+let registeredBroadcastFn: BroadcastFn | null = null;
+
+/**
+ * Register the IPC broadcast function so the macOS adapter can deliver
+ * notifications through the daemon's IPC socket. Must be called once
+ * during daemon startup (before any signals are emitted).
+ */
+export function registerBroadcastFn(fn: BroadcastFn): void {
+  registeredBroadcastFn = fn;
+  // Reset the broadcaster so it picks up the new broadcast function
+  broadcasterInstance = null;
+}
+
+function getBroadcaster(): NotificationBroadcaster {
+  if (!broadcasterInstance) {
+    const adapters = [
+      new TelegramAdapter(),
+    ];
+    if (registeredBroadcastFn) {
+      adapters.unshift(new MacOSAdapter(registeredBroadcastFn));
+    }
+    broadcasterInstance = new NotificationBroadcaster(adapters);
+  }
+  return broadcasterInstance;
+}
+
+// ── Connected channels resolution ──────────────────────────────────────
+
+function getConnectedChannels(): NotificationChannel[] {
+  // macOS is always considered connected (IPC socket is always available
+  // when the daemon is running). Telegram is connected if its adapter
+  // can resolve a destination.
+  const channels: NotificationChannel[] = ['macos'];
+  // Telegram availability is checked downstream by the destination
+  // resolver, so we always include it as available and let the
+  // deterministic checks handle cases where no binding exists.
+  channels.push('telegram');
+  return channels;
+}
+
+// ── Public API ─────────────────────────────────────────────────────────
+
+export interface EmitSignalParams {
+  /** Free-form event name, e.g. 'reminder.fired', 'schedule.complete'. */
+  sourceEventName: string;
+  /** Source channel that produced the event. */
+  sourceChannel: string;
+  /** Session or conversation ID from the source context. */
+  sourceSessionId: string;
+  /** Logical assistant ID (defaults to 'self'). */
+  assistantId?: string;
+  /** Attention hints for the decision engine. */
+  attentionHints: AttentionHints;
+  /** Arbitrary context payload passed to the decision engine. */
+  contextPayload?: Record<string, unknown>;
+  /** Optional deduplication key. */
+  dedupeKey?: string;
+}
+
+/**
+ * Emit a notification signal through the full pipeline:
+ * createEvent -> evaluateSignal -> runDeterministicChecks -> dispatchDecision.
+ *
+ * Fire-and-forget safe: all errors are caught and logged. The caller
+ * should not await this in critical paths unless it needs the result.
+ */
+export async function emitNotificationSignal(params: EmitSignalParams): Promise<void> {
+  const config = getConfig();
+  if (!config.notifications.enabled) {
+    log.debug({ sourceEventName: params.sourceEventName }, 'Notification system disabled, skipping signal');
+    return;
+  }
+
+  const signalId = uuid();
+  const assistantId = params.assistantId ?? 'self';
+
+  const signal: NotificationSignal = {
+    signalId,
+    assistantId,
+    createdAt: Date.now(),
+    sourceChannel: params.sourceChannel,
+    sourceSessionId: params.sourceSessionId,
+    sourceEventName: params.sourceEventName,
+    contextPayload: params.contextPayload ?? {},
+    attentionHints: params.attentionHints,
+  };
+
+  try {
+    // Step 1: Persist the event
+    const eventRow = createEvent({
+      id: signalId,
+      assistantId,
+      sourceEventName: params.sourceEventName,
+      sourceChannel: params.sourceChannel,
+      sourceSessionId: params.sourceSessionId,
+      attentionHints: params.attentionHints,
+      payload: params.contextPayload ?? {},
+      dedupeKey: params.dedupeKey,
+    });
+
+    if (!eventRow) {
+      log.info({ signalId, dedupeKey: params.dedupeKey }, 'Signal deduplicated at event store level');
+      return;
+    }
+
+    // Step 2: Evaluate the signal through the decision engine
+    const connectedChannels = getConnectedChannels();
+    const decision = await evaluateSignal(signal, connectedChannels);
+
+    // Step 3: Run deterministic pre-send checks
+    if (decision.shouldNotify) {
+      const checkContext: DeterministicCheckContext = {
+        connectedChannels,
+      };
+      const checkResult = await runDeterministicChecks(signal, decision, checkContext);
+
+      if (!checkResult.passed) {
+        log.info(
+          { signalId, reason: checkResult.reason },
+          'Signal blocked by deterministic checks',
+        );
+        return;
+      }
+    }
+
+    // Step 4: Dispatch through the broadcaster
+    const broadcaster = getBroadcaster();
+    const dispatchResult = await dispatchDecision(signal, decision, broadcaster);
+
+    log.info(
+      {
+        signalId,
+        sourceEventName: params.sourceEventName,
+        dispatched: dispatchResult.dispatched,
+        reason: dispatchResult.reason,
+      },
+      'Signal pipeline complete',
+    );
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    log.error(
+      { err: errMsg, signalId, sourceEventName: params.sourceEventName },
+      'Signal pipeline failed',
+    );
+  }
+}

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -13,6 +13,7 @@
 import { v4 as uuid } from 'uuid';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
+import { getActiveBinding } from '../memory/channel-guardian-store.js';
 import { createEvent } from './events-store.js';
 import { evaluateSignal } from './decision-engine.js';
 import { runDeterministicChecks, type DeterministicCheckContext } from './deterministic-checks.js';
@@ -56,15 +57,19 @@ function getBroadcaster(): NotificationBroadcaster {
 
 // ── Connected channels resolution ──────────────────────────────────────
 
-function getConnectedChannels(): NotificationChannel[] {
+function getConnectedChannels(assistantId: string): NotificationChannel[] {
   // macOS is always considered connected (IPC socket is always available
-  // when the daemon is running). Telegram is connected if its adapter
-  // can resolve a destination.
+  // when the daemon is running).
   const channels: NotificationChannel[] = ['macos'];
-  // Telegram availability is checked downstream by the destination
-  // resolver, so we always include it as available and let the
-  // deterministic checks handle cases where no binding exists.
-  channels.push('telegram');
+  // Only report Telegram as connected when there is an active guardian
+  // binding for this assistant. Without a binding, the destination
+  // resolver will fail to resolve a chat ID and dispatch will silently
+  // drop the message — which is worse than the decision engine knowing
+  // up front that the channel is unavailable.
+  const telegramBinding = getActiveBinding(assistantId, 'telegram');
+  if (telegramBinding) {
+    channels.push('telegram');
+  }
   return channels;
 }
 
@@ -134,7 +139,7 @@ export async function emitNotificationSignal(params: EmitSignalParams): Promise<
     }
 
     // Step 2: Evaluate the signal through the decision engine
-    const connectedChannels = getConnectedChannels();
+    const connectedChannels = getConnectedChannels(assistantId);
     const decision = await evaluateSignal(signal, connectedChannels);
 
     // Step 3: Run deterministic pre-send checks

--- a/assistant/src/runtime/routes/channel-inbound-routes.ts
+++ b/assistant/src/runtime/routes/channel-inbound-routes.ts
@@ -47,6 +47,7 @@ import type {
 import type { GuardianRuntimeContext } from '../../daemon/session-runtime-assembly.js';
 import { composeApprovalMessageGenerative } from '../approval-message-composer.js';
 import { refreshThreadEscalation } from '../../memory/inbox-escalation-projection.js';
+import { emitNotificationSignal } from '../../notifications/emit-signal.js';
 import {
   type GuardianContext,
   verifyGatewayOrigin,
@@ -362,6 +363,30 @@ export async function handleChannelInbound(
 
     // Update inbox thread escalation state so the desktop UI badge is accurate
     refreshThreadEscalation(result.conversationId, assistantId);
+
+    // Emit notification signal through the unified pipeline (fire-and-forget).
+    // This lets the decision engine route escalation alerts to all configured
+    // channels, supplementing the direct guardian notification below.
+    void emitNotificationSignal({
+      sourceEventName: 'ingress.escalation',
+      sourceChannel: sourceChannel,
+      sourceSessionId: result.conversationId,
+      assistantId,
+      attentionHints: {
+        requiresAction: true,
+        urgency: 'high',
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
+      contextPayload: {
+        conversationId: result.conversationId,
+        sourceChannel,
+        externalChatId,
+        senderIdentifier: body.senderName || body.senderUsername || body.senderExternalUserId || 'Unknown sender',
+        eventId: result.eventId,
+      },
+      dedupeKey: `escalation:${result.eventId}`,
+    });
 
     // Notify the guardian about the pending escalation via channel delivery
     const senderIdentifier = body.senderName || body.senderUsername || body.senderExternalUserId || 'Unknown sender';


### PR DESCRIPTION
Migrate notification producers to signal → decision → broadcast pipeline. Create emit-signal.ts entry point, migrate reminder fired, schedule complete, guardian question, and ingress escalation producers. Remove legacy direct routing for migrated flows. Closes #8291.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
