### PR TITLE
fix: add NaN validation to CLI parseInt calls

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -261,7 +261,13 @@ export async function startCli(): Promise<void> {
     process.stdout.write(`\u2514 > `);
 
     rl.once('line', (answer) => {
-      const idx = parseInt(answer.trim(), 10) - 1;
+      const parsed = parseInt(answer.trim(), 10);
+      if (Number.isNaN(parsed)) {
+        process.stdout.write('  Invalid input — enter a number.\n');
+        renderPatternSelection(req, decision);
+        return;
+      }
+      const idx = parsed - 1;
       if (idx >= 0 && idx < req.allowlistOptions.length) {
         const selectedPattern = req.allowlistOptions[idx].pattern;
         // pendingConfirmation stays true through scope selection
@@ -288,8 +294,14 @@ export async function startCli(): Promise<void> {
     process.stdout.write(`\u2514 > `);
 
     rl.once('line', (answer) => {
+      const parsed = parseInt(answer.trim(), 10);
+      if (Number.isNaN(parsed)) {
+        process.stdout.write('  Invalid input — enter a number.\n');
+        renderScopeSelection(req, selectedPattern, decision);
+        return;
+      }
       pendingConfirmation = false;
-      const idx = parseInt(answer.trim(), 10) - 1;
+      const idx = parsed - 1;
       if (idx >= 0 && idx < req.scopeOptions.length) {
         send({
           type: 'confirmation_response',
@@ -327,7 +339,13 @@ export async function startCli(): Promise<void> {
         send({ type: 'session_create' });
         return;
       }
-      const idx = parseInt(trimmed, 10) - 1;
+      const parsed = parseInt(trimmed, 10);
+      if (Number.isNaN(parsed)) {
+        process.stdout.write('  Invalid input — enter a number or "n".\n');
+        renderSessionPicker(sessions);
+        return;
+      }
+      const idx = parsed - 1;
       if (idx >= 0 && idx < sessions.length) {
         if (sessions[idx].id === sessionId) {
           // Already on this session


### PR DESCRIPTION
Add NaN validation after parseInt() calls in CLI to provide user-friendly error messages instead of silent failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
