### PR TITLE
fix: default IPC/desktop sessions to guardian actor role

### DIFF
--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -402,7 +402,9 @@ async function executeApprove(
     });
   }
   session.setAssistantId(assistantId);
-  session.setGuardianContext(null);
+  // Daemon inbox handler — the guardian approved this escalation, so tag as
+  // guardian to avoid 'unverified_channel' blocking memory extraction.
+  session.setGuardianContext({ actorRole: 'guardian', sourceChannel: sourceChannel ?? 'macos' });
   session.setCommandIntent(null);
 
   // Process the message through the agent loop (no IPC event callback

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -136,7 +136,9 @@ export async function handleUserMessage(
       assistantMessageChannel: ipcChannel,
     });
     session.setAssistantId('self');
-    session.setGuardianContext(null);
+    // IPC/desktop user IS the guardian — default to guardian role so messages
+    // are not tagged 'unverified_channel' (which blocks memory extraction).
+    session.setGuardianContext({ actorRole: 'guardian', sourceChannel: ipcChannel });
     session.setCommandIntent(null);
     // Fire-and-forget: don't block the IPC handler so the connection can
     // continue receiving messages (e.g. cancel, confirmations, or

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -699,11 +699,14 @@ export class DaemonServer {
       throw new Error('Session is already processing a message');
     }
 
+    const resolvedChannel = resolveTurnChannel(sourceChannel, options?.transport?.channelId);
     session.setAssistantId(options?.assistantId ?? 'self');
-    session.setGuardianContext(options?.guardianContext ?? null);
+    // IPC/desktop callers don't supply guardianContext — the local daemon user
+    // IS the guardian, so default to guardian role to avoid tagging messages as
+    // 'unverified_channel' and blocking memory extraction.
+    session.setGuardianContext(options?.guardianContext ?? { actorRole: 'guardian', sourceChannel: resolvedChannel });
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
     session.setCommandIntent(options?.commandIntent ?? null);
-    const resolvedChannel = resolveTurnChannel(sourceChannel, options?.transport?.channelId);
     session.setTurnChannelContext({
       userMessageChannel: resolvedChannel,
       assistantMessageChannel: resolvedChannel,
@@ -746,11 +749,14 @@ export class DaemonServer {
       throw new Error('Session is already processing a message');
     }
 
+    const resolvedChannel2 = resolveTurnChannel(sourceChannel, options?.transport?.channelId);
     session.setAssistantId(options?.assistantId ?? 'self');
-    session.setGuardianContext(options?.guardianContext ?? null);
+    // IPC/desktop callers don't supply guardianContext — the local daemon user
+    // IS the guardian, so default to guardian role to avoid tagging messages as
+    // 'unverified_channel' and blocking memory extraction.
+    session.setGuardianContext(options?.guardianContext ?? { actorRole: 'guardian', sourceChannel: resolvedChannel2 });
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
     session.setCommandIntent(options?.commandIntent ?? null);
-    const resolvedChannel2 = resolveTurnChannel(sourceChannel, options?.transport?.channelId);
     session.setTurnChannelContext({
       userMessageChannel: resolvedChannel2,
       assistantMessageChannel: resolvedChannel2,


### PR DESCRIPTION
## Summary
- Default guardian context to actorRole: 'guardian' for IPC/desktop daemon sessions
- Prevents regression where macOS user messages were tagged as 'unverified_channel' and blocked from memory extraction
- Desktop/IPC users are the guardian by definition — only external channels without guardian context should be unverified

Addresses feedback on #8548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
