### PR TITLE
M7: Permissions + Hardening + Green CI (#8458)

### DIFF
--- a/assistant/src/__tests__/fixtures/media-reuse-fixtures.ts
+++ b/assistant/src/__tests__/fixtures/media-reuse-fixtures.ts
@@ -36,6 +36,7 @@ export const FAKE_SELFIE_ATTACHMENT: StoredAttachment = {
   sizeBytes: Buffer.from(TINY_PNG_BASE64, 'base64').length,
   kind: 'image',
   thumbnailBase64: null,
+  filePath: null,
   createdAt: NOW,
 };
 
@@ -47,6 +48,7 @@ export const FAKE_DOCUMENT_ATTACHMENT: StoredAttachment = {
   sizeBytes: 4096,
   kind: 'document',
   thumbnailBase64: null,
+  filePath: null,
   createdAt: NOW,
 };
 
@@ -58,6 +60,7 @@ export const FAKE_PHOTO_ATTACHMENT: StoredAttachment = {
   sizeBytes: Buffer.from(TINY_JPEG_BASE64, 'base64').length,
   kind: 'image',
   thumbnailBase64: null,
+  filePath: null,
   createdAt: NOW,
 };
 

--- a/assistant/src/__tests__/recording-cleanup.test.ts
+++ b/assistant/src/__tests__/recording-cleanup.test.ts
@@ -34,7 +34,7 @@ mock.module('../config/loader.js', () => ({
   }),
 }));
 
-import { initializeDb, getDb, resetDb } from '../memory/db.js';
+import { initializeDb, resetDb, rawRun, rawGet } from '../memory/db.js';
 import { uploadFileBackedAttachment } from '../memory/attachments-store.js';
 import { startRecordingCleanupWorker } from '../daemon/recording-cleanup.js';
 import type { RecordingConfig } from '../config/types.js';
@@ -47,9 +47,8 @@ afterAll(() => {
 });
 
 function resetTables() {
-  const db = getDb();
-  db.run('DELETE FROM message_attachments');
-  db.run('DELETE FROM attachments');
+  rawRun('DELETE FROM message_attachments');
+  rawRun('DELETE FROM attachments');
 }
 
 function makeConfig(overrides: Partial<RecordingConfig> = {}): RecordingConfig {
@@ -71,8 +70,7 @@ function insertExpiredAttachment(
 ): string {
   const att = uploadFileBackedAttachment(filename, 'video/mp4', filePath, 1024);
   // Directly update createdAt to simulate an old attachment
-  const db = getDb();
-  db.run('UPDATE attachments SET created_at = ? WHERE id = ?', createdAt, att.id);
+  rawRun('UPDATE attachments SET created_at = ? WHERE id = ?', createdAt, att.id);
   return att.id;
 }
 
@@ -90,11 +88,8 @@ describe('startRecordingCleanupWorker', () => {
     const worker = startRecordingCleanupWorker(makeConfig({ defaultRetentionDays: 30 }));
 
     // The initial sweep runs synchronously in the constructor
-    const db = getDb();
-    const row = db.run('SELECT id FROM attachments WHERE id = ?', attId);
-
     // Attachment record should be deleted
-    const remaining = db.query('SELECT id FROM attachments WHERE id = ?').get(attId);
+    const remaining = rawGet<{ id: string }>('SELECT id FROM attachments WHERE id = ?', attId);
     expect(remaining).toBeNull();
 
     // File should be deleted
@@ -113,8 +108,7 @@ describe('startRecordingCleanupWorker', () => {
 
     const worker = startRecordingCleanupWorker(makeConfig({ defaultRetentionDays: 30 }));
 
-    const db = getDb();
-    const remaining = db.query('SELECT id FROM attachments WHERE id = ?').get(attId);
+    const remaining = rawGet<{ id: string }>('SELECT id FROM attachments WHERE id = ?', attId);
     expect(remaining).not.toBeNull();
 
     expect(existsSync(filePath)).toBe(true);
@@ -124,9 +118,8 @@ describe('startRecordingCleanupWorker', () => {
 
   test('does not remove non-file-backed attachments', () => {
     // Upload a regular (non-file-backed) attachment
-    const db = getDb();
     const id = 'inline-attachment-id';
-    db.run(
+    rawRun(
       `INSERT INTO attachments (id, original_filename, mime_type, size_bytes, kind, data_base64, created_at)
        VALUES (?, ?, ?, ?, ?, ?, ?)`,
       id, 'screenshot.png', 'image/png', 100, 'image', 'iVBORw0K',
@@ -136,7 +129,7 @@ describe('startRecordingCleanupWorker', () => {
     const worker = startRecordingCleanupWorker(makeConfig({ defaultRetentionDays: 30 }));
 
     // Non-file-backed attachment should still exist (filePath IS NULL)
-    const remaining = db.query('SELECT id FROM attachments WHERE id = ?').get(id);
+    const remaining = rawGet<{ id: string }>('SELECT id FROM attachments WHERE id = ?', id);
     expect(remaining).not.toBeNull();
 
     worker.stop();
@@ -151,8 +144,7 @@ describe('startRecordingCleanupWorker', () => {
 
     const worker = startRecordingCleanupWorker(makeConfig({ defaultRetentionDays: 0 }));
 
-    const db = getDb();
-    const remaining = db.query('SELECT id FROM attachments WHERE id = ?').get(attId);
+    const remaining = rawGet<{ id: string }>('SELECT id FROM attachments WHERE id = ?', attId);
     expect(remaining).not.toBeNull();
     expect(existsSync(filePath)).toBe(true);
 
@@ -170,8 +162,7 @@ describe('startRecordingCleanupWorker', () => {
     const worker = startRecordingCleanupWorker(makeConfig({ defaultRetentionDays: 30 }));
 
     // Attachment record should still be cleaned up from DB
-    const db = getDb();
-    const remaining = db.query('SELECT id FROM attachments WHERE id = ?').get(attId);
+    const remaining = rawGet<{ id: string }>('SELECT id FROM attachments WHERE id = ?', attId);
     expect(remaining).toBeNull();
 
     worker.stop();

--- a/assistant/src/tools/assets/search.ts
+++ b/assistant/src/tools/assets/search.ts
@@ -189,11 +189,12 @@ export function searchAttachments(params: AssetSearchParams): StoredAttachment[]
       size_bytes: number;
       kind: string;
       thumbnail_base64: string | null;
+      file_path: string | null;
       created_at: number;
     }
 
     const rows = rawAll<AttachmentRow>(
-      `SELECT a.id, a.original_filename, a.mime_type, a.size_bytes, a.kind, a.thumbnail_base64, a.created_at
+      `SELECT a.id, a.original_filename, a.mime_type, a.size_bytes, a.kind, a.thumbnail_base64, a.file_path, a.created_at
        FROM attachments a
        WHERE ${whereParts.join(' AND ')}
        ORDER BY a.created_at DESC
@@ -208,6 +209,7 @@ export function searchAttachments(params: AssetSearchParams): StoredAttachment[]
       sizeBytes: r.size_bytes,
       kind: r.kind,
       thumbnailBase64: r.thumbnail_base64,
+      filePath: r.file_path ?? null,
       createdAt: r.created_at,
     }));
   }
@@ -224,6 +226,7 @@ export function searchAttachments(params: AssetSearchParams): StoredAttachment[]
       sizeBytes: attachments.sizeBytes,
       kind: attachments.kind,
       thumbnailBase64: attachments.thumbnailBase64,
+      filePath: attachments.filePath,
       createdAt: attachments.createdAt,
     })
     .from(attachments)

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -28,6 +28,26 @@ extension AppDelegate {
         return false
     }
 
+    // MARK: - Screen Recording Permission
+
+    /// Poll for screen recording permission after prompting, giving the user time to grant it in System Settings.
+    /// Mirrors `waitForAccessibilityPermission()` — checks once, triggers the OS prompt if needed, then polls.
+    private func waitForScreenRecordingPermission() async -> Bool {
+        // Already granted — no need to prompt or poll
+        if PermissionManager.screenRecordingStatus() == .granted { return true }
+
+        // Trigger the OS prompt / open System Settings
+        PermissionManager.requestScreenRecordingAccess()
+
+        // Poll every 500ms for up to 30 seconds
+        for _ in 0..<60 {
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            if Task.isCancelled { return false }
+            if PermissionManager.screenRecordingStatus() == .granted { return true }
+        }
+        return false
+    }
+
     // MARK: - Recording Source Picker
 
     /// Determines whether the recording source picker should be shown, and if so,
@@ -36,6 +56,17 @@ extension AppDelegate {
     ///
     /// Auto-applies saved preferences when valid, skipping the picker entirely.
     private func resolveRecordingOptions(for routed: TaskRoutedMessage) async -> IPCRecordingOptions? {
+        // Check screen recording permission before showing picker
+        let hasPermission = await waitForScreenRecordingPermission()
+        guard hasPermission else {
+            log.error("Screen recording permission denied — cannot show recording source picker")
+            self.mainWindow?.windowState.showToast(
+                message: "Screen recording requires permission. Grant it in System Settings \u{2192} Privacy & Security \u{2192} Screen Recording.",
+                style: .error
+            )
+            return nil
+        }
+
         let pickerVM = RecordingSourcePickerViewModel()
 
         let needsPicker = routed.recordingOptions?.promptForSource == true || pickerVM.hasMultipleDisplays


### PR DESCRIPTION
## Summary
- Fix TypeScript compile errors caused by missing `filePath` field in `StoredAttachment` test fixtures and asset search query results
- Fix `recording-cleanup.test.ts` to use project-standard `rawRun`/`rawGet` helpers instead of raw `db.run()`/`db.query().get()` patterns
- Add `waitForScreenRecordingPermission()` polling method to `AppDelegate+Sessions.swift` (mirrors existing `waitForAccessibilityPermission()`)
- Add screen recording permission preflight check in `resolveRecordingOptions()` before showing the recording source picker

## Test plan
- [x] `npx tsc --noEmit` passes cleanly (zero errors)
- [x] `bun test src/__tests__/recording-cleanup.test.ts` — all 6 tests pass
- [ ] Manual: verify screen recording permission prompt appears when starting a recording session without prior permission grant
- [ ] Manual: verify toast error message appears if permission is denied/times out

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
