### PR TITLE
refactor: simplify Skills Available tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -140,25 +140,12 @@ struct AgentPanelContent: View {
 
     // MARK: - Available Skills Tab
 
-    /// ClaWHub skills filtered to exclude already-installed ones, with local search and sort.
-    /// When filtering to Vellum-only, installed Vellum skills are kept so the catalog is always visible.
+    /// Available skills filtered to exclude already-installed ones.
     private var availableClawhubSkills: [ClawhubSkillItem] {
         let installedNames = Set(skillsManager.skills.map(\.name))
 
-        // Source filter — applied before installed-name exclusion so we can
-        // relax the exclusion for Vellum-only view.
-        var filtered: [ClawhubSkillItem]
-        switch skillSourceFilter {
-        case .all:
-            filtered = skillsManager.searchResults
-                .filter { !installedNames.contains($0.name) }
-        case .vellum:
-            // Show all Vellum catalog skills even if already installed
-            filtered = skillsManager.searchResults.filter { $0.isVellum }
-        case .community:
-            filtered = skillsManager.searchResults
-                .filter { !$0.isVellum && !installedNames.contains($0.name) }
-        }
+        var filtered = skillsManager.searchResults
+            .filter { !installedNames.contains($0.name) }
 
         // Local fuzzy filter by name/description
         if hasActiveSearch {
@@ -170,14 +157,7 @@ struct AgentPanelContent: View {
             }
         }
 
-        switch skillSortOrder {
-        case .installs:
-            return filtered.sorted { $0.installs > $1.installs }
-        case .stars:
-            return filtered.sorted { $0.stars > $1.stars }
-        case .newest:
-            return filtered.sorted { $0.createdAt > $1.createdAt }
-        }
+        return filtered.sorted { $0.installs > $1.installs }
     }
 
     @ViewBuilder
@@ -210,51 +190,6 @@ struct AgentPanelContent: View {
     @ViewBuilder
     private var availableSkillsList: some View {
         VStack(spacing: VSpacing.lg) {
-            // Source filter
-            HStack(spacing: VSpacing.sm) {
-                Text("Source:")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
-
-                ForEach(SkillSourceFilter.allCases, id: \.self) { filter in
-                    Button(action: { skillSourceFilter = filter }) {
-                        Text(filter.rawValue)
-                            .font(VFont.caption)
-                            .foregroundColor(skillSourceFilter == filter ? VColor.accent : VColor.textMuted)
-                            .padding(.horizontal, VSpacing.sm)
-                            .padding(.vertical, VSpacing.xs)
-                            .background(skillSourceFilter == filter ? VColor.accent.opacity(0.15) : Color.clear)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                    }
-                    .buttonStyle(.plain)
-                }
-
-                Spacer()
-            }
-
-            // Sort picker
-            HStack(spacing: VSpacing.sm) {
-                Text("Sort:")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
-
-                ForEach(SkillSortOrder.allCases, id: \.self) { order in
-                    Button(action: { skillSortOrder = order }) {
-                        Text(order.rawValue)
-                            .font(VFont.caption)
-                            .foregroundColor(skillSortOrder == order ? VColor.accent : VColor.textMuted)
-                            .padding(.horizontal, VSpacing.sm)
-                            .padding(.vertical, VSpacing.xs)
-                            .background(skillSortOrder == order ? VColor.accent.opacity(0.15) : Color.clear)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                    }
-                    .buttonStyle(.plain)
-                }
-
-                Spacer()
-            }
-
-            // ClaWHub skills
             if skillsManager.isSearching {
                 HStack {
                     Spacer()
@@ -267,17 +202,15 @@ struct AgentPanelContent: View {
                 ForEach(availableClawhubSkills) { skill in
                     clawhubSkillCard(skill)
                 }
-            } else if hasActiveSearch || skillSourceFilter != .all {
+            } else if hasActiveSearch {
                 VStack(spacing: VSpacing.md) {
                     VEmptyState(
-                        title: hasActiveSearch ? "No matches in Available" : "No results",
-                        subtitle: hasActiveSearch
-                            ? "No available skills matched \"\(globalSkillSearchQuery)\""
-                            : "No \(skillSourceFilter.rawValue) skills found",
+                        title: "No matches in Available",
+                        subtitle: "No available skills matched \"\(globalSkillSearchQuery)\"",
                         icon: "magnifyingglass"
                     )
 
-                    if hasActiveSearch, !filteredUserSkills.isEmpty {
+                    if !filteredUserSkills.isEmpty {
                         Button {
                             withAnimation(VAnimation.fast) { selectedTab = .installed }
                         } label: {
@@ -291,28 +224,6 @@ struct AgentPanelContent: View {
                 .frame(minHeight: 100)
             }
 
-            // Community disclaimer — hidden when filtering to Vellum-only
-            if skillSourceFilter != .vellum {
-                VStack(spacing: VSpacing.sm) {
-                    HStack(spacing: VSpacing.sm) {
-                        Image(systemName: "exclamationmark.shield.fill")
-                            .font(.system(size: 10))
-                            .foregroundColor(Amber._500)
-                        Text("Community skills are not verified by Vellum. Review before installing.")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-                    }
-
-                    HStack(spacing: VSpacing.sm) {
-                        Image(systemName: "sparkles")
-                            .font(.system(size: 10))
-                            .foregroundColor(VColor.accent)
-                        Text("Browse more on ClawhHub")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-                    }
-                }
-            }
         }
         .onAppear {
             skillsManager.searchSkills()
@@ -323,26 +234,12 @@ struct AgentPanelContent: View {
     @State private var installAttemptId: UUID?
     @State private var installTimeoutTask: Task<Void, Never>?
     @State private var globalSkillSearchQuery = ""
-    @State private var skillSortOrder: SkillSortOrder = .installs
-    @State private var skillSourceFilter: SkillSourceFilter = .all
 
     private var normalizedSkillQuery: String {
         globalSkillSearchQuery.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 
     private var hasActiveSearch: Bool { !normalizedSkillQuery.isEmpty }
-
-    private enum SkillSortOrder: String, CaseIterable {
-        case installs = "Installs"
-        case stars = "Stars"
-        case newest = "Newest"
-    }
-
-    private enum SkillSourceFilter: String, CaseIterable {
-        case all = "All"
-        case vellum = "Vellum"
-        case community = "Community"
-    }
 
     /// How long ago a skill was published, as a human-readable string.
     private func skillAge(_ createdAt: Int) -> String {


### PR DESCRIPTION
## Summary
- Remove Source filter (All/Vellum/Community) from the Available skills tab
- Remove Sort picker (Installs/Stars/Newest) — now defaults to sorting by installs
- Remove community disclaimer and "Browse more on ClawhHub" link
- Clean up associated state vars and enums (SkillSourceFilter, SkillSortOrder)

## Original prompt
On the "Available" tab of the Skills page lets:
1. remove the concept of "Source"
2. Remove "Sort"
3. Remove mention of "Clawhub"

And generally simplify to only what exists today. We can add stuff back later as it becomes real

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
