### PR TITLE
fix: use title case for Privacy & Security settings heading

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -792,7 +792,7 @@ struct SettingsPanel: View {
 
             // PRIVACY & SECURITY section
             VStack(alignment: .leading, spacing: VSpacing.md) {
-                Text("PRIVACY & SECURITY")
+                Text("Privacy & Security")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
 


### PR DESCRIPTION
## Summary
- Changes "PRIVACY & SECURITY" to "Privacy & Security" in the macOS settings panel to match the title case style used by all other section headings

## Original prompt
Right now "PRIVACY & SECURITY" is all caps and doesn't match the style of the other section titles on this settings page in mac. Fix it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
