### PR TITLE
fix: M5 review feedback — lazy-load, orphans, RFC 7233

### DIFF
--- a/assistant/src/daemon/handlers/computer-use.ts
+++ b/assistant/src/daemon/handlers/computer-use.ts
@@ -209,6 +209,22 @@ export function handleRecordingStatus(
         return;
       }
 
+      // Find the latest assistant message BEFORE creating the attachment to
+      // avoid orphaned attachment rows when no message exists to link to.
+      const conversationId = msg.sessionId;
+      const db = getDb();
+      const latestAssistantMsg = db
+        .select({ id: messages.id })
+        .from(messages)
+        .where(and(eq(messages.conversationId, conversationId), eq(messages.role, 'assistant')))
+        .orderBy(desc(messages.createdAt))
+        .get();
+
+      if (!latestAssistantMsg) {
+        log.warn({ sessionId: msg.sessionId }, 'No assistant message found in session to link recording attachment — skipping attachment creation');
+        return;
+      }
+
       const stat = statSync(msg.filePath);
       const sizeBytes = stat.size;
       const filename = basename(msg.filePath);
@@ -220,23 +236,8 @@ export function handleRecordingStatus(
       const attachment = uploadFileBackedAttachment(filename, mimeType, msg.filePath, sizeBytes);
       log.info({ sessionId: msg.sessionId, attachmentId: attachment.id, sizeBytes, filePath: msg.filePath }, 'Created file-backed attachment for recording');
 
-      // The CU session uses sessionId as the conversationId in the agent loop.
-      // Find the latest assistant message in that conversation to link the attachment.
-      const conversationId = msg.sessionId;
-      const db = getDb();
-      const latestAssistantMsg = db
-        .select({ id: messages.id })
-        .from(messages)
-        .where(and(eq(messages.conversationId, conversationId), eq(messages.role, 'assistant')))
-        .orderBy(desc(messages.createdAt))
-        .get();
-
-      if (latestAssistantMsg) {
-        linkAttachmentToMessage(latestAssistantMsg.id, attachment.id, 0);
-        log.info({ sessionId: msg.sessionId, messageId: latestAssistantMsg.id, attachmentId: attachment.id }, 'Linked recording attachment to assistant message');
-      } else {
-        log.warn({ sessionId: msg.sessionId }, 'No assistant message found in session to link recording attachment');
-      }
+      linkAttachmentToMessage(latestAssistantMsg.id, attachment.id, 0);
+      log.info({ sessionId: msg.sessionId, messageId: latestAssistantMsg.id, attachmentId: attachment.id }, 'Linked recording attachment to assistant message');
     } catch (err) {
       log.error({ err, sessionId: msg.sessionId, filePath: msg.filePath }, 'Failed to create attachment for recording');
     }

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -445,7 +445,10 @@ export function handleHistoryRequest(
         // the client, so non-video attachments always keep their inline data.
         const MAX_INLINE_B64_SIZE = 512 * 1024;
         attachments = linked.map((a) => {
-          const omit = a.mimeType.startsWith('video/') && a.dataBase64.length > MAX_INLINE_B64_SIZE;
+          // File-backed attachments (filePath set, dataBase64 empty) must always
+          // use lazy-load mode so the client fetches content via the HTTP endpoint.
+          const isFileBacked = !!a.filePath;
+          const omit = isFileBacked || (a.mimeType.startsWith('video/') && a.dataBase64.length > MAX_INLINE_B64_SIZE);
 
           // Lazily generate thumbnails for existing video attachments on first history load.
           if (a.mimeType.startsWith('video/') && !a.thumbnailBase64) {

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -175,15 +175,18 @@ export function handleGetAttachmentContent(attachmentId: string, req: Request): 
     }
 
     const start = parseInt(match[1], 10);
-    const end = match[2] ? parseInt(match[2], 10) : fileSize - 1;
+    const rawEnd = match[2] ? parseInt(match[2], 10) : fileSize - 1;
 
-    if (start >= fileSize || end >= fileSize || start > end) {
+    // Per RFC 7233, only return 416 when start is beyond the resource.
+    // When end exceeds the resource, clamp it to the last byte.
+    if (start >= fileSize || start > rawEnd) {
       return new Response('Range not satisfiable', {
         status: 416,
         headers: { 'Content-Range': `bytes */${fileSize}` },
       });
     }
 
+    const end = Math.min(rawEnd, fileSize - 1);
     const contentLength = end - start + 1;
     return new Response(file.slice(start, end + 1), {
       status: 206,
@@ -221,15 +224,18 @@ export function handleGetAttachmentContent(attachmentId: string, req: Request): 
   }
 
   const start = parseInt(match[1], 10);
-  const end = match[2] ? parseInt(match[2], 10) : totalSize - 1;
+  const rawEnd = match[2] ? parseInt(match[2], 10) : totalSize - 1;
 
-  if (start >= totalSize || end >= totalSize || start > end) {
+  // Per RFC 7233, only return 416 when start is beyond the resource.
+  // When end exceeds the resource, clamp it to the last byte.
+  if (start >= totalSize || start > rawEnd) {
     return new Response('Range not satisfiable', {
       status: 416,
       headers: { 'Content-Range': `bytes */${totalSize}` },
     });
   }
 
+  const end = Math.min(rawEnd, totalSize - 1);
   const contentLength = end - start + 1;
   return new Response(buffer.subarray(start, end + 1), {
     status: 206,


### PR DESCRIPTION
## Summary
- Fix file-backed attachments not triggering lazy-load in client (Codex P1)
- Prevent orphaned attachment rows by querying for message first (Codex P2)
- Clamp Range end per RFC 7233 instead of returning 416 (Devin)

Addresses feedback on #8431
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
