### PR TITLE
fix: reset confirmation feedback state on surface data updates (PR #8409)

### DIFF
--- a/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
@@ -36,11 +36,21 @@ public struct ConfirmationSurfaceView: View {
         return "confirm"
     }
 
+    /// Composite identity for detecting data changes from surface updates.
+    private var dataIdentity: String {
+        "\(data.message)|\(data.detail ?? "")|\(data.confirmLabel ?? "")|\(data.cancelLabel ?? "")|\(data.destructive)"
+    }
+
     public var body: some View {
-        if let selectedAction {
-            selectedActionFeedback(selectedAction)
-        } else {
-            pendingContent
+        Group {
+            if let selectedAction {
+                selectedActionFeedback(selectedAction)
+            } else {
+                pendingContent
+            }
+        }
+        .onChange(of: dataIdentity) { _, _ in
+            selectedAction = nil
         }
     }
 


### PR DESCRIPTION
Addresses review feedback on PR #8409. After a user clicks confirm/cancel, the view now resets its selectedAction state when the server sends an updated confirmation surface (via ui_surface_update). This prevents the feedback indicator from permanently blocking updated content or actionable buttons.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
