### PR TITLE
fix: respect env var precedence in http-token watcher

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -43,13 +43,22 @@ function startHttpTokenWatcher(cfg: GatewayConfig): FSWatcher | null {
     ?? join(process.env.BASE_DATA_DIR?.trim() || homedir(), ".vellum", "http-token");
 
   const dir = dirname(tokenPath);
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
+  try {
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+  } catch (err) {
+    log.warn({ err, path: dir }, "Cannot create token directory, skipping http-token watcher");
+    return null;
   }
 
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
   function refresh(): void {
+    // Skip file-based refresh when env vars explicitly pin the tokens —
+    // respect the same precedence as loadConfig().
+    if (process.env.RUNTIME_BEARER_TOKEN) return;
+
     try {
       const token = readFileSync(tokenPath, "utf-8").trim() || undefined;
       if (token && token !== cfg.runtimeBearerToken) {


### PR DESCRIPTION
## Summary

Addresses review feedback on #8389.

**Env var precedence (Codex P1 + Devin):** When `RUNTIME_BEARER_TOKEN` is set via env var (cloud deploys), the file watcher now skips refresh entirely — the env var takes priority, matching the precedence in `loadConfig()`. Previously, a daemon file write would silently override the env-pinned token.

**mkdirSync crash (Codex P2):** Wrapped the directory creation in try-catch so a non-writable parent directory gracefully skips the watcher instead of crashing the gateway at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
