### PR TITLE
fix: correct provenance fallback and notifier guardian context

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -4482,13 +4482,13 @@ describe('Memory regressions', () => {
     expect(validUnverified.success).toBe(true);
   });
 
-  test('provenanceFromGuardianContext returns guardian default when no context', () => {
+  test('provenanceFromGuardianContext returns unverified_channel default when no context', () => {
     const result = provenanceFromGuardianContext(null);
-    expect(result.provenanceActorRole).toBe('guardian');
+    expect(result.provenanceActorRole).toBe('unverified_channel');
     expect(result.provenanceSourceChannel).toBeUndefined();
 
     const result2 = provenanceFromGuardianContext(undefined);
-    expect(result2.provenanceActorRole).toBe('guardian');
+    expect(result2.provenanceActorRole).toBe('unverified_channel');
   });
 
   test('provenanceFromGuardianContext extracts fields from guardian context', () => {

--- a/assistant/src/daemon/session-notifiers.ts
+++ b/assistant/src/daemon/session-notifiers.ts
@@ -9,6 +9,7 @@
 
 import type { Message } from '../providers/types.js';
 import type { ServerMessage } from './ipc-protocol.js';
+import type { GuardianRuntimeContext } from './session-runtime-assembly.js';
 import { createAssistantMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
@@ -41,6 +42,7 @@ import { buildCallCompletionMessage } from '../calls/call-conversation-messages.
 export interface NotifierSessionContext {
   sendToClient: (msg: ServerMessage) => void;
   messages: Message[];
+  guardianContext?: GuardianRuntimeContext;
 }
 
 /**
@@ -103,7 +105,7 @@ export function registerSessionNotifiers(
       conversationId,
       'assistant',
       JSON.stringify([{ type: 'text', text: questionText }]),
-      { ...provenanceFromGuardianContext(null), userMessageChannel: 'voice', assistantMessageChannel: 'voice' },
+      { ...provenanceFromGuardianContext(ctx.guardianContext), userMessageChannel: 'voice', assistantMessageChannel: 'voice' },
     );
 
     ctx.messages.push(createAssistantMessage(questionText));

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -44,11 +44,12 @@ export type MessageMetadata = z.infer<typeof messageMetadataSchema>;
 
 /**
  * Extract provenance metadata fields from a GuardianRuntimeContext.
- * When no guardian context is provided (e.g. daemon UI), defaults to
- * guardian actor role since the macOS/iOS app user is the guardian.
+ * When no guardian context is provided, defaults to 'unverified_channel'
+ * because the absence of guardian context means we cannot verify trust —
+ * callers with actual guardian trust should always supply a real context.
  */
 export function provenanceFromGuardianContext(ctx: GuardianRuntimeContext | null | undefined): Record<string, unknown> {
-  if (!ctx) return { provenanceActorRole: 'guardian' };
+  if (!ctx) return { provenanceActorRole: 'unverified_channel' };
   return {
     provenanceActorRole: ctx.actorRole,
     provenanceSourceChannel: ctx.sourceChannel,


### PR DESCRIPTION
## Summary
- Fix provenanceFromGuardianContext(null) to return 'unverified_channel' instead of 'guardian' — missing guardian context should not be trusted
- Pass actual guardian context through session-notifiers.ts instead of hardcoding null

Addresses feedback on #8505.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
