### PR TITLE
fix: reset copied-state when canceling confirmation timer (#8494)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -44,6 +44,7 @@ final class CopyThreadState {
     func cancel() {
         confirmationTimer?.cancel()
         confirmationTimer = nil
+        showConfirmation = false
     }
 }
 


### PR DESCRIPTION
Addresses review feedback from PR #8494. When CopyThreadState.cancel() is called (e.g., on onDisappear), also reset showConfirmation to false. Without this, if the window disappears during the 1.5s confirmation interval, the stale checkmark persists when the window reappears.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
