### PR TITLE
Fix: Address M3 review feedback (promptForSource + panel close)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -45,8 +45,9 @@ extension AppDelegate {
             return pickerVM.selectedRecordingOptions
         }
 
-        // Try auto-apply from saved preference
-        if pickerVM.canAutoApply() {
+        // Try auto-apply from saved preference, but only when the caller
+        // didn't explicitly request the picker via promptForSource.
+        if routed.recordingOptions?.promptForSource != true, pickerVM.canAutoApply() {
             log.info("Auto-applied saved recording source preference")
             return pickerVM.selectedRecordingOptions
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -241,6 +241,8 @@ extension AppDelegate {
                         } catch {
                             log.error("Failed to send CU session abort after picker cancel: \(error)")
                         }
+                        self.recordingPickerWindow?.close()
+                        self.recordingPickerWindow = nil
                         return
                     }
                     self.recordingPickerWindow?.close()

--- a/clients/macos/vellum-assistant/ComputerUse/RecordingSourcePickerWindow.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/RecordingSourcePickerWindow.swift
@@ -9,6 +9,18 @@ final class RecordingSourcePickerWindow {
     private let viewModel: RecordingSourcePickerViewModel
     private let onStart: () -> Void
     private let onCancel: () -> Void
+    private let panelDelegate = PanelDelegate()
+
+    /// Intercepts the native close button (X) so we can resume the
+    /// continuation that would otherwise be stuck forever.
+    private class PanelDelegate: NSObject, NSWindowDelegate {
+        var onClose: (() -> Void)?
+
+        func windowWillClose(_ notification: Notification) {
+            onClose?()
+            onClose = nil
+        }
+    }
 
     init(viewModel: RecordingSourcePickerViewModel, onStart: @escaping () -> Void, onCancel: @escaping () -> Void) {
         self.viewModel = viewModel
@@ -20,10 +32,13 @@ final class RecordingSourcePickerWindow {
         let pickerView = RecordingSourcePickerView(
             viewModel: viewModel,
             onStart: { [weak self] in
+                // Disarm the delegate before closing to prevent double-fire
+                self?.panelDelegate.onClose = nil
                 self?.close()
                 self?.onStart()
             },
             onCancel: { [weak self] in
+                self?.panelDelegate.onClose = nil
                 self?.close()
                 self?.onCancel()
             }
@@ -48,6 +63,12 @@ final class RecordingSourcePickerWindow {
         panel.isOpaque = false
         panel.isReleasedWhenClosed = false
 
+        // Wire up the delegate so native X-button close triggers onCancel
+        panelDelegate.onClose = { [weak self] in
+            self?.onCancel()
+        }
+        panel.delegate = panelDelegate
+
         // Center on screen
         if let screen = NSScreen.main {
             let screenFrame = screen.visibleFrame
@@ -62,6 +83,8 @@ final class RecordingSourcePickerWindow {
     }
 
     func close() {
+        // Disarm delegate before closing to prevent double-fire
+        panelDelegate.onClose = nil
         panel?.close()
         panel = nil
     }


### PR DESCRIPTION
## Summary
- Respect promptForSource flag: always show picker when explicitly requested
- Handle native panel close button: add NSWindowDelegate to resume continuation on windowWillClose
- Guard against double-fire on continuation resume

Fixes feedback on #8408
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
