### PR TITLE
fix: route reconnect history request through store/restorer

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -228,6 +228,7 @@ class IOSThreadStore: ObservableObject {
         } else {
             // Switched back to standalone mode — reload persisted threads.
             isConnectedMode = false
+            isLoadingInitialThreads = false
             let loaded = Self.load()
             if loaded.isEmpty {
                 let thread = IOSThread()
@@ -373,14 +374,27 @@ class IOSThreadStore: ObservableObject {
     /// Return the ChatViewModel for the given thread, creating it if necessary.
     func viewModel(for threadId: UUID) -> ChatViewModel {
         if let existing = viewModels[threadId] {
+            wireReconnectCallback(vm: existing, threadId: threadId)
             observeForActivityTracking(vm: existing, threadId: threadId)
             return existing
         }
         let vm = ChatViewModel(daemonClient: daemonClient)
         viewModels[threadId] = vm
+        wireReconnectCallback(vm: vm, threadId: threadId)
         observeForTitleGeneration(vm: vm, threadId: threadId)
         observeForActivityTracking(vm: vm, threadId: threadId)
         return vm
+    }
+
+    /// Wire the reconnect history callback so the store registers in
+    /// pendingHistoryBySessionId and the response is properly routed back.
+    private func wireReconnectCallback(vm: ChatViewModel, threadId: UUID) {
+        guard vm.onReconnectHistoryNeeded == nil else { return }
+        vm.onReconnectHistoryNeeded = { [weak self, weak vm] sessionId in
+            guard let self, let _ = vm, let daemon = self.daemonClient as? DaemonClient else { return }
+            self.pendingHistoryBySessionId[sessionId] = threadId
+            try? daemon.sendHistoryRequest(sessionId: sessionId)
+        }
     }
 
     /// Watch for the first completed assistant reply to auto-title the thread.

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -562,6 +562,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 self.updateLastInteracted(threadId: threadId)
             }
         }
+        viewModel.onReconnectHistoryNeeded = { [weak self] sessionId in
+            guard let self else { return }
+            self.sessionRestorer.requestReconnectHistory(sessionId: sessionId)
+        }
         return viewModel
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -98,6 +98,21 @@ final class ThreadSessionRestorer {
         }
     }
 
+    /// Request history re-fetch for a reconnect catch-up. Registers the sessionId
+    /// so the response is properly routed back via handleHistoryResponse.
+    func requestReconnectHistory(sessionId: String) {
+        guard let delegate else { return }
+        // Find the thread that owns this sessionId.
+        guard let thread = delegate.threads.first(where: { $0.sessionId == sessionId }) else { return }
+        pendingHistoryBySessionId[sessionId] = thread.id
+        do {
+            try daemonClient.sendHistoryRequest(sessionId: sessionId)
+        } catch {
+            log.error("Failed to send reconnect history_request: \(error.localizedDescription)")
+            pendingHistoryBySessionId.removeValue(forKey: sessionId)
+        }
+    }
+
     // MARK: - Response Handlers (internal for testability)
 
     func handleSessionListResponse(_ response: SessionListResponseMessage) {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -210,6 +210,10 @@ public final class ChatViewModel: ObservableObject {
     /// Causes `populateFromHistory` to do a full message replace instead of
     /// prepending, so the missed assistant response is displayed.
     private var needsReconnectCatchUp: Bool = false
+    /// Called when the SSE stream reconnects while a run was in progress.
+    /// The store/restorer registers the sessionId in pendingHistoryBySessionId
+    /// and sends a history request so the response is routed back properly.
+    public var onReconnectHistoryNeeded: ((_ sessionId: String) -> Void)?
     var pendingUserMessage: String?
     /// Optional callback for sending notifications when tool-use messages complete
     public var onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)?
@@ -453,7 +457,7 @@ public final class ChatViewModel: ObservableObject {
                     self?.currentAssistantMessageId = nil
                     if let sessionId = self?.sessionId {
                         self?.needsReconnectCatchUp = true
-                        try? self?.daemonClient.send(HistoryRequestMessage(sessionId: sessionId))
+                        self?.onReconnectHistoryNeeded?(sessionId)
                     }
                 }
                 #if os(iOS)


### PR DESCRIPTION
## Summary
Addresses review feedback from #8441 (both Devin P1 and Codex P1+P2):

- **P1:** The reconnect catch-up sent `HistoryRequestMessage` directly from `ChatViewModel`, but the response was silently dropped because the sessionId wasn't registered in `pendingHistoryBySessionId` on either `IOSThreadStore` (iOS) or `ThreadSessionRestorer` (macOS). The history response never reached `populateFromHistory`, making the entire reconnect catch-up feature non-functional.
- **P2:** `isLoadingInitialThreads` was not cleared in the standalone branch of `rebindDaemonClient`, which could leave the Chats tab stuck on "Loading chats..." forever.

## Implementation
- Added `onReconnectHistoryNeeded` callback on `ChatViewModel` — called when the SSE stream reconnects while a run was in progress
- **iOS:** `IOSThreadStore.wireReconnectCallback()` sets the callback to register in `pendingHistoryBySessionId` and send via `DaemonClient.sendHistoryRequest()`
- **macOS:** `ThreadManager.makeViewModel()` wires the callback through `ThreadSessionRestorer.requestReconnectHistory()`, which does the same registration + send
- Clear `isLoadingInitialThreads` in standalone `rebindDaemonClient` branch

## Files Changed
- `clients/shared/Features/Chat/ChatViewModel.swift` — add callback, use it instead of direct send
- `clients/ios/App/IOSThreadStore.swift` — wire callback, fix P2 bug
- `clients/macos/.../ThreadManager.swift` — wire callback in `makeViewModel()`
- `clients/macos/.../ThreadSessionRestorer.swift` — add `requestReconnectHistory()` method

## Test plan
- [ ] macOS builds and launches
- [ ] SSE reconnect during active run → history is re-fetched and missed response appears
- [ ] iOS: rebinding to standalone mode clears loading state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
