### PR TITLE
fix: clear silence timer during active processing to prevent false 'Are you still there?'

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -329,6 +329,14 @@ export class CallController {
     const runVersion = ++this.llmRunVersion;
     const runSignal = this.abortController.signal;
 
+    // Clear silence timer while actively processing. The caller said
+    // something (or a turn was triggered), so silence detection should
+    // pause until we finish responding and return to idle.
+    if (this.silenceTimer) {
+      clearTimeout(this.silenceTimer);
+      this.silenceTimer = null;
+    }
+
     try {
       this.state = 'speaking';
 
@@ -536,10 +544,11 @@ export class CallController {
         return;
       }
 
-      // Normal turn complete — flush any instructions that arrived while
-      // the LLM was active.
+      // Normal turn complete — restart silence detection and flush any
+      // instructions that arrived while the LLM was active.
       this.state = 'idle';
       this.currentTurnHandle = null;
+      this.resetSilenceTimer();
       this.flushPendingInstructions();
     } catch (err: unknown) {
       this.currentTurnHandle = null;
@@ -555,6 +564,7 @@ export class CallController {
         );
         if (this.isCurrentRun(runVersion)) {
           this.state = 'idle';
+          this.resetSilenceTimer();
         }
         return;
       }
@@ -568,6 +578,7 @@ export class CallController {
       log.error({ err, callSessionId: this.callSessionId }, 'Voice turn error');
       this.relay.sendTextToken('I\'m sorry, I encountered a technical issue. Could you repeat that?', true);
       this.state = 'idle';
+      this.resetSilenceTimer();
       this.flushPendingInstructions();
     }
   }


### PR DESCRIPTION
## Summary
- Clear the silence timer at the start of `runTurnInner()` so it doesn't fire while the assistant is actively processing (LLM inference, tool calls)
- Restart the silence timer when the controller returns to `idle` state (normal completion, abort, error)
- Leave the timer cleared during `waiting_on_user` state (consultation timer handles that) and after `END_CALL` (call is ending)

## Original prompt
### Bug #3: Silence timeout fires while assistant is actively processing tool calls

**Problem:** During inbound voice calls, the 30-second silence timer (`SILENCE_TIMEOUT_MS` in `call-constants.ts`) fires and sends "Are you still there?" to the caller even when the assistant is actively processing their request (e.g. running LLM inference, executing tool calls like `host_bash`). The timer only resets on new caller utterances, not on assistant-side activity.

**Evidence from logs:** In call session `ec8230b7`, the caller said "Can you tell me how many files I have on my desktop?" at timestamp `:65.824`. The assistant began processing this request, which involved calling the LLM and then executing `host_bash` with `ls ~/Desktop | wc -l`. The `host_bash` tool permission request didn't fire until `:25.871` (60 seconds later), and the tool execution + second LLM turn didn't complete until `:28.117`. Meanwhile, at `:95.831` (exactly 30 seconds after the last caller utterance), the silence timer fired and sent "Are you still there?" even though the assistant was actively working on the caller's request.

**Root cause:** In `assistant/src/calls/call-controller.ts`, `resetSilenceTimer()` is called in `handleCallerUtterance()` and `startInitialGreeting()`, but NOT when the controller enters `processing` or `speaking` state. The silence timer continues counting down during LLM inference and tool execution. If the total processing time exceeds 30 seconds, the timer fires.

**File to modify:** `assistant/src/calls/call-controller.ts`

**Fix:** Clear the silence timer when entering `runTurnInner()` (i.e. when the assistant starts actively processing), and only restart it when the controller returns to `idle` state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
