### PR TITLE
fix: add max_tokens cap to swarm synthesis LLM call

### DIFF
--- a/assistant/src/swarm/synthesizer.ts
+++ b/assistant/src/swarm/synthesizer.ts
@@ -13,10 +13,21 @@ export async function synthesizeResults(opts: {
 }): Promise<string> {
   const { objective, results, provider, model } = opts;
 
-  const taskSummaries = results.map((r) => {
+  // Cap individual summaries and total input to avoid blowing up context on large plans
+  const MAX_SUMMARY_CHARS = 500;
+  const MAX_TOTAL_CHARS = 12_000;
+
+  let taskSummaries = results.map((r) => {
     const status = r.status === 'completed' ? 'completed' : 'FAILED';
-    return `[${r.taskId}] (${status}): ${r.summary}`;
+    const summary = r.summary.length > MAX_SUMMARY_CHARS
+      ? r.summary.slice(0, MAX_SUMMARY_CHARS) + '...'
+      : r.summary;
+    return `[${r.taskId}] (${status}): ${summary}`;
   }).join('\n');
+
+  if (taskSummaries.length > MAX_TOTAL_CHARS) {
+    taskSummaries = taskSummaries.slice(0, MAX_TOTAL_CHARS) + '\n... (truncated)';
+  }
 
   const systemPrompt = 'You are a synthesis assistant. Combine the outputs from multiple specialist workers into a coherent, concise final answer. Focus on the user\'s original objective.';
 


### PR DESCRIPTION
Add input truncation to the LLM synthesis call in synthesizer.ts to prevent unbounded context from large plans. Individual task summaries are capped at 500 chars and total input at 12K chars. The output max_tokens was already set to 4096.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
