### PR TITLE
Fix: Address M1 review feedback (slash bypass + task_routed flag)

### DIFF
--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -72,8 +72,9 @@ export async function handleTaskSubmit(
     const isRecordingRequested = detectRecordingIntent(msg.task);
     rlog.info({ interactionType, isRecordingRequested, slashBypass: slashCandidate.kind === 'candidate', taskLength: msg.task.length }, 'Task classified');
 
-    // Recording always requires computer_use — override text_qa when recording is requested
-    const effectiveType = (interactionType === 'text_qa' && isRecordingRequested)
+    // Recording requires computer_use — but only override when this is NOT a slash candidate,
+    // so that slash-command routing (e.g. "/do record my screen ...") is preserved.
+    const effectiveType = (isRecordingRequested && slashCandidate.kind !== 'candidate')
       ? 'computer_use' as const
       : interactionType;
 
@@ -96,6 +97,7 @@ export async function handleTaskSubmit(
         type: 'task_routed',
         sessionId,
         interactionType: 'computer_use',
+        requiresRecording: isRecordingRequested || undefined,
       });
     } else {
       // Create text QA session and immediately start processing

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -250,6 +250,7 @@ export function wireEscalationHandler(
       interactionType: 'computer_use',
       task,
       escalatedFrom: sourceSessionId,
+      requiresRecording: isRecordingRequested || undefined,
     });
 
     return true;

--- a/assistant/src/daemon/ipc-contract/computer-use.ts
+++ b/assistant/src/daemon/ipc-contract/computer-use.ts
@@ -117,6 +117,8 @@ export interface TaskRouted {
   task?: string;
   /** Set when a text_qa session escalates to computer_use via computer_use_request_control. */
   escalatedFrom?: string;
+  /** When true, the client should start screen recording for this session. */
+  requiresRecording?: boolean;
 }
 
 export interface RideShotgunProgress {

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -4196,13 +4196,16 @@ public struct IPCTaskRouted: Codable, Sendable {
     public let task: String?
     /// Set when a text_qa session escalates to computer_use via computer_use_request_control.
     public let escalatedFrom: String?
+    /// When true, the client should start screen recording for this session.
+    public let requiresRecording: Bool?
 
-    public init(type: String, sessionId: String, interactionType: String, task: String? = nil, escalatedFrom: String? = nil) {
+    public init(type: String, sessionId: String, interactionType: String, task: String? = nil, escalatedFrom: String? = nil, requiresRecording: Bool? = nil) {
         self.type = type
         self.sessionId = sessionId
         self.interactionType = interactionType
         self.task = task
         self.escalatedFrom = escalatedFrom
+        self.requiresRecording = requiresRecording
     }
 }
 


### PR DESCRIPTION
## Summary
- Preserve slash-command bypass: recording intent no longer overrides slash candidate routing
- Expose requiresRecording on task_routed server message so clients receive the flag
- Addresses feedback from Codex review on #8388

Fixes feedback on #8388
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
