### PR TITLE
fix: prevent unbounded Set growth in Linear watcher

### DIFF
--- a/assistant/src/watcher/providers/linear.ts
+++ b/assistant/src/watcher/providers/linear.ts
@@ -439,13 +439,23 @@ export const linearProvider: WatcherProvider = {
       // credentialService so that multiple Linear watchers sharing the same credential
       // maintain independent baselines and cannot clobber each other's state.
       const stateCache = getStateCache(watcherKey);
+      const currentIssueIds = new Set<string>();
       for (const issue of assignedIssues) {
+        currentIssueIds.add(issue.id);
         const previousStateId = stateCache.get(issue.id);
         if (previousStateId !== undefined && previousStateId !== issue.state.id) {
           items.push(issueToStatusChangeItem(issue, previousStateId));
         }
         // Always update the map so the next poll has an accurate baseline.
         stateCache.set(issue.id, issue.state.id);
+      }
+
+      // Evict issues no longer returned by the assigned-issues query (unassigned,
+      // completed, archived) so the cache doesn't grow without bound.
+      for (const issueId of stateCache.keys()) {
+        if (!currentIssueIds.has(issueId)) {
+          stateCache.delete(issueId);
+        }
       }
 
       const newWatermark = new Date().toISOString();


### PR DESCRIPTION
Prune stale entries from the per-watcher state cache after each poll cycle. Issues no longer returned by the assigned-issues query (unassigned, completed, archived) are evicted so the cache stays bounded to the current set of assigned issues.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
