### PR TITLE
fix: voice barge-in race condition & guardian inbound greeting

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -574,7 +574,9 @@ export class CallController {
 
   private isExpectedAbortError(err: unknown): boolean {
     if (!(err instanceof Error)) return false;
-    return err.name === 'AbortError' || err.name === 'APIUserAbortError';
+    return err.name === 'AbortError'
+      || err.name === 'APIUserAbortError'
+      || err.message === 'Session is already processing a message';
   }
 
   private isCurrentRun(runVersion: number): boolean {

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -89,6 +89,7 @@ export interface VoiceTurnHandle {
 function buildVoiceCallControlPrompt(opts: {
   isInbound: boolean;
   task?: string | null;
+  isCallerGuardian?: boolean;
 }): string {
   const config = getConfig();
   const disclosureEnabled = config.calls?.disclosure?.enabled === true;
@@ -134,8 +135,16 @@ function buildVoiceCallControlPrompt(opts: {
   );
 
   if (opts.isInbound) {
+    if (opts.isCallerGuardian) {
+      lines.push(
+        '10. If the latest user turn is [CALL_OPENING], this is your user calling you. Answer casually and briefly, like picking up a call from someone you know well. For example: "Hey!" or "What\'s up?" Do NOT introduce yourself, do NOT say you are calling on behalf of anyone, and do NOT ask how you can help in a formal way. Keep it short and natural.',
+      );
+    } else {
+      lines.push(
+        '10. If the latest user turn is [CALL_OPENING], greet the caller warmly and ask how you can help. Vary the wording; do not use a fixed template.',
+      );
+    }
     lines.push(
-      '10. If the latest user turn is [CALL_OPENING], greet the caller warmly and ask how you can help. Vary the wording; do not use a fixed template.',
       '11. If the latest user turn includes [CALL_OPENING_ACK], treat it as the caller acknowledging your greeting and continue the conversation naturally.',
     );
   } else {
@@ -201,9 +210,12 @@ export async function startVoiceTurn(opts: VoiceTurnOptions): Promise<VoiceTurnH
 
   // Build the call-control protocol prompt so the model knows how to emit
   // control markers (ASK_GUARDIAN, END_CALL, CALL_OPENING, etc.).
+  const isCallerGuardian = opts.guardianContext?.actorRole === 'guardian';
+
   const voiceCallControlPrompt = buildVoiceCallControlPrompt({
     isInbound: opts.isInbound,
     task: opts.task,
+    isCallerGuardian,
   });
 
   const { run, abort } = await orchestrator.startRun(

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -198,7 +198,18 @@ export class RunOrchestrator {
     const session = await this.deps.getOrCreateSession(conversationId, transport);
 
     if (session.isProcessing()) {
-      throw new Error('Session is already processing a message');
+      // Voice barge-in can race with turn teardown. Wait briefly for the
+      // previous run to finish aborting before giving up.
+      const maxWaitMs = 3000;
+      const pollIntervalMs = 50;
+      let waited = 0;
+      while (session.isProcessing() && waited < maxWaitMs) {
+        await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+        waited += pollIntervalMs;
+      }
+      if (session.isProcessing()) {
+        throw new Error('Session is already processing a message');
+      }
     }
 
     // Determine the correct strictSideEffects value for this run:


### PR DESCRIPTION
## Summary
- **Bug #1 (race condition):** When a caller speaks a follow-up before the assistant finishes processing, `startRun()` would throw "Session is already processing a message" causing the assistant to say "I encountered a technical issue." Now the orchestrator polls briefly (up to 3s) for the previous run to tear down, and the error is treated as an expected abort as defense-in-depth.
- **Bug #2 (guardian greeting):** When the guardian calls the assistant's phone number, the assistant would greet formally ("Hey there, this is Credence calling on behalf of Noa..."). Now the voice call control prompt detects guardian callers and instructs the model to answer casually ("Hey!" / "What's up?").

## Original prompt

### Bug #1: Race condition — "Session is already processing a message" crashes voice turns
Add retry loop in `run-orchestrator.ts` before throwing, and recognize the error as expected in `call-controller.ts`.

### Bug #2: Assistant greets the caller on inbound calls from the guardian
Thread `isCallerGuardian` through `buildVoiceCallControlPrompt` to differentiate greeting behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
