### PR TITLE
refactor: extract gateway bearer auth into shared middleware factory

### DIFF
--- a/gateway/src/http/middleware/deliver-auth.ts
+++ b/gateway/src/http/middleware/deliver-auth.ts
@@ -1,0 +1,39 @@
+import type { GatewayConfig } from "../../config.js";
+import { validateBearerToken } from "../auth/bearer.js";
+
+/**
+ * Creates a fail-closed auth check for delivery routes.
+ *
+ * When no bearer token is configured and the route-specific bypass flag is
+ * not set, the request is refused (503) rather than silently allowing
+ * unauthenticated access. The bypass flag is intended for local development
+ * only.
+ *
+ * Returns null when auth passes (caller should continue), or a Response to
+ * short-circuit with.
+ */
+export function checkDeliverAuth(
+  req: Request,
+  config: GatewayConfig,
+  bypassFlag: keyof GatewayConfig,
+): Response | null {
+  if (!config.runtimeProxyBearerToken) {
+    if (config[bypassFlag]) {
+      return null;
+    }
+    return Response.json(
+      { error: "Service not configured: bearer token required" },
+      { status: 503 },
+    );
+  }
+
+  const authResult = validateBearerToken(
+    req.headers.get("authorization"),
+    config.runtimeProxyBearerToken,
+  );
+  if (!authResult.authorized) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return null;
+}

--- a/gateway/src/http/routes/sms-deliver.ts
+++ b/gateway/src/http/routes/sms-deliver.ts
@@ -1,7 +1,7 @@
 import type { GatewayConfig } from "../../config.js";
 import { fetchImpl } from "../../fetch.js";
-import { validateBearerToken } from "../auth/bearer.js";
 import { getLogger } from "../../logger.js";
+import { checkDeliverAuth } from "../middleware/deliver-auth.js";
 
 const log = getLogger("sms-deliver");
 
@@ -88,27 +88,8 @@ export function createSmsDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "Method not allowed" }, { status: 405 });
     }
 
-    // Fail-closed auth: when no bearer token is configured and the explicit
-    // dev-only bypass flag is not set, refuse to serve requests (503) rather
-    // than silently allowing unauthenticated access.
-    if (!config.runtimeProxyBearerToken) {
-      if (config.smsDeliverAuthBypass) {
-        // Dev-only bypass — skip auth entirely.
-      } else {
-        return Response.json(
-          { error: "Service not configured: bearer token required" },
-          { status: 503 },
-        );
-      }
-    } else {
-      const authResult = validateBearerToken(
-        req.headers.get("authorization"),
-        config.runtimeProxyBearerToken,
-      );
-      if (!authResult.authorized) {
-        return Response.json({ error: "Unauthorized" }, { status: 401 });
-      }
-    }
+    const authResponse = checkDeliverAuth(req, config, "smsDeliverAuthBypass");
+    if (authResponse) return authResponse;
 
     // Verify Twilio SMS sending is configured
     if (!config.twilioAccountSid || !config.twilioAuthToken) {

--- a/gateway/src/http/routes/telegram-deliver.ts
+++ b/gateway/src/http/routes/telegram-deliver.ts
@@ -1,6 +1,6 @@
 import type { GatewayConfig } from "../../config.js";
-import { validateBearerToken } from "../auth/bearer.js";
 import { getLogger } from "../../logger.js";
+import { checkDeliverAuth } from "../middleware/deliver-auth.js";
 import type { RuntimeAttachmentMeta } from "../../runtime/client.js";
 import { sendTelegramAttachments, sendTelegramReply } from "../../telegram/send.js";
 
@@ -27,27 +27,8 @@ export function createTelegramDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "Method not allowed" }, { status: 405 });
     }
 
-    // Fail-closed auth: when no bearer token is configured and the explicit
-    // dev-only bypass flag is not set, refuse to serve requests (503) rather
-    // than silently allowing unauthenticated access.
-    if (!config.runtimeProxyBearerToken) {
-      if (config.telegramDeliverAuthBypass) {
-        // Dev-only bypass — skip auth entirely.
-      } else {
-        return Response.json(
-          { error: "Service not configured: bearer token required" },
-          { status: 503 },
-        );
-      }
-    } else {
-      const authResult = validateBearerToken(
-        req.headers.get("authorization"),
-        config.runtimeProxyBearerToken,
-      );
-      if (!authResult.authorized) {
-        return Response.json({ error: "Unauthorized" }, { status: 401 });
-      }
-    }
+    const authResponse = checkDeliverAuth(req, config, "telegramDeliverAuthBypass");
+    if (authResponse) return authResponse;
 
     let body: {
       chatId?: string;

--- a/gateway/src/http/routes/whatsapp-deliver.ts
+++ b/gateway/src/http/routes/whatsapp-deliver.ts
@@ -1,6 +1,6 @@
 import type { GatewayConfig } from "../../config.js";
-import { validateBearerToken } from "../auth/bearer.js";
 import { getLogger } from "../../logger.js";
+import { checkDeliverAuth } from "../middleware/deliver-auth.js";
 import { sendWhatsAppReply } from "../../whatsapp/send.js";
 
 const log = getLogger("whatsapp-deliver");
@@ -14,27 +14,8 @@ export function createWhatsAppDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "Method not allowed" }, { status: 405 });
     }
 
-    // Fail-closed auth: when no bearer token is configured and the explicit
-    // dev-only bypass flag is not set, refuse to serve requests (503) rather
-    // than silently allowing unauthenticated access.
-    if (!config.runtimeProxyBearerToken) {
-      if (config.whatsappDeliverAuthBypass) {
-        // Dev-only bypass — skip auth entirely.
-      } else {
-        return Response.json(
-          { error: "Service not configured: bearer token required" },
-          { status: 503 },
-        );
-      }
-    } else {
-      const authResult = validateBearerToken(
-        req.headers.get("authorization"),
-        config.runtimeProxyBearerToken,
-      );
-      if (!authResult.authorized) {
-        return Response.json({ error: "Unauthorized" }, { status: 401 });
-      }
-    }
+    const authResponse = checkDeliverAuth(req, config, "whatsappDeliverAuthBypass");
+    if (authResponse) return authResponse;
 
     // Verify WhatsApp sending is configured
     if (!config.whatsappPhoneNumberId || !config.whatsappAccessToken) {


### PR DESCRIPTION
Extract duplicated bearer auth logic from telegram-deliver, sms-deliver, and whatsapp-deliver routes into a shared createDeliverAuthMiddleware factory.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
