### PR TITLE
fix: auto-start SSE on HTTP transport connect

### DIFF
--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -111,6 +111,9 @@ final class HTTPTransport {
 
     /// Verify reachability via health check and start periodic health monitoring.
     /// Connection status is driven by health checks, not SSE.
+    /// SSE is auto-started after the first successful health check so that
+    /// system events (e.g. pairing approval requests) are received immediately,
+    /// even before any UI window appears.
     func connect() async throws {
         shouldReconnect = true
 
@@ -119,6 +122,11 @@ final class HTTPTransport {
 
         // Start periodic health checks
         startHealthCheckLoop()
+
+        // Auto-start SSE so system events (pairing, etc.) are received
+        // immediately. MainWindowView.onAppear also calls startSSE() but
+        // that's a no-op when the stream is already running.
+        startSSE()
     }
 
     /// Run a single health check against the gateway.


### PR DESCRIPTION
## Summary

When using HTTP transport (`VELLUM_FLAG_LOCAL_HTTP_ENABLED=1`), the SSE event stream was only started when `MainWindowView.onAppear` fired. System events like pairing approval requests were lost if they arrived before the main window appeared — the macOS app would never show the approval prompt.

## Fix

Auto-start the SSE stream in `HTTPTransport.connect()` immediately after the first health check passes. The existing `startSSE()` call in `MainWindowView.onAppear` becomes a harmless no-op (guarded by `guard sseTask == nil`).

## Testing

1. Set `VELLUM_FLAG_LOCAL_HTTP_ENABLED=1` in `.env`
2. Build and launch macOS app
3. Scan QR code from iOS — pairing approval prompt should appear on Mac immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
