### PR TITLE
Fix lint in call controller test

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -82,10 +82,9 @@ function createMockVoiceTurn(tokens: string[]) {
       opts.onComplete();
     }
 
-    let aborted = false;
     return {
       runId: `run-${Date.now()}`,
-      abort: () => { aborted = true; },
+      abort: () => {},
     };
   };
 }


### PR DESCRIPTION
## Summary
- remove unused aborted state from call-controller test mock

## Testing
- bun run lint
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
