### PR TITLE
test: add tests for skills subsystem

### DIFF
--- a/assistant/src/__tests__/active-skill-tools.test.ts
+++ b/assistant/src/__tests__/active-skill-tools.test.ts
@@ -375,4 +375,48 @@ describe('deriveActiveSkills', () => {
     ];
     expect(deriveActiveSkillIds(messages)).toEqual(['deploy', 'oncall']);
   });
+
+  test('tool_result with empty string content is handled gracefully', () => {
+    const messages: Message[] = [
+      skillLoadUseMsg('t1'),
+      toolResultMsg('t1', ''),
+    ];
+    expect(deriveActiveSkills(messages)).toEqual([]);
+  });
+
+  test('marker with extra whitespace in attributes still matches', () => {
+    const messages: Message[] = [
+      skillLoadUseMsg('t1'),
+      toolResultMsg('t1', '<loaded_skill  id="deploy"  version="v1:abc"  />'),
+    ];
+    const entries = deriveActiveSkills(messages);
+    expect(entries).toEqual([{ id: 'deploy', version: 'v1:abc' }]);
+  });
+
+  test('marker with empty id attribute is rejected', () => {
+    const messages: Message[] = [
+      skillLoadUseMsg('t1'),
+      toolResultMsg('t1', '<loaded_skill id="" />'),
+    ];
+    expect(deriveActiveSkills(messages)).toEqual([]);
+  });
+
+  test('many duplicate markers across many messages are all deduplicated', () => {
+    const messages: Message[] = [];
+    for (let i = 0; i < 10; i++) {
+      const id = `t${i}`;
+      messages.push(skillLoadUseMsg(id));
+      messages.push(toolResultMsg(id, '<loaded_skill id="repeat" version="v1:same" />'));
+    }
+    const entries = deriveActiveSkills(messages);
+    expect(entries).toEqual([{ id: 'repeat', version: 'v1:same' }]);
+  });
+
+  test('marker with version but missing id is rejected', () => {
+    const messages: Message[] = [
+      skillLoadUseMsg('t1'),
+      toolResultMsg('t1', '<loaded_skill version="v1:abc" />'),
+    ];
+    expect(deriveActiveSkills(messages)).toEqual([]);
+  });
 });

--- a/assistant/src/__tests__/clawhub.test.ts
+++ b/assistant/src/__tests__/clawhub.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { mock } from 'bun:test';
+
+let TEST_DIR = '';
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => TEST_DIR,
+  getWorkspaceSkillsDir: () => join(TEST_DIR, 'skills'),
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import {
+  clawhubInstall,
+  clawhubInspect,
+} from '../skills/clawhub.js';
+
+beforeEach(() => {
+  TEST_DIR = mkdtempSync(join(tmpdir(), 'clawhub-test-'));
+  mkdirSync(join(TEST_DIR, 'skills'), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Slug validation (exercised through public API)
+// ---------------------------------------------------------------------------
+
+describe('clawhubInstall slug validation', () => {
+  test('rejects empty slug', async () => {
+    const result = await clawhubInstall('');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid skill slug');
+  });
+
+  test('rejects slug starting with a dot', async () => {
+    const result = await clawhubInstall('.hidden');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid skill slug');
+  });
+
+  test('rejects slug starting with a hyphen', async () => {
+    const result = await clawhubInstall('-dashed');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid skill slug');
+  });
+
+  test('rejects slug with path traversal', async () => {
+    const result = await clawhubInstall('../escape');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid skill slug');
+  });
+
+  test('rejects slug with spaces', async () => {
+    const result = await clawhubInstall('my skill');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid skill slug');
+  });
+
+  test('rejects slug with double slash', async () => {
+    const result = await clawhubInstall('ns//skill');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid skill slug');
+  });
+
+  test('rejects slug ending with slash', async () => {
+    const result = await clawhubInstall('skill/');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid skill slug');
+  });
+
+  test('rejects slug with special characters', async () => {
+    const result = await clawhubInstall('skill@latest');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid skill slug');
+  });
+});
+
+describe('clawhubInspect slug validation', () => {
+  test('rejects empty slug', async () => {
+    const result = await clawhubInspect('');
+    expect(result.error).toContain('Invalid skill slug');
+    expect(result.data).toBeUndefined();
+  });
+
+  test('rejects slug with path traversal', async () => {
+    const result = await clawhubInspect('../../etc/passwd');
+    expect(result.error).toContain('Invalid skill slug');
+  });
+
+  test('rejects slug with spaces', async () => {
+    const result = await clawhubInspect('bad slug');
+    expect(result.error).toContain('Invalid skill slug');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integrity manifest edge cases (via filesystem)
+// ---------------------------------------------------------------------------
+
+describe('integrity manifest', () => {
+  test('malformed integrity JSON is handled gracefully on next install', async () => {
+    // Write corrupted integrity manifest
+    const integrityPath = join(TEST_DIR, 'skills', '.integrity.json');
+    writeFileSync(integrityPath, '{not valid json!!!', 'utf-8');
+
+    // clawhubInstall will fail because npx clawhub is not available,
+    // but it should not crash on malformed manifest. The slug validation
+    // passes so it proceeds to runClawhub which will fail.
+    const result = await clawhubInstall('valid-slug');
+    // Should fail due to subprocess failure, not manifest parse error
+    expect(result.success).toBe(false);
+    // The error should be about the command failing, not JSON parsing
+    expect(result.error).toBeDefined();
+    expect(result.error).not.toContain('JSON');
+  });
+
+  test('missing integrity manifest file does not block install', async () => {
+    const integrityPath = join(TEST_DIR, 'skills', '.integrity.json');
+    expect(existsSync(integrityPath)).toBe(false);
+
+    // Will fail on subprocess, but should not fail on missing manifest
+    const result = await clawhubInstall('valid-slug');
+    expect(result.success).toBe(false);
+    expect(result.error).not.toContain('integrity');
+  });
+});

--- a/assistant/src/__tests__/frontmatter.test.ts
+++ b/assistant/src/__tests__/frontmatter.test.ts
@@ -1,0 +1,218 @@
+import { describe, test, expect } from 'bun:test';
+import { parseFrontmatterFields, FRONTMATTER_REGEX } from '../skills/frontmatter.js';
+
+describe('FRONTMATTER_REGEX', () => {
+  test('matches a standard frontmatter block', () => {
+    const input = '---\nname: "Test"\n---\nBody content';
+    expect(FRONTMATTER_REGEX.test(input)).toBe(true);
+  });
+
+  test('does not match content without frontmatter delimiters', () => {
+    expect(FRONTMATTER_REGEX.test('no frontmatter here')).toBe(false);
+  });
+
+  test('does not match frontmatter that does not start at beginning of file', () => {
+    expect(FRONTMATTER_REGEX.test('text before\n---\nname: "X"\n---\n')).toBe(false);
+  });
+
+  test('matches frontmatter with CRLF line endings', () => {
+    const input = '---\r\nname: "Test"\r\n---\r\nBody';
+    expect(FRONTMATTER_REGEX.test(input)).toBe(true);
+  });
+
+  test('matches frontmatter at EOF without trailing newline', () => {
+    const input = '---\nname: "Test"\n---';
+    expect(FRONTMATTER_REGEX.test(input)).toBe(true);
+  });
+});
+
+describe('parseFrontmatterFields', () => {
+  test('returns null when no frontmatter is present', () => {
+    expect(parseFrontmatterFields('Just some text')).toBeNull();
+    expect(parseFrontmatterFields('')).toBeNull();
+  });
+
+  test('parses unquoted values', () => {
+    const result = parseFrontmatterFields('---\nkey: value\n---\nBody');
+    expect(result).not.toBeNull();
+    expect(result!.fields.key).toBe('value');
+    expect(result!.body).toBe('Body');
+  });
+
+  test('parses double-quoted values', () => {
+    const result = parseFrontmatterFields('---\nname: "Test Skill"\n---\n');
+    expect(result).not.toBeNull();
+    expect(result!.fields.name).toBe('Test Skill');
+  });
+
+  test('parses single-quoted values', () => {
+    const result = parseFrontmatterFields("---\nname: 'Test Skill'\n---\n");
+    expect(result).not.toBeNull();
+    expect(result!.fields.name).toBe('Test Skill');
+  });
+
+  test('handles multiple fields', () => {
+    const input = '---\nname: "Alpha"\ndescription: "Beta"\nemoji: "X"\n---\nBody';
+    const result = parseFrontmatterFields(input);
+    expect(result).not.toBeNull();
+    expect(result!.fields.name).toBe('Alpha');
+    expect(result!.fields.description).toBe('Beta');
+    expect(result!.fields.emoji).toBe('X');
+  });
+
+  test('skips empty lines and comments', () => {
+    const input = '---\nname: "Test"\n\n# a comment\ndescription: "Desc"\n---\nBody';
+    const result = parseFrontmatterFields(input);
+    expect(result).not.toBeNull();
+    expect(result!.fields.name).toBe('Test');
+    expect(result!.fields.description).toBe('Desc');
+    expect(Object.keys(result!.fields)).toHaveLength(2);
+  });
+
+  test('skips lines without a colon separator', () => {
+    const input = '---\nname: "Test"\nno-colon-here\n---\nBody';
+    const result = parseFrontmatterFields(input);
+    expect(result).not.toBeNull();
+    expect(Object.keys(result!.fields)).toHaveLength(1);
+    expect(result!.fields.name).toBe('Test');
+  });
+
+  // -- Escape sequence handling (double-quoted) --
+
+  test('unescapes \\n to newline in double-quoted values', () => {
+    const result = parseFrontmatterFields('---\ndesc: "Line1\\nLine2"\n---\n');
+    expect(result!.fields.desc).toBe('Line1\nLine2');
+  });
+
+  test('unescapes \\r to carriage return in double-quoted values', () => {
+    const result = parseFrontmatterFields('---\ndesc: "Line1\\rLine2"\n---\n');
+    expect(result!.fields.desc).toBe('Line1\rLine2');
+  });
+
+  test('unescapes \\\\ to single backslash in double-quoted values', () => {
+    const result = parseFrontmatterFields('---\npath: "C:\\\\Users"\n---\n');
+    expect(result!.fields.path).toBe('C:\\Users');
+  });
+
+  test('unescapes \\" to literal quote in double-quoted values', () => {
+    const result = parseFrontmatterFields('---\nname: "Say \\"hello\\""\n---\n');
+    expect(result!.fields.name).toBe('Say "hello"');
+  });
+
+  test('handles \\\\n correctly (escaped backslash followed by n, not newline)', () => {
+    // \\n in the source → the regex sees \\n → should produce \ followed by n (literal)
+    // The single-pass regex handles: \\ → \ and the trailing n is not part of an escape
+    const result = parseFrontmatterFields('---\npath: "back\\\\name"\n---\n');
+    expect(result!.fields.path).toBe('back\\name');
+  });
+
+  test('does not unescape sequences in single-quoted values', () => {
+    const result = parseFrontmatterFields("---\npath: 'back\\\\slash'\n---\n");
+    // Single-quoted YAML treats backslashes literally
+    expect(result!.fields.path).toBe('back\\\\slash');
+  });
+
+  test('preserves \\n literal in single-quoted values', () => {
+    const result = parseFrontmatterFields("---\ndesc: 'has \\n in it'\n---\n");
+    expect(result!.fields.desc).toBe('has \\n in it');
+  });
+
+  // -- Multiple colons edge case --
+
+  test('handles values containing colons (only splits on first colon)', () => {
+    const result = parseFrontmatterFields('---\nurl: "http://example.com:8080"\n---\n');
+    expect(result!.fields.url).toBe('http://example.com:8080');
+  });
+
+  test('handles unquoted values containing colons', () => {
+    const result = parseFrontmatterFields('---\nurl: http://example.com:8080/path\n---\n');
+    expect(result!.fields.url).toBe('http://example.com:8080/path');
+  });
+
+  test('key with colon in value and no quotes', () => {
+    const result = parseFrontmatterFields('---\ntime: 12:30:00\n---\n');
+    expect(result!.fields.time).toBe('12:30:00');
+  });
+
+  // -- Body extraction --
+
+  test('body includes everything after the closing delimiter', () => {
+    const input = '---\nname: "X"\n---\nLine 1\nLine 2\nLine 3';
+    const result = parseFrontmatterFields(input);
+    expect(result!.body).toBe('Line 1\nLine 2\nLine 3');
+  });
+
+  test('body is empty string when nothing follows delimiter', () => {
+    const input = '---\nname: "X"\n---\n';
+    const result = parseFrontmatterFields(input);
+    expect(result!.body).toBe('');
+  });
+
+  // -- Edge cases with quoting --
+
+  test('value that starts with quote but does not end with matching quote is treated as unquoted', () => {
+    // "hello world (no closing quote) — should be treated as the raw value
+    const result = parseFrontmatterFields('---\nname: "hello world\n---\n');
+    expect(result!.fields.name).toBe('"hello world');
+  });
+
+  test('mismatched quotes (double-start, single-end) treated as unquoted', () => {
+    const result = parseFrontmatterFields("---\nname: \"hello'\n---\n");
+    expect(result!.fields.name).toBe("\"hello'");
+  });
+
+  test('empty double-quoted value', () => {
+    const result = parseFrontmatterFields('---\nname: ""\n---\n');
+    expect(result!.fields.name).toBe('');
+  });
+
+  test('empty single-quoted value', () => {
+    const result = parseFrontmatterFields("---\nname: ''\n---\n");
+    expect(result!.fields.name).toBe('');
+  });
+
+  test('value with leading/trailing whitespace inside quotes', () => {
+    const result = parseFrontmatterFields('---\nname: "  spaced  "\n---\n');
+    expect(result!.fields.name).toBe('  spaced  ');
+  });
+
+  test('value with only whitespace (no quotes) is trimmed', () => {
+    const result = parseFrontmatterFields('---\nname:    \n---\n');
+    expect(result!.fields.name).toBe('');
+  });
+
+  // -- JSON array values --
+
+  test('JSON array value is preserved as raw string', () => {
+    const result = parseFrontmatterFields('---\nincludes: ["a","b"]\n---\n');
+    expect(result!.fields.includes).toBe('["a","b"]');
+  });
+
+  // -- Boolean-like values --
+
+  test('boolean-like values are preserved as strings', () => {
+    const result = parseFrontmatterFields('---\nuser-invocable: false\ndisable-model-invocation: true\n---\n');
+    expect(result!.fields['user-invocable']).toBe('false');
+    expect(result!.fields['disable-model-invocation']).toBe('true');
+  });
+
+  // -- CRLF handling --
+
+  test('handles CRLF line endings in frontmatter fields', () => {
+    const input = '---\r\nname: "Test"\r\ndescription: "Desc"\r\n---\r\nBody';
+    const result = parseFrontmatterFields(input);
+    expect(result).not.toBeNull();
+    expect(result!.fields.name).toBe('Test');
+    expect(result!.fields.description).toBe('Desc');
+    expect(result!.body).toBe('Body');
+  });
+
+  // -- Multiple escape sequences in one value --
+
+  test('handles multiple escape sequences in a single double-quoted value', () => {
+    // File content between quotes: a\nb\rc\\
+    // After unescape: a<newline>b<cr>c<backslash>
+    const result = parseFrontmatterFields('---\ndesc: "a\\nb\\rc\\\\"\n---\n');
+    expect(result!.fields.desc).toBe('a\nb\rc\\');
+  });
+});

--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -25,6 +25,7 @@ import {
   removeSkillsIndexEntry,
   createManagedSkill,
   deleteManagedSkill,
+  readSkillVersion,
 } from '../skills/managed-store.js';
 import { loadSkillCatalog } from '../config/skills.js';
 
@@ -604,5 +605,117 @@ describe('deleteManagedSkill', () => {
     } finally {
       spy.mockRestore();
     }
+  });
+});
+
+describe('version metadata', () => {
+  test('readSkillVersion returns null for non-existent skill', () => {
+    expect(readSkillVersion('nonexistent')).toBeNull();
+  });
+
+  test('readSkillVersion returns null when skill exists but has no version.json', () => {
+    createManagedSkill({
+      id: 'no-version',
+      name: 'No Version',
+      description: 'Created without version',
+      bodyMarkdown: 'Body.',
+    });
+    expect(readSkillVersion('no-version')).toBeNull();
+  });
+
+  test('createManagedSkill writes version.json when version is provided', () => {
+    createManagedSkill({
+      id: 'versioned',
+      name: 'Versioned',
+      description: 'Has a version',
+      bodyMarkdown: 'Body.',
+      version: 'v1:abc123',
+    });
+
+    const version = readSkillVersion('versioned');
+    expect(version).toBe('v1:abc123');
+  });
+
+  test('version.json contains valid JSON with version and installedAt', () => {
+    createManagedSkill({
+      id: 'version-meta',
+      name: 'Meta',
+      description: 'Check metadata shape',
+      bodyMarkdown: 'Body.',
+      version: 'v1:deadbeef',
+    });
+
+    const metaPath = join(TEST_DIR, 'skills', 'version-meta', 'version.json');
+    expect(existsSync(metaPath)).toBe(true);
+    const meta = JSON.parse(readFileSync(metaPath, 'utf-8'));
+    expect(meta.version).toBe('v1:deadbeef');
+    expect(typeof meta.installedAt).toBe('string');
+    // installedAt should be a valid ISO date
+    expect(new Date(meta.installedAt).toISOString()).toBe(meta.installedAt);
+  });
+
+  test('overwrite updates version.json', () => {
+    createManagedSkill({
+      id: 'update-version',
+      name: 'V1',
+      description: 'First',
+      bodyMarkdown: 'Body.',
+      version: 'v1:first',
+    });
+    expect(readSkillVersion('update-version')).toBe('v1:first');
+
+    createManagedSkill({
+      id: 'update-version',
+      name: 'V2',
+      description: 'Second',
+      bodyMarkdown: 'Body.',
+      version: 'v1:second',
+      overwrite: true,
+    });
+    expect(readSkillVersion('update-version')).toBe('v1:second');
+  });
+
+  test('readSkillVersion returns null for corrupted version.json', () => {
+    createManagedSkill({
+      id: 'corrupt-version',
+      name: 'Corrupt',
+      description: 'Will corrupt version file',
+      bodyMarkdown: 'Body.',
+      version: 'v1:valid',
+    });
+
+    // Corrupt the version.json
+    const metaPath = join(TEST_DIR, 'skills', 'corrupt-version', 'version.json');
+    writeFileSync(metaPath, '{invalid json!!!', 'utf-8');
+
+    expect(readSkillVersion('corrupt-version')).toBeNull();
+  });
+});
+
+describe('validateManagedSkillId edge cases', () => {
+  test('rejects non-string input', () => {
+    // @ts-expect-error testing runtime validation
+    expect(validateManagedSkillId(null)).not.toBeNull();
+    // @ts-expect-error testing runtime validation
+    expect(validateManagedSkillId(undefined)).not.toBeNull();
+    // @ts-expect-error testing runtime validation
+    expect(validateManagedSkillId(123)).not.toBeNull();
+  });
+
+  test('rejects IDs with only dots', () => {
+    expect(validateManagedSkillId('...')).not.toBeNull();
+  });
+
+  test('rejects single dot (hidden dir)', () => {
+    expect(validateManagedSkillId('.')).not.toBeNull();
+  });
+
+  test('accepts single character ID', () => {
+    expect(validateManagedSkillId('a')).toBeNull();
+    expect(validateManagedSkillId('0')).toBeNull();
+  });
+
+  test('accepts ID with all allowed character types', () => {
+    expect(validateManagedSkillId('a1.b2-c3_d4')).toBeNull();
   });
 });


### PR DESCRIPTION
Add tests for frontmatter parsing (escape sequences, multiple colons, edge cases), clawhub slug validation and integrity manifest handling, active skill derivation edge cases (empty content, extra whitespace, empty id, mass deduplication), and managed-store version metadata tracking.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
