### PR TITLE
M1: Recording Intent + Routing Foundation

### DIFF
--- a/assistant/src/__tests__/recording-intent.test.ts
+++ b/assistant/src/__tests__/recording-intent.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'bun:test';
+import { detectRecordingIntent } from '../daemon/recording-intent.js';
+
+describe('detectRecordingIntent', () => {
+  describe('positive cases', () => {
+    const positiveCases = [
+      'record my screen',
+      'record the screen',
+      'record screen',
+      'Record my display',
+      'record my desktop',
+      'record my session',
+      'screen record this',
+      'screenrecord while I work',
+      'capture my screen',
+      'capture the display',
+      'capture my desktop',
+      'record this',
+      'record while I work',
+      'record what I do',
+      'record me doing this',
+      'start recording',
+      'record a video',
+      'record video of my workflow',
+      'video record this session',
+      'make a recording',
+      'take a recording',
+      'take a screen recording',
+    ];
+
+    for (const input of positiveCases) {
+      it(`detects recording intent: "${input}"`, () => {
+        expect(detectRecordingIntent(input)).toBe(true);
+      });
+    }
+  });
+
+  describe('negative cases', () => {
+    const negativeCases = [
+      'open Safari',
+      'check my email',
+      'write a function',
+      'what is the weather',
+      'record in the database',
+      'help me with this task',
+      'open the recording app',
+    ];
+
+    for (const input of negativeCases) {
+      it(`does not detect recording intent: "${input}"`, () => {
+        expect(detectRecordingIntent(input)).toBe(false);
+      });
+    }
+  });
+});

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -72,8 +72,9 @@ export async function handleTaskSubmit(
     const isRecordingRequested = detectRecordingIntent(msg.task);
     rlog.info({ interactionType, isRecordingRequested, slashBypass: slashCandidate.kind === 'candidate', taskLength: msg.task.length }, 'Task classified');
 
-    // Recording always requires computer_use — override text_qa when recording is requested
-    const effectiveType = (interactionType === 'text_qa' && isRecordingRequested)
+    // Recording requires computer_use — but only override when this is NOT a slash candidate,
+    // so that slash-command routing (e.g. "/do record my screen ...") is preserved.
+    const effectiveType = (isRecordingRequested && slashCandidate.kind !== 'candidate')
       ? 'computer_use' as const
       : interactionType;
 
@@ -96,6 +97,7 @@ export async function handleTaskSubmit(
         type: 'task_routed',
         sessionId,
         interactionType: 'computer_use',
+        requiresRecording: isRecordingRequested || undefined,
       });
     } else {
       // Create text QA session and immediately start processing

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -19,6 +19,7 @@ import type {
 } from '../ipc-protocol.js';
 import { log, wireEscalationHandler, renderHistoryContent, defineHandlers, type HandlerContext } from './shared.js';
 import { handleCuSessionCreate } from './computer-use.js';
+import { detectRecordingIntent } from '../recording-intent.js';
 
 // ─── Task submit handler ────────────────────────────────────────────────────
 
@@ -68,9 +69,15 @@ export async function handleTaskSubmit(
     const interactionType = slashCandidate.kind === 'candidate'
       ? 'text_qa' as const
       : await classifyInteraction(msg.task, msg.source);
-    rlog.info({ interactionType, slashBypass: slashCandidate.kind === 'candidate', taskLength: msg.task.length }, 'Task classified');
+    const isRecordingRequested = detectRecordingIntent(msg.task);
+    rlog.info({ interactionType, isRecordingRequested, slashBypass: slashCandidate.kind === 'candidate', taskLength: msg.task.length }, 'Task classified');
 
-    if (interactionType === 'computer_use') {
+    // Recording always requires computer_use — override text_qa when recording is requested
+    const effectiveType = (interactionType === 'text_qa' && isRecordingRequested)
+      ? 'computer_use' as const
+      : interactionType;
+
+    if (effectiveType === 'computer_use') {
       // Create CU session (reuse handleCuSessionCreate logic)
       const sessionId = uuid();
       const cuMsg: CuSessionCreate = {
@@ -81,6 +88,7 @@ export async function handleTaskSubmit(
         screenHeight: msg.screenHeight,
         attachments: msg.attachments,
         interactionType: 'computer_use',
+        requiresRecording: isRecordingRequested || undefined,
       };
       handleCuSessionCreate(cuMsg, socket, ctx);
 

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -250,6 +250,7 @@ export function wireEscalationHandler(
       interactionType: 'computer_use',
       task,
       escalatedFrom: sourceSessionId,
+      requiresRecording: isRecordingRequested || undefined,
     });
 
     return true;

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -9,6 +9,7 @@ import type { ClientMessage, CuSessionCreate, ServerMessage, SessionTransportMet
 import type { SecretPromptResult } from '../../permissions/secret-prompter.js';
 import { getConfig } from '../../config/loader.js';
 import type { DebouncerMap } from '../../util/debounce.js';
+import { detectRecordingIntent } from '../recording-intent.js';
 import type { GuardianRuntimeContext } from '../session-runtime-assembly.js';
 
 const log = getLogger('handlers');
@@ -230,6 +231,7 @@ export function wireEscalationHandler(
       return false;
     }
 
+    const isRecordingRequested = detectRecordingIntent(task);
     const cuSessionId = uuid();
     const cuMsg: CuSessionCreate = {
       type: 'cu_session_create',
@@ -238,6 +240,7 @@ export function wireEscalationHandler(
       screenWidth,
       screenHeight,
       interactionType: 'computer_use',
+      requiresRecording: isRecordingRequested || undefined,
     };
     handleCuSessionCreate(cuMsg, currentSocket, ctx);
 

--- a/assistant/src/daemon/ipc-contract/computer-use.ts
+++ b/assistant/src/daemon/ipc-contract/computer-use.ts
@@ -12,6 +12,8 @@ export interface CuSessionCreate {
   screenHeight: number;
   attachments?: UserMessageAttachment[];
   interactionType?: 'computer_use' | 'text_qa';
+  /** When true, the client should start screen recording for this session. */
+  requiresRecording?: boolean;
 }
 
 export interface CuSessionAbort {

--- a/assistant/src/daemon/ipc-contract/computer-use.ts
+++ b/assistant/src/daemon/ipc-contract/computer-use.ts
@@ -117,6 +117,8 @@ export interface TaskRouted {
   task?: string;
   /** Set when a text_qa session escalates to computer_use via computer_use_request_control. */
   escalatedFrom?: string;
+  /** When true, the client should start screen recording for this session. */
+  requiresRecording?: boolean;
 }
 
 export interface RideShotgunProgress {

--- a/assistant/src/daemon/recording-intent.ts
+++ b/assistant/src/daemon/recording-intent.ts
@@ -1,0 +1,21 @@
+/**
+ * Detect whether the user is requesting screen recording.
+ * This is independent of QA intent — a prompt can trigger both.
+ */
+export function detectRecordingIntent(taskText: string): boolean {
+  const lower = taskText.toLowerCase().trim();
+
+  const recordingPatterns = [
+    /\brecord\s+((my|the|a)\s+)?(screen|display|desktop|session)\b/,
+    /\bscreen\s*record/,
+    /\bcapture\s+((my|the|a)\s+)?(screen|display|desktop)\b/,
+    /\brecord\s+(this|while|what|me)\b/,
+    /\bstart\s+recording\b/,
+    /\brecord\s+(a\s+)?video\b/,
+    /\bvideo\s+record/,
+    /\bmake\s+a\s+recording\b/,
+    /\btake\s+a\s+(screen\s+)?recording\b/,
+  ];
+
+  return recordingPatterns.some(p => p.test(lower));
+}

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -4196,13 +4196,16 @@ public struct IPCTaskRouted: Codable, Sendable {
     public let task: String?
     /// Set when a text_qa session escalates to computer_use via computer_use_request_control.
     public let escalatedFrom: String?
+    /// When true, the client should start screen recording for this session.
+    public let requiresRecording: Bool?
 
-    public init(type: String, sessionId: String, interactionType: String, task: String? = nil, escalatedFrom: String? = nil) {
+    public init(type: String, sessionId: String, interactionType: String, task: String? = nil, escalatedFrom: String? = nil, requiresRecording: Bool? = nil) {
         self.type = type
         self.sessionId = sessionId
         self.interactionType = interactionType
         self.task = task
         self.escalatedFrom = escalatedFrom
+        self.requiresRecording = requiresRecording
     }
 }
 


### PR DESCRIPTION
## Summary
- Add detectRecordingIntent() function for natural language recording request detection
- Integrate recording intent into task_submit and escalation routing
- When recording is requested, route to computer_use with requiresRecording=true
- Add comprehensive tests for recording intent detection

Closes #8378

## Original prompt
Part of #8377: Standalone Screen Recording Skill
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
