### PR TITLE
feat: add benchmark regression detection to CI

### DIFF
--- a/.github/workflows/ci-benchmarks.yaml
+++ b/.github/workflows/ci-benchmarks.yaml
@@ -1,0 +1,60 @@
+name: CI Benchmark Regression Detection
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'assistant/**'
+      - '.github/workflows/ci-benchmarks.yaml'
+
+concurrency:
+  group: ci-benchmarks-${{ github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  benchmarks:
+    name: Run Benchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: assistant
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.8'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Download previous baseline
+        id: baseline
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          name: benchmark-baseline
+          workflow: ci-benchmarks.yaml
+          branch: main
+          path: assistant/baseline
+          if_no_artifact_found: warn
+        continue-on-error: true
+
+      - name: Run benchmarks
+        run: bash scripts/run-benchmarks.sh
+
+      - name: Compare against baseline
+        if: steps.baseline.outcome == 'success'
+        run: bash scripts/compare-benchmarks.sh baseline/benchmark-results.json benchmark-results.json
+
+      - name: Upload results as new baseline
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-baseline
+          path: assistant/benchmark-results.json
+          retention-days: 90
+          overwrite: true

--- a/assistant/scripts/compare-benchmarks.sh
+++ b/assistant/scripts/compare-benchmarks.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Compare current benchmark results against a baseline and alert on >10%
+# regressions. Exits non-zero if any benchmark regressed beyond the threshold.
+#
+# Usage: compare-benchmarks.sh <baseline.json> <current.json>
+# ---------------------------------------------------------------------------
+
+THRESHOLD="${BENCHMARK_REGRESSION_THRESHOLD:-10}"
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <baseline.json> <current.json>"
+  exit 1
+fi
+
+BASELINE="$1"
+CURRENT="$2"
+
+if [[ ! -f "${BASELINE}" ]]; then
+  echo "No baseline found at ${BASELINE} — skipping regression check (first run)"
+  exit 0
+fi
+
+if [[ ! -f "${CURRENT}" ]]; then
+  echo "ERROR: Current results not found at ${CURRENT}"
+  exit 1
+fi
+
+echo "Comparing benchmarks (regression threshold: ${THRESHOLD}%)"
+echo "Baseline commit: $(jq -r '.commit // "unknown"' "${BASELINE}")"
+echo "Current commit:  $(jq -r '.commit // "unknown"' "${CURRENT}")"
+echo ""
+
+regressions=0
+comparisons=0
+
+# For each file in the current results, find its baseline and compare
+while IFS= read -r file; do
+  current_ms=$(jq -r --arg f "$file" '.results[] | select(.file == $f) | .duration_ms' "${CURRENT}")
+  baseline_ms=$(jq -r --arg f "$file" '.results[] | select(.file == $f) | .duration_ms' "${BASELINE}")
+
+  if [[ -z "${baseline_ms}" || "${baseline_ms}" == "null" ]]; then
+    echo "  NEW  ${file}: ${current_ms}ms (no baseline)"
+    continue
+  fi
+
+  comparisons=$((comparisons + 1))
+
+  if [[ "${baseline_ms}" -eq 0 ]]; then
+    echo "  SKIP ${file}: baseline was 0ms"
+    continue
+  fi
+
+  # Calculate percentage change: (current - baseline) / baseline * 100
+  pct_change=$(( (current_ms - baseline_ms) * 100 / baseline_ms ))
+
+  if [[ ${pct_change} -gt ${THRESHOLD} ]]; then
+    echo "  REGR ${file}: ${baseline_ms}ms -> ${current_ms}ms (+${pct_change}%)"
+    regressions=$((regressions + 1))
+  elif [[ ${pct_change} -lt -${THRESHOLD} ]]; then
+    echo "  IMPR ${file}: ${baseline_ms}ms -> ${current_ms}ms (${pct_change}%)"
+  else
+    echo "  OK   ${file}: ${baseline_ms}ms -> ${current_ms}ms (${pct_change:+${pct_change}}%)"
+  fi
+done < <(jq -r '.results[].file' "${CURRENT}")
+
+echo ""
+echo "Compared ${comparisons} benchmarks, found ${regressions} regression(s)"
+
+if [[ ${regressions} -gt 0 ]]; then
+  echo ""
+  echo "WARNING: ${regressions} benchmark(s) regressed by more than ${THRESHOLD}%"
+  # Write to GitHub step summary if available
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo "### Benchmark Regression Detected"
+      echo ""
+      echo "${regressions} benchmark(s) regressed by more than ${THRESHOLD}%."
+      echo "Check the workflow output for details."
+    } >> "${GITHUB_STEP_SUMMARY}"
+  fi
+  exit 1
+fi
+
+echo "No regressions detected"

--- a/assistant/scripts/run-benchmarks.sh
+++ b/assistant/scripts/run-benchmarks.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Benchmark runner that outputs JSON results for CI regression detection.
+#
+# Runs each *.benchmark.test.ts file in its own process (same isolation
+# strategy as test.sh) and captures pass/fail + wall-clock duration.
+#
+# Output: writes benchmark-results.json to the working directory with
+# per-file timing data suitable for baseline comparison.
+# ---------------------------------------------------------------------------
+
+RESULTS_FILE="${BENCHMARK_RESULTS_FILE:-benchmark-results.json}"
+
+results_dir="$(mktemp -d)"
+trap 'rm -rf "${results_dir}"' EXIT
+
+bench_files=()
+while IFS= read -r f; do
+  bench_files+=("$f")
+done < <(find src/__tests__ -maxdepth 1 -type f -name '*.benchmark.test.ts' | sort)
+
+if [[ ${#bench_files[@]} -eq 0 ]]; then
+  echo "No benchmark files found"
+  exit 1
+fi
+
+echo "Running ${#bench_files[@]} benchmark files"
+
+overall_pass=true
+
+for bench_file in "${bench_files[@]}"; do
+  base="$(basename "${bench_file}")"
+  safe_name="$(echo "${bench_file}" | tr "/" "_")"
+  out_file="${results_dir}/${safe_name}.out"
+
+  start_ms=$(perl -MTime::HiRes=time -e 'printf "%d", time*1000')
+  bun test "${bench_file}" > "${out_file}" 2>&1
+  exit_code=$?
+  end_ms=$(perl -MTime::HiRes=time -e 'printf "%d", time*1000')
+
+  elapsed=$(( end_ms - start_ms ))
+
+  if [[ ${exit_code} -ne 0 ]]; then
+    echo "  FAIL ${base} (${elapsed}ms)"
+    echo "${bench_file}" >> "${results_dir}/failures"
+    overall_pass=false
+  else
+    echo "  PASS ${base} (${elapsed}ms)"
+  fi
+
+  # Store per-file result as a line of JSON
+  echo "{\"file\":\"${base}\",\"duration_ms\":${elapsed},\"passed\":$([ ${exit_code} -eq 0 ] && echo true || echo false)}" >> "${results_dir}/results.jsonl"
+done
+
+# Build final JSON output
+{
+  echo "{"
+  echo "  \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\","
+  echo "  \"commit\": \"${GITHUB_SHA:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}\","
+  echo "  \"results\": ["
+  first=true
+  while IFS= read -r line; do
+    if [ "$first" = true ]; then
+      first=false
+    else
+      echo ","
+    fi
+    printf "    %s" "$line"
+  done < "${results_dir}/results.jsonl"
+  echo ""
+  echo "  ]"
+  echo "}"
+} > "${RESULTS_FILE}"
+
+echo ""
+echo "Results written to ${RESULTS_FILE}"
+
+# Print failures if any
+if [[ -f "${results_dir}/failures" ]]; then
+  echo ""
+  echo "Failed benchmarks:"
+  while IFS= read -r f; do
+    safe_name="$(echo "${f}" | tr "/" "_")"
+    echo "──────────────────────────────────────────"
+    echo "FAIL: ${f}"
+    echo "──────────────────────────────────────────"
+    cat "${results_dir}/${safe_name}.out"
+    echo ""
+  done < "${results_dir}/failures"
+  exit 1
+fi
+
+echo "All ${#bench_files[@]} benchmark files passed"


### PR DESCRIPTION
Add CI step to run benchmark tests, compare against stored baselines, and alert on >10% regressions. Store results as artifacts.

## Changes

- **`.github/workflows/ci-benchmarks.yaml`**: New CI workflow that triggers on pushes to main when assistant/ files change. Downloads the previous baseline artifact, runs all 9 benchmark test files, compares results, and uploads the new baseline.

- **`assistant/scripts/run-benchmarks.sh`**: Benchmark runner that executes each `*.benchmark.test.ts` file in isolation (same process-isolation strategy as the main test runner) and outputs structured JSON results with per-file timing data.

- **`assistant/scripts/compare-benchmarks.sh`**: Comparison script that checks each benchmark's wall-clock duration against the previous baseline and flags >10% regressions. Gracefully handles first runs (no baseline) and new benchmark files. Writes regression alerts to the GitHub step summary.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
