### PR TITLE
feat: universal daemon title generation for all conversation creation paths

### DIFF
--- a/assistant/src/__tests__/agent-heartbeat-service.test.ts
+++ b/assistant/src/__tests__/agent-heartbeat-service.test.ts
@@ -44,6 +44,13 @@ mock.module('../util/logger.js', () => ({
     warn: () => {},
     error: () => {},
   }),
+  isDebug: () => false,
+}));
+
+// Mock conversation title service
+mock.module('../memory/conversation-title-service.js', () => ({
+  GENERATING_TITLE: 'Generating title...',
+  queueGenerateConversationTitle: () => {},
 }));
 
 // Import after mocks are set up
@@ -120,12 +127,12 @@ describe('AgentHeartbeatService', () => {
     expect(processMessageCalls[0].content).toContain('Check the current weather');
   });
 
-  test('creates background conversation titled "Agent Heartbeat"', async () => {
+  test('creates background conversation with generating title placeholder', async () => {
     const service = createService();
     await service.runOnce();
 
     expect(createdConversations).toHaveLength(1);
-    expect(createdConversations[0].title).toBe('Agent Heartbeat');
+    expect(createdConversations[0].title).toBe('Generating title...');
     expect(createdConversations[0].threadType).toBe('background');
   });
 

--- a/assistant/src/agent-heartbeat/agent-heartbeat-service.ts
+++ b/assistant/src/agent-heartbeat/agent-heartbeat-service.ts
@@ -3,6 +3,7 @@ import { getLogger } from '../util/logger.js';
 import { getWorkspacePromptPath } from '../util/platform.js';
 import { getConfig } from '../config/loader.js';
 import { createConversation } from '../memory/conversation-store.js';
+import { GENERATING_TITLE, queueGenerateConversationTitle } from '../memory/conversation-title-service.js';
 import type { AgentHeartbeatAlert } from '../daemon/ipc-contract.js';
 
 const log = getLogger('agent-heartbeat');
@@ -94,8 +95,12 @@ export class AgentHeartbeatService {
       const prompt = this.buildPrompt(checklist);
 
       const conversation = createConversation({
-        title: 'Agent Heartbeat',
+        title: GENERATING_TITLE,
         threadType: 'background',
+      });
+      queueGenerateConversationTitle({
+        conversationId: conversation.id,
+        context: { origin: 'heartbeat', systemHint: 'Agent Heartbeat' },
       });
 
       await this.deps.processMessage(conversation.id, prompt);

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -30,6 +30,7 @@ import type { CallSession } from './types.js';
 import { VALID_CALLER_IDENTITY_MODES } from '../config/schema.js';
 import type { AssistantConfig } from '../config/types.js';
 import { getOrCreateConversation } from '../memory/conversation-key-store.js';
+import { queueGenerateConversationTitle } from '../memory/conversation-title-service.js';
 import { upsertBinding } from '../memory/external-conversation-store.js';
 import { addPointerMessage } from './call-pointer-messages.js';
 
@@ -236,6 +237,16 @@ export function createInboundVoiceSession(
   updateCallSession(session.id, { providerCallSid: callSid });
   session.providerCallSid = callSid;
 
+  queueGenerateConversationTitle({
+    conversationId: voiceConversationId,
+    context: {
+      origin: 'voice_inbound',
+      sourceChannel: 'voice',
+      assistantId,
+      systemHint: `Inbound call from ${fromNumber}`,
+    },
+  });
+
   log.info(
     { callSessionId: session.id, callSid, voiceConversationId, from: fromNumber, to: toNumber, assistantId },
     'Created new inbound voice session',
@@ -318,6 +329,17 @@ export async function startCall(input: StartCallInput): Promise<StartCallResult 
       conversationId: voiceConversationId,
     });
     session.conversationId = voiceConversationId;
+
+    queueGenerateConversationTitle({
+      conversationId: voiceConversationId,
+      context: {
+        origin: 'voice_outbound',
+        sourceChannel: 'voice',
+        assistantId,
+        systemHint: `Outbound call to ${phoneNumber}`,
+        triggerTextSnippet: task,
+      },
+    });
 
     log.info({ callSessionId: session.id, voiceConversationId, initiatedFrom: conversationId, to: phoneNumber, from: fromNumber, task }, 'Initiating outbound call');
 

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -22,7 +22,7 @@ import {
 import { deliverChannelReply } from '../runtime/gateway-client.js';
 import { getUserConsultationTimeoutMs } from './call-constants.js';
 import { getOrCreateConversation } from '../memory/conversation-key-store.js';
-import { addMessage } from '../memory/conversation-store.js';
+import { addMessage, updateConversationTitle } from '../memory/conversation-store.js';
 import type { CallPendingQuestion } from './types.js';
 import { readHttpToken } from '../util/platform.js';
 import type { ServerMessage } from '../daemon/ipc-contract.js';
@@ -164,6 +164,10 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
 
         // Now await LLM-generated copy for the message content and thread title
         const guardianCopy = await guardianCopyPromise;
+
+        // Persist the generated thread title to the DB (replaces the
+        // "Generating title..." placeholder set by getOrCreateConversation)
+        updateConversationTitle(macConversationId, guardianCopy.threadTitle);
 
         // Add the guardian question as the initial message in the thread
         addMessage(

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -28,6 +28,7 @@ import type {
   ConversationSearchRequest,
 } from '../ipc-protocol.js';
 import { getConfig } from '../../config/loader.js';
+import { GENERATING_TITLE } from '../../memory/conversation-title-service.js';
 import { getSubagentManager } from '../../subagent/index.js';
 import {
   log,
@@ -271,8 +272,9 @@ export async function handleSessionCreate(
   ctx: HandlerContext,
 ): Promise<void> {
   const threadType = normalizeThreadType(msg.threadType);
+  const title = msg.title ?? (msg.initialMessage ? GENERATING_TITLE : 'New Conversation');
   const conversation = conversationStore.createConversation({
-    title: msg.title ?? 'New Conversation',
+    title,
     threadType,
   });
   const session = await ctx.getOrCreateSession(conversation.id, socket, true, {

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -55,6 +55,8 @@ export interface EventHandlerDeps {
   readonly onEvent: (msg: ServerMessage) => void;
   readonly reqId: string;
   readonly isFirstMessage: boolean;
+  /** Whether the conversation title is replaceable — controls firstAssistantText accumulation for title generation. */
+  readonly shouldGenerateTitle: boolean;
   readonly rlog: pino.Logger;
   readonly turnChannelContext: TurnChannelContext;
 }
@@ -112,7 +114,7 @@ export function handleTextDelta(
   state.pendingDirectiveDisplayBuffer = drained.bufferedRemainder;
   if (drained.emitText.length > 0) {
     deps.onEvent({ type: 'assistant_text_delta', text: drained.emitText, sessionId: deps.ctx.conversationId });
-    if (deps.isFirstMessage) state.firstAssistantText += drained.emitText;
+    if (deps.shouldGenerateTitle) state.firstAssistantText += drained.emitText;
   }
 }
 
@@ -259,7 +261,7 @@ export function handleMessageComplete(
       text: state.pendingDirectiveDisplayBuffer,
       sessionId: deps.ctx.conversationId,
     });
-    if (deps.isFirstMessage) state.firstAssistantText += state.pendingDirectiveDisplayBuffer;
+    if (deps.shouldGenerateTitle) state.firstAssistantText += state.pendingDirectiveDisplayBuffer;
     state.pendingDirectiveDisplayBuffer = '';
   }
 

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -25,6 +25,7 @@ import type { ToolProfiler } from '../events/tool-profiling-listener.js';
 import type { ContextWindowManager } from '../context/window-manager.js';
 import { getHookManager } from '../hooks/manager.js';
 import { truncate } from '../util/truncate.js';
+import { isReplaceableTitle, queueGenerateConversationTitle } from '../memory/conversation-title-service.js';
 import { stripMemoryRecallMessages } from '../memory/retriever.js';
 import { getApp, listAppFiles } from '../memory/app-store.js';
 import type { ConflictGate } from './session-conflict-gate.js';
@@ -335,11 +336,16 @@ export async function runAgentLoopImpl(
 
     let preRunHistoryLength = runMessages.length;
 
+    const shouldGenerateTitle = isReplaceableTitle(
+      conversationStore.getConversation(ctx.conversationId)?.title ?? null,
+    );
+
     const deps: EventHandlerDeps = {
       ctx,
       onEvent,
       reqId,
       isFirstMessage,
+      shouldGenerateTitle,
       rlog,
       turnChannelContext: capturedTurnChannelContext,
     };
@@ -629,11 +635,25 @@ export async function runAgentLoopImpl(
       });
     }
 
-    if (isFirstMessage) {
-      generateTitle(ctx, content, state.firstAssistantText, onEvent, abortController.signal)
-        .catch((err) => {
-          log.warn({ err, conversationId: ctx.conversationId }, 'Failed to generate conversation title (non-fatal, using default title)');
-        });
+    // Generate title if the current conversation title is still a replaceable
+    // placeholder. This replaces the previous `isFirstMessage` gate so that
+    // assistant-seeded/system-seeded threads also receive generated titles.
+    const currentConv = conversationStore.getConversation(ctx.conversationId);
+    if (isReplaceableTitle(currentConv?.title ?? null)) {
+      queueGenerateConversationTitle({
+        conversationId: ctx.conversationId,
+        provider: ctx.provider,
+        userMessage: content,
+        assistantResponse: state.firstAssistantText || undefined,
+        onTitleUpdated: (title) => {
+          onEvent({
+            type: 'session_title_updated',
+            sessionId: ctx.conversationId,
+            title,
+          });
+        },
+        signal: abortController.signal,
+      });
     }
   } catch (err) {
     const errorCtx = { phase: 'agent_loop' as const, aborted: abortController.signal.aborted };
@@ -704,44 +724,6 @@ export async function runAgentLoopImpl(
     }
 
     ctx.drainQueue(yieldedForHandoff ? 'checkpoint_handoff' : 'loop_complete');
-  }
-}
-
-// ── generateTitle ────────────────────────────────────────────────────
-
-async function generateTitle(
-  ctx: Pick<AgentLoopSessionContext, 'conversationId' | 'provider'>,
-  userMessage: string,
-  assistantResponse: string,
-  onEvent: (msg: ServerMessage) => void,
-  sessionSignal?: AbortSignal,
-): Promise<void> {
-  const config = getConfig();
-  const prompt = `Generate a very short title for this conversation. Rules: at most 5 words, at most 40 characters, no quotes.\n\nUser: ${truncate(userMessage, 200, '')}\nAssistant: ${truncate(assistantResponse, 200, '')}`;
-  const signal = sessionSignal
-    ? AbortSignal.any([sessionSignal, AbortSignal.timeout(10_000)])
-    : AbortSignal.timeout(10_000);
-  const response = await ctx.provider.sendMessage(
-    [{ role: 'user', content: [{ type: 'text', text: prompt }] }],
-    [],
-    undefined,
-    { config: { max_tokens: config.daemon.titleGenerationMaxTokens }, signal },
-  );
-
-  const textBlock = response.content.find((b) => b.type === 'text');
-  if (textBlock && textBlock.type === 'text') {
-    let title = textBlock.text.trim().replace(/^["']|["']$/g, '');
-    const words = title.split(/\s+/);
-    if (words.length > 5) title = words.slice(0, 5).join(' ');
-    if (title.length > 40) title = title.slice(0, 40).trimEnd();
-    if (!title) return;
-    conversationStore.updateConversationTitle(ctx.conversationId, title);
-    onEvent({
-      type: 'session_title_updated',
-      sessionId: ctx.conversationId,
-      title,
-    });
-    log.info({ conversationId: ctx.conversationId, title }, 'Auto-generated conversation title');
   }
 }
 

--- a/assistant/src/memory/conversation-key-store.ts
+++ b/assistant/src/memory/conversation-key-store.ts
@@ -11,6 +11,7 @@ import { eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
 import { conversations, conversationKeys } from './schema.js';
+import { GENERATING_TITLE } from './conversation-title-service.js';
 
 export interface ConversationKeyMapping {
   id: string;
@@ -116,7 +117,7 @@ export function getOrCreateConversation(
     tx.insert(conversations)
       .values({
         id: conversationId,
-        title: `Runtime: ${conversationKey}`,
+        title: GENERATING_TITLE,
         createdAt: now,
         updatedAt: now,
         totalInputTokens: 0,

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -1,0 +1,231 @@
+/**
+ * Shared conversation title generation service.
+ *
+ * Provides a single reusable primitive for generating and persisting
+ * conversation titles across all creation paths. Enforces a safe
+ * overwrite policy: only replaceable placeholder/system titles are
+ * overwritten, never user-provided custom titles.
+ */
+
+import * as conversationStore from './conversation-store.js';
+import { getConfiguredProvider } from '../providers/provider-send-message.js';
+import { getConfig } from '../config/loader.js';
+import { truncate } from '../util/truncate.js';
+import { getLogger } from '../util/logger.js';
+import type { Provider } from '../providers/types.js';
+
+const log = getLogger('conversation-title-service');
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export type TitleOrigin =
+  | 'runtime_api'
+  | 'channel_inbound'
+  | 'voice_outbound'
+  | 'voice_inbound'
+  | 'guardian_request'
+  | 'schedule'
+  | 'reminder'
+  | 'task'
+  | 'watcher'
+  | 'subagent'
+  | 'heartbeat'
+  | 'ipc'
+  | 'task_submit'
+  | 'misc';
+
+export interface TitleContext {
+  origin: TitleOrigin;
+  conversationKey?: string;
+  sourceChannel?: string;
+  assistantId?: string;
+  externalChatId?: string;
+  displayName?: string;
+  username?: string;
+  triggerTextSnippet?: string;
+  systemHint?: string;
+  metadataHints?: string[];
+  uxBrief?: string;
+}
+
+// ── Placeholder / loading state ──────────────────────────────────────
+
+export const GENERATING_TITLE = 'Generating title...';
+export const UNTITLED_FALLBACK = 'Untitled Conversation';
+
+// ── Replaceability check ─────────────────────────────────────────────
+
+const REPLACEABLE_PATTERNS = [
+  /^Runtime:\s/,
+  /^New Conversation$/,
+  /^Untitled$/,
+  /^Untitled Conversation$/,
+  /^Generating title\.\.\.$/,
+];
+
+/**
+ * Check whether a title is a system-generated placeholder that can be
+ * safely overwritten by auto-generated titles. Returns `false` for
+ * user-provided custom titles.
+ */
+export function isReplaceableTitle(title: string | null): boolean {
+  if (title == null || title.trim() === '') return true;
+  return REPLACEABLE_PATTERNS.some((pattern) => pattern.test(title));
+}
+
+// ── Title generation ─────────────────────────────────────────────────
+
+export interface GenerateTitleParams {
+  conversationId: string;
+  /** Provider to use for LLM call. Falls back to getConfiguredProvider(). */
+  provider?: Provider;
+  /** Context about how/where the conversation was created. */
+  context?: TitleContext;
+  /** User message text (first turn). */
+  userMessage?: string;
+  /** Assistant response text (first turn). */
+  assistantResponse?: string;
+  /** Callback to emit title update events. */
+  onTitleUpdated?: (title: string) => void;
+  /** Abort signal. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Generate a conversation title via LLM and persist it, but only if the
+ * current title is still replaceable (safe overwrite policy).
+ */
+export async function generateAndPersistConversationTitle(
+  params: GenerateTitleParams,
+): Promise<{ title: string; updated: boolean }> {
+  const { conversationId, context, userMessage, assistantResponse, onTitleUpdated, signal } = params;
+
+  // Check current title is replaceable
+  const conversation = conversationStore.getConversation(conversationId);
+  if (conversation && !isReplaceableTitle(conversation.title)) {
+    return { title: conversation.title!, updated: false };
+  }
+
+  const provider = params.provider ?? getConfiguredProvider();
+  if (!provider) {
+    // No provider available — fall back to context-derived title or untitled
+    const fallback = deriveFallbackTitle(context) ?? UNTITLED_FALLBACK;
+    conversationStore.updateConversationTitle(conversationId, fallback);
+    onTitleUpdated?.(fallback);
+    return { title: fallback, updated: true };
+  }
+
+  const config = getConfig();
+  const prompt = buildTitlePrompt(context, userMessage, assistantResponse);
+  const timeoutSignal = AbortSignal.timeout(10_000);
+  const combinedSignal = signal
+    ? AbortSignal.any([signal, timeoutSignal])
+    : timeoutSignal;
+
+  const response = await provider.sendMessage(
+    [{ role: 'user', content: [{ type: 'text', text: prompt }] }],
+    [],
+    undefined,
+    { config: { max_tokens: config.daemon.titleGenerationMaxTokens }, signal: combinedSignal },
+  );
+
+  const textBlock = response.content.find((b) => b.type === 'text');
+  if (textBlock && textBlock.type === 'text') {
+    let title = normalizeTitle(textBlock.text);
+    if (!title) {
+      title = deriveFallbackTitle(context) ?? UNTITLED_FALLBACK;
+    }
+
+    // Re-check replaceability before persisting (race guard)
+    const current = conversationStore.getConversation(conversationId);
+    if (current && !isReplaceableTitle(current.title)) {
+      return { title: current.title!, updated: false };
+    }
+
+    conversationStore.updateConversationTitle(conversationId, title);
+    onTitleUpdated?.(title);
+    log.info({ conversationId, title }, 'Auto-generated conversation title');
+    return { title, updated: true };
+  }
+
+  // No text in response — use fallback
+  const fallback = deriveFallbackTitle(context) ?? UNTITLED_FALLBACK;
+  conversationStore.updateConversationTitle(conversationId, fallback);
+  onTitleUpdated?.(fallback);
+  return { title: fallback, updated: true };
+}
+
+/**
+ * Fire-and-forget wrapper for title generation. Failures are logged
+ * but do not propagate. On failure, replaces loading placeholder with
+ * a stable fallback title so loading state is never permanent.
+ */
+export function queueGenerateConversationTitle(
+  params: GenerateTitleParams,
+): void {
+  generateAndPersistConversationTitle(params).catch((err) => {
+    log.warn(
+      { err, conversationId: params.conversationId },
+      'Failed to generate conversation title (non-fatal)',
+    );
+    // Replace loading placeholder with stable fallback
+    try {
+      const conversation = conversationStore.getConversation(params.conversationId);
+      if (conversation && conversation.title === GENERATING_TITLE) {
+        const fallback = deriveFallbackTitle(params.context) ?? UNTITLED_FALLBACK;
+        conversationStore.updateConversationTitle(params.conversationId, fallback);
+        params.onTitleUpdated?.(fallback);
+      }
+    } catch {
+      // Best-effort
+    }
+  });
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────
+
+function buildTitlePrompt(
+  context?: TitleContext,
+  userMessage?: string,
+  assistantResponse?: string,
+): string {
+  const parts: string[] = [
+    'Generate a very short title for this conversation. Rules: at most 5 words, at most 40 characters, no quotes.',
+  ];
+
+  if (context) {
+    const hints: string[] = [];
+    if (context.sourceChannel) hints.push(`Channel: ${context.sourceChannel}`);
+    if (context.displayName) hints.push(`User: ${context.displayName}`);
+    if (context.systemHint) hints.push(`Context: ${context.systemHint}`);
+    if (context.uxBrief) hints.push(`Brief: ${context.uxBrief}`);
+    if (context.metadataHints?.length) hints.push(`Hints: ${context.metadataHints.join(', ')}`);
+    if (hints.length > 0) {
+      parts.push('', 'Metadata:', ...hints);
+    }
+  }
+
+  if (userMessage) {
+    parts.push('', `User: ${truncate(userMessage, 200, '')}`);
+  }
+  if (assistantResponse) {
+    parts.push(`Assistant: ${truncate(assistantResponse, 200, '')}`);
+  }
+
+  return parts.join('\n');
+}
+
+function normalizeTitle(raw: string): string {
+  let title = raw.trim().replace(/^["']|["']$/g, '');
+  const words = title.split(/\s+/);
+  if (words.length > 5) title = words.slice(0, 5).join(' ');
+  if (title.length > 40) title = title.slice(0, 40).trimEnd();
+  return title;
+}
+
+function deriveFallbackTitle(context?: TitleContext): string | null {
+  if (!context) return null;
+  if (context.systemHint) return truncate(context.systemHint, 40, '');
+  if (context.uxBrief) return truncate(context.uxBrief, 40, '');
+  return null;
+}

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -1,5 +1,6 @@
 import { getLogger } from '../util/logger.js';
 import { createConversation } from '../memory/conversation-store.js';
+import { GENERATING_TITLE, queueGenerateConversationTitle } from '../memory/conversation-title-service.js';
 import {
   claimDueSchedules,
   createScheduleRun,
@@ -103,14 +104,22 @@ async function runScheduleOnce(
         const message = err instanceof Error ? err.message : String(err);
         log.warn({ err, jobId: job.id, name: job.name, taskId, syntax: job.syntax, expression: job.expression, isRruleSet }, 'Scheduled task execution failed');
         // Create a fallback conversation for the schedule run record
-        const fallbackConversation = createConversation({ title: `Schedule: ${job.name}`, source: 'schedule' });
+        const fallbackConversation = createConversation({ title: GENERATING_TITLE, source: 'schedule' });
+        queueGenerateConversationTitle({
+          conversationId: fallbackConversation.id,
+          context: { origin: 'schedule', systemHint: `Schedule: ${job.name}` },
+        });
         const runId = createScheduleRun(job.id, fallbackConversation.id);
         completeScheduleRun(runId, { status: 'error', error: message });
       }
       continue;
     }
 
-    const conversation = createConversation({ title: `Schedule: ${job.name}`, source: 'schedule' });
+    const conversation = createConversation({ title: GENERATING_TITLE, source: 'schedule' });
+    queueGenerateConversationTitle({
+      conversationId: conversation.id,
+      context: { origin: 'schedule', systemHint: `Schedule: ${job.name}` },
+    });
     const runId = createScheduleRun(job.id, conversation.id);
     const isRruleSetMsg = job.syntax === 'rrule' && hasSetConstructs(job.expression);
 
@@ -131,7 +140,11 @@ async function runScheduleOnce(
   const dueReminders = claimDueReminders(now);
   for (const reminder of dueReminders) {
     if (reminder.mode === 'execute') {
-      const conversation = createConversation({ title: `Reminder: ${reminder.label}`, source: 'reminder' });
+      const conversation = createConversation({ title: GENERATING_TITLE, source: 'reminder' });
+      queueGenerateConversationTitle({
+        conversationId: conversation.id,
+        context: { origin: 'reminder', systemHint: `Reminder: ${reminder.label}` },
+      });
       setReminderConversationId(reminder.id, conversation.id);
       try {
         log.info({ reminderId: reminder.id, label: reminder.label, conversationId: conversation.id }, 'Executing reminder');

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -11,6 +11,7 @@
 import { v4 as uuid } from 'uuid';
 import { Session, type SessionMemoryPolicy } from '../daemon/session.js';
 import { createConversation } from '../memory/conversation-store.js';
+import { GENERATING_TITLE, queueGenerateConversationTitle } from '../memory/conversation-title-service.js';
 import { getConfig } from '../config/loader.js';
 import { getFailoverProvider } from '../providers/registry.js';
 import { RateLimitProvider } from '../providers/ratelimit.js';
@@ -111,8 +112,12 @@ export class SubagentManager {
     // ── Create conversation ─────────────────────────────────────────
     const subagentId = uuid();
     const conversation = createConversation({
-      title: `Subagent: ${config.label}`,
+      title: GENERATING_TITLE,
       threadType: 'background',
+    });
+    queueGenerateConversationTitle({
+      conversationId: conversation.id,
+      context: { origin: 'subagent', systemHint: `Subagent: ${config.label}` },
     });
 
     // ── Build session dependencies ──────────────────────────────────

--- a/assistant/src/tasks/task-runner.ts
+++ b/assistant/src/tasks/task-runner.ts
@@ -1,5 +1,6 @@
 import { getLogger } from '../util/logger.js';
 import { createConversation } from '../memory/conversation-store.js';
+import { GENERATING_TITLE, queueGenerateConversationTitle } from '../memory/conversation-title-service.js';
 import { getTask, createTaskRun, updateTaskRun } from './task-store.js';
 import { buildTaskRules, setTaskRunRules, clearTaskRunRules } from './ephemeral-permissions.js';
 import { sanitizeToolList } from './tool-sanitizer.js';
@@ -43,7 +44,11 @@ export async function runTask(
   }
 
   const run = createTaskRun(task.id);
-  const conversation = createConversation({ title: `Task: ${task.title}`, threadType: 'background' });
+  const conversation = createConversation({ title: GENERATING_TITLE, threadType: 'background' });
+  queueGenerateConversationTitle({
+    conversationId: conversation.id,
+    context: { origin: 'task', systemHint: `Task: ${task.title}` },
+  });
 
   updateTaskRun(run.id, {
     conversationId: conversation.id,

--- a/assistant/src/watcher/engine.ts
+++ b/assistant/src/watcher/engine.ts
@@ -7,6 +7,7 @@
 
 import { getLogger } from '../util/logger.js';
 import { createConversation } from '../memory/conversation-store.js';
+import { GENERATING_TITLE, queueGenerateConversationTitle } from '../memory/conversation-title-service.js';
 import { getWatcherProvider } from './provider-registry.js';
 import {
   claimDueWatchers,
@@ -143,8 +144,12 @@ export async function runWatchersOnce(
       let conversationId = watcher.conversationId;
       if (!conversationId) {
         const conv = createConversation({
-          title: `Watcher: ${watcher.name}`,
+          title: GENERATING_TITLE,
           threadType: 'background' as 'standard' | 'private',
+        });
+        queueGenerateConversationTitle({
+          conversationId: conv.id,
+          context: { origin: 'watcher', systemHint: `Watcher: ${watcher.name}` },
         });
         conversationId = conv.id;
         setWatcherConversationId(watcher.id, conversationId);


### PR DESCRIPTION
## Summary
- Introduces `conversation-title-service.ts` — a shared module with `isReplaceableTitle()`, `queueGenerateConversationTitle()`, and the `GENERATING_TITLE` placeholder constant
- Updates all 12+ conversation creation paths (scheduler, tasks, watchers, subagents, heartbeat, voice calls, guardian dispatch, runtime API, IPC sessions, channel inbound) to use `"Generating title..."` placeholder with async LLM title generation
- Refactors the agent loop to use replaceability-based title generation (checks if current title is a system placeholder) instead of the previous `isFirstMessage` gate, ensuring titles are generated even for re-opened or system-seeded conversations

## Original prompt
/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/.private/plans/universal-daemon-title-generation-plan-2026-02-25.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
