### PR TITLE
feat: add automatic old conversation pruning

### DIFF
--- a/assistant/src/config/memory-schema.ts
+++ b/assistant/src/config/memory-schema.ts
@@ -272,6 +272,25 @@ export const MemoryCleanupConfigSchema = z.object({
     .int('memory.cleanup.supersededItemRetentionMs must be an integer')
     .positive('memory.cleanup.supersededItemRetentionMs must be a positive integer')
     .default(30 * 24 * 60 * 60 * 1000),
+  conversationPruning: z.object({
+    enabled: z
+      .boolean({ error: 'memory.cleanup.conversationPruning.enabled must be a boolean' })
+      .default(true),
+    retentionDays: z
+      .number({ error: 'memory.cleanup.conversationPruning.retentionDays must be a number' })
+      .int('memory.cleanup.conversationPruning.retentionDays must be an integer')
+      .positive('memory.cleanup.conversationPruning.retentionDays must be a positive integer')
+      .default(90),
+    batchSize: z
+      .number({ error: 'memory.cleanup.conversationPruning.batchSize must be a number' })
+      .int('memory.cleanup.conversationPruning.batchSize must be an integer')
+      .positive('memory.cleanup.conversationPruning.batchSize must be a positive integer')
+      .default(20),
+  }).default({
+    enabled: true,
+    retentionDays: 90,
+    batchSize: 20,
+  }),
 });
 
 export const MemoryExtractionConfigSchema = z.object({
@@ -470,6 +489,11 @@ export const MemoryConfigSchema = z.object({
     enqueueIntervalMs: 6 * 60 * 60 * 1000,
     resolvedConflictRetentionMs: 30 * 24 * 60 * 60 * 1000,
     supersededItemRetentionMs: 30 * 24 * 60 * 60 * 1000,
+    conversationPruning: {
+      enabled: true,
+      retentionDays: 90,
+      batchSize: 20,
+    },
   }),
   extraction: MemoryExtractionConfigSchema.default({
     useLLM: true,

--- a/assistant/src/memory/job-handlers/cleanup.ts
+++ b/assistant/src/memory/job-handlers/cleanup.ts
@@ -1,11 +1,12 @@
 import { and, asc, eq, inArray, lt } from 'drizzle-orm';
 import type { AssistantConfig } from '../../config/types.js';
 import { getLogger } from '../../util/logger.js';
-import { getDb } from '../db.js';
+import { getDb, rawAll } from '../db.js';
 import { checkContradictions } from '../contradiction-checker.js';
 import { enqueueMemoryJob, type MemoryJob } from '../jobs-store.js';
 import { asPositiveMs, asString } from '../job-utils.js';
 import { memoryEmbeddings, memoryItemEntities, memoryItems } from '../schema.js';
+import { deleteConversation } from '../conversation-store.js';
 
 const log = getLogger('memory-jobs-worker');
 
@@ -55,4 +56,41 @@ export function cleanupStaleSupersededItemsJob(job: MemoryJob, config: Assistant
     retentionMs,
     cutoff,
   }, 'Cleaned up stale superseded memory items');
+}
+
+export function pruneOldConversationsJob(job: MemoryJob, config: AssistantConfig): void {
+  const pruningConfig = config.memory.cleanup.conversationPruning;
+  if (!pruningConfig.enabled) return;
+
+  const retentionDays = (typeof job.payload.retentionDays === 'number' && job.payload.retentionDays > 0)
+    ? job.payload.retentionDays
+    : pruningConfig.retentionDays;
+  const batchSize = (typeof job.payload.batchSize === 'number' && job.payload.batchSize > 0)
+    ? job.payload.batchSize
+    : pruningConfig.batchSize;
+
+  const cutoffMs = Date.now() - retentionDays * 86_400_000;
+
+  // Find conversations with no activity since the cutoff.
+  // updatedAt is bumped on every message, so it reflects last activity.
+  const stale = rawAll<{ id: string }>(
+    `SELECT id FROM conversations WHERE updated_at < ? ORDER BY updated_at ASC LIMIT ?`,
+    cutoffMs, batchSize,
+  );
+  if (stale.length === 0) return;
+
+  for (const { id } of stale) {
+    deleteConversation(id);
+  }
+
+  log.info({
+    pruned: stale.length,
+    retentionDays,
+    cutoffMs,
+  }, 'Pruned old conversations');
+
+  // If we hit the batch limit, re-enqueue to continue in the next tick
+  if (stale.length >= batchSize) {
+    enqueueMemoryJob('prune_old_conversations', { retentionDays, batchSize });
+  }
 }

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -13,6 +13,7 @@ export type MemoryJobType =
   | 'resolve_pending_conflicts_for_message'
   | 'cleanup_resolved_conflicts'
   | 'cleanup_stale_superseded_items'
+  | 'prune_old_conversations'
   | 'backfill_entity_relations'
   | 'check_contradictions'
   | 'refresh_weekly_summary'
@@ -203,6 +204,24 @@ export function enqueueCleanupStaleSupersededItemsJob(retentionMs?: number): str
     ? { retentionMs }
     : {};
   return enqueueMemoryJob('cleanup_stale_superseded_items', payload);
+}
+
+export function enqueuePruneOldConversationsJob(retentionDays?: number, batchSize?: number): string {
+  const db = getDb();
+  const existing = db
+    .select()
+    .from(memoryJobs)
+    .where(and(
+      eq(memoryJobs.type, 'prune_old_conversations'),
+      inArray(memoryJobs.status, ['pending', 'running']),
+    ))
+    .orderBy(asc(memoryJobs.createdAt))
+    .get();
+  if (existing) return existing.id;
+  const payload: Record<string, unknown> = {};
+  if (typeof retentionDays === 'number' && retentionDays > 0) payload.retentionDays = retentionDays;
+  if (typeof batchSize === 'number' && batchSize > 0) payload.batchSize = batchSize;
+  return enqueueMemoryJob('prune_old_conversations', payload);
 }
 
 export function claimMemoryJobs(limit: number): MemoryJob[] {

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -8,6 +8,7 @@ import {
   deferMemoryJob,
   enqueueCleanupResolvedConflictsJob,
   enqueueCleanupStaleSupersededItemsJob,
+  enqueuePruneOldConversationsJob,
   failMemoryJob,
   type MemoryJob,
   resetRunningJobsToPending,
@@ -25,7 +26,7 @@ import { bumpMemoryVersion } from './recall-cache.js';
 import { embedSegmentJob, embedItemJob, embedSummaryJob } from './job-handlers/embedding.js';
 import { extractItemsJob, extractEntitiesJob } from './job-handlers/extraction.js';
 import { resolvePendingConflictsForMessageJob, cleanupResolvedConflictsJob } from './job-handlers/conflict.js';
-import { checkContradictionsJob, cleanupStaleSupersededItemsJob } from './job-handlers/cleanup.js';
+import { checkContradictionsJob, cleanupStaleSupersededItemsJob, pruneOldConversationsJob } from './job-handlers/cleanup.js';
 import { buildConversationSummaryJob, buildGlobalSummaryJob } from './job-handlers/summarization.js';
 import { backfillJob, backfillEntityRelationsJob } from './job-handlers/backfill.js';
 import { rebuildIndexJob, deleteQdrantVectorsJob } from './job-handlers/index-maintenance.js';
@@ -224,6 +225,9 @@ async function processJob(job: MemoryJob, config: AssistantConfig): Promise<void
     case 'cleanup_stale_superseded_items':
       cleanupStaleSupersededItemsJob(job, config);
       return;
+    case 'prune_old_conversations':
+      pruneOldConversationsJob(job, config);
+      return;
     case 'check_contradictions':
       await checkContradictionsJob(job);
       return;
@@ -276,10 +280,15 @@ export function maybeEnqueueScheduledCleanupJobs(config: AssistantConfig, nowMs 
 
   const resolvedConflictsJobId = enqueueCleanupResolvedConflictsJob(cleanup.resolvedConflictRetentionMs);
   const staleSupersededItemsJobId = enqueueCleanupStaleSupersededItemsJob(cleanup.supersededItemRetentionMs);
+  const pruning = cleanup.conversationPruning;
+  const pruneConversationsJobId = pruning.enabled
+    ? enqueuePruneOldConversationsJob(pruning.retentionDays, pruning.batchSize)
+    : undefined;
   lastScheduledCleanupEnqueueMs = nowMs;
   log.debug({
     resolvedConflictsJobId,
     staleSupersededItemsJobId,
+    pruneConversationsJobId,
     enqueueIntervalMs: cleanup.enqueueIntervalMs,
     resolvedConflictRetentionMs: cleanup.resolvedConflictRetentionMs,
     supersededItemRetentionMs: cleanup.supersededItemRetentionMs,


### PR DESCRIPTION
Add 90-day retention policy and periodic pruning background job in MemoryJobsWorker for old conversations.

- Add `conversationPruning` config to `MemoryCleanupConfigSchema` with `enabled`, `retentionDays` (default 90), and `batchSize` (default 20)
- Add `prune_old_conversations` job type to `MemoryJobType` union with deduped enqueue function
- Add `pruneOldConversationsJob` handler that finds conversations with no activity past the retention window and deletes them in batches using existing `deleteConversation`
- Wire pruning into `maybeEnqueueScheduledCleanupJobs` so it runs on the same periodic schedule as other cleanup jobs
- Re-enqueues itself when batch is full to drain all stale conversations across multiple ticks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
