### PR TITLE
fix: enforce hard cache cap after TTL purge in RejectionRateLimiter (#8493)

### DIFF
--- a/gateway/src/rejection-rate-limiter.ts
+++ b/gateway/src/rejection-rate-limiter.ts
@@ -34,6 +34,15 @@ export class RejectionRateLimiter {
           this.timestamps.delete(key);
         }
       }
+      // Hard cap: if still over limit after purging expired entries,
+      // drop the oldest entries until we're under the limit.
+      if (this.timestamps.size >= MAX_REJECTION_CACHE_SIZE) {
+        const sorted = [...this.timestamps.entries()].sort((a, b) => a[1] - b[1]);
+        const toRemove = sorted.length - MAX_REJECTION_CACHE_SIZE + 1; // +1 for the incoming entry
+        for (let i = 0; i < toRemove; i++) {
+          this.timestamps.delete(sorted[i][0]);
+        }
+      }
     }
 
     this.timestamps.set(recipientId, now);


### PR DESCRIPTION
Addresses review feedback from PR #8493 (RejectionRateLimiter lazy TTL-based cleanup).

Both Codex and Devin flagged that after purging expired entries, if the map was still at/above MAX_REJECTION_CACHE_SIZE, the code would unconditionally insert new entries, allowing unbounded memory growth.

Added a second eviction phase: after TTL purge, if still over the limit, sort by timestamp and drop the oldest entries to make room for the new one. This restores the hard cap guarantee.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
