### PR TITLE
fix: remove --external react-devtools-core from CLI builds

### DIFF
--- a/.github/workflows/ci-main-cli.yaml
+++ b/.github/workflows/ci-main-cli.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Compile check
         run: |
-          bun build --compile src/index.ts --external react-devtools-core --outfile /tmp/vellum-cli-compile-check
+          bun build --compile src/index.ts --outfile /tmp/vellum-cli-compile-check
           rm -f /tmp/vellum-cli-compile-check
 
       - name: Track consecutive failures

--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -102,10 +102,8 @@ jobs:
         run: |
           bun install
           bun build --compile --target=bun-darwin-arm64 src/index.ts \
-            --external react-devtools-core \
             --outfile ../clients/macos/cli-bin/vellum-cli-arm64
           bun build --compile --target=bun-darwin-x64 src/index.ts \
-            --external react-devtools-core \
             --outfile ../clients/macos/cli-bin/vellum-cli-x64
           lipo -create \
             ../clients/macos/cli-bin/vellum-cli-arm64 \

--- a/.github/workflows/ci-nightly-release.yml
+++ b/.github/workflows/ci-nightly-release.yml
@@ -107,10 +107,8 @@ jobs:
         run: |
           bun install
           bun build --compile --target=bun-darwin-arm64 src/index.ts \
-            --external react-devtools-core \
             --outfile ../clients/macos/cli-bin/vellum-cli-arm64
           bun build --compile --target=bun-darwin-x64 src/index.ts \
-            --external react-devtools-core \
             --outfile ../clients/macos/cli-bin/vellum-cli-x64
           lipo -create \
             ../clients/macos/cli-bin/vellum-cli-arm64 \

--- a/.github/workflows/pr-cli.yaml
+++ b/.github/workflows/pr-cli.yaml
@@ -40,5 +40,5 @@ jobs:
 
       - name: Compile check
         run: |
-          bun build --compile src/index.ts --external react-devtools-core --outfile /tmp/vellum-cli-compile-check
+          bun build --compile src/index.ts --outfile /tmp/vellum-cli-compile-check
           rm -f /tmp/vellum-cli-compile-check

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -108,10 +108,8 @@ jobs:
         run: |
           bun install
           bun build --compile --target=bun-darwin-arm64 src/index.ts \
-            --external react-devtools-core \
             --outfile ../clients/macos/cli-bin/vellum-cli-arm64
           bun build --compile --target=bun-darwin-x64 src/index.ts \
-            --external react-devtools-core \
             --outfile ../clients/macos/cli-bin/vellum-cli-x64
           lipo -create \
             ../clients/macos/cli-bin/vellum-cli-arm64 \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,10 +245,8 @@ jobs:
         run: |
           bun install
           bun build --compile --target=bun-darwin-arm64 src/index.ts \
-            --external react-devtools-core \
             --outfile ../clients/macos/cli-bin/vellum-cli-arm64
           bun build --compile --target=bun-darwin-x64 src/index.ts \
-            --external react-devtools-core \
             --outfile ../clients/macos/cli-bin/vellum-cli-x64
           lipo -create \
             ../clients/macos/cli-bin/vellum-cli-arm64 \


### PR DESCRIPTION
## Summary

Fixes CLI crash during hatch/onboarding: `Cannot find package 'react-devtools-core' from '/$bunfs/root/vellum-cli-arm64'`.

## Problem

All CI/release workflows compiled the CLI binary with `--external react-devtools-core`, which tells Bun to exclude the package from the bundle and resolve it at runtime. In standalone compiled binaries there is no `node_modules` on disk, so Bun throws a fatal resolution error that bypasses JavaScript's `try/catch`.

Ink's reconciler conditionally imports `react-devtools-core` behind a `DEV=true` check, but Bun's module resolution failure for external packages is not a catchable JavaScript exception — it crashes the process.

## Fix

Remove `--external react-devtools-core` from all 6 workflow files. This aligns CI/release builds with the local `build.sh` (line 233), which already omits `--external` and bundles the package successfully. The bundled devtools code is dead code in production (only activated when `DEV=true`).

## Files Changed

- `.github/workflows/release.yml`
- `.github/workflows/ci-main-macos.yaml`
- `.github/workflows/ci-main-cli.yaml`
- `.github/workflows/ci-nightly-release.yml`
- `.github/workflows/pr-cli.yaml`
- `.github/workflows/pr-macos.yaml`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
