### PR TITLE
fix(ios): preserve thread id during cached merge override

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -344,6 +344,7 @@ class IOSThreadStore: ObservableObject {
                 for var restored in restoredThreads {
                     if let local = localOverrides[restored.sessionId ?? ""] {
                         restored = IOSThread(
+                            id: restored.id,
                             title: local.title,
                             createdAt: restored.createdAt,
                             lastActivityAt: restored.lastActivityAt,


### PR DESCRIPTION
## Summary

- Pass `id: restored.id` when reconstructing an IOSThread for locally-edited overrides in the Case 2 (cached) merge path
- Without it, `IOSThread.init` defaulted to `UUID()`, generating a new id that didn't match the VM stored under the original `restored.id`, orphaning the VM

## Test plan

- [ ] Rename a cached thread before daemon response → thread retains its VM association after daemon refresh
- [ ] Archive/unarchive a cached thread → thread still shows history correctly after daemon refresh

Fixes review feedback from #8468.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
