### PR TITLE
fix: propagate queue-full status through subagent message path

### DIFF
--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -397,8 +397,8 @@ describe('SubagentManager sendMessage validation', () => {
     const subagentId = 'sub-1';
     injectFakeSubagent(manager, subagentId, makeState(subagentId));
 
-    expect(manager.sendMessage(subagentId, '')).toBe(false);
-    expect(manager.sendMessage(subagentId, '   ')).toBe(false);
-    expect(manager.sendMessage(subagentId, '\n\t')).toBe(false);
+    expect(manager.sendMessage(subagentId, '')).toBe('empty');
+    expect(manager.sendMessage(subagentId, '   ')).toBe('empty');
+    expect(manager.sendMessage(subagentId, '\n\t')).toBe('empty');
   });
 });

--- a/assistant/src/daemon/handlers/subagents.ts
+++ b/assistant/src/daemon/handlers/subagents.ts
@@ -109,10 +109,17 @@ export function handleSubagentMessage(
     return;
   }
 
-  const sent = manager.sendMessage(msg.subagentId, msg.content);
+  const result = manager.sendMessage(msg.subagentId, msg.content);
 
-  if (!sent) {
-    log.warn({ subagentId: msg.subagentId }, 'Client sent message to terminal subagent');
+  if (result === 'queue_full') {
+    log.warn({ subagentId: msg.subagentId }, 'Subagent message rejected — queue full');
+    ctx.send(socket, {
+      type: 'error',
+      message: `Subagent "${msg.subagentId}" message queue is full. Please wait for current messages to be processed.`,
+      category: 'queue_full',
+    });
+  } else if (result !== 'sent') {
+    log.warn({ subagentId: msg.subagentId, reason: result }, 'Client sent message to terminal subagent');
     ctx.send(socket, {
       type: 'error',
       message: `Subagent "${msg.subagentId}" not found or in terminal state.`,

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -343,20 +343,20 @@ export class SubagentManager {
 
   // ── Send message to subagent ──────────────────────────────────────────
 
-  sendMessage(subagentId: string, content: string): boolean {
+  sendMessage(subagentId: string, content: string): 'sent' | 'empty' | 'not_found' | 'terminal' | 'queue_full' {
     const trimmed = content?.trim();
-    if (!trimmed) return false;
+    if (!trimmed) return 'empty';
 
     const managed = this.subagents.get(subagentId);
-    if (!managed) return false;
-    if (TERMINAL_STATUSES.has(managed.state.status)) return false;
+    if (!managed) return 'not_found';
+    if (TERMINAL_STATUSES.has(managed.state.status)) return 'terminal';
 
     const onEvent = managed.session.sendToClient;
     const requestId = uuid();
 
     // If the session is busy, queue the message; otherwise process immediately.
     const result = managed.session.enqueueMessage(trimmed, [], onEvent, requestId);
-    if (result.rejected) return false;
+    if (result.rejected) return 'queue_full';
     if (!result.queued) {
       // Session is idle — send directly.  Fire-and-forget so we don't block.
       const messageId = managed.session.persistUserMessage(trimmed, []);
@@ -364,7 +364,7 @@ export class SubagentManager {
         log.error({ subagentId, err }, 'Subagent message processing failed');
       });
     }
-    return true;
+    return 'sent';
   }
 
   // ── Queries ───────────────────────────────────────────────────────────

--- a/assistant/src/tools/subagent/message.ts
+++ b/assistant/src/tools/subagent/message.ts
@@ -23,9 +23,16 @@ export async function executeSubagentMessage(
     };
   }
 
-  const sent = manager.sendMessage(subagentId, content);
+  const result = manager.sendMessage(subagentId, content);
 
-  if (!sent) {
+  if (result === 'queue_full') {
+    return {
+      content: `Subagent "${subagentId}" message queue is full. Please wait for current messages to be processed.`,
+      isError: true,
+    };
+  }
+
+  if (result !== 'sent') {
     return {
       content: `Could not send message to subagent "${subagentId}". It may not exist or be in a terminal state.`,
       isError: true,


### PR DESCRIPTION
Addresses feedback on #8358: ensures the queue-full condition is properly communicated through the SubagentManager.sendMessage and handleSubagentMessage call paths instead of being mapped to misleading not-found errors.

Changes sendMessage return type from boolean to a discriminated string union ('sent' | 'empty' | 'not_found' | 'terminal' | 'queue_full') so callers can distinguish between different failure modes. Updates both call sites (IPC handler and tool) to surface queue-full as a distinct error category.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
