### PR TITLE
M1: Wait-State and Escalation Safety

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -800,6 +800,128 @@ describe('call-controller', () => {
     controller.destroy();
   });
 
+  // ── waiting_on_user re-entry guard ────────────────────────────────
+
+  test('handleCallerUtterance: does NOT trigger startVoiceTurn when waiting_on_user', async () => {
+    // Trigger ASK_GUARDIAN to enter waiting_on_user state
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Hold on. [ASK_GUARDIAN: What time works?]'],
+    ));
+    const { controller } = setupController();
+    await controller.handleCallerUtterance('Book me in');
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    // Track calls to startVoiceTurn from this point
+    let turnCallCount = 0;
+    mockStartVoiceTurn.mockImplementation(async (opts: { onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      turnCallCount++;
+      opts.onTextDelta('Should not appear.');
+      opts.onComplete();
+      return { runId: 'run-blocked', abort: () => {} };
+    });
+
+    // Caller speaks while waiting — should be queued, not processed
+    await controller.handleCallerUtterance('Hello? Are you still there?');
+    expect(turnCallCount).toBe(0);
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    controller.destroy();
+  });
+
+  test('queued caller utterance IS processed after handleUserAnswer resolves', async () => {
+    // Trigger ASK_GUARDIAN to enter waiting_on_user state
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Checking. [ASK_GUARDIAN: Confirm appointment?]'],
+    ));
+    const { relay, controller } = setupController();
+    await controller.handleCallerUtterance('I want to schedule');
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    // Caller speaks while waiting — queued
+    await controller.handleCallerUtterance('Actually make it 4pm');
+
+    // Set up mocks for the answer turn and subsequent queued utterance turn
+    let turnContents: string[] = [];
+    mockStartVoiceTurn.mockImplementation(async (opts: { content: string; onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      turnContents.push(opts.content);
+      if (opts.content.includes('[USER_ANSWERED:')) {
+        opts.onTextDelta('Confirmed.');
+      } else {
+        opts.onTextDelta('Got it, 4pm.');
+      }
+      opts.onComplete();
+      return { runId: `run-${turnContents.length}`, abort: () => {} };
+    });
+
+    const accepted = await controller.handleUserAnswer('Yes, confirmed');
+    expect(accepted).toBe(true);
+
+    // Give fire-and-forget turns time to complete
+    await new Promise((r) => setTimeout(r, 100));
+
+    // The answer turn should have fired
+    expect(turnContents.some((c) => c.includes('[USER_ANSWERED: Yes, confirmed]'))).toBe(true);
+    // The queued caller utterance should also have been processed
+    expect(turnContents.some((c) => c.includes('Actually make it 4pm'))).toBe(true);
+
+    controller.destroy();
+  });
+
+  test('no duplicate guardian dispatch: subsequent handleCallerUtterance during waiting_on_user does not produce another ASK_GUARDIAN', async () => {
+    // Trigger ASK_GUARDIAN to enter waiting_on_user
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Let me ask. [ASK_GUARDIAN: Preferred date?]'],
+    ));
+    const { session, controller } = setupController();
+    await controller.handleCallerUtterance('Schedule please');
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    // Count how many times startVoiceTurn is invoked after this point
+    let postGuardianTurnCount = 0;
+    mockStartVoiceTurn.mockImplementation(async (opts: { onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      postGuardianTurnCount++;
+      // Simulate the model trying to emit another ASK_GUARDIAN
+      opts.onTextDelta('[ASK_GUARDIAN: Preferred date again?]');
+      opts.onComplete();
+      return { runId: 'run-dup', abort: () => {} };
+    });
+
+    // Multiple caller utterances during waiting_on_user — all should be queued
+    await controller.handleCallerUtterance('Hello?');
+    await controller.handleCallerUtterance('Anyone there?');
+
+    // No turns should have started
+    expect(postGuardianTurnCount).toBe(0);
+    // State should still be waiting_on_user
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    controller.destroy();
+  });
+
+  test('handleUserAnswer: returns false when not in waiting_on_user state (stale/duplicate guard)', async () => {
+    const { controller } = setupController();
+
+    // idle state
+    expect(await controller.handleUserAnswer('some answer')).toBe(false);
+
+    // processing state — trigger a turn first
+    mockStartVoiceTurn.mockImplementation(async (opts: { onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      // Slow turn — give time to call handleUserAnswer while processing
+      await new Promise((r) => setTimeout(r, 200));
+      opts.onTextDelta('Response.');
+      opts.onComplete();
+      return { runId: 'run-proc', abort: () => {} };
+    });
+    const turnPromise = controller.handleCallerUtterance('Test');
+    // Give it a moment to enter processing state
+    await new Promise((r) => setTimeout(r, 10));
+    expect(await controller.handleUserAnswer('stale answer')).toBe(false);
+
+    // Clean up
+    await turnPromise.catch(() => {});
+    controller.destroy();
+  });
+
   test('handleUserInstruction: does not trigger turn when controller is not idle', async () => {
     // First, trigger ASK_GUARDIAN so controller enters waiting_on_user
     mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -49,6 +49,18 @@ mock.module('../config/loader.js', () => ({
   }),
 }));
 
+// ── Call constants mock ──────────────────────────────────────────────
+
+let mockConsultationTimeoutMs = 90_000;
+
+mock.module('../calls/call-constants.js', () => ({
+  getMaxCallDurationMs: () => 12 * 60 * 1000,
+  getUserConsultationTimeoutMs: () => mockConsultationTimeoutMs,
+  SILENCE_TIMEOUT_MS: 30_000,
+  MAX_CALL_DURATION_MS: 3600 * 1000,
+  USER_CONSULTATION_TIMEOUT_MS: 120 * 1000,
+}));
+
 // ── Voice session bridge mock ────────────────────────────────────────
 
 /**
@@ -213,6 +225,8 @@ describe('call-controller', () => {
     resetTables();
     // Reset the bridge mock to default behaviour
     mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(['Hello', ' there']));
+    // Reset consultation timeout to the default (long) value
+    mockConsultationTimeoutMs = 90_000;
   });
 
   // ── handleCallerUtterance ─────────────────────────────────────────
@@ -951,6 +965,87 @@ describe('call-controller', () => {
     const events = getCallEvents(session.id);
     const instructionEvents = events.filter((e) => e.eventType === 'user_instruction_relayed');
     expect(instructionEvents.length).toBe(1);
+
+    controller.destroy();
+  });
+
+  // ── Post-end-call drain guard ───────────────────────────────────
+
+  test('handleUserAnswer: queued caller utterances are discarded (not processed) when answer turn ends the call', async () => {
+    // Trigger ASK_GUARDIAN to enter waiting_on_user state
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Checking. [ASK_GUARDIAN: Confirm cancellation?]'],
+    ));
+    const { session, relay, controller } = setupController();
+    await controller.handleCallerUtterance('I want to cancel');
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    // Queue a caller utterance while waiting
+    await controller.handleCallerUtterance('Never mind, just cancel it');
+
+    // Set up mock so the answer turn ends the call with [END_CALL]
+    let turnContents: string[] = [];
+    mockStartVoiceTurn.mockImplementation(async (opts: { content: string; onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      turnContents.push(opts.content);
+      opts.onTextDelta('Alright, your appointment is cancelled. Goodbye! [END_CALL]');
+      opts.onComplete();
+      return { runId: `run-${turnContents.length}`, abort: () => {} };
+    });
+
+    const accepted = await controller.handleUserAnswer('Yes, cancel it');
+    expect(accepted).toBe(true);
+
+    // Give fire-and-forget turns time to complete
+    await new Promise((r) => setTimeout(r, 100));
+
+    // The answer turn should have fired
+    expect(turnContents.some((c) => c.includes('[USER_ANSWERED: Yes, cancel it]'))).toBe(true);
+    // The queued caller utterance should NOT have been processed — only the answer turn
+    expect(turnContents.length).toBe(1);
+
+    // Call should be completed
+    const updatedSession = getCallSession(session.id);
+    expect(updatedSession!.status).toBe('completed');
+    expect(relay.endCalled).toBe(true);
+
+    controller.destroy();
+  });
+
+  // ── Consultation timeout with merged instructions + utterances ──
+
+  test('consultation timeout: merges pending instructions and caller utterances into a single turn', async () => {
+    // Use a short consultation timeout so we can wait for it in the test
+    mockConsultationTimeoutMs = 50;
+
+    // Trigger ASK_GUARDIAN to enter waiting_on_user state
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Let me check. [ASK_GUARDIAN: What time works?]'],
+    ));
+    const { controller } = setupController();
+    await controller.handleCallerUtterance('Book me in');
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    // Queue an instruction and a caller utterance while waiting
+    await controller.handleUserInstruction('Suggest morning slots');
+    await controller.handleCallerUtterance('Actually, I prefer 10am');
+
+    // Set up mock to capture what content the merged turn receives
+    let turnContents: string[] = [];
+    mockStartVoiceTurn.mockImplementation(async (opts: { content: string; onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      turnContents.push(opts.content);
+      opts.onTextDelta('Got it, let me check 10am availability.');
+      opts.onComplete();
+      return { runId: `run-${turnContents.length}`, abort: () => {} };
+    });
+
+    // Wait for the short consultation timeout to fire
+    await new Promise((r) => setTimeout(r, 200));
+
+    // A single merged turn should have been fired containing both the
+    // instruction marker and the caller utterance
+    expect(turnContents.length).toBe(1);
+    expect(turnContents[0]).toContain('[USER_INSTRUCTION: Suggest morning slots]');
+    expect(turnContents[0]).toContain('Actually, I prefer 10am');
 
     controller.destroy();
   });

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -243,7 +243,16 @@ export class CallController {
     // Fire-and-forget: unblock the caller so the HTTP response and answer
     // persistence happen immediately, before LLM streaming begins.
     this.runTurn(content)
-      .then(() => this.drainPendingCallerUtterances())
+      .then(() => {
+        // If the answer turn ended the call (e.g. [END_CALL]), don't drain
+        // queued utterances — just discard them to avoid starting a fresh
+        // turn on a dead session.
+        if (this.state === 'idle' && this.isCallCompleted()) {
+          this.pendingCallerUtterances = [];
+          return;
+        }
+        this.drainPendingCallerUtterances();
+      })
       .catch((err) =>
         log.error({ err, callSessionId: this.callSessionId }, 'runTurn failed after user answer'),
       );
@@ -525,8 +534,24 @@ export class CallController {
             this.state = 'idle';
             updateCallSession(this.callSessionId, { status: 'in_progress' });
             expirePendingQuestions(this.callSessionId);
-            this.flushPendingInstructions();
-            this.drainPendingCallerUtterances();
+
+            const hasInstructions = this.pendingInstructions.length > 0;
+            const hasUtterances = this.pendingCallerUtterances.length > 0;
+
+            if (hasInstructions && hasUtterances) {
+              // Merge both queues into a single turn to avoid the race where
+              // flushPendingInstructions fires a turn that gets aborted by
+              // drainPendingCallerUtterances, losing the instructions.
+              const instructionPrefix = this.pendingInstructions
+                .map((instr) => `[USER_INSTRUCTION: ${instr}]`)
+                .join('\n');
+              this.pendingInstructions = [];
+              this.drainPendingCallerUtterances(instructionPrefix);
+            } else if (hasInstructions) {
+              this.flushPendingInstructions();
+            } else if (hasUtterances) {
+              this.drainPendingCallerUtterances();
+            }
           }
         }, getUserConsultationTimeoutMs());
         return;
@@ -611,6 +636,17 @@ export class CallController {
   }
 
   /**
+   * Check whether the underlying call session has already ended.
+   * Used to guard against post-completion work (e.g. draining queued
+   * utterances after an [END_CALL] turn).
+   */
+  private isCallCompleted(): boolean {
+    const session = getCallSession(this.callSessionId);
+    if (!session) return true;
+    return session.status === 'completed' || session.status === 'failed' || session.status === 'cancelled';
+  }
+
+  /**
    * Drain any instructions that were queued while the LLM was active.
    */
   private flushPendingInstructions(): void {
@@ -635,13 +671,28 @@ export class CallController {
    * Drain caller utterances that were queued while waiting_on_user.
    * Only the most recent utterance is processed — older ones are discarded
    * as stale since the caller likely moved on.
+   *
+   * @param contentPrefix — optional string (e.g. instruction markers) to
+   *   prepend to the turn content so instructions and the caller utterance
+   *   are sent as a single turn, avoiding concurrent-turn races.
    */
-  private drainPendingCallerUtterances(): void {
+  private drainPendingCallerUtterances(contentPrefix?: string): void {
     if (this.pendingCallerUtterances.length === 0) return;
 
     // Keep only the most recent utterance; discard stale older ones
     const latest = this.pendingCallerUtterances[this.pendingCallerUtterances.length - 1];
     this.pendingCallerUtterances = [];
+
+    if (contentPrefix) {
+      // Merge prefix content with the caller utterance into a single turn
+      const callerContent = this.formatCallerUtterance(latest.transcript, latest.speaker);
+      const combined = `${contentPrefix}\n${callerContent}`;
+      this.resetSilenceTimer();
+      this.runTurn(combined).catch((err) =>
+        log.error({ err, callSessionId: this.callSessionId }, 'runTurn failed after draining queued caller utterance with prefix'),
+      );
+      return;
+    }
 
     // Fire-and-forget so we don't block the current turn's cleanup.
     this.handleCallerUtterance(latest.transcript, latest.speaker).catch((err) =>

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -69,6 +69,8 @@ export class CallController {
   private isInbound: boolean;
   /** Instructions queued while an LLM turn is in-flight or during waiting_on_user */
   private pendingInstructions: string[] = [];
+  /** Caller utterances queued while waiting_on_user to prevent re-entrant turns */
+  private pendingCallerUtterances: Array<{transcript: string, speaker?: PromptSpeakerContext}> = [];
   /** Ensures the call opener is triggered at most once per call. */
   private initialGreetingStarted = false;
   /** Marks that the next caller turn should be treated as an opening acknowledgment. */
@@ -149,6 +151,17 @@ export class CallController {
    * Handle a final caller utterance from the ConversationRelay.
    */
   async handleCallerUtterance(transcript: string, speaker?: PromptSpeakerContext): Promise<void> {
+    // Do not start a new turn while waiting for guardian input — queue
+    // the utterance so it can be processed after the answer arrives.
+    if (this.state === 'waiting_on_user') {
+      log.warn(
+        { callSessionId: this.callSessionId },
+        'Caller utterance received while waiting_on_user — queued for after answer.',
+      );
+      this.pendingCallerUtterances.push({ transcript, speaker });
+      return;
+    }
+
     const interruptedInFlight = this.state === 'processing' || this.state === 'speaking';
     // If we're already processing or speaking, abort the in-flight generation
     if (interruptedInFlight) {
@@ -229,9 +242,11 @@ export class CallController {
 
     // Fire-and-forget: unblock the caller so the HTTP response and answer
     // persistence happen immediately, before LLM streaming begins.
-    this.runTurn(content).catch((err) =>
-      log.error({ err, callSessionId: this.callSessionId }, 'runTurn failed after user answer'),
-    );
+    this.runTurn(content)
+      .then(() => this.drainPendingCallerUtterances())
+      .catch((err) =>
+        log.error({ err, callSessionId: this.callSessionId }, 'runTurn failed after user answer'),
+      );
     return true;
   }
 
@@ -511,6 +526,7 @@ export class CallController {
             updateCallSession(this.callSessionId, { status: 'in_progress' });
             expirePendingQuestions(this.callSessionId);
             this.flushPendingInstructions();
+            this.drainPendingCallerUtterances();
           }
         }, getUserConsultationTimeoutMs());
         return;
@@ -612,6 +628,24 @@ export class CallController {
     // Fire-and-forget so we don't block the current turn's cleanup.
     this.runTurn(content).catch((err) =>
       log.error({ err, callSessionId: this.callSessionId }, 'runTurn failed after flushing queued instructions'),
+    );
+  }
+
+  /**
+   * Drain caller utterances that were queued while waiting_on_user.
+   * Only the most recent utterance is processed — older ones are discarded
+   * as stale since the caller likely moved on.
+   */
+  private drainPendingCallerUtterances(): void {
+    if (this.pendingCallerUtterances.length === 0) return;
+
+    // Keep only the most recent utterance; discard stale older ones
+    const latest = this.pendingCallerUtterances[this.pendingCallerUtterances.length - 1];
+    this.pendingCallerUtterances = [];
+
+    // Fire-and-forget so we don't block the current turn's cleanup.
+    this.handleCallerUtterance(latest.transcript, latest.speaker).catch((err) =>
+      log.error({ err, callSessionId: this.callSessionId }, 'runTurn failed after draining queued caller utterance'),
     );
   }
 

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -685,7 +685,17 @@ export class CallController {
 
     if (contentPrefix) {
       // Merge prefix content with the caller utterance into a single turn
-      const callerContent = this.formatCallerUtterance(latest.transcript, latest.speaker);
+      let callerContent = this.formatCallerUtterance(latest.transcript, latest.speaker);
+
+      // Preserve opening-ack semantics when draining bypasses handleCallerUtterance
+      if (this.awaitingOpeningAck) {
+        callerContent = callerContent.length > 0
+          ? `${CALL_OPENING_ACK_MARKER}\n${callerContent}`
+          : CALL_OPENING_ACK_MARKER;
+        this.awaitingOpeningAck = false;
+        this.lastSentWasOpener = false;
+      }
+
       const combined = `${contentPrefix}\n${callerContent}`;
       this.resetSilenceTimer();
       this.runTurn(combined).catch((err) =>


### PR DESCRIPTION
Fix re-entrant turns during waiting_on_user state in call controller. When a caller utterance arrives while the controller is waiting for guardian input, queue it instead of starting a new turn. This prevents duplicate [ASK_GUARDIAN] dispatches and fabricated approval paths. Queued utterances are drained when the wait state resolves (answer received or timeout). Part of #8459.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
