### PR TITLE
fix: add DispatchWorkItem cleanup in MainWindowView onDisappear

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -674,6 +674,8 @@ struct MainWindowView: View {
             daemonClient.startSSE()
         }
         .onDisappear {
+            copyThreadConfirmationTimer?.cancel()
+            copyThreadConfirmationTimer = nil
             daemonClient.stopSSE()
         }
         .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in


### PR DESCRIPTION
Cancel the copyThreadConfirmationTimer DispatchWorkItem in onDisappear to prevent leaked work items.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
