### PR TITLE
feat: add tooltip for truncated thread titles in macOS sidebar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -815,6 +815,7 @@ struct MainWindowView: View {
                     .foregroundColor(VColor.textPrimary)
                     .lineLimit(1)
                     .truncationMode(.tail)
+                    .help(thread.title)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, VSpacing.md)


### PR DESCRIPTION
## Summary
- Adds `.help(thread.title)` modifier to thread title text in the sidebar so hovering over a truncated title shows the full name as a native macOS tooltip

## Original prompt
when the title of a thread is too long in the side nav for macos, we show a "..." suffix and truncate it. However, we should also show a tooltip on hover that shows the full name in this case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
