### PR TITLE
fix: make error bubble chrome span full width and fix overflow button offset (PR #8312)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -72,9 +72,11 @@ struct ChatBubble: View {
 
     private func bubbleChrome<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
         let isPlainAssistant = !isUser && !message.isError
+        let overflowOffset: CGFloat = message.isError ? -(24 + VSpacing.sm) : (24 + VSpacing.sm)
         return content()
             .padding(.horizontal, isPlainAssistant ? 0 : VSpacing.lg)
             .padding(.vertical, isPlainAssistant ? 0 : VSpacing.md)
+            .frame(maxWidth: message.isError ? .infinity : nil, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)
                     .fill(bubbleFill)
@@ -87,7 +89,7 @@ struct ChatBubble: View {
                     overflowMenuButton
                         .opacity(showOverflowMenu ? 1 : 0)
                         .animation(VAnimation.fast, value: showOverflowMenu)
-                        .offset(x: isUser ? -(24 + VSpacing.sm) : (24 + VSpacing.sm))
+                        .offset(x: isUser ? -(24 + VSpacing.sm) : overflowOffset)
                 }
             }
             .frame(maxWidth: message.isError ? .infinity : 520, alignment: isUser ? .trailing : .leading)


### PR DESCRIPTION
Addresses review feedback on PR #8312. Moves maxWidth:.infinity before the background/border overlays so the error bubble chrome actually spans full chat width. Adjusts overflow menu button offset for error messages to use a negative value, placing it inside the bubble's trailing edge to prevent clipping.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
