### PR TITLE
fix: enforce log file permissions on existing files at startup

### DIFF
--- a/assistant/src/util/logger.ts
+++ b/assistant/src/util/logger.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, unlinkSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readdirSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { Writable } from 'node:stream';
 import pino from 'pino';
@@ -67,6 +67,8 @@ function buildRotatingLogger(config: LogFileConfig): pino.Logger {
   const today = formatDate(new Date());
   const filePath = logFilePathForDate(config.dir, new Date());
   const fileStream = pino.destination({ dest: filePath, sync: false, mkdir: true, mode: 0o600 });
+  // Tighten permissions on pre-existing log files that may have been created with looser modes
+  try { chmodSync(filePath, 0o600); } catch { /* best-effort */ }
 
   activeLogDate = today;
   activeLogFileConfig = config;
@@ -130,7 +132,10 @@ function getRootLogger(): pino.Logger {
     }
 
     try {
-      const fileStream = pino.destination({ dest: getLogPath(), sync: false, mkdir: true, mode: 0o600 });
+      const logPath = getLogPath();
+      const fileStream = pino.destination({ dest: logPath, sync: false, mkdir: true, mode: 0o600 });
+      // Tighten permissions on pre-existing log files that may have been created with looser modes
+      try { chmodSync(logPath, 0o600); } catch { /* best-effort */ }
 
       if (getDebugMode()) {
         const prettyStream = pinoPretty({ destination: 2 });

--- a/gateway/src/logger.ts
+++ b/gateway/src/logger.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import pino from "pino";
 import pinoPretty from "pino-pretty";
@@ -64,6 +64,8 @@ function buildLogger(config: LogFileConfig | null): pino.Logger {
   const today = formatDate(new Date());
   const filePath = logFilePathForDate(config.dir, new Date());
   const fileStream = pino.destination({ dest: filePath, sync: false, mkdir: true, mode: 0o600 });
+  // Tighten permissions on pre-existing log files that may have been created with looser modes
+  try { chmodSync(filePath, 0o600); } catch { /* best-effort */ }
 
   activeLogDate = today;
   activeConfig = config;


### PR DESCRIPTION
Add chmod at startup to enforce 0o600 on existing log files that may have been created with looser permissions by prior versions. Addressed in followup to #8252.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
