### PR TITLE
fix: unreserve dedup cache entries on CircuitBreakerOpenError before returning 503

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -292,6 +292,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
       } catch (err) {
         if (err instanceof CircuitBreakerOpenError) {
           acknowledgeCallbackQuery(normalized.message.callbackQueryId, "start_command_circuit_open");
+          if (updateId !== undefined) dedupCache.unreserve(updateId);
           return Response.json(
             { error: "Service temporarily unavailable" },
             { status: 503, headers: { "Retry-After": String(err.retryAfterSecs) } },
@@ -490,6 +491,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
       if (err instanceof CircuitBreakerOpenError) {
         tlog.warn({ retryAfterSecs: err.retryAfterSecs }, "Circuit breaker open — returning 503");
         if (isCallback) acknowledgeCallbackQuery(normalized.message.callbackQueryId, "circuit_open");
+        if (updateId !== undefined) dedupCache.unreserve(updateId);
         return Response.json(
           { error: "Service temporarily unavailable" },
           { status: 503, headers: { "Retry-After": String(err.retryAfterSecs) } },

--- a/gateway/src/http/routes/twilio-sms-webhook.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.ts
@@ -208,6 +208,7 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
     } catch (err) {
       if (err instanceof CircuitBreakerOpenError) {
         tlog.warn({ retryAfterSecs: err.retryAfterSecs }, "Circuit breaker open — returning 503");
+        dedupCache.unreserve(messageSid);
         return Response.json(
           { error: "Service temporarily unavailable" },
           { status: 503, headers: { "Retry-After": String(err.retryAfterSecs) } },

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -209,6 +209,7 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
       } catch (err) {
         if (err instanceof CircuitBreakerOpenError) {
           tlog.warn({ retryAfterSecs: err.retryAfterSecs }, "Circuit breaker open — returning 503");
+          dedupCache.unreserve(whatsappMessageId);
           return Response.json(
             { error: "Service temporarily unavailable" },
             { status: 503, headers: { "Retry-After": String(err.retryAfterSecs) } },


### PR DESCRIPTION
Addresses feedback on #8367: adds dedupCache.unreserve() calls in all CircuitBreakerOpenError catch blocks across Telegram, Twilio SMS, and WhatsApp webhook handlers to prevent message loss on retries.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
