### PR TITLE
Fix opening-ack in consultation timeout drain path

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -685,7 +685,17 @@ export class CallController {
 
     if (contentPrefix) {
       // Merge prefix content with the caller utterance into a single turn
-      const callerContent = this.formatCallerUtterance(latest.transcript, latest.speaker);
+      let callerContent = this.formatCallerUtterance(latest.transcript, latest.speaker);
+
+      // Preserve opening-ack semantics when draining bypasses handleCallerUtterance
+      if (this.awaitingOpeningAck) {
+        callerContent = callerContent.length > 0
+          ? `${CALL_OPENING_ACK_MARKER}\n${callerContent}`
+          : CALL_OPENING_ACK_MARKER;
+        this.awaitingOpeningAck = false;
+        this.lastSentWasOpener = false;
+      }
+
       const combined = `${contentPrefix}\n${callerContent}`;
       this.resetSilenceTimer();
       this.runTurn(combined).catch((err) =>


### PR DESCRIPTION
Address Codex P2 review on #8471: preserve CALL_OPENING_ACK marker handling in the merged consultation-timeout drain path. Check and reset awaitingOpeningAck when draining queued caller utterances. Part of #8459.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
