### PR TITLE
Fix normalizeText() destroying markdown formatting

### DIFF
--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -277,6 +277,16 @@ function normalizeText(text: string): string {
     .trim();
 }
 
+// Lighter normalization for markdown that preserves indentation, multiple spaces,
+// and trailing whitespace — all of which carry semantic meaning in markdown
+// (code blocks, nested lists, table alignment, line breaks).
+function normalizeMarkdown(text: string): string {
+  return text
+    .replace(/\r/g, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
 function htmlToText(html: string): string {
   let text = html;
   text = text.replace(/<!--[\s\S]*?-->/g, ' ');
@@ -625,7 +635,9 @@ export async function executeWebFetch(
     const markdownTokens = response.headers.get('x-markdown-tokens') ?? undefined;
 
     let processed = body.text.replace(/\0/g, '');
-    if (html && !rawMode) {
+    if (markdown) {
+      processed = normalizeMarkdown(processed);
+    } else if (html && !rawMode) {
       processed = htmlToText(processed);
     } else {
       processed = normalizeText(processed);


### PR DESCRIPTION
Adds a normalizeMarkdown() function that preserves indentation and multiple spaces (needed for code blocks, nested lists, and table alignment) while still removing carriage returns and limiting excessive blank lines. Markdown responses now use this instead of normalizeText().
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
