### PR TITLE
fix: cap unbounded Set growth in channel delivery store

### DIFF
--- a/assistant/src/memory/channel-delivery-store.ts
+++ b/assistant/src/memory/channel-delivery-store.ts
@@ -381,6 +381,9 @@ const deliveredRuns = new Set<string>();
 /** TTL for delivery claims — 10 minutes, well beyond the poll max-wait. */
 const CLAIM_TTL_MS = 10 * 60 * 1000;
 
+/** Hard cap to bound memory even under sustained high throughput within the TTL window. */
+const MAX_DELIVERED_RUNS = 10_000;
+
 /**
  * Atomically claim the right to deliver the final reply for a run.
  * Returns `true` if this caller won the claim (and should proceed with
@@ -390,11 +393,18 @@ const CLAIM_TTL_MS = 10 * 60 * 1000;
  * execute within the same process. The Set is never persisted; on restart
  * there are no in-flight pollers to race.
  *
- * Claims are automatically evicted after CLAIM_TTL_MS to prevent
- * unbounded Set growth over the lifetime of the process.
+ * Claims are evicted after CLAIM_TTL_MS and the Set is hard-capped at
+ * MAX_DELIVERED_RUNS entries. When the cap is reached, the oldest entries
+ * (by insertion order) are evicted first — safe because older runs are
+ * long past the race window.
  */
 export function claimRunDelivery(runId: string): boolean {
   if (deliveredRuns.has(runId)) return false;
+  if (deliveredRuns.size >= MAX_DELIVERED_RUNS) {
+    // Set iteration order matches insertion order; evict the oldest entry.
+    const oldest = deliveredRuns.values().next().value!;
+    deliveredRuns.delete(oldest);
+  }
   deliveredRuns.add(runId);
   setTimeout(() => deliveredRuns.delete(runId), CLAIM_TTL_MS);
   return true;


### PR DESCRIPTION
Add max size cap (10,000 entries) with oldest-first eviction to the delivered message IDs Set in channel-delivery-store.ts to prevent unbounded memory growth.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
