### PR TITLE
fix: tag config-inbox guardian actions with guardian provenance

### DIFF
--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -23,7 +23,7 @@ import {
   type ApprovalRequestStatus,
 } from '../../memory/channel-guardian-store.js';
 import { refreshThreadEscalation } from '../../memory/inbox-escalation-projection.js';
-import { addMessage, getMessages, provenanceFromGuardianContext } from '../../memory/conversation-store.js';
+import { addMessage, getMessages } from '../../memory/conversation-store.js';
 import { getBindingByConversation } from '../../memory/external-conversation-store.js';
 import { updateThreadActivity } from '../../memory/inbox-thread-store.js';
 import { getLatestStoredPayload } from '../../memory/channel-delivery-store.js';
@@ -478,7 +478,7 @@ async function executeDeny(
 
   // Store a system note about the denial in the conversation
   addMessage(conversationId, 'assistant', denialText, {
-    ...provenanceFromGuardianContext(null),
+    provenanceActorRole: 'guardian' as const,
     userMessageChannel: sourceChannel,
     assistantMessageChannel: sourceChannel,
   });
@@ -514,7 +514,7 @@ export function handleAssistantInboxReply(
       'assistant',
       content,
       {
-        ...provenanceFromGuardianContext(null),
+        provenanceActorRole: 'guardian' as const,
         ...(bindingChannel
           ? { userMessageChannel: bindingChannel, assistantMessageChannel: bindingChannel }
           : {}),


### PR DESCRIPTION
## Summary
- Replace provenanceFromGuardianContext(null) with explicit provenanceActorRole: 'guardian' at config-inbox.ts executeDeny and handleAssistantInboxReply call sites
- These are guardian-initiated daemon UI actions and should always be trusted

Addresses feedback on #8529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
