### PR TITLE
fix: add timeout-minutes to gateway CI workflow

### DIFF
--- a/.github/workflows/ci-main-gateway.yaml
+++ b/.github/workflows/ci-main-gateway.yaml
@@ -11,6 +11,7 @@ jobs:
   checks:
     name: Lint, Type Check & Test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: gateway


### PR DESCRIPTION
Add timeout-minutes: 10 to ci-main-gateway.yaml to prevent runaway CI jobs, matching the pattern in ci-main-assistant.yaml.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
