### PR TITLE
Fix: Clean up picker window on cancel

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -241,6 +241,8 @@ extension AppDelegate {
                         } catch {
                             log.error("Failed to send CU session abort after picker cancel: \(error)")
                         }
+                        self.recordingPickerWindow?.close()
+                        self.recordingPickerWindow = nil
                         return
                     }
                     self.recordingPickerWindow?.close()


### PR DESCRIPTION
## Summary
- Nil out recordingPickerWindow in cancel path to prevent stale reference
- Minor resource leak fix from Devin review on #8411

Fixes feedback on #8411
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
