### PR TITLE
test: add tests for elevenlabs-config and twilio-config

### DIFF
--- a/assistant/src/__tests__/elevenlabs-config.test.ts
+++ b/assistant/src/__tests__/elevenlabs-config.test.ts
@@ -1,0 +1,92 @@
+import { describe, test, expect, mock } from 'bun:test';
+
+// ── Mocks (must come before source imports) ──────────────────────────
+
+let mockApiKey: string | null = null;
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../security/secure-keys.js', () => ({
+  getSecureKey: (key: string) => {
+    if (key === 'credential:elevenlabs:api_key') return mockApiKey;
+    return null;
+  },
+}));
+
+let mockVoiceConfig = {
+  elevenlabs: {
+    agentId: 'agent-123',
+    apiBaseUrl: 'https://api.elevenlabs.io',
+    registerCallTimeoutMs: 5000,
+  },
+};
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    calls: { voice: mockVoiceConfig },
+  }),
+}));
+
+import { getElevenLabsConfig } from '../calls/elevenlabs-config.js';
+
+describe('elevenlabs-config', () => {
+  test('returns config when API key and agent ID are set', () => {
+    mockApiKey = 'sk-test-key-123';
+    mockVoiceConfig = {
+      elevenlabs: {
+        agentId: 'agent-abc',
+        apiBaseUrl: 'https://api.elevenlabs.io',
+        registerCallTimeoutMs: 10000,
+      },
+    };
+
+    const config = getElevenLabsConfig();
+    expect(config.apiKey).toBe('sk-test-key-123');
+    expect(config.agentId).toBe('agent-abc');
+    expect(config.apiBaseUrl).toBe('https://api.elevenlabs.io');
+    expect(config.registerCallTimeoutMs).toBe(10000);
+  });
+
+  test('throws ConfigError when API key is missing', () => {
+    mockApiKey = null;
+    mockVoiceConfig = {
+      elevenlabs: {
+        agentId: 'agent-abc',
+        apiBaseUrl: 'https://api.elevenlabs.io',
+        registerCallTimeoutMs: 5000,
+      },
+    };
+
+    expect(() => getElevenLabsConfig()).toThrow(/API key is not configured/);
+  });
+
+  test('throws ConfigError when API key is empty string', () => {
+    mockApiKey = '';
+    mockVoiceConfig = {
+      elevenlabs: {
+        agentId: 'agent-abc',
+        apiBaseUrl: 'https://api.elevenlabs.io',
+        registerCallTimeoutMs: 5000,
+      },
+    };
+
+    expect(() => getElevenLabsConfig()).toThrow(/API key is not configured/);
+  });
+
+  test('throws ConfigError when agent ID is missing', () => {
+    mockApiKey = 'sk-valid';
+    mockVoiceConfig = {
+      elevenlabs: {
+        agentId: '',
+        apiBaseUrl: 'https://api.elevenlabs.io',
+        registerCallTimeoutMs: 5000,
+      },
+    };
+
+    expect(() => getElevenLabsConfig()).toThrow(/agent ID is not configured/);
+  });
+});

--- a/assistant/src/__tests__/twilio-config.test.ts
+++ b/assistant/src/__tests__/twilio-config.test.ts
@@ -1,0 +1,110 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+// ── Mocks (must come before source imports) ──────────────────────────
+
+let mockSecureKeys: Record<string, string | null> = {};
+let mockPhoneNumberEnv: string | undefined;
+let mockWssBaseUrl: string | undefined;
+let mockLoadConfigResult: Record<string, unknown> = {};
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../security/secure-keys.js', () => ({
+  getSecureKey: (key: string) => mockSecureKeys[key] ?? null,
+}));
+
+mock.module('../config/env.js', () => ({
+  getTwilioPhoneNumberEnv: () => mockPhoneNumberEnv,
+  getTwilioWssBaseUrl: () => mockWssBaseUrl,
+}));
+
+mock.module('../config/loader.js', () => ({
+  loadConfig: () => mockLoadConfigResult,
+}));
+
+mock.module('../inbound/public-ingress-urls.js', () => ({
+  getPublicBaseUrl: () => 'https://test.example.com',
+  getTwilioRelayUrl: () => 'wss://test.example.com/twilio/relay',
+}));
+
+import { getTwilioConfig } from '../calls/twilio-config.js';
+
+describe('twilio-config', () => {
+  beforeEach(() => {
+    mockSecureKeys = {
+      'credential:twilio:account_sid': 'AC_test_sid',
+      'credential:twilio:auth_token': 'test_auth_token',
+    };
+    mockPhoneNumberEnv = undefined;
+    mockWssBaseUrl = undefined;
+    mockLoadConfigResult = {
+      sms: { phoneNumber: '+15551234567' },
+    };
+  });
+
+  test('returns config when credentials and phone number are set', () => {
+    const config = getTwilioConfig();
+    expect(config.accountSid).toBe('AC_test_sid');
+    expect(config.authToken).toBe('test_auth_token');
+    expect(config.phoneNumber).toBe('+15551234567');
+    expect(config.webhookBaseUrl).toBe('https://test.example.com');
+    expect(config.wssBaseUrl).toBe('wss://test.example.com/twilio/relay');
+  });
+
+  test('throws ConfigError when account SID is missing', () => {
+    mockSecureKeys['credential:twilio:account_sid'] = null;
+    expect(() => getTwilioConfig()).toThrow(/Twilio credentials not configured/);
+  });
+
+  test('throws ConfigError when auth token is missing', () => {
+    mockSecureKeys['credential:twilio:auth_token'] = null;
+    expect(() => getTwilioConfig()).toThrow(/Twilio credentials not configured/);
+  });
+
+  test('throws ConfigError when phone number is missing', () => {
+    mockLoadConfigResult = { sms: {} };
+    mockPhoneNumberEnv = undefined;
+    mockSecureKeys['credential:twilio:phone_number'] = null;
+    expect(() => getTwilioConfig()).toThrow(/Twilio phone number not configured/);
+  });
+
+  test('prefers TWILIO_PHONE_NUMBER env var over config phone number', () => {
+    mockPhoneNumberEnv = '+15559999999';
+    const config = getTwilioConfig();
+    expect(config.phoneNumber).toBe('+15559999999');
+  });
+
+  test('falls back to secure key for phone number', () => {
+    mockLoadConfigResult = { sms: {} };
+    mockPhoneNumberEnv = undefined;
+    mockSecureKeys['credential:twilio:phone_number'] = '+15558888888';
+    const config = getTwilioConfig();
+    expect(config.phoneNumber).toBe('+15558888888');
+  });
+
+  test('resolves assistant-scoped phone number when assistantId is provided', () => {
+    mockLoadConfigResult = {
+      sms: {
+        phoneNumber: '+15551234567',
+        assistantPhoneNumbers: { 'ast-1': '+15557777777' },
+      },
+    };
+    const config = getTwilioConfig('ast-1');
+    expect(config.phoneNumber).toBe('+15557777777');
+  });
+
+  test('falls back to global phone number when assistant has no dedicated number', () => {
+    mockLoadConfigResult = {
+      sms: {
+        phoneNumber: '+15551234567',
+        assistantPhoneNumbers: { 'ast-1': '+15557777777' },
+      },
+    };
+    const config = getTwilioConfig('ast-unknown');
+    expect(config.phoneNumber).toBe('+15551234567');
+  });
+});


### PR DESCRIPTION
Add tests for the two remaining untested files in the calls/ module with testable logic: elevenlabs-config.ts (API key/agent ID validation) and twilio-config.ts (credential resolution, phone number fallback chain, assistant-scoped numbers). The other 20 source files in calls/ already have comprehensive test coverage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
