### PR TITLE
fix: address review feedback on skill version tracking (#8502)

### DIFF
--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -216,6 +216,12 @@ export function createManagedSkill(params: CreateManagedSkillParams): CreateMana
 
   if (params.version) {
     writeVersionMeta(params.id, params.version);
+  } else {
+    // Remove stale version metadata when overwriting without a version
+    const metaPath = getVersionMetaPath(params.id);
+    if (existsSync(metaPath)) {
+      rmSync(metaPath);
+    }
   }
 
   log.info({ id: params.id, path: skillFilePath, version: params.version }, 'Created managed skill');


### PR DESCRIPTION
Addresses review feedback from PR #8502 (version tracking for managed skills)

Both Devin and Codex flagged the same bug: when createManagedSkill is called with overwrite=true but without a version parameter, the existing version.json from a previous install persists, leaving stale version metadata. This adds an else branch that removes the stale version.json when no version is provided.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
