### PR TITLE
fix: use FIFO order in waitForDownload for consistent download consumption (PR #8164)

### DIFF
--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -792,7 +792,7 @@ class BrowserManager {
     // Check if an unconsumed download already completed for this session
     const existing = this.downloads.get(sessionId);
     if (existing && existing.length > 0) {
-      const info = existing.pop()!;
+      const info = existing.shift()!;
       if (existing.length === 0) this.downloads.delete(sessionId);
       return Promise.resolve(info);
     }


### PR DESCRIPTION
Addresses review feedback on PR #8164. Changes existing.pop() to existing.shift() in waitForDownload so unconsumed downloads are consumed in FIFO order, consistent with how pending waiters are resolved via shift() in setupDownloadTracking.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
