### PR TITLE
fix: guard conversation deletes with retention cutoff re-check (#8517)

### DIFF
--- a/assistant/src/memory/job-handlers/cleanup.ts
+++ b/assistant/src/memory/job-handlers/cleanup.ts
@@ -88,14 +88,25 @@ export function pruneOldConversationsJob(job: MemoryJob, config: AssistantConfig
   if (stale.length === 0) return;
 
   const db = getDb();
+  let pruned = 0;
   for (const { id } of stale) {
     db.transaction(() => {
+      // Re-check staleness inside the transaction to avoid racing with a conversation
+      // that became active again between the initial SELECT and this DELETE.
+      const still = rawAll<{ id: string }>(
+        `SELECT id FROM conversations WHERE id = ? AND updated_at < ?`,
+        id,
+        cutoffMs,
+      );
+      if (still.length === 0) return;
+
       // Non-cascading tables
       rawRun(`DELETE FROM llm_request_logs WHERE conversation_id = ?`, id);
       rawRun(`DELETE FROM tool_invocations WHERE conversation_id = ?`, id);
       rawRun(`DELETE FROM messages WHERE conversation_id = ?`, id);
       // Conversation row deletion cascades to remaining dependent tables
       rawRun(`DELETE FROM conversations WHERE id = ?`, id);
+      pruned++;
     });
   }
 
@@ -104,7 +115,8 @@ export function pruneOldConversationsJob(job: MemoryJob, config: AssistantConfig
   }
 
   log.info({
-    pruned: stale.length,
+    pruned,
+    skipped: stale.length - pruned,
     retentionDays,
     cutoffMs,
   }, 'Pruned old conversations');


### PR DESCRIPTION
Addresses review feedback from PR #8517. Adds a staleness re-check inside the transaction before deleting a conversation, preventing a race condition where a conversation becomes active again between the initial SELECT and the DELETE.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
