### PR TITLE
fix: SSE reconnect catch-up and iOS loading chats indicator

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -57,6 +57,9 @@ class IOSThreadStore: ObservableObject {
     @Published var isLoadingMoreThreads: Bool = false
     /// Whether the daemon indicated more sessions exist beyond what is currently loaded.
     @Published var hasMoreThreads: Bool = false
+    /// True while the first page of threads is being fetched from the daemon.
+    /// Used by the UI to show a loading indicator instead of a placeholder thread.
+    @Published var isLoadingInitialThreads: Bool = false
 
     /// ViewModels keyed by thread ID, created lazily on first access.
     private var viewModels: [UUID: ChatViewModel] = [:]
@@ -94,6 +97,7 @@ class IOSThreadStore: ObservableObject {
         if let daemon = daemonClient as? DaemonClient {
             // Connected mode — load threads from daemon
             isConnectedMode = true
+            isLoadingInitialThreads = true
             let defaultThread = IOSThread()
             threads = [defaultThread]
             setupDaemonCallbacks(daemon)
@@ -214,6 +218,7 @@ class IOSThreadStore: ObservableObject {
             // discarded by the handler (setupDaemonCallbacks will bump it again on
             // the fresh page-1 send, keeping expectedSessionListGeneration in sync).
             isConnectedMode = true
+            isLoadingInitialThreads = true
             threads = [IOSThread()]
             threadListOffset = 0
             sessionListGeneration += 1
@@ -250,12 +255,14 @@ class IOSThreadStore: ObservableObject {
         guard !filteredSessions.isEmpty || (response.hasMore == false && threadListOffset == 0) else {
             // Empty non-first page means nothing more to append.
             isLoadingMoreThreads = false
+            isLoadingInitialThreads = false
             hasMoreThreads = response.hasMore ?? false
             return
         }
 
         hasMoreThreads = response.hasMore ?? false
         isLoadingMoreThreads = false
+        isLoadingInitialThreads = false
 
         var restoredThreads: [IOSThread] = []
         for session in filteredSessions {

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -36,7 +36,9 @@ struct ThreadListView: View {
     }
 
     var body: some View {
-        if horizontalSizeClass == .regular {
+        if store.isLoadingInitialThreads {
+            loadingView
+        } else if horizontalSizeClass == .regular {
             NavigationSplitView {
                 threadList
             } detail: {
@@ -50,6 +52,17 @@ struct ThreadListView: View {
                     }
             }
         }
+    }
+
+    private var loadingView: some View {
+        VStack(spacing: VSpacing.md) {
+            ProgressView()
+            Text("Loading chats\u{2026}")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .navigationTitle("Chats")
     }
 
     // MARK: - Detail Views

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -206,6 +206,10 @@ public final class ChatViewModel: ObservableObject {
     /// Cleared and actioned in the sessionId didSet observer.
     private var needsOfflineFlush: Bool = false
     #endif
+    /// Set to true when reconnecting after an SSE gap while a run was in progress.
+    /// Causes `populateFromHistory` to do a full message replace instead of
+    /// prepending, so the missed assistant response is displayed.
+    private var needsReconnectCatchUp: Bool = false
     var pendingUserMessage: String?
     /// Optional callback for sending notifications when tool-use messages complete
     public var onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)?
@@ -439,6 +443,19 @@ public final class ChatViewModel: ObservableObject {
                 // produce a false healthy state after transient disconnects — the banner
                 // would disappear until the user sends another message. Preserve the
                 // last-known state; it will be updated when the next turn is processed.
+                // If a run was in progress when the connection dropped, the
+                // client may have missed the messageComplete (or the full
+                // assistant response). Reset the spinner and re-fetch history
+                // so the UI catches up on anything that happened during the gap.
+                if self?.isThinking == true || self?.isSending == true {
+                    self?.isThinking = false
+                    self?.isSending = false
+                    self?.currentAssistantMessageId = nil
+                    if let sessionId = self?.sessionId {
+                        self?.needsReconnectCatchUp = true
+                        try? self?.daemonClient.send(HistoryRequestMessage(sessionId: sessionId))
+                    }
+                }
                 #if os(iOS)
                 // If we already have a session ID, flush immediately. Otherwise
                 // defer: sessionId's didSet will trigger flushOfflineQueue() once
@@ -1710,8 +1727,14 @@ public final class ChatViewModel: ObservableObject {
         }
 
         self.isLoadingHistory = true
-        let hasUserSentMessages = messages.contains { $0.role == .user }
-        if hasUserSentMessages {
+        if needsReconnectCatchUp {
+            // Reconnect catch-up: the SSE stream dropped while a run was
+            // in progress, so the client may have missed the assistant's
+            // response. Do a full replace with the server's authoritative
+            // message list instead of the normal prepend-only dedup.
+            needsReconnectCatchUp = false
+            self.messages = chatMessages
+        } else if messages.contains(where: { $0.role == .user }) {
             // History arrived after the user already sent messages.
             // The history payload includes ALL persisted messages — including
             // ones the user sent (and any assistant replies) before the


### PR DESCRIPTION
## Summary
- Recover from missed SSE events after daemon reconnect — when the stream drops mid-run, reset thinking state and re-fetch history so the missed assistant response appears
- Add "Loading chats..." indicator to the iOS Chats tab to match the pattern used by Home, Identity, and Tasks tabs (instead of showing a confusing placeholder empty thread)

## Changes

### SSE Reconnect Catch-Up (`ChatViewModel.swift`)
- Added `needsReconnectCatchUp` flag
- On `daemonDidReconnect`: if a run was in progress (`isThinking` or `isSending`), reset spinner state and re-fetch message history
- In `populateFromHistory`: when catching up after reconnect, do a full message replace instead of the normal prepend-only dedup

### iOS Loading State (`IOSThreadStore.swift`, `ThreadListView.swift`)
- Added `isLoadingInitialThreads` published property to `IOSThreadStore`
- Set to `true` on init (connected mode) and `rebindDaemonClient`
- Cleared when first session list response arrives
- `ThreadListView` shows centered spinner with "Loading chats..." text while loading

## Test plan
- [ ] macOS builds and launches
- [ ] iOS: opening app shows "Loading chats..." spinner instead of empty "New Chat"
- [ ] iOS: after threads load, list appears normally
- [ ] Send message, kill daemon mid-response, wait for reconnect — response appears after catch-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
