### PR TITLE
perf: replace O(n^2) matching with dictionary-based O(n) algorithm in AXTreeDiff

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/AXTreeDiff.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/AXTreeDiff.swift
@@ -66,13 +66,26 @@ enum AXTreeDiff {
             var unmatchedPrev = prevByKey[key] ?? []
             var unmatchedCurr = currByKey[key] ?? []
 
-            // Remove identical pairs (unchanged elements)
-            for snap in Array(unmatchedPrev) {
-                if let idx = unmatchedCurr.firstIndex(of: snap),
-                   let prevIdx = unmatchedPrev.firstIndex(of: snap) {
-                    unmatchedCurr.remove(at: idx)
-                    unmatchedPrev.remove(at: prevIdx)
+            // Remove identical pairs (unchanged elements) using frequency map for O(n)
+            var currCounts: [ElementSnapshot: Int] = [:]
+            for snap in unmatchedCurr {
+                currCounts[snap, default: 0] += 1
+            }
+            unmatchedPrev = unmatchedPrev.filter { snap in
+                if let count = currCounts[snap], count > 0 {
+                    currCounts[snap] = count - 1
+                    return false
                 }
+                return true
+            }
+            // currCounts now holds only unmatched remainder counts
+            var remainderCounts = currCounts
+            unmatchedCurr = unmatchedCurr.filter { snap in
+                if let count = remainderCounts[snap], count > 0 {
+                    remainderCounts[snap] = count - 1
+                    return true
+                }
+                return false
             }
 
             // Pair remaining as changes (same structural key, different state)


### PR DESCRIPTION
Replace firstIndex(of:) inner loop with dictionary-based frequency map approach for O(n) matching.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
