### PR TITLE
fix: retry recording cleanup on non-ENOENT unlink failure

### DIFF
--- a/assistant/src/daemon/recording-cleanup.ts
+++ b/assistant/src/daemon/recording-cleanup.ts
@@ -39,9 +39,16 @@ function sweepExpiredRecordings(config: RecordingConfig): void {
   for (const att of expired) {
     try {
       unlinkSync(att.filePath);
-    } catch (err) {
-      // File may already be deleted or moved; log and continue
-      log.debug({ err, filePath: att.filePath, attachmentId: att.id }, 'Could not delete recording file (may already be removed)');
+    } catch (err: unknown) {
+      const code = err instanceof Error && 'code' in err ? (err as NodeJS.ErrnoException).code : undefined;
+      if (code === 'ENOENT') {
+        // File already gone — safe to clean up DB records
+        log.debug({ err, filePath: att.filePath, attachmentId: att.id }, 'Recording file already removed');
+      } else {
+        // Transient or permission error — skip DB cleanup so next sweep retries
+        log.warn({ err, filePath: att.filePath, attachmentId: att.id }, 'Could not delete recording file; will retry on next sweep');
+        continue;
+      }
     }
 
     try {


### PR DESCRIPTION
## Summary
- Only delete attachment DB records when file is successfully removed or missing (ENOENT)
- On other unlink failures (EPERM, EACCES, etc.), log and skip so next sweep retries

Addresses feedback on #8438
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
