### PR TITLE
M2: Generate shared IPC models and add DaemonClient draft/create methods

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -645,7 +645,7 @@ struct MainWindowView: View {
                             onDebug: {
                                 sidebar.showControlCenterDrawer = false
                                 windowState.selection = .panel(.debug)
-                            },
+                            }
                         )
                         .frame(width: drawerWidth)
                         .offset(x: drawerX, y: -28)

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -252,6 +252,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `skills_inspect_response` message.
     public var onSkillsInspectResponse: ((SkillsInspectResponseMessage) -> Void)?
 
+    /// Called when the daemon sends a `skills_draft_response` message.
+    public var onSkillsDraftResponse: ((SkillsDraftResponseMessage) -> Void)?
+
     /// Called when the daemon sends a `trace_event` message.
     public var onTraceEvent: ((TraceEventMessage) -> Void)?
 
@@ -910,6 +913,16 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Configure a skill's environment, API key, or config.
     public func configureSkill(name: String, env: [String: String]? = nil, apiKey: String? = nil, config: [String: AnyCodable]? = nil) throws {
         try send(SkillsConfigureMessage(name: name, env: env, apiKey: apiKey, config: config))
+    }
+
+    /// Draft metadata for a skill from source text.
+    public func draftSkill(sourceText: String) throws {
+        try send(SkillsDraftRequestMessage(sourceText: sourceText))
+    }
+
+    /// Create a new managed skill.
+    public func createSkill(skillId: String, name: String, description: String, emoji: String? = nil, bodyMarkdown: String, userInvocable: Bool? = nil, disableModelInvocation: Bool? = nil, overwrite: Bool? = nil) throws {
+        try send(SkillsCreateMessage(skillId: skillId, name: name, description: description, emoji: emoji, bodyMarkdown: bodyMarkdown, userInvocable: userInvocable, disableModelInvocation: disableModelInvocation, overwrite: overwrite))
     }
 
     // MARK: - Queue Management

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -99,6 +99,8 @@ extension DaemonClient {
             onSkillsOperationResponse?(msg)
         case .skillsInspectResponse(let msg):
             onSkillsInspectResponse?(msg)
+        case .skillsDraftResponse(let msg):
+            onSkillsDraftResponse?(msg)
         case .appsListResponse(let msg):
             onAppsListResponse?(msg)
         case .homeBaseGetResponse(let msg):

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -3721,6 +3721,30 @@ public struct IPCSkillsConfigureRequest: Codable, Sendable {
     }
 }
 
+public struct IPCSkillsCreateRequest: Codable, Sendable {
+    public let type: String
+    public let skillId: String
+    public let name: String
+    public let description: String
+    public let emoji: String?
+    public let bodyMarkdown: String
+    public let userInvocable: Bool?
+    public let disableModelInvocation: Bool?
+    public let overwrite: Bool?
+
+    public init(type: String, skillId: String, name: String, description: String, emoji: String? = nil, bodyMarkdown: String, userInvocable: Bool? = nil, disableModelInvocation: Bool? = nil, overwrite: Bool? = nil) {
+        self.type = type
+        self.skillId = skillId
+        self.name = name
+        self.description = description
+        self.emoji = emoji
+        self.bodyMarkdown = bodyMarkdown
+        self.userInvocable = userInvocable
+        self.disableModelInvocation = disableModelInvocation
+        self.overwrite = overwrite
+    }
+}
+
 public struct IPCSkillsDisableRequest: Codable, Sendable {
     public let type: String
     public let name: String
@@ -3728,6 +3752,48 @@ public struct IPCSkillsDisableRequest: Codable, Sendable {
     public init(type: String, name: String) {
         self.type = type
         self.name = name
+    }
+}
+
+public struct IPCSkillsDraftRequest: Codable, Sendable {
+    public let type: String
+    public let sourceText: String
+
+    public init(type: String, sourceText: String) {
+        self.type = type
+        self.sourceText = sourceText
+    }
+}
+
+public struct IPCSkillsDraftResponse: Codable, Sendable {
+    public let type: String
+    public let success: Bool
+    public let draft: IPCSkillsDraftResponseDraft?
+    public let warnings: [String]?
+    public let error: String?
+
+    public init(type: String, success: Bool, draft: IPCSkillsDraftResponseDraft? = nil, warnings: [String]? = nil, error: String? = nil) {
+        self.type = type
+        self.success = success
+        self.draft = draft
+        self.warnings = warnings
+        self.error = error
+    }
+}
+
+public struct IPCSkillsDraftResponseDraft: Codable, Sendable {
+    public let skillId: String
+    public let name: String
+    public let description: String
+    public let emoji: String?
+    public let bodyMarkdown: String
+
+    public init(skillId: String, name: String, description: String, emoji: String? = nil, bodyMarkdown: String) {
+        self.skillId = skillId
+        self.name = name
+        self.description = description
+        self.emoji = emoji
+        self.bodyMarkdown = bodyMarkdown
     }
 }
 

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -645,6 +645,29 @@ extension IPCSkillsInspectRequest {
     }
 }
 
+/// Draft a skill from source text.
+/// Backed by generated `IPCSkillsDraftRequest`.
+public typealias SkillsDraftRequestMessage = IPCSkillsDraftRequest
+
+extension IPCSkillsDraftRequest {
+    public init(sourceText: String) {
+        self.init(type: "skills_draft", sourceText: sourceText)
+    }
+}
+
+/// Create a managed skill.
+/// Backed by generated `IPCSkillsCreateRequest`.
+public typealias SkillsCreateMessage = IPCSkillsCreateRequest
+
+extension IPCSkillsCreateRequest {
+    public init(skillId: String, name: String, description: String, emoji: String? = nil, bodyMarkdown: String, userInvocable: Bool? = nil, disableModelInvocation: Bool? = nil, overwrite: Bool? = nil) {
+        self.init(type: "skills_create", skillId: skillId, name: name, description: description, emoji: emoji, bodyMarkdown: bodyMarkdown, userInvocable: userInvocable, disableModelInvocation: disableModelInvocation, overwrite: overwrite)
+    }
+}
+
+/// Backed by generated `IPCSkillsDraftResponse`.
+public typealias SkillsDraftResponseMessage = IPCSkillsDraftResponse
+
 /// Response to a sign_bundle_payload request from the daemon.
 /// Backed by generated `IPCSignBundlePayloadResponse`.
 public typealias SignBundlePayloadResponseMessage = IPCSignBundlePayloadResponse
@@ -2119,6 +2142,7 @@ public enum ServerMessage: Decodable, Sendable {
     case skillStateChanged(SkillStateChangedMessage)
     case skillsOperationResponse(SkillsOperationResponseMessage)
     case skillsInspectResponse(SkillsInspectResponseMessage)
+    case skillsDraftResponse(SkillsDraftResponseMessage)
     case suggestionResponse(SuggestionResponseMessage)
     case toolUseStart(ToolUseStartMessage)
     case toolInputDelta(ToolInputDeltaMessage)
@@ -2354,6 +2378,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "skills_inspect_response":
             let message = try SkillsInspectResponseMessage(from: decoder)
             self = .skillsInspectResponse(message)
+        case "skills_draft_response":
+            let message = try SkillsDraftResponseMessage(from: decoder)
+            self = .skillsDraftResponse(message)
         case "suggestion_response":
             let message = try SuggestionResponseMessage(from: decoder)
             self = .suggestionResponse(message)


### PR DESCRIPTION
Regenerate shared Swift IPC types for skills_draft, skills_create, and skills_draft_response. Add convenience typealiases, DaemonClient helper methods, and ServerMessage routing. Part of #8549.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
