### PR TITLE
Fix: Stop recorder on all Session exit paths (#8478)

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -203,6 +203,7 @@ final class ComputerUseSession: ObservableObject {
                 log.error("Failed to send session abort message: \(error)")
             }
             logger.finishSession(result: "failed: no window")
+            await stopRecorderIfNeeded()
             return
         }
 
@@ -287,20 +288,28 @@ final class ComputerUseSession: ObservableObject {
         }
 
         // Stop recording if it was started
-        if requiresRecording && recordingState == .started {
-            if let recorder = screenRecorder {
-                do {
-                    let result = try await recorder.stop()
-                    updateRecordingStopped(filePath: result.filePath, durationMs: result.durationMs)
-                } catch {
-                    log.error("Failed to stop screen recording: \(error.localizedDescription)")
-                    updateRecordingState(.failed(reason: error.localizedDescription))
-                }
-            } else {
-                updateRecordingState(.stopped)
-            }
-            screenRecorder = nil
+        if requiresRecording {
+            await stopRecorderIfNeeded()
         }
+    }
+
+    // MARK: - Recording Cleanup
+
+    /// Ensures the screen recorder is stopped and cleaned up.
+    /// Safe to call even when no recorder is active.
+    private func stopRecorderIfNeeded() async {
+        guard let recorder = screenRecorder, recorder.isRecording else {
+            screenRecorder = nil
+            return
+        }
+        do {
+            let result = try await recorder.stop()
+            updateRecordingStopped(filePath: result.filePath, durationMs: result.durationMs)
+        } catch {
+            log.error("Failed to stop screen recording during cleanup: \(error.localizedDescription)")
+            updateRecordingState(.failed(reason: error.localizedDescription))
+        }
+        screenRecorder = nil
     }
 
     // MARK: - Action Handler


### PR DESCRIPTION
## Summary
- Add stopRecorderIfNeeded() helper method
- Ensure recorder is stopped on all early exit paths in run()
- Prevents background recording leak on session failure

Addresses Codex feedback on #8478

Part of #8451 (Standalone Screen Recording Skill)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
