### PR TITLE
fix: address review feedback on WhatsApp media delivery (#8520)

### DIFF
--- a/gateway/src/http/routes/whatsapp-deliver.ts
+++ b/gateway/src/http/routes/whatsapp-deliver.ts
@@ -62,6 +62,10 @@ export function createWhatsAppDeliverHandler(config: GatewayConfig) {
 
     const { text, assistantId, attachments, approval } = body;
 
+    if (text !== undefined && typeof text !== "string") {
+      return Response.json({ error: "text must be a string" }, { status: 400 });
+    }
+
     // Validate approval payload shape when present.
     if (approval !== undefined) {
       if (approval === null || typeof approval !== "object" || Array.isArray(approval)) {

--- a/gateway/src/whatsapp/send.ts
+++ b/gateway/src/whatsapp/send.ts
@@ -129,5 +129,9 @@ export async function sendWhatsAppAttachments(
     } catch (err) {
       log.error({ err, to }, "Failed to send attachment failure notice");
     }
+
+    if (failures.length === attachments.length) {
+      throw new Error(`All ${failures.length} attachment(s) failed to deliver`);
+    }
   }
 }


### PR DESCRIPTION
Addresses review feedback from PR #8520 (native WhatsApp media delivery):

- Add typeof string validation for text field to prevent silent delivery failures with non-string truthy values (e.g. text: 123)
- Throw when all attachment deliveries fail so the endpoint returns 502 instead of 200, preventing silent message loss
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
