### PR TITLE
fix: use replacer function to avoid $ special pattern in SBPL path escaping (#8507)

### DIFF
--- a/assistant/src/tools/terminal/backends/native.ts
+++ b/assistant/src/tools/terminal/backends/native.ts
@@ -90,7 +90,7 @@ function getProfilePath(workingDir: string): string {
   const hash = createHash('sha256').update(workingDir).digest('hex').slice(0, HASH_DISPLAY_LENGTH);
   const path = join(dir, `sandbox-profile-${hash}.sb`);
 
-  const profile = SANDBOX_PROFILE.replace(/__WORKING_DIR__/g, escapeSBPL(workingDir));
+  const profile = SANDBOX_PROFILE.replace(/__WORKING_DIR__/g, () => escapeSBPL(workingDir));
   writeFileSync(path, profile + '\n');
   return path;
 }


### PR DESCRIPTION
Addresses review feedback from PR #8507. When workingDir contains $ followed by certain characters ($&, $', $`, $$, $1-$9), String.prototype.replace interprets them as special replacement patterns instead of literal text. Using a function as the replacement argument avoids this issue.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
