### PR TITLE
fix: roll back consumed OAuth state on runtime failure (#8500)

### DIFF
--- a/gateway/src/__tests__/oauth-callback.test.ts
+++ b/gateway/src/__tests__/oauth-callback.test.ts
@@ -203,38 +203,64 @@ describe("OAuth callback handler", () => {
     expect(sentBody.code).toBeUndefined();
   });
 
-  test("runtime returning 404 (unknown state) shows error page", async () => {
-    fetchMock = mock(async () =>
-      Response.json({ error: "Unknown state" }, { status: 404 }),
-    );
+  test("runtime returning 404 (unknown state) shows error page and allows retry", async () => {
+    let callCount = 0;
+    fetchMock = mock(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return Response.json({ error: "Unknown state" }, { status: 404 });
+      }
+      return Response.json({ ok: true }, { status: 200 });
+    });
 
     const handler = createOAuthCallbackHandler(makeConfig());
-    const req = new Request(
+    const req1 = new Request(
       `http://localhost:7830/webhooks/oauth/callback?state=${VALID_STATE}&code=code`,
       { method: "GET" },
     );
 
-    const res = await handler(req);
-    expect(res.status).toBe(400);
+    const res1 = await handler(req1);
+    expect(res1.status).toBe(400);
+    expect(await res1.text()).toContain("Authorization Failed");
 
-    const body = await res.text();
-    expect(body).toContain("Authorization Failed");
+    // State should be rolled back so a retry succeeds
+    const req2 = new Request(
+      `http://localhost:7830/webhooks/oauth/callback?state=${VALID_STATE}&code=code`,
+      { method: "GET" },
+    );
+    const res2 = await handler(req2);
+    expect(res2.status).toBe(200);
+    expect(callCount).toBe(2);
   });
 
-  test("runtime unreachable returns 502 error page", async () => {
-    fetchMock = mock(async () => { throw new Error("Connection refused"); });
+  test("runtime unreachable returns 502 error page and allows retry", async () => {
+    let callCount = 0;
+    fetchMock = mock(async () => {
+      callCount++;
+      if (callCount === 1) {
+        throw new Error("Connection refused");
+      }
+      return Response.json({ ok: true }, { status: 200 });
+    });
 
     const handler = createOAuthCallbackHandler(makeConfig());
-    const req = new Request(
+    const req1 = new Request(
       `http://localhost:7830/webhooks/oauth/callback?state=${VALID_STATE}&code=code`,
       { method: "GET" },
     );
 
-    const res = await handler(req);
-    expect(res.status).toBe(502);
+    const res1 = await handler(req1);
+    expect(res1.status).toBe(502);
+    expect(await res1.text()).toContain("Authorization Failed");
 
-    const body = await res.text();
-    expect(body).toContain("Authorization Failed");
+    // State should be rolled back so a retry succeeds
+    const req2 = new Request(
+      `http://localhost:7830/webhooks/oauth/callback?state=${VALID_STATE}&code=code`,
+      { method: "GET" },
+    );
+    const res2 = await handler(req2);
+    expect(res2.status).toBe(200);
+    expect(callCount).toBe(2);
   });
 
   test("omits Authorization header when runtimeBearerToken is undefined", async () => {

--- a/gateway/src/http/routes/oauth-callback.ts
+++ b/gateway/src/http/routes/oauth-callback.ts
@@ -22,6 +22,14 @@ function markStateConsumed(state: string): void {
   consumedStates.set(state, timer);
 }
 
+function rollBackConsumedState(state: string): void {
+  const timer = consumedStates.get(state);
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    consumedStates.delete(state);
+  }
+}
+
 /** Exported for testing — clears all consumed state entries. */
 export function _resetConsumedStates(): void {
   for (const timer of consumedStates.values()) clearTimeout(timer);
@@ -58,8 +66,9 @@ export function createOAuthCallbackHandler(config: GatewayConfig) {
       });
     }
 
-    // Mark consumed before forwarding so concurrent duplicate callbacks
-    // are blocked even if the runtime hasn't responded yet.
+    // Optimistically mark consumed so concurrent duplicate callbacks are
+    // blocked while the runtime processes this one. Rolled back on failure
+    // so transient errors don't permanently block retries.
     markStateConsumed(state);
 
     try {
@@ -77,11 +86,13 @@ export function createOAuthCallbackHandler(config: GatewayConfig) {
         });
       }
 
+      rollBackConsumedState(state);
       return new Response(
         renderErrorPage("Authorization failed. Please try again."),
         { status: 400, headers: { "Content-Type": "text/html" } },
       );
     } catch (err) {
+      rollBackConsumedState(state);
       log.error({ err }, "Failed to forward OAuth callback to runtime");
       return new Response(
         renderErrorPage("Authorization failed. Please try again."),


### PR DESCRIPTION
Addresses review feedback from PR #8500. Moves state consumption rollback so that transient runtime failures (non-2xx responses, connection errors) don't permanently block OAuth state retries for the TTL duration. The optimistic mark-before-forward pattern is preserved for concurrent duplicate protection, but now rolls back on failure.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
