### PR TITLE
fix: initialize pairing handlers so approval responses are processed

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -46,6 +46,7 @@ import { createApprovalCopyGenerator, createApprovalConversationGenerator } from
 import { initializeProvidersAndTools, registerWatcherProviders, registerMessagingProviders } from './providers-setup.js';
 import { installShutdownHandlers } from './shutdown-handlers.js';
 import { writePid, cleanupPidFile } from './daemon-control.js';
+import { initPairingHandlers } from './handlers/pairing.js';
 
 // Re-export public API so existing consumers don't need to change imports
 export {
@@ -264,6 +265,7 @@ export async function runDaemon(): Promise<void> {
     await runtimeHttp.start();
     setRelayBroadcast((msg) => server.broadcast(msg));
     runtimeHttp.setPairingBroadcast((msg) => server.broadcast(msg));
+    initPairingHandlers(runtimeHttp.getPairingStore(), bearerToken);
     server.setHttpPort(httpPort);
     log.info({ port: httpPort, hostname }, 'Daemon startup: runtime HTTP server listening');
   } catch (err) {


### PR DESCRIPTION
## Summary

`initPairingHandlers()` was defined in `pairing.ts` but never called anywhere. This left `pairingStoreRef` as `null`, so when macOS sent a `pairing_approval_response` over IPC, the handler hit the null check on line 29 and silently returned. Result: iOS stayed stuck on "Waiting for approval" forever, and "Always Allow" never persisted to the approved devices list.

## Fix

Call `initPairingHandlers(pairingStore, bearerToken)` in `lifecycle.ts` right after the HTTP server starts, using the same PairingStore instance that handles the HTTP pairing endpoints.

## Testing

1. Show QR code on Mac, scan from iOS
2. Mac shows approval prompt → tap "Always Allow"
3. iOS should transition from "Waiting for approval" to connected
4. Device should appear in Approved Devices list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
