### PR TITLE
fix: address review feedback on AGENTS.md error handling (#8519)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,7 @@ Use the existing `VellumError` hierarchy (`ToolError`, `ConfigError`, `ProviderE
 throw new ConfigError('Missing required provider configuration');
 
 // Good: subagent manager throws when depth limit is exceeded
-throw new Error('Cannot spawn subagent: parent is itself a subagent');
+throw new AssistantError('Cannot spawn subagent: parent is itself a subagent');
 ```
 
 ### 2. Result objects for operations that can fail in expected ways


### PR DESCRIPTION
Addresses review feedback from PR #8519 (error handling patterns in AGENTS.md)

Codex flagged a contradiction: the docs say to use the VellumError hierarchy instead of bare Error, but the second example used throw new Error(...). Fixed the example to use AssistantError instead.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
