### PR TITLE
fix(ios): only clear thread cache on confirmed empty session list

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -271,8 +271,11 @@ class IOSThreadStore: ObservableObject {
 
         let filteredSessions = response.sessions.filter { $0.threadType != "private" }
 
-        // Handle empty first-page response: clear stale cached sessions.
-        if filteredSessions.isEmpty && threadListOffset == 0 {
+        // Handle confirmed-empty first-page response: clear stale cached sessions.
+        // Only clear when hasMore is explicitly false (authoritative empty result).
+        // Transient failures (HTTP errors, decode errors) emit hasMore: nil and must
+        // not wipe the cache — the user should keep seeing cached threads.
+        if filteredSessions.isEmpty && threadListOffset == 0 && response.hasMore == false {
             let keepThreads = threads.filter { $0.sessionId == nil || $0.isPrivate }
             for thread in threads where thread.sessionId != nil && !thread.isPrivate {
                 viewModels.removeValue(forKey: thread.id)


### PR DESCRIPTION
## Summary

- Gate empty first-page cache clearing on `hasMore == false` (authoritative empty result)
- `HTTPDaemonClient` emits `sessions: []` with `hasMore: nil` on transient failures (HTTP non-200, decode errors, network errors)
- Without this fix, a temporary network glitch would incorrectly wipe the cached thread list

## Test plan

- [ ] Network error during session list fetch → cached threads remain visible
- [ ] Daemon genuinely has no sessions (`hasMore: false`) → stale cached threads cleared

Fixes Codex review feedback from #8468.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
