### PR TITLE
fix: kill clawhub subprocess on timeout to prevent zombie processes

### DIFF
--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -201,8 +201,9 @@ async function runClawhub(args: string[], opts?: { cwd?: string; timeout?: numbe
     stderr: 'pipe',
   });
 
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    setTimeout(() => {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeoutPromise = new Promise<[string, string]>((_, reject) => {
+    timer = setTimeout(() => {
       proc.kill();
       reject(new Error(`clawhub command timed out after ${timeout}ms`));
     }, timeout);
@@ -213,8 +214,11 @@ async function runClawhub(args: string[], opts?: { cwd?: string; timeout?: numbe
       new Response(proc.stdout).text(),
       new Response(proc.stderr).text(),
     ]),
-    timeoutPromise.then(() => ['', ''] as [string, string]),
-  ]);
+    timeoutPromise,
+  ]).finally(() => clearTimeout(timer!));
+
+  // Suppress unhandled rejection from the losing timeout promise
+  timeoutPromise.catch(() => {});
 
   const exitCode = await proc.exited;
 


### PR DESCRIPTION
After Promise.race() timeout, actively kill the subprocess to prevent zombie clawhub processes from accumulating. Also clear the timeout timer on normal completion to prevent unhandled rejections and unnecessary proc.kill() calls on already-exited processes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
