### PR TITLE
docs: route text generation through the assistant daemon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,14 @@ The `RetryProvider` resolves intents to provider-specific models automatically. 
 
 Use generic terms in comments, logs, and variable names — write "LLM" instead of "Haiku"/"Sonnet"/"Claude". The system is multi-provider; naming should reflect that.
 
+### Text generation goes through the assistant daemon
+
+When you need to generate text (summaries, replies, rewrites, classifications, etc.), route the request through the assistant/daemon process — do **not** make direct calls to an LLM provider or side-step the daemon.
+
+Why: the assistant daemon carries context, identity, and user preferences. Text produced through the daemon is shaped by all of that, which is what we want in almost every case. Calling a provider directly discards that context and produces generic output.
+
+There may be narrow cases where a direct provider call is acceptable (e.g., a low-level embedding or a purely mechanical transformation with no user-facing prose). If you believe your case qualifies, call it out explicitly in the PR description and get sign-off — don't silently bypass the daemon.
+
 ## Approval Flow Resilience
 
 - **Rich delivery failures must degrade gracefully.** If delivering a rich approval prompt (e.g., Telegram inline buttons) fails, fall back to plain text with parser-compatible instructions (e.g., `Reply "yes" to approve`) — never auto-deny.


### PR DESCRIPTION
## Summary
- Adds a new subsection under "LLM Provider Abstraction" in AGENTS.md clarifying that text generation should go through the assistant/daemon process, not direct LLM provider calls
- Explains the rationale: the daemon carries context, identity, and user preferences that should influence generated text
- Allows narrow exceptions (e.g., embeddings, mechanical transformations) with explicit PR sign-off

## Original prompt
Lets update AGENTS.md to add some guidance around using llms to generate text. In almost all cases, generation of text should go through the assistant/daemon process. We should avoid making direct calls to any specific llm provider or making llm calls by side-stepping the assistant daemon. Why? Because the assistant has contect, an identity, knows your preferences, etc. and we generally want text that gets generated to be influenced by all that. There may be specific cases where going direct to the model provider is acceptable, but it should be done very intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
