### PR TITLE
M5: Runtime HTTP Port Forwarding (#8456)

### DIFF
--- a/clients/macos/vellum-assistant/Utils/RuntimeHTTP.swift
+++ b/clients/macos/vellum-assistant/Utils/RuntimeHTTP.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Resolves the runtime HTTP base URL for the local daemon.
+/// Used to construct URLs like `\(RuntimeHTTP.baseURL)/v1/attachments/\(id)/content`.
+enum RuntimeHTTP {
+    /// Base URL for the local daemon's HTTP server (e.g., "http://localhost:7821").
+    static var baseURL: String {
+        let port = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "7821"
+        return "http://localhost:\(port)"
+    }
+
+    /// Construct a URL for streaming attachment content (video, etc.).
+    static func attachmentContentURL(attachmentId: String) -> URL? {
+        URL(string: "\(baseURL)/v1/attachments/\(attachmentId)/content")
+    }
+}


### PR DESCRIPTION
## Summary
- Add RuntimeHTTP utility enum for resolving daemon HTTP base URL
- Provide attachmentContentURL(attachmentId:) builder for M6 playback
- Centralizes RUNTIME_HTTP_PORT resolution logic

Part of #8451 (Standalone Screen Recording Skill)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
