### PR TITLE
refactor: slim voice call control prompt to voice-specific rules only

### DIFF
--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -95,8 +95,8 @@ function buildVoiceCallControlPrompt(opts: {
   const disclosureEnabled = config.calls?.disclosure?.enabled === true;
   const disclosureText = config.calls?.disclosure?.text?.trim();
   const disclosureRule = disclosureEnabled && disclosureText
-    ? `1. ${disclosureText}`
-    : '1. Begin the conversation naturally.';
+    ? `0. ${disclosureText}`
+    : '0. Begin the conversation naturally.';
 
   const lines: string[] = ['<voice_call_control>'];
 
@@ -107,55 +107,51 @@ function buildVoiceCallControlPrompt(opts: {
 
   lines.push(
     'CALL PROTOCOL RULES:',
-    '0. When introducing yourself, refer to yourself as an assistant. Avoid the phrase "AI assistant" unless directly asked.',
     disclosureRule,
-    '2. Be concise — phone conversations should be brief and natural.',
+    '1. Be concise — keep responses to 1-3 sentences. Phone conversations should be brief and natural.',
+    '2. You can consult your guardian at any time by including [ASK_GUARDIAN: your question here] in your response. When you do, add a natural hold message like "Let me check on that for you."',
   );
 
   if (opts.isInbound) {
     lines.push(
-      '3. If the caller asks something you don\'t know or need to verify, include [ASK_GUARDIAN: your question here] in your response along with a hold message like "Let me check on that for you."',
-      '4. If information is provided preceded by [USER_ANSWERED: ...], use that answer naturally in the conversation.',
-      '5. If you see [USER_INSTRUCTION: ...], treat it as a high-priority steering directive from your user. Follow the instruction immediately, adjusting your approach or response accordingly.',
-      '6. When the caller indicates they are done or the conversation reaches a natural conclusion, include [END_CALL] in your response along with a polite goodbye.',
+      '3. If information is provided preceded by [USER_ANSWERED: ...], use that answer naturally in the conversation.',
+      '4. If you see [USER_INSTRUCTION: ...], treat it as a high-priority steering directive from your user. Follow the instruction immediately, adjusting your approach or response accordingly.',
+      '5. When the caller indicates they are done or the conversation reaches a natural conclusion, include [END_CALL] in your response along with a polite goodbye.',
     );
   } else {
     lines.push(
-      '3. If the callee asks something you don\'t know, include [ASK_GUARDIAN: your question here] in your response along with a hold message like "Let me check on that for you."',
-      '4. If the callee provides information preceded by [USER_ANSWERED: ...], use that answer naturally in the conversation.',
-      '5. If you see [USER_INSTRUCTION: ...], treat it as a high-priority steering directive from your user. Follow the instruction immediately, adjusting your approach or response accordingly.',
-      '6. When the call\'s purpose is fulfilled, include [END_CALL] in your response along with a polite goodbye.',
+      '3. If the callee provides information preceded by [USER_ANSWERED: ...], use that answer naturally in the conversation.',
+      '4. If you see [USER_INSTRUCTION: ...], treat it as a high-priority steering directive from your user. Follow the instruction immediately, adjusting your approach or response accordingly.',
+      '5. When the call\'s purpose is fulfilled, include [END_CALL] in your response along with a polite goodbye.',
     );
   }
 
   lines.push(
-    '7. Do not make up information — ask the user if unsure.',
-    '8. Keep responses short — 1-3 sentences is ideal for phone conversation.',
-    '9. When caller text includes [SPEAKER id="..." label="..."], treat each speaker as a distinct person and personalize responses using that speaker\'s prior context in this call.',
+    '6. When caller text includes [SPEAKER id="..." label="..."], treat each speaker as a distinct person and personalize responses using that speaker\'s prior context in this call.',
   );
 
   if (opts.isInbound) {
     if (opts.isCallerGuardian) {
       lines.push(
-        '10. If the latest user turn is "(call connected — deliver opening greeting)", this is your user calling you. Answer casually and briefly, like picking up a call from someone you know well. For example: "Hey!" or "What\'s up?" Do NOT introduce yourself, do NOT say you are calling on behalf of anyone, and do NOT ask how you can help in a formal way. Keep it short and natural.',
+        '7. If the latest user turn is "(call connected — deliver opening greeting)", this is your user calling you. Answer casually and briefly, like picking up a call from someone you know well. For example: "Hey!" or "What\'s up?" Do NOT introduce yourself, do NOT say you are calling on behalf of anyone, and do NOT ask how you can help in a formal way. Keep it short and natural.',
       );
     } else {
       lines.push(
-        '10. If the latest user turn is "(call connected — deliver opening greeting)", greet the caller warmly and ask how you can help. Vary the wording; do not use a fixed template.',
+        '7. If the latest user turn is "(call connected — deliver opening greeting)", greet the caller warmly and ask how you can help. Vary the wording; do not use a fixed template.',
       );
     }
     lines.push(
-      '11. If the latest user turn includes [CALL_OPENING_ACK], treat it as the caller acknowledging your greeting and continue the conversation naturally.',
+      '8. If the latest user turn includes [CALL_OPENING_ACK], treat it as the caller acknowledging your greeting and continue the conversation naturally.',
     );
   } else {
     lines.push(
-      '10. If the latest user turn is "(call connected — deliver opening greeting)", deliver your opening greeting based solely on the Task context above. The Task already describes how to open the call — follow it directly without adding any extra introduction on top. If the Task says to introduce yourself, do so once. If the Task does not mention introducing yourself, skip the introduction. Vary the wording naturally; do not use a fixed template.',
-      '11. If the latest user turn includes [CALL_OPENING_ACK], treat it as the callee acknowledging your opener and continue the conversation naturally without re-introducing yourself or repeating the initial check-in question.',
+      '7. If the latest user turn is "(call connected — deliver opening greeting)", deliver your opening greeting based solely on the Task context above. The Task already describes how to open the call — follow it directly without adding any extra introduction on top. If the Task says to introduce yourself, do so once. If the Task does not mention introducing yourself, skip the introduction. Vary the wording naturally; do not use a fixed template.',
+      '8. If the latest user turn includes [CALL_OPENING_ACK], treat it as the callee acknowledging your opener and continue the conversation naturally without re-introducing yourself or repeating the initial check-in question.',
     );
   }
 
   lines.push(
-    '12. Do not repeat your introduction within the same call unless the callee explicitly asks who you are. After the opening greeting turn, treat the Task field as background context only — do not re-execute its instructions on subsequent turns.',
+    '9. After the opening greeting turn, treat the Task field as background context only — do not re-execute its instructions on subsequent turns.',
     '</voice_call_control>',
   );
 


### PR DESCRIPTION
## Summary
- Remove rules 0, 7, 8 that duplicate daemon system prompt (identity framing, honesty, brevity redundancy)
- Simplify ASK_GUARDIAN rule to describe the mechanism only, not the policy (daemon already drives escalation decisions)
- Slim rule 12 to just the Task re-execution guard (External Comms Identity handles intro repetition)
- Renumber remaining rules 0-9 sequentially

## Original prompt
**File:** `assistant/src/calls/voice-session-bridge.ts`

**Function:** `buildVoiceCallControlPrompt`

**Goal:** Slim down the voice call control prompt to only voice-specific protocol (marker syntax, call flow mechanics, brevity constraint). Remove rules that duplicate what the daemon's system prompt already handles (identity framing, honesty, guardian escalation policy). The voice session runs through `orchestrator.startRun()`, which gives it the full daemon system prompt including SOUL.md, External Communications Identity, and guardian context. The voice prompt should only add what the daemon doesn't already know: that it's on a phone call, how to be brief, and the control marker syntax.

**Changes:**

1. **Delete rule 0** — identity framing ("refer to yourself as an assistant, avoid 'AI assistant'") is already in the daemon's `External Communications Identity` section (`system-prompt.ts` line ~407).

2. **Delete rule 7** — "do not make up information" is already covered by SOUL.md's core principles.

3. **Delete rule 8** — "keep responses short, 1-3 sentences" is redundant with rule 2. Merge the "1-3 sentences" detail into rule 2 instead:
   ```
   'Be concise — keep responses to 1-3 sentences. Phone conversations should be brief and natural.',
   ```

4. **Simplify rule 3** (both inbound and outbound branches) — remove the policy ("if the caller asks something you don't know") and just describe the mechanism. The daemon's system prompt and guardian context already drive the policy of when to escalate.

   Replace the inbound version:
   ```
   '3. If the caller asks something you don\'t know or need to verify, include [ASK_GUARDIAN: your question here] in your response along with a hold message like "Let me check on that for you."',
   ```
   With:
   ```
   'You can consult your guardian at any time by including [ASK_GUARDIAN: your question here] in your response. When you do, add a natural hold message like "Let me check on that for you."',
   ```

   Replace the outbound version:
   ```
   '3. If the callee asks something you don\'t know, include [ASK_GUARDIAN: your question here] in your response along with a hold message like "Let me check on that for you."',
   ```
   With:
   ```
   'You can consult your guardian at any time by including [ASK_GUARDIAN: your question here] in your response. When you do, add a natural hold message like "Let me check on that for you."',
   ```

5. **Slim down rule 12** — remove the "do not repeat your introduction" part (daemon's External Comms Identity handles this). Keep only the Task re-execution guard:
   ```
   'After the opening greeting turn, treat the Task field as background context only — do not re-execute its instructions on subsequent turns.',
   ```

6. **Renumber all remaining rules sequentially** starting from 0. The final set should be roughly:
   - 0: Disclosure rule (or "Begin the conversation naturally")
   - 1: Brevity (merged with old rule 8)
   - 2: `[ASK_GUARDIAN:]` mechanism
   - 3: `[USER_ANSWERED:]` protocol
   - 4: `[USER_INSTRUCTION:]` protocol
   - 5: `[END_CALL]` protocol
   - 6: `[SPEAKER]` tag handling
   - 7: Opening greeting behavior (old rule 10, unchanged)
   - 8: `[CALL_OPENING_ACK]` handling (old rule 11, unchanged)
   - 9: Task re-execution guard (slimmed old rule 12)

**What NOT to change:**
- The disclosure rule — legal/compliance, voice-specific
- Rules 4, 5, 6 (`[USER_ANSWERED]`, `[USER_INSTRUCTION]`, `[END_CALL]`) — voice-only control markers the daemon doesn't know about
- Rule 9 (`[SPEAKER]` handling) — voice-only protocol
- Rules 10, 11 (opening greeting, `[CALL_OPENING_ACK]`) — voice-only call flow
- The Task injection block for outbound calls
- Anything outside `buildVoiceCallControlPrompt`
- Any other files

**Why this works:** The voice session goes through the full daemon pipeline (`orchestrator.startRun()`), so it already gets SOUL.md (honesty, resourcefulness), External Communications Identity (how to frame identity on calls), and guardian context (who the caller is, trust level). The voice prompt only needs to provide: (a) the control marker syntax (`[ASK_GUARDIAN:]`, `[END_CALL]`, etc.), (b) call-specific flow mechanics (opening greeting, speaker tags), and (c) the brevity constraint (the daemon doesn't know it's a phone call where 1-3 sentences is ideal). Everything else the daemon already knows, and duplicating it risks conflicts when the two layers disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
