### PR TITLE
feat: add automatic old conversation pruning with configurable retention

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -217,6 +217,7 @@ describe('AssistantConfigSchema', () => {
       enqueueIntervalMs: 6 * 60 * 60 * 1000,
       resolvedConflictRetentionMs: 30 * 24 * 60 * 60 * 1000,
       supersededItemRetentionMs: 30 * 24 * 60 * 60 * 1000,
+      conversationRetentionDays: 90,
     });
   });
 

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -87,6 +87,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
       enqueueIntervalMs: 6 * 60 * 60 * 1000,
       resolvedConflictRetentionMs: 30 * 24 * 60 * 60 * 1000,
       supersededItemRetentionMs: 30 * 24 * 60 * 60 * 1000,
+      conversationRetentionDays: 90,
     },
     extraction: {
       useLLM: true,

--- a/assistant/src/config/memory-schema.ts
+++ b/assistant/src/config/memory-schema.ts
@@ -272,6 +272,11 @@ export const MemoryCleanupConfigSchema = z.object({
     .int('memory.cleanup.supersededItemRetentionMs must be an integer')
     .positive('memory.cleanup.supersededItemRetentionMs must be a positive integer')
     .default(30 * 24 * 60 * 60 * 1000),
+  conversationRetentionDays: z
+    .number({ error: 'memory.cleanup.conversationRetentionDays must be a number' })
+    .int('memory.cleanup.conversationRetentionDays must be an integer')
+    .nonnegative('memory.cleanup.conversationRetentionDays must be non-negative')
+    .default(90),
 });
 
 export const MemoryExtractionConfigSchema = z.object({
@@ -470,6 +475,7 @@ export const MemoryConfigSchema = z.object({
     enqueueIntervalMs: 6 * 60 * 60 * 1000,
     resolvedConflictRetentionMs: 30 * 24 * 60 * 60 * 1000,
     supersededItemRetentionMs: 30 * 24 * 60 * 60 * 1000,
+    conversationRetentionDays: 90,
   }),
   extraction: MemoryExtractionConfigSchema.default({
     useLLM: true,

--- a/assistant/src/memory/job-handlers/cleanup.ts
+++ b/assistant/src/memory/job-handlers/cleanup.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq, inArray, lt } from 'drizzle-orm';
 import type { AssistantConfig } from '../../config/types.js';
 import { getLogger } from '../../util/logger.js';
-import { getDb } from '../db.js';
+import { getDb, rawAll, rawRun } from '../db.js';
 import { checkContradictions } from '../contradiction-checker.js';
 import { enqueueMemoryJob, type MemoryJob } from '../jobs-store.js';
 import { asPositiveMs, asString } from '../job-utils.js';
@@ -55,4 +55,57 @@ export function cleanupStaleSupersededItemsJob(job: MemoryJob, config: Assistant
     retentionMs,
     cutoff,
   }, 'Cleaned up stale superseded memory items');
+}
+
+const PRUNE_BATCH_LIMIT = 100;
+
+/**
+ * Delete conversations that have had no activity (updatedAt) for longer than
+ * the configured retention period. Processes in batches so a single job doesn't
+ * hold the DB lock for too long.
+ *
+ * Tables with onDelete cascade on conversation FK (memory_segments,
+ * conversation_keys, channel_inbound_events, message_runs, call_sessions,
+ * external_conversation_bindings, assistant_inbox_thread_state) are handled
+ * automatically. Tables without cascade (messages, tool_invocations,
+ * llm_request_logs) are deleted explicitly before removing the conversation row.
+ */
+export function pruneOldConversationsJob(job: MemoryJob, config: AssistantConfig): void {
+  const retentionDays = typeof job.payload.retentionDays === 'number' && Number.isFinite(job.payload.retentionDays) && job.payload.retentionDays >= 0
+    ? job.payload.retentionDays
+    : config.memory.cleanup.conversationRetentionDays;
+
+  // 0 means disabled
+  if (retentionDays === 0) return;
+
+  const cutoffMs = Date.now() - retentionDays * 86_400_000;
+
+  const stale = rawAll<{ id: string }>(
+    `SELECT id FROM conversations WHERE updated_at < ? ORDER BY updated_at ASC LIMIT ?`,
+    cutoffMs,
+    PRUNE_BATCH_LIMIT,
+  );
+  if (stale.length === 0) return;
+
+  const db = getDb();
+  for (const { id } of stale) {
+    db.transaction(() => {
+      // Non-cascading tables
+      rawRun(`DELETE FROM llm_request_logs WHERE conversation_id = ?`, id);
+      rawRun(`DELETE FROM tool_invocations WHERE conversation_id = ?`, id);
+      rawRun(`DELETE FROM messages WHERE conversation_id = ?`, id);
+      // Conversation row deletion cascades to remaining dependent tables
+      rawRun(`DELETE FROM conversations WHERE id = ?`, id);
+    });
+  }
+
+  if (stale.length === PRUNE_BATCH_LIMIT) {
+    enqueueMemoryJob('prune_old_conversations', { retentionDays });
+  }
+
+  log.info({
+    pruned: stale.length,
+    retentionDays,
+    cutoffMs,
+  }, 'Pruned old conversations');
 }

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -13,6 +13,7 @@ export type MemoryJobType =
   | 'resolve_pending_conflicts_for_message'
   | 'cleanup_resolved_conflicts'
   | 'cleanup_stale_superseded_items'
+  | 'prune_old_conversations'
   | 'backfill_entity_relations'
   | 'check_contradictions'
   | 'refresh_weekly_summary'
@@ -203,6 +204,43 @@ export function enqueueCleanupStaleSupersededItemsJob(retentionMs?: number): str
     ? { retentionMs }
     : {};
   return enqueueMemoryJob('cleanup_stale_superseded_items', payload);
+}
+
+export function enqueuePruneOldConversationsJob(retentionDays?: number): string {
+  const db = getDb();
+  const existing = db
+    .select()
+    .from(memoryJobs)
+    .where(and(
+      eq(memoryJobs.type, 'prune_old_conversations'),
+      inArray(memoryJobs.status, ['pending', 'running']),
+    ))
+    .orderBy(asc(memoryJobs.createdAt))
+    .get();
+  if (existing) {
+    if (existing.status === 'pending' && typeof retentionDays === 'number' && Number.isFinite(retentionDays) && retentionDays >= 0) {
+      let payload: Record<string, unknown> = {};
+      try {
+        payload = JSON.parse(existing.payload) as Record<string, unknown>;
+      } catch {
+        payload = {};
+      }
+      if (payload.retentionDays !== retentionDays) {
+        db.update(memoryJobs)
+          .set({
+            payload: JSON.stringify({ ...payload, retentionDays }),
+            updatedAt: Date.now(),
+          })
+          .where(eq(memoryJobs.id, existing.id))
+          .run();
+      }
+    }
+    return existing.id;
+  }
+  const payload = typeof retentionDays === 'number' && Number.isFinite(retentionDays) && retentionDays >= 0
+    ? { retentionDays }
+    : {};
+  return enqueueMemoryJob('prune_old_conversations', payload);
 }
 
 export function claimMemoryJobs(limit: number): MemoryJob[] {

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -8,6 +8,7 @@ import {
   deferMemoryJob,
   enqueueCleanupResolvedConflictsJob,
   enqueueCleanupStaleSupersededItemsJob,
+  enqueuePruneOldConversationsJob,
   failMemoryJob,
   type MemoryJob,
   resetRunningJobsToPending,
@@ -25,7 +26,7 @@ import { bumpMemoryVersion } from './recall-cache.js';
 import { embedSegmentJob, embedItemJob, embedSummaryJob } from './job-handlers/embedding.js';
 import { extractItemsJob, extractEntitiesJob } from './job-handlers/extraction.js';
 import { resolvePendingConflictsForMessageJob, cleanupResolvedConflictsJob } from './job-handlers/conflict.js';
-import { checkContradictionsJob, cleanupStaleSupersededItemsJob } from './job-handlers/cleanup.js';
+import { checkContradictionsJob, cleanupStaleSupersededItemsJob, pruneOldConversationsJob } from './job-handlers/cleanup.js';
 import { buildConversationSummaryJob, buildGlobalSummaryJob } from './job-handlers/summarization.js';
 import { backfillJob, backfillEntityRelationsJob } from './job-handlers/backfill.js';
 import { rebuildIndexJob, deleteQdrantVectorsJob } from './job-handlers/index-maintenance.js';
@@ -224,6 +225,9 @@ async function processJob(job: MemoryJob, config: AssistantConfig): Promise<void
     case 'cleanup_stale_superseded_items':
       cleanupStaleSupersededItemsJob(job, config);
       return;
+    case 'prune_old_conversations':
+      pruneOldConversationsJob(job, config);
+      return;
     case 'check_contradictions':
       await checkContradictionsJob(job);
       return;
@@ -276,13 +280,18 @@ export function maybeEnqueueScheduledCleanupJobs(config: AssistantConfig, nowMs 
 
   const resolvedConflictsJobId = enqueueCleanupResolvedConflictsJob(cleanup.resolvedConflictRetentionMs);
   const staleSupersededItemsJobId = enqueueCleanupStaleSupersededItemsJob(cleanup.supersededItemRetentionMs);
+  const pruneConversationsJobId = cleanup.conversationRetentionDays > 0
+    ? enqueuePruneOldConversationsJob(cleanup.conversationRetentionDays)
+    : null;
   lastScheduledCleanupEnqueueMs = nowMs;
   log.debug({
     resolvedConflictsJobId,
     staleSupersededItemsJobId,
+    pruneConversationsJobId,
     enqueueIntervalMs: cleanup.enqueueIntervalMs,
     resolvedConflictRetentionMs: cleanup.resolvedConflictRetentionMs,
     supersededItemRetentionMs: cleanup.supersededItemRetentionMs,
+    conversationRetentionDays: cleanup.conversationRetentionDays,
   }, 'Enqueued scheduled memory cleanup jobs');
   return true;
 }


### PR DESCRIPTION
Add 90-day retention policy and periodic pruning background job in MemoryJobsWorker for old conversations.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
