### PR TITLE
M1: IPC + Conversation Plumbing (#8452)

### DIFF
--- a/assistant/src/daemon/ipc-contract/computer-use.ts
+++ b/assistant/src/daemon/ipc-contract/computer-use.ts
@@ -32,6 +32,8 @@ export interface CuSessionCreate {
   requiresRecording?: boolean;
   /** Recording source/options selected by the client or requested by the daemon. */
   recordingOptions?: RecordingOptions;
+  /** Conversation ID to attach recording artifacts (e.g., screen recordings) to. */
+  attachToConversationId?: string;
 }
 
 export interface CuSessionAbort {
@@ -71,6 +73,8 @@ export interface TaskSubmit {
   screenHeight: number;
   attachments?: UserMessageAttachment[];
   source?: 'voice' | 'text';
+  /** The conversation ID of the active thread when the task was submitted. */
+  conversationId?: string;
 }
 
 export interface RideShotgunStart {

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -202,13 +202,15 @@ extension AppDelegate {
                     extractedText: $0.extractedText
                 )
             }
+            let activeConversationId = self.mainWindow?.threadManager?.activeThread?.sessionId
             do {
                 try self.daemonClient.send(TaskSubmitMessage(
                     task: effectiveTask,
                     screenWidth: Int(screenBounds.width),
                     screenHeight: Int(screenBounds.height),
                     attachments: ipcAttachments,
-                    source: submission.source
+                    source: submission.source,
+                    conversationId: activeConversationId
                 ))
             } catch {
                 log.error("Failed to send task submit message: \(error)")

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1317,8 +1317,10 @@ public struct IPCCuSessionCreate: Codable, Sendable {
     public let requiresRecording: Bool?
     /// Recording source/options selected by the client or requested by the daemon.
     public let recordingOptions: IPCRecordingOptions?
+    /// Conversation ID to attach recording artifacts (e.g., screen recordings) to.
+    public let attachToConversationId: String?
 
-    public init(type: String, sessionId: String, task: String, screenWidth: Int, screenHeight: Int, attachments: [IPCUserMessageAttachment]? = nil, interactionType: String? = nil, requiresRecording: Bool? = nil, recordingOptions: IPCRecordingOptions? = nil) {
+    public init(type: String, sessionId: String, task: String, screenWidth: Int, screenHeight: Int, attachments: [IPCUserMessageAttachment]? = nil, interactionType: String? = nil, requiresRecording: Bool? = nil, recordingOptions: IPCRecordingOptions? = nil, attachToConversationId: String? = nil) {
         self.type = type
         self.sessionId = sessionId
         self.task = task
@@ -1328,6 +1330,7 @@ public struct IPCCuSessionCreate: Codable, Sendable {
         self.interactionType = interactionType
         self.requiresRecording = requiresRecording
         self.recordingOptions = recordingOptions
+        self.attachToConversationId = attachToConversationId
     }
 }
 
@@ -4293,14 +4296,17 @@ public struct IPCTaskSubmit: Codable, Sendable {
     public let screenHeight: Int
     public let attachments: [IPCUserMessageAttachment]?
     public let source: String?
+    /// The conversation ID of the active thread when the task was submitted.
+    public let conversationId: String?
 
-    public init(type: String, task: String, screenWidth: Int, screenHeight: Int, attachments: [IPCUserMessageAttachment]? = nil, source: String? = nil) {
+    public init(type: String, task: String, screenWidth: Int, screenHeight: Int, attachments: [IPCUserMessageAttachment]? = nil, source: String? = nil, conversationId: String? = nil) {
         self.type = type
         self.task = task
         self.screenWidth = screenWidth
         self.screenHeight = screenHeight
         self.attachments = attachments
         self.source = source
+        self.conversationId = conversationId
     }
 }
 

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -148,8 +148,8 @@ extension IPCUserMessageAttachment {
 public typealias CuSessionCreateMessage = IPCCuSessionCreate
 
 extension IPCCuSessionCreate {
-    public init(sessionId: String, task: String, screenWidth: Int, screenHeight: Int, attachments: [IPCAttachment]?, interactionType: String?) {
-        self.init(type: "cu_session_create", sessionId: sessionId, task: task, screenWidth: screenWidth, screenHeight: screenHeight, attachments: attachments, interactionType: interactionType)
+    public init(sessionId: String, task: String, screenWidth: Int, screenHeight: Int, attachments: [IPCAttachment]?, interactionType: String?, attachToConversationId: String? = nil) {
+        self.init(type: "cu_session_create", sessionId: sessionId, task: task, screenWidth: screenWidth, screenHeight: screenHeight, attachments: attachments, interactionType: interactionType, attachToConversationId: attachToConversationId)
     }
 }
 
@@ -310,8 +310,8 @@ extension IPCUserMessage {
 public typealias TaskSubmitMessage = IPCTaskSubmit
 
 extension IPCTaskSubmit {
-    public init(task: String, screenWidth: Int, screenHeight: Int, attachments: [IPCAttachment]?, source: String?) {
-        self.init(type: "task_submit", task: task, screenWidth: screenWidth, screenHeight: screenHeight, attachments: attachments, source: source)
+    public init(task: String, screenWidth: Int, screenHeight: Int, attachments: [IPCAttachment]?, source: String?, conversationId: String? = nil) {
+        self.init(type: "task_submit", task: task, screenWidth: screenWidth, screenHeight: screenHeight, attachments: attachments, source: source, conversationId: conversationId)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `conversationId` to `TaskSubmit` IPC message
- Add `attachToConversationId` to `CuSessionCreate` IPC message
- Regenerate Swift IPC code
- Wire macOS submit path to send active thread conversation ID

Part of #8451 (Standalone Screen Recording Skill)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
