### PR TITLE
fix: show immediate feedback on confirmation surface actions

### DIFF
--- a/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
@@ -5,6 +5,13 @@ public struct ConfirmationSurfaceView: View {
     public let actions: [SurfaceActionButton]
     public let onAction: (String) -> Void
 
+    private enum SelectedAction {
+        case confirmed
+        case cancelled
+    }
+
+    @State private var selectedAction: SelectedAction?
+
     public init(data: ConfirmationSurfaceData, actions: [SurfaceActionButton], onAction: @escaping (String) -> Void) {
         self.data = data
         self.actions = actions
@@ -30,6 +37,14 @@ public struct ConfirmationSurfaceView: View {
     }
 
     public var body: some View {
+        if let selectedAction {
+            selectedActionFeedback(selectedAction)
+        } else {
+            pendingContent
+        }
+    }
+
+    private var pendingContent: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             // Header with icon
             HStack(spacing: VSpacing.md) {
@@ -56,6 +71,7 @@ public struct ConfirmationSurfaceView: View {
                     label: data.cancelLabel ?? "Cancel",
                     style: .tertiary
                 ) {
+                    selectedAction = .cancelled
                     onAction(cancelActionId)
                 }
 
@@ -63,9 +79,37 @@ public struct ConfirmationSurfaceView: View {
                     label: data.confirmLabel ?? "Confirm",
                     style: data.destructive ? .danger : .primary
                 ) {
+                    selectedAction = .confirmed
                     onAction(confirmActionId)
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private func selectedActionFeedback(_ action: SelectedAction) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            switch action {
+            case .confirmed:
+                ProgressView()
+                    .controlSize(.small)
+                Text(data.confirmLabel.map { "\($0)..." } ?? "In progress...")
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.textPrimary)
+            case .cancelled:
+                Image(systemName: "xmark.circle.fill")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                Text("Dismissed")
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.textSecondary)
+            }
+        }
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.backgroundSubtle.opacity(0.5))
+        )
     }
 }


### PR DESCRIPTION
## Summary
- When clicking "Get Started" (confirm) on a confirmation surface, immediately replace the card with a spinner + "Getting started..." chip
- When clicking "Not Now" (cancel), immediately replace with a "Dismissed" chip
- Prevents the modal from staying visible when the daemon is slow to respond or the session is interrupted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
