### PR TITLE
feat: auto-upsert ingress member on successful guardian verify

### DIFF
--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -13,7 +13,7 @@ import { getPendingConfirmationsByConversation } from '../../memory/runs-store.j
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { IngressBlockedError } from '../../util/errors.js';
 import { getLogger } from '../../util/logger.js';
-import { findMember, updateLastSeen } from '../../memory/ingress-member-store.js';
+import { findMember, updateLastSeen, upsertMember } from '../../memory/ingress-member-store.js';
 import {
   getGuardianBinding,
   validateAndConsumeChallenge,
@@ -434,6 +434,20 @@ export async function handleChannelInbound(
         body.senderUsername,
         body.senderName,
       );
+
+      if (verifyResult.success) {
+        upsertMember({
+          assistantId,
+          sourceChannel,
+          externalUserId: body.senderExternalUserId,
+          externalChatId,
+          status: 'active',
+          policy: 'allow',
+          displayName: body.senderName,
+          username: body.senderUsername,
+        });
+        log.info({ sourceChannel, externalUserId: body.senderExternalUserId }, 'Guardian verified: auto-upserted ingress member');
+      }
 
       const replyText = verifyResult.success
         ? await composeApprovalMessageGenerative({


### PR DESCRIPTION
When /guardian_verify succeeds, automatically creates/updates an ingress member record with status=active and policy=allow for the verifying actor. This means a verified guardian can immediately start messaging the assistant without needing a separate invite or manual membership.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
