### PR TITLE
fix: revert server.ts guardian context fallback to null

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -701,10 +701,7 @@ export class DaemonServer {
 
     const resolvedChannel = resolveTurnChannel(sourceChannel, options?.transport?.channelId);
     session.setAssistantId(options?.assistantId ?? 'self');
-    // IPC/desktop callers don't supply guardianContext — the local daemon user
-    // IS the guardian, so default to guardian role to avoid tagging messages as
-    // 'unverified_channel' and blocking memory extraction.
-    session.setGuardianContext(options?.guardianContext ?? { actorRole: 'guardian', sourceChannel: resolvedChannel });
+    session.setGuardianContext(options?.guardianContext ?? null);
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
     session.setCommandIntent(options?.commandIntent ?? null);
     session.setTurnChannelContext({
@@ -751,10 +748,7 @@ export class DaemonServer {
 
     const resolvedChannel2 = resolveTurnChannel(sourceChannel, options?.transport?.channelId);
     session.setAssistantId(options?.assistantId ?? 'self');
-    // IPC/desktop callers don't supply guardianContext — the local daemon user
-    // IS the guardian, so default to guardian role to avoid tagging messages as
-    // 'unverified_channel' and blocking memory extraction.
-    session.setGuardianContext(options?.guardianContext ?? { actorRole: 'guardian', sourceChannel: resolvedChannel2 });
+    session.setGuardianContext(options?.guardianContext ?? null);
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
     session.setCommandIntent(options?.commandIntent ?? null);
     session.setTurnChannelContext({


### PR DESCRIPTION
## Summary
- Revert persistAndProcessMessage and processMessage guardian context fallback from { actorRole: 'guardian' } back to null
- The guardian default was too broad — it affected external channel paths (conversation-routes, channel-retry-sweep, lifecycle) that should be unverified
- IPC/desktop callers in sessions.ts and config-inbox.ts already set guardian context explicitly

Addresses feedback on #8556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
