### PR TITLE
Fix remaining conversation title-generation gaps after #8542

### DIFF
--- a/assistant/src/__tests__/conversation-key-store.test.ts
+++ b/assistant/src/__tests__/conversation-key-store.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { eq } from 'drizzle-orm';
+
+const testDir = mkdtempSync(join(tmpdir(), 'conversation-key-store-test-'));
+const queueGenerateConversationTitleMock = mock((_params: unknown) => {});
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../memory/conversation-title-service.js', () => ({
+  GENERATING_TITLE: 'Generating title...',
+  queueGenerateConversationTitle: (params: unknown) => queueGenerateConversationTitleMock(params),
+}));
+
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
+import { getOrCreateConversation } from '../memory/conversation-key-store.js';
+import { conversations } from '../memory/schema.js';
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+describe('conversation-key-store title generation', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM conversation_keys');
+    db.run('DELETE FROM conversations');
+    queueGenerateConversationTitleMock.mockClear();
+  });
+
+  test('queues title generation on first create when context is provided', () => {
+    const context = {
+      origin: 'runtime_api' as const,
+      sourceChannel: 'telegram',
+      assistantId: 'self',
+      externalChatId: 'chat-1',
+    };
+
+    const result = getOrCreateConversation('telegram:chat-1', context);
+    expect(result.created).toBe(true);
+    expect(queueGenerateConversationTitleMock).toHaveBeenCalledTimes(1);
+    expect(queueGenerateConversationTitleMock).toHaveBeenCalledWith({
+      conversationId: result.conversationId,
+      context: {
+        ...context,
+        conversationKey: 'telegram:chat-1',
+      },
+    });
+
+    const db = getDb();
+    const row = db
+      .select({ title: conversations.title })
+      .from(conversations)
+      .where(eq(conversations.id, result.conversationId))
+      .get();
+
+    expect(row?.title).toBe('Generating title...');
+  });
+
+  test('does not queue title generation when mapping already exists', () => {
+    const context = { origin: 'runtime_api' as const };
+    const first = getOrCreateConversation('runtime:key-1', context);
+    expect(first.created).toBe(true);
+    queueGenerateConversationTitleMock.mockClear();
+
+    const second = getOrCreateConversation('runtime:key-1', context);
+    expect(second.created).toBe(false);
+    expect(second.conversationId).toBe(first.conversationId);
+    expect(queueGenerateConversationTitleMock).not.toHaveBeenCalled();
+  });
+
+  test('does not queue title generation when no context is provided', () => {
+    const result = getOrCreateConversation('runtime:key-2');
+    expect(result.created).toBe(true);
+    expect(queueGenerateConversationTitleMock).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/__tests__/sms-messaging-provider.test.ts
+++ b/assistant/src/__tests__/sms-messaging-provider.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { SmsSendResult } from '../messaging/providers/sms/client.js';
 
 const sendSmsMock = mock(async (..._args: unknown[]): Promise<SmsSendResult> => ({ messageSid: 'SM-mock-sid', status: 'queued' }));
-const getOrCreateConversationMock = mock((_key: string) => ({ conversationId: 'conv-1' }));
+const getOrCreateConversationMock = mock((_key: string, _context?: unknown) => ({ conversationId: 'conv-1' }));
 const upsertOutboundBindingMock = mock((_input: Record<string, unknown>) => {});
 
 let secureKeys: Record<string, string | undefined> = {
@@ -32,7 +32,7 @@ mock.module('../config/loader.js', () => ({
 }));
 
 mock.module('../memory/conversation-key-store.js', () => ({
-  getOrCreateConversation: (key: string) => getOrCreateConversationMock(key),
+  getOrCreateConversation: (key: string, context?: unknown) => getOrCreateConversationMock(key, context),
 }));
 
 mock.module('../memory/external-conversation-store.js', () => ({
@@ -88,7 +88,15 @@ describe('smsMessagingProvider', () => {
       'hi',
       'ast-alpha',
     );
-    expect(getOrCreateConversationMock).toHaveBeenCalledWith('asst:ast-alpha:sms:+15550002222');
+    expect(getOrCreateConversationMock).toHaveBeenCalledWith(
+      'asst:ast-alpha:sms:+15550002222',
+      {
+        origin: 'channel_inbound',
+        sourceChannel: 'sms',
+        assistantId: 'ast-alpha',
+        externalChatId: '+15550002222',
+      },
+    );
     expect(upsertOutboundBindingMock).not.toHaveBeenCalled();
   });
 
@@ -116,7 +124,15 @@ describe('smsMessagingProvider', () => {
       assistantId: 'self',
     });
 
-    expect(getOrCreateConversationMock).toHaveBeenCalledWith('sms:+15550003333');
+    expect(getOrCreateConversationMock).toHaveBeenCalledWith(
+      'sms:+15550003333',
+      {
+        origin: 'channel_inbound',
+        sourceChannel: 'sms',
+        assistantId: 'self',
+        externalChatId: '+15550003333',
+      },
+    );
     expect(upsertOutboundBindingMock).toHaveBeenCalledWith({
       conversationId: 'conv-1',
       sourceChannel: 'sms',

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -30,7 +30,6 @@ import type { CallSession } from './types.js';
 import { VALID_CALLER_IDENTITY_MODES } from '../config/schema.js';
 import type { AssistantConfig } from '../config/types.js';
 import { getOrCreateConversation } from '../memory/conversation-key-store.js';
-import { queueGenerateConversationTitle } from '../memory/conversation-title-service.js';
 import { upsertBinding } from '../memory/external-conversation-store.js';
 import { addPointerMessage } from './call-pointer-messages.js';
 
@@ -218,7 +217,13 @@ export function createInboundVoiceSession(
   const voiceConvKey = assistantId && assistantId !== 'self'
     ? `asst:${assistantId}:voice:inbound:${callSid}`
     : `voice:inbound:${callSid}`;
-  const { conversationId: voiceConversationId } = getOrCreateConversation(voiceConvKey);
+  const { conversationId: voiceConversationId } = getOrCreateConversation(voiceConvKey, {
+    origin: 'voice_inbound',
+    sourceChannel: 'voice',
+    assistantId,
+    externalChatId: callSid,
+    systemHint: `Inbound call from ${fromNumber}`,
+  });
 
   upsertBinding({
     conversationId: voiceConversationId,
@@ -236,16 +241,6 @@ export function createInboundVoiceSession(
 
   updateCallSession(session.id, { providerCallSid: callSid });
   session.providerCallSid = callSid;
-
-  queueGenerateConversationTitle({
-    conversationId: voiceConversationId,
-    context: {
-      origin: 'voice_inbound',
-      sourceChannel: 'voice',
-      assistantId,
-      systemHint: `Inbound call from ${fromNumber}`,
-    },
-  });
 
   log.info(
     { callSessionId: session.id, callSid, voiceConversationId, from: fromNumber, to: toNumber, assistantId },
@@ -315,7 +310,14 @@ export async function startCall(input: StartCallInput): Promise<StartCallResult 
     const voiceConvKey = assistantId
       ? `asst:${assistantId}:voice:call:${session.id}`
       : `voice:call:${session.id}`;
-    const { conversationId: voiceConversationId } = getOrCreateConversation(voiceConvKey);
+    const { conversationId: voiceConversationId } = getOrCreateConversation(voiceConvKey, {
+      origin: 'voice_outbound',
+      sourceChannel: 'voice',
+      assistantId,
+      externalChatId: session.id,
+      systemHint: `Outbound call to ${phoneNumber}`,
+      triggerTextSnippet: task,
+    });
 
     upsertBinding({
       conversationId: voiceConversationId,
@@ -329,17 +331,6 @@ export async function startCall(input: StartCallInput): Promise<StartCallResult 
       conversationId: voiceConversationId,
     });
     session.conversationId = voiceConversationId;
-
-    queueGenerateConversationTitle({
-      conversationId: voiceConversationId,
-      context: {
-        origin: 'voice_outbound',
-        sourceChannel: 'voice',
-        assistantId,
-        systemHint: `Outbound call to ${phoneNumber}`,
-        triggerTextSnippet: task,
-      },
-    });
 
     log.info({ callSessionId: session.id, voiceConversationId, initiatedFrom: conversationId, to: phoneNumber, from: fromNumber, task }, 'Initiating outbound call');
 

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -154,7 +154,14 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
         // before awaiting LLM copy — prevents a race where an external channel
         // reply resolves the request before the macOS delivery is created.
         const macConvKey = `asst:${assistantId}:guardian:request:${request.id}`;
-        const { conversationId: macConversationId } = getOrCreateConversation(macConvKey);
+        const { conversationId: macConversationId } = getOrCreateConversation(macConvKey, {
+          origin: 'guardian_request',
+          sourceChannel: 'macos',
+          assistantId,
+          externalChatId: request.id,
+          systemHint: 'Guardian approval request',
+          triggerTextSnippet: pendingQuestion.questionText,
+        });
 
         const delivery = createGuardianActionDelivery({
           requestId: request.id,

--- a/assistant/src/daemon/handlers/config-scheduling.ts
+++ b/assistant/src/daemon/handlers/config-scheduling.ts
@@ -1,6 +1,7 @@
 import * as net from 'node:net';
 import { listSchedules, updateSchedule, deleteSchedule, describeCronExpression, getSchedule, createScheduleRun, completeScheduleRun } from '../../schedule/schedule-store.js';
 import { createConversation } from '../../memory/conversation-store.js';
+import { GENERATING_TITLE, queueGenerateConversationTitle } from '../../memory/conversation-title-service.js';
 import { listReminders, cancelReminder } from '../../tools/reminder/reminder-store.js';
 import type {
   ScheduleToggle,
@@ -101,7 +102,11 @@ export async function handleScheduleRunNow(
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.warn({ err, jobId: schedule.id, name: schedule.name, taskId }, 'Manual scheduled task execution failed');
-      const fallbackConversation = createConversation({ title: `Schedule (manual): ${schedule.name}`, source: 'schedule' });
+      const fallbackConversation = createConversation({ title: GENERATING_TITLE, source: 'schedule' });
+      queueGenerateConversationTitle({
+        conversationId: fallbackConversation.id,
+        context: { origin: 'schedule', systemHint: `Schedule (manual): ${schedule.name}` },
+      });
       const runId = createScheduleRun(schedule.id, fallbackConversation.id);
       completeScheduleRun(runId, { status: 'error', error: message });
     }
@@ -109,7 +114,11 @@ export async function handleScheduleRunNow(
     return;
   }
 
-  const conversation = createConversation({ title: `Schedule (manual): ${schedule.name}`, source: 'schedule' });
+  const conversation = createConversation({ title: GENERATING_TITLE, source: 'schedule' });
+  queueGenerateConversationTitle({
+    conversationId: conversation.id,
+    context: { origin: 'schedule', systemHint: `Schedule (manual): ${schedule.name}` },
+  });
   const runId = createScheduleRun(schedule.id, conversation.id);
 
   try {

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -10,6 +10,7 @@ import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { parseSlashCandidate } from '../../skills/slash-commands.js';
 import { classifySessionError, buildSessionErrorMessage } from '../session-error.js';
 import { resolveBlobPath, deleteBlob, isValidBlobId } from '../ipc-blob-store.js';
+import { GENERATING_TITLE, queueGenerateConversationTitle } from '../../memory/conversation-title-service.js';
 import type {
   TaskSubmit,
   SuggestionRequest,
@@ -91,7 +92,15 @@ export async function handleTaskSubmit(
       });
     } else {
       // Create text QA session and immediately start processing
-      const conversation = conversationStore.createConversation(msg.task);
+      const conversation = conversationStore.createConversation(GENERATING_TITLE);
+      queueGenerateConversationTitle({
+        conversationId: conversation.id,
+        context: {
+          origin: 'task_submit',
+          triggerTextSnippet: msg.task,
+          systemHint: msg.source ? `Task submit (${msg.source})` : 'Task submit',
+        },
+      });
       ctx.socketToSession.set(socket, conversation.id);
       const session = await ctx.getOrCreateSession(conversation.id, socket, true);
 

--- a/assistant/src/memory/channel-delivery-store.ts
+++ b/assistant/src/memory/channel-delivery-store.ts
@@ -89,10 +89,20 @@ export function recordInbound(
       mapping = { conversationId: legacyMapping.conversationId, created: false };
       setConversationKeyIfAbsent(scopedKey, legacyMapping.conversationId);
     } else {
-      mapping = getOrCreateConversation(scopedKey);
+      mapping = getOrCreateConversation(scopedKey, {
+        origin: 'channel_inbound',
+        sourceChannel,
+        assistantId,
+        externalChatId,
+      });
     }
   } else {
-    mapping = getOrCreateConversation(scopedKey);
+    mapping = getOrCreateConversation(scopedKey, {
+      origin: 'channel_inbound',
+      sourceChannel,
+      assistantId,
+      externalChatId,
+    });
   }
   const now = Date.now();
   const eventId = uuid();

--- a/assistant/src/memory/conversation-key-store.ts
+++ b/assistant/src/memory/conversation-key-store.ts
@@ -11,7 +11,8 @@ import { eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
 import { conversations, conversationKeys } from './schema.js';
-import { GENERATING_TITLE } from './conversation-title-service.js';
+import { GENERATING_TITLE, queueGenerateConversationTitle } from './conversation-title-service.js';
+import type { TitleContext } from './conversation-title-service.js';
 
 export interface ConversationKeyMapping {
   id: string;
@@ -97,10 +98,11 @@ export function setConversationKeyIfAbsent(conversationKey: string, conversation
  */
 export function getOrCreateConversation(
   conversationKey: string,
+  titleContext?: TitleContext,
 ): { conversationId: string; created: boolean } {
   const db = getDb();
 
-  return db.transaction((tx) => {
+  const mapping = db.transaction((tx) => {
     const existing = tx
       .select()
       .from(conversationKeys)
@@ -140,4 +142,16 @@ export function getOrCreateConversation(
 
     return { conversationId, created: true };
   });
+
+  if (mapping.created && titleContext) {
+    queueGenerateConversationTitle({
+      conversationId: mapping.conversationId,
+      context: {
+        ...titleContext,
+        conversationKey,
+      },
+    });
+  }
+
+  return mapping;
 }

--- a/assistant/src/messaging/providers/sms/adapter.ts
+++ b/assistant/src/messaging/providers/sms/adapter.ts
@@ -157,7 +157,12 @@ export const smsMessagingProvider: MessagingProvider = {
       const conversationKey = assistantId && assistantId !== 'self'
         ? `asst:${assistantId}:${sourceChannel}:${conversationId}`
         : `${sourceChannel}:${conversationId}`;
-      const { conversationId: internalId } = getOrCreateConversation(conversationKey);
+      const { conversationId: internalId } = getOrCreateConversation(conversationKey, {
+        origin: 'channel_inbound',
+        sourceChannel,
+        assistantId,
+        externalChatId: conversationId,
+      });
       // external_conversation_bindings is assistant-agnostic (unique by
       // sourceChannel + externalChatId). Restrict proactive writes to self so
       // multi-assistant sends cannot clobber each other's binding metadata.

--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -123,7 +123,11 @@ export const telegramBotMessagingProvider: MessagingProvider = {
     try {
       const sourceChannel = 'telegram';
       const conversationKey = `${sourceChannel}:${conversationId}`;
-      const { conversationId: internalId } = getOrCreateConversation(conversationKey);
+      const { conversationId: internalId } = getOrCreateConversation(conversationKey, {
+        origin: 'channel_inbound',
+        sourceChannel,
+        externalChatId: conversationId,
+      });
       externalConversationStore.upsertOutboundBinding({
         conversationId: internalId,
         sourceChannel,

--- a/assistant/src/messaging/providers/whatsapp/adapter.ts
+++ b/assistant/src/messaging/providers/whatsapp/adapter.ts
@@ -100,7 +100,12 @@ export const whatsappMessagingProvider: MessagingProvider = {
       const conversationKey = assistantId && assistantId !== 'self'
         ? `asst:${assistantId}:${sourceChannel}:${conversationId}`
         : `${sourceChannel}:${conversationId}`;
-      const { conversationId: internalId } = getOrCreateConversation(conversationKey);
+      const { conversationId: internalId } = getOrCreateConversation(conversationKey, {
+        origin: 'channel_inbound',
+        sourceChannel,
+        assistantId,
+        externalChatId: conversationId,
+      });
       if (!assistantId || assistantId === 'self') {
         externalConversationStore.upsertOutboundBinding({
           conversationId: internalId,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -267,7 +267,11 @@ export async function handleSendMessage(
     }
   }
 
-  const mapping = getOrCreateConversation(conversationKey);
+  const mapping = getOrCreateConversation(conversationKey, {
+    origin: 'runtime_api',
+    sourceChannel,
+    triggerTextSnippet: trimmedContent.length > 0 ? trimmedContent : undefined,
+  });
 
   // ── Queue-if-busy path (preferred when sendMessageDeps is wired) ────
   if (deps.sendMessageDeps) {

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -41,7 +41,9 @@ export function handleSubscribeAssistantEvents(
   const hub = options?.hub ?? assistantEventHub;
   const heartbeatIntervalMs = options?.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
 
-  const mapping = getOrCreateConversation(conversationKey);
+  const mapping = getOrCreateConversation(conversationKey, {
+    origin: 'runtime_api',
+  });
   const encoder = new TextEncoder();
 
   // ── Eager subscribe ──────────────────────────────────────────────────────

--- a/assistant/src/runtime/routes/run-routes.ts
+++ b/assistant/src/runtime/routes/run-routes.ts
@@ -63,7 +63,11 @@ export async function handleCreateRun(
     }
   }
 
-  const mapping = getOrCreateConversation(conversationKey);
+  const mapping = getOrCreateConversation(conversationKey, {
+    origin: 'runtime_api',
+    sourceChannel,
+    triggerTextSnippet: trimmedContent.length > 0 ? trimmedContent : undefined,
+  });
 
   try {
     const { run } = await runOrchestrator.startRun(


### PR DESCRIPTION
## Summary
Follow-up to #8542 after reviewing merged behavior against the requirement that all new conversations get daemon-generated titles with a loading placeholder.

This PR closes the remaining gaps:

- extends `getOrCreateConversation(...)` with optional title context and auto-queues title generation on first create
- wires missing key-backed creation paths to pass title context:
  - runtime routes (`conversation`, `runs`, `assistant-events`)
  - channel delivery store
  - SMS / Telegram / WhatsApp outbound adapters
  - call-domain + guardian dispatch (moved to context-at-creation model)
- fixes two leftover static-title creation paths:
  - manual schedule run-now fallback + normal run
  - `task_submit` text QA path
- updates SMS provider tests for the new context argument
- adds new `conversation-key-store` tests to lock in queue-on-create behavior

## Why
Reviewing #8542 showed some flows still creating conversations with static titles or creating key-based conversations without title-generation context, which left placeholders or non-useful titles in some paths.

## Validation
- `bun test src/__tests__/conversation-key-store.test.ts`
- `bun test src/__tests__/sms-messaging-provider.test.ts`
- `bun test src/__tests__/channel-delivery-store.test.ts`
- `bun test src/__tests__/guardian-dispatch.test.ts`
- `bun test src/__tests__/call-domain.test.ts`
- `bun test src/__tests__/runtime-events-sse.test.ts`
- `bun test src/__tests__/runtime-events-sse-parity.test.ts`
- `bun test src/__tests__/runtime-runs.test.ts`
- `bun test src/__tests__/handlers-task-submit-slash.test.ts`

## Notes
`bunx tsc --noEmit` still fails on an existing unrelated schema default mismatch in `src/config/schema.ts` (`conversationRetentionDays` missing in a default config object).