### PR TITLE
refactor: extract shared cycle detection utility for swarm graph operations

### DIFF
--- a/assistant/src/swarm/graph-utils.ts
+++ b/assistant/src/swarm/graph-utils.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared graph utilities for swarm DAG operations.
+ */
+
+export interface GraphNode {
+  id: string;
+  dependencies: string[];
+}
+
+/**
+ * Detect cycles in a directed graph using Kahn's algorithm.
+ * Returns the IDs of nodes involved in cycles, or null if the graph is acyclic.
+ */
+export function detectCycles(nodes: GraphNode[]): string[] | null {
+  const inDegree = new Map<string, number>();
+  const adj = new Map<string, string[]>();
+
+  for (const node of nodes) {
+    inDegree.set(node.id, 0);
+    adj.set(node.id, []);
+  }
+
+  for (const node of nodes) {
+    for (const dep of node.dependencies) {
+      adj.get(dep)?.push(node.id);
+      inDegree.set(node.id, (inDegree.get(node.id) ?? 0) + 1);
+    }
+  }
+
+  const queue: string[] = [];
+  for (const [id, deg] of inDegree) {
+    if (deg === 0) queue.push(id);
+  }
+
+  let processed = 0;
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    processed++;
+    for (const neighbor of adj.get(current)!) {
+      const newDeg = (inDegree.get(neighbor) ?? 0) - 1;
+      inDegree.set(neighbor, newDeg);
+      if (newDeg === 0) queue.push(neighbor);
+    }
+  }
+
+  if (processed < nodes.length) {
+    return nodes
+      .filter((n) => (inDegree.get(n.id) ?? 0) > 0)
+      .map((n) => n.id);
+  }
+
+  return null;
+}

--- a/assistant/src/swarm/orchestrator.ts
+++ b/assistant/src/swarm/orchestrator.ts
@@ -4,6 +4,7 @@ import type { SwarmWorkerBackend } from './worker-backend.js';
 import { runWorkerTask } from './worker-runner.js';
 import type { Provider } from '../providers/types.js';
 import { synthesizeResults } from './synthesizer.js';
+import { detectCycles } from './graph-utils.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('swarm-orchestrator');
@@ -47,9 +48,9 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
   const startTime = Date.now();
 
   // Safety net: reject cyclic plans even if the caller skipped validation
-  const cyclePath = detectCycle(plan.tasks);
-  if (cyclePath) {
-    throw new Error(`Swarm plan contains a dependency cycle: ${cyclePath.join(' -> ')}`);
+  const cycleNodes = detectCycles(plan.tasks);
+  if (cycleNodes) {
+    throw new Error(`Swarm plan contains a dependency cycle: ${cycleNodes.join(' -> ')}`);
   }
 
   onStatus?.({ kind: 'plan_created', message: `Plan with ${plan.tasks.length} tasks` });
@@ -290,72 +291,6 @@ function blockDependents(
       blockDependents(depId, dependents, blocked, onStatus);
     }
   }
-}
-
-/**
- * DFS-based cycle detection. Returns the cycle path (e.g. ['a', 'b', 'c', 'a'])
- * if a cycle exists, or null if the graph is a valid DAG.
- */
-function detectCycle(tasks: SwarmTaskNode[]): string[] | null {
-  const adj = new Map<string, string[]>();
-  for (const t of tasks) {
-    adj.set(t.id, []);
-  }
-  for (const t of tasks) {
-    for (const dep of t.dependencies) {
-      // Edge from dep -> t.id (dep must finish before t)
-      adj.get(dep)?.push(t.id);
-    }
-  }
-
-  const WHITE = 0, GRAY = 1, BLACK = 2;
-  const color = new Map<string, number>();
-  for (const t of tasks) color.set(t.id, WHITE);
-
-  const parent = new Map<string, string>();
-
-  // Iterative DFS to avoid stack overflow on deep acyclic chains
-  for (const t of tasks) {
-    if (color.get(t.id) !== WHITE) continue;
-
-    const stack: Array<{ node: string; neighborIdx: number }> = [
-      { node: t.id, neighborIdx: 0 },
-    ];
-    color.set(t.id, GRAY);
-
-    while (stack.length > 0) {
-      const frame = stack[stack.length - 1];
-      const neighbors = adj.get(frame.node) ?? [];
-
-      if (frame.neighborIdx >= neighbors.length) {
-        // All neighbors visited — mark node as fully processed
-        color.set(frame.node, BLACK);
-        stack.pop();
-        continue;
-      }
-
-      const neighbor = neighbors[frame.neighborIdx];
-      frame.neighborIdx++;
-
-      if (color.get(neighbor) === GRAY) {
-        // Back edge found — reconstruct cycle path
-        const cycle = [neighbor];
-        for (let i = stack.length - 1; i >= 0; i--) {
-          cycle.push(stack[i].node);
-          if (stack[i].node === neighbor) break;
-        }
-        cycle.reverse();
-        return cycle;
-      }
-
-      if (color.get(neighbor) === WHITE) {
-        parent.set(neighbor, frame.node);
-        color.set(neighbor, GRAY);
-        stack.push({ node: neighbor, neighborIdx: 0 });
-      }
-    }
-  }
-  return null;
 }
 
 /** Resolves after `ms` milliseconds, or immediately if the signal fires first. */

--- a/assistant/src/swarm/plan-validator.ts
+++ b/assistant/src/swarm/plan-validator.ts
@@ -1,6 +1,7 @@
 import type { SwarmPlan, SwarmTaskNode } from './types.js';
 import { VALID_SWARM_ROLES } from './types.js';
 import type { SwarmLimits } from './limits.js';
+import { detectCycles } from './graph-utils.js';
 
 export class SwarmPlanValidationError extends Error {
   constructor(
@@ -83,9 +84,9 @@ export function validateAndNormalizePlan(
 
   // --- Cycle detection (Kahn's algorithm) ---
   if (!hasDuplicateIds(tasks) && issues.length === 0) {
-    const cycleResult = detectCycles(tasks);
-    if (cycleResult) {
-      issues.push(`Plan contains a dependency cycle: ${cycleResult}.`);
+    const cycleNodes = detectCycles(tasks);
+    if (cycleNodes) {
+      issues.push(`Plan contains a dependency cycle: ${cycleNodes.join(' -> ')}.`);
     }
   }
 
@@ -105,48 +106,3 @@ function hasDuplicateIds(tasks: SwarmTaskNode[]): boolean {
   return false;
 }
 
-/**
- * Detect cycles using Kahn's algorithm. Returns a description of the cycle
- * if one exists, or null if the graph is acyclic.
- */
-function detectCycles(tasks: SwarmTaskNode[]): string | null {
-  const inDegree = new Map<string, number>();
-  const adj = new Map<string, string[]>();
-
-  for (const task of tasks) {
-    inDegree.set(task.id, 0);
-    adj.set(task.id, []);
-  }
-
-  for (const task of tasks) {
-    for (const dep of task.dependencies) {
-      adj.get(dep)!.push(task.id);
-      inDegree.set(task.id, (inDegree.get(task.id) ?? 0) + 1);
-    }
-  }
-
-  const queue: string[] = [];
-  for (const [id, deg] of inDegree) {
-    if (deg === 0) queue.push(id);
-  }
-
-  let processed = 0;
-  while (queue.length > 0) {
-    const node = queue.shift()!;
-    processed++;
-    for (const neighbor of adj.get(node)!) {
-      const newDeg = (inDegree.get(neighbor) ?? 0) - 1;
-      inDegree.set(neighbor, newDeg);
-      if (newDeg === 0) queue.push(neighbor);
-    }
-  }
-
-  if (processed < tasks.length) {
-    const stuck = tasks
-      .filter((t) => (inDegree.get(t.id) ?? 0) > 0)
-      .map((t) => t.id);
-    return stuck.join(' -> ');
-  }
-
-  return null;
-}


### PR DESCRIPTION
Extract duplicated cycle detection logic into shared graph-utils.ts using Kahn's algorithm.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
