### PR TITLE
fix: add warning when swarm plan tasks are truncated

### DIFF
--- a/assistant/src/swarm/plan-validator.ts
+++ b/assistant/src/swarm/plan-validator.ts
@@ -38,8 +38,9 @@ export function validateAndNormalizePlan(
   }));
   const originalIds = new Set(tasks.map((task) => task.id));
 
-  // --- Task count limit (silent truncation) ---
+  // --- Task count limit ---
   if (tasks.length > limits.maxTasks) {
+    issues.push(`Plan truncated from ${tasks.length} tasks to ${limits.maxTasks}`);
     tasks = tasks.slice(0, limits.maxTasks);
   }
 


### PR DESCRIPTION
Add an issue/warning message when tasks exceed maxTasks limit and get silently truncated in plan-validator.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
