### PR TITLE
fix: address review feedback on benchmark CI (#8522)

### DIFF
--- a/.github/workflows/ci-benchmarks.yaml
+++ b/.github/workflows/ci-benchmarks.yaml
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/ci-benchmarks.yaml'
 
 concurrency:
-  group: ci-benchmarks-${{ github.run_id }}
+  group: ci-benchmarks-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -51,7 +51,7 @@ jobs:
         run: bash scripts/compare-benchmarks.sh baseline/benchmark-results.json benchmark-results.json
 
       - name: Upload results as new baseline
-        if: always()
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-baseline

--- a/assistant/scripts/compare-benchmarks.sh
+++ b/assistant/scripts/compare-benchmarks.sh
@@ -53,16 +53,16 @@ while IFS= read -r file; do
     continue
   fi
 
-  # Calculate percentage change: (current - baseline) / baseline * 100
-  pct_change=$(( (current_ms - baseline_ms) * 100 / baseline_ms ))
+  # Calculate percentage change with awk to avoid integer truncation
+  pct_change=$(awk "BEGIN { printf \"%.1f\", ($current_ms - $baseline_ms) / $baseline_ms * 100 }")
 
-  if [[ ${pct_change} -gt ${THRESHOLD} ]]; then
+  if awk "BEGIN { exit !($pct_change > $THRESHOLD) }"; then
     echo "  REGR ${file}: ${baseline_ms}ms -> ${current_ms}ms (+${pct_change}%)"
     regressions=$((regressions + 1))
-  elif [[ ${pct_change} -lt -${THRESHOLD} ]]; then
+  elif awk "BEGIN { exit !($pct_change < -$THRESHOLD) }"; then
     echo "  IMPR ${file}: ${baseline_ms}ms -> ${current_ms}ms (${pct_change}%)"
   else
-    echo "  OK   ${file}: ${baseline_ms}ms -> ${current_ms}ms (${pct_change:+${pct_change}}%)"
+    echo "  OK   ${file}: ${baseline_ms}ms -> ${current_ms}ms (${pct_change}%)"
   fi
 done < <(jq -r '.results[].file' "${CURRENT}")
 


### PR DESCRIPTION
Addresses review feedback from PR #8522 (benchmark regression detection in CI):

- Fix concurrency group to use github.ref instead of github.run_id so cancel-in-progress actually cancels prior runs
- Change baseline upload condition from always() to success() to prevent corrupted baselines from failed runs
- Use awk for percentage calculation to avoid integer truncation missing borderline regressions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
