### PR TITLE
feat: integrate Playwright tests into PR CI workflow

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -2,9 +2,20 @@ name: Playwright Tests
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [labeled, synchronize, opened, reopened]
+    paths:
+      - 'playwright/**'
+      - 'assistant/**'
+      - '.github/workflows/playwright.yaml'
+
+concurrency:
+  group: playwright-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   playwright:
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'preview')
     name: Playwright Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
Add pull_request trigger with preview label filter to playwright.yaml so web app regressions are caught before merge.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
