### PR TITLE
fix: replace force-unwrap with safe optional binding in AXTreeDiff

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/AXTreeDiff.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/AXTreeDiff.swift
@@ -68,9 +68,10 @@ enum AXTreeDiff {
 
             // Remove identical pairs (unchanged elements)
             for snap in Array(unmatchedPrev) {
-                if let idx = unmatchedCurr.firstIndex(of: snap) {
+                if let idx = unmatchedCurr.firstIndex(of: snap),
+                   let prevIdx = unmatchedPrev.firstIndex(of: snap) {
                     unmatchedCurr.remove(at: idx)
-                    unmatchedPrev.remove(at: unmatchedPrev.firstIndex(of: snap)!)
+                    unmatchedPrev.remove(at: prevIdx)
                 }
             }
 


### PR DESCRIPTION
Replace force-unwrap of firstIndex(of:) with guard-let to prevent crash when index is not found in AXTreeDiff.swift.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
