### PR TITLE
M3: Daemon Finalization Mapping + Attachment Linking (#8454)

### DIFF
--- a/assistant/src/__tests__/cu-session-finalized.test.ts
+++ b/assistant/src/__tests__/cu-session-finalized.test.ts
@@ -36,10 +36,11 @@ mock.module('../config/loader.js', () => ({
 }));
 
 import { initializeDb, getDb, resetDb } from '../memory/db.js';
-import { attachments } from '../memory/schema.js';
+import { attachments, messages } from '../memory/schema.js';
 import { createConversation, addMessage } from '../memory/conversation-store.js';
 import { getAttachmentMetadataForMessage } from '../memory/attachments-store.js';
-import { handleRecordingStatus } from '../daemon/handlers/computer-use.js';
+import { handleRecordingStatus, cuSessionAttachConversationId } from '../daemon/handlers/computer-use.js';
+import { eq } from 'drizzle-orm';
 import type { RecordingStatus } from '../daemon/ipc-contract/computer-use.js';
 import type { HandlerContext } from '../daemon/handlers/shared.js';
 
@@ -56,6 +57,7 @@ function resetTables() {
   db.run('DELETE FROM attachments');
   db.run('DELETE FROM messages');
   db.run('DELETE FROM conversations');
+  cuSessionAttachConversationId.clear();
 }
 
 function createMockSocket(): net.Socket {
@@ -92,11 +94,15 @@ describe('handleRecordingStatus - recording finalization', () => {
 
   test('creates file-backed attachment when recording stops with filePath', () => {
     const sessionId = 'test-session-001';
+    const conversationId = 'conv-001';
 
-    // Create conversation and messages using sessionId as conversationId
-    createConversation(sessionId);
-    addMessage(sessionId, 'user', 'Start the test');
-    addMessage(sessionId, 'assistant', 'Running the test now');
+    // Set up the attachToConversationId mapping
+    cuSessionAttachConversationId.set(sessionId, conversationId);
+
+    // Create conversation and messages using the target conversationId
+    createConversation(conversationId);
+    addMessage(conversationId, 'user', 'Start the test');
+    addMessage(conversationId, 'assistant', 'Running the test now');
 
     // Create a real recording file
     const filePath = join(testDir, 'recording-001.mov');
@@ -124,10 +130,13 @@ describe('handleRecordingStatus - recording finalization', () => {
 
   test('links attachment to latest assistant message', () => {
     const sessionId = 'test-session-002';
+    const conversationId = 'conv-002';
 
-    createConversation(sessionId);
-    addMessage(sessionId, 'user', 'Do something');
-    const assistantMsg = addMessage(sessionId, 'assistant', 'Done');
+    cuSessionAttachConversationId.set(sessionId, conversationId);
+
+    createConversation(conversationId);
+    addMessage(conversationId, 'user', 'Do something');
+    const assistantMsg = addMessage(conversationId, 'assistant', 'Done');
 
     const filePath = join(testDir, 'recording-002.mp4');
     writeFileSync(filePath, 'video content');
@@ -148,11 +157,54 @@ describe('handleRecordingStatus - recording finalization', () => {
     expect(attachmentMeta[0].filePath).toBe(filePath);
   });
 
+  test('creates assistant message when none exists in target conversation', () => {
+    const sessionId = 'test-session-create-msg';
+    const conversationId = 'conv-create-msg';
+
+    cuSessionAttachConversationId.set(sessionId, conversationId);
+
+    // Create conversation with only a user message — no assistant message
+    createConversation(conversationId);
+    addMessage(conversationId, 'user', 'Start recording');
+
+    const filePath = join(testDir, 'recording-create-msg.mov');
+    writeFileSync(filePath, 'video data');
+
+    const msg: RecordingStatus = {
+      type: 'recording_status',
+      sessionId,
+      status: 'stopped',
+      filePath,
+      durationMs: 2000,
+    };
+
+    handleRecordingStatus(msg, createMockSocket(), createMockCtx());
+
+    // A new assistant message should have been created
+    const db = getDb();
+    const assistantMsgs = db
+      .select()
+      .from(messages)
+      .where(eq(messages.conversationId, conversationId))
+      .all()
+      .filter(m => m.role === 'assistant');
+    expect(assistantMsgs.length).toBe(1);
+    expect(assistantMsgs[0].content).toBe('Screen recording attached.');
+
+    // Attachment should be linked to that new message
+    const attachmentMeta = getAttachmentMetadataForMessage(assistantMsgs[0].id);
+    expect(attachmentMeta.length).toBe(1);
+    expect(attachmentMeta[0].filePath).toBe(filePath);
+  });
+
   test('does not crash when filePath does not exist', () => {
     const sessionId = 'test-session-003';
+    const conversationId = 'conv-003';
 
-    createConversation(sessionId);
-    addMessage(sessionId, 'assistant', 'test');
+    cuSessionAttachConversationId.set(sessionId, conversationId);
+
+    createConversation(conversationId);
+    addMessage(conversationId, 'assistant', 'test');
 
     const msg: RecordingStatus = {
       type: 'recording_status',
@@ -173,8 +225,8 @@ describe('handleRecordingStatus - recording finalization', () => {
     expect(rows.length).toBe(0);
   });
 
-  test('does not create attachment when session has no conversation', () => {
-    // Session doesn't exist as a conversation, so no messages to link to
+  test('does not create attachment when no attachToConversationId is set', () => {
+    // No mapping entry — simulates a session without attachToConversationId
     const sessionId = 'orphan-session';
 
     const filePath = join(testDir, 'recording-orphan.mov');
@@ -188,7 +240,7 @@ describe('handleRecordingStatus - recording finalization', () => {
       durationMs: 1000,
     };
 
-    // Should not throw even when there's no conversation/messages
+    // Should not throw even when there's no mapping
     expect(() => {
       handleRecordingStatus(msg, createMockSocket(), createMockCtx());
     }).not.toThrow();

--- a/assistant/src/daemon/handlers/computer-use.ts
+++ b/assistant/src/daemon/handlers/computer-use.ts
@@ -1,6 +1,7 @@
 import * as net from 'node:net';
 import { existsSync, statSync } from 'node:fs';
 import { basename } from 'node:path';
+import { v4 as uuidv4 } from 'uuid';
 import { getConfig } from '../../config/loader.js';
 import { getFailoverProvider } from '../../providers/registry.js';
 import { RateLimitProvider } from '../../providers/ratelimit.js';
@@ -21,6 +22,9 @@ import { log, defineHandlers, type HandlerContext } from './shared.js';
 
 const cuObservationSequenceBySession = new Map<string, number>();
 
+/** Stores the conversation ID to attach recordings to, keyed by CU session ID. */
+export const cuSessionAttachConversationId = new Map<string, string>();
+
 function removeCuSessionReferences(
   ctx: HandlerContext,
   sessionId: string,
@@ -32,6 +36,7 @@ function removeCuSessionReferences(
   }
   ctx.cuSessions.delete(sessionId);
   cuObservationSequenceBySession.delete(sessionId);
+  cuSessionAttachConversationId.delete(sessionId);
   ctx.cuObservationParseSequence.delete(sessionId);
   for (const [sock, ids] of ctx.socketToCuSession) {
     if (ids.delete(sessionId) && ids.size === 0) {
@@ -92,6 +97,10 @@ export function handleCuSessionCreate(
     ctx.socketToCuSession.set(socket, sessionIds);
   }
   sessionIds.add(msg.sessionId);
+
+  if (msg.attachToConversationId) {
+    cuSessionAttachConversationId.set(msg.sessionId, msg.attachToConversationId);
+  }
 
   log.info({ sessionId: msg.sessionId, taskLength: msg.task.length }, 'Computer-use session created');
 }
@@ -209,9 +218,12 @@ export function handleRecordingStatus(
         return;
       }
 
-      // Find the latest assistant message BEFORE creating the attachment to
-      // avoid orphaned attachment rows when no message exists to link to.
-      const conversationId = msg.sessionId;
+      const conversationId = cuSessionAttachConversationId.get(msg.sessionId);
+      if (!conversationId) {
+        log.warn({ sessionId: msg.sessionId }, 'No attachToConversationId found for session — cannot link recording');
+        return;
+      }
+
       const db = getDb();
       const latestAssistantMsg = db
         .select({ id: messages.id })
@@ -220,9 +232,21 @@ export function handleRecordingStatus(
         .orderBy(desc(messages.createdAt))
         .get();
 
-      if (!latestAssistantMsg) {
-        log.warn({ sessionId: msg.sessionId }, 'No assistant message found in session to link recording attachment — skipping attachment creation');
-        return;
+      let messageId: string;
+      if (latestAssistantMsg) {
+        messageId = latestAssistantMsg.id;
+      } else {
+        // Create a minimal assistant message to hold the recording attachment
+        const newMsgId = uuidv4();
+        db.insert(messages).values({
+          id: newMsgId,
+          conversationId,
+          role: 'assistant',
+          content: 'Screen recording attached.',
+          createdAt: Date.now(),
+        }).run();
+        messageId = newMsgId;
+        log.info({ sessionId: msg.sessionId, conversationId, messageId }, 'Created assistant message for recording attachment');
       }
 
       const stat = statSync(msg.filePath);
@@ -236,8 +260,8 @@ export function handleRecordingStatus(
       const attachment = uploadFileBackedAttachment(filename, mimeType, msg.filePath, sizeBytes);
       log.info({ sessionId: msg.sessionId, attachmentId: attachment.id, sizeBytes, filePath: msg.filePath }, 'Created file-backed attachment for recording');
 
-      linkAttachmentToMessage(latestAssistantMsg.id, attachment.id, 0);
-      log.info({ sessionId: msg.sessionId, messageId: latestAssistantMsg.id, attachmentId: attachment.id }, 'Linked recording attachment to assistant message');
+      linkAttachmentToMessage(messageId, attachment.id, 0);
+      log.info({ sessionId: msg.sessionId, messageId, attachmentId: attachment.id }, 'Linked recording attachment to assistant message');
     } catch (err) {
       log.error({ err, sessionId: msg.sessionId, filePath: msg.filePath }, 'Failed to create attachment for recording');
     }


### PR DESCRIPTION
## Summary
- Store attachToConversationId from CuSessionCreate in module-level map
- Fix handleRecordingStatus to use stored conversationId instead of sessionId
- Create assistant message if none exists in target conversation
- Clean up map on session removal

Part of #8451 (Standalone Screen Recording Skill)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
