### PR TITLE
M3: macOS Recording Source Picker UI (Deterministic)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -45,8 +45,9 @@ extension AppDelegate {
             return pickerVM.selectedRecordingOptions
         }
 
-        // Try auto-apply from saved preference
-        if pickerVM.canAutoApply() {
+        // Try auto-apply from saved preference, but only when the caller
+        // didn't explicitly request the picker via promptForSource.
+        if routed.recordingOptions?.promptForSource != true, pickerVM.canAutoApply() {
             log.info("Auto-applied saved recording source preference")
             return pickerVM.selectedRecordingOptions
         }
@@ -240,6 +241,8 @@ extension AppDelegate {
                         } catch {
                             log.error("Failed to send CU session abort after picker cancel: \(error)")
                         }
+                        self.recordingPickerWindow?.close()
+                        self.recordingPickerWindow = nil
                         return
                     }
                     self.recordingPickerWindow?.close()

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -1,4 +1,5 @@
 import AppKit
+import SwiftUI
 import UserNotifications
 import VellumAssistantShared
 import os
@@ -25,6 +26,45 @@ extension AppDelegate {
             if ActionExecutor.checkAccessibilityPermission(prompt: false) { return true }
         }
         return false
+    }
+
+    // MARK: - Recording Source Picker
+
+    /// Determines whether the recording source picker should be shown, and if so,
+    /// presents it as a modal window. Returns the selected recording options, or nil
+    /// if the user cancelled.
+    ///
+    /// Auto-applies saved preferences when valid, skipping the picker entirely.
+    private func resolveRecordingOptions(for routed: TaskRoutedMessage) async -> IPCRecordingOptions? {
+        let pickerVM = RecordingSourcePickerViewModel()
+
+        let needsPicker = routed.recordingOptions?.promptForSource == true || pickerVM.hasMultipleDisplays
+
+        guard needsPicker else {
+            // Single display, no prompt requested — use default options
+            return pickerVM.selectedRecordingOptions
+        }
+
+        // Try auto-apply from saved preference
+        if pickerVM.canAutoApply() {
+            log.info("Auto-applied saved recording source preference")
+            return pickerVM.selectedRecordingOptions
+        }
+
+        // Show the picker and wait for user selection
+        return await withCheckedContinuation { continuation in
+            let pickerWindow = RecordingSourcePickerWindow(
+                viewModel: pickerVM,
+                onStart: {
+                    continuation.resume(returning: pickerVM.selectedRecordingOptions)
+                },
+                onCancel: {
+                    continuation.resume(returning: nil)
+                }
+            )
+            pickerWindow.show()
+            self.recordingPickerWindow = pickerWindow
+        }
     }
 
     // MARK: - Escalation
@@ -185,6 +225,27 @@ extension AppDelegate {
                     }
                     return
                 }
+
+                // Resolve recording options if the session requires recording.
+                // The resolved options are logged here; a subsequent milestone will
+                // pass them to the session/recorder init.
+                if routed.requiresRecording == true {
+                    if let pickerResult = await self.resolveRecordingOptions(for: routed) {
+                        log.info("Recording options resolved — scope: \(pickerResult.captureScope ?? "default"), audio: \(pickerResult.includeAudio ?? false)")
+                    } else {
+                        // User cancelled the picker — abort the session
+                        log.info("User cancelled recording source picker — aborting session \(routed.sessionId)")
+                        do {
+                            try self.daemonClient.send(CuSessionAbortMessage(sessionId: routed.sessionId))
+                        } catch {
+                            log.error("Failed to send CU session abort after picker cancel: \(error)")
+                        }
+                        return
+                    }
+                    self.recordingPickerWindow?.close()
+                    self.recordingPickerWindow = nil
+                }
+
                 let storedMaxSteps = UserDefaults.standard.integer(forKey: "maxStepsPerSession")
                 let maxSteps = storedMaxSteps > 0 ? storedMaxSteps : 50
                 let session = ComputerUseSession(

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -106,6 +106,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private var wakeWordCoordinator: WakeWordCoordinator?
     private var voiceTranscriptionWindow: VoiceTranscriptionWindow?
     var thinkingWindow: ThinkingIndicatorWindow?
+    var recordingPickerWindow: RecordingSourcePickerWindow?
     private var quickInputWindow: QuickInputWindow?
     private var quickInputHotKeyRef: EventHotKeyRef?
     private var quickInputEventHandlerRef: EventHandlerRef?

--- a/clients/macos/vellum-assistant/ComputerUse/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/RecordingSourcePickerView.swift
@@ -1,0 +1,225 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct RecordingSourcePickerView: View {
+    @ObservedObject var viewModel: RecordingSourcePickerViewModel
+    let onStart: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            // Header
+            Text("Select Recording Source")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textPrimary)
+
+            // Scope segmented control
+            VSegmentedControl(
+                items: CaptureScope.allCases.map { $0.rawValue.capitalized },
+                selection: scopeBinding
+            )
+
+            // Source list
+            ScrollView {
+                VStack(spacing: VSpacing.sm) {
+                    if viewModel.captureScope == .display {
+                        displayList
+                    } else {
+                        windowList
+                    }
+                }
+            }
+            .frame(maxHeight: 240)
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            // Toggles
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                VToggle(isOn: $viewModel.includeAudio, label: "Include system audio")
+
+                VToggle(isOn: $viewModel.rememberChoice, label: "Remember this choice")
+            }
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            // Action buttons
+            HStack {
+                Spacer()
+
+                VButton(label: "Cancel", style: .tertiary, size: .medium) {
+                    onCancel()
+                }
+
+                VButton(label: "Start Recording", style: .primary, size: .medium, isDisabled: !hasValidSelection) {
+                    if viewModel.rememberChoice {
+                        viewModel.savePreference()
+                    }
+                    onStart()
+                }
+            }
+        }
+        .padding(VSpacing.lg)
+        .background(VColor.background)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .frame(width: 420, height: 440)
+        .onAppear {
+            viewModel.enumerateDisplays()
+            if viewModel.captureScope == .window {
+                viewModel.enumerateWindows()
+            }
+        }
+        .onChange(of: viewModel.captureScope) { _ in
+            if viewModel.captureScope == .window {
+                viewModel.enumerateWindows()
+            }
+        }
+    }
+
+    // MARK: - Display List
+
+    private var displayList: some View {
+        ForEach(viewModel.displays) { display in
+            sourceRow(
+                title: display.name,
+                subtitle: display.resolution + (display.isMain ? " (Main)" : ""),
+                icon: "display",
+                isSelected: viewModel.selectedDisplayId == display.id
+            ) {
+                viewModel.selectedDisplayId = display.id
+            }
+        }
+    }
+
+    // MARK: - Window List
+
+    private var windowList: some View {
+        Group {
+            if viewModel.windows.isEmpty {
+                VStack(spacing: VSpacing.sm) {
+                    Text("No windows found")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Text("Open an application window and try again.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(VSpacing.lg)
+            } else {
+                ForEach(viewModel.windows) { window in
+                    sourceRow(
+                        title: window.name,
+                        subtitle: window.ownerName,
+                        icon: "macwindow",
+                        isSelected: viewModel.selectedWindowId == window.id
+                    ) {
+                        viewModel.selectedWindowId = window.id
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Source Row
+
+    private func sourceRow(
+        title: String,
+        subtitle: String,
+        icon: String,
+        isSelected: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: VSpacing.md) {
+                Image(systemName: icon)
+                    .font(.system(size: 16))
+                    .foregroundColor(isSelected ? VColor.accent : VColor.textSecondary)
+                    .frame(width: 24)
+
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    Text(title)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                        .lineLimit(1)
+
+                    Text(subtitle)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                if isSelected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(VColor.accent)
+                        .font(.system(size: 16))
+                }
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(isSelected ? VColor.accentSubtle : .clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(isSelected ? VColor.accent.opacity(0.3) : .clear, lineWidth: 1)
+            )
+            .contentShape(RoundedRectangle(cornerRadius: VRadius.md))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(title), \(subtitle)")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    // MARK: - Helpers
+
+    private var scopeBinding: Binding<Int> {
+        Binding<Int>(
+            get: {
+                CaptureScope.allCases.firstIndex(of: viewModel.captureScope) ?? 0
+            },
+            set: { newIndex in
+                if newIndex < CaptureScope.allCases.count {
+                    viewModel.captureScope = CaptureScope.allCases[newIndex]
+                }
+            }
+        )
+    }
+
+    private var hasValidSelection: Bool {
+        switch viewModel.captureScope {
+        case .display:
+            return viewModel.selectedDisplayId != nil
+        case .window:
+            return viewModel.selectedWindowId != nil
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+struct RecordingSourcePickerView_Preview: PreviewProvider {
+    static var previews: some View {
+        RecordingSourcePickerPreviewWrapper()
+            .frame(width: 420, height: 440)
+            .previewDisplayName("RecordingSourcePickerView")
+    }
+}
+
+private struct RecordingSourcePickerPreviewWrapper: View {
+    @StateObject private var viewModel = RecordingSourcePickerViewModel()
+
+    var body: some View {
+        RecordingSourcePickerView(
+            viewModel: viewModel,
+            onStart: {},
+            onCancel: {}
+        )
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/ComputerUse/RecordingSourcePickerViewModel.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/RecordingSourcePickerViewModel.swift
@@ -1,0 +1,247 @@
+import Foundation
+import CoreGraphics
+import AppKit
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "RecordingSourcePicker")
+
+// MARK: - Display Source
+
+/// Represents a physical display available for recording.
+struct DisplaySource: Identifiable, Equatable {
+    let id: CGDirectDisplayID
+    let name: String
+    let width: Int
+    let height: Int
+    let isMain: Bool
+
+    var resolution: String { "\(width) x \(height)" }
+}
+
+// MARK: - Window Source
+
+/// Represents an on-screen window available for recording.
+struct WindowSource: Identifiable, Equatable {
+    let id: CGWindowID
+    let name: String
+    let ownerName: String
+    let ownerPID: pid_t
+}
+
+// MARK: - Capture Scope
+
+enum CaptureScope: String, CaseIterable {
+    case display
+    case window
+}
+
+// MARK: - Saved Preference
+
+/// Persisted recording source preference for auto-apply on subsequent sessions.
+struct RecordingSourcePreference: Codable, Equatable {
+    let scope: String
+    let displayId: CGDirectDisplayID?
+    let windowOwnerName: String?
+    let includeAudio: Bool
+}
+
+// MARK: - ViewModel
+
+@MainActor
+final class RecordingSourcePickerViewModel: ObservableObject {
+    @Published var captureScope: CaptureScope = .display
+    @Published var selectedDisplayId: CGDirectDisplayID?
+    @Published var selectedWindowId: CGWindowID?
+    @Published var includeAudio: Bool = false
+    @Published var rememberChoice: Bool = false
+
+    @Published private(set) var displays: [DisplaySource] = []
+    @Published private(set) var windows: [WindowSource] = []
+
+    private let userDefaultsKey = "recordingSourcePreference"
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        enumerateDisplays()
+    }
+
+    // MARK: - Computed Properties
+
+    var hasMultipleDisplays: Bool {
+        displays.count > 1
+    }
+
+    var selectedRecordingOptions: IPCRecordingOptions {
+        switch captureScope {
+        case .display:
+            return IPCRecordingOptions(
+                captureScope: "display",
+                displayId: selectedDisplayId.map { String($0) },
+                windowId: nil,
+                includeAudio: includeAudio,
+                promptForSource: nil
+            )
+        case .window:
+            return IPCRecordingOptions(
+                captureScope: "window",
+                displayId: nil,
+                windowId: selectedWindowId.map { Double($0) },
+                includeAudio: includeAudio,
+                promptForSource: nil
+            )
+        }
+    }
+
+    // MARK: - Source Enumeration
+
+    func enumerateDisplays() {
+        var displayCount: UInt32 = 0
+        CGGetActiveDisplayList(0, nil, &displayCount)
+
+        guard displayCount > 0 else {
+            displays = []
+            return
+        }
+
+        var displayIDs = [CGDirectDisplayID](repeating: 0, count: Int(displayCount))
+        CGGetActiveDisplayList(displayCount, &displayIDs, &displayCount)
+
+        let mainDisplayID = CGMainDisplayID()
+
+        displays = displayIDs.enumerated().map { index, displayID in
+            let width = CGDisplayPixelsWide(displayID)
+            let height = CGDisplayPixelsHigh(displayID)
+            let isMain = displayID == mainDisplayID
+
+            // Try to get a friendly name from NSScreen
+            let name = Self.screenName(for: displayID, index: index, isMain: isMain)
+
+            return DisplaySource(
+                id: displayID,
+                name: name,
+                width: width,
+                height: height,
+                isMain: isMain
+            )
+        }
+
+        // Auto-select the main display if nothing is selected
+        if selectedDisplayId == nil {
+            selectedDisplayId = displays.first(where: { $0.isMain })?.id ?? displays.first?.id
+        }
+
+        log.info("Enumerated \(self.displays.count) display(s)")
+    }
+
+    func enumerateWindows() {
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        guard let windowList = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
+            windows = []
+            return
+        }
+
+        let selfPID = ProcessInfo.processInfo.processIdentifier
+
+        windows = windowList.compactMap { info -> WindowSource? in
+            guard let windowID = info[kCGWindowNumber as String] as? CGWindowID,
+                  let ownerPID = info[kCGWindowOwnerPID as String] as? pid_t,
+                  let ownerName = info[kCGWindowOwnerName as String] as? String,
+                  let layer = info[kCGWindowLayer as String] as? Int,
+                  layer == 0, // Normal windows only (not menu bar, dock, etc.)
+                  ownerPID != selfPID // Exclude our own windows
+            else { return nil }
+
+            let windowName = info[kCGWindowName as String] as? String
+            let displayName = windowName?.isEmpty == false ? windowName! : ownerName
+
+            return WindowSource(
+                id: windowID,
+                name: displayName,
+                ownerName: ownerName,
+                ownerPID: ownerPID
+            )
+        }
+
+        // Auto-select the first window if nothing is selected
+        if selectedWindowId == nil {
+            selectedWindowId = windows.first?.id
+        }
+
+        log.info("Enumerated \(self.windows.count) window(s)")
+    }
+
+    // MARK: - Preference Persistence
+
+    func savePreference() {
+        let preference = RecordingSourcePreference(
+            scope: captureScope.rawValue,
+            displayId: captureScope == .display ? selectedDisplayId : nil,
+            windowOwnerName: captureScope == .window ? windows.first(where: { $0.id == selectedWindowId })?.ownerName : nil,
+            includeAudio: includeAudio
+        )
+
+        if let data = try? JSONEncoder().encode(preference) {
+            defaults.set(data, forKey: userDefaultsKey)
+            log.info("Saved recording source preference")
+        }
+    }
+
+    func loadPreference() -> RecordingSourcePreference? {
+        guard let data = defaults.data(forKey: userDefaultsKey) else { return nil }
+        return try? JSONDecoder().decode(RecordingSourcePreference.self, from: data)
+    }
+
+    func clearPreference() {
+        defaults.removeObject(forKey: userDefaultsKey)
+    }
+
+    /// Attempts to apply a saved preference. Returns true if the saved source
+    /// still exists and was successfully applied, false otherwise.
+    func canAutoApply() -> Bool {
+        guard let pref = loadPreference() else { return false }
+
+        if pref.scope == CaptureScope.display.rawValue {
+            // Saved display must still be connected
+            guard let displayId = pref.displayId,
+                  displays.contains(where: { $0.id == displayId }) else {
+                return false
+            }
+            captureScope = .display
+            selectedDisplayId = displayId
+            includeAudio = pref.includeAudio
+            return true
+        } else if pref.scope == CaptureScope.window.rawValue {
+            // For windows, match by owner name since window IDs are ephemeral
+            enumerateWindows()
+            guard let ownerName = pref.windowOwnerName,
+                  let matchingWindow = windows.first(where: { $0.ownerName == ownerName }) else {
+                return false
+            }
+            captureScope = .window
+            selectedWindowId = matchingWindow.id
+            includeAudio = pref.includeAudio
+            return true
+        }
+
+        return false
+    }
+
+    // MARK: - Private Helpers
+
+    private static func screenName(for displayID: CGDirectDisplayID, index: Int, isMain: Bool) -> String {
+        // Try to match NSScreen to get the localized name
+        if let screen = NSScreen.screens.first(where: { screen in
+            guard let screenNumber = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID else {
+                return false
+            }
+            return screenNumber == displayID
+        }) {
+            return screen.localizedName
+        }
+
+        // Fallback name
+        return isMain ? "Main Display" : "Display \(index + 1)"
+    }
+}

--- a/clients/macos/vellum-assistant/ComputerUse/RecordingSourcePickerWindow.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/RecordingSourcePickerWindow.swift
@@ -9,6 +9,18 @@ final class RecordingSourcePickerWindow {
     private let viewModel: RecordingSourcePickerViewModel
     private let onStart: () -> Void
     private let onCancel: () -> Void
+    private let panelDelegate = PanelDelegate()
+
+    /// Intercepts the native close button (X) so we can resume the
+    /// continuation that would otherwise be stuck forever.
+    private class PanelDelegate: NSObject, NSWindowDelegate {
+        var onClose: (() -> Void)?
+
+        func windowWillClose(_ notification: Notification) {
+            onClose?()
+            onClose = nil
+        }
+    }
 
     init(viewModel: RecordingSourcePickerViewModel, onStart: @escaping () -> Void, onCancel: @escaping () -> Void) {
         self.viewModel = viewModel
@@ -20,10 +32,13 @@ final class RecordingSourcePickerWindow {
         let pickerView = RecordingSourcePickerView(
             viewModel: viewModel,
             onStart: { [weak self] in
+                // Disarm the delegate before closing to prevent double-fire
+                self?.panelDelegate.onClose = nil
                 self?.close()
                 self?.onStart()
             },
             onCancel: { [weak self] in
+                self?.panelDelegate.onClose = nil
                 self?.close()
                 self?.onCancel()
             }
@@ -48,6 +63,12 @@ final class RecordingSourcePickerWindow {
         panel.isOpaque = false
         panel.isReleasedWhenClosed = false
 
+        // Wire up the delegate so native X-button close triggers onCancel
+        panelDelegate.onClose = { [weak self] in
+            self?.onCancel()
+        }
+        panel.delegate = panelDelegate
+
         // Center on screen
         if let screen = NSScreen.main {
             let screenFrame = screen.visibleFrame
@@ -62,6 +83,8 @@ final class RecordingSourcePickerWindow {
     }
 
     func close() {
+        // Disarm delegate before closing to prevent double-fire
+        panelDelegate.onClose = nil
         panel?.close()
         panel = nil
     }

--- a/clients/macos/vellum-assistant/ComputerUse/RecordingSourcePickerWindow.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/RecordingSourcePickerWindow.swift
@@ -1,0 +1,68 @@
+import AppKit
+import SwiftUI
+import VellumAssistantShared
+
+/// A modal window that presents the recording source picker before a session starts.
+@MainActor
+final class RecordingSourcePickerWindow {
+    private var panel: NSPanel?
+    private let viewModel: RecordingSourcePickerViewModel
+    private let onStart: () -> Void
+    private let onCancel: () -> Void
+
+    init(viewModel: RecordingSourcePickerViewModel, onStart: @escaping () -> Void, onCancel: @escaping () -> Void) {
+        self.viewModel = viewModel
+        self.onStart = onStart
+        self.onCancel = onCancel
+    }
+
+    func show() {
+        let pickerView = RecordingSourcePickerView(
+            viewModel: viewModel,
+            onStart: { [weak self] in
+                self?.close()
+                self?.onStart()
+            },
+            onCancel: { [weak self] in
+                self?.close()
+                self?.onCancel()
+            }
+        )
+
+        let hostingView = NSHostingView(rootView: pickerView)
+        hostingView.setFrameSize(hostingView.fittingSize)
+
+        let panel = NSPanel(
+            contentRect: NSRect(origin: .zero, size: hostingView.fittingSize),
+            styleMask: [.titled, .closable, .hudWindow, .utilityWindow, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.contentView = hostingView
+        panel.isFloatingPanel = true
+        panel.level = .floating
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.hasShadow = true
+        panel.backgroundColor = NSColor.clear
+        panel.isOpaque = false
+        panel.isReleasedWhenClosed = false
+
+        // Center on screen
+        if let screen = NSScreen.main {
+            let screenFrame = screen.visibleFrame
+            let windowSize = hostingView.fittingSize
+            let x = screenFrame.midX - windowSize.width / 2
+            let y = screenFrame.midY - windowSize.height / 2
+            panel.setFrameOrigin(NSPoint(x: x, y: y))
+        }
+
+        panel.orderFront(nil)
+        self.panel = panel
+    }
+
+    func close() {
+        panel?.close()
+        panel = nil
+    }
+}

--- a/clients/macos/vellum-assistantTests/RecordingSourcePickerTests.swift
+++ b/clients/macos/vellum-assistantTests/RecordingSourcePickerTests.swift
@@ -1,0 +1,202 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+final class RecordingSourcePickerTests: XCTestCase {
+
+    /// Creates an isolated UserDefaults suite and returns both the defaults and suite name for cleanup.
+    private func makeTestDefaults() -> (UserDefaults, String) {
+        let suiteName = "RecordingSourcePickerTests_\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        return (defaults, suiteName)
+    }
+
+    // MARK: - Default State
+
+    @MainActor
+    func testDefaultState_hasCaptureScope_display() async {
+        let vm = RecordingSourcePickerViewModel()
+        XCTAssertEqual(vm.captureScope, .display)
+    }
+
+    @MainActor
+    func testDefaultState_audioOff() async {
+        let vm = RecordingSourcePickerViewModel()
+        XCTAssertFalse(vm.includeAudio)
+    }
+
+    @MainActor
+    func testDefaultState_rememberChoiceOff() async {
+        let vm = RecordingSourcePickerViewModel()
+        XCTAssertFalse(vm.rememberChoice)
+    }
+
+    @MainActor
+    func testDefaultState_displaysEnumerated() async {
+        let vm = RecordingSourcePickerViewModel()
+        // There should be at least one display on any Mac
+        XCTAssertGreaterThanOrEqual(vm.displays.count, 1)
+    }
+
+    @MainActor
+    func testDefaultState_mainDisplaySelected() async {
+        let vm = RecordingSourcePickerViewModel()
+        // The main display should be auto-selected
+        XCTAssertNotNil(vm.selectedDisplayId)
+    }
+
+    // MARK: - hasMultipleDisplays
+
+    @MainActor
+    func testHasMultipleDisplays_consistentWithCount() async {
+        let vm = RecordingSourcePickerViewModel()
+        // Verify the property is consistent with the actual display count.
+        if vm.displays.count == 1 {
+            XCTAssertFalse(vm.hasMultipleDisplays)
+        } else {
+            XCTAssertTrue(vm.hasMultipleDisplays)
+        }
+    }
+
+    // MARK: - Selected Recording Options
+
+    @MainActor
+    func testSelectedRecordingOptions_displayScope() async {
+        let vm = RecordingSourcePickerViewModel()
+        vm.captureScope = .display
+        vm.includeAudio = true
+
+        let options = vm.selectedRecordingOptions
+        XCTAssertEqual(options.captureScope, "display")
+        XCTAssertEqual(options.includeAudio, true)
+        XCTAssertNil(options.windowId)
+        // displayId should be set since we have at least one display
+        XCTAssertNotNil(options.displayId)
+    }
+
+    @MainActor
+    func testSelectedRecordingOptions_windowScope() async {
+        let vm = RecordingSourcePickerViewModel()
+        vm.captureScope = .window
+        vm.selectedWindowId = 12345
+        vm.includeAudio = false
+
+        let options = vm.selectedRecordingOptions
+        XCTAssertEqual(options.captureScope, "window")
+        XCTAssertEqual(options.includeAudio, false)
+        XCTAssertEqual(options.windowId, 12345)
+        XCTAssertNil(options.displayId)
+    }
+
+    // MARK: - Preference Persistence
+
+    @MainActor
+    func testSaveAndLoadPreference() async {
+        let (defaults, suiteName) = makeTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let vm = RecordingSourcePickerViewModel(defaults: defaults)
+        vm.captureScope = .display
+        vm.includeAudio = true
+        vm.savePreference()
+
+        let loaded = vm.loadPreference()
+        XCTAssertNotNil(loaded)
+        XCTAssertEqual(loaded?.scope, "display")
+        XCTAssertEqual(loaded?.includeAudio, true)
+    }
+
+    @MainActor
+    func testClearPreference() async {
+        let (defaults, suiteName) = makeTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let vm = RecordingSourcePickerViewModel(defaults: defaults)
+        vm.savePreference()
+        XCTAssertNotNil(vm.loadPreference())
+
+        vm.clearPreference()
+        XCTAssertNil(vm.loadPreference())
+    }
+
+    // MARK: - canAutoApply
+
+    @MainActor
+    func testCanAutoApply_noSavedPreference_returnsFalse() async {
+        let (defaults, suiteName) = makeTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let vm = RecordingSourcePickerViewModel(defaults: defaults)
+        XCTAssertFalse(vm.canAutoApply())
+    }
+
+    @MainActor
+    func testCanAutoApply_savedDisplayStillExists_returnsTrue() async {
+        let (defaults, suiteName) = makeTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let vm = RecordingSourcePickerViewModel(defaults: defaults)
+
+        // Save a preference for the current main display
+        vm.captureScope = .display
+        vm.selectedDisplayId = vm.displays.first?.id
+        vm.savePreference()
+
+        // Create a new VM with the same defaults — it should auto-apply
+        let vm2 = RecordingSourcePickerViewModel(defaults: defaults)
+        XCTAssertTrue(vm2.canAutoApply())
+    }
+
+    @MainActor
+    func testCanAutoApply_savedDisplayNoLongerExists_returnsFalse() async {
+        let (defaults, suiteName) = makeTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let vm = RecordingSourcePickerViewModel(defaults: defaults)
+
+        // Manually save a preference with a fake display ID that doesn't exist
+        let fakePreference = RecordingSourcePreference(
+            scope: "display",
+            displayId: 99999,
+            windowOwnerName: nil,
+            includeAudio: false
+        )
+        if let data = try? JSONEncoder().encode(fakePreference) {
+            defaults.set(data, forKey: "recordingSourcePreference")
+        }
+
+        XCTAssertFalse(vm.canAutoApply())
+    }
+
+    @MainActor
+    func testCanAutoApply_savedWindowNoMatchingApp_returnsFalse() async {
+        let (defaults, suiteName) = makeTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let vm = RecordingSourcePickerViewModel(defaults: defaults)
+
+        // Manually save a preference with a non-existent window owner
+        let fakePreference = RecordingSourcePreference(
+            scope: "window",
+            displayId: nil,
+            windowOwnerName: "NonExistentApp_\(UUID().uuidString)",
+            includeAudio: false
+        )
+        if let data = try? JSONEncoder().encode(fakePreference) {
+            defaults.set(data, forKey: "recordingSourcePreference")
+        }
+
+        XCTAssertFalse(vm.canAutoApply())
+    }
+
+    // MARK: - Window Enumeration
+
+    @MainActor
+    func testEnumerateWindows_populatesWindowsList() async {
+        let vm = RecordingSourcePickerViewModel()
+        vm.enumerateWindows()
+        // On a running Mac there should be at least one window visible
+        // (the test runner itself), but we allow zero in headless CI.
+        XCTAssertGreaterThanOrEqual(vm.windows.count, 0)
+    }
+}


### PR DESCRIPTION
## Summary
- Add RecordingSourcePickerViewModel for display/window enumeration and selection persistence
- Add RecordingSourcePickerView with SwiftUI picker UI using design system tokens
- Add RecordingSourcePickerWindow for presenting the picker as a floating panel
- Integrate picker into session creation flow — show before recording-required sessions
- Add 15 ViewModel tests for preference persistence, auto-apply logic, and default state

Closes #8380

## Original prompt
Part of #8377: Standalone Screen Recording Skill
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
