### PR TITLE
feat: add code coverage reporting to CI

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -43,10 +43,46 @@ jobs:
       - name: Lint
         run: bun run lint
 
-      - name: Test
-        run: bun run test
+      - name: Test with coverage
+        run: bun run test:coverage
         env:
           EXCLUDE_EXPERIMENTAL: 'true'
+
+      - name: Coverage summary
+        if: success()
+        run: |
+          LCOV="coverage/lcov.info"
+          if [[ ! -s "${LCOV}" ]]; then
+            echo "No coverage data found"
+            exit 0
+          fi
+
+          # Parse lcov: count lines found (LF) and lines hit (LH)
+          TOTAL_LF=0
+          TOTAL_LH=0
+          while IFS= read -r line; do
+            case "${line}" in
+              LF:*) TOTAL_LF=$(( TOTAL_LF + ${line#LF:} )) ;;
+              LH:*) TOTAL_LH=$(( TOTAL_LH + ${line#LH:} )) ;;
+            esac
+          done < "${LCOV}"
+
+          if [[ ${TOTAL_LF} -gt 0 ]]; then
+            PCT=$(( TOTAL_LH * 100 / TOTAL_LF ))
+            echo "Line coverage: ${TOTAL_LH}/${TOTAL_LF} (${PCT}%)"
+            echo "### Code Coverage: ${PCT}%" >> "${GITHUB_STEP_SUMMARY}"
+            echo "${TOTAL_LH} of ${TOTAL_LF} lines covered" >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "No line data in coverage report"
+          fi
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: assistant/coverage/lcov.info
+          retention-days: 30
 
       - name: Track consecutive failures
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ node_modules
 !.yarn/versions
 
 # testing
-/coverage
+coverage/
 
 # next.js
 .next/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Vellum Assistant
 
+[![CI](https://github.com/vellum-ai/vellum-assistant/actions/workflows/ci-main-assistant.yaml/badge.svg)](https://github.com/vellum-ai/vellum-assistant/actions/workflows/ci-main-assistant.yaml)
+
 AI-powered assistant platform by Vellum.
 
 ## Architecture

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -18,6 +18,7 @@
     "lint": "eslint",
     "typecheck": "bunx tsc --noEmit",
     "test": "bash scripts/test.sh",
+    "test:coverage": "COVERAGE=true bash scripts/test.sh",
     "test:stable": "EXCLUDE_EXPERIMENTAL=true bash scripts/test.sh",
     "test:bench": "find src/__tests__ -maxdepth 1 -type f -name '*.benchmark.test.ts' -print0 | xargs -0 -P 1 -I {} bun test {}",
     "test:filesystem-tools": "bash scripts/test-filesystem-tools.sh"

--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -10,10 +10,14 @@ set -uo pipefail
 # To avoid order-dependent CI flakes, run each test file in its own Bun process.
 #
 # Files run in parallel (configurable via TEST_WORKERS, default: CPU count).
+#
+# Coverage: set COVERAGE=true to generate per-file lcov reports, merged into
+# coverage/lcov.info at the end.
 # ---------------------------------------------------------------------------
 
 EXCLUDE_EXPERIMENTAL="${EXCLUDE_EXPERIMENTAL:-false}"
 WORKERS="${TEST_WORKERS:-$(sysctl -n hw.logicalcpu 2>/dev/null || nproc 2>/dev/null || echo 8)}"
+COVERAGE="${COVERAGE:-false}"
 
 EXPERIMENTAL_FILES=(
   "skill-load-tool.test.ts"
@@ -55,22 +59,36 @@ echo "Running ${#test_files[@]} test files (${WORKERS} workers)"
 results_dir="$(mktemp -d)"
 trap 'rm -rf "${results_dir}"' EXIT
 
+# When coverage is enabled, each test file writes lcov to its own subdirectory
+if [[ "${COVERAGE}" == "true" ]]; then
+  coverage_base="$(pwd)/coverage"
+  rm -rf "${coverage_base}"
+  mkdir -p "${coverage_base}"
+fi
+
 # Run tests in parallel, capturing output per file
 printf '%s\n' "${test_files[@]}" | xargs -P "${WORKERS}" -I {} bash -c '
   test_file="$1"
   results_dir="$2"
   exclude_exp="$3"
+  coverage_enabled="$4"
 
   safe_name="$(echo "${test_file}" | tr "/" "_")"
   out_file="${results_dir}/${safe_name}.out"
-  time_file="${results_dir}/${safe_name}.time"
+
+  coverage_args=""
+  if [[ "${coverage_enabled}" == "true" ]]; then
+    cov_dir="${results_dir}/cov_${safe_name}"
+    mkdir -p "${cov_dir}"
+    coverage_args="--coverage --coverage-reporter=lcov --coverage-dir=${cov_dir}"
+  fi
 
   start_ms=$(perl -MTime::HiRes=time -e "printf \"%d\", time*1000")
 
   if [[ "${exclude_exp}" == "true" ]]; then
-    bun test --test-name-pattern "^(?!.*\\[experimental\\])" "${test_file}" > "${out_file}" 2>&1
+    bun test ${coverage_args} --test-name-pattern "^(?!.*\\[experimental\\])" "${test_file}" > "${out_file}" 2>&1
   else
-    bun test "${test_file}" > "${out_file}" 2>&1
+    bun test ${coverage_args} "${test_file}" > "${out_file}" 2>&1
   fi
   exit_code=$?
 
@@ -84,7 +102,7 @@ printf '%s\n' "${test_files[@]}" | xargs -P "${WORKERS}" -I {} bash -c '
   else
     echo "  ✓ ${base} (${elapsed}ms)"
   fi
-' _ {} "${results_dir}" "${EXCLUDE_EXPERIMENTAL}"
+' _ {} "${results_dir}" "${EXCLUDE_EXPERIMENTAL}" "${COVERAGE}"
 xargs_exit=$?
 
 # Verify tests actually ran — catch xargs startup failures (e.g. invalid TEST_WORKERS)
@@ -122,6 +140,22 @@ if [[ -f "${results_dir}/failures" ]]; then
   done < "${results_dir}/failures"
   echo "========================================"
   exit 1
+fi
+
+# Merge per-file lcov reports into a single coverage/lcov.info
+if [[ "${COVERAGE}" == "true" ]]; then
+  merged="${coverage_base}/lcov.info"
+  : > "${merged}"
+  for lcov_file in "${results_dir}"/cov_*/lcov.info; do
+    if [[ -f "${lcov_file}" ]]; then
+      cat "${lcov_file}" >> "${merged}"
+    fi
+  done
+  if [[ -s "${merged}" ]]; then
+    echo "Coverage report written to coverage/lcov.info"
+  else
+    echo "Warning: no coverage data was generated"
+  fi
 fi
 
 echo "All ${#test_files[@]} test files passed"


### PR DESCRIPTION
Add bun test --coverage to CI pipeline, upload coverage artifacts, and add coverage badge to README.

Changes:
- Update test.sh to support COVERAGE=true env var for per-file lcov generation and merging
- Add test:coverage script to package.json
- Update CI workflow to run tests with coverage, parse lcov summary, and upload artifacts
- Add CI status badge to README
- Fix .gitignore to ignore coverage/ in all subdirectories
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
