### PR TITLE
fix: validate daemon timeout bounds in readDaemonTimeouts

### DIFF
--- a/assistant/src/daemon/daemon-control.ts
+++ b/assistant/src/daemon/daemon-control.ts
@@ -19,6 +19,10 @@ const DAEMON_TIMEOUT_DEFAULTS = {
   sigkillGracePeriodMs: 2000,
 };
 
+function isPositiveInteger(v: unknown): v is number {
+  return typeof v === 'number' && Number.isInteger(v) && v > 0;
+}
+
 /**
  * Read daemon timeout values directly from the config JSON file, bypassing
  * loadConfig() and its ensureMigratedDataDir()/ensureDataDir() side effects.
@@ -30,18 +34,15 @@ function readDaemonTimeouts(): typeof DAEMON_TIMEOUT_DEFAULTS {
     const raw = JSON.parse(readFileSync(getWorkspaceConfigPath(), 'utf-8'));
     if (raw.daemon && typeof raw.daemon === 'object') {
       return {
-        startupSocketWaitMs:
-          typeof raw.daemon.startupSocketWaitMs === 'number'
-            ? raw.daemon.startupSocketWaitMs
-            : DAEMON_TIMEOUT_DEFAULTS.startupSocketWaitMs,
-        stopTimeoutMs:
-          typeof raw.daemon.stopTimeoutMs === 'number'
-            ? raw.daemon.stopTimeoutMs
-            : DAEMON_TIMEOUT_DEFAULTS.stopTimeoutMs,
-        sigkillGracePeriodMs:
-          typeof raw.daemon.sigkillGracePeriodMs === 'number'
-            ? raw.daemon.sigkillGracePeriodMs
-            : DAEMON_TIMEOUT_DEFAULTS.sigkillGracePeriodMs,
+        startupSocketWaitMs: isPositiveInteger(raw.daemon.startupSocketWaitMs)
+          ? raw.daemon.startupSocketWaitMs
+          : DAEMON_TIMEOUT_DEFAULTS.startupSocketWaitMs,
+        stopTimeoutMs: isPositiveInteger(raw.daemon.stopTimeoutMs)
+          ? raw.daemon.stopTimeoutMs
+          : DAEMON_TIMEOUT_DEFAULTS.stopTimeoutMs,
+        sigkillGracePeriodMs: isPositiveInteger(raw.daemon.sigkillGracePeriodMs)
+          ? raw.daemon.sigkillGracePeriodMs
+          : DAEMON_TIMEOUT_DEFAULTS.sigkillGracePeriodMs,
       };
     }
   } catch {


### PR DESCRIPTION
Addresses feedback on #8368: adds bounds validation (positive integer check) to readDaemonTimeouts() so invalid values like 0, negative, or non-integers fall back to defaults.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
