### PR TITLE
M4: Wire Recorder Into CU Session Lifecycle (#8455)

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -203,6 +203,7 @@ final class ComputerUseSession: ObservableObject {
                 log.error("Failed to send session abort message: \(error)")
             }
             logger.finishSession(result: "failed: no window")
+            await stopRecorderIfNeeded()
             return
         }
 
@@ -287,20 +288,28 @@ final class ComputerUseSession: ObservableObject {
         }
 
         // Stop recording if it was started
-        if requiresRecording && recordingState == .started {
-            if let recorder = screenRecorder {
-                do {
-                    let result = try await recorder.stop()
-                    updateRecordingStopped(filePath: result.filePath, durationMs: result.durationMs)
-                } catch {
-                    log.error("Failed to stop screen recording: \(error.localizedDescription)")
-                    updateRecordingState(.failed(reason: error.localizedDescription))
-                }
-            } else {
-                updateRecordingState(.stopped)
-            }
-            screenRecorder = nil
+        if requiresRecording {
+            await stopRecorderIfNeeded()
         }
+    }
+
+    // MARK: - Recording Cleanup
+
+    /// Ensures the screen recorder is stopped and cleaned up.
+    /// Safe to call even when no recorder is active.
+    private func stopRecorderIfNeeded() async {
+        guard let recorder = screenRecorder, recorder.isRecording else {
+            screenRecorder = nil
+            return
+        }
+        do {
+            let result = try await recorder.stop()
+            updateRecordingStopped(filePath: result.filePath, durationMs: result.durationMs)
+        } catch {
+            log.error("Failed to stop screen recording during cleanup: \(error.localizedDescription)")
+            updateRecordingState(.failed(reason: error.localizedDescription))
+        }
+        screenRecorder = nil
     }
 
     // MARK: - Action Handler

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -67,6 +67,7 @@ final class ComputerUseSession: ObservableObject {
     private let verifier: ActionVerifier
     private let logger: SessionLogger
     private let initialDelayMs: UInt64
+    private var screenRecorder: ScreenRecorder?
     private var didChromeAccessibilityCheck = false
     private var previousAXTreeText: String?
     private var previousElements: [AXElement]?
@@ -130,11 +131,21 @@ final class ComputerUseSession: ObservableObject {
         log.info("Session starting — task: \(self.task, privacy: .public)")
 
         // Start recording if required — must succeed before destructive actions are allowed.
-        // When a real ScreenRecorder is wired up, its start() call goes here and
-        // updateRecordingState(.started) should only be called after it confirms recording.
         if requiresRecording {
-            // TODO: call screenRecorder.start() and only transition on success
-            updateRecordingState(.started)
+            let recorder = ScreenRecorder()
+            self.screenRecorder = recorder
+            do {
+                try await recorder.start(
+                    captureScope: recordingOptions?.captureScope,
+                    displayId: recordingOptions?.displayId,
+                    windowId: recordingOptions?.windowId,
+                    includeAudio: recordingOptions?.includeAudio ?? false
+                )
+                updateRecordingState(.started)
+            } catch {
+                log.error("Failed to start screen recording: \(error.localizedDescription)")
+                updateRecordingState(.failed(reason: error.localizedDescription))
+            }
         }
 
         let screenSize = screenCapture.screenSize()
@@ -277,7 +288,18 @@ final class ComputerUseSession: ObservableObject {
 
         // Stop recording if it was started
         if requiresRecording && recordingState == .started {
-            updateRecordingState(.stopped)
+            if let recorder = screenRecorder {
+                do {
+                    let result = try await recorder.stop()
+                    updateRecordingStopped(filePath: result.filePath, durationMs: result.durationMs)
+                } catch {
+                    log.error("Failed to stop screen recording: \(error.localizedDescription)")
+                    updateRecordingState(.failed(reason: error.localizedDescription))
+                }
+            } else {
+                updateRecordingState(.stopped)
+            }
+            screenRecorder = nil
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace TODO placeholder with real ScreenRecorder.start() call
- Wire stop path to call ScreenRecorder.stop() and send filePath/durationMs
- Handle recording start/stop errors gracefully

Part of #8451 (Standalone Screen Recording Skill)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
