### PR TITLE
fix: replace hardcoded model ID with modelIntent in swarm orchestrator

### DIFF
--- a/assistant/src/swarm/orchestrator.ts
+++ b/assistant/src/swarm/orchestrator.ts
@@ -224,7 +224,9 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
       objective: plan.objective,
       results: allResults,
       provider: opts.synthesisProvider,
-      model: opts.synthesisModel ?? 'claude-sonnet-4-6',
+      ...(opts.synthesisModel
+        ? { model: opts.synthesisModel }
+        : { modelIntent: 'quality-optimized' as const }),
     });
   } else {
     if (!signal?.aborted) onStatus?.({ kind: 'synthesis_started' });

--- a/assistant/src/swarm/synthesizer.ts
+++ b/assistant/src/swarm/synthesizer.ts
@@ -1,4 +1,4 @@
-import type { Provider, Message } from '../providers/types.js';
+import type { Provider, Message, ModelIntent } from '../providers/types.js';
 import type { SwarmTaskResult } from './types.js';
 
 /**
@@ -9,9 +9,10 @@ export async function synthesizeResults(opts: {
   objective: string;
   results: SwarmTaskResult[];
   provider: Provider;
-  model: string;
+  model?: string;
+  modelIntent?: ModelIntent;
 }): Promise<string> {
-  const { objective, results, provider, model } = opts;
+  const { objective, results, provider, model, modelIntent } = opts;
 
   const taskSummaries = results.map((r) => {
     const status = r.status === 'completed' ? 'completed' : 'FAILED';
@@ -36,7 +37,7 @@ Synthesize these results into a clear, complete answer for the user.`;
       messages,
       undefined,
       systemPrompt,
-      { config: { max_tokens: 4096, model } },
+      { config: { max_tokens: 4096, ...(model ? { model } : { modelIntent }) } },
     );
 
     const textBlock = response.content.find((b) => b.type === 'text');


### PR DESCRIPTION
Replace hardcoded 'claude-sonnet-4-6' with modelIntent: 'quality-optimized' in swarm orchestrator synthesis, following the provider abstraction principle.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
