### PR TITLE
feat: implement native WhatsApp media delivery

### DIFF
--- a/gateway/src/http/routes/whatsapp-deliver.ts
+++ b/gateway/src/http/routes/whatsapp-deliver.ts
@@ -1,7 +1,8 @@
 import type { GatewayConfig } from "../../config.js";
 import { getLogger } from "../../logger.js";
+import type { RuntimeAttachmentMeta } from "../../runtime/client.js";
 import { checkDeliverAuth } from "../middleware/deliver-auth.js";
-import { sendWhatsAppReply } from "../../whatsapp/send.js";
+import { sendWhatsAppAttachments, sendWhatsAppReply } from "../../whatsapp/send.js";
 
 const log = getLogger("whatsapp-deliver");
 
@@ -31,7 +32,7 @@ export function createWhatsAppDeliverHandler(config: GatewayConfig) {
       to?: string;
       text?: string;
       assistantId?: string;
-      attachments?: unknown[];
+      attachments?: RuntimeAttachmentMeta[];
     };
     try {
       body = (await req.json()) as typeof body;
@@ -46,28 +47,40 @@ export function createWhatsAppDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "to is required" }, { status: 400 });
     }
 
-    const { text } = body;
+    const { text, assistantId, attachments } = body;
 
-    // When text is missing but attachments are present, produce a graceful fallback
-    // since WhatsApp media delivery is not yet implemented.
-    const hasAttachments = Array.isArray(body.attachments) && body.attachments.length > 0;
-    const effectiveText =
-      (!text || (typeof text === "string" && text.trim().length === 0)) && hasAttachments
-        ? "I have a media attachment to share, but WhatsApp media delivery is not yet supported."
-        : text;
+    if (!text && (!attachments || attachments.length === 0)) {
+      return Response.json({ error: "text or attachments required" }, { status: 400 });
+    }
 
-    if (!effectiveText || typeof effectiveText !== "string") {
-      return Response.json({ error: "text is required" }, { status: 400 });
+    if (attachments) {
+      if (!Array.isArray(attachments)) {
+        return Response.json({ error: "attachments must be an array" }, { status: 400 });
+      }
+      for (const att of attachments) {
+        if (att === null || typeof att !== "object" || Array.isArray(att)) {
+          return Response.json({ error: "each attachment must be an object" }, { status: 400 });
+        }
+        if (!att.id || typeof att.id !== "string") {
+          return Response.json({ error: "each attachment must have an id" }, { status: 400 });
+        }
+      }
     }
 
     try {
-      await sendWhatsAppReply(config, to, effectiveText);
+      if (text) {
+        await sendWhatsAppReply(config, to, text);
+      }
+
+      if (attachments && attachments.length > 0) {
+        await sendWhatsAppAttachments(config, to, assistantId, attachments);
+      }
     } catch (err) {
       tlog.error({ err, to }, "Failed to deliver WhatsApp reply");
       return Response.json({ error: "Delivery failed" }, { status: 502 });
     }
 
-    tlog.info({ to, textLength: effectiveText.length }, "WhatsApp reply sent");
+    tlog.info({ to, hasText: !!text, attachmentCount: attachments?.length ?? 0 }, "WhatsApp reply sent");
     return Response.json({ ok: true });
   };
 }

--- a/gateway/src/whatsapp/api.ts
+++ b/gateway/src/whatsapp/api.ts
@@ -151,6 +151,96 @@ export async function sendWhatsAppTextMessage(
   );
 }
 
+export interface WhatsAppMediaUploadResult {
+  id: string;
+}
+
+/**
+ * Upload media to WhatsApp Business Cloud API and get a reusable media ID.
+ * The media ID can then be used in sendWhatsAppMediaMessage.
+ */
+export async function uploadWhatsAppMedia(
+  config: GatewayConfig,
+  blob: Blob,
+  filename: string,
+  mimeType: string,
+): Promise<WhatsAppMediaUploadResult> {
+  if (!config.whatsappPhoneNumberId || !config.whatsappAccessToken) {
+    throw new Error("WhatsApp credentials not configured");
+  }
+
+  return retryableWhatsAppFetch<WhatsAppMediaUploadResult>(
+    config,
+    "uploadMedia",
+    () => {
+      const form = new FormData();
+      form.set("messaging_product", "whatsapp");
+      form.set("file", blob, filename);
+      form.set("type", mimeType);
+
+      return fetchImpl(
+        `${WHATSAPP_API_BASE}/${config.whatsappPhoneNumberId}/media`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${config.whatsappAccessToken}`,
+          },
+          body: form,
+          signal: AbortSignal.timeout(config.whatsappTimeoutMs),
+        },
+      );
+    },
+  );
+}
+
+export type WhatsAppMediaType = "image" | "video" | "document";
+
+/**
+ * Send a media message via the WhatsApp Business Cloud API.
+ * Requires a previously uploaded media ID from uploadWhatsAppMedia.
+ */
+export async function sendWhatsAppMediaMessage(
+  config: GatewayConfig,
+  to: string,
+  mediaType: WhatsAppMediaType,
+  mediaId: string,
+  filename?: string,
+  caption?: string,
+): Promise<WhatsAppSendMessageResult> {
+  if (!config.whatsappPhoneNumberId || !config.whatsappAccessToken) {
+    throw new Error("WhatsApp credentials not configured");
+  }
+
+  const mediaPayload: Record<string, unknown> = { id: mediaId };
+  if (caption) mediaPayload.caption = caption;
+  // WhatsApp only supports filename on document type
+  if (mediaType === "document" && filename) mediaPayload.filename = filename;
+
+  return retryableWhatsAppFetch<WhatsAppSendMessageResult>(
+    config,
+    "sendMediaMessage",
+    () =>
+      fetchImpl(
+        `${WHATSAPP_API_BASE}/${config.whatsappPhoneNumberId}/messages`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${config.whatsappAccessToken}`,
+          },
+          body: JSON.stringify({
+            messaging_product: "whatsapp",
+            recipient_type: "individual",
+            to,
+            type: mediaType,
+            [mediaType]: mediaPayload,
+          }),
+          signal: AbortSignal.timeout(config.whatsappTimeoutMs),
+        },
+      ),
+  );
+}
+
 /**
  * Mark an incoming WhatsApp message as read.
  * Best-effort — callers should not propagate errors from this.

--- a/gateway/src/whatsapp/send.ts
+++ b/gateway/src/whatsapp/send.ts
@@ -1,12 +1,22 @@
 import type { GatewayConfig } from "../config.js";
 import { getLogger } from "../logger.js";
+import { downloadAttachment, downloadAttachmentById, type RuntimeAttachmentMeta } from "../runtime/client.js";
 import { splitText } from "../util/split-text.js";
-import { sendWhatsAppTextMessage } from "./api.js";
+import { sendWhatsAppTextMessage, uploadWhatsAppMedia, sendWhatsAppMediaMessage, type WhatsAppMediaType } from "./api.js";
 
 const log = getLogger("whatsapp-send");
 
 // WhatsApp supports up to 4096 characters per text message
 const WHATSAPP_MAX_MESSAGE_LEN = 4096;
+
+const IMAGE_MIME_PREFIXES = ["image/jpeg", "image/png", "image/webp"];
+const VIDEO_MIME_PREFIXES = ["video/mp4", "video/3gpp"];
+
+function resolveMediaType(mimeType: string): WhatsAppMediaType {
+  if (IMAGE_MIME_PREFIXES.some((p) => mimeType.startsWith(p))) return "image";
+  if (VIDEO_MIME_PREFIXES.some((p) => mimeType.startsWith(p))) return "video";
+  return "document";
+}
 
 export async function sendWhatsAppReply(
   config: GatewayConfig,
@@ -20,4 +30,59 @@ export async function sendWhatsAppReply(
   }
 
   log.debug({ to, chunks: chunks.length }, "WhatsApp reply sent");
+}
+
+export async function sendWhatsAppAttachments(
+  config: GatewayConfig,
+  to: string,
+  assistantId: string | undefined,
+  attachments: RuntimeAttachmentMeta[],
+): Promise<void> {
+  const failures: string[] = [];
+
+  for (const meta of attachments) {
+    if (meta.sizeBytes !== undefined && meta.sizeBytes > config.maxAttachmentBytes) {
+      log.warn({ attachmentId: meta.id, sizeBytes: meta.sizeBytes }, "Skipping oversized outbound attachment");
+      failures.push(meta.filename ?? meta.id);
+      continue;
+    }
+
+    try {
+      const payload = assistantId
+        ? await downloadAttachment(config, assistantId, meta.id)
+        : await downloadAttachmentById(config, meta.id);
+
+      const mimeType = meta.mimeType ?? payload.mimeType ?? "application/octet-stream";
+      const filename = meta.filename ?? payload.filename ?? meta.id;
+      const buffer = Buffer.from(payload.data, "base64");
+      const sizeBytes = meta.sizeBytes ?? payload.sizeBytes ?? buffer.length;
+
+      if (sizeBytes > config.maxAttachmentBytes) {
+        log.warn({ attachmentId: meta.id, sizeBytes }, "Skipping oversized outbound attachment (detected after download)");
+        failures.push(filename);
+        continue;
+      }
+
+      const blob = new Blob([buffer], { type: mimeType });
+      const mediaType = resolveMediaType(mimeType);
+
+      const uploaded = await uploadWhatsAppMedia(config, blob, filename, mimeType);
+      await sendWhatsAppMediaMessage(config, to, mediaType, uploaded.id, filename);
+
+      log.debug({ to, attachmentId: meta.id, filename, mediaType }, "Attachment sent to WhatsApp");
+    } catch (err) {
+      const displayName = meta.filename ?? meta.id;
+      log.error({ err, attachmentId: meta.id, filename: displayName }, "Failed to send attachment to WhatsApp");
+      failures.push(displayName);
+    }
+  }
+
+  if (failures.length > 0) {
+    const notice = `${failures.length} attachment(s) could not be delivered: ${failures.join(", ")}`;
+    try {
+      await sendWhatsAppReply(config, to, notice);
+    } catch (err) {
+      log.error({ err, to }, "Failed to send attachment failure notice");
+    }
+  }
 }


### PR DESCRIPTION
Replace text fallback with native WhatsApp Business API media upload and send for images, videos, and documents.

## Changes

- **gateway/src/whatsapp/api.ts**: Add `uploadWhatsAppMedia` (uploads binary via FormData to the media endpoint) and `sendWhatsAppMediaMessage` (sends image/video/document messages referencing an uploaded media ID). Both use the existing `retryableWhatsAppFetch` infrastructure.

- **gateway/src/whatsapp/send.ts**: Add `sendWhatsAppAttachments` mirroring the Telegram pattern — downloads attachments from the runtime, resolves MIME type to WhatsApp media type (image/video/document), uploads to WhatsApp, then sends. Includes oversized attachment checks and graceful failure notices.

- **gateway/src/http/routes/whatsapp-deliver.ts**: Accept typed `RuntimeAttachmentMeta[]` attachments with validation. Remove the text fallback for media-only messages. Route text and attachments through their respective send functions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
