### PR TITLE
fix: throw typed cancellation error from permission checks

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -312,7 +312,7 @@ async function buildCommandCandidates(toolName: string, input: Record<string, un
 }
 
 export async function classifyRisk(toolName: string, input: Record<string, unknown>, workingDir?: string, preParsed?: ParsedCommand, manifestOverride?: ManifestOverride, signal?: AbortSignal): Promise<RiskLevel> {
-  if (signal?.aborted) throw new Error('Cancelled');
+  signal?.throwIfAborted();
 
   // Check cache first (skip when preParsed is provided since caller already
   // parsed and we'd just be duplicating the key computation cost).
@@ -473,7 +473,7 @@ export async function check(
   manifestOverride?: ManifestOverride,
   signal?: AbortSignal,
 ): Promise<PermissionCheckResult> {
-  if (signal?.aborted) throw new Error('Cancelled');
+  signal?.throwIfAborted();
 
   // For shell tools, parse once and share the result to avoid duplicate tree-sitter work.
   let shellParsed: ParsedCommand | undefined;
@@ -615,7 +615,7 @@ function friendlyHostname(url: URL): string {
 }
 
 export async function generateAllowlistOptions(toolName: string, input: Record<string, unknown>, signal?: AbortSignal): Promise<AllowlistOption[]> {
-  if (signal?.aborted) throw new Error('Cancelled');
+  signal?.throwIfAborted();
   if (toolName === 'bash' || toolName === 'host_bash') {
     const command = ((input.command as string) ?? '').trim();
     return buildShellAllowlistOptions(command);

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -699,15 +699,18 @@ export class ToolExecutor {
     } catch (err) {
       const durationMs = Date.now() - startTime;
       const msg = err instanceof Error ? err.message : String(err);
-      const isExpected = err instanceof PermissionDeniedError || err instanceof ToolError || err instanceof TokenExpiredError;
+      const isAbort = err instanceof Error && err.name === 'AbortError';
+      const isExpected = isAbort || err instanceof PermissionDeniedError || err instanceof ToolError || err instanceof TokenExpiredError;
 
-      const errorCategory = err instanceof PermissionDeniedError
-        ? 'permission_denied' as const
-        : err instanceof TokenExpiredError
-          ? 'auth' as const
-          : err instanceof ToolError
-            ? 'tool_failure' as const
-            : 'unexpected' as const;
+      const errorCategory = isAbort
+        ? 'tool_failure' as const
+        : err instanceof PermissionDeniedError
+          ? 'permission_denied' as const
+          : err instanceof TokenExpiredError
+            ? 'auth' as const
+            : err instanceof ToolError
+              ? 'tool_failure' as const
+              : 'unexpected' as const;
 
       emitLifecycleEvent(context, {
         type: 'error',


### PR DESCRIPTION
Replace generic Error('Cancelled') with signal.throwIfAborted() so the executor recognizes permission check cancellations as expected aborts (AbortError with errorCategory: 'tool_failure') rather than unexpected errors. Also update executor catch block to detect AbortError by name. Addressed in followup to #8253.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
