### PR TITLE
M2: IPC Contract for Recording Source Selection

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -131,6 +131,12 @@ exports[`IPC message snapshots ClientMessage types sandbox_set serializes to exp
 
 exports[`IPC message snapshots ClientMessage types cu_session_create serializes to expected JSON 1`] = `
 {
+  "recordingOptions": {
+    "captureScope": "display",
+    "displayId": "69734112",
+    "includeAudio": false,
+    "promptForSource": true,
+  },
   "screenHeight": 1080,
   "screenWidth": 1920,
   "sessionId": "cu-sess-001",
@@ -1036,6 +1042,33 @@ exports[`IPC message snapshots ClientMessage types assistant_inbox_reply seriali
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types pairing_approval_response serializes to expected JSON 1`] = `
+{
+  "decision": "approve_once",
+  "pairingRequestId": "pair-001",
+  "type": "pairing_approval_response",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types approved_devices_list serializes to expected JSON 1`] = `
+{
+  "type": "approved_devices_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types approved_device_remove serializes to expected JSON 1`] = `
+{
+  "hashedDeviceId": "hashed-device-001",
+  "type": "approved_device_remove",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types approved_devices_clear serializes to expected JSON 1`] = `
+{
+  "type": "approved_devices_clear",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types auth_result serializes to expected JSON 1`] = `
 {
   "success": true,
@@ -1476,6 +1509,11 @@ exports[`IPC message snapshots ServerMessage types cu_error serializes to expect
 exports[`IPC message snapshots ServerMessage types task_routed serializes to expected JSON 1`] = `
 {
   "interactionType": "computer_use",
+  "recordingOptions": {
+    "captureScope": "window",
+    "includeAudio": true,
+    "windowId": 12345,
+  },
   "sessionId": "sess-routed-001",
   "type": "task_routed",
 }
@@ -2878,33 +2916,6 @@ exports[`IPC message snapshots ServerMessage types assistant_inbox_reply_respons
   "messageId": "msg-reply-001",
   "success": true,
   "type": "assistant_inbox_reply_response",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types pairing_approval_response serializes to expected JSON 1`] = `
-{
-  "decision": "approve_once",
-  "pairingRequestId": "pair-001",
-  "type": "pairing_approval_response",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types approved_devices_list serializes to expected JSON 1`] = `
-{
-  "type": "approved_devices_list",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types approved_device_remove serializes to expected JSON 1`] = `
-{
-  "hashedDeviceId": "hashed-device-001",
-  "type": "approved_device_remove",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types approved_devices_clear serializes to expected JSON 1`] = `
-{
-  "type": "approved_devices_clear",
 }
 `;
 

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -99,6 +99,12 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     task: 'Open Safari and search for weather',
     screenWidth: 1920,
     screenHeight: 1080,
+    recordingOptions: {
+      captureScope: 'display',
+      displayId: '69734112',
+      includeAudio: false,
+      promptForSource: true,
+    },
   },
   cu_session_abort: {
     type: 'cu_session_abort',
@@ -945,6 +951,11 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     type: 'task_routed',
     sessionId: 'sess-routed-001',
     interactionType: 'computer_use',
+    recordingOptions: {
+      captureScope: 'window',
+      windowId: 12345,
+      includeAudio: true,
+    },
   },
   ride_shotgun_progress: {
     type: 'ride_shotgun_progress',

--- a/assistant/src/daemon/ipc-contract/computer-use.ts
+++ b/assistant/src/daemon/ipc-contract/computer-use.ts
@@ -2,6 +2,22 @@
 
 import type { UserMessageAttachment, IpcBlobRef } from './shared.js';
 
+// === Recording options ===
+
+/** Options describing what the client should record and how. */
+export interface RecordingOptions {
+  /** Whether to capture the full display or a single window. */
+  captureScope?: 'display' | 'window';
+  /** CGDirectDisplayID identifying which display to record. */
+  displayId?: string;
+  /** CGWindowID identifying which window to record. */
+  windowId?: number;
+  /** Whether to include system audio in the recording. */
+  includeAudio?: boolean;
+  /** When true, prompt the user to choose a source before recording starts. */
+  promptForSource?: boolean;
+}
+
 // === Client → Server ===
 
 export interface CuSessionCreate {
@@ -14,6 +30,8 @@ export interface CuSessionCreate {
   interactionType?: 'computer_use' | 'text_qa';
   /** When true, the client should start screen recording for this session. */
   requiresRecording?: boolean;
+  /** Recording source/options selected by the client or requested by the daemon. */
+  recordingOptions?: RecordingOptions;
 }
 
 export interface CuSessionAbort {
@@ -119,6 +137,8 @@ export interface TaskRouted {
   escalatedFrom?: string;
   /** When true, the client should start screen recording for this session. */
   requiresRecording?: boolean;
+  /** Recording source/options the client should use for this session. */
+  recordingOptions?: RecordingOptions;
 }
 
 export interface RideShotgunProgress {

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1313,8 +1313,12 @@ public struct IPCCuSessionCreate: Codable, Sendable {
     public let screenHeight: Int
     public let attachments: [IPCUserMessageAttachment]?
     public let interactionType: String?
+    /// When true, the client should start screen recording for this session.
+    public let requiresRecording: Bool?
+    /// Recording source/options selected by the client or requested by the daemon.
+    public let recordingOptions: IPCRecordingOptions?
 
-    public init(type: String, sessionId: String, task: String, screenWidth: Int, screenHeight: Int, attachments: [IPCUserMessageAttachment]? = nil, interactionType: String? = nil) {
+    public init(type: String, sessionId: String, task: String, screenWidth: Int, screenHeight: Int, attachments: [IPCUserMessageAttachment]? = nil, interactionType: String? = nil, requiresRecording: Bool? = nil, recordingOptions: IPCRecordingOptions? = nil) {
         self.type = type
         self.sessionId = sessionId
         self.task = task
@@ -1322,6 +1326,8 @@ public struct IPCCuSessionCreate: Codable, Sendable {
         self.screenHeight = screenHeight
         self.attachments = attachments
         self.interactionType = interactionType
+        self.requiresRecording = requiresRecording
+        self.recordingOptions = recordingOptions
     }
 }
 
@@ -3018,6 +3024,28 @@ public struct IPCPublishPageResponse: Codable, Sendable {
     }
 }
 
+/// Options describing what the client should record and how.
+public struct IPCRecordingOptions: Codable, Sendable {
+    /// Whether to capture the full display or a single window.
+    public let captureScope: String?
+    /// CGDirectDisplayID identifying which display to record.
+    public let displayId: String?
+    /// CGWindowID identifying which window to record.
+    public let windowId: Double?
+    /// Whether to include system audio in the recording.
+    public let includeAudio: Bool?
+    /// When true, prompt the user to choose a source before recording starts.
+    public let promptForSource: Bool?
+
+    public init(captureScope: String? = nil, displayId: String? = nil, windowId: Double? = nil, includeAudio: Bool? = nil, promptForSource: Bool? = nil) {
+        self.captureScope = captureScope
+        self.displayId = displayId
+        self.windowId = windowId
+        self.includeAudio = includeAudio
+        self.promptForSource = promptForSource
+    }
+}
+
 public struct IPCRegenerateRequest: Codable, Sendable {
     public let type: String
     public let sessionId: String
@@ -4198,14 +4226,17 @@ public struct IPCTaskRouted: Codable, Sendable {
     public let escalatedFrom: String?
     /// When true, the client should start screen recording for this session.
     public let requiresRecording: Bool?
+    /// Recording source/options the client should use for this session.
+    public let recordingOptions: IPCRecordingOptions?
 
-    public init(type: String, sessionId: String, interactionType: String, task: String? = nil, escalatedFrom: String? = nil, requiresRecording: Bool? = nil) {
+    public init(type: String, sessionId: String, interactionType: String, task: String? = nil, escalatedFrom: String? = nil, requiresRecording: Bool? = nil, recordingOptions: IPCRecordingOptions? = nil) {
         self.type = type
         self.sessionId = sessionId
         self.interactionType = interactionType
         self.task = task
         self.escalatedFrom = escalatedFrom
         self.requiresRecording = requiresRecording
+        self.recordingOptions = recordingOptions
     }
 }
 


### PR DESCRIPTION
## Summary
- Add recordingOptions object (captureScope, displayId, windowId, includeAudio, promptForSource) to CU IPC contract
- Fields appear on CuSessionCreate, TaskRouted, and CuSessionRoutedMessage
- Regenerate Swift IPC types and update snapshots

Closes #8379

## Original prompt
Part of #8377: Standalone Screen Recording Skill
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
