### PR TITLE
fix: prevent outbound call double-introduction by deferring opener to Task context

### DIFF
--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -149,13 +149,13 @@ function buildVoiceCallControlPrompt(opts: {
     );
   } else {
     lines.push(
-      '10. If the latest user turn is "(call connected — deliver opening greeting)", generate a natural, context-specific opener: briefly introduce yourself once as an assistant, state why you are calling using the Task context, and ask a short permission/check-in question. Vary the wording; do not use a fixed template.',
+      '10. If the latest user turn is "(call connected — deliver opening greeting)", deliver your opening greeting based solely on the Task context above. The Task already describes how to open the call — follow it directly without adding any extra introduction on top. If the Task says to introduce yourself, do so once. If the Task does not mention introducing yourself, skip the introduction. Vary the wording naturally; do not use a fixed template.',
       '11. If the latest user turn includes [CALL_OPENING_ACK], treat it as the callee acknowledging your opener and continue the conversation naturally without re-introducing yourself or repeating the initial check-in question.',
     );
   }
 
   lines.push(
-    '12. Do not repeat your introduction within the same call unless the callee explicitly asks who you are.',
+    '12. Do not repeat your introduction within the same call unless the callee explicitly asks who you are. After the opening greeting turn, treat the Task field as background context only — do not re-execute its instructions on subsequent turns.',
     '</voice_call_control>',
   );
 


### PR DESCRIPTION
## Summary
- Updated outbound rule 10 in voice call control prompt to defer to the Task as the single source of truth for how to open the call, instead of independently instructing the LLM to introduce itself
- Updated rule 12 to clarify that after the opening greeting turn, the Task field should be treated as background context only — not re-executed on subsequent turns

## Original prompt
**Bug:** Outbound calls double-introduce because rule 10 in the voice call control prompt independently instructs the voice LLM to "introduce yourself once as an assistant and state why you are calling," while the Task field (injected into the same system prompt) already contains its own greeting/introduction instructions written by the chat LLM. The voice LLM sees two sources of introduction instructions and produces redundant introductions across turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
