### PR TITLE
fix: only evict TTL-expired delivery claims at cap (#8487)

### DIFF
--- a/assistant/src/memory/channel-delivery-store.ts
+++ b/assistant/src/memory/channel-delivery-store.ts
@@ -376,7 +376,8 @@ export function getDeadLetterEvents(): Array<{
 // of them actually sends the message. The guard is run-scoped so old
 // assistant messages from previous runs are not affected.
 
-const deliveredRuns = new Set<string>();
+/** Map from runId to insertion timestamp (ms). */
+const deliveredRuns = new Map<string, number>();
 
 /** TTL for delivery claims — 10 minutes, well beyond the poll max-wait. */
 const CLAIM_TTL_MS = 10 * 60 * 1000;
@@ -390,22 +391,30 @@ const MAX_DELIVERED_RUNS = 10_000;
  * delivery). Returns `false` if another caller already claimed it.
  *
  * This is an in-memory guard — sufficient because both racing pollers
- * execute within the same process. The Set is never persisted; on restart
+ * execute within the same process. The Map is never persisted; on restart
  * there are no in-flight pollers to race.
  *
- * Claims are evicted after CLAIM_TTL_MS and the Set is hard-capped at
- * MAX_DELIVERED_RUNS entries. When the cap is reached, the oldest entries
- * (by insertion order) are evicted first — safe because older runs are
- * long past the race window.
+ * Claims are evicted after CLAIM_TTL_MS. When the hard cap is reached,
+ * only TTL-expired entries are evicted — active claims are never removed
+ * early, preserving the at-most-once delivery guarantee.
  */
 export function claimRunDelivery(runId: string): boolean {
   if (deliveredRuns.has(runId)) return false;
   if (deliveredRuns.size >= MAX_DELIVERED_RUNS) {
-    // Set iteration order matches insertion order; evict the oldest entry.
-    const oldest = deliveredRuns.values().next().value!;
-    deliveredRuns.delete(oldest);
+    // Only evict entries whose TTL has expired. Map iteration order
+    // matches insertion order, so oldest entries come first.
+    const now = Date.now();
+    for (const [id, insertedAt] of deliveredRuns) {
+      if (now - insertedAt >= CLAIM_TTL_MS) {
+        deliveredRuns.delete(id);
+      } else {
+        // Remaining entries are newer; stop scanning.
+        break;
+      }
+    }
   }
-  deliveredRuns.add(runId);
+  const now = Date.now();
+  deliveredRuns.set(runId, now);
   setTimeout(() => deliveredRuns.delete(runId), CLAIM_TTL_MS);
   return true;
 }


### PR DESCRIPTION
Addresses review feedback from PR #8487 (cap unbounded Set growth in channel delivery store).

The Codex review identified that oldest-first eviction at the hard cap could remove a still-active claim before its CLAIM_TTL_MS expired, breaking the at-most-once delivery guarantee. If throughput exceeded MAX_DELIVERED_RUNS within the 10-minute TTL window, an earlier run could be evicted while its competing poller was still in flight, allowing a duplicate delivery.

Fix: switch from Set<string> to Map<string, number> to track insertion timestamps. When the cap is reached, only evict entries whose TTL has actually expired — never remove active claims early. If all entries are still within their TTL, the map is allowed to temporarily exceed the cap (the setTimeout cleanup will reclaim them).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
