### PR TITLE
fix(ios): set sessionId on lazily-created VMs for cached threads

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -393,8 +393,20 @@ class IOSThreadStore: ObservableObject {
         }
         let vm = ChatViewModel(daemonClient: daemonClient)
         viewModels[threadId] = vm
+
+        // Copy sessionId from the thread so the VM joins the existing
+        // daemon session instead of bootstrapping a new one.
+        if let thread = threads.first(where: { $0.id == threadId }) {
+            vm.sessionId = thread.sessionId
+        }
+
         wireReconnectCallback(vm: vm, threadId: threadId)
-        observeForTitleGeneration(vm: vm, threadId: threadId)
+
+        // Only auto-title threads without a daemon session (new local threads).
+        // Daemon threads already have titles from the session list.
+        if threads.first(where: { $0.id == threadId })?.sessionId == nil {
+            observeForTitleGeneration(vm: vm, threadId: threadId)
+        }
         observeForActivityTracking(vm: vm, threadId: threadId)
         return vm
     }


### PR DESCRIPTION
## Summary

- When a user taps a cached thread, `viewModel(for:)` creates a new `ChatViewModel` but previously didn't copy the thread's `sessionId`, causing the VM to bootstrap a new daemon session instead of joining the existing one
- Skip auto-title generation for daemon-backed threads (they already have titles from the session list)

## Implementation

In `viewModel(for:)`, when creating a new VM:
1. Copy `sessionId` from the `IOSThread` to the `ChatViewModel` so it joins the existing daemon session
2. Only call `observeForTitleGeneration` when the thread has no `sessionId` (new local threads)

## Test plan

- [ ] Open a cached thread, send a message → confirm it uses the same daemon session (no new session created)
- [ ] New local threads still get auto-titled after first assistant reply
- [ ] Daemon-backed threads keep their existing titles

This is PR 2 of 3 for the iOS thread list cache optimization. Builds on #8466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
