### PR TITLE
feat: add per-task timeout distinction in swarm

### DIFF
--- a/assistant/src/__tests__/swarm-plan-validator.test.ts
+++ b/assistant/src/__tests__/swarm-plan-validator.test.ts
@@ -325,6 +325,7 @@ describe('resolveSwarmLimits', () => {
       maxTasks: 8,
       maxRetriesPerTask: 1,
       workerTimeoutSec: 900,
+      roleTimeoutsSec: {},
     });
   });
 });

--- a/assistant/src/__tests__/swarm-recursion.test.ts
+++ b/assistant/src/__tests__/swarm-recursion.test.ts
@@ -39,6 +39,7 @@ mock.module('../config/loader.js', () => ({
       maxTasks: 8,
       maxRetriesPerTask: 1,
       workerTimeoutSec: 900,
+      roleTimeoutsSec: {},
       plannerModel: 'claude-haiku-4-5-20251001',
       synthesizerModel: 'claude-sonnet-4-6',
     },

--- a/assistant/src/__tests__/swarm-session-integration.test.ts
+++ b/assistant/src/__tests__/swarm-session-integration.test.ts
@@ -30,6 +30,7 @@ mock.module('../config/loader.js', () => ({
       maxTasks: 4,
       maxRetriesPerTask: 1,
       workerTimeoutSec: 900,
+      roleTimeoutsSec: {},
       plannerModel: 'claude-haiku-4-5-20251001',
       synthesizerModel: 'claude-sonnet-4-6',
     },

--- a/assistant/src/__tests__/swarm-tool.test.ts
+++ b/assistant/src/__tests__/swarm-tool.test.ts
@@ -21,6 +21,7 @@ mock.module('../config/loader.js', () => ({
       maxTasks: 8,
       maxRetriesPerTask: 1,
       workerTimeoutSec: 900,
+      roleTimeoutsSec: {},
       plannerModel: 'claude-haiku-4-5-20251001',
       synthesizerModel: 'claude-sonnet-4-6',
     },
@@ -29,7 +30,7 @@ mock.module('../config/loader.js', () => ({
     provider: 'anthropic',
     providerOrder: ['anthropic'],
     apiKeys: { anthropic: 'test-key' },
-    swarm: { enabled: false, maxWorkers: 3, maxTasks: 8, maxRetriesPerTask: 1, workerTimeoutSec: 900, plannerModel: 'h', synthesizerModel: 's' },
+    swarm: { enabled: false, maxWorkers: 3, maxTasks: 8, maxRetriesPerTask: 1, workerTimeoutSec: 900, roleTimeoutsSec: {}, plannerModel: 'h', synthesizerModel: 's' },
   }),
 }));
 

--- a/assistant/src/config/agent-schema.ts
+++ b/assistant/src/config/agent-schema.ts
@@ -67,6 +67,14 @@ export const SwarmConfigSchema = z.object({
     .int('swarm.workerTimeoutSec must be an integer')
     .positive('swarm.workerTimeoutSec must be a positive integer')
     .default(900),
+  roleTimeoutsSec: z
+    .object({
+      router: z.number().int().positive().optional(),
+      researcher: z.number().int().positive().optional(),
+      coder: z.number().int().positive().optional(),
+      reviewer: z.number().int().positive().optional(),
+    })
+    .default({}),
   plannerModel: z
     .string({ error: 'swarm.plannerModel must be a string' })
     .default('claude-haiku-4-5-20251001'),

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -184,6 +184,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     maxTasks: 8,
     maxRetriesPerTask: 1,
     workerTimeoutSec: 900,
+    roleTimeoutsSec: {},
     plannerModel: 'claude-haiku-4-5-20251001',
     synthesizerModel: 'claude-sonnet-4-6',
   },

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -360,6 +360,7 @@ export const AssistantConfigSchema = z.object({
     maxTasks: 8,
     maxRetriesPerTask: 1,
     workerTimeoutSec: 900,
+    roleTimeoutsSec: {},
     plannerModel: 'claude-haiku-4-5-20251001',
     synthesizerModel: 'claude-sonnet-4-6',
   }),

--- a/assistant/src/swarm/index.ts
+++ b/assistant/src/swarm/index.ts
@@ -10,7 +10,7 @@ export type {
 export { VALID_SWARM_ROLES } from './types.js';
 
 export type { SwarmLimits } from './limits.js';
-export { resolveSwarmLimits, SWARM_HARD_LIMITS } from './limits.js';
+export { resolveSwarmLimits, getTimeoutForRole, SWARM_HARD_LIMITS } from './limits.js';
 
 export {
   validateAndNormalizePlan,

--- a/assistant/src/swarm/limits.ts
+++ b/assistant/src/swarm/limits.ts
@@ -2,11 +2,15 @@
  * Runtime limits for swarm execution, resolved from config.
  */
 
+import type { SwarmRole } from './types.js';
+
 export interface SwarmLimits {
   maxWorkers: number;
   maxTasks: number;
   maxRetriesPerTask: number;
   workerTimeoutSec: number;
+  /** Per-role timeout overrides. When set, takes precedence over workerTimeoutSec for that role. */
+  roleTimeoutsSec: Partial<Record<SwarmRole, number>>;
 }
 
 /** Hard ceilings that config values are clamped to. */
@@ -24,7 +28,17 @@ export function resolveSwarmLimits(config: {
   maxTasks: number;
   maxRetriesPerTask: number;
   workerTimeoutSec: number;
+  roleTimeoutsSec?: Partial<Record<SwarmRole, number>>;
 }): SwarmLimits {
+  const resolvedRoleTimeouts: Partial<Record<SwarmRole, number>> = {};
+  if (config.roleTimeoutsSec) {
+    for (const [role, timeout] of Object.entries(config.roleTimeoutsSec)) {
+      if (timeout != null) {
+        resolvedRoleTimeouts[role as SwarmRole] = Math.max(1, timeout);
+      }
+    }
+  }
+
   return {
     maxWorkers: Math.min(Math.max(1, config.maxWorkers), SWARM_HARD_LIMITS.maxWorkers),
     maxTasks: Math.min(Math.max(1, config.maxTasks), SWARM_HARD_LIMITS.maxTasks),
@@ -33,5 +47,11 @@ export function resolveSwarmLimits(config: {
       SWARM_HARD_LIMITS.maxRetriesPerTask,
     ),
     workerTimeoutSec: Math.max(1, config.workerTimeoutSec),
+    roleTimeoutsSec: resolvedRoleTimeouts,
   };
+}
+
+/** Get the effective timeout for a given role, falling back to the global workerTimeoutSec. */
+export function getTimeoutForRole(limits: SwarmLimits, role: SwarmRole): number {
+  return limits.roleTimeoutsSec[role] ?? limits.workerTimeoutSec;
 }

--- a/assistant/src/swarm/orchestrator.ts
+++ b/assistant/src/swarm/orchestrator.ts
@@ -1,5 +1,6 @@
 import type { SwarmPlan, SwarmTaskNode, SwarmTaskResult, SwarmExecutionSummary } from './types.js';
 import type { SwarmLimits } from './limits.js';
+import { getTimeoutForRole } from './limits.js';
 import type { SwarmWorkerBackend } from './worker-backend.js';
 import { runWorkerTask } from './worker-runner.js';
 import type { Provider } from '../providers/types.js';
@@ -141,6 +142,8 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
       .filter((d): d is { taskId: string; summary: string } => d != null);
 
     try {
+      const taskTimeoutMs = getTimeoutForRole(limits, task.role) * 1000;
+
       let result = await runWorkerTask({
         task,
         upstreamContext: plan.objective,
@@ -148,7 +151,7 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
         backend,
         workingDir,
         model,
-        timeoutMs: limits.workerTimeoutSec * 1000,
+        timeoutMs: taskTimeoutMs,
         signal,
       });
 
@@ -167,7 +170,7 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
           backend,
           workingDir,
           model,
-          timeoutMs: limits.workerTimeoutSec * 1000,
+          timeoutMs: taskTimeoutMs,
           signal,
         });
       }

--- a/assistant/src/tools/swarm/delegate.ts
+++ b/assistant/src/tools/swarm/delegate.ts
@@ -81,6 +81,7 @@ export const swarmDelegateTool: Tool = {
         maxTasks: config.swarm.maxTasks,
         maxRetriesPerTask: config.swarm.maxRetriesPerTask,
         workerTimeoutSec: config.swarm.workerTimeoutSec,
+        roleTimeoutsSec: config.swarm.roleTimeoutsSec,
       });
 
       // Generate plan


### PR DESCRIPTION
Add role-specific timeout overrides in swarm limits config (research, code, test) instead of one global workerTimeoutSec.

Users can now configure per-role timeouts via `swarm.roleTimeoutsSec` (e.g., `{ researcher: 300, coder: 600, reviewer: 180 }`). When a role has no override, the global `workerTimeoutSec` is used as fallback.

Changes:
- Added `roleTimeoutsSec` to `SwarmConfigSchema` (optional per-role overrides)
- Added `roleTimeoutsSec` to `SwarmLimits` interface with clamping in `resolveSwarmLimits`
- Added `getTimeoutForRole()` helper to resolve effective timeout per role
- Updated orchestrator to use role-specific timeouts when dispatching tasks
- Updated all test fixtures to include the new field
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
