### PR TITLE
fix: handle empty content result distinctly in subagent message callers

### DIFF
--- a/assistant/src/daemon/handlers/subagents.ts
+++ b/assistant/src/daemon/handlers/subagents.ts
@@ -118,6 +118,13 @@ export function handleSubagentMessage(
       message: `Subagent "${msg.subagentId}" message queue is full. Please wait for current messages to be processed.`,
       category: 'queue_full',
     });
+  } else if (result === 'empty') {
+    log.warn({ subagentId: msg.subagentId }, 'Subagent message rejected — empty content');
+    ctx.send(socket, {
+      type: 'error',
+      message: 'Message content is empty or whitespace-only.',
+      category: 'empty_content',
+    });
   } else if (result !== 'sent') {
     log.warn({ subagentId: msg.subagentId, reason: result }, 'Client sent message to terminal subagent');
     ctx.send(socket, {

--- a/assistant/src/tools/subagent/message.ts
+++ b/assistant/src/tools/subagent/message.ts
@@ -32,6 +32,13 @@ export async function executeSubagentMessage(
     };
   }
 
+  if (result === 'empty') {
+    return {
+      content: 'Message content is empty or whitespace-only.',
+      isError: true,
+    };
+  }
+
   if (result !== 'sent') {
     return {
       content: `Could not send message to subagent "${subagentId}". It may not exist or be in a terminal state.`,


### PR DESCRIPTION
Addresses feedback on #8397: adds explicit handling for the 'empty' return value from sendMessage in both handleSubagentMessage and executeSubagentMessage, so users see 'message content is empty' instead of misleading 'not found' errors.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
