### PR TITLE
fix: evict stale issues from Linear state cache to prevent unbounded growth

### DIFF
--- a/assistant/src/watcher/providers/linear.ts
+++ b/assistant/src/watcher/providers/linear.ts
@@ -439,13 +439,23 @@ export const linearProvider: WatcherProvider = {
       // credentialService so that multiple Linear watchers sharing the same credential
       // maintain independent baselines and cannot clobber each other's state.
       const stateCache = getStateCache(watcherKey);
+      const currentIssueIds = new Set<string>();
       for (const issue of assignedIssues) {
+        currentIssueIds.add(issue.id);
         const previousStateId = stateCache.get(issue.id);
         if (previousStateId !== undefined && previousStateId !== issue.state.id) {
           items.push(issueToStatusChangeItem(issue, previousStateId));
         }
         // Always update the map so the next poll has an accurate baseline.
         stateCache.set(issue.id, issue.state.id);
+      }
+
+      // Evict issues no longer in the assigned set (unassigned, completed, etc.)
+      // so the cache stays bounded to the current working set.
+      for (const issueId of stateCache.keys()) {
+        if (!currentIssueIds.has(issueId)) {
+          stateCache.delete(issueId);
+        }
       }
 
       const newWatermark = new Date().toISOString();

--- a/gateway/src/__tests__/reply-path.test.ts
+++ b/gateway/src/__tests__/reply-path.test.ts
@@ -4,24 +4,26 @@ import {
   TELEGRAM_CHANNEL_TRANSPORT_HINTS,
   TELEGRAM_CHANNEL_TRANSPORT_UX_BRIEF,
 } from "../channels/transport-hints.js";
-import { splitText } from "../telegram/send.js";
+import { splitText } from "../util/split-text.js";
 
 describe("splitText", () => {
+  const MAX_LEN = 4000;
+
   test("returns single chunk for short text", () => {
-    const chunks = splitText("Hello!");
+    const chunks = splitText("Hello!", MAX_LEN);
     expect(chunks).toEqual(["Hello!"]);
   });
 
   test("returns single chunk for exactly max length", () => {
-    const text = "x".repeat(4000);
-    const chunks = splitText(text);
+    const text = "x".repeat(MAX_LEN);
+    const chunks = splitText(text, MAX_LEN);
     expect(chunks).toHaveLength(1);
     expect(chunks[0]).toBe(text);
   });
 
   test("splits text exceeding max length", () => {
     const text = "x".repeat(8500);
-    const chunks = splitText(text);
+    const chunks = splitText(text, MAX_LEN);
     expect(chunks).toHaveLength(3);
     expect(chunks[0]).toHaveLength(4000);
     expect(chunks[1]).toHaveLength(4000);
@@ -30,7 +32,7 @@ describe("splitText", () => {
   });
 
   test("handles empty string", () => {
-    const chunks = splitText("");
+    const chunks = splitText("", MAX_LEN);
     expect(chunks).toEqual([""]);
   });
 });

--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -2,6 +2,7 @@ import type { GatewayConfig } from "../config.js";
 import type { ApprovalPayload } from "../http/routes/telegram-deliver.js";
 import { getLogger } from "../logger.js";
 import { downloadAttachment, downloadAttachmentById, type RuntimeAttachmentMeta } from "../runtime/client.js";
+import { splitText } from "../util/split-text.js";
 import { callTelegramApi, callTelegramApiMultipart } from "./api.js";
 
 const log = getLogger("telegram-send");
@@ -12,25 +13,6 @@ const TELEGRAM_MAX_MESSAGE_LEN = 4000;
 export const TELEGRAM_MAX_CALLBACK_DATA_BYTES = 64;
 
 const IMAGE_MIME_PREFIXES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
-
-function splitText(text: string): string[] {
-  if (text.length <= TELEGRAM_MAX_MESSAGE_LEN) {
-    return [text];
-  }
-
-  const chunks: string[] = [];
-  let cursor = 0;
-  while (cursor < text.length) {
-    let end = Math.min(cursor + TELEGRAM_MAX_MESSAGE_LEN, text.length);
-    // Avoid splitting a surrogate pair
-    if (end < text.length && text.charCodeAt(end - 1) >= 0xd800 && text.charCodeAt(end - 1) <= 0xdbff) {
-      end--;
-    }
-    chunks.push(text.slice(cursor, end));
-    cursor = end;
-  }
-  return chunks;
-}
 
 export function buildInlineKeyboard(
   approval: ApprovalPayload,
@@ -59,7 +41,7 @@ export async function sendTelegramReply(
   text: string,
   approval?: ApprovalPayload,
 ): Promise<void> {
-  const chunks = splitText(text);
+  const chunks = splitText(text, TELEGRAM_MAX_MESSAGE_LEN);
 
   for (let i = 0; i < chunks.length; i++) {
     const payload: Record<string, unknown> = {
@@ -158,5 +140,3 @@ export async function sendTypingIndicator(config: GatewayConfig, chatId: string)
     return false;
   }
 }
-
-export { splitText };

--- a/gateway/src/util/split-text.ts
+++ b/gateway/src/util/split-text.ts
@@ -1,0 +1,22 @@
+/**
+ * Split text into chunks that respect a maximum length, avoiding
+ * splits in the middle of Unicode surrogate pairs.
+ */
+export function splitText(text: string, maxLength: number): string[] {
+  if (text.length <= maxLength) {
+    return [text];
+  }
+
+  const chunks: string[] = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    let end = Math.min(cursor + maxLength, text.length);
+    // Avoid splitting a surrogate pair
+    if (end < text.length && text.charCodeAt(end - 1) >= 0xd800 && text.charCodeAt(end - 1) <= 0xdbff) {
+      end--;
+    }
+    chunks.push(text.slice(cursor, end));
+    cursor = end;
+  }
+  return chunks;
+}

--- a/gateway/src/whatsapp/send.ts
+++ b/gateway/src/whatsapp/send.ts
@@ -1,5 +1,6 @@
 import type { GatewayConfig } from "../config.js";
 import { getLogger } from "../logger.js";
+import { splitText } from "../util/split-text.js";
 import { sendWhatsAppTextMessage } from "./api.js";
 
 const log = getLogger("whatsapp-send");
@@ -7,35 +8,12 @@ const log = getLogger("whatsapp-send");
 // WhatsApp supports up to 4096 characters per text message
 const WHATSAPP_MAX_MESSAGE_LEN = 4096;
 
-function splitText(text: string): string[] {
-  if (text.length <= WHATSAPP_MAX_MESSAGE_LEN) {
-    return [text];
-  }
-
-  const chunks: string[] = [];
-  let cursor = 0;
-  while (cursor < text.length) {
-    let end = Math.min(cursor + WHATSAPP_MAX_MESSAGE_LEN, text.length);
-    // Avoid splitting a surrogate pair
-    if (
-      end < text.length &&
-      text.charCodeAt(end - 1) >= 0xd800 &&
-      text.charCodeAt(end - 1) <= 0xdbff
-    ) {
-      end--;
-    }
-    chunks.push(text.slice(cursor, end));
-    cursor = end;
-  }
-  return chunks;
-}
-
 export async function sendWhatsAppReply(
   config: GatewayConfig,
   to: string,
   text: string,
 ): Promise<void> {
-  const chunks = splitText(text);
+  const chunks = splitText(text, WHATSAPP_MAX_MESSAGE_LEN);
 
   for (const chunk of chunks) {
     await sendWhatsAppTextMessage(config, to, chunk);


### PR DESCRIPTION
The per-watcher state cache in linear.ts only added entries but never removed them. Issues that were unassigned or completed would remain in the map indefinitely. After each poll, reconcile the cache by removing entries for issues no longer in the assigned set.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
