### PR TITLE
Replace Whisper STT with on-device SFSpeechRecognizer in voice mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -99,16 +99,9 @@ extension MainWindowView {
             VoiceModePanel(
                 manager: voiceModeManager,
                 voiceService: voiceModeManager.voiceService,
-                settingsStore: settingsStore,
                 onClose: {
                     voiceModeManager.deactivate()
                     windowState.selection = nil
-                },
-                onKeySaved: {
-                    if let viewModel = threadManager.activeViewModel {
-                        voiceModeManager.activate(chatViewModel: viewModel, settingsStore: settingsStore)
-                        voiceModeManager.startListening()
-                    }
                 }
             )
         case .assistantInbox:

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -504,7 +504,7 @@ struct SettingsPanel: View {
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
 
-                    Text("Used for Voice Mode (Whisper transcription). Get your key at platform.openai.com/api-keys")
+                    Text("Optional. Get your key at platform.openai.com/api-keys")
                         .font(VFont.caption)
                         .foregroundColor(VColor.textMuted)
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -24,7 +24,6 @@ struct SettingsPanel: View {
     @State private var braveKeyText: String = ""
     @State private var perplexityKeyText: String = ""
     @State private var imageGenKeyText: String = ""
-    @State private var openaiKeyText: String = ""
     @State private var elevenLabsKeyText: String = ""
     @State private var showingTrustRules = false
     @State private var showingReminders = false
@@ -463,54 +462,6 @@ struct SettingsPanel: View {
                     VButton(label: "Save", style: .primary) {
                         store.saveImageGenKey(imageGenKeyText)
                         imageGenKeyText = ""
-                    }
-                }
-            }
-            .padding(VSpacing.lg)
-            .vCard(background: VColor.surfaceSubtle)
-
-            // OPENAI section (for Voice Mode — Whisper + TTS)
-            VStack(alignment: .leading, spacing: VSpacing.md) {
-                Text("OpenAI")
-                    .font(VFont.sectionTitle)
-                    .foregroundColor(VColor.textPrimary)
-
-                if store.hasOpenAIKey {
-                    HStack(spacing: VSpacing.sm) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(VColor.success)
-                            .font(.system(size: 14))
-                        Text(store.maskedOpenAIKey)
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textSecondary)
-                        Spacer()
-                        VButton(label: "Clear", style: .danger) {
-                            store.clearOpenAIKey()
-                            openaiKeyText = ""
-                        }
-                    }
-                } else {
-                    HStack(spacing: VSpacing.xs) {
-                        Text("Enter OpenAI API Key")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textSecondary)
-                        Image(systemName: "info.circle")
-                            .font(.system(size: 12))
-                            .foregroundColor(VColor.textMuted)
-                    }
-
-                    SecureField("Your OpenAI API key", text: $openaiKeyText)
-                        .vInputStyle()
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
-
-                    Text("Optional. Get your key at platform.openai.com/api-keys")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
-
-                    VButton(label: "Save", style: .primary) {
-                        store.saveOpenAIKey(openaiKeyText)
-                        openaiKeyText = ""
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -15,14 +15,12 @@ public final class SettingsStore: ObservableObject {
     @Published var hasBraveKey: Bool
     @Published var hasPerplexityKey: Bool
     @Published var hasImageGenKey: Bool
-    @Published var hasOpenAIKey: Bool
     @Published var hasElevenLabsKey: Bool
     @Published var hasVercelKey: Bool = false
     @Published var maskedKey: String = ""
     @Published var maskedBraveKey: String = ""
     @Published var maskedPerplexityKey: String = ""
     @Published var maskedImageGenKey: String = ""
-    @Published var maskedOpenAIKey: String = ""
     @Published var maskedElevenLabsKey: String = ""
 
     // MARK: - Model Selection
@@ -234,9 +232,6 @@ public final class SettingsStore: ObservableObject {
         let imageGenKey = APIKeyManager.getKey(for: "gemini")
         self.hasImageGenKey = imageGenKey != nil
         self.maskedImageGenKey = Self.maskKey(imageGenKey)
-        let openaiKey = APIKeyManager.getKey(for: "openai")
-        self.hasOpenAIKey = openaiKey != nil
-        self.maskedOpenAIKey = Self.maskKey(openaiKey)
         let elevenLabsKey = APIKeyManager.getKey(for: "elevenlabs")
         self.hasElevenLabsKey = elevenLabsKey != nil
         self.maskedElevenLabsKey = Self.maskKey(elevenLabsKey)
@@ -592,20 +587,6 @@ public final class SettingsStore: ObservableObject {
         maskedImageGenKey = ""
     }
 
-    func saveOpenAIKey(_ raw: String) {
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        APIKeyManager.setKey(trimmed, for: "openai")
-        hasOpenAIKey = true
-        maskedOpenAIKey = Self.maskKey(trimmed)
-    }
-
-    func clearOpenAIKey() {
-        APIKeyManager.deleteKey(for: "openai")
-        hasOpenAIKey = false
-        maskedOpenAIKey = ""
-    }
-
     func saveElevenLabsKey(_ raw: String) {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
@@ -646,10 +627,6 @@ public final class SettingsStore: ObservableObject {
         let imageGenKey = APIKeyManager.getKey(for: "gemini")
         hasImageGenKey = imageGenKey != nil
         maskedImageGenKey = Self.maskKey(imageGenKey)
-
-        let openaiKey = APIKeyManager.getKey(for: "openai")
-        hasOpenAIKey = openaiKey != nil
-        maskedOpenAIKey = Self.maskKey(openaiKey)
 
         let elevenLabsKey = APIKeyManager.getKey(for: "elevenlabs")
         hasElevenLabsKey = elevenLabsKey != nil

--- a/clients/macos/vellum-assistant/Features/Settings/WakeWordSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WakeWordSettingsView.swift
@@ -94,7 +94,7 @@ struct WakeWordSettingsView: View {
                 }
             }
 
-            Text("Type any word or phrase. Uses on-device speech recognition — no data leaves your Mac. Requires restart of wake word listening to take effect.")
+            Text("Type any word or phrase. Uses on-device speech recognition — no data leaves your Mac.")
                 .font(VFont.caption)
                 .foregroundColor(VColor.textMuted)
         }

--- a/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
@@ -8,6 +8,7 @@ private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "Op
 enum VoiceServiceError: Error, LocalizedError {
     case speechRecognitionUnavailable
     case notAuthorized
+    case noAPIKey
     case invalidResponse
     case apiError(statusCode: Int, message: String)
     case noAudioData
@@ -17,6 +18,7 @@ enum VoiceServiceError: Error, LocalizedError {
         switch self {
         case .speechRecognitionUnavailable: return "Speech recognition unavailable"
         case .notAuthorized: return "Speech recognition not authorized"
+        case .noAPIKey: return "API key not configured"
         case .invalidResponse: return "Invalid API response"
         case .apiError(let code, let msg): return "API error (\(code)): \(msg)"
         case .noAudioData: return "No audio data recorded"
@@ -474,7 +476,7 @@ final class OpenAIVoiceService: ObservableObject {
     /// Call ElevenLabs REST API to convert text to speech. Returns MP3 audio data.
     private func fetchElevenLabsTTS(text: String) async throws -> Data {
         guard let elevenLabsKey else {
-            throw VoiceServiceError.noAudioData
+            throw VoiceServiceError.noAPIKey
         }
 
         let voiceId = Self.elevenLabsVoiceId

--- a/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
@@ -1,27 +1,32 @@
 import Foundation
 import AVFoundation
+import Speech
 import os
 
 private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "OpenAIVoiceService")
 
-enum OpenAIVoiceError: Error, LocalizedError {
-    case noAPIKey
+enum VoiceServiceError: Error, LocalizedError {
+    case speechRecognitionUnavailable
+    case notAuthorized
     case invalidResponse
     case apiError(statusCode: Int, message: String)
     case noAudioData
+    case noTranscription
 
     var errorDescription: String? {
         switch self {
-        case .noAPIKey: return "API key not configured"
+        case .speechRecognitionUnavailable: return "Speech recognition unavailable"
+        case .notAuthorized: return "Speech recognition not authorized"
         case .invalidResponse: return "Invalid API response"
         case .apiError(let code, let msg): return "API error (\(code)): \(msg)"
         case .noAudioData: return "No audio data recorded"
+        case .noTranscription: return "No transcription result"
         }
     }
 }
 
-/// Voice service: Whisper STT (OpenAI) + TTS (ElevenLabs REST API).
-/// Records audio, detects silence, transcribes via Whisper, speaks via ElevenLabs.
+/// Voice service: SFSpeechRecognizer STT (on-device) + TTS (ElevenLabs REST API).
+/// Records audio, detects silence, transcribes via SFSpeechRecognizer, speaks via ElevenLabs.
 @MainActor
 final class OpenAIVoiceService: ObservableObject {
     @Published var amplitude: Float = 0
@@ -30,8 +35,6 @@ final class OpenAIVoiceService: ObservableObject {
     // MARK: - Recording State
 
     private let audioEngine = AVAudioEngine()
-    private var rawPCMData = Data()
-    private var recordingFormat: AVAudioFormat?
     private var isRecording = false
 
     /// Fires once when silence is detected after speech.
@@ -47,10 +50,20 @@ final class OpenAIVoiceService: ObservableObject {
     private var hasSpeechOccurred = false
     private var enginePrewarmed = false
 
-    private static let silenceThreshold: Float = 0.005
-    private static let speechThreshold: Float = 0.008
+    private static let silenceThreshold: Float = 0.002
+    private static let speechThreshold: Float = 0.004
     private static let silenceTimeout: TimeInterval = 1.0
     private static let minRecordingDuration: TimeInterval = 0.5
+
+    // MARK: - SFSpeechRecognizer STT State
+
+    private var speechRecognizer: SFSpeechRecognizer?
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionTask: SFSpeechRecognitionTask?
+    /// The latest transcription text from the ongoing recognition task.
+    private var latestTranscription: String = ""
+    /// Continuation to deliver the final transcription when recording stops.
+    private var transcriptionContinuation: CheckedContinuation<String?, Never>?
 
     // MARK: - ElevenLabs TTS State
 
@@ -68,19 +81,38 @@ final class OpenAIVoiceService: ObservableObject {
 
     // MARK: - API Keys
 
-    var apiKey: String? { APIKeyManager.getKey(for: "openai") }
     var elevenLabsKey: String? { APIKeyManager.getKey(for: "elevenlabs") }
-    var hasAPIKey: Bool { apiKey != nil }
     var hasElevenLabsKey: Bool { elevenLabsKey != nil }
+
+    // MARK: - Speech Recognition Authorization
+
+    /// Check if speech recognition is authorized. Returns true if authorized.
+    nonisolated static func isSpeechRecognitionAuthorized() -> Bool {
+        SFSpeechRecognizer.authorizationStatus() == .authorized
+    }
+
+    /// Request speech recognition authorization if not yet determined.
+    nonisolated static func requestSpeechRecognitionAuthorization(completion: @escaping (Bool) -> Void) {
+        let status = SFSpeechRecognizer.authorizationStatus()
+        switch status {
+        case .authorized:
+            completion(true)
+        case .notDetermined:
+            SFSpeechRecognizer.requestAuthorization { newStatus in
+                DispatchQueue.main.async {
+                    completion(newStatus == .authorized)
+                }
+            }
+        default:
+            completion(false)
+        }
+    }
 
     // MARK: - Recording
 
     /// Pre-initialize the audio engine so the first recording starts instantly.
     func prewarmEngine() {
         guard !enginePrewarmed else { return }
-        // Only touch the input node to force its creation — do NOT call
-        // audioEngine.prepare() here, because preparing before the tap is
-        // installed can prevent the tap callback from receiving buffers.
         let _ = audioEngine.inputNode
         enginePrewarmed = true
         log.info("Audio engine pre-warmed")
@@ -89,9 +121,10 @@ final class OpenAIVoiceService: ObservableObject {
     func startRecording() {
         guard !isRecording else { return }
 
-        rawPCMData = Data()
         silenceHandled = false
         hasSpeechOccurred = false
+        latestTranscription = ""
+
         let inputNode = audioEngine.inputNode
         let format = inputNode.outputFormat(forBus: 0)
 
@@ -100,27 +133,90 @@ final class OpenAIVoiceService: ObservableObject {
             return
         }
 
-        recordingFormat = format
+        // Set up SFSpeechRecognizer
+        let recognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
+        guard let recognizer, recognizer.isAvailable else {
+            log.error("SFSpeechRecognizer not available")
+            return
+        }
+        speechRecognizer = recognizer
 
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        if recognizer.supportsOnDeviceRecognition {
+            request.requiresOnDeviceRecognition = true
+        }
+        request.addsPunctuation = false
+        recognitionRequest = request
+
+        // Start recognition task
+        recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
+            guard let self else { return }
+
+            if let result {
+                let text = result.bestTranscription.formattedString
+                log.debug("Partial transcription: \(text, privacy: .public)")
+                Task { @MainActor [weak self] in
+                    self?.latestTranscription = text
+                }
+
+                if result.isFinal {
+                    Task { @MainActor [weak self] in
+                        guard let self else { return }
+                        let finalText = self.latestTranscription
+                        log.info("Final transcription: \(finalText, privacy: .public)")
+                        self.transcriptionContinuation?.resume(returning: finalText.isEmpty ? nil : finalText)
+                        self.transcriptionContinuation = nil
+                    }
+                }
+            }
+
+            if let error {
+                let nsError = error as NSError
+                // Ignore cancellation errors (code 216) — expected when we call endAudio()
+                if nsError.domain == "kAFAssistantErrorDomain" && nsError.code == 216 {
+                    return
+                }
+                // Code 1110 = "no speech detected" — not a real error, just empty input
+                if nsError.domain == "kAFAssistantErrorDomain" && nsError.code == 1110 {
+                    log.info("No speech detected in audio")
+                    Task { @MainActor [weak self] in
+                        guard let self else { return }
+                        self.transcriptionContinuation?.resume(returning: nil)
+                        self.transcriptionContinuation = nil
+                    }
+                    return
+                }
+                log.error("Recognition error: \(nsError.domain, privacy: .public)/\(nsError.code, privacy: .public) \(error.localizedDescription, privacy: .public)")
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    // If we have partial transcription, use it despite the error
+                    let text = self.latestTranscription
+                    self.transcriptionContinuation?.resume(returning: text.isEmpty ? nil : text)
+                    self.transcriptionContinuation = nil
+                }
+            }
+        }
+
+        // Install audio tap — feeds buffers to SFSpeechRecognizer + computes RMS for amplitude
         inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { [weak self] buffer, _ in
             guard let floatData = buffer.floatChannelData else { return }
             let frameCount = Int(buffer.frameLength)
             guard frameCount > 0 else { return }
 
-            var chunk = Data(capacity: frameCount * 2)
+            // Feed buffer to speech recognizer
+            request.append(buffer)
+
+            // Compute RMS for amplitude display and silence detection
             var sum: Float = 0
             for i in 0..<frameCount {
                 let sample = floatData[0][i]
-                let clamped = max(-1.0, min(1.0, sample))
-                var int16 = Int16(clamped * Float(Int16.max))
-                withUnsafeBytes(of: &int16) { chunk.append(contentsOf: $0) }
                 sum += sample * sample
             }
             let rms = sqrt(sum / Float(frameCount))
 
             Task { @MainActor [weak self] in
                 guard let self, self.isRecording else { return }
-                self.rawPCMData.append(chunk)
                 self.amplitude = min(rms * 5, 1.0)
 
                 if rms > Self.speechThreshold {
@@ -148,16 +244,16 @@ final class OpenAIVoiceService: ObservableObject {
             isRecording = true
             lastSpeechTime = Date()
             recordingStartTime = Date()
-            log.info("Recording started")
+            log.info("Recording started (SFSpeechRecognizer, onDevice: \(recognizer.supportsOnDeviceRecognition, privacy: .public))")
         } catch {
             log.error("Failed to start audio engine: \(error.localizedDescription)")
             audioEngine.inputNode.removeTap(onBus: 0)
-            recordingFormat = nil
+            tearDownRecognition()
         }
     }
 
-    /// Stop recording and return the audio data as WAV.
-    func stopRecordingAndGetAudio() -> Data? {
+    /// Stop recording and return the transcription from SFSpeechRecognizer.
+    func stopRecordingAndGetTranscription() async -> String? {
         guard isRecording else { return nil }
 
         isRecording = false
@@ -168,21 +264,42 @@ final class OpenAIVoiceService: ObservableObject {
             audioEngine.inputNode.removeTap(onBus: 0)
         }
 
-        guard let format = recordingFormat, !rawPCMData.isEmpty else {
-            log.warning("No audio data recorded")
-            return nil
+        // Signal end of audio to the recognizer
+        recognitionRequest?.endAudio()
+
+        // If we already have transcription text, return it immediately
+        // (the final callback may not fire for short utterances)
+        let currentText = latestTranscription.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !currentText.isEmpty {
+            log.info("Returning current transcription: \(currentText, privacy: .public)")
+            tearDownRecognition()
+            recordingStartTime = nil
+            return currentText
         }
 
-        let wavData = createWAV(pcmData: rawPCMData, sampleRate: UInt32(format.sampleRate))
-        rawPCMData = Data()
-        recordingFormat = nil
+        // Wait briefly for the final result from the recognition task
+        let result: String? = await withCheckedContinuation { continuation in
+            self.transcriptionContinuation = continuation
+
+            // Timeout: don't wait forever if recognizer doesn't respond
+            Task {
+                try? await Task.sleep(nanoseconds: 2_000_000_000) // 2s timeout
+                if let cont = self.transcriptionContinuation {
+                    self.transcriptionContinuation = nil
+                    let text = self.latestTranscription.trimmingCharacters(in: .whitespacesAndNewlines)
+                    cont.resume(returning: text.isEmpty ? nil : text)
+                }
+            }
+        }
+
+        tearDownRecognition()
         recordingStartTime = nil
 
-        log.info("Recording stopped, WAV size: \(wavData.count) bytes")
-        return wavData
+        log.info("Recording stopped, transcription: \(result ?? "<none>", privacy: .public)")
+        return result
     }
 
-    /// Force stop recording without returning audio data.
+    /// Force stop recording without returning transcription.
     func cancelRecording() {
         guard isRecording else { return }
         isRecording = false
@@ -191,8 +308,10 @@ final class OpenAIVoiceService: ObservableObject {
             audioEngine.stop()
             audioEngine.inputNode.removeTap(onBus: 0)
         }
-        rawPCMData = Data()
-        recordingFormat = nil
+        // Resume any waiting continuation with nil
+        transcriptionContinuation?.resume(returning: nil)
+        transcriptionContinuation = nil
+        tearDownRecognition()
         recordingStartTime = nil
     }
 
@@ -208,51 +327,12 @@ final class OpenAIVoiceService: ObservableObject {
         log.info("Audio engine shut down")
     }
 
-    // MARK: - Whisper STT
-
-    func transcribe(_ audioData: Data) async throws -> String {
-        guard let apiKey else {
-            throw OpenAIVoiceError.noAPIKey
-        }
-
-        let url = URL(string: "https://api.openai.com/v1/audio/transcriptions")!
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        request.timeoutInterval = 30
-
-        let boundary = UUID().uuidString
-        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
-
-        var body = Data()
-        body.append(contentsOf: "--\(boundary)\r\n".utf8)
-        body.append(contentsOf: "Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n".utf8)
-        body.append(contentsOf: "Content-Type: audio/wav\r\n\r\n".utf8)
-        body.append(audioData)
-        body.append(contentsOf: "\r\n".utf8)
-        body.append(contentsOf: "--\(boundary)\r\n".utf8)
-        body.append(contentsOf: "Content-Disposition: form-data; name=\"model\"\r\n\r\n".utf8)
-        body.append(contentsOf: "whisper-1\r\n".utf8)
-        body.append(contentsOf: "--\(boundary)--\r\n".utf8)
-
-        request.httpBody = body
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw OpenAIVoiceError.invalidResponse
-        }
-
-        guard httpResponse.statusCode == 200 else {
-            let errorBody = String(data: data, encoding: .utf8) ?? "Unknown error"
-            log.error("Whisper API error (\(httpResponse.statusCode)): \(errorBody)")
-            throw OpenAIVoiceError.apiError(statusCode: httpResponse.statusCode, message: errorBody)
-        }
-
-        struct WhisperResponse: Decodable { let text: String }
-        let result = try JSONDecoder().decode(WhisperResponse.self, from: data)
-        log.info("Whisper transcription: \(result.text, privacy: .public)")
-        return result.text
+    private func tearDownRecognition() {
+        recognitionTask?.cancel()
+        recognitionTask = nil
+        recognitionRequest = nil
+        speechRecognizer = nil
+        latestTranscription = ""
     }
 
     // MARK: - ElevenLabs TTS (REST API)
@@ -391,7 +471,7 @@ final class OpenAIVoiceService: ObservableObject {
     /// Call ElevenLabs REST API to convert text to speech. Returns MP3 audio data.
     private func fetchElevenLabsTTS(text: String) async throws -> Data {
         guard let elevenLabsKey else {
-            throw OpenAIVoiceError.noAPIKey
+            throw VoiceServiceError.noAudioData
         }
 
         let voiceId = Self.elevenLabsVoiceId
@@ -417,17 +497,17 @@ final class OpenAIVoiceService: ObservableObject {
         let (data, response) = try await URLSession.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            throw OpenAIVoiceError.invalidResponse
+            throw VoiceServiceError.invalidResponse
         }
 
         guard httpResponse.statusCode == 200 else {
             let errorBody = String(data: data, encoding: .utf8) ?? "Unknown error"
             log.error("ElevenLabs API error (\(httpResponse.statusCode)): \(errorBody)")
-            throw OpenAIVoiceError.apiError(statusCode: httpResponse.statusCode, message: errorBody)
+            throw VoiceServiceError.apiError(statusCode: httpResponse.statusCode, message: errorBody)
         }
 
         guard !data.isEmpty else {
-            throw OpenAIVoiceError.noAudioData
+            throw VoiceServiceError.noAudioData
         }
 
         return data
@@ -449,41 +529,5 @@ final class OpenAIVoiceService: ObservableObject {
     private func stopSpeakingAmplitudePolling() {
         speakingTimer?.invalidate()
         speakingTimer = nil
-    }
-
-    // MARK: - WAV Encoding
-
-    private func createWAV(pcmData: Data, sampleRate: UInt32) -> Data {
-        let numChannels: UInt16 = 1
-        let bitsPerSample: UInt16 = 16
-        let bytesPerSample = bitsPerSample / 8
-        let dataSize = UInt32(pcmData.count)
-
-        var wav = Data(capacity: 44 + pcmData.count)
-        wav.append(contentsOf: "RIFF".utf8)
-        appendLE(&wav, 36 + dataSize)
-        wav.append(contentsOf: "WAVE".utf8)
-        wav.append(contentsOf: "fmt ".utf8)
-        appendLE(&wav, UInt32(16))
-        appendLE(&wav, UInt16(1)) // PCM
-        appendLE(&wav, numChannels)
-        appendLE(&wav, sampleRate)
-        appendLE(&wav, sampleRate * UInt32(numChannels) * UInt32(bytesPerSample))
-        appendLE(&wav, numChannels * bytesPerSample)
-        appendLE(&wav, bitsPerSample)
-        wav.append(contentsOf: "data".utf8)
-        appendLE(&wav, dataSize)
-        wav.append(pcmData)
-        return wav
-    }
-
-    private func appendLE(_ data: inout Data, _ value: UInt32) {
-        var v = value.littleEndian
-        withUnsafeBytes(of: &v) { data.append(contentsOf: $0) }
-    }
-
-    private func appendLE(_ data: inout Data, _ value: UInt16) {
-        var v = value.littleEndian
-        withUnsafeBytes(of: &v) { data.append(contentsOf: $0) }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
@@ -118,8 +118,9 @@ final class OpenAIVoiceService: ObservableObject {
         log.info("Audio engine pre-warmed")
     }
 
-    func startRecording() {
-        guard !isRecording else { return }
+    @discardableResult
+    func startRecording() -> Bool {
+        guard !isRecording else { return false }
 
         silenceHandled = false
         hasSpeechOccurred = false
@@ -130,14 +131,14 @@ final class OpenAIVoiceService: ObservableObject {
 
         guard format.channelCount > 0 else {
             log.error("No audio input channels")
-            return
+            return false
         }
 
         // Set up SFSpeechRecognizer
         let recognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
         guard let recognizer, recognizer.isAvailable else {
             log.error("SFSpeechRecognizer not available")
-            return
+            return false
         }
         speechRecognizer = recognizer
 
@@ -161,9 +162,9 @@ final class OpenAIVoiceService: ObservableObject {
                 }
 
                 if result.isFinal {
+                    let finalText = text
                     Task { @MainActor [weak self] in
                         guard let self else { return }
-                        let finalText = self.latestTranscription
                         log.info("Final transcription: \(finalText, privacy: .public)")
                         self.transcriptionContinuation?.resume(returning: finalText.isEmpty ? nil : finalText)
                         self.transcriptionContinuation = nil
@@ -245,10 +246,12 @@ final class OpenAIVoiceService: ObservableObject {
             lastSpeechTime = Date()
             recordingStartTime = Date()
             log.info("Recording started (SFSpeechRecognizer, onDevice: \(recognizer.supportsOnDeviceRecognition, privacy: .public))")
+            return true
         } catch {
             log.error("Failed to start audio engine: \(error.localizedDescription)")
             audioEngine.inputNode.removeTap(onBus: 0)
             tearDownRecognition()
+            return false
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -43,8 +43,6 @@ final class VoiceModeManager: ObservableObject {
         self.voiceService = OpenAIVoiceService()
     }
 
-    var hasAPIKey: Bool { voiceService.hasAPIKey }
-
     var stateLabel: String {
         if !pendingPermissionIds.isEmpty {
             switch state {
@@ -67,8 +65,15 @@ final class VoiceModeManager: ObservableObject {
         guard state == .off else { return }
         wasAutoDeactivated = false
 
-        guard voiceService.hasAPIKey else {
-            log.error("Voice mode: no OpenAI API key configured")
+        guard OpenAIVoiceService.isSpeechRecognitionAuthorized() else {
+            log.error("Voice mode: speech recognition not authorized")
+            OpenAIVoiceService.requestSpeechRecognitionAuthorization { authorized in
+                if authorized {
+                    log.info("Speech recognition authorized — retry activating voice mode")
+                } else {
+                    log.warning("Speech recognition authorization denied")
+                }
+            }
             return
         }
 
@@ -194,63 +199,34 @@ final class VoiceModeManager: ObservableObject {
         guard state == .listening else { return }
 
         state = .processing
-        log.info("Voice mode: silence detected, transcribing via Whisper")
+        log.info("Voice mode: silence detected, getting transcription")
 
         // Reset streaming TTS state for the new turn
         voiceService.resetStreamingTTS()
 
-        guard let audioData = voiceService.stopRecordingAndGetAudio() else {
-            state = .idle
-            return
-        }
-
         Task {
-            do {
-                let text = try await voiceService.transcribe(audioData)
-                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            let text = await voiceService.stopRecordingAndGetTranscription()
+            let trimmed = (text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
 
-                guard !trimmed.isEmpty, let chatViewModel else {
-                    state = .idle
-                    return
-                }
-
-                // If we're awaiting a permission response, handle it separately
-                if !self.pendingPermissionIds.isEmpty {
-                    self.partialTranscription = trimmed
-                    self.handlePermissionResponse(trimmed)
-                    return
-                }
-
-                partialTranscription = trimmed
-
-                // Send the transcribed message through the daemon (full context)
-                chatViewModel.pendingVoiceMessage = true
-                chatViewModel.inputText = trimmed
-                chatViewModel.sendMessage()
-                log.info("Voice mode: sent transcription to chat via daemon")
-            } catch {
-                log.error("Transcription failed: \(error.localizedDescription)")
-                partialTranscription = ""
-                if let voiceError = error as? OpenAIVoiceError {
-                    switch voiceError {
-                    case .apiError(let statusCode, _):
-                        if statusCode == 429 {
-                            self.errorMessage = "OpenAI rate limit exceeded. Check your billing at platform.openai.com"
-                        } else if statusCode == 401 {
-                            self.errorMessage = "Invalid OpenAI API key. Update it in Settings."
-                        } else {
-                            self.errorMessage = "OpenAI API error (\(statusCode))"
-                        }
-                    case .noAPIKey:
-                        self.errorMessage = "OpenAI API key not configured. Add it in Settings."
-                    default:
-                        self.errorMessage = "Transcription failed: \(error.localizedDescription)"
-                    }
-                } else {
-                    self.errorMessage = "Transcription failed: \(error.localizedDescription)"
-                }
+            guard !trimmed.isEmpty, let chatViewModel else {
                 state = .idle
+                return
             }
+
+            // If we're awaiting a permission response, handle it separately
+            if !self.pendingPermissionIds.isEmpty {
+                self.partialTranscription = trimmed
+                self.handlePermissionResponse(trimmed)
+                return
+            }
+
+            partialTranscription = trimmed
+
+            // Send the transcribed message through the daemon (full context)
+            chatViewModel.pendingVoiceMessage = true
+            chatViewModel.inputText = trimmed
+            chatViewModel.sendMessage()
+            log.info("Voice mode: sent transcription to chat via daemon")
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -30,6 +30,8 @@ final class VoiceModeManager: ObservableObject {
     private weak var settingsStore: SettingsStore?
     private var previousOnVoiceResponseComplete: ((String) -> Void)?
     private var previousOnVoiceTextDelta: ((String) -> Void)?
+    /// Guards against async auth callback activating after the panel is closed.
+    private var awaitingAuthorization = false
     /// Safety timeout to recover from stuck TTS.
     private var ttsTimeoutTask: Task<Void, Never>?
     /// Timer that fires when the conversation has been idle too long.
@@ -67,8 +69,10 @@ final class VoiceModeManager: ObservableObject {
 
         guard OpenAIVoiceService.isSpeechRecognitionAuthorized() else {
             log.error("Voice mode: speech recognition not authorized")
+            awaitingAuthorization = true
             OpenAIVoiceService.requestSpeechRecognitionAuthorization { [weak self] authorized in
-                guard let self else { return }
+                guard let self, self.awaitingAuthorization else { return }
+                self.awaitingAuthorization = false
                 if authorized {
                     log.info("Speech recognition authorized — retrying activation")
                     self.activate(chatViewModel: chatViewModel, settingsStore: settingsStore)
@@ -80,6 +84,7 @@ final class VoiceModeManager: ObservableObject {
             return
         }
 
+        awaitingAuthorization = false
         self.chatViewModel = chatViewModel
         self.settingsStore = settingsStore
 
@@ -131,6 +136,7 @@ final class VoiceModeManager: ObservableObject {
     }
 
     func deactivate() {
+        awaitingAuthorization = false
         guard state != .off else { return }
 
         // Cancel conversation timeout before setting state to .off

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -67,9 +67,12 @@ final class VoiceModeManager: ObservableObject {
 
         guard OpenAIVoiceService.isSpeechRecognitionAuthorized() else {
             log.error("Voice mode: speech recognition not authorized")
-            OpenAIVoiceService.requestSpeechRecognitionAuthorization { authorized in
+            OpenAIVoiceService.requestSpeechRecognitionAuthorization { [weak self] authorized in
+                guard let self else { return }
                 if authorized {
-                    log.info("Speech recognition authorized — retry activating voice mode")
+                    log.info("Speech recognition authorized — retrying activation")
+                    self.activate(chatViewModel: chatViewModel, settingsStore: settingsStore)
+                    self.startListening()
                 } else {
                     log.warning("Speech recognition authorization denied")
                 }
@@ -182,7 +185,11 @@ final class VoiceModeManager: ObservableObject {
         partialTranscription = ""
         errorMessage = ""
         state = .listening
-        voiceService.startRecording()
+        guard voiceService.startRecording() else {
+            errorMessage = "Speech recognition unavailable"
+            state = .idle
+            return
+        }
         log.info("Voice mode: started listening")
     }
 

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModePanel.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModePanel.swift
@@ -4,15 +4,12 @@ import VellumAssistantShared
 struct VoiceModePanel: View {
     @ObservedObject var manager: VoiceModeManager
     @ObservedObject var voiceService: OpenAIVoiceService
-    @ObservedObject var settingsStore: SettingsStore
     let onClose: () -> Void
-    var onKeySaved: (() -> Void)?
 
     @State private var showingInfo = false
     @State private var spinAngle: Double = 0
     @State private var ringJitter: [CGFloat] = [0, 0, 0]
     @State private var jitterTimer: Timer?
-    @State private var openaiKeyText: String = ""
 
     private let orbSize: CGFloat = 120
 
@@ -59,7 +56,7 @@ struct VoiceModePanel: View {
             // Info panel
             if showingInfo {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    infoRow(label: "STT", value: "OpenAI Whisper")
+                    infoRow(label: "STT", value: "Apple Speech (on-device)")
                     infoRow(label: "LLM", value: "Your selected model")
                     infoRow(label: "TTS", value: "ElevenLabs Flash v2.5")
                     Divider().background(VColor.surfaceBorder)
@@ -77,101 +74,60 @@ struct VoiceModePanel: View {
 
             Spacer()
 
-            if !manager.hasAPIKey {
-                VStack(spacing: VSpacing.lg) {
-                    Image(systemName: "key.fill")
-                        .font(.system(size: 32))
-                        .foregroundColor(VColor.textMuted)
-                    Text("OpenAI API key required")
-                        .font(VFont.bodyMedium)
-                        .foregroundColor(VColor.textSecondary)
-                        .textSelection(.enabled)
-                    Text("Enter your OpenAI API key to use voice mode with Whisper and TTS.")
+            // Voice orb
+            voiceOrb
+                .padding(.bottom, VSpacing.xxl)
+
+            // State label
+            Text(manager.stateLabel)
+                .font(VFont.bodyMedium)
+                .foregroundColor(VColor.textSecondary)
+                .padding(.bottom, VSpacing.sm)
+                .textSelection(.enabled)
+
+            // Error message
+            if !manager.errorMessage.isEmpty {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(VColor.warning)
+                        .font(.system(size: 14))
+                    Text(manager.errorMessage)
                         .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
+                        .foregroundColor(VColor.warning)
                         .multilineTextAlignment(.center)
-                        .padding(.horizontal, VSpacing.xl)
                         .textSelection(.enabled)
-
-                    VStack(spacing: VSpacing.md) {
-                        SecureField("Your OpenAI API key", text: $openaiKeyText)
-                            .vInputStyle()
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textPrimary)
-                            .onSubmit {
-                                guard !openaiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-                                settingsStore.saveOpenAIKey(openaiKeyText)
-                                openaiKeyText = ""
-                                onKeySaved?()
-                            }
-
-                        VButton(label: "Save", style: .primary, isDisabled: openaiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
-                            settingsStore.saveOpenAIKey(openaiKeyText)
-                            openaiKeyText = ""
-                            onKeySaved?()
-                        }
-                    }
-                    .padding(.horizontal, VSpacing.xl)
                 }
-            } else {
-                // Voice orb
-                voiceOrb
-                    .padding(.bottom, VSpacing.xxl)
-
-                // State label
-                Text(manager.stateLabel)
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.textSecondary)
-                    .padding(.bottom, VSpacing.sm)
-                    .textSelection(.enabled)
-
-                // Error message
-                if !manager.errorMessage.isEmpty {
-                    HStack(spacing: VSpacing.sm) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundColor(VColor.warning)
-                            .font(.system(size: 14))
-                        Text(manager.errorMessage)
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.warning)
-                            .multilineTextAlignment(.center)
-                            .textSelection(.enabled)
-                    }
-                    .padding(.horizontal, VSpacing.xl)
-                    .padding(.vertical, VSpacing.md)
-                    .background(VColor.warning.opacity(0.1))
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                    .padding(.horizontal, VSpacing.xl)
-                    .padding(.bottom, VSpacing.lg)
-                }
-
+                .padding(.horizontal, VSpacing.xl)
+                .padding(.vertical, VSpacing.md)
+                .background(VColor.warning.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                .padding(.horizontal, VSpacing.xl)
+                .padding(.bottom, VSpacing.lg)
             }
 
             Spacer()
 
             // Controls
-            if manager.hasAPIKey {
-                VStack(spacing: VSpacing.md) {
-                    Button(action: { manager.toggleListening() }) {
-                        Image(systemName: micIcon)
-                            .font(.system(size: 20, weight: .medium))
-                            .foregroundColor(micButtonForeground)
-                            .frame(width: 56, height: 56)
-                            .background(micButtonBackground)
-                            .clipShape(Circle())
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(manager.state == .processing)
-
-                    Button(action: onClose) {
-                        Text("End Voice Mode")
-                            .font(VFont.captionMedium)
-                            .foregroundColor(VColor.textMuted)
-                    }
-                    .buttonStyle(.plain)
+            VStack(spacing: VSpacing.md) {
+                Button(action: { manager.toggleListening() }) {
+                    Image(systemName: micIcon)
+                        .font(.system(size: 20, weight: .medium))
+                        .foregroundColor(micButtonForeground)
+                        .frame(width: 56, height: 56)
+                        .background(micButtonBackground)
+                        .clipShape(Circle())
                 }
-                .padding(.bottom, VSpacing.xxl)
+                .buttonStyle(.plain)
+                .disabled(manager.state == .processing)
+
+                Button(action: onClose) {
+                    Text("End Voice Mode")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textMuted)
+                }
+                .buttonStyle(.plain)
             }
+            .padding(.bottom, VSpacing.xxl)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(VColor.background)

--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/AlwaysOnAudioMonitor.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/AlwaysOnAudioMonitor.swift
@@ -26,6 +26,7 @@ final class AlwaysOnAudioMonitor: ObservableObject {
 
     private let engine: WakeWordEngine
     private var configurationChangeObserver: NSObjectProtocol?
+    private var keywordObserver: NSObjectProtocol?
 
     // MARK: - Init
 
@@ -33,10 +34,14 @@ final class AlwaysOnAudioMonitor: ObservableObject {
         self.engine = engine
         setupEngineCallback()
         setupNotificationObservers()
+        observeKeywordChanges()
     }
 
     deinit {
         if let observer = configurationChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        if let observer = keywordObserver {
             NotificationCenter.default.removeObserver(observer)
         }
         engine.stop()
@@ -89,6 +94,20 @@ final class AlwaysOnAudioMonitor: ObservableObject {
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
                 self?.handleConfigurationChange()
+            }
+        }
+    }
+
+    private func observeKeywordChanges() {
+        keywordObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                let newKeyword = UserDefaults.standard.string(forKey: "wakeWordKeyword") ?? "computer"
+                self.engine.updateKeyword(newKeyword)
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/SpeechWakeWordEngine.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/SpeechWakeWordEngine.swift
@@ -22,7 +22,7 @@ final class SpeechWakeWordEngine: WakeWordEngine {
     private(set) var isRunning = false
 
     /// The keyword phrase to detect (e.g. "computer", "hey vellum").
-    let keyword: String
+    private(set) var keyword: String
 
     private let audioEngine = AVAudioEngine()
     private var speechRecognizer: SFSpeechRecognizer?
@@ -42,7 +42,7 @@ final class SpeechWakeWordEngine: WakeWordEngine {
     private var sessionGeneration = 0
 
     /// Word-boundary regex for matching the keyword in transcriptions.
-    private let keywordPattern: Regex<Substring>?
+    private var keywordPattern: Regex<Substring>?
 
     /// Rolling session duration — restart before the ~60s timeout.
     private static let sessionDuration: TimeInterval = 55
@@ -117,6 +117,28 @@ final class SpeechWakeWordEngine: WakeWordEngine {
         speechRecognizer = nil
 
         log.info("SpeechWakeWordEngine stopped")
+    }
+
+    // MARK: - Keyword Update
+
+    func updateKeyword(_ newKeyword: String) {
+        let trimmed = newKeyword.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolved = trimmed.isEmpty ? "computer" : trimmed
+        guard resolved != keyword else { return }
+
+        let escaped = NSRegularExpression.escapedPattern(for: resolved)
+        guard let pattern = try? Regex<Substring>("(?i)\\b\(escaped)\\b") else {
+            log.error("Failed to compile keyword regex for '\(resolved)' — keeping current keyword")
+            return
+        }
+
+        log.info("Updating keyword from '\(self.keyword, privacy: .public)' to '\(resolved, privacy: .public)'")
+        keyword = resolved
+        keywordPattern = pattern
+
+        if isRunning {
+            restartSession()
+        }
     }
 
     // MARK: - Recognition session management

--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordEngine.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordEngine.swift
@@ -15,4 +15,7 @@ protocol WakeWordEngine: AnyObject {
 
     /// Stop the detection engine and release resources.
     func stop()
+
+    /// Update the keyword phrase and restart detection if running.
+    func updateKeyword(_ keyword: String)
 }


### PR DESCRIPTION
## Summary
- Replaces OpenAI Whisper API calls with Apple's `SFSpeechRecognizer` for speech-to-text in voice mode, eliminating the OpenAI API key requirement for STT
- Audio buffers are fed directly to `SFSpeechAudioBufferRecognitionRequest` during recording; transcription is returned when silence is detected
- Removes the OpenAI API key gate from the voice mode panel — voice orb and controls are always shown
- Lowers speech/silence detection thresholds for better sensitivity at normal speaking volume
- TTS (ElevenLabs) is completely unaffected

## Test plan
- [ ] `./build.sh` compiles without errors
- [ ] Open voice mode panel — no API key prompt appears, voice orb shows immediately
- [ ] Speak at normal volume — silence detection triggers and transcription appears in chat
- [ ] Verify TTS still works (ElevenLabs path untouched)
- [ ] Verify wake word → voice mode still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
