### PR TITLE
fix: remove unused imports and fix null check in notifications

### DIFF
--- a/assistant/src/notifications/deliveries-store.ts
+++ b/assistant/src/notifications/deliveries-store.ts
@@ -6,7 +6,7 @@
  * (decision, channel, destination) are tracked via the `attempt` counter.
  */
 
-import { and, eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { getDb } from '../memory/db.js';
 import { notificationDeliveries } from '../memory/schema.js';
 import type { NotificationChannel, NotificationDeliveryStatus } from './types.js';

--- a/assistant/src/notifications/preference-extractor.ts
+++ b/assistant/src/notifications/preference-extractor.ts
@@ -179,7 +179,7 @@ function validateExtractionOutput(input: Record<string, unknown>): ExtractionRes
   const preferences: ExtractedPreference[] = [];
 
   for (const raw of input.preferences) {
-    if (typeof raw !== 'object' || raw === null) continue;
+    if (typeof raw !== 'object' || !raw) continue;
     const p = raw as Record<string, unknown>;
 
     if (typeof p.preferenceText !== 'string' || !p.preferenceText.trim()) continue;

--- a/assistant/src/notifications/preferences-store.ts
+++ b/assistant/src/notifications/preferences-store.ts
@@ -7,7 +7,7 @@
  * resolution.
  */
 
-import { and, desc, eq } from 'drizzle-orm';
+import { desc, eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from '../memory/db.js';
 import { notificationPreferences } from '../memory/schema.js';


### PR DESCRIPTION
Remove unused 'and' import from deliveries-store.ts and preferences-store.ts. Fix === null check in preference-extractor.ts to use \!raw instead, per ESLint no-restricted-syntax rule.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
