### PR TITLE
fix: thumbnails for file-backed video attachments

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -7,7 +7,7 @@ import * as externalConversationStore from '../../memory/external-conversation-s
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { classifySessionError, buildSessionErrorMessage } from '../session-error.js';
 import { getAttachmentsForMessage, setAttachmentThumbnail } from '../../memory/attachments-store.js';
-import { generateVideoThumbnail } from '../video-thumbnail.js';
+import { generateVideoThumbnail, generateVideoThumbnailFromFile } from '../video-thumbnail.js';
 import type { UserMessageAttachment } from '../ipc-contract.js';
 import { normalizeThreadType } from '../ipc-protocol.js';
 import type {
@@ -453,9 +453,11 @@ export function handleHistoryRequest(
           // Lazily generate thumbnails for existing video attachments on first history load.
           if (a.mimeType.startsWith('video/') && !a.thumbnailBase64) {
             const attachmentId = a.id;
-            const base64 = a.dataBase64;
+            const thumbPromise = isFileBacked && a.filePath
+              ? generateVideoThumbnailFromFile(a.filePath)
+              : generateVideoThumbnail(a.dataBase64);
             silentlyWithLog(
-              generateVideoThumbnail(base64).then((thumb) => {
+              thumbPromise.then((thumb) => {
                 if (thumb) setAttachmentThumbnail(attachmentId, thumb);
               }),
               'video thumbnail generation',

--- a/assistant/src/daemon/video-thumbnail.ts
+++ b/assistant/src/daemon/video-thumbnail.ts
@@ -14,6 +14,39 @@ import { getLogger } from '../util/logger.js';
 const log = getLogger('video-thumbnail');
 
 /**
+ * Run ffmpeg to extract first frame as a JPEG thumbnail.
+ * Returns the thumbnail as a base64 string, or null on failure.
+ */
+async function extractThumbnail(inputPath: string, outputPath: string): Promise<string | null> {
+  const proc = Bun.spawn([
+    'ffmpeg', '-y',
+    '-i', inputPath,
+    '-vframes', '1',
+    '-vf', 'scale=720:-2',
+    '-q:v', '5',
+    outputPath,
+  ], { stderr: 'pipe' });
+
+  // Race against a 10s timeout to avoid hanging on slow/stuck ffmpeg.
+  // The timer handle is cleared via finally() so it doesn't leak when ffmpeg exits normally.
+  let timer: ReturnType<typeof setTimeout>;
+  const exitCode = await Promise.race([
+    proc.exited.finally(() => clearTimeout(timer)),
+    new Promise<never>((_, reject) =>
+      timer = setTimeout(() => { proc.kill(); reject(new Error('ffmpeg timed out')); }, 10_000)
+    ),
+  ]);
+
+  if (exitCode !== 0) {
+    log.warn({ exitCode }, 'ffmpeg thumbnail extraction failed');
+    return null;
+  }
+
+  const jpegData = await readFile(outputPath);
+  return jpegData.toString('base64');
+}
+
+/**
  * Generate a JPEG thumbnail from base64-encoded video data.
  * Returns null if ffmpeg is unavailable or extraction fails.
  */
@@ -25,38 +58,32 @@ export async function generateVideoThumbnail(dataBase64: string): Promise<string
   try {
     const videoBuffer = Buffer.from(dataBase64, 'base64');
     await writeFile(inputPath, videoBuffer);
-
-    const proc = Bun.spawn([
-      'ffmpeg', '-y',
-      '-i', inputPath,
-      '-vframes', '1',
-      '-vf', 'scale=720:-2',
-      '-q:v', '5',
-      outputPath,
-    ], { stderr: 'pipe' });
-
-    // Race against a 10s timeout to avoid hanging on slow/stuck ffmpeg.
-    // The timer handle is cleared via finally() so it doesn't leak when ffmpeg exits normally.
-    let timer: ReturnType<typeof setTimeout>;
-    const exitCode = await Promise.race([
-      proc.exited.finally(() => clearTimeout(timer)),
-      new Promise<never>((_, reject) =>
-        timer = setTimeout(() => { proc.kill(); reject(new Error('ffmpeg timed out')); }, 10_000)
-      ),
-    ]);
-
-    if (exitCode !== 0) {
-      log.warn({ exitCode }, 'ffmpeg thumbnail extraction failed');
-      return null;
-    }
-
-    const jpegData = await readFile(outputPath);
-    return jpegData.toString('base64');
+    return await extractThumbnail(inputPath, outputPath);
   } catch (err) {
     log.warn({ error: (err as Error).message }, 'Video thumbnail generation failed');
     return null;
   } finally {
     try { await unlink(inputPath); } catch { /* ignore */ }
+    try { await unlink(outputPath); } catch { /* ignore */ }
+  }
+}
+
+/**
+ * Generate a JPEG thumbnail directly from a video file on disk.
+ * Skips the base64-decode/temp-write step, useful for file-backed attachments
+ * where the video already exists at a known path.
+ * Returns null if ffmpeg is unavailable or extraction fails.
+ */
+export async function generateVideoThumbnailFromFile(filePath: string): Promise<string | null> {
+  const id = randomUUID();
+  const outputPath = join(tmpdir(), `vellum-thumb-out-${id}.jpg`);
+
+  try {
+    return await extractThumbnail(filePath, outputPath);
+  } catch (err) {
+    log.warn({ error: (err as Error).message }, 'Video thumbnail generation from file failed');
+    return null;
+  } finally {
     try { await unlink(outputPath); } catch { /* ignore */ }
   }
 }


### PR DESCRIPTION
## Summary
- Add generateVideoThumbnailFromFile() for file-path-based thumbnail extraction
- Use it for file-backed attachments in sessions.ts instead of empty base64

Addresses feedback on #8432
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
