### PR TITLE
M5: Attachment Creation + Inline Playback + Drag/Save

### DIFF
--- a/assistant/src/__tests__/attachment-content-route.test.ts
+++ b/assistant/src/__tests__/attachment-content-route.test.ts
@@ -1,0 +1,173 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'attach-content-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  getRootDir: () => testDir,
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    model: 'test',
+    provider: 'test',
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  }),
+}));
+
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
+import {
+  uploadAttachment,
+  uploadFileBackedAttachment,
+} from '../memory/attachments-store.js';
+import { handleGetAttachmentContent } from '../runtime/routes/attachment-routes.js';
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+function resetTables() {
+  const db = getDb();
+  db.run('DELETE FROM message_attachments');
+  db.run('DELETE FROM attachments');
+}
+
+// ---------------------------------------------------------------------------
+// handleGetAttachmentContent
+// ---------------------------------------------------------------------------
+
+describe('handleGetAttachmentContent', () => {
+  beforeEach(resetTables);
+
+  test('returns 404 for non-existent attachment', () => {
+    const req = new Request('http://localhost/v1/attachments/nonexistent/content');
+    const res = handleGetAttachmentContent('nonexistent', req);
+    expect(res.status).toBe(404);
+  });
+
+  test('returns full content for base64 attachment without Range header', async () => {
+    const data = Buffer.from('hello world').toString('base64');
+    const stored = uploadAttachment('test.txt', 'text/plain', data);
+
+    const req = new Request('http://localhost/v1/attachments/' + stored.id + '/content');
+    const res = handleGetAttachmentContent(stored.id, req);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/plain');
+    expect(res.headers.get('Accept-Ranges')).toBe('bytes');
+
+    const body = await res.arrayBuffer();
+    const text = new TextDecoder().decode(body);
+    expect(text).toBe('hello world');
+  });
+
+  test('returns full content for file-backed attachment without Range header', async () => {
+    const filePath = join(testDir, 'test-video.mp4');
+    const content = 'fake video content for testing';
+    writeFileSync(filePath, content);
+
+    const stored = uploadFileBackedAttachment('test-video.mp4', 'video/mp4', filePath, content.length);
+
+    const req = new Request('http://localhost/v1/attachments/' + stored.id + '/content');
+    const res = handleGetAttachmentContent(stored.id, req);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('video/mp4');
+    expect(res.headers.get('Accept-Ranges')).toBe('bytes');
+
+    const body = await res.arrayBuffer();
+    const text = new TextDecoder().decode(body);
+    expect(text).toBe(content);
+  });
+
+  test('returns 206 with correct Content-Range for range request on file-backed attachment', async () => {
+    const filePath = join(testDir, 'test-range.mp4');
+    const content = 'abcdefghijklmnopqrstuvwxyz';
+    writeFileSync(filePath, content);
+
+    const stored = uploadFileBackedAttachment('test-range.mp4', 'video/mp4', filePath, content.length);
+
+    const req = new Request('http://localhost/v1/attachments/' + stored.id + '/content', {
+      headers: { Range: 'bytes=0-4' },
+    });
+    const res = handleGetAttachmentContent(stored.id, req);
+
+    expect(res.status).toBe(206);
+    expect(res.headers.get('Content-Range')).toBe(`bytes 0-4/${content.length}`);
+    expect(res.headers.get('Content-Length')).toBe('5');
+
+    const body = await res.arrayBuffer();
+    const text = new TextDecoder().decode(body);
+    expect(text).toBe('abcde');
+  });
+
+  test('returns 206 with correct Content-Range for range request on base64 attachment', async () => {
+    const originalContent = 'abcdefghijklmnopqrstuvwxyz';
+    const data = Buffer.from(originalContent).toString('base64');
+    const stored = uploadAttachment('test.txt', 'text/plain', data);
+
+    const req = new Request('http://localhost/v1/attachments/' + stored.id + '/content', {
+      headers: { Range: 'bytes=5-9' },
+    });
+    const res = handleGetAttachmentContent(stored.id, req);
+
+    expect(res.status).toBe(206);
+    expect(res.headers.get('Content-Range')).toBe(`bytes 5-9/${originalContent.length}`);
+    expect(res.headers.get('Content-Length')).toBe('5');
+
+    const body = await res.arrayBuffer();
+    const text = new TextDecoder().decode(body);
+    expect(text).toBe('fghij');
+  });
+
+  test('returns 416 for invalid range beyond file size', () => {
+    const filePath = join(testDir, 'test-small.mp4');
+    writeFileSync(filePath, 'small');
+
+    const stored = uploadFileBackedAttachment('test-small.mp4', 'video/mp4', filePath, 5);
+
+    const req = new Request('http://localhost/v1/attachments/' + stored.id + '/content', {
+      headers: { Range: 'bytes=100-200' },
+    });
+    const res = handleGetAttachmentContent(stored.id, req);
+
+    expect(res.status).toBe(416);
+    expect(res.headers.get('Content-Range')).toBe('bytes */5');
+  });
+
+  test('returns 416 for malformed Range header', () => {
+    const filePath = join(testDir, 'test-malformed.mp4');
+    writeFileSync(filePath, 'content');
+
+    const stored = uploadFileBackedAttachment('test-malformed.mp4', 'video/mp4', filePath, 7);
+
+    const req = new Request('http://localhost/v1/attachments/' + stored.id + '/content', {
+      headers: { Range: 'invalid-range' },
+    });
+    const res = handleGetAttachmentContent(stored.id, req);
+
+    expect(res.status).toBe(416);
+  });
+});

--- a/assistant/src/__tests__/cu-session-finalized.test.ts
+++ b/assistant/src/__tests__/cu-session-finalized.test.ts
@@ -1,0 +1,228 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import * as net from 'node:net';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'cu-finalized-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  getRootDir: () => testDir,
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    model: 'test',
+    provider: 'test',
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  }),
+}));
+
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
+import { attachments } from '../memory/schema.js';
+import { createConversation, addMessage } from '../memory/conversation-store.js';
+import { getAttachmentMetadataForMessage } from '../memory/attachments-store.js';
+import { handleRecordingStatus } from '../daemon/handlers/computer-use.js';
+import type { RecordingStatus } from '../daemon/ipc-contract/computer-use.js';
+import type { HandlerContext } from '../daemon/handlers/shared.js';
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+function resetTables() {
+  const db = getDb();
+  db.run('DELETE FROM message_attachments');
+  db.run('DELETE FROM attachments');
+  db.run('DELETE FROM messages');
+  db.run('DELETE FROM conversations');
+}
+
+function createMockSocket(): net.Socket {
+  return {} as net.Socket;
+}
+
+function createMockCtx(): HandlerContext {
+  return {
+    sessions: new Map(),
+    socketToSession: new Map(),
+    cuSessions: new Map(),
+    socketToCuSession: new Map(),
+    cuObservationParseSequence: new Map(),
+    socketSandboxOverride: new Map(),
+    sharedRequestTimestamps: [],
+    debounceTimers: new Map() as unknown as HandlerContext['debounceTimers'],
+    suppressConfigReload: false,
+    setSuppressConfigReload: () => {},
+    updateConfigFingerprint: () => {},
+    send: () => {},
+    broadcast: () => {},
+    clearAllSessions: () => 0,
+    getOrCreateSession: async () => { throw new Error('not implemented'); },
+    touchSession: () => {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Recording finalization in handleRecordingStatus
+// ---------------------------------------------------------------------------
+
+describe('handleRecordingStatus - recording finalization', () => {
+  beforeEach(resetTables);
+
+  test('creates file-backed attachment when recording stops with filePath', () => {
+    const sessionId = 'test-session-001';
+
+    // Create conversation and messages using sessionId as conversationId
+    createConversation(sessionId);
+    addMessage(sessionId, 'user', 'Start the test');
+    addMessage(sessionId, 'assistant', 'Running the test now');
+
+    // Create a real recording file
+    const filePath = join(testDir, 'recording-001.mov');
+    writeFileSync(filePath, 'fake video data for testing purposes');
+
+    const msg: RecordingStatus = {
+      type: 'recording_status',
+      sessionId,
+      status: 'stopped',
+      filePath,
+      durationMs: 5000,
+    };
+
+    handleRecordingStatus(msg, createMockSocket(), createMockCtx());
+
+    // Check that a file-backed attachment was created
+    const db = getDb();
+    const rows = db.select().from(attachments).all();
+
+    expect(rows.length).toBe(1);
+    expect(rows[0].filePath).toBe(filePath);
+    expect(rows[0].dataBase64).toBe('');
+    expect(rows[0].mimeType).toBe('video/quicktime');
+  });
+
+  test('links attachment to latest assistant message', () => {
+    const sessionId = 'test-session-002';
+
+    createConversation(sessionId);
+    addMessage(sessionId, 'user', 'Do something');
+    const assistantMsg = addMessage(sessionId, 'assistant', 'Done');
+
+    const filePath = join(testDir, 'recording-002.mp4');
+    writeFileSync(filePath, 'video content');
+
+    const msg: RecordingStatus = {
+      type: 'recording_status',
+      sessionId,
+      status: 'stopped',
+      filePath,
+      durationMs: 3000,
+    };
+
+    handleRecordingStatus(msg, createMockSocket(), createMockCtx());
+
+    // Verify attachment is linked to the assistant message
+    const attachmentMeta = getAttachmentMetadataForMessage(assistantMsg.id);
+    expect(attachmentMeta.length).toBe(1);
+    expect(attachmentMeta[0].filePath).toBe(filePath);
+  });
+
+  test('does not crash when filePath does not exist', () => {
+    const sessionId = 'test-session-003';
+
+    createConversation(sessionId);
+    addMessage(sessionId, 'assistant', 'test');
+
+    const msg: RecordingStatus = {
+      type: 'recording_status',
+      sessionId,
+      status: 'stopped',
+      filePath: join(testDir, 'nonexistent-recording.mov'),
+      durationMs: 1000,
+    };
+
+    // Should not throw
+    expect(() => {
+      handleRecordingStatus(msg, createMockSocket(), createMockCtx());
+    }).not.toThrow();
+
+    // No attachment should be created
+    const db = getDb();
+    const rows = db.select().from(attachments).all();
+    expect(rows.length).toBe(0);
+  });
+
+  test('does not create attachment when session has no conversation', () => {
+    // Session doesn't exist as a conversation, so no messages to link to
+    const sessionId = 'orphan-session';
+
+    const filePath = join(testDir, 'recording-orphan.mov');
+    writeFileSync(filePath, 'video');
+
+    const msg: RecordingStatus = {
+      type: 'recording_status',
+      sessionId,
+      status: 'stopped',
+      filePath,
+      durationMs: 1000,
+    };
+
+    // Should not throw even when there's no conversation/messages
+    expect(() => {
+      handleRecordingStatus(msg, createMockSocket(), createMockCtx());
+    }).not.toThrow();
+  });
+
+  test('does not create attachment for non-stopped status', () => {
+    const sessionId = 'test-session-started';
+
+    const msg: RecordingStatus = {
+      type: 'recording_status',
+      sessionId,
+      status: 'started',
+    };
+
+    handleRecordingStatus(msg, createMockSocket(), createMockCtx());
+
+    const db = getDb();
+    const rows = db.select().from(attachments).all();
+    expect(rows.length).toBe(0);
+  });
+
+  test('does not create attachment for stopped status without filePath', () => {
+    const sessionId = 'test-session-no-path';
+
+    const msg: RecordingStatus = {
+      type: 'recording_status',
+      sessionId,
+      status: 'stopped',
+    };
+
+    handleRecordingStatus(msg, createMockSocket(), createMockCtx());
+
+    const db = getDb();
+    const rows = db.select().from(attachments).all();
+    expect(rows.length).toBe(0);
+  });
+});

--- a/assistant/src/daemon/handlers/computer-use.ts
+++ b/assistant/src/daemon/handlers/computer-use.ts
@@ -209,6 +209,22 @@ export function handleRecordingStatus(
         return;
       }
 
+      // Find the latest assistant message BEFORE creating the attachment to
+      // avoid orphaned attachment rows when no message exists to link to.
+      const conversationId = msg.sessionId;
+      const db = getDb();
+      const latestAssistantMsg = db
+        .select({ id: messages.id })
+        .from(messages)
+        .where(and(eq(messages.conversationId, conversationId), eq(messages.role, 'assistant')))
+        .orderBy(desc(messages.createdAt))
+        .get();
+
+      if (!latestAssistantMsg) {
+        log.warn({ sessionId: msg.sessionId }, 'No assistant message found in session to link recording attachment — skipping attachment creation');
+        return;
+      }
+
       const stat = statSync(msg.filePath);
       const sizeBytes = stat.size;
       const filename = basename(msg.filePath);
@@ -220,23 +236,8 @@ export function handleRecordingStatus(
       const attachment = uploadFileBackedAttachment(filename, mimeType, msg.filePath, sizeBytes);
       log.info({ sessionId: msg.sessionId, attachmentId: attachment.id, sizeBytes, filePath: msg.filePath }, 'Created file-backed attachment for recording');
 
-      // The CU session uses sessionId as the conversationId in the agent loop.
-      // Find the latest assistant message in that conversation to link the attachment.
-      const conversationId = msg.sessionId;
-      const db = getDb();
-      const latestAssistantMsg = db
-        .select({ id: messages.id })
-        .from(messages)
-        .where(and(eq(messages.conversationId, conversationId), eq(messages.role, 'assistant')))
-        .orderBy(desc(messages.createdAt))
-        .get();
-
-      if (latestAssistantMsg) {
-        linkAttachmentToMessage(latestAssistantMsg.id, attachment.id, 0);
-        log.info({ sessionId: msg.sessionId, messageId: latestAssistantMsg.id, attachmentId: attachment.id }, 'Linked recording attachment to assistant message');
-      } else {
-        log.warn({ sessionId: msg.sessionId }, 'No assistant message found in session to link recording attachment');
-      }
+      linkAttachmentToMessage(latestAssistantMsg.id, attachment.id, 0);
+      log.info({ sessionId: msg.sessionId, messageId: latestAssistantMsg.id, attachmentId: attachment.id }, 'Linked recording attachment to assistant message');
     } catch (err) {
       log.error({ err, sessionId: msg.sessionId, filePath: msg.filePath }, 'Failed to create attachment for recording');
     }

--- a/assistant/src/daemon/handlers/computer-use.ts
+++ b/assistant/src/daemon/handlers/computer-use.ts
@@ -1,9 +1,15 @@
 import * as net from 'node:net';
+import { existsSync, statSync } from 'node:fs';
+import { basename } from 'node:path';
 import { getConfig } from '../../config/loader.js';
 import { getFailoverProvider } from '../../providers/registry.js';
 import { RateLimitProvider } from '../../providers/ratelimit.js';
 import { ComputerUseSession } from '../computer-use-session.js';
 import { readBlob, deleteBlob, validateBlobKindEncoding } from '../ipc-blob-store.js';
+import { uploadFileBackedAttachment, linkAttachmentToMessage } from '../../memory/attachments-store.js';
+import { getDb } from '../../memory/db.js';
+import { messages } from '../../memory/schema.js';
+import { eq, desc, and } from 'drizzle-orm';
 import type {
   CuSessionCreate,
   CuSessionAbort,
@@ -186,13 +192,6 @@ export function handleRecordingStatus(
   _socket: net.Socket,
   ctx: HandlerContext,
 ): void {
-  const session = ctx.cuSessions.get(msg.sessionId);
-  if (!session) {
-    // Session already cleaned up — still log the recording status for telemetry
-    log.info({ sessionId: msg.sessionId, status: msg.status, filePath: msg.filePath, durationMs: msg.durationMs }, 'Recording status for completed session');
-    return;
-  }
-
   log.info({
     sessionId: msg.sessionId,
     status: msg.status,
@@ -200,6 +199,48 @@ export function handleRecordingStatus(
     durationMs: msg.durationMs,
     error: msg.error,
   }, 'Recording status update');
+
+  // When recording stops with a file path, create a file-backed attachment
+  // and link it to the latest assistant message in the session's conversation.
+  if (msg.status === 'stopped' && msg.filePath) {
+    try {
+      if (!existsSync(msg.filePath)) {
+        log.error({ sessionId: msg.sessionId, filePath: msg.filePath }, 'Recording file does not exist');
+        return;
+      }
+
+      const stat = statSync(msg.filePath);
+      const sizeBytes = stat.size;
+      const filename = basename(msg.filePath);
+
+      // Infer MIME type from extension
+      const ext = filename.split('.').pop()?.toLowerCase();
+      const mimeType = ext === 'mov' ? 'video/quicktime' : ext === 'mp4' ? 'video/mp4' : 'video/mp4';
+
+      const attachment = uploadFileBackedAttachment(filename, mimeType, msg.filePath, sizeBytes);
+      log.info({ sessionId: msg.sessionId, attachmentId: attachment.id, sizeBytes, filePath: msg.filePath }, 'Created file-backed attachment for recording');
+
+      // The CU session uses sessionId as the conversationId in the agent loop.
+      // Find the latest assistant message in that conversation to link the attachment.
+      const conversationId = msg.sessionId;
+      const db = getDb();
+      const latestAssistantMsg = db
+        .select({ id: messages.id })
+        .from(messages)
+        .where(and(eq(messages.conversationId, conversationId), eq(messages.role, 'assistant')))
+        .orderBy(desc(messages.createdAt))
+        .get();
+
+      if (latestAssistantMsg) {
+        linkAttachmentToMessage(latestAssistantMsg.id, attachment.id, 0);
+        log.info({ sessionId: msg.sessionId, messageId: latestAssistantMsg.id, attachmentId: attachment.id }, 'Linked recording attachment to assistant message');
+      } else {
+        log.warn({ sessionId: msg.sessionId }, 'No assistant message found in session to link recording attachment');
+      }
+    } catch (err) {
+      log.error({ err, sessionId: msg.sessionId, filePath: msg.filePath }, 'Failed to create attachment for recording');
+    }
+  }
 }
 
 export const computerUseHandlers = defineHandlers({

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -445,7 +445,10 @@ export function handleHistoryRequest(
         // the client, so non-video attachments always keep their inline data.
         const MAX_INLINE_B64_SIZE = 512 * 1024;
         attachments = linked.map((a) => {
-          const omit = a.mimeType.startsWith('video/') && a.dataBase64.length > MAX_INLINE_B64_SIZE;
+          // File-backed attachments (filePath set, dataBase64 empty) must always
+          // use lazy-load mode so the client fetches content via the HTTP endpoint.
+          const isFileBacked = !!a.filePath;
+          const omit = isFileBacked || (a.mimeType.startsWith('video/') && a.dataBase64.length > MAX_INLINE_B64_SIZE);
 
           // Lazily generate thumbnails for existing video attachments on first history load.
           if (a.mimeType.startsWith('video/') && !a.thumbnailBase64) {

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -7,7 +7,7 @@ import * as externalConversationStore from '../../memory/external-conversation-s
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { classifySessionError, buildSessionErrorMessage } from '../session-error.js';
 import { getAttachmentsForMessage, setAttachmentThumbnail } from '../../memory/attachments-store.js';
-import { generateVideoThumbnail } from '../video-thumbnail.js';
+import { generateVideoThumbnail, generateVideoThumbnailFromFile } from '../video-thumbnail.js';
 import type { UserMessageAttachment } from '../ipc-contract.js';
 import { normalizeThreadType } from '../ipc-protocol.js';
 import type {
@@ -453,9 +453,11 @@ export function handleHistoryRequest(
           // Lazily generate thumbnails for existing video attachments on first history load.
           if (a.mimeType.startsWith('video/') && !a.thumbnailBase64) {
             const attachmentId = a.id;
-            const base64 = a.dataBase64;
+            const thumbPromise = isFileBacked && a.filePath
+              ? generateVideoThumbnailFromFile(a.filePath)
+              : generateVideoThumbnail(a.dataBase64);
             silentlyWithLog(
-              generateVideoThumbnail(base64).then((thumb) => {
+              thumbPromise.then((thumb) => {
                 if (thumb) setAttachmentThumbnail(attachmentId, thumb);
               }),
               'video thumbnail generation',

--- a/assistant/src/daemon/video-thumbnail.ts
+++ b/assistant/src/daemon/video-thumbnail.ts
@@ -14,6 +14,39 @@ import { getLogger } from '../util/logger.js';
 const log = getLogger('video-thumbnail');
 
 /**
+ * Run ffmpeg to extract first frame as a JPEG thumbnail.
+ * Returns the thumbnail as a base64 string, or null on failure.
+ */
+async function extractThumbnail(inputPath: string, outputPath: string): Promise<string | null> {
+  const proc = Bun.spawn([
+    'ffmpeg', '-y',
+    '-i', inputPath,
+    '-vframes', '1',
+    '-vf', 'scale=720:-2',
+    '-q:v', '5',
+    outputPath,
+  ], { stderr: 'pipe' });
+
+  // Race against a 10s timeout to avoid hanging on slow/stuck ffmpeg.
+  // The timer handle is cleared via finally() so it doesn't leak when ffmpeg exits normally.
+  let timer: ReturnType<typeof setTimeout>;
+  const exitCode = await Promise.race([
+    proc.exited.finally(() => clearTimeout(timer)),
+    new Promise<never>((_, reject) =>
+      timer = setTimeout(() => { proc.kill(); reject(new Error('ffmpeg timed out')); }, 10_000)
+    ),
+  ]);
+
+  if (exitCode !== 0) {
+    log.warn({ exitCode }, 'ffmpeg thumbnail extraction failed');
+    return null;
+  }
+
+  const jpegData = await readFile(outputPath);
+  return jpegData.toString('base64');
+}
+
+/**
  * Generate a JPEG thumbnail from base64-encoded video data.
  * Returns null if ffmpeg is unavailable or extraction fails.
  */
@@ -25,38 +58,32 @@ export async function generateVideoThumbnail(dataBase64: string): Promise<string
   try {
     const videoBuffer = Buffer.from(dataBase64, 'base64');
     await writeFile(inputPath, videoBuffer);
-
-    const proc = Bun.spawn([
-      'ffmpeg', '-y',
-      '-i', inputPath,
-      '-vframes', '1',
-      '-vf', 'scale=720:-2',
-      '-q:v', '5',
-      outputPath,
-    ], { stderr: 'pipe' });
-
-    // Race against a 10s timeout to avoid hanging on slow/stuck ffmpeg.
-    // The timer handle is cleared via finally() so it doesn't leak when ffmpeg exits normally.
-    let timer: ReturnType<typeof setTimeout>;
-    const exitCode = await Promise.race([
-      proc.exited.finally(() => clearTimeout(timer)),
-      new Promise<never>((_, reject) =>
-        timer = setTimeout(() => { proc.kill(); reject(new Error('ffmpeg timed out')); }, 10_000)
-      ),
-    ]);
-
-    if (exitCode !== 0) {
-      log.warn({ exitCode }, 'ffmpeg thumbnail extraction failed');
-      return null;
-    }
-
-    const jpegData = await readFile(outputPath);
-    return jpegData.toString('base64');
+    return await extractThumbnail(inputPath, outputPath);
   } catch (err) {
     log.warn({ error: (err as Error).message }, 'Video thumbnail generation failed');
     return null;
   } finally {
     try { await unlink(inputPath); } catch { /* ignore */ }
+    try { await unlink(outputPath); } catch { /* ignore */ }
+  }
+}
+
+/**
+ * Generate a JPEG thumbnail directly from a video file on disk.
+ * Skips the base64-decode/temp-write step, useful for file-backed attachments
+ * where the video already exists at a known path.
+ * Returns null if ffmpeg is unavailable or extraction fails.
+ */
+export async function generateVideoThumbnailFromFile(filePath: string): Promise<string | null> {
+  const id = randomUUID();
+  const outputPath = join(tmpdir(), `vellum-thumb-out-${id}.jpg`);
+
+  try {
+    return await extractThumbnail(filePath, outputPath);
+  } catch (err) {
+    log.warn({ error: (err as Error).message }, 'Video thumbnail generation from file failed');
+    return null;
+  } finally {
     try { await unlink(outputPath); } catch { /* ignore */ }
   }
 }

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -17,6 +17,7 @@ export interface StoredAttachment {
   sizeBytes: number;
   kind: string;
   thumbnailBase64: string | null;
+  filePath: string | null;
   createdAt: number;
 }
 
@@ -182,6 +183,7 @@ export function uploadAttachment(
       sizeBytes: attachments.sizeBytes,
       kind: attachments.kind,
       thumbnailBase64: attachments.thumbnailBase64,
+      filePath: attachments.filePath,
       createdAt: attachments.createdAt,
     })
     .from(attachments)
@@ -215,6 +217,48 @@ export function uploadAttachment(
     sizeBytes,
     kind,
     thumbnailBase64: null,
+    filePath: null,
+    createdAt: now,
+  };
+}
+
+/**
+ * Create a file-backed attachment record. The actual data lives on disk at
+ * `filePath`; `dataBase64` is stored as an empty string to satisfy the NOT NULL
+ * constraint while avoiding duplicating potentially large video files in SQLite.
+ */
+export function uploadFileBackedAttachment(
+  filename: string,
+  mimeType: string,
+  filePath: string,
+  sizeBytes: number,
+): StoredAttachment {
+  const db = getDb();
+  const now = Date.now();
+  const kind = classifyKind(mimeType);
+  const id = uuid();
+
+  db.insert(attachments)
+    .values({
+      id,
+      originalFilename: filename,
+      mimeType,
+      sizeBytes,
+      kind,
+      dataBase64: '',
+      filePath,
+      createdAt: now,
+    })
+    .run();
+
+  return {
+    id,
+    originalFilename: filename,
+    mimeType,
+    sizeBytes,
+    kind,
+    thumbnailBase64: null,
+    filePath,
     createdAt: now,
   };
 }
@@ -281,6 +325,7 @@ export function getAttachmentsByIds(
         sizeBytes: row.sizeBytes,
         kind: row.kind,
         thumbnailBase64: row.thumbnailBase64,
+        filePath: row.filePath,
         dataBase64: row.dataBase64,
         createdAt: row.createdAt,
       });
@@ -356,6 +401,7 @@ export function getAttachmentMetadataForMessage(
         sizeBytes: attachments.sizeBytes,
         kind: attachments.kind,
         thumbnailBase64: attachments.thumbnailBase64,
+        filePath: attachments.filePath,
         createdAt: attachments.createdAt,
       })
       .from(attachments)

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -536,6 +536,7 @@ export function initializeDb(): void {
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN memory_scope_id TEXT NOT NULL DEFAULT 'default'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN origin_channel TEXT`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE attachments ADD COLUMN thumbnail_base64 TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE attachments ADD COLUMN file_path TEXT`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE cron_jobs ADD COLUMN schedule_syntax TEXT NOT NULL DEFAULT 'cron'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE messages ADD COLUMN metadata TEXT`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE memory_embeddings ADD COLUMN content_hash TEXT`); } catch { /* already exists */ }

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -181,6 +181,7 @@ export const attachments = sqliteTable('attachments', {
   dataBase64: text('data_base64').notNull(),
   contentHash: text('content_hash'),
   thumbnailBase64: text('thumbnail_base64'),
+  filePath: text('file_path'),
   createdAt: integer('created_at').notNull(),
 });
 

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -27,6 +27,7 @@ import {
   handleUploadAttachment,
   handleDeleteAttachment,
   handleGetAttachment,
+  handleGetAttachmentContent,
 } from './routes/attachment-routes.js';
 import {
   handleCreateRun,
@@ -563,6 +564,9 @@ export class RuntimeHttpServer {
 
       if (endpoint === 'attachments' && req.method === 'POST') return await handleUploadAttachment(req);
       if (endpoint === 'attachments' && req.method === 'DELETE') return await handleDeleteAttachment(req);
+
+      const attachmentContentMatch = endpoint.match(/^attachments\/([^/]+)\/content$/);
+      if (attachmentContentMatch && req.method === 'GET') return handleGetAttachmentContent(attachmentContentMatch[1], req);
 
       const attachmentMatch = endpoint.match(/^attachments\/([^/]+)$/);
       if (attachmentMatch && req.method === 'GET') return handleGetAttachment(attachmentMatch[1]);

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -131,3 +131,113 @@ export function handleGetAttachment(attachmentId: string): Response {
     data: attachment.dataBase64,
   });
 }
+
+/**
+ * Serve attachment content with Range header support for video seeking.
+ * File-backed attachments are streamed directly from disk; base64 attachments
+ * are decoded and served as binary.
+ */
+export function handleGetAttachmentContent(attachmentId: string, req: Request): Response {
+  const attachment = attachmentsStore.getAttachmentById(attachmentId);
+  if (!attachment) {
+    return Response.json({ error: 'Attachment not found' }, { status: 404 });
+  }
+
+  const contentType = attachment.mimeType;
+
+  // File-backed attachment: serve from disk with Range support
+  if (attachment.filePath) {
+    const file = Bun.file(attachment.filePath);
+    const fileSize = file.size;
+
+    if (fileSize === 0) {
+      return Response.json({ error: 'Attachment file is empty or missing' }, { status: 404 });
+    }
+
+    const rangeHeader = req.headers.get('Range');
+    if (!rangeHeader) {
+      return new Response(file, {
+        status: 200,
+        headers: {
+          'Content-Type': contentType,
+          'Content-Length': String(fileSize),
+          'Accept-Ranges': 'bytes',
+        },
+      });
+    }
+
+    const match = rangeHeader.match(/^bytes=(\d+)-(\d*)$/);
+    if (!match) {
+      return new Response('Invalid Range header', {
+        status: 416,
+        headers: { 'Content-Range': `bytes */${fileSize}` },
+      });
+    }
+
+    const start = parseInt(match[1], 10);
+    const end = match[2] ? parseInt(match[2], 10) : fileSize - 1;
+
+    if (start >= fileSize || end >= fileSize || start > end) {
+      return new Response('Range not satisfiable', {
+        status: 416,
+        headers: { 'Content-Range': `bytes */${fileSize}` },
+      });
+    }
+
+    const contentLength = end - start + 1;
+    return new Response(file.slice(start, end + 1), {
+      status: 206,
+      headers: {
+        'Content-Type': contentType,
+        'Content-Range': `bytes ${start}-${end}/${fileSize}`,
+        'Content-Length': String(contentLength),
+        'Accept-Ranges': 'bytes',
+      },
+    });
+  }
+
+  // Base64-backed attachment: decode and serve
+  const buffer = Buffer.from(attachment.dataBase64, 'base64');
+  const totalSize = buffer.length;
+
+  const rangeHeader = req.headers.get('Range');
+  if (!rangeHeader) {
+    return new Response(buffer, {
+      status: 200,
+      headers: {
+        'Content-Type': contentType,
+        'Content-Length': String(totalSize),
+        'Accept-Ranges': 'bytes',
+      },
+    });
+  }
+
+  const match = rangeHeader.match(/^bytes=(\d+)-(\d*)$/);
+  if (!match) {
+    return new Response('Invalid Range header', {
+      status: 416,
+      headers: { 'Content-Range': `bytes */${totalSize}` },
+    });
+  }
+
+  const start = parseInt(match[1], 10);
+  const end = match[2] ? parseInt(match[2], 10) : totalSize - 1;
+
+  if (start >= totalSize || end >= totalSize || start > end) {
+    return new Response('Range not satisfiable', {
+      status: 416,
+      headers: { 'Content-Range': `bytes */${totalSize}` },
+    });
+  }
+
+  const contentLength = end - start + 1;
+  return new Response(buffer.subarray(start, end + 1), {
+    status: 206,
+    headers: {
+      'Content-Type': contentType,
+      'Content-Range': `bytes ${start}-${end}/${totalSize}`,
+      'Content-Length': String(contentLength),
+      'Accept-Ranges': 'bytes',
+    },
+  });
+}

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -175,15 +175,18 @@ export function handleGetAttachmentContent(attachmentId: string, req: Request): 
     }
 
     const start = parseInt(match[1], 10);
-    const end = match[2] ? parseInt(match[2], 10) : fileSize - 1;
+    const rawEnd = match[2] ? parseInt(match[2], 10) : fileSize - 1;
 
-    if (start >= fileSize || end >= fileSize || start > end) {
+    // Per RFC 7233, only return 416 when start is beyond the resource.
+    // When end exceeds the resource, clamp it to the last byte.
+    if (start >= fileSize || start > rawEnd) {
       return new Response('Range not satisfiable', {
         status: 416,
         headers: { 'Content-Range': `bytes */${fileSize}` },
       });
     }
 
+    const end = Math.min(rawEnd, fileSize - 1);
     const contentLength = end - start + 1;
     return new Response(file.slice(start, end + 1), {
       status: 206,
@@ -221,15 +224,18 @@ export function handleGetAttachmentContent(attachmentId: string, req: Request): 
   }
 
   const start = parseInt(match[1], 10);
-  const end = match[2] ? parseInt(match[2], 10) : totalSize - 1;
+  const rawEnd = match[2] ? parseInt(match[2], 10) : totalSize - 1;
 
-  if (start >= totalSize || end >= totalSize || start > end) {
+  // Per RFC 7233, only return 416 when start is beyond the resource.
+  // When end exceeds the resource, clamp it to the last byte.
+  if (start >= totalSize || start > rawEnd) {
     return new Response('Range not satisfiable', {
       status: 416,
       headers: { 'Content-Range': `bytes */${totalSize}` },
     });
   }
 
+  const end = Math.min(rawEnd, totalSize - 1);
   const contentLength = end - start + 1;
   return new Response(buffer.subarray(start, end + 1), {
     status: 206,


### PR DESCRIPTION
## Summary
- Add filePath column to attachments schema for file-backed storage
- Add uploadFileBackedAttachment() store function
- Add GET /v1/attachments/:id/content endpoint with Range header support for video seeking
- Enhance handleRecordingStatus to create and link file-backed attachments on recording stop
- Add tests for content streaming and recording finalization

Closes #8382
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
