### PR TITLE
feat: enforce assistant-scope consistency for ingress members

### DIFF
--- a/assistant/src/__tests__/ingress-member-store.test.ts
+++ b/assistant/src/__tests__/ingress-member-store.test.ts
@@ -1,0 +1,291 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'ingress-member-store-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { initializeDb, resetDb } from '../memory/db.js';
+import {
+  upsertMember,
+  findMember,
+  listMembers,
+  updateLastSeen,
+} from '../memory/ingress-member-store.js';
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+function resetMembersTable() {
+  const { getDb } = require('../memory/db.js');
+  const db = getDb();
+  db.run('DELETE FROM assistant_ingress_members');
+}
+
+describe('ingress-member-store: multi-assistant isolation', () => {
+  beforeEach(() => {
+    resetMembersTable();
+  });
+
+  test('upsertMember for assistant A does not create a member for assistant B', () => {
+    upsertMember({
+      assistantId: 'assistant-a',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+      status: 'active',
+      policy: 'allow',
+    });
+
+    const memberA = findMember({
+      assistantId: 'assistant-a',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+    });
+    const memberB = findMember({
+      assistantId: 'assistant-b',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+    });
+
+    expect(memberA).not.toBeNull();
+    expect(memberA!.assistantId).toBe('assistant-a');
+    expect(memberB).toBeNull();
+  });
+
+  test('findMember with assistantId A does not return members from assistantId B', () => {
+    upsertMember({
+      assistantId: 'assistant-a',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+      status: 'active',
+      policy: 'allow',
+    });
+    upsertMember({
+      assistantId: 'assistant-b',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+      status: 'active',
+      policy: 'deny',
+    });
+
+    const memberA = findMember({
+      assistantId: 'assistant-a',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+    });
+    const memberB = findMember({
+      assistantId: 'assistant-b',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+    });
+
+    expect(memberA).not.toBeNull();
+    expect(memberA!.policy).toBe('allow');
+    expect(memberB).not.toBeNull();
+    expect(memberB!.policy).toBe('deny');
+    expect(memberA!.id).not.toBe(memberB!.id);
+  });
+
+  test('upsertMember for same user across two assistants creates separate records', () => {
+    const memberA = upsertMember({
+      assistantId: 'assistant-a',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-x',
+      displayName: 'User X for A',
+      status: 'active',
+      policy: 'allow',
+    });
+
+    const memberB = upsertMember({
+      assistantId: 'assistant-b',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-x',
+      displayName: 'User X for B',
+      status: 'pending',
+      policy: 'escalate',
+    });
+
+    expect(memberA.id).not.toBe(memberB.id);
+    expect(memberA.assistantId).toBe('assistant-a');
+    expect(memberB.assistantId).toBe('assistant-b');
+    expect(memberA.displayName).toBe('User X for A');
+    expect(memberB.displayName).toBe('User X for B');
+    expect(memberA.status).toBe('active');
+    expect(memberB.status).toBe('pending');
+    expect(memberA.policy).toBe('allow');
+    expect(memberB.policy).toBe('escalate');
+  });
+
+  test('listMembers filtered by assistantId only returns that assistant members', () => {
+    upsertMember({
+      assistantId: 'assistant-a',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+      status: 'active',
+      policy: 'allow',
+    });
+    upsertMember({
+      assistantId: 'assistant-a',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-2',
+      status: 'active',
+      policy: 'allow',
+    });
+    upsertMember({
+      assistantId: 'assistant-b',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-3',
+      status: 'active',
+      policy: 'allow',
+    });
+
+    const membersA = listMembers({ assistantId: 'assistant-a' });
+    const membersB = listMembers({ assistantId: 'assistant-b' });
+
+    expect(membersA).toHaveLength(2);
+    expect(membersA.every(m => m.assistantId === 'assistant-a')).toBe(true);
+    expect(membersB).toHaveLength(1);
+    expect(membersB[0].assistantId).toBe('assistant-b');
+    expect(membersB[0].externalUserId).toBe('user-3');
+  });
+
+  test('listMembers defaults to assistantId "self" when not specified', () => {
+    upsertMember({
+      sourceChannel: 'telegram',
+      externalUserId: 'user-default',
+      status: 'active',
+      policy: 'allow',
+    });
+    upsertMember({
+      assistantId: 'other-assistant',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-other',
+      status: 'active',
+      policy: 'allow',
+    });
+
+    const defaultMembers = listMembers();
+    expect(defaultMembers).toHaveLength(1);
+    expect(defaultMembers[0].assistantId).toBe('self');
+    expect(defaultMembers[0].externalUserId).toBe('user-default');
+  });
+
+  test('upsertMember updates existing record within same assistant, not across assistants', () => {
+    upsertMember({
+      assistantId: 'assistant-a',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+      displayName: 'Original Name',
+      status: 'active',
+      policy: 'allow',
+    });
+    upsertMember({
+      assistantId: 'assistant-b',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+      displayName: 'Name for B',
+      status: 'active',
+      policy: 'allow',
+    });
+
+    // Update within assistant-a should not affect assistant-b's record
+    const updatedA = upsertMember({
+      assistantId: 'assistant-a',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+      displayName: 'Updated Name for A',
+    });
+
+    expect(updatedA.displayName).toBe('Updated Name for A');
+
+    const memberB = findMember({
+      assistantId: 'assistant-b',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+    });
+    expect(memberB).not.toBeNull();
+    expect(memberB!.displayName).toBe('Name for B');
+  });
+
+  test('updateLastSeen does not cross assistant boundaries', () => {
+    const memberA = upsertMember({
+      assistantId: 'assistant-a',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+      status: 'active',
+      policy: 'allow',
+    });
+    const memberB = upsertMember({
+      assistantId: 'assistant-b',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+      status: 'active',
+      policy: 'allow',
+    });
+
+    expect(memberA.lastSeenAt).toBeNull();
+    expect(memberB.lastSeenAt).toBeNull();
+
+    updateLastSeen(memberA.id);
+
+    const refreshedA = findMember({
+      assistantId: 'assistant-a',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+    });
+    const refreshedB = findMember({
+      assistantId: 'assistant-b',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-1',
+    });
+
+    expect(refreshedA!.lastSeenAt).not.toBeNull();
+    expect(refreshedB!.lastSeenAt).toBeNull();
+  });
+
+  test('findMember with externalChatId also scopes by assistantId', () => {
+    upsertMember({
+      assistantId: 'assistant-a',
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-100',
+      status: 'active',
+      policy: 'allow',
+    });
+
+    const foundA = findMember({
+      assistantId: 'assistant-a',
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-100',
+    });
+    const foundB = findMember({
+      assistantId: 'assistant-b',
+      sourceChannel: 'telegram',
+      externalChatId: 'chat-100',
+    });
+
+    expect(foundA).not.toBeNull();
+    expect(foundB).toBeNull();
+  });
+});

--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -188,6 +188,7 @@ export function handleIngressMember(
     switch (msg.action) {
       case 'list': {
         const members = listMembers({
+          assistantId: msg.assistantId,
           sourceChannel: msg.sourceChannel,
           status: msg.status,
           policy: msg.policy,
@@ -210,6 +211,7 @@ export function handleIngressMember(
           return;
         }
         const member = upsertMember({
+          assistantId: msg.assistantId,
           sourceChannel: msg.sourceChannel,
           externalUserId: msg.externalUserId,
           externalChatId: msg.externalChatId,

--- a/assistant/src/daemon/ipc-contract/inbox.ts
+++ b/assistant/src/daemon/ipc-contract/inbox.ts
@@ -28,6 +28,8 @@ export interface IngressInviteRequest {
 export interface IngressMemberRequest {
   type: 'ingress_member';
   action: 'list' | 'upsert' | 'revoke' | 'block';
+  /** Assistant ID for scoping member operations (defaults to 'self'). */
+  assistantId?: string;
   /** Source channel (required for upsert, optional filter for list). */
   sourceChannel?: string;
   /** External user ID (upsert only). */

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -155,6 +155,7 @@ export async function handleChannelInbound(
 
   if (body.senderExternalUserId) {
     resolvedMember = findMember({
+      assistantId,
       sourceChannel,
       externalUserId: body.senderExternalUserId,
       externalChatId,


### PR DESCRIPTION
Audits and fixes all ingress member read/write paths to consistently scope by assistantId, preventing membership bleed between assistants. Adds multi-assistant regression tests verifying that member operations are properly isolated per assistant.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
