### PR TITLE
Fix: Schedule dedupe key + Telegram channel check

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -654,7 +654,7 @@ export async function runDaemon(): Promise<void> {
           scheduleId: schedule.id,
           name: schedule.name,
         },
-        dedupeKey: `schedule:${schedule.id}:${Date.now()}`,
+        dedupeKey: `schedule:${schedule.id}`,
       });
     },
     (notification) => {

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -13,6 +13,7 @@
 import { v4 as uuid } from 'uuid';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
+import { getActiveBinding } from '../memory/channel-guardian-store.js';
 import { createEvent } from './events-store.js';
 import { evaluateSignal } from './decision-engine.js';
 import { runDeterministicChecks, type DeterministicCheckContext } from './deterministic-checks.js';
@@ -56,15 +57,19 @@ function getBroadcaster(): NotificationBroadcaster {
 
 // ── Connected channels resolution ──────────────────────────────────────
 
-function getConnectedChannels(): NotificationChannel[] {
+function getConnectedChannels(assistantId: string): NotificationChannel[] {
   // macOS is always considered connected (IPC socket is always available
-  // when the daemon is running). Telegram is connected if its adapter
-  // can resolve a destination.
+  // when the daemon is running).
   const channels: NotificationChannel[] = ['macos'];
-  // Telegram availability is checked downstream by the destination
-  // resolver, so we always include it as available and let the
-  // deterministic checks handle cases where no binding exists.
-  channels.push('telegram');
+  // Only report Telegram as connected when there is an active guardian
+  // binding for this assistant. Without a binding, the destination
+  // resolver will fail to resolve a chat ID and dispatch will silently
+  // drop the message — which is worse than the decision engine knowing
+  // up front that the channel is unavailable.
+  const telegramBinding = getActiveBinding(assistantId, 'telegram');
+  if (telegramBinding) {
+    channels.push('telegram');
+  }
   return channels;
 }
 
@@ -134,7 +139,7 @@ export async function emitNotificationSignal(params: EmitSignalParams): Promise<
     }
 
     // Step 2: Evaluate the signal through the decision engine
-    const connectedChannels = getConnectedChannels();
+    const connectedChannels = getConnectedChannels(assistantId);
     const decision = await evaluateSignal(signal, connectedChannels);
 
     // Step 3: Run deterministic pre-send checks


### PR DESCRIPTION
Fix two review issues on #8369: (1) Remove Date.now() from schedule.complete dedupeKey for proper deduplication, (2) Make getConnectedChannels() check actual Telegram binding availability instead of hardcoding it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
