### PR TITLE
refactor: migrate Swift HTTPTransport and CLI from /v1/runs to /v1/messages

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -39,6 +39,7 @@ import {
   handleConfirm,
   handleSecret,
   handleTrustRule,
+  handleListPendingInteractions,
 } from './routes/approval-routes.js';
 import {
   handleDeleteConversation,
@@ -575,6 +576,7 @@ export class RuntimeHttpServer {
       if (endpoint === 'confirm' && req.method === 'POST') return await handleConfirm(req);
       if (endpoint === 'secret' && req.method === 'POST') return await handleSecret(req);
       if (endpoint === 'trust-rules' && req.method === 'POST') return await handleTrustRule(req);
+      if (endpoint === 'pending-interactions' && req.method === 'GET') return handleListPendingInteractions(url);
 
       if (endpoint === 'attachments' && req.method === 'POST') return await handleUploadAttachment(req);
       if (endpoint === 'attachments' && req.method === 'DELETE') return await handleDeleteAttachment(req);

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -5,6 +5,7 @@
  * by requestId — orthogonal to message sending.
  */
 import * as pendingInteractions from '../pending-interactions.js';
+import { getConversationByKey } from '../../memory/conversation-key-store.js';
 import { addRule } from '../../permissions/trust-store.js';
 import { getTool } from '../../tools/registry.js';
 import { getLogger } from '../../util/logger.js';
@@ -176,4 +177,62 @@ export async function handleTrustRule(req: Request): Promise<Response> {
     log.error({ err }, 'Failed to add trust rule');
     return Response.json({ error: 'Failed to add trust rule' }, { status: 500 });
   }
+}
+
+/**
+ * GET /v1/pending-interactions?conversationKey=...
+ *
+ * Returns pending confirmations and secrets for a conversation, allowing
+ * polling-based clients (like the CLI) to discover approval requests
+ * without SSE.
+ */
+export function handleListPendingInteractions(url: URL): Response {
+  const conversationKey = url.searchParams.get('conversationKey');
+  const conversationId = url.searchParams.get('conversationId');
+
+  let resolvedConversationId: string | undefined;
+  if (conversationId) {
+    resolvedConversationId = conversationId;
+  } else if (conversationKey) {
+    const mapping = getConversationByKey(conversationKey);
+    resolvedConversationId = mapping?.conversationId;
+  } else {
+    return Response.json(
+      { error: 'conversationKey or conversationId query parameter is required' },
+      { status: 400 },
+    );
+  }
+
+  if (!resolvedConversationId) {
+    return Response.json({ pendingConfirmation: null, pendingSecret: null });
+  }
+
+  const interactions = pendingInteractions.getByConversation(resolvedConversationId);
+
+  const confirmation = interactions.find((i) => i.kind === 'confirmation');
+  const secret = interactions.find((i) => i.kind === 'secret');
+
+  return Response.json({
+    pendingConfirmation: confirmation
+      ? {
+          requestId: confirmation.requestId,
+          toolName: confirmation.confirmationDetails?.toolName,
+          toolUseId: confirmation.requestId,
+          input: confirmation.confirmationDetails?.input ?? {},
+          riskLevel: confirmation.confirmationDetails?.riskLevel ?? 'unknown',
+          executionTarget: confirmation.confirmationDetails?.executionTarget,
+          allowlistOptions: confirmation.confirmationDetails?.allowlistOptions?.map((o) => ({
+            label: o.label,
+            pattern: o.pattern,
+          })),
+          scopeOptions: confirmation.confirmationDetails?.scopeOptions,
+          persistentDecisionsAllowed: confirmation.confirmationDetails?.persistentDecisionsAllowed,
+        }
+      : null,
+    pendingSecret: secret
+      ? {
+          requestId: secret.requestId,
+        }
+      : null,
+  });
 }

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -61,30 +61,17 @@ interface PendingConfirmation {
   persistentDecisionsAllowed?: boolean;
 }
 
-interface CreateRunResponse {
-  id: string;
-  status: string;
-  messageId: string | null;
-  createdAt: string;
-}
-
-interface GetRunResponse {
-  id: string;
-  status: string;
-  messageId: string | null;
-  pendingConfirmation: PendingConfirmation | null;
-  pendingSecret: PendingSecret | null;
-  error: string | null;
-  createdAt: string;
-  updatedAt: string;
-}
-
 interface SubmitDecisionResponse {
   accepted: boolean;
 }
 
 interface AddTrustRuleResponse {
   accepted: boolean;
+}
+
+interface PendingInteractionsResponse {
+  pendingConfirmation: (PendingConfirmation & { requestId: string }) | null;
+  pendingSecret: (PendingSecret & { requestId?: string }) | null;
 }
 
 type TrustDecision = "always_allow" | "always_allow_high_risk" | "always_deny";
@@ -177,55 +164,20 @@ async function sendMessage(
   );
 }
 
-async function createRun(
-  baseUrl: string,
-  assistantId: string,
-  content: string,
-  signal?: AbortSignal,
-  bearerToken?: string,
-): Promise<CreateRunResponse> {
-  return runtimeRequest<CreateRunResponse>(
-    baseUrl,
-    assistantId,
-    "/runs",
-    {
-      method: "POST",
-      body: JSON.stringify({ conversationKey: assistantId, content }),
-      signal,
-    },
-    bearerToken,
-  );
-}
-
-async function getRun(
-  baseUrl: string,
-  assistantId: string,
-  runId: string,
-  bearerToken?: string,
-): Promise<GetRunResponse> {
-  return runtimeRequest<GetRunResponse>(
-    baseUrl,
-    assistantId,
-    `/runs/${runId}`,
-    undefined,
-    bearerToken,
-  );
-}
-
 async function submitDecision(
   baseUrl: string,
   assistantId: string,
-  runId: string,
+  requestId: string,
   decision: "allow" | "deny",
   bearerToken?: string,
 ): Promise<SubmitDecisionResponse> {
   return runtimeRequest<SubmitDecisionResponse>(
     baseUrl,
     assistantId,
-    `/runs/${runId}/decision`,
+    "/confirm",
     {
       method: "POST",
-      body: JSON.stringify({ decision }),
+      body: JSON.stringify({ requestId, decision }),
     },
     bearerToken,
   );
@@ -234,7 +186,7 @@ async function submitDecision(
 async function addTrustRule(
   baseUrl: string,
   assistantId: string,
-  runId: string,
+  requestId: string,
   pattern: string,
   scope: string,
   decision: "allow" | "deny",
@@ -243,11 +195,26 @@ async function addTrustRule(
   return runtimeRequest<AddTrustRuleResponse>(
     baseUrl,
     assistantId,
-    `/runs/${runId}/trust-rule`,
+    "/trust-rules",
     {
       method: "POST",
-      body: JSON.stringify({ pattern, scope, decision }),
+      body: JSON.stringify({ requestId, pattern, scope, decision }),
     },
+    bearerToken,
+  );
+}
+
+async function pollPendingInteractions(
+  baseUrl: string,
+  assistantId: string,
+  bearerToken?: string,
+): Promise<PendingInteractionsResponse> {
+  const params = new URLSearchParams({ conversationKey: assistantId });
+  return runtimeRequest<PendingInteractionsResponse>(
+    baseUrl,
+    assistantId,
+    `/pending-interactions?${params.toString()}`,
+    undefined,
     bearerToken,
   );
 }
@@ -282,7 +249,7 @@ function formatConfirmationPreview(toolName: string, input: Record<string, unkno
 async function handleConfirmationPrompt(
   baseUrl: string,
   assistantId: string,
-  runId: string,
+  requestId: string,
   confirmation: PendingConfirmation,
   chatApp: ChatAppHandle,
   bearerToken?: string,
@@ -305,7 +272,7 @@ async function handleConfirmationPrompt(
   const index = await chatApp.showSelection("Tool Approval", options);
 
   if (index === 0) {
-    await submitDecision(baseUrl, assistantId, runId, "allow", bearerToken);
+    await submitDecision(baseUrl, assistantId, requestId, "allow", bearerToken);
     chatApp.addStatus("\u2714 Allowed", "green");
     return;
   }
@@ -313,7 +280,7 @@ async function handleConfirmationPrompt(
     await handlePatternSelection(
       baseUrl,
       assistantId,
-      runId,
+      requestId,
       confirmation,
       chatApp,
       "always_allow",
@@ -325,7 +292,7 @@ async function handleConfirmationPrompt(
     await handlePatternSelection(
       baseUrl,
       assistantId,
-      runId,
+      requestId,
       confirmation,
       chatApp,
       "always_deny",
@@ -334,14 +301,14 @@ async function handleConfirmationPrompt(
     return;
   }
 
-  await submitDecision(baseUrl, assistantId, runId, "deny", bearerToken);
+  await submitDecision(baseUrl, assistantId, requestId, "deny", bearerToken);
   chatApp.addStatus("\u2718 Denied", "yellow");
 }
 
 async function handlePatternSelection(
   baseUrl: string,
   assistantId: string,
-  runId: string,
+  requestId: string,
   confirmation: PendingConfirmation,
   chatApp: ChatAppHandle,
   trustDecision: TrustDecision,
@@ -358,7 +325,7 @@ async function handlePatternSelection(
     await handleScopeSelection(
       baseUrl,
       assistantId,
-      runId,
+      requestId,
       confirmation,
       chatApp,
       selectedPattern,
@@ -368,14 +335,14 @@ async function handlePatternSelection(
     return;
   }
 
-  await submitDecision(baseUrl, assistantId, runId, "deny", bearerToken);
+  await submitDecision(baseUrl, assistantId, requestId, "deny", bearerToken);
   chatApp.addStatus("\u2718 Denied", "yellow");
 }
 
 async function handleScopeSelection(
   baseUrl: string,
   assistantId: string,
-  runId: string,
+  requestId: string,
   confirmation: PendingConfirmation,
   chatApp: ChatAppHandle,
   selectedPattern: string,
@@ -393,7 +360,7 @@ async function handleScopeSelection(
     await addTrustRule(
       baseUrl,
       assistantId,
-      runId,
+      requestId,
       selectedPattern,
       scopeOptions[index].scope,
       ruleDecision,
@@ -402,7 +369,7 @@ async function handleScopeSelection(
     await submitDecision(
       baseUrl,
       assistantId,
-      runId,
+      requestId,
       ruleDecision === "deny" ? "deny" : "allow",
       bearerToken,
     );
@@ -415,7 +382,7 @@ async function handleScopeSelection(
     return;
   }
 
-  await submitDecision(baseUrl, assistantId, runId, "deny", bearerToken);
+  await submitDecision(baseUrl, assistantId, requestId, "deny", bearerToken);
   chatApp.addStatus("\u2718 Denied", "yellow");
 }
 
@@ -1474,9 +1441,8 @@ function ChatApp({
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), SEND_TIMEOUT_MS);
 
-        let runId: string | undefined;
         try {
-          const runResult = await createRun(
+          const sendResult = await sendMessage(
             runtimeUrl,
             assistantId,
             trimmed,
@@ -1484,29 +1450,20 @@ function ChatApp({
             bearerToken,
           );
           clearTimeout(timeoutId);
-          runId = runResult.id;
-        } catch (createErr) {
-          clearTimeout(timeoutId);
-          const is409 = createErr instanceof Error && createErr.message.includes("HTTP 409");
-          if (is409) {
-            h.setBusy(false);
-            h.hideSpinner();
-            h.showError("Assistant is still working. Please wait and try again.");
-            return;
-          }
-          const sendResult = await sendMessage(
-            runtimeUrl,
-            assistantId,
-            trimmed,
-            undefined,
-            bearerToken,
-          );
           if (!sendResult.accepted) {
             h.setBusy(false);
             h.hideSpinner();
             h.showError("Message was not accepted by the assistant");
             return;
           }
+        } catch (sendErr) {
+          clearTimeout(timeoutId);
+          h.setBusy(false);
+          h.hideSpinner();
+          const errorMsg = `Failed to send: ${sendErr instanceof Error ? sendErr.message : sendErr}`;
+          h.showError(errorMsg);
+          chatLogRef.current.push({ role: "error", content: errorMsg });
+          return;
         }
 
         h.showSpinner("Working...");
@@ -1514,75 +1471,47 @@ function ChatApp({
         while (true) {
           await new Promise((resolve) => setTimeout(resolve, RESPONSE_POLL_INTERVAL_MS));
 
-          if (runId) {
-            try {
-              const runStatus = await getRun(runtimeUrl, assistantId, runId, bearerToken);
+          // Check for pending confirmations/secrets
+          try {
+            const pending = await pollPendingInteractions(runtimeUrl, assistantId, bearerToken);
 
-              if (runStatus.status === "needs_confirmation" && runStatus.pendingConfirmation) {
-                h.hideSpinner();
-                await handleConfirmationPrompt(
+            if (pending.pendingConfirmation) {
+              h.hideSpinner();
+              await handleConfirmationPrompt(
+                runtimeUrl,
+                assistantId,
+                pending.pendingConfirmation.requestId,
+                pending.pendingConfirmation,
+                h,
+                bearerToken,
+              );
+              h.showSpinner("Working...");
+              continue;
+            }
+
+            if (pending.pendingSecret) {
+              const secretRequestId = pending.pendingSecret.requestId ?? "";
+              h.hideSpinner();
+              await h.handleSecretPrompt(pending.pendingSecret, async (value, delivery) => {
+                await runtimeRequest(
                   runtimeUrl,
                   assistantId,
-                  runId,
-                  runStatus.pendingConfirmation,
-                  h,
+                  "/secret",
+                  {
+                    method: "POST",
+                    body: JSON.stringify({ requestId: secretRequestId, value, delivery }),
+                  },
                   bearerToken,
                 );
-                h.showSpinner("Working...");
-                continue;
-              }
-
-              if (runStatus.status === "needs_secret" && runStatus.pendingSecret) {
-                h.hideSpinner();
-                await h.handleSecretPrompt(runStatus.pendingSecret, async (value, delivery) => {
-                  await runtimeRequest(
-                    runtimeUrl,
-                    assistantId,
-                    `/runs/${runId}/secret`,
-                    {
-                      method: "POST",
-                      body: JSON.stringify({ value, delivery }),
-                    },
-                    bearerToken,
-                  );
-                });
-                h.showSpinner("Working...");
-                continue;
-              }
-
-              if (runStatus.status === "completed") {
-                try {
-                  const pollResult = await pollMessages(runtimeUrl, assistantId, bearerToken);
-                  for (const msg of pollResult.messages) {
-                    if (!seenMessageIdsRef.current.has(msg.id)) {
-                      seenMessageIdsRef.current.add(msg.id);
-                      if (msg.role === "assistant") {
-                        h.addMessage(msg);
-                        chatLogRef.current.push({ role: "assistant", content: msg.content });
-                      }
-                    }
-                  }
-                } catch {
-                  // Final poll failure; continue to cleanup
-                }
-                h.setBusy(false);
-                h.hideSpinner();
-                return;
-              }
-
-              if (runStatus.status === "failed") {
-                h.setBusy(false);
-                h.hideSpinner();
-                const errorMsg = runStatus.error ?? "Run failed";
-                h.showError(errorMsg);
-                chatLogRef.current.push({ role: "error", content: errorMsg });
-                return;
-              }
-            } catch {
-              // Run status poll failure; fall through to message poll
+              });
+              h.showSpinner("Working...");
+              continue;
             }
+          } catch {
+            // Pending interactions poll failure; fall through to message poll
           }
 
+          // Poll for new messages to detect completion
           try {
             const pollResult = await pollMessages(runtimeUrl, assistantId, bearerToken);
             for (const msg of pollResult.messages) {
@@ -1591,11 +1520,9 @@ function ChatApp({
                 if (msg.role === "assistant") {
                   h.addMessage(msg);
                   chatLogRef.current.push({ role: "assistant", content: msg.content });
-                  if (!runId) {
-                    h.setBusy(false);
-                    h.hideSpinner();
-                    return;
-                  }
+                  h.setBusy(false);
+                  h.hideSpinner();
+                  return;
                 }
               }
             }
@@ -1613,14 +1540,9 @@ function ChatApp({
           h.showError(errorMsg);
           chatLogRef.current.push({ role: "error", content: errorMsg });
         } else {
-          const is409 = error instanceof Error && error.message.includes("HTTP 409");
-          if (is409) {
-            h.showError("Assistant is still working. Please wait and try again.");
-          } else {
-            const errorMsg = `Failed to send: ${error instanceof Error ? error.message : error}`;
-            h.showError(errorMsg);
-            chatLogRef.current.push({ role: "error", content: errorMsg });
-          }
+          const errorMsg = `Failed to send: ${error instanceof Error ? error.message : error}`;
+          h.showError(errorMsg);
+          chatLogRef.current.push({ role: "error", content: errorMsg });
         }
       }
     },

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -67,9 +67,6 @@ final class HTTPTransport {
     /// Health check interval in seconds.
     private let healthCheckInterval: TimeInterval = 15.0
 
-    /// Currently active run ID, tracked for decision/secret endpoints.
-    private(set) var activeRunId: String?
-
     /// Whether the assistant is reachable (health check passes).
     private(set) var isConnected: Bool = false
 
@@ -273,7 +270,7 @@ final class HTTPTransport {
     /// Translate an IPC message to the appropriate HTTP API call.
     func send<T: Encodable>(_ message: T) throws {
         if let msg = message as? UserMessageMessage {
-            Task { await self.createRun(content: msg.content, sessionId: msg.sessionId) }
+            Task { await self.sendMessage(content: msg.content, sessionId: msg.sessionId) }
         } else if let msg = message as? ConfirmationResponseMessage {
             Task { await self.sendDecision(requestId: msg.requestId, decision: msg.decision) }
         } else if let msg = message as? SecretResponseMessage {
@@ -304,8 +301,8 @@ final class HTTPTransport {
 
     // MARK: - HTTP Endpoints
 
-    private func createRun(content: String?, sessionId: String) async {
-        guard let url = URL(string: "\(baseURL)/v1/runs") else { return }
+    private func sendMessage(content: String?, sessionId: String) async {
+        guard let url = URL(string: "\(baseURL)/v1/messages") else { return }
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -326,19 +323,11 @@ final class HTTPTransport {
 
             guard let http = response as? HTTPURLResponse else { return }
 
-            if http.statusCode == 201 || http.statusCode == 200 {
-                do {
-                    if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-                       let runId = json["id"] as? String {
-                        self.activeRunId = runId
-                        log.info("Run created: \(runId)")
-                    }
-                } catch {
-                    log.error("Failed to deserialize create run response: \(error)")
-                }
+            if http.statusCode == 202 || http.statusCode == 200 {
+                log.info("Message sent successfully")
             } else {
                 let errorBody = String(data: data, encoding: .utf8) ?? "unknown"
-                log.error("Create run failed (\(http.statusCode)): \(errorBody)")
+                log.error("Send message failed (\(http.statusCode)): \(errorBody)")
                 onMessage?(.sessionError(SessionErrorMessage(
                     sessionId: sessionId,
                     code: .providerApi,
@@ -347,7 +336,7 @@ final class HTTPTransport {
                 )))
             }
         } catch {
-            log.error("Create run error: \(error.localizedDescription)")
+            log.error("Send message error: \(error.localizedDescription)")
             onMessage?(.sessionError(SessionErrorMessage(
                 sessionId: sessionId,
                 code: .providerApi,
@@ -358,19 +347,17 @@ final class HTTPTransport {
     }
 
     private func sendDecision(requestId: String, decision: String) async {
-        guard let runId = activeRunId else {
-            log.warning("No active run ID for decision response")
-            return
-        }
-
-        guard let url = URL(string: "\(baseURL)/v1/runs/\(runId)/decision") else { return }
+        guard let url = URL(string: "\(baseURL)/v1/confirm") else { return }
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         applyAuth(&request)
 
-        let body: [String: Any] = ["decision": decision]
+        let body: [String: Any] = [
+            "requestId": requestId,
+            "decision": decision
+        ]
 
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
@@ -385,21 +372,15 @@ final class HTTPTransport {
     }
 
     private func sendSecret(requestId: String, value: String?) async {
-        // Secrets can be delivered via the /v1/secrets endpoint for persistence,
-        // or via the run's decision flow. Use the secrets endpoint.
-        guard let url = URL(string: "\(baseURL)/v1/secrets") else { return }
+        guard let url = URL(string: "\(baseURL)/v1/secret") else { return }
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         applyAuth(&request)
 
-        // The secret_request includes service/field info but we receive it via
-        // the SecretResponseMessage which only has requestId and value.
-        // For now, send as a credential with the requestId as name.
         let body: [String: Any] = [
-            "type": "credential",
-            "name": requestId,
+            "requestId": requestId,
             "value": value ?? ""
         ]
 
@@ -407,7 +388,7 @@ final class HTTPTransport {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
             let (_, response) = try await URLSession.shared.data(for: request)
 
-            if let http = response as? HTTPURLResponse, http.statusCode != 201 {
+            if let http = response as? HTTPURLResponse, http.statusCode != 200 {
                 log.error("Secret response failed (\(http.statusCode))")
             }
         } catch {
@@ -550,7 +531,6 @@ final class HTTPTransport {
         sseTask = nil
         setConnected(false)
         setSSEConnected(false)
-        activeRunId = nil
     }
 
     // MARK: - SSE Reconnect


### PR DESCRIPTION
PR 4/6: remove-runs plan. Migrates Swift and CLI clients to new message/approval endpoints.

## Summary

- **Swift HTTPTransport**: Changed `createRun()` (POST /v1/runs) to `sendMessage()` (POST /v1/messages). Updated `sendDecision()` to POST /v1/confirm with `{ requestId, decision }`. Updated `sendSecret()` to POST /v1/secret with `{ requestId, value }`. Removed `activeRunId` property and all run-related state tracking.

- **CLI**: Replaced `createRun()` with `sendMessage()` (POST /v1/messages). Replaced `submitDecision()` with POST /v1/confirm. Replaced `addTrustRule()` with POST /v1/trust-rules. Removed `getRun()` status polling and all run-related types (`CreateRunResponse`, `GetRunResponse`). Added polling via new `GET /v1/pending-interactions` endpoint for approval discovery.

- **Server**: Added `GET /v1/pending-interactions?conversationKey=...` endpoint so polling-based clients (CLI) can discover pending confirmations/secrets without SSE.

## Test plan

- [ ] CLI: send a message, verify it reaches the assistant via POST /v1/messages
- [ ] CLI: trigger a tool approval, verify the confirmation prompt appears via pending-interactions polling
- [ ] CLI: submit allow/deny decisions, verify they resolve via POST /v1/confirm
- [ ] CLI: test trust rule allowlist/denylist flow via POST /v1/trust-rules
- [ ] Swift: send a message via HTTP transport, verify it hits POST /v1/messages
- [ ] Swift: approve a tool confirmation, verify it hits POST /v1/confirm
- [ ] Swift: provide a secret, verify it hits POST /v1/secret
- [ ] Verify no remaining references to /v1/runs in Swift or CLI code
- [ ] CLI type-check: `cd cli && bunx tsc --noEmit` passes
- [ ] Swift build: `cd clients/macos && ./build.sh` succeeds
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
