### PR TITLE
Fix M1 review feedback: end-call drain guard and timeout race

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -49,6 +49,18 @@ mock.module('../config/loader.js', () => ({
   }),
 }));
 
+// ── Call constants mock ──────────────────────────────────────────────
+
+let mockConsultationTimeoutMs = 90_000;
+
+mock.module('../calls/call-constants.js', () => ({
+  getMaxCallDurationMs: () => 12 * 60 * 1000,
+  getUserConsultationTimeoutMs: () => mockConsultationTimeoutMs,
+  SILENCE_TIMEOUT_MS: 30_000,
+  MAX_CALL_DURATION_MS: 3600 * 1000,
+  USER_CONSULTATION_TIMEOUT_MS: 120 * 1000,
+}));
+
 // ── Voice session bridge mock ────────────────────────────────────────
 
 /**
@@ -213,6 +225,8 @@ describe('call-controller', () => {
     resetTables();
     // Reset the bridge mock to default behaviour
     mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(['Hello', ' there']));
+    // Reset consultation timeout to the default (long) value
+    mockConsultationTimeoutMs = 90_000;
   });
 
   // ── handleCallerUtterance ─────────────────────────────────────────
@@ -951,6 +965,87 @@ describe('call-controller', () => {
     const events = getCallEvents(session.id);
     const instructionEvents = events.filter((e) => e.eventType === 'user_instruction_relayed');
     expect(instructionEvents.length).toBe(1);
+
+    controller.destroy();
+  });
+
+  // ── Post-end-call drain guard ───────────────────────────────────
+
+  test('handleUserAnswer: queued caller utterances are discarded (not processed) when answer turn ends the call', async () => {
+    // Trigger ASK_GUARDIAN to enter waiting_on_user state
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Checking. [ASK_GUARDIAN: Confirm cancellation?]'],
+    ));
+    const { session, relay, controller } = setupController();
+    await controller.handleCallerUtterance('I want to cancel');
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    // Queue a caller utterance while waiting
+    await controller.handleCallerUtterance('Never mind, just cancel it');
+
+    // Set up mock so the answer turn ends the call with [END_CALL]
+    let turnContents: string[] = [];
+    mockStartVoiceTurn.mockImplementation(async (opts: { content: string; onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      turnContents.push(opts.content);
+      opts.onTextDelta('Alright, your appointment is cancelled. Goodbye! [END_CALL]');
+      opts.onComplete();
+      return { runId: `run-${turnContents.length}`, abort: () => {} };
+    });
+
+    const accepted = await controller.handleUserAnswer('Yes, cancel it');
+    expect(accepted).toBe(true);
+
+    // Give fire-and-forget turns time to complete
+    await new Promise((r) => setTimeout(r, 100));
+
+    // The answer turn should have fired
+    expect(turnContents.some((c) => c.includes('[USER_ANSWERED: Yes, cancel it]'))).toBe(true);
+    // The queued caller utterance should NOT have been processed — only the answer turn
+    expect(turnContents.length).toBe(1);
+
+    // Call should be completed
+    const updatedSession = getCallSession(session.id);
+    expect(updatedSession!.status).toBe('completed');
+    expect(relay.endCalled).toBe(true);
+
+    controller.destroy();
+  });
+
+  // ── Consultation timeout with merged instructions + utterances ──
+
+  test('consultation timeout: merges pending instructions and caller utterances into a single turn', async () => {
+    // Use a short consultation timeout so we can wait for it in the test
+    mockConsultationTimeoutMs = 50;
+
+    // Trigger ASK_GUARDIAN to enter waiting_on_user state
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Let me check. [ASK_GUARDIAN: What time works?]'],
+    ));
+    const { controller } = setupController();
+    await controller.handleCallerUtterance('Book me in');
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    // Queue an instruction and a caller utterance while waiting
+    await controller.handleUserInstruction('Suggest morning slots');
+    await controller.handleCallerUtterance('Actually, I prefer 10am');
+
+    // Set up mock to capture what content the merged turn receives
+    let turnContents: string[] = [];
+    mockStartVoiceTurn.mockImplementation(async (opts: { content: string; onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      turnContents.push(opts.content);
+      opts.onTextDelta('Got it, let me check 10am availability.');
+      opts.onComplete();
+      return { runId: `run-${turnContents.length}`, abort: () => {} };
+    });
+
+    // Wait for the short consultation timeout to fire
+    await new Promise((r) => setTimeout(r, 200));
+
+    // A single merged turn should have been fired containing both the
+    // instruction marker and the caller utterance
+    expect(turnContents.length).toBe(1);
+    expect(turnContents[0]).toContain('[USER_INSTRUCTION: Suggest morning slots]');
+    expect(turnContents[0]).toContain('Actually, I prefer 10am');
 
     controller.destroy();
   });

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -243,7 +243,16 @@ export class CallController {
     // Fire-and-forget: unblock the caller so the HTTP response and answer
     // persistence happen immediately, before LLM streaming begins.
     this.runTurn(content)
-      .then(() => this.drainPendingCallerUtterances())
+      .then(() => {
+        // If the answer turn ended the call (e.g. [END_CALL]), don't drain
+        // queued utterances — just discard them to avoid starting a fresh
+        // turn on a dead session.
+        if (this.state === 'idle' && this.isCallCompleted()) {
+          this.pendingCallerUtterances = [];
+          return;
+        }
+        this.drainPendingCallerUtterances();
+      })
       .catch((err) =>
         log.error({ err, callSessionId: this.callSessionId }, 'runTurn failed after user answer'),
       );
@@ -525,8 +534,24 @@ export class CallController {
             this.state = 'idle';
             updateCallSession(this.callSessionId, { status: 'in_progress' });
             expirePendingQuestions(this.callSessionId);
-            this.flushPendingInstructions();
-            this.drainPendingCallerUtterances();
+
+            const hasInstructions = this.pendingInstructions.length > 0;
+            const hasUtterances = this.pendingCallerUtterances.length > 0;
+
+            if (hasInstructions && hasUtterances) {
+              // Merge both queues into a single turn to avoid the race where
+              // flushPendingInstructions fires a turn that gets aborted by
+              // drainPendingCallerUtterances, losing the instructions.
+              const instructionPrefix = this.pendingInstructions
+                .map((instr) => `[USER_INSTRUCTION: ${instr}]`)
+                .join('\n');
+              this.pendingInstructions = [];
+              this.drainPendingCallerUtterances(instructionPrefix);
+            } else if (hasInstructions) {
+              this.flushPendingInstructions();
+            } else if (hasUtterances) {
+              this.drainPendingCallerUtterances();
+            }
           }
         }, getUserConsultationTimeoutMs());
         return;
@@ -611,6 +636,17 @@ export class CallController {
   }
 
   /**
+   * Check whether the underlying call session has already ended.
+   * Used to guard against post-completion work (e.g. draining queued
+   * utterances after an [END_CALL] turn).
+   */
+  private isCallCompleted(): boolean {
+    const session = getCallSession(this.callSessionId);
+    if (!session) return true;
+    return session.status === 'completed' || session.status === 'failed' || session.status === 'cancelled';
+  }
+
+  /**
    * Drain any instructions that were queued while the LLM was active.
    */
   private flushPendingInstructions(): void {
@@ -635,13 +671,28 @@ export class CallController {
    * Drain caller utterances that were queued while waiting_on_user.
    * Only the most recent utterance is processed — older ones are discarded
    * as stale since the caller likely moved on.
+   *
+   * @param contentPrefix — optional string (e.g. instruction markers) to
+   *   prepend to the turn content so instructions and the caller utterance
+   *   are sent as a single turn, avoiding concurrent-turn races.
    */
-  private drainPendingCallerUtterances(): void {
+  private drainPendingCallerUtterances(contentPrefix?: string): void {
     if (this.pendingCallerUtterances.length === 0) return;
 
     // Keep only the most recent utterance; discard stale older ones
     const latest = this.pendingCallerUtterances[this.pendingCallerUtterances.length - 1];
     this.pendingCallerUtterances = [];
+
+    if (contentPrefix) {
+      // Merge prefix content with the caller utterance into a single turn
+      const callerContent = this.formatCallerUtterance(latest.transcript, latest.speaker);
+      const combined = `${contentPrefix}\n${callerContent}`;
+      this.resetSilenceTimer();
+      this.runTurn(combined).catch((err) =>
+        log.error({ err, callSessionId: this.callSessionId }, 'runTurn failed after draining queued caller utterance with prefix'),
+      );
+      return;
+    }
 
     // Fire-and-forget so we don't block the current turn's cleanup.
     this.handleCallerUtterance(latest.transcript, latest.speaker).catch((err) =>


### PR DESCRIPTION
Address review feedback on #8465: (1) Skip draining queued utterances after an end-call turn to prevent post-goodbye LLM work. (2) Merge pending instructions into drained caller utterance during consultation timeout to prevent instruction loss from concurrent turns. Part of #8459.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
