### PR TITLE
feat: run /guardian_verify before ACL deny

### DIFF
--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -149,6 +149,10 @@ export async function handleChannelInbound(
   // recordInbound (where we have a conversationId).
   let resolvedMember: ReturnType<typeof findMember> = null;
 
+  // /guardian_verify must bypass the ACL membership check — users without a
+  // member record need to verify before they can be recognized as members.
+  const isGuardianVerifyCommand = trimmedContent.startsWith('/guardian_verify ');
+
   if (body.senderExternalUserId) {
     resolvedMember = findMember({
       sourceChannel,
@@ -156,23 +160,25 @@ export async function handleChannelInbound(
       externalChatId,
     });
 
-    if (!resolvedMember) {
+    if (!resolvedMember && !isGuardianVerifyCommand) {
       log.info({ sourceChannel, externalUserId: body.senderExternalUserId }, 'Ingress ACL: no member record, denying');
       return Response.json({ accepted: true, denied: true, reason: 'not_a_member' });
     }
 
-    if (resolvedMember.status !== 'active') {
-      log.info({ sourceChannel, memberId: resolvedMember.id, status: resolvedMember.status }, 'Ingress ACL: member not active, denying');
-      return Response.json({ accepted: true, denied: true, reason: `member_${resolvedMember.status}` });
-    }
+    if (resolvedMember) {
+      if (resolvedMember.status !== 'active') {
+        log.info({ sourceChannel, memberId: resolvedMember.id, status: resolvedMember.status }, 'Ingress ACL: member not active, denying');
+        return Response.json({ accepted: true, denied: true, reason: `member_${resolvedMember.status}` });
+      }
 
-    if (resolvedMember.policy === 'deny') {
-      log.info({ sourceChannel, memberId: resolvedMember.id }, 'Ingress ACL: member policy deny');
-      return Response.json({ accepted: true, denied: true, reason: 'policy_deny' });
-    }
+      if (resolvedMember.policy === 'deny') {
+        log.info({ sourceChannel, memberId: resolvedMember.id }, 'Ingress ACL: member policy deny');
+        return Response.json({ accepted: true, denied: true, reason: 'policy_deny' });
+      }
 
-    // 'allow' or 'escalate' — update last seen and continue
-    updateLastSeen(resolvedMember.id);
+      // 'allow' or 'escalate' — update last seen and continue
+      updateLastSeen(resolvedMember.id);
+    }
   }
 
   if (hasAttachments) {


### PR DESCRIPTION
Moves the /guardian_verify command intercept to run before the ingress ACL membership check, so users without a member record can still verify as guardian. Only /guardian_verify is exempted — all other messages from non-members are still denied.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
