### PR TITLE
M2: Provenance Plumbing

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -4482,13 +4482,13 @@ describe('Memory regressions', () => {
     expect(validUnverified.success).toBe(true);
   });
 
-  test('provenanceFromGuardianContext returns guardian default when no context', () => {
+  test('provenanceFromGuardianContext returns unverified_channel default when no context', () => {
     const result = provenanceFromGuardianContext(null);
-    expect(result.provenanceActorRole).toBe('guardian');
+    expect(result.provenanceActorRole).toBe('unverified_channel');
     expect(result.provenanceSourceChannel).toBeUndefined();
 
     const result2 = provenanceFromGuardianContext(undefined);
-    expect(result2.provenanceActorRole).toBe('guardian');
+    expect(result2.provenanceActorRole).toBe('unverified_channel');
   });
 
   test('provenanceFromGuardianContext extracts fields from guardian context', () => {

--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -104,7 +104,7 @@ import {
   searchMemoryItems,
   stripMemoryRecallMessages,
 } from '../memory/retriever.js';
-import { addMessage, createConversation, getConversationMemoryScopeId } from '../memory/conversation-store.js';
+import { addMessage, createConversation, getConversationMemoryScopeId, messageMetadataSchema, provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import { backfillJob } from '../memory/job-handlers/backfill.js';
 import { buildConversationSummaryJob, buildGlobalSummaryJob } from '../memory/job-handlers/summarization.js';
 import {
@@ -4431,5 +4431,97 @@ describe('Memory regressions', () => {
     for (const seg of segments) {
       expect(seg.scopeId).toBe(conv.memoryScopeId);
     }
+  });
+
+  // ── Provenance plumbing tests ────────────────────────────────────────
+
+  test('provenance fields are preserved in stored message metadata', () => {
+    const conv = createConversation('provenance-preserve');
+    const metadata = {
+      userMessageChannel: 'telegram' as const,
+      provenanceActorRole: 'non-guardian' as const,
+      provenanceSourceChannel: 'telegram' as const,
+      provenanceGuardianExternalUserId: 'guardian-123',
+      provenanceRequesterIdentifier: 'Alice',
+    };
+    const msg = addMessage(conv.id, 'user', 'Hello from telegram', metadata);
+
+    const db = getDb();
+    const stored = db
+      .select({ metadata: messages.metadata })
+      .from(messages)
+      .where(eq(messages.id, msg.id))
+      .get();
+
+    expect(stored).toBeTruthy();
+    const parsed = JSON.parse(stored!.metadata!);
+    expect(parsed.provenanceActorRole).toBe('non-guardian');
+    expect(parsed.provenanceSourceChannel).toBe('telegram');
+    expect(parsed.provenanceGuardianExternalUserId).toBe('guardian-123');
+    expect(parsed.provenanceRequesterIdentifier).toBe('Alice');
+  });
+
+  test('messageMetadataSchema validates provenance fields', () => {
+    const valid = messageMetadataSchema.safeParse({
+      provenanceActorRole: 'guardian',
+      provenanceSourceChannel: 'macos',
+    });
+    expect(valid.success).toBe(true);
+
+    const validNonGuardian = messageMetadataSchema.safeParse({
+      provenanceActorRole: 'non-guardian',
+      provenanceSourceChannel: 'telegram',
+      provenanceGuardianExternalUserId: 'g-123',
+      provenanceRequesterIdentifier: 'Bob',
+    });
+    expect(validNonGuardian.success).toBe(true);
+
+    const validUnverified = messageMetadataSchema.safeParse({
+      provenanceActorRole: 'unverified_channel',
+    });
+    expect(validUnverified.success).toBe(true);
+  });
+
+  test('provenanceFromGuardianContext returns guardian default when no context', () => {
+    const result = provenanceFromGuardianContext(null);
+    expect(result.provenanceActorRole).toBe('guardian');
+    expect(result.provenanceSourceChannel).toBeUndefined();
+
+    const result2 = provenanceFromGuardianContext(undefined);
+    expect(result2.provenanceActorRole).toBe('guardian');
+  });
+
+  test('provenanceFromGuardianContext extracts fields from guardian context', () => {
+    const ctx = {
+      sourceChannel: 'telegram' as const,
+      actorRole: 'non-guardian' as const,
+      guardianExternalUserId: 'g-456',
+      requesterIdentifier: 'Charlie',
+    };
+    const result = provenanceFromGuardianContext(ctx);
+    expect(result.provenanceActorRole).toBe('non-guardian');
+    expect(result.provenanceSourceChannel).toBe('telegram');
+    expect(result.provenanceGuardianExternalUserId).toBe('g-456');
+    expect(result.provenanceRequesterIdentifier).toBe('Charlie');
+  });
+
+  test('indexMessageNow receives provenanceActorRole when metadata includes it', () => {
+    const conv = createConversation('provenance-indexer');
+    const metadata = {
+      provenanceActorRole: 'non-guardian' as const,
+      provenanceSourceChannel: 'telegram' as const,
+    };
+    // addMessage parses metadata and passes provenanceActorRole to indexMessageNow.
+    // We verify indirectly: the message is persisted with metadata and segments are indexed.
+    const msg = addMessage(conv.id, 'user', 'Test provenance indexing message with enough content to segment', metadata);
+    expect(msg.id).toBeTruthy();
+
+    // Verify segments were created (indexMessageNow was called successfully)
+    const segments = getDb()
+      .select()
+      .from(memorySegments)
+      .where(eq(memorySegments.messageId, msg.id))
+      .all();
+    expect(segments.length).toBeGreaterThan(0);
   });
 });

--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -23,7 +23,7 @@ import {
   type ApprovalRequestStatus,
 } from '../../memory/channel-guardian-store.js';
 import { refreshThreadEscalation } from '../../memory/inbox-escalation-projection.js';
-import { addMessage, getMessages, provenanceFromGuardianContext } from '../../memory/conversation-store.js';
+import { addMessage, getMessages } from '../../memory/conversation-store.js';
 import { getBindingByConversation } from '../../memory/external-conversation-store.js';
 import { updateThreadActivity } from '../../memory/inbox-thread-store.js';
 import { getLatestStoredPayload } from '../../memory/channel-delivery-store.js';
@@ -478,7 +478,7 @@ async function executeDeny(
 
   // Store a system note about the denial in the conversation
   addMessage(conversationId, 'assistant', denialText, {
-    ...provenanceFromGuardianContext(null),
+    provenanceActorRole: 'guardian' as const,
     userMessageChannel: sourceChannel,
     assistantMessageChannel: sourceChannel,
   });
@@ -514,7 +514,7 @@ export function handleAssistantInboxReply(
       'assistant',
       content,
       {
-        ...provenanceFromGuardianContext(null),
+        provenanceActorRole: 'guardian' as const,
         ...(bindingChannel
           ? { userMessageChannel: bindingChannel, assistantMessageChannel: bindingChannel }
           : {}),

--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -23,7 +23,7 @@ import {
   type ApprovalRequestStatus,
 } from '../../memory/channel-guardian-store.js';
 import { refreshThreadEscalation } from '../../memory/inbox-escalation-projection.js';
-import { addMessage, getMessages } from '../../memory/conversation-store.js';
+import { addMessage, getMessages, provenanceFromGuardianContext } from '../../memory/conversation-store.js';
 import { getBindingByConversation } from '../../memory/external-conversation-store.js';
 import { updateThreadActivity } from '../../memory/inbox-thread-store.js';
 import { getLatestStoredPayload } from '../../memory/channel-delivery-store.js';
@@ -478,6 +478,7 @@ async function executeDeny(
 
   // Store a system note about the denial in the conversation
   addMessage(conversationId, 'assistant', denialText, {
+    ...provenanceFromGuardianContext(null),
     userMessageChannel: sourceChannel,
     assistantMessageChannel: sourceChannel,
   });
@@ -512,9 +513,12 @@ export function handleAssistantInboxReply(
       conversationId,
       'assistant',
       content,
-      bindingChannel
-        ? { userMessageChannel: bindingChannel, assistantMessageChannel: bindingChannel }
-        : undefined,
+      {
+        ...provenanceFromGuardianContext(null),
+        ...(bindingChannel
+          ? { userMessageChannel: bindingChannel, assistantMessageChannel: bindingChannel }
+          : {}),
+      },
     );
 
     // Update thread activity timestamps (resets unread count, updates last_outbound_at)

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -13,6 +13,7 @@ import { buildSystemPrompt } from '../config/system-prompt.js';
 import { checkIngressForSecrets } from '../security/secret-ingress.js';
 import { IngressBlockedError } from '../util/errors.js';
 import * as conversationStore from '../memory/conversation-store.js';
+import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import * as attachmentsStore from '../memory/attachments-store.js';
 import { Session, DEFAULT_MEMORY_POLICY, type SessionMemoryPolicy } from './session.js';
 import { parseChannelId, type ChannelId } from '../channels/types.js';
@@ -768,9 +769,13 @@ export class DaemonServer {
 
     if (slashResult.kind === 'unknown') {
       const serverTurnCtx = session.getTurnChannelContext();
-      const serverChannelMeta = serverTurnCtx
-        ? { userMessageChannel: serverTurnCtx.userMessageChannel, assistantMessageChannel: serverTurnCtx.assistantMessageChannel }
-        : undefined;
+      const serverProvenance = provenanceFromGuardianContext(session.guardianContext);
+      const serverChannelMeta = {
+        ...serverProvenance,
+        ...(serverTurnCtx
+          ? { userMessageChannel: serverTurnCtx.userMessageChannel, assistantMessageChannel: serverTurnCtx.assistantMessageChannel }
+          : {}),
+      };
       const userMsg = createUserMessage(content, attachments);
       const persisted = conversationStore.addMessage(
         conversationId,

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -14,6 +14,7 @@ import type { AgentEvent } from '../agent/loop.js';
 import type { AgentLoopSessionContext } from './session-agent-loop.js';
 import type { DirectiveRequest } from './assistant-attachments.js';
 import * as conversationStore from '../memory/conversation-store.js';
+import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import { classifySessionError, isContextTooLarge, buildSessionErrorMessage } from './session-error.js';
 import { isProviderOrderingError } from './session-slash.js';
 import { cleanAssistantContent, drainDirectiveDisplayBuffer } from './assistant-attachments.js';
@@ -275,6 +276,7 @@ export function handleMessageComplete(
       }),
     );
     const toolResultMetadata = {
+      ...provenanceFromGuardianContext(deps.ctx.guardianContext),
       userMessageChannel: deps.turnChannelContext.userMessageChannel,
       assistantMessageChannel: deps.turnChannelContext.assistantMessageChannel,
     };
@@ -317,6 +319,7 @@ export function handleMessageComplete(
   }
 
   const assistantChannelMetadata = {
+    ...provenanceFromGuardianContext(deps.ctx.guardianContext),
     userMessageChannel: deps.turnChannelContext.userMessageChannel,
     assistantMessageChannel: deps.turnChannelContext.assistantMessageChannel,
   };

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -15,7 +15,7 @@ import type { AgentLoop, CheckpointDecision, AgentEvent } from '../agent/loop.js
 import type { Provider } from '../providers/types.js';
 import { createAssistantMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
-import { getConversationOriginChannel } from '../memory/conversation-store.js';
+import { getConversationOriginChannel, provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import type { PermissionPrompter } from '../permissions/prompter.js';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
@@ -244,6 +244,7 @@ export async function runAgentLoopImpl(
 
     if (memoryResult.conflictClarification) {
       const loopChannelMeta = {
+        ...provenanceFromGuardianContext(ctx.guardianContext),
         userMessageChannel: capturedTurnChannelContext.userMessageChannel,
         assistantMessageChannel: capturedTurnChannelContext.assistantMessageChannel,
       };
@@ -526,6 +527,7 @@ export async function runAgentLoopImpl(
         }),
       );
       const toolResultMetadata = {
+        ...provenanceFromGuardianContext(ctx.guardianContext),
         userMessageChannel: capturedTurnChannelContext.userMessageChannel,
         assistantMessageChannel: capturedTurnChannelContext.assistantMessageChannel,
       };
@@ -548,6 +550,7 @@ export async function runAgentLoopImpl(
     const hasAssistantResponse = newMessages.some((msg) => msg.role === 'assistant');
     if (!hasAssistantResponse && state.providerErrorUserMessage && !abortController.signal.aborted && !yieldedForHandoff) {
       const errChannelMeta = {
+        ...provenanceFromGuardianContext(ctx.guardianContext),
         userMessageChannel: capturedTurnChannelContext.userMessageChannel,
         assistantMessageChannel: capturedTurnChannelContext.assistantMessageChannel,
       };

--- a/assistant/src/daemon/session-messaging.ts
+++ b/assistant/src/daemon/session-messaging.ts
@@ -12,9 +12,11 @@ import { parseChannelId } from '../channels/types.js';
 import type { ServerMessage, UserMessageAttachment } from './ipc-protocol.js';
 import { createUserMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
+import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import type { SecretPrompter } from '../permissions/secret-prompter.js';
 import type { MessageQueue } from './session-queue-manager.js';
 import { getLogger } from '../util/logger.js';
+import type { GuardianRuntimeContext } from './session-runtime-assembly.js';
 
 const log = getLogger('session-messaging');
 
@@ -27,6 +29,7 @@ export interface MessagingSessionContext {
   abortController: AbortController | null;
   currentRequestId?: string;
   readonly queue: MessageQueue;
+  guardianContext?: GuardianRuntimeContext;
   getTurnChannelContext(): TurnChannelContext | null;
 }
 
@@ -105,13 +108,17 @@ export function persistUserMessage(
 
   try {
     const turnCtx = extractTurnChannelContext(metadata) ?? ctx.getTurnChannelContext();
-    const mergedMetadata = turnCtx
-      ? {
-          ...(metadata ?? {}),
-          userMessageChannel: turnCtx.userMessageChannel,
-          assistantMessageChannel: turnCtx.assistantMessageChannel,
-        }
-      : metadata;
+    const provenance = provenanceFromGuardianContext(ctx.guardianContext);
+    const mergedMetadata = {
+      ...(metadata ?? {}),
+      ...provenance,
+      ...(turnCtx
+        ? {
+            userMessageChannel: turnCtx.userMessageChannel,
+            assistantMessageChannel: turnCtx.assistantMessageChannel,
+          }
+        : {}),
+    };
 
     const persistedUserMessage = conversationStore.addMessage(
       ctx.conversationId,

--- a/assistant/src/daemon/session-notifiers.ts
+++ b/assistant/src/daemon/session-notifiers.ts
@@ -9,6 +9,7 @@
 
 import type { Message } from '../providers/types.js';
 import type { ServerMessage } from './ipc-protocol.js';
+import type { GuardianRuntimeContext } from './session-runtime-assembly.js';
 import { createAssistantMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
@@ -41,6 +42,7 @@ import { buildCallCompletionMessage } from '../calls/call-conversation-messages.
 export interface NotifierSessionContext {
   sendToClient: (msg: ServerMessage) => void;
   messages: Message[];
+  guardianContext?: GuardianRuntimeContext;
 }
 
 /**
@@ -103,7 +105,7 @@ export function registerSessionNotifiers(
       conversationId,
       'assistant',
       JSON.stringify([{ type: 'text', text: questionText }]),
-      { ...provenanceFromGuardianContext(null), userMessageChannel: 'voice', assistantMessageChannel: 'voice' },
+      { ...provenanceFromGuardianContext(ctx.guardianContext), userMessageChannel: 'voice', assistantMessageChannel: 'voice' },
     );
 
     ctx.messages.push(createAssistantMessage(questionText));

--- a/assistant/src/daemon/session-notifiers.ts
+++ b/assistant/src/daemon/session-notifiers.ts
@@ -11,6 +11,7 @@ import type { Message } from '../providers/types.js';
 import type { ServerMessage } from './ipc-protocol.js';
 import { createAssistantMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
+import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import {
   registerWatchStartNotifier,
   unregisterWatchStartNotifier,
@@ -102,7 +103,7 @@ export function registerSessionNotifiers(
       conversationId,
       'assistant',
       JSON.stringify([{ type: 'text', text: questionText }]),
-      { userMessageChannel: 'voice', assistantMessageChannel: 'voice' },
+      { ...provenanceFromGuardianContext(null), userMessageChannel: 'voice', assistantMessageChannel: 'voice' },
     );
 
     ctx.messages.push(createAssistantMessage(questionText));

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -10,12 +10,14 @@ import type { Message } from '../providers/types.js';
 import type { TurnChannelContext } from '../channels/types.js';
 import { parseChannelId } from '../channels/types.js';
 import type { ServerMessage, UserMessageAttachment } from './ipc-protocol.js';
+import type { GuardianRuntimeContext } from './session-runtime-assembly.js';
 import type { UsageStats } from './ipc-contract.js';
 import type { MessageQueue } from './session-queue-manager.js';
 import type { QueueDrainReason } from './session-queue-manager.js';
 import type { TraceEmitter } from './trace-emitter.js';
 import { createUserMessage, createAssistantMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
+import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import {
   getPendingDeliveryByConversation,
   getGuardianActionRequest,
@@ -72,6 +74,7 @@ export interface ProcessSessionContext {
   preactivatedSkillIds?: string[];
   /** Assistant identity — used for scoping notification preferences. */
   readonly assistantId?: string;
+  guardianContext?: GuardianRuntimeContext;
   persistUserMessage(content: string, attachments: UserMessageAttachment[], requestId?: string, metadata?: Record<string, unknown>): string;
   runAgentLoop(
     content: string,
@@ -154,9 +157,13 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
   // failed write never leaves an unpersisted message in memory.
   if (slashResult.kind === 'unknown') {
     try {
-      const drainChannelMeta = queuedTurnCtx
-        ? { userMessageChannel: queuedTurnCtx.userMessageChannel, assistantMessageChannel: queuedTurnCtx.assistantMessageChannel }
-        : undefined;
+      const drainProvenance = provenanceFromGuardianContext(session.guardianContext);
+      const drainChannelMeta = {
+        ...drainProvenance,
+        ...(queuedTurnCtx
+          ? { userMessageChannel: queuedTurnCtx.userMessageChannel, assistantMessageChannel: queuedTurnCtx.assistantMessageChannel }
+          : {}),
+      };
       const userMsg = createUserMessage(next.content, next.attachments);
       conversationStore.addMessage(
         session.conversationId,
@@ -293,7 +300,7 @@ export async function processMessage(
   if (guardianDelivery) {
     const guardianRequest = getGuardianActionRequest(guardianDelivery.requestId);
     if (guardianRequest && guardianRequest.status === 'pending') {
-      const guardianChannelMeta = { userMessageChannel: 'macos' as const, assistantMessageChannel: 'macos' as const };
+      const guardianChannelMeta = { userMessageChannel: 'macos' as const, assistantMessageChannel: 'macos' as const, provenanceActorRole: 'guardian' as const };
       const userMsg = createUserMessage(content, attachments);
       const persisted = conversationStore.addMessage(
         session.conversationId,
@@ -349,9 +356,13 @@ export async function processMessage(
   // so that a failed write never leaves an unpersisted message in memory.
   if (slashResult.kind === 'unknown') {
     const pmTurnCtx = session.getTurnChannelContext();
-    const pmChannelMeta = pmTurnCtx
-      ? { userMessageChannel: pmTurnCtx.userMessageChannel, assistantMessageChannel: pmTurnCtx.assistantMessageChannel }
-      : undefined;
+    const pmProvenance = provenanceFromGuardianContext(session.guardianContext);
+    const pmChannelMeta = {
+      ...pmProvenance,
+      ...(pmTurnCtx
+        ? { userMessageChannel: pmTurnCtx.userMessageChannel, assistantMessageChannel: pmTurnCtx.assistantMessageChannel }
+        : {}),
+    };
     const userMsg = createUserMessage(content, attachments);
     const persisted = conversationStore.addMessage(
       session.conversationId,

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -44,11 +44,12 @@ export type MessageMetadata = z.infer<typeof messageMetadataSchema>;
 
 /**
  * Extract provenance metadata fields from a GuardianRuntimeContext.
- * When no guardian context is provided (e.g. daemon UI), defaults to
- * guardian actor role since the macOS/iOS app user is the guardian.
+ * When no guardian context is provided, defaults to 'unverified_channel'
+ * because the absence of guardian context means we cannot verify trust —
+ * callers with actual guardian trust should always supply a real context.
  */
 export function provenanceFromGuardianContext(ctx: GuardianRuntimeContext | null | undefined): Record<string, unknown> {
-  if (!ctx) return { provenanceActorRole: 'guardian' };
+  if (!ctx) return { provenanceActorRole: 'unverified_channel' };
   return {
     provenanceActorRole: ctx.actorRole,
     provenanceSourceChannel: ctx.sourceChannel,

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -11,6 +11,7 @@ import { isChannelId, CHANNEL_IDS } from '../channels/types.js';
 import { getLogger } from '../util/logger.js';
 import { deleteOrphanAttachments } from './attachments-store.js';
 import { createRowMapper } from '../util/row-mapper.js';
+import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
 
 const log = getLogger('conversation-store');
 
@@ -32,9 +33,29 @@ export const messageMetadataSchema = z.object({
   userMessageChannel: channelIdSchema.optional(),
   assistantMessageChannel: channelIdSchema.optional(),
   subagentNotification: subagentNotificationSchema.optional(),
+  // Provenance fields for trust-aware memory gating (M3)
+  provenanceActorRole: z.enum(['guardian', 'non-guardian', 'unverified_channel']).optional(),
+  provenanceSourceChannel: channelIdSchema.optional(),
+  provenanceGuardianExternalUserId: z.string().optional(),
+  provenanceRequesterIdentifier: z.string().optional(),
 }).passthrough();
 
 export type MessageMetadata = z.infer<typeof messageMetadataSchema>;
+
+/**
+ * Extract provenance metadata fields from a GuardianRuntimeContext.
+ * When no guardian context is provided (e.g. daemon UI), defaults to
+ * guardian actor role since the macOS/iOS app user is the guardian.
+ */
+export function provenanceFromGuardianContext(ctx: GuardianRuntimeContext | null | undefined): Record<string, unknown> {
+  if (!ctx) return { provenanceActorRole: 'guardian' };
+  return {
+    provenanceActorRole: ctx.actorRole,
+    provenanceSourceChannel: ctx.sourceChannel,
+    provenanceGuardianExternalUserId: ctx.guardianExternalUserId,
+    provenanceRequesterIdentifier: ctx.requesterIdentifier,
+  };
+}
 
 export interface ConversationRow {
   id: string;
@@ -261,6 +282,8 @@ export function addMessage(conversationId: string, role: string, content: string
   try {
     const config = getConfig();
     const scopeId = getConversationMemoryScopeId(conversationId);
+    const parsed = metadata ? messageMetadataSchema.safeParse(metadata) : null;
+    const provenanceActorRole = parsed?.success ? parsed.data.provenanceActorRole : undefined;
     indexMessageNow({
       messageId: message.id,
       conversationId: message.conversationId,
@@ -268,6 +291,7 @@ export function addMessage(conversationId: string, role: string, content: string
       content: message.content,
       createdAt: message.createdAt,
       scopeId,
+      provenanceActorRole,
     }, config.memory);
   } catch (err) {
     log.warn({ err, conversationId, messageId: message.id }, 'Failed to index message for memory');

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -21,6 +21,8 @@ export interface IndexMessageInput {
   content: string;
   createdAt: number;
   scopeId?: string;
+  // Provenance for trust-aware extraction gating (M3)
+  provenanceActorRole?: 'guardian' | 'non-guardian' | 'unverified_channel';
 }
 
 export interface IndexMessageResult {


### PR DESCRIPTION
Add cross-channel message provenance metadata to all persisted messages. Extends messageMetadataSchema with provenance fields (actorRole, sourceChannel, guardianExternalUserId, requesterIdentifier). Extends IndexMessageInput to carry provenanceActorRole for downstream trust-gating in M3. Propagates provenance through all addMessage call sites using guardianContext. Part of #8459.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
