### PR TITLE
feat: generalize approval handling across all channels

### DIFF
--- a/assistant/src/runtime/channel-approval-types.ts
+++ b/assistant/src/runtime/channel-approval-types.ts
@@ -62,7 +62,7 @@ export interface ApprovalUIMetadata {
 // ---------------------------------------------------------------------------
 
 /** How the user communicated their decision. */
-export type ApprovalDecisionSource = 'telegram_button' | 'plain_text';
+export type ApprovalDecisionSource = 'telegram_button' | 'whatsapp_button' | 'plain_text';
 
 /** The structured result of a user's approval decision. */
 export interface ApprovalDecisionResult {

--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -194,7 +194,7 @@ export function buildGuardianApprovalPrompt(
  * All other channels fall back to plain-text instructions embedded in the
  * message body.
  */
-const RICH_APPROVAL_CHANNELS: ReadonlySet<string> = new Set(['telegram']);
+const RICH_APPROVAL_CHANNELS: ReadonlySet<string> = new Set(['telegram', 'whatsapp']);
 
 /**
  * Returns true when the given channel supports rich approval UI such as

--- a/assistant/src/runtime/routes/channel-route-shared.ts
+++ b/assistant/src/runtime/routes/channel-route-shared.ts
@@ -76,13 +76,14 @@ const VALID_ACTIONS: ReadonlySet<string> = new Set<string>([
   'reject',
 ]);
 
-export function parseCallbackData(data: string): ApprovalDecisionResult | null {
+export function parseCallbackData(data: string, sourceChannel?: string): ApprovalDecisionResult | null {
   const parts = data.split(':');
   if (parts.length < 3 || parts[0] !== 'apr') return null;
   const runId = parts[1];
   const action = parts.slice(2).join(':');
   if (!runId || !VALID_ACTIONS.has(action)) return null;
-  return { action: action as ApprovalAction, source: 'telegram_button', runId };
+  const source = sourceChannel === 'whatsapp' ? 'whatsapp_button' as const : 'telegram_button' as const;
+  return { action: action as ApprovalAction, source, runId };
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -99,7 +99,7 @@ export async function handleApprovalInterception(
     // Callback/button path: deterministic and takes priority.
     let callbackDecision: ApprovalDecisionResult | null = null;
     if (callbackData) {
-      callbackDecision = parseCallbackData(callbackData);
+      callbackDecision = parseCallbackData(callbackData, sourceChannel);
     }
 
     // When a callback button provides a run ID, use the scoped lookup so
@@ -764,7 +764,7 @@ export async function handleApprovalInterception(
   // Try to extract a decision from callback data (button press) first.
   // Callback/button path remains deterministic and takes priority.
   if (callbackData) {
-    const cbDecision = parseCallbackData(callbackData);
+    const cbDecision = parseCallbackData(callbackData, sourceChannel);
     if (cbDecision) {
       // When the decision came from a callback button, validate that the embedded
       // run ID matches the currently pending run. A stale button (from a previous

--- a/gateway/src/http/routes/sms-deliver.ts
+++ b/gateway/src/http/routes/sms-deliver.ts
@@ -106,6 +106,12 @@ export function createSmsDeliverHandler(config: GatewayConfig) {
       text?: string;
       assistantId?: string;
       attachments?: unknown[];
+      approval?: {
+        runId?: string;
+        requestId?: string;
+        actions?: Array<{ id?: string; label?: string }>;
+        plainTextFallback?: string;
+      };
     };
     try {
       body = (await req.json()) as typeof body;
@@ -113,7 +119,7 @@ export function createSmsDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "Invalid JSON" }, { status: 400 });
     }
 
-    const { text } = body;
+    const { text, approval } = body;
     const assistantId = typeof body.assistantId === "string" ? body.assistantId : undefined;
     // Accept `chatId` as an alias for `to` so runtime channel callbacks
     // (which send `{ chatId, text }`) work without translation.
@@ -136,6 +142,12 @@ export function createSmsDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "text is required" }, { status: 400 });
     }
 
+    // When an approval payload is present with a plainTextFallback, append it
+    // to the SMS body so the recipient knows how to approve/reject via text.
+    const smsBody = approval?.plainTextFallback && typeof approval.plainTextFallback === "string"
+      ? `${effectiveText}\n\n${approval.plainTextFallback}`
+      : effectiveText;
+
     const from = resolveFromNumber(config, assistantId);
     if (!from) {
       tlog.error({ assistantId }, "Twilio SMS phone number not configured");
@@ -152,14 +164,14 @@ export function createSmsDeliverHandler(config: GatewayConfig) {
         config.twilioAuthToken,
         from,
         to,
-        effectiveText,
+        smsBody,
       );
     } catch (err) {
       tlog.error({ err, to }, "Failed to send SMS via Twilio");
       return Response.json({ error: "SMS delivery failed" }, { status: 502 });
     }
 
-    tlog.info({ to, textLength: effectiveText.length, messageSid: result.sid, status: result.status }, "SMS accepted by Twilio");
+    tlog.info({ to, textLength: smsBody.length, messageSid: result.sid, status: result.status }, "SMS accepted by Twilio");
     return Response.json({
       ok: true,
       messageSid: result.sid,

--- a/gateway/src/http/routes/whatsapp-deliver.ts
+++ b/gateway/src/http/routes/whatsapp-deliver.ts
@@ -6,6 +6,18 @@ import { sendWhatsAppAttachments, sendWhatsAppReply } from "../../whatsapp/send.
 
 const log = getLogger("whatsapp-deliver");
 
+export type ApprovalAction = {
+  id: string;
+  label: string;
+};
+
+export type ApprovalPayload = {
+  runId: string;
+  requestId: string;
+  actions: ApprovalAction[];
+  plainTextFallback: string;
+};
+
 export function createWhatsAppDeliverHandler(config: GatewayConfig) {
   return async (req: Request): Promise<Response> => {
     const traceId = req.headers.get("x-trace-id") ?? undefined;
@@ -33,6 +45,7 @@ export function createWhatsAppDeliverHandler(config: GatewayConfig) {
       text?: string;
       assistantId?: string;
       attachments?: RuntimeAttachmentMeta[];
+      approval?: ApprovalPayload;
     };
     try {
       body = (await req.json()) as typeof body;
@@ -47,7 +60,40 @@ export function createWhatsAppDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "to is required" }, { status: 400 });
     }
 
-    const { text, assistantId, attachments } = body;
+    const { text, assistantId, attachments, approval } = body;
+
+    // Validate approval payload shape when present.
+    if (approval !== undefined) {
+      if (approval === null || typeof approval !== "object" || Array.isArray(approval)) {
+        return Response.json({ error: "approval must be an object" }, { status: 400 });
+      }
+      if (!text) {
+        return Response.json(
+          { error: "text is required when approval is present" },
+          { status: 400 },
+        );
+      }
+      if (!approval.runId || typeof approval.runId !== "string") {
+        return Response.json({ error: "approval.runId is required" }, { status: 400 });
+      }
+      if (!approval.requestId || typeof approval.requestId !== "string") {
+        return Response.json({ error: "approval.requestId is required" }, { status: 400 });
+      }
+      if (!Array.isArray(approval.actions) || approval.actions.length === 0) {
+        return Response.json({ error: "approval.actions must be a non-empty array" }, { status: 400 });
+      }
+      for (const action of approval.actions) {
+        if (action === null || typeof action !== "object" || Array.isArray(action)) {
+          return Response.json({ error: "each approval action must be an object" }, { status: 400 });
+        }
+        if (!action.id || typeof action.id !== "string") {
+          return Response.json({ error: "each approval action must have an id" }, { status: 400 });
+        }
+        if (!action.label || typeof action.label !== "string") {
+          return Response.json({ error: "each approval action must have a label" }, { status: 400 });
+        }
+      }
+    }
 
     if (!text && (!attachments || attachments.length === 0)) {
       return Response.json({ error: "text or attachments required" }, { status: 400 });
@@ -69,7 +115,7 @@ export function createWhatsAppDeliverHandler(config: GatewayConfig) {
 
     try {
       if (text) {
-        await sendWhatsAppReply(config, to, text);
+        await sendWhatsAppReply(config, to, text, approval);
       }
 
       if (attachments && attachments.length > 0) {
@@ -80,7 +126,7 @@ export function createWhatsAppDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "Delivery failed" }, { status: 502 });
     }
 
-    tlog.info({ to, hasText: !!text, attachmentCount: attachments?.length ?? 0 }, "WhatsApp reply sent");
+    tlog.info({ to, hasText: !!text, attachmentCount: attachments?.length ?? 0, hasApproval: !!approval }, "WhatsApp reply sent");
     return Response.json({ ok: true });
   };
 }

--- a/gateway/src/whatsapp/api.ts
+++ b/gateway/src/whatsapp/api.ts
@@ -242,6 +242,55 @@ export async function sendWhatsAppMediaMessage(
 }
 
 /**
+ * Send an interactive button message via the WhatsApp Business Cloud API.
+ * Used for approval prompts where the user can tap a button to respond.
+ * WhatsApp supports up to 3 reply buttons per interactive message.
+ */
+export async function sendWhatsAppInteractiveMessage(
+  config: GatewayConfig,
+  to: string,
+  bodyText: string,
+  buttons: Array<{ id: string; title: string }>,
+): Promise<WhatsAppSendMessageResult> {
+  if (!config.whatsappPhoneNumberId || !config.whatsappAccessToken) {
+    throw new Error("WhatsApp credentials not configured");
+  }
+
+  return retryableWhatsAppFetch<WhatsAppSendMessageResult>(
+    config,
+    "sendInteractiveMessage",
+    () =>
+      fetchImpl(
+        `${WHATSAPP_API_BASE}/${config.whatsappPhoneNumberId}/messages`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${config.whatsappAccessToken}`,
+          },
+          body: JSON.stringify({
+            messaging_product: "whatsapp",
+            recipient_type: "individual",
+            to,
+            type: "interactive",
+            interactive: {
+              type: "button",
+              body: { text: bodyText },
+              action: {
+                buttons: buttons.map((b) => ({
+                  type: "reply",
+                  reply: { id: b.id, title: b.title },
+                })),
+              },
+            },
+          }),
+          signal: AbortSignal.timeout(config.whatsappTimeoutMs),
+        },
+      ),
+  );
+}
+
+/**
  * Mark an incoming WhatsApp message as read.
  * Best-effort — callers should not propagate errors from this.
  */

--- a/gateway/src/whatsapp/normalize.ts
+++ b/gateway/src/whatsapp/normalize.ts
@@ -16,6 +16,20 @@ interface WhatsAppTextMessage {
   text: { body: string };
 }
 
+interface WhatsAppInteractiveMessage {
+  id: string;
+  from: string;
+  timestamp: string;
+  type: "interactive";
+  interactive: {
+    type: "button_reply";
+    button_reply: {
+      id: string;
+      title: string;
+    };
+  };
+}
+
 interface WhatsAppAudioMessage {
   id: string;
   from: string;
@@ -23,7 +37,7 @@ interface WhatsAppAudioMessage {
   type: "audio" | "video" | "image" | "document" | "sticker";
 }
 
-type WhatsAppMessage = WhatsAppTextMessage | WhatsAppAudioMessage;
+type WhatsAppMessage = WhatsAppTextMessage | WhatsAppInteractiveMessage | WhatsAppAudioMessage;
 
 interface WhatsAppValue {
   messaging_product: "whatsapp";
@@ -84,14 +98,27 @@ export function normalizeWhatsAppWebhook(
     if (!messages || messages.length === 0) continue;
 
     for (const msg of messages) {
-      // Only forward text messages; other types (image, audio, etc.) are not supported
-      if (msg.type !== "text") continue;
+      let body: string;
+      let callbackData: string | undefined;
 
-      const textMsg = msg as WhatsAppTextMessage;
-      const body = textMsg.text?.body?.trim() ?? "";
+      if (msg.type === "text") {
+        const textMsg = msg as WhatsAppTextMessage;
+        body = textMsg.text?.body?.trim() ?? "";
+      } else if (msg.type === "interactive") {
+        // Interactive button reply — extract the button ID as callback data
+        const interactiveMsg = msg as WhatsAppInteractiveMessage;
+        if (interactiveMsg.interactive?.type !== "button_reply") continue;
+        const buttonReply = interactiveMsg.interactive.button_reply;
+        if (!buttonReply?.id) continue;
+        callbackData = buttonReply.id;
+        body = buttonReply.title ?? "";
+      } else {
+        // Other types (image, audio, etc.) are not supported
+        continue;
+      }
 
       // from is the sender's WhatsApp phone number in E.164 format
-      const from = textMsg.from;
+      const from = msg.from;
       if (!from) continue;
 
       // Resolve display name from contacts array when available
@@ -99,24 +126,25 @@ export function normalizeWhatsAppWebhook(
       const displayName = contact?.profile?.name ?? from;
 
       results.push({
-        whatsappMessageId: textMsg.id,
+        whatsappMessageId: msg.id,
         event: {
           version: "v1",
           sourceChannel: "whatsapp",
-          receivedAt: new Date(Number(textMsg.timestamp) * 1000).toISOString(),
+          receivedAt: new Date(Number(msg.timestamp) * 1000).toISOString(),
           message: {
             content: body,
             // Use sender phone number as the chat identifier for 1:1 conversations
             externalChatId: from,
-            externalMessageId: textMsg.id,
+            externalMessageId: msg.id,
+            ...(callbackData ? { callbackData } : {}),
           },
           sender: {
             externalUserId: from,
             displayName,
           },
           source: {
-            updateId: textMsg.id,
-            messageId: textMsg.id,
+            updateId: msg.id,
+            messageId: msg.id,
             chatType: "private",
           },
           raw: payload,

--- a/gateway/src/whatsapp/send.ts
+++ b/gateway/src/whatsapp/send.ts
@@ -1,8 +1,9 @@
 import type { GatewayConfig } from "../config.js";
+import type { ApprovalPayload } from "../http/routes/whatsapp-deliver.js";
 import { getLogger } from "../logger.js";
 import { downloadAttachment, downloadAttachmentById, type RuntimeAttachmentMeta } from "../runtime/client.js";
 import { splitText } from "../util/split-text.js";
-import { sendWhatsAppTextMessage, uploadWhatsAppMedia, sendWhatsAppMediaMessage, type WhatsAppMediaType } from "./api.js";
+import { sendWhatsAppInteractiveMessage, sendWhatsAppTextMessage, uploadWhatsAppMedia, sendWhatsAppMediaMessage, type WhatsAppMediaType } from "./api.js";
 
 const log = getLogger("whatsapp-send");
 
@@ -18,11 +19,55 @@ function resolveMediaType(mimeType: string): WhatsAppMediaType {
   return "document";
 }
 
+// WhatsApp interactive message body text limit is 1024 characters
+const WHATSAPP_INTERACTIVE_BODY_MAX_LEN = 1024;
+
+// WhatsApp reply button title limit is 20 characters
+const WHATSAPP_BUTTON_TITLE_MAX_LEN = 20;
+
+// WhatsApp supports a maximum of 3 reply buttons
+const WHATSAPP_MAX_BUTTONS = 3;
+
 export async function sendWhatsAppReply(
   config: GatewayConfig,
   to: string,
   text: string,
+  approval?: ApprovalPayload,
 ): Promise<void> {
+  if (approval) {
+    // WhatsApp interactive buttons: up to 3 buttons, 20-char titles, 1024-char body
+    const buttons = approval.actions.slice(0, WHATSAPP_MAX_BUTTONS).map((action) => ({
+      id: `apr:${approval.runId}:${action.id}`,
+      title: action.label.slice(0, WHATSAPP_BUTTON_TITLE_MAX_LEN),
+    }));
+
+    // If text fits in the interactive body limit, send as single interactive message
+    if (text.length <= WHATSAPP_INTERACTIVE_BODY_MAX_LEN) {
+      await sendWhatsAppInteractiveMessage(config, to, text, buttons);
+      log.debug({ to }, "WhatsApp interactive approval reply sent");
+      return;
+    }
+
+    // Text too long for interactive body: send text chunks first, then
+    // interactive message with truncated body and buttons at the end
+    const chunks = splitText(text, WHATSAPP_MAX_MESSAGE_LEN);
+    for (let i = 0; i < chunks.length - 1; i++) {
+      await sendWhatsAppTextMessage(config, to, chunks[i]);
+    }
+
+    const lastChunk = chunks[chunks.length - 1];
+    if (lastChunk.length <= WHATSAPP_INTERACTIVE_BODY_MAX_LEN) {
+      await sendWhatsAppInteractiveMessage(config, to, lastChunk, buttons);
+    } else {
+      // Last chunk still too long — send it as text, then a short interactive prompt
+      await sendWhatsAppTextMessage(config, to, lastChunk);
+      await sendWhatsAppInteractiveMessage(config, to, "Choose an action:", buttons);
+    }
+
+    log.debug({ to, chunks: chunks.length }, "WhatsApp approval reply sent");
+    return;
+  }
+
   const chunks = splitText(text, WHATSAPP_MAX_MESSAGE_LEN);
 
   for (const chunk of chunks) {


### PR DESCRIPTION
Add approval payload support to WhatsApp (interactive buttons) and SMS (plain-text instructions), matching Telegram's existing implementation.

## Changes

### WhatsApp (rich approval UI with interactive buttons)
- Added `sendWhatsAppInteractiveMessage` to WhatsApp API for sending interactive button messages
- Updated WhatsApp deliver handler to accept and validate `approval` payload (matching Telegram's pattern)
- Updated `sendWhatsAppReply` to render interactive buttons when approval payload is present
- Updated WhatsApp webhook normalizer to handle interactive `button_reply` messages, extracting callback data
- Added `'whatsapp'` to `RICH_APPROVAL_CHANNELS` in the assistant
- Added `'whatsapp_button'` to `ApprovalDecisionSource` type

### SMS (plain-text approval instructions)
- Updated SMS deliver handler to accept `approval` payload and append `plainTextFallback` to SMS body

### Shared
- Updated `parseCallbackData` to accept optional `sourceChannel` parameter for correct decision source attribution
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
