### PR TITLE
fix: drop legacy conversation_id index and remove from Drizzle schema

### DIFF
--- a/assistant/src/memory/migrations/016-memory-segments-indexes.ts
+++ b/assistant/src/memory/migrations/016-memory-segments-indexes.ts
@@ -8,4 +8,5 @@ import type { DrizzleDb } from '../db-connection.js';
  */
 export function migrateMemorySegmentsIndexes(database: DrizzleDb): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_segments_scope_id ON memory_segments(scope_id)`);
+  database.run(/*sql*/ `DROP INDEX IF EXISTS idx_memory_segments_conversation_id`);
 }

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -64,7 +64,6 @@ export const memorySegments = sqliteTable('memory_segments', {
   updatedAt: integer('updated_at').notNull(),
 }, (table) => [
   index('idx_memory_segments_scope_id').on(table.scopeId),
-  index('idx_memory_segments_conversation_id').on(table.conversationId),
 ]);
 
 export const memoryItems = sqliteTable('memory_items', {


### PR DESCRIPTION
Addresses feedback on #8357: adds DROP INDEX IF EXISTS to clean up existing DBs and removes the redundant index declaration from the Drizzle schema.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
