### PR TITLE
fix: prevent concurrent failures from escalating circuit breaker cooldown (#8509)

### DIFF
--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -39,7 +39,12 @@ const refreshBreakers = new Map<string, RefreshBreakerState>();
 function isRefreshBreakerOpen(service: string): boolean {
   const state = refreshBreakers.get(service);
   if (!state || state.consecutiveFailures < REFRESH_FAILURE_THRESHOLD) return false;
-  return Date.now() - state.openedAt < state.cooldownMs;
+  if (Date.now() - state.openedAt < state.cooldownMs) return true;
+  // Cooldown expired — transition to half-open: reset failure count so the
+  // next batch of failures must reach the threshold again to re-trip. The
+  // existing cooldownMs is preserved so re-tripping will escalate it.
+  state.consecutiveFailures = 0;
+  return false;
 }
 
 function recordRefreshSuccess(service: string): void {
@@ -57,8 +62,10 @@ function recordRefreshFailure(service: string): void {
   }
   state.consecutiveFailures++;
   if (state.consecutiveFailures >= REFRESH_FAILURE_THRESHOLD) {
-    // Double cooldown on each successive trip, capped at MAX_COOLDOWN_MS
-    if (state.openedAt > 0) {
+    // Only escalate cooldown on the exact failure that trips the breaker.
+    // Concurrent in-flight failures that arrive after the threshold is
+    // already crossed must not double the cooldown again.
+    if (state.consecutiveFailures === REFRESH_FAILURE_THRESHOLD && state.openedAt > 0) {
       state.cooldownMs = Math.min(state.cooldownMs * 2, MAX_COOLDOWN_MS);
     }
     state.openedAt = Date.now();


### PR DESCRIPTION
Addresses review feedback from PR #8509 (circuit breaker to token refresh to prevent retry storms).

## Changes

- Only escalate (double) cooldown when consecutiveFailures exactly equals the threshold — the single failure that trips the breaker. Concurrent in-flight failures that arrive after the threshold is crossed no longer double the cooldown.
- When cooldown expires (half-open transition), reset consecutiveFailures to 0 so the next batch must reach the threshold again to re-trip, while preserving the existing cooldownMs so re-tripping properly escalates.

This prevents a single outage burst from pushing the breaker to max cooldown, which would keep refreshes suspended far longer than intended.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
