### PR TITLE
feat: add version tracking for managed skills

### DIFF
--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -125,6 +125,34 @@ export function removeSkillsIndexEntry(id: string): void {
   log.info({ id }, 'Removed managed skill from SKILLS.md index');
 }
 
+// ─── Version metadata ─────────────────────────────────────────────────────────
+
+interface SkillVersionMeta {
+  version: string;
+  installedAt: string;
+}
+
+function getVersionMetaPath(id: string): string {
+  return join(getManagedSkillDir(id), 'version.json');
+}
+
+function writeVersionMeta(id: string, version: string): void {
+  const meta: SkillVersionMeta = { version, installedAt: new Date().toISOString() };
+  atomicWriteFile(getVersionMetaPath(id), JSON.stringify(meta, null, 2) + '\n');
+}
+
+export function readSkillVersion(id: string): string | null {
+  const metaPath = getVersionMetaPath(id);
+  if (!existsSync(metaPath)) return null;
+  try {
+    const raw = readFileSync(metaPath, 'utf-8');
+    const meta: SkillVersionMeta = JSON.parse(raw);
+    return meta.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
 // ─── Create / Delete ─────────────────────────────────────────────────────────
 
 export interface CreateManagedSkillParams {
@@ -138,6 +166,7 @@ export interface CreateManagedSkillParams {
   overwrite?: boolean;
   addToIndex?: boolean;
   includes?: string[];
+  version?: string;
 }
 
 export interface CreateManagedSkillResult {
@@ -184,7 +213,12 @@ export function createManagedSkill(params: CreateManagedSkillParams): CreateMana
 
   mkdirSync(skillDir, { recursive: true });
   atomicWriteFile(skillFilePath, content);
-  log.info({ id: params.id, path: skillFilePath }, 'Created managed skill');
+
+  if (params.version) {
+    writeVersionMeta(params.id, params.version);
+  }
+
+  log.info({ id: params.id, path: skillFilePath, version: params.version }, 'Created managed skill');
 
   let indexUpdated = false;
   if (params.addToIndex !== false) {

--- a/assistant/src/tools/skills/vellum-catalog.ts
+++ b/assistant/src/tools/skills/vellum-catalog.ts
@@ -11,6 +11,7 @@ export interface CatalogEntry {
   description: string;
   emoji?: string;
   includes?: string[];
+  version?: string;
 }
 
 export { fetchCatalogEntries as listCatalogEntries, checkVellumSkill };
@@ -23,9 +24,10 @@ export { fetchCatalogEntries as listCatalogEntries, checkVellumSkill };
 export async function installFromVellumCatalog(skillId: string, options?: { overwrite?: boolean }): Promise<{ success: boolean; skillName?: string; error?: string }> {
   const trimmedId = skillId.trim();
 
-  // Verify skill exists in catalog
-  const exists = await checkVellumSkill(trimmedId);
-  if (!exists) {
+  // Verify skill exists in catalog and get its metadata
+  const catalogEntries = await fetchCatalogEntries();
+  const catalogEntry = catalogEntries.find((e) => e.id === trimmedId);
+  if (!catalogEntry) {
     return { success: false, error: `Skill "${trimmedId}" not found in the Vellum catalog` };
   }
 
@@ -83,6 +85,7 @@ export async function installFromVellumCatalog(skillId: string, options?: { over
     includes,
     overwrite: options?.overwrite ?? true,
     addToIndex: true,
+    version: catalogEntry.version,
   });
 
   if (!result.created) {


### PR DESCRIPTION
Add optional version field to managed skill schema and populate during install/update for update detection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
