### PR TITLE
refactor: simplify safe-blitz per-milestone feedback to direct push

### DIFF
--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -1,6 +1,6 @@
 Plan a feature end-to-end, create GitHub issues on the project board, execute milestones sequentially with per-milestone review gates onto a feature branch, and present the final PR for manual review.
 
-Unlike `/blitz`, this command does NOT merge directly to main. Instead, it creates a **feature branch** and processes milestones **one at a time** — each milestone is executed, then recursively swept for review feedback until all feedback (including transitive feedback) is exhausted. Only after reviews are fully clean is the milestone PR merged into the feature branch. After all milestones are complete, a final sweep runs on the entire feature branch. Then a PR from the feature branch into main is created, and a holistic Codex review is triggered. Codex feedback is iterated on until approved, CI is verified stable, and only then are you prompted to merge.
+Unlike `/blitz`, this command does NOT merge directly to main. Instead, it creates a **feature branch** and processes milestones **one at a time** — each milestone is executed, then review feedback is addressed by pushing fixes directly to the milestone PR branch until all feedback is exhausted. Only after reviews are fully clean is the milestone PR merged into the feature branch. After all milestones are complete, a final sweep runs on the entire feature branch. Then a PR from the feature branch into main is created, and a holistic Codex review is triggered. Codex feedback is iterated on until approved, CI is verified stable, and only then are you prompted to merge.
 
 The user passed: `$ARGUMENTS`
 
@@ -43,7 +43,7 @@ git push -u origin <feature-branch-name>
 
 This keeps your current branch unchanged so safe-blitz doesn't block your main working tree.
 
-3. Store the feature branch name for later phases. Milestone agents will use `--base <feature-branch-name>`. Feedback agents during per-milestone sweeps will use `--base <milestone-pr-branch>` (see Phase 4c).
+3. Store the feature branch name for later phases. Milestone agents will use `--base <feature-branch-name>`. Per-milestone feedback agents will push directly to the milestone PR branch (see Phase 4c).
 
 ## Phase 2: Plan & Spec
 
@@ -66,18 +66,19 @@ Do NOT use `.claude/phases/populate-todo.md` here. Instead, maintain an internal
 
 ## Phase 4: Execute Milestones with Review Gates
 
-**CRITICAL: Review-before-merge policy.** Milestone PRs must NOT be merged into the feature branch until all reviews are addressed and there is no pending feedback. The merge happens only after the per-milestone sweep completes cleanly. This is the defining guarantee of safe-blitz — if a PR is merged before reviews are clean, the review gate is meaningless.
+**CRITICAL: Review-before-merge policy.** Milestone PRs must NOT be merged into the feature branch until all reviews are addressed and there is no pending feedback. The merge happens only after the per-milestone feedback loop completes cleanly. This is the defining guarantee of safe-blitz — if a PR is merged before reviews are clean, the review gate is meaningless.
 
-Process milestones **one at a time** (sequentially). For each milestone, execute it, run a recursive sweep to exhaust all review feedback, and only THEN merge the milestone PR into the feature branch. This ensures each milestone is fully reviewed before its code lands on the feature branch.
+Process milestones **one at a time** (sequentially). For each milestone, execute it, run a direct feedback loop to address all review feedback by pushing fixes to the milestone branch, and only THEN merge the milestone PR into the feature branch. This ensures each milestone is fully reviewed before its code lands on the feature branch.
 
-The safe-blitz only considers a milestone "done" when its PR AND all transitive feedback PRs have been fully reviewed with no remaining change requests, AND the milestone PR has been merged into the feature branch after the sweep.
+The safe-blitz only considers a milestone "done" when its PR has been fully reviewed with no remaining change requests (all feedback addressed via direct pushes to the milestone branch), AND the milestone PR has been merged into the feature branch.
 
 ### Agent prompt template
 
-The following prompt template is used for both milestone tasks and feedback tasks. The `<base-branch>` placeholder is filled in by the lead when spawning the agent:
+The following prompt template is used for milestone tasks and final sweep feedback tasks. The `<base-branch>` placeholder is filled in by the lead when spawning the agent:
 - For **milestone tasks**: `<base-branch>` = `<feature-branch-name>`
-- For **feedback tasks during per-milestone sweep**: `<base-branch>` = `<milestone-pr-branch>` (the milestone PR's head branch)
 - For **feedback tasks during final sweep** (Phase 5): `<base-branch>` = `<feature-branch-name>`
+
+Per-milestone feedback uses a different workflow — see "Per-milestone feedback agent prompt" below.
 
 ```
 You are working on a single task in an isolated git worktree.
@@ -121,6 +122,57 @@ For "Address the feedback on <PR URL>" tasks:
 
 ```
 
+### Per-milestone feedback agent prompt
+
+This template is used for feedback tasks during the per-milestone review loop (Phase 4c). Instead of creating a new PR, the agent pushes fixes directly to the milestone PR branch.
+
+```
+You are working on a single task in an isolated git worktree.
+
+## Project context
+Read AGENTS.md in the repo root for project conventions and structure.
+
+## Repo-specific gotchas
+- `gh pr view` does NOT support a `merged` --json field. Use `state` and `mergedAt`: `gh pr view <N> --json state,mergedAt,title,url`
+- This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- Do NOT wait for CI checks to pass before merging. Merge immediately.
+- `tail` and `head` may not be available in the shell. Don't pipe to them.
+
+## Your worktree
+<absolute path to worktree>
+ALL work happens here. Do NOT touch the main repo.
+
+## Your task
+Address the review feedback on PR #<milestone-pr-number> (<milestone-pr-url>):
+<summary of changes requested>
+
+## Workflow
+1. Read the review comments on the milestone PR to understand what changes are requested:
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/<milestone-pr-number>/reviews --jq '.[-1].body'
+   gh api repos/{owner}/{repo}/pulls/<milestone-pr-number>/comments --jq '.[] | {path: .path, body: .body, line: .line}'
+   ```
+2. Implement the requested fixes in your worktree.
+3. Do NOT run tests, type-checking (tsc), or linting unless the task specifically requires it.
+4. Commit and push directly to the milestone PR branch:
+   ```bash
+   cd <worktree>
+   git add -A
+   git commit -m "<descriptive message about what feedback was addressed>"
+   git push origin HEAD:<milestone-pr-branch>
+   ```
+5. Resolve the addressed review threads:
+   ```bash
+   .claude/gh-review resolve-threads <milestone-pr-number> "Addressed in direct push to <milestone-pr-branch>"
+   ```
+6. Do NOT create a new PR. Do NOT use .claude/ship.
+7. Send a message to "lead" with:
+   - A summary of what feedback was addressed
+   - Which files were modified
+   - Any issues or concerns
+
+```
+
 ### For each milestone (in order):
 
 #### 4a. Add to TODO.md and execute
@@ -157,35 +209,54 @@ For "Address the feedback on <PR URL>" tasks:
    git fetch origin <milestone-pr-branch>
    ```
 
-#### 4c. Per-milestone recursive sweep
+#### 4c. Per-milestone feedback loop
 
-Run the recursive sweep (`.claude/phases/sweep.md`) with `--namespace <namespace>`. **Skip the entry pause** — treat as `--auto` for per-milestone sweeps. The user-facing pause only applies to the final sweep in Phase 5.
+Instead of using the full sweep+swarm machinery (which creates new PRs), per-milestone feedback is handled by pushing fixes directly to the milestone PR branch. This is faster and avoids the overhead of creating, reviewing, and merging intermediate feedback PRs.
 
-When the sweep says "back to the Swarm phase," run the swarm workflow (`.claude/commands/swarm.md`) with these modifications:
-- Pass `--namespace <namespace>` so only namespaced feedback items are processed.
-- Pass the worker count as the first positional argument (or default: 12).
-- All agents must use `--base <milestone-pr-branch>` (the milestone PR's head branch, not the feature branch or main). This means feedback PRs target the milestone branch, so fixes accumulate on the milestone PR.
-- Create worktrees from the milestone PR's branch: `.claude/worktree create swarm/<namespace>/task-<counter> origin/<milestone-pr-branch>`.
-- Agents must NOT use `--merge` in `.claude/ship`. All PRs are created without auto-merging.
-- **Merge override for "Address the feedback" tasks**: When the swarm encounters a feedback task referencing a PR that targets the milestone branch (i.e., it's a feedback PR, not the original milestone PR), merge that referenced PR into the milestone branch first (`gh pr merge <number> --squash`) so the next-level feedback agent has the code. Do NOT merge the original milestone PR (#`<milestone-pr-number>`, which targets the feature branch) — it must stay unmerged until Phase 4c.5.
+Maintain an internal counter for worktree naming (e.g., `fix-1`, `fix-2`, ...).
 
-Since milestones are added to TODO.md one at a time (and removed when executed), the only namespaced items in TODO.md during the sweep are feedback items for the current milestone. The swarm will process those and nothing else.
+**Feedback loop:**
 
-When the sweep says "final phase," proceed to step 4c.5.
+1. **Check for reviews**: Poll `.claude/check-pr-reviews <milestone-pr-number>` to check review status.
+   - If status is `pending`, wait 60 seconds and poll again.
+   - If status is `rate_limited`, wait 120 seconds and poll again.
+   - If status is `approved`, proceed to Phase 4c.5.
+   - If status is `changes_requested`, proceed to step 2.
+
+2. **Address the feedback**:
+   a. Read the review comments to understand what's requested.
+   b. Create a worktree from the milestone PR branch:
+      ```bash
+      .claude/worktree create swarm/<namespace>/fix-<counter> origin/<milestone-pr-branch>
+      ```
+   c. Spawn a `general-purpose` agent using the **per-milestone feedback agent prompt** (see above). The agent pushes fixes directly to `<milestone-pr-branch>` instead of creating a new PR.
+   d. When the agent finishes, clean up the worktree:
+      ```bash
+      .claude/worktree remove swarm/<namespace>/fix-<counter> --delete-branch
+      ```
+   e. Fetch the updated milestone branch:
+      ```bash
+      git fetch origin <milestone-pr-branch>
+      ```
+
+3. **Wait for new reviews**: After fixes are pushed, poll for new reviews on the milestone PR:
+   - Poll `.claude/check-pr-reviews <milestone-pr-number>` every 60 seconds.
+   - If `changes_requested`, return to step 2.
+   - If no new reviews arrive within **3 minutes**, or status is `approved`, proceed to Phase 4c.5.
+
+Repeat steps 1-3 until the exit condition: no remaining feedback AND either `approved` or no new reviews for 3 minutes.
 
 #### 4c.5. Merge milestone PR into feature branch
 
-This step runs ONLY after the per-milestone sweep completes cleanly (all reviews addressed, no pending feedback). This is the review-before-merge gate.
+This step runs ONLY after the per-milestone feedback loop completes cleanly (all reviews addressed, no pending feedback). This is the review-before-merge gate.
 
-1. Merge any remaining unmerged feedback PRs into the milestone branch (squash merge, in order of PR number). These are feedback PRs that were approved but not yet merged:
-   ```bash
-   gh pr merge <feedback-pr-number> --squash
-   ```
-2. Merge the milestone PR into the feature branch:
+Since feedback was pushed directly to the milestone branch (no intermediate feedback PRs to merge), simply merge the milestone PR:
+
+1. Merge the milestone PR into the feature branch:
    ```bash
    gh pr merge <milestone-pr-number> --squash
    ```
-3. Fetch the updated feature branch:
+2. Fetch the updated feature branch:
    ```bash
    git fetch origin <feature-branch-name>
    ```
@@ -208,7 +279,7 @@ After all milestones are merged and their individual reviews are clean, run one 
 Read and follow `.claude/phases/sweep.md` with `--namespace <namespace>`. Unless `--auto` was passed, this is where the user-facing pause happens: **"All milestones complete. Run final sweep for review feedback?"**
 
 This final sweep catches:
-- Any cross-milestone issues that individual per-milestone sweeps missed
+- Any cross-milestone issues that individual per-milestone feedback loops missed
 - Any remaining unreviewed PRs from any milestone
 
 When the sweep says "back to the Swarm phase," run the swarm workflow (`.claude/commands/swarm.md`) with these modifications (note: these differ from Phase 4c because the final sweep operates on the feature branch, not a milestone branch):
@@ -418,6 +489,6 @@ gh project view "$GH_PROJECT_NUMBER" --owner "$GH_PROJECT_OWNER" --format json |
 ## Important
 
 Read and follow `.claude/phases/blitz-important.md`. Additionally:
-- If an agent hits merge conflicts after another agent's PR landed, tell it to rebase against the appropriate branch: `git pull --rebase origin <milestone-pr-branch>` during per-milestone sweeps, or `git pull --rebase origin <feature-branch-name>` during the final sweep.
-- **Do NOT merge milestone PRs into the feature branch until the per-milestone sweep completes cleanly.** The merge happens in Phase 4c.5 — never before.
+- If an agent hits merge conflicts after another agent's PR landed, tell it to rebase against the appropriate branch: `git pull --rebase origin <milestone-pr-branch>` during per-milestone feedback loops, or `git pull --rebase origin <feature-branch-name>` during the final sweep.
+- **Do NOT merge milestone PRs into the feature branch until the per-milestone feedback loop completes cleanly.** The merge happens in Phase 4c.5 — never before.
 - **Do NOT merge the final PR until Phase 8** — after Codex holistic review is approved and CI is stable, and only with explicit user confirmation.


### PR DESCRIPTION
## Summary
- Replace the per-milestone sweep+swarm feedback loop (which creates intermediate feedback PRs) with a direct-push model where fixes are pushed straight to the milestone PR branch
- Add a new "per-milestone feedback agent prompt" template that instructs agents to commit and push directly to the milestone branch instead of using `.claude/ship` to create new PRs
- Simplify Phase 4c.5 by removing the step to merge intermediate feedback PRs (they no longer exist)
- After pushing fixes, poll for new reviews with a 3-minute timeout before proceeding to merge

## Original prompt
Lets update the safe-blitz command. When addressing PR feedback on milestone PRs, push your changes directly to that milestone branch. Do not bother opening a new PR, waiting for feedback on that one, and then merging that PR into the milestone PR. INstead, after pushing your changes directly to the milestone pr, wait for new reviews following your push and then address any need feedback. Repeat until there is no feedback remaining and/or there are no new reviews after 3 minutes. From there, proceed to merge the milestone pr into the feature branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
