### PR TITLE
Fix: Remove schedule dedupeKey for recurring support

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -654,7 +654,6 @@ export async function runDaemon(): Promise<void> {
           scheduleId: schedule.id,
           name: schedule.name,
         },
-        dedupeKey: `schedule:${schedule.id}`,
       });
     },
     (notification) => {


### PR DESCRIPTION
Remove static dedupeKey from schedule.complete signals to prevent permanent deduplication of recurring schedule notifications. Schedules have natural dedup via the claim mechanism. Addresses feedback on #8376.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
