### PR TITLE
Cross-Channel Guardian Trust and Memory Provenance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,10 @@ Returning `undefined` is acceptable only for **lookup functions** where "not fou
 | Filesystem tools (`path-policy.ts`, `edit-engine.ts`) | Discriminated union (`{ ok, reason }`) | Validation outcomes that the caller must handle (out of bounds, not found, ambiguous) |
 | Subagent manager (`subagent/manager.ts`) | Throws for precondition violations, string literal unions for expected outcomes | Depth limit exceeded is a bug; `sendMessage` returns `'not_found' | 'terminal' | 'queue_full'` as expected states |
 
+## Memory Provenance Invariant
+
+All memory extraction and retrieval decisions must consider actor-role provenance. Untrusted actors (non-guardian, unverified_channel) must not trigger profile extraction or receive memory recall/conflict disclosures. This invariant is enforced in `indexer.ts` (write gate) and `session-memory.ts` (read gate).
+
 ## Tooling Direction
 
 Do not add new tool registrations using the `class ____Tool implements Tool {` pattern.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -987,6 +987,18 @@ Runtime profile flow (per turn):
 2. Session injects that block only into runtime prompt state.
 3. Session strips the injected profile block before persisting conversation history, so dynamic profile context never pollutes durable message rows.
 
+### Provenance-Aware Memory Pipeline
+
+Every persisted message carries provenance metadata (`provenanceActorRole`, `provenanceSourceChannel`, etc.) derived from the `GuardianRuntimeContext` resolved by `guardian-context-resolver.ts`. This metadata records which actor produced the message and through which channel, enabling downstream trust decisions without re-resolving identity at read time.
+
+Two trust gates enforce actor-role-based access control over the memory pipeline:
+
+- **Write gate** (`indexer.ts`): The `extract_items` and `resolve_conflicts` jobs only run for messages from trusted actors (guardian or legacy/undefined provenance). Messages from untrusted actors (non-guardian, unverified_channel) are still segmented and embedded — so they appear in conversation context — but no profile extraction or conflict resolution is triggered. This prevents untrusted channels from injecting or mutating long-term memory items.
+
+- **Read gate** (`session-memory.ts`): When the current session's actor is untrusted, the memory recall pipeline returns a no-op context — no recall injection, no dynamic profile, no conflict clarification prompts. This ensures untrusted actors cannot surface or exploit previously extracted memory.
+
+Trust policy is **cross-channel and actor-role-based**: decisions use `guardianContext.actorRole`, not the channel string. Desktop/IPC sessions default to `actorRole: 'guardian'`. External channels (Telegram, SMS, WhatsApp, voice) provide explicit guardian context via the resolver. Legacy messages without provenance metadata are treated as trusted for backwards compatibility; going forward, all new messages carry provenance.
+
 ---
 
 ## Private Threads — Isolated Memory and Strict Side-Effect Controls

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -49,6 +49,18 @@ mock.module('../config/loader.js', () => ({
   }),
 }));
 
+// ── Call constants mock ──────────────────────────────────────────────
+
+let mockConsultationTimeoutMs = 90_000;
+
+mock.module('../calls/call-constants.js', () => ({
+  getMaxCallDurationMs: () => 12 * 60 * 1000,
+  getUserConsultationTimeoutMs: () => mockConsultationTimeoutMs,
+  SILENCE_TIMEOUT_MS: 30_000,
+  MAX_CALL_DURATION_MS: 3600 * 1000,
+  USER_CONSULTATION_TIMEOUT_MS: 120 * 1000,
+}));
+
 // ── Voice session bridge mock ────────────────────────────────────────
 
 /**
@@ -212,6 +224,8 @@ describe('call-controller', () => {
     resetTables();
     // Reset the bridge mock to default behaviour
     mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(['Hello', ' there']));
+    // Reset consultation timeout to the default (long) value
+    mockConsultationTimeoutMs = 90_000;
   });
 
   // ── handleCallerUtterance ─────────────────────────────────────────
@@ -799,6 +813,128 @@ describe('call-controller', () => {
     controller.destroy();
   });
 
+  // ── waiting_on_user re-entry guard ────────────────────────────────
+
+  test('handleCallerUtterance: does NOT trigger startVoiceTurn when waiting_on_user', async () => {
+    // Trigger ASK_GUARDIAN to enter waiting_on_user state
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Hold on. [ASK_GUARDIAN: What time works?]'],
+    ));
+    const { controller } = setupController();
+    await controller.handleCallerUtterance('Book me in');
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    // Track calls to startVoiceTurn from this point
+    let turnCallCount = 0;
+    mockStartVoiceTurn.mockImplementation(async (opts: { onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      turnCallCount++;
+      opts.onTextDelta('Should not appear.');
+      opts.onComplete();
+      return { runId: 'run-blocked', abort: () => {} };
+    });
+
+    // Caller speaks while waiting — should be queued, not processed
+    await controller.handleCallerUtterance('Hello? Are you still there?');
+    expect(turnCallCount).toBe(0);
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    controller.destroy();
+  });
+
+  test('queued caller utterance IS processed after handleUserAnswer resolves', async () => {
+    // Trigger ASK_GUARDIAN to enter waiting_on_user state
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Checking. [ASK_GUARDIAN: Confirm appointment?]'],
+    ));
+    const { relay, controller } = setupController();
+    await controller.handleCallerUtterance('I want to schedule');
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    // Caller speaks while waiting — queued
+    await controller.handleCallerUtterance('Actually make it 4pm');
+
+    // Set up mocks for the answer turn and subsequent queued utterance turn
+    let turnContents: string[] = [];
+    mockStartVoiceTurn.mockImplementation(async (opts: { content: string; onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      turnContents.push(opts.content);
+      if (opts.content.includes('[USER_ANSWERED:')) {
+        opts.onTextDelta('Confirmed.');
+      } else {
+        opts.onTextDelta('Got it, 4pm.');
+      }
+      opts.onComplete();
+      return { runId: `run-${turnContents.length}`, abort: () => {} };
+    });
+
+    const accepted = await controller.handleUserAnswer('Yes, confirmed');
+    expect(accepted).toBe(true);
+
+    // Give fire-and-forget turns time to complete
+    await new Promise((r) => setTimeout(r, 100));
+
+    // The answer turn should have fired
+    expect(turnContents.some((c) => c.includes('[USER_ANSWERED: Yes, confirmed]'))).toBe(true);
+    // The queued caller utterance should also have been processed
+    expect(turnContents.some((c) => c.includes('Actually make it 4pm'))).toBe(true);
+
+    controller.destroy();
+  });
+
+  test('no duplicate guardian dispatch: subsequent handleCallerUtterance during waiting_on_user does not produce another ASK_GUARDIAN', async () => {
+    // Trigger ASK_GUARDIAN to enter waiting_on_user
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Let me ask. [ASK_GUARDIAN: Preferred date?]'],
+    ));
+    const { session, controller } = setupController();
+    await controller.handleCallerUtterance('Schedule please');
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    // Count how many times startVoiceTurn is invoked after this point
+    let postGuardianTurnCount = 0;
+    mockStartVoiceTurn.mockImplementation(async (opts: { onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      postGuardianTurnCount++;
+      // Simulate the model trying to emit another ASK_GUARDIAN
+      opts.onTextDelta('[ASK_GUARDIAN: Preferred date again?]');
+      opts.onComplete();
+      return { runId: 'run-dup', abort: () => {} };
+    });
+
+    // Multiple caller utterances during waiting_on_user — all should be queued
+    await controller.handleCallerUtterance('Hello?');
+    await controller.handleCallerUtterance('Anyone there?');
+
+    // No turns should have started
+    expect(postGuardianTurnCount).toBe(0);
+    // State should still be waiting_on_user
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    controller.destroy();
+  });
+
+  test('handleUserAnswer: returns false when not in waiting_on_user state (stale/duplicate guard)', async () => {
+    const { controller } = setupController();
+
+    // idle state
+    expect(await controller.handleUserAnswer('some answer')).toBe(false);
+
+    // processing state — trigger a turn first
+    mockStartVoiceTurn.mockImplementation(async (opts: { onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      // Slow turn — give time to call handleUserAnswer while processing
+      await new Promise((r) => setTimeout(r, 200));
+      opts.onTextDelta('Response.');
+      opts.onComplete();
+      return { runId: 'run-proc', abort: () => {} };
+    });
+    const turnPromise = controller.handleCallerUtterance('Test');
+    // Give it a moment to enter processing state
+    await new Promise((r) => setTimeout(r, 10));
+    expect(await controller.handleUserAnswer('stale answer')).toBe(false);
+
+    // Clean up
+    await turnPromise.catch(() => {});
+    controller.destroy();
+  });
+
   test('handleUserInstruction: does not trigger turn when controller is not idle', async () => {
     // First, trigger ASK_GUARDIAN so controller enters waiting_on_user
     mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
@@ -828,6 +964,87 @@ describe('call-controller', () => {
     const events = getCallEvents(session.id);
     const instructionEvents = events.filter((e) => e.eventType === 'user_instruction_relayed');
     expect(instructionEvents.length).toBe(1);
+
+    controller.destroy();
+  });
+
+  // ── Post-end-call drain guard ───────────────────────────────────
+
+  test('handleUserAnswer: queued caller utterances are discarded (not processed) when answer turn ends the call', async () => {
+    // Trigger ASK_GUARDIAN to enter waiting_on_user state
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Checking. [ASK_GUARDIAN: Confirm cancellation?]'],
+    ));
+    const { session, relay, controller } = setupController();
+    await controller.handleCallerUtterance('I want to cancel');
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    // Queue a caller utterance while waiting
+    await controller.handleCallerUtterance('Never mind, just cancel it');
+
+    // Set up mock so the answer turn ends the call with [END_CALL]
+    let turnContents: string[] = [];
+    mockStartVoiceTurn.mockImplementation(async (opts: { content: string; onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      turnContents.push(opts.content);
+      opts.onTextDelta('Alright, your appointment is cancelled. Goodbye! [END_CALL]');
+      opts.onComplete();
+      return { runId: `run-${turnContents.length}`, abort: () => {} };
+    });
+
+    const accepted = await controller.handleUserAnswer('Yes, cancel it');
+    expect(accepted).toBe(true);
+
+    // Give fire-and-forget turns time to complete
+    await new Promise((r) => setTimeout(r, 100));
+
+    // The answer turn should have fired
+    expect(turnContents.some((c) => c.includes('[USER_ANSWERED: Yes, cancel it]'))).toBe(true);
+    // The queued caller utterance should NOT have been processed — only the answer turn
+    expect(turnContents.length).toBe(1);
+
+    // Call should be completed
+    const updatedSession = getCallSession(session.id);
+    expect(updatedSession!.status).toBe('completed');
+    expect(relay.endCalled).toBe(true);
+
+    controller.destroy();
+  });
+
+  // ── Consultation timeout with merged instructions + utterances ──
+
+  test('consultation timeout: merges pending instructions and caller utterances into a single turn', async () => {
+    // Use a short consultation timeout so we can wait for it in the test
+    mockConsultationTimeoutMs = 50;
+
+    // Trigger ASK_GUARDIAN to enter waiting_on_user state
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Let me check. [ASK_GUARDIAN: What time works?]'],
+    ));
+    const { controller } = setupController();
+    await controller.handleCallerUtterance('Book me in');
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    // Queue an instruction and a caller utterance while waiting
+    await controller.handleUserInstruction('Suggest morning slots');
+    await controller.handleCallerUtterance('Actually, I prefer 10am');
+
+    // Set up mock to capture what content the merged turn receives
+    let turnContents: string[] = [];
+    mockStartVoiceTurn.mockImplementation(async (opts: { content: string; onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      turnContents.push(opts.content);
+      opts.onTextDelta('Got it, let me check 10am availability.');
+      opts.onComplete();
+      return { runId: `run-${turnContents.length}`, abort: () => {} };
+    });
+
+    // Wait for the short consultation timeout to fire
+    await new Promise((r) => setTimeout(r, 200));
+
+    // A single merged turn should have been fired containing both the
+    // instruction marker and the caller utterance
+    expect(turnContents.length).toBe(1);
+    expect(turnContents[0]).toContain('[USER_INSTRUCTION: Suggest morning slots]');
+    expect(turnContents[0]).toContain('Actually, I prefer 10am');
 
     controller.destroy();
   });

--- a/assistant/src/__tests__/conversation-routes.test.ts
+++ b/assistant/src/__tests__/conversation-routes.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, mock, test } from 'bun:test';
+import type { RuntimeMessageSessionOptions } from '../runtime/http-types.js';
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../memory/conversation-key-store.js', () => ({
+  getOrCreateConversation: () => ({ conversationId: 'conv-legacy-test' }),
+  getConversationByKey: () => null,
+}));
+
+mock.module('../memory/attachments-store.js', () => ({
+  getAttachmentsByIds: () => [],
+}));
+
+import { handleSendMessage } from '../runtime/routes/conversation-routes.js';
+
+describe('handleSendMessage', () => {
+  test('legacy fallback passes guardian context to processor', async () => {
+    let capturedOptions: RuntimeMessageSessionOptions | undefined;
+    let capturedSourceChannel: string | undefined;
+
+    const req = new Request('http://localhost/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        conversationKey: 'legacy-fallback-key',
+        content: 'Hello from legacy fallback',
+        sourceChannel: 'telegram',
+      }),
+    });
+
+    const res = await handleSendMessage(req, {
+      processMessage: async (_conversationId, _content, _attachmentIds, options, sourceChannel) => {
+        capturedOptions = options;
+        capturedSourceChannel = sourceChannel;
+        return { messageId: 'msg-legacy-fallback' };
+      },
+    });
+
+    const body = await res.json() as { accepted: boolean; messageId: string };
+    expect(res.status).toBe(202);
+    expect(body.accepted).toBe(true);
+    expect(body.messageId).toBe('msg-legacy-fallback');
+    expect(capturedSourceChannel).toBe('telegram');
+    expect(capturedOptions?.guardianContext).toEqual({
+      actorRole: 'guardian',
+      sourceChannel: 'telegram',
+    });
+  });
+});

--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -4524,4 +4524,193 @@ describe('Memory regressions', () => {
       .all();
     expect(segments.length).toBeGreaterThan(0);
   });
+
+  // ── Trust-aware extraction gating tests (M3) ───────────────────────
+
+  test('untrusted actor messages do not enqueue extract_items', () => {
+    const db = getDb();
+    const now = Date.now();
+    db.insert(conversations).values({
+      id: 'conv-untrusted-gate',
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-untrusted-gate',
+      conversationId: 'conv-untrusted-gate',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'Untrusted user preference for dark mode.' }]),
+      createdAt: now,
+    }).run();
+
+    const result = indexMessageNow({
+      messageId: 'msg-untrusted-gate',
+      conversationId: 'conv-untrusted-gate',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'Untrusted user preference for dark mode.' }]),
+      createdAt: now,
+      provenanceActorRole: 'non-guardian',
+    }, DEFAULT_CONFIG.memory);
+
+    expect(result.indexedSegments).toBeGreaterThan(0);
+
+    // No extract_items or resolve_conflicts jobs should be enqueued
+    const extractJobs = db.select().from(memoryJobs)
+      .where(
+        and(
+          eq(memoryJobs.type, 'extract_items'),
+        ),
+      )
+      .all()
+      .filter(j => JSON.parse(j.payload).messageId === 'msg-untrusted-gate');
+    expect(extractJobs.length).toBe(0);
+
+    // enqueuedJobs should reflect: embed jobs + summary (1), no extract (0), no conflict (0)
+    const expectedJobs = result.indexedSegments + 1; // embed per segment + summary
+    expect(result.enqueuedJobs).toBe(expectedJobs);
+  });
+
+  test('trusted guardian messages still enqueue extraction', () => {
+    const db = getDb();
+    const now = Date.now();
+    db.insert(conversations).values({
+      id: 'conv-trusted-gate',
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-trusted-gate',
+      conversationId: 'conv-trusted-gate',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'Trusted guardian preference for light mode.' }]),
+      createdAt: now,
+    }).run();
+
+    const result = indexMessageNow({
+      messageId: 'msg-trusted-gate',
+      conversationId: 'conv-trusted-gate',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'Trusted guardian preference for light mode.' }]),
+      createdAt: now,
+      provenanceActorRole: 'guardian',
+    }, DEFAULT_CONFIG.memory);
+
+    expect(result.indexedSegments).toBeGreaterThan(0);
+
+    // extract_items job should be enqueued for trusted guardian
+    const extractJobs = db.select().from(memoryJobs)
+      .where(eq(memoryJobs.type, 'extract_items'))
+      .all()
+      .filter(j => JSON.parse(j.payload).messageId === 'msg-trusted-gate');
+    expect(extractJobs.length).toBe(1);
+
+    // enqueuedJobs: embed per segment + extract_items (counts as 2: extract + summary) + conflict
+    // For user role: shouldExtract=true, shouldResolveConflicts=true (if enabled)
+    expect(result.enqueuedJobs).toBeGreaterThan(result.indexedSegments + 1);
+  });
+
+  test('legacy messages without provenance still enqueue extraction', () => {
+    const db = getDb();
+    const now = Date.now();
+    db.insert(conversations).values({
+      id: 'conv-legacy-gate',
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-legacy-gate',
+      conversationId: 'conv-legacy-gate',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'Legacy message with no provenance info.' }]),
+      createdAt: now,
+    }).run();
+
+    const result = indexMessageNow({
+      messageId: 'msg-legacy-gate',
+      conversationId: 'conv-legacy-gate',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'Legacy message with no provenance info.' }]),
+      createdAt: now,
+      // provenanceActorRole is intentionally omitted (undefined) for backwards compat
+    }, DEFAULT_CONFIG.memory);
+
+    expect(result.indexedSegments).toBeGreaterThan(0);
+
+    // extract_items job should still be enqueued for legacy messages (backwards compat)
+    const extractJobs = db.select().from(memoryJobs)
+      .where(eq(memoryJobs.type, 'extract_items'))
+      .all()
+      .filter(j => JSON.parse(j.payload).messageId === 'msg-legacy-gate');
+    expect(extractJobs.length).toBe(1);
+
+    // enqueuedJobs should include extraction jobs
+    expect(result.enqueuedJobs).toBeGreaterThan(result.indexedSegments + 1);
+  });
+
+  test('unverified_channel messages do not enqueue extract_items', () => {
+    const db = getDb();
+    const now = Date.now();
+    db.insert(conversations).values({
+      id: 'conv-unverified-gate',
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-unverified-gate',
+      conversationId: 'conv-unverified-gate',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'Unverified channel preference for compact layout.' }]),
+      createdAt: now,
+    }).run();
+
+    const result = indexMessageNow({
+      messageId: 'msg-unverified-gate',
+      conversationId: 'conv-unverified-gate',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'Unverified channel preference for compact layout.' }]),
+      createdAt: now,
+      provenanceActorRole: 'unverified_channel',
+    }, DEFAULT_CONFIG.memory);
+
+    expect(result.indexedSegments).toBeGreaterThan(0);
+
+    // No extract_items jobs should be enqueued for unverified channel
+    const extractJobs = db.select().from(memoryJobs)
+      .where(eq(memoryJobs.type, 'extract_items'))
+      .all()
+      .filter(j => JSON.parse(j.payload).messageId === 'msg-unverified-gate');
+    expect(extractJobs.length).toBe(0);
+
+    // enqueuedJobs should reflect: embed jobs + summary (1), no extract (0), no conflict (0)
+    const expectedJobs = result.indexedSegments + 1; // embed per segment + summary
+    expect(result.enqueuedJobs).toBe(expectedJobs);
+  });
 });

--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -105,7 +105,7 @@ import {
   stripMemoryRecallMessages,
 } from '../memory/retriever.js';
 import { addMessage, createConversation, getConversationMemoryScopeId, messageMetadataSchema, provenanceFromGuardianContext } from '../memory/conversation-store.js';
-import { backfillJob } from '../memory/job-handlers/backfill.js';
+import { backfillEntityRelationsJob, backfillJob } from '../memory/job-handlers/backfill.js';
 import { buildConversationSummaryJob, buildGlobalSummaryJob } from '../memory/job-handlers/summarization.js';
 import {
   conversations,
@@ -4430,6 +4430,127 @@ describe('Memory regressions', () => {
     expect(segments.length).toBeGreaterThan(0);
     for (const seg of segments) {
       expect(seg.scopeId).toBe(conv.memoryScopeId);
+    }
+  });
+
+  test('backfillJob preserves provenance trust gating during reindex', () => {
+    const db = getDb();
+
+    const conv = createConversation('Backfill provenance trust gate');
+    const msgId = 'msg-backfill-untrusted-provenance';
+    db.insert(messages).values({
+      id: msgId,
+      conversationId: conv.id,
+      role: 'user',
+      content: 'Untrusted sender says preferences should not become durable profile memory.',
+      metadata: JSON.stringify({
+        provenanceActorRole: 'non-guardian',
+        provenanceSourceChannel: 'telegram',
+      }),
+      createdAt: conv.createdAt + 1,
+    }).run();
+
+    const fakeJob = {
+      id: 'job-backfill-untrusted-provenance',
+      type: 'backfill' as const,
+      payload: { force: true },
+      status: 'running' as const,
+      attempts: 0,
+      deferrals: 0,
+      runAfter: 0,
+      lastError: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    backfillJob(fakeJob, TEST_CONFIG);
+
+    const segments = db
+      .select()
+      .from(memorySegments)
+      .where(eq(memorySegments.messageId, msgId))
+      .all();
+    expect(segments.length).toBeGreaterThan(0);
+
+    const extractJobs = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.type, 'extract_items'))
+      .all()
+      .filter((job) => JSON.parse(job.payload).messageId === msgId);
+    expect(extractJobs).toHaveLength(0);
+  });
+
+  test('relation backfill skips untrusted provenance messages', () => {
+    const db = getDb();
+    const now = Date.now();
+    const originalEnabled = TEST_CONFIG.memory.entity.enabled;
+    const originalRelationsEnabled = TEST_CONFIG.memory.entity.extractRelations.enabled;
+    const originalBatchSize = TEST_CONFIG.memory.entity.extractRelations.backfillBatchSize;
+
+    TEST_CONFIG.memory.entity.enabled = true;
+    TEST_CONFIG.memory.entity.extractRelations.enabled = true;
+    TEST_CONFIG.memory.entity.extractRelations.backfillBatchSize = 50;
+
+    try {
+      db.insert(conversations).values({
+        id: 'conv-relation-provenance-gate',
+        title: null,
+        createdAt: now,
+        updatedAt: now,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalEstimatedCost: 0,
+        contextSummary: null,
+        contextCompactedMessageCount: 0,
+        contextCompactedAt: null,
+      }).run();
+
+      db.insert(messages).values([
+        {
+          id: 'msg-relation-trusted',
+          conversationId: 'conv-relation-provenance-gate',
+          role: 'user',
+          content: JSON.stringify([{ type: 'text', text: 'Trusted guardian message for relation backfill.' }]),
+          metadata: JSON.stringify({ provenanceActorRole: 'guardian', provenanceSourceChannel: 'telegram' }),
+          createdAt: now + 1,
+        },
+        {
+          id: 'msg-relation-untrusted',
+          conversationId: 'conv-relation-provenance-gate',
+          role: 'user',
+          content: JSON.stringify([{ type: 'text', text: 'Untrusted message that should be excluded from relation backfill extraction.' }]),
+          metadata: JSON.stringify({ provenanceActorRole: 'non-guardian', provenanceSourceChannel: 'telegram' }),
+          createdAt: now + 2,
+        },
+      ]).run();
+
+      const relationJob = {
+        id: 'job-relation-provenance-gate',
+        type: 'backfill_entity_relations' as const,
+        payload: { force: true },
+        status: 'running' as const,
+        attempts: 0,
+        deferrals: 0,
+        runAfter: 0,
+        lastError: null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+      backfillEntityRelationsJob(relationJob, TEST_CONFIG);
+
+      const extractJobs = db
+        .select()
+        .from(memoryJobs)
+        .where(eq(memoryJobs.type, 'extract_entities'))
+        .all();
+      const extractedMessageIds = extractJobs.map((job) => JSON.parse(job.payload).messageId);
+
+      expect(extractedMessageIds).toContain('msg-relation-trusted');
+      expect(extractedMessageIds).not.toContain('msg-relation-untrusted');
+    } finally {
+      TEST_CONFIG.memory.entity.enabled = originalEnabled;
+      TEST_CONFIG.memory.entity.extractRelations.enabled = originalRelationsEnabled;
+      TEST_CONFIG.memory.entity.extractRelations.backfillBatchSize = originalBatchSize;
     }
   });
 

--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -104,7 +104,7 @@ import {
   searchMemoryItems,
   stripMemoryRecallMessages,
 } from '../memory/retriever.js';
-import { addMessage, createConversation, getConversationMemoryScopeId } from '../memory/conversation-store.js';
+import { addMessage, createConversation, getConversationMemoryScopeId, messageMetadataSchema, provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import { backfillJob } from '../memory/job-handlers/backfill.js';
 import { buildConversationSummaryJob, buildGlobalSummaryJob } from '../memory/job-handlers/summarization.js';
 import {
@@ -4431,5 +4431,97 @@ describe('Memory regressions', () => {
     for (const seg of segments) {
       expect(seg.scopeId).toBe(conv.memoryScopeId);
     }
+  });
+
+  // ── Provenance plumbing tests ────────────────────────────────────────
+
+  test('provenance fields are preserved in stored message metadata', () => {
+    const conv = createConversation('provenance-preserve');
+    const metadata = {
+      userMessageChannel: 'telegram' as const,
+      provenanceActorRole: 'non-guardian' as const,
+      provenanceSourceChannel: 'telegram' as const,
+      provenanceGuardianExternalUserId: 'guardian-123',
+      provenanceRequesterIdentifier: 'Alice',
+    };
+    const msg = addMessage(conv.id, 'user', 'Hello from telegram', metadata);
+
+    const db = getDb();
+    const stored = db
+      .select({ metadata: messages.metadata })
+      .from(messages)
+      .where(eq(messages.id, msg.id))
+      .get();
+
+    expect(stored).toBeTruthy();
+    const parsed = JSON.parse(stored!.metadata!);
+    expect(parsed.provenanceActorRole).toBe('non-guardian');
+    expect(parsed.provenanceSourceChannel).toBe('telegram');
+    expect(parsed.provenanceGuardianExternalUserId).toBe('guardian-123');
+    expect(parsed.provenanceRequesterIdentifier).toBe('Alice');
+  });
+
+  test('messageMetadataSchema validates provenance fields', () => {
+    const valid = messageMetadataSchema.safeParse({
+      provenanceActorRole: 'guardian',
+      provenanceSourceChannel: 'macos',
+    });
+    expect(valid.success).toBe(true);
+
+    const validNonGuardian = messageMetadataSchema.safeParse({
+      provenanceActorRole: 'non-guardian',
+      provenanceSourceChannel: 'telegram',
+      provenanceGuardianExternalUserId: 'g-123',
+      provenanceRequesterIdentifier: 'Bob',
+    });
+    expect(validNonGuardian.success).toBe(true);
+
+    const validUnverified = messageMetadataSchema.safeParse({
+      provenanceActorRole: 'unverified_channel',
+    });
+    expect(validUnverified.success).toBe(true);
+  });
+
+  test('provenanceFromGuardianContext returns unverified_channel default when no context', () => {
+    const result = provenanceFromGuardianContext(null);
+    expect(result.provenanceActorRole).toBe('unverified_channel');
+    expect(result.provenanceSourceChannel).toBeUndefined();
+
+    const result2 = provenanceFromGuardianContext(undefined);
+    expect(result2.provenanceActorRole).toBe('unverified_channel');
+  });
+
+  test('provenanceFromGuardianContext extracts fields from guardian context', () => {
+    const ctx = {
+      sourceChannel: 'telegram' as const,
+      actorRole: 'non-guardian' as const,
+      guardianExternalUserId: 'g-456',
+      requesterIdentifier: 'Charlie',
+    };
+    const result = provenanceFromGuardianContext(ctx);
+    expect(result.provenanceActorRole).toBe('non-guardian');
+    expect(result.provenanceSourceChannel).toBe('telegram');
+    expect(result.provenanceGuardianExternalUserId).toBe('g-456');
+    expect(result.provenanceRequesterIdentifier).toBe('Charlie');
+  });
+
+  test('indexMessageNow receives provenanceActorRole when metadata includes it', () => {
+    const conv = createConversation('provenance-indexer');
+    const metadata = {
+      provenanceActorRole: 'non-guardian' as const,
+      provenanceSourceChannel: 'telegram' as const,
+    };
+    // addMessage parses metadata and passes provenanceActorRole to indexMessageNow.
+    // We verify indirectly: the message is persisted with metadata and segments are indexed.
+    const msg = addMessage(conv.id, 'user', 'Test provenance indexing message with enough content to segment', metadata);
+    expect(msg.id).toBeTruthy();
+
+    // Verify segments were created (indexMessageNow was called successfully)
+    const segments = getDb()
+      .select()
+      .from(memorySegments)
+      .where(eq(memorySegments.messageId, msg.id))
+      .all();
+    expect(segments.length).toBeGreaterThan(0);
   });
 });

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -69,6 +69,8 @@ export class CallController {
   private isInbound: boolean;
   /** Instructions queued while an LLM turn is in-flight or during waiting_on_user */
   private pendingInstructions: string[] = [];
+  /** Caller utterances queued while waiting_on_user to prevent re-entrant turns */
+  private pendingCallerUtterances: Array<{transcript: string, speaker?: PromptSpeakerContext}> = [];
   /** Ensures the call opener is triggered at most once per call. */
   private initialGreetingStarted = false;
   /** Marks that the next caller turn should be treated as an opening acknowledgment. */
@@ -149,6 +151,17 @@ export class CallController {
    * Handle a final caller utterance from the ConversationRelay.
    */
   async handleCallerUtterance(transcript: string, speaker?: PromptSpeakerContext): Promise<void> {
+    // Do not start a new turn while waiting for guardian input — queue
+    // the utterance so it can be processed after the answer arrives.
+    if (this.state === 'waiting_on_user') {
+      log.warn(
+        { callSessionId: this.callSessionId },
+        'Caller utterance received while waiting_on_user — queued for after answer.',
+      );
+      this.pendingCallerUtterances.push({ transcript, speaker });
+      return;
+    }
+
     const interruptedInFlight = this.state === 'processing' || this.state === 'speaking';
     // If we're already processing or speaking, abort the in-flight generation
     if (interruptedInFlight) {
@@ -229,9 +242,20 @@ export class CallController {
 
     // Fire-and-forget: unblock the caller so the HTTP response and answer
     // persistence happen immediately, before LLM streaming begins.
-    this.runTurn(content).catch((err) =>
-      log.error({ err, callSessionId: this.callSessionId }, 'runTurn failed after user answer'),
-    );
+    this.runTurn(content)
+      .then(() => {
+        // If the answer turn ended the call (e.g. [END_CALL]), don't drain
+        // queued utterances — just discard them to avoid starting a fresh
+        // turn on a dead session.
+        if (this.state === 'idle' && this.isCallCompleted()) {
+          this.pendingCallerUtterances = [];
+          return;
+        }
+        this.drainPendingCallerUtterances();
+      })
+      .catch((err) =>
+        log.error({ err, callSessionId: this.callSessionId }, 'runTurn failed after user answer'),
+      );
     return true;
   }
 
@@ -510,7 +534,24 @@ export class CallController {
             this.state = 'idle';
             updateCallSession(this.callSessionId, { status: 'in_progress' });
             expirePendingQuestions(this.callSessionId);
-            this.flushPendingInstructions();
+
+            const hasInstructions = this.pendingInstructions.length > 0;
+            const hasUtterances = this.pendingCallerUtterances.length > 0;
+
+            if (hasInstructions && hasUtterances) {
+              // Merge both queues into a single turn to avoid the race where
+              // flushPendingInstructions fires a turn that gets aborted by
+              // drainPendingCallerUtterances, losing the instructions.
+              const instructionPrefix = this.pendingInstructions
+                .map((instr) => `[USER_INSTRUCTION: ${instr}]`)
+                .join('\n');
+              this.pendingInstructions = [];
+              this.drainPendingCallerUtterances(instructionPrefix);
+            } else if (hasInstructions) {
+              this.flushPendingInstructions();
+            } else if (hasUtterances) {
+              this.drainPendingCallerUtterances();
+            }
           }
         }, getUserConsultationTimeoutMs());
         return;
@@ -595,6 +636,17 @@ export class CallController {
   }
 
   /**
+   * Check whether the underlying call session has already ended.
+   * Used to guard against post-completion work (e.g. draining queued
+   * utterances after an [END_CALL] turn).
+   */
+  private isCallCompleted(): boolean {
+    const session = getCallSession(this.callSessionId);
+    if (!session) return true;
+    return session.status === 'completed' || session.status === 'failed' || session.status === 'cancelled';
+  }
+
+  /**
    * Drain any instructions that were queued while the LLM was active.
    */
   private flushPendingInstructions(): void {
@@ -612,6 +664,49 @@ export class CallController {
     // Fire-and-forget so we don't block the current turn's cleanup.
     this.runTurn(content).catch((err) =>
       log.error({ err, callSessionId: this.callSessionId }, 'runTurn failed after flushing queued instructions'),
+    );
+  }
+
+  /**
+   * Drain caller utterances that were queued while waiting_on_user.
+   * Only the most recent utterance is processed — older ones are discarded
+   * as stale since the caller likely moved on.
+   *
+   * @param contentPrefix — optional string (e.g. instruction markers) to
+   *   prepend to the turn content so instructions and the caller utterance
+   *   are sent as a single turn, avoiding concurrent-turn races.
+   */
+  private drainPendingCallerUtterances(contentPrefix?: string): void {
+    if (this.pendingCallerUtterances.length === 0) return;
+
+    // Keep only the most recent utterance; discard stale older ones
+    const latest = this.pendingCallerUtterances[this.pendingCallerUtterances.length - 1];
+    this.pendingCallerUtterances = [];
+
+    if (contentPrefix) {
+      // Merge prefix content with the caller utterance into a single turn
+      let callerContent = this.formatCallerUtterance(latest.transcript, latest.speaker);
+
+      // Preserve opening-ack semantics when draining bypasses handleCallerUtterance
+      if (this.awaitingOpeningAck) {
+        callerContent = callerContent.length > 0
+          ? `${CALL_OPENING_ACK_MARKER}\n${callerContent}`
+          : CALL_OPENING_ACK_MARKER;
+        this.awaitingOpeningAck = false;
+        this.lastSentWasOpener = false;
+      }
+
+      const combined = `${contentPrefix}\n${callerContent}`;
+      this.resetSilenceTimer();
+      this.runTurn(combined).catch((err) =>
+        log.error({ err, callSessionId: this.callSessionId }, 'runTurn failed after draining queued caller utterance with prefix'),
+      );
+      return;
+    }
+
+    // Fire-and-forget so we don't block the current turn's cleanup.
+    this.handleCallerUtterance(latest.transcript, latest.speaker).catch((err) =>
+      log.error({ err, callSessionId: this.callSessionId }, 'runTurn failed after draining queued caller utterance'),
     );
   }
 

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -253,9 +253,10 @@ export class CallController {
         }
         this.drainPendingCallerUtterances();
       })
-      .catch((err) =>
-        log.error({ err, callSessionId: this.callSessionId }, 'runTurn failed after user answer'),
-      );
+      .catch((err) => {
+        this.pendingCallerUtterances = [];
+        log.error({ err, callSessionId: this.callSessionId }, 'runTurn failed after user answer');
+      });
     return true;
   }
 

--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -404,7 +404,9 @@ async function executeApprove(
     });
   }
   session.setAssistantId(assistantId);
-  session.setGuardianContext(null);
+  // Daemon inbox handler — the guardian approved this escalation, so tag as
+  // guardian to avoid 'unverified_channel' blocking memory extraction.
+  session.setGuardianContext({ actorRole: 'guardian', sourceChannel: sourceChannel ?? 'macos' });
   session.setCommandIntent(null);
 
   // Process the message through the agent loop (no IPC event callback

--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -480,6 +480,7 @@ async function executeDeny(
 
   // Store a system note about the denial in the conversation
   addMessage(conversationId, 'assistant', denialText, {
+    provenanceActorRole: 'guardian' as const,
     userMessageChannel: sourceChannel,
     assistantMessageChannel: sourceChannel,
   });
@@ -514,9 +515,12 @@ export function handleAssistantInboxReply(
       conversationId,
       'assistant',
       content,
-      bindingChannel
-        ? { userMessageChannel: bindingChannel, assistantMessageChannel: bindingChannel }
-        : undefined,
+      {
+        provenanceActorRole: 'guardian' as const,
+        ...(bindingChannel
+          ? { userMessageChannel: bindingChannel, assistantMessageChannel: bindingChannel }
+          : {}),
+      },
     );
 
     // Update thread activity timestamps (resets unread count, updates last_outbound_at)

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -137,7 +137,9 @@ export async function handleUserMessage(
       assistantMessageChannel: ipcChannel,
     });
     session.setAssistantId('self');
-    session.setGuardianContext(null);
+    // IPC/desktop user IS the guardian — default to guardian role so messages
+    // are not tagged 'unverified_channel' (which blocks memory extraction).
+    session.setGuardianContext({ actorRole: 'guardian', sourceChannel: ipcChannel });
     session.setCommandIntent(null);
     // Fire-and-forget: don't block the IPC handler so the connection can
     // continue receiving messages (e.g. cancel, confirmations, or

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -13,6 +13,7 @@ import { buildSystemPrompt } from '../config/system-prompt.js';
 import { checkIngressForSecrets } from '../security/secret-ingress.js';
 import { IngressBlockedError } from '../util/errors.js';
 import * as conversationStore from '../memory/conversation-store.js';
+import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import * as attachmentsStore from '../memory/attachments-store.js';
 import { Session, DEFAULT_MEMORY_POLICY, type SessionMemoryPolicy } from './session.js';
 import { parseChannelId, type ChannelId } from '../channels/types.js';
@@ -768,9 +769,13 @@ export class DaemonServer {
 
     if (slashResult.kind === 'unknown') {
       const serverTurnCtx = session.getTurnChannelContext();
-      const serverChannelMeta = serverTurnCtx
-        ? { userMessageChannel: serverTurnCtx.userMessageChannel, assistantMessageChannel: serverTurnCtx.assistantMessageChannel }
-        : undefined;
+      const serverProvenance = provenanceFromGuardianContext(session.guardianContext);
+      const serverChannelMeta = {
+        ...serverProvenance,
+        ...(serverTurnCtx
+          ? { userMessageChannel: serverTurnCtx.userMessageChannel, assistantMessageChannel: serverTurnCtx.assistantMessageChannel }
+          : {}),
+      };
       const userMsg = createUserMessage(content, attachments);
       const persisted = conversationStore.addMessage(
         conversationId,

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -699,11 +699,11 @@ export class DaemonServer {
       throw new Error('Session is already processing a message');
     }
 
+    const resolvedChannel = resolveTurnChannel(sourceChannel, options?.transport?.channelId);
     session.setAssistantId(options?.assistantId ?? 'self');
     session.setGuardianContext(options?.guardianContext ?? null);
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
     session.setCommandIntent(options?.commandIntent ?? null);
-    const resolvedChannel = resolveTurnChannel(sourceChannel, options?.transport?.channelId);
     session.setTurnChannelContext({
       userMessageChannel: resolvedChannel,
       assistantMessageChannel: resolvedChannel,
@@ -746,11 +746,11 @@ export class DaemonServer {
       throw new Error('Session is already processing a message');
     }
 
+    const resolvedChannel2 = resolveTurnChannel(sourceChannel, options?.transport?.channelId);
     session.setAssistantId(options?.assistantId ?? 'self');
     session.setGuardianContext(options?.guardianContext ?? null);
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
     session.setCommandIntent(options?.commandIntent ?? null);
-    const resolvedChannel2 = resolveTurnChannel(sourceChannel, options?.transport?.channelId);
     session.setTurnChannelContext({
       userMessageChannel: resolvedChannel2,
       assistantMessageChannel: resolvedChannel2,

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -14,6 +14,7 @@ import type { AgentEvent } from '../agent/loop.js';
 import type { AgentLoopSessionContext } from './session-agent-loop.js';
 import type { DirectiveRequest } from './assistant-attachments.js';
 import * as conversationStore from '../memory/conversation-store.js';
+import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import { classifySessionError, isContextTooLarge, buildSessionErrorMessage } from './session-error.js';
 import { isProviderOrderingError } from './session-slash.js';
 import { cleanAssistantContent, drainDirectiveDisplayBuffer } from './assistant-attachments.js';
@@ -277,6 +278,7 @@ export function handleMessageComplete(
       }),
     );
     const toolResultMetadata = {
+      ...provenanceFromGuardianContext(deps.ctx.guardianContext),
       userMessageChannel: deps.turnChannelContext.userMessageChannel,
       assistantMessageChannel: deps.turnChannelContext.assistantMessageChannel,
     };
@@ -319,6 +321,7 @@ export function handleMessageComplete(
   }
 
   const assistantChannelMetadata = {
+    ...provenanceFromGuardianContext(deps.ctx.guardianContext),
     userMessageChannel: deps.turnChannelContext.userMessageChannel,
     assistantMessageChannel: deps.turnChannelContext.assistantMessageChannel,
   };

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -236,6 +236,7 @@ export async function runAgentLoopImpl(
         conflictGate: ctx.conflictGate,
         scopeId: ctx.memoryPolicy.scopeId,
         includeDefaultFallback: ctx.memoryPolicy.includeDefaultFallback,
+        guardianActorRole: ctx.guardianContext?.actorRole,
       },
       content,
       userMessageId,

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -15,7 +15,7 @@ import type { AgentLoop, CheckpointDecision, AgentEvent } from '../agent/loop.js
 import type { Provider } from '../providers/types.js';
 import { createAssistantMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
-import { getConversationOriginChannel } from '../memory/conversation-store.js';
+import { getConversationOriginChannel, provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import type { PermissionPrompter } from '../permissions/prompter.js';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
@@ -245,6 +245,7 @@ export async function runAgentLoopImpl(
 
     if (memoryResult.conflictClarification) {
       const loopChannelMeta = {
+        ...provenanceFromGuardianContext(ctx.guardianContext),
         userMessageChannel: capturedTurnChannelContext.userMessageChannel,
         assistantMessageChannel: capturedTurnChannelContext.assistantMessageChannel,
       };
@@ -532,6 +533,7 @@ export async function runAgentLoopImpl(
         }),
       );
       const toolResultMetadata = {
+        ...provenanceFromGuardianContext(ctx.guardianContext),
         userMessageChannel: capturedTurnChannelContext.userMessageChannel,
         assistantMessageChannel: capturedTurnChannelContext.assistantMessageChannel,
       };
@@ -554,6 +556,7 @@ export async function runAgentLoopImpl(
     const hasAssistantResponse = newMessages.some((msg) => msg.role === 'assistant');
     if (!hasAssistantResponse && state.providerErrorUserMessage && !abortController.signal.aborted && !yieldedForHandoff) {
       const errChannelMeta = {
+        ...provenanceFromGuardianContext(ctx.guardianContext),
         userMessageChannel: capturedTurnChannelContext.userMessageChannel,
         assistantMessageChannel: capturedTurnChannelContext.assistantMessageChannel,
       };

--- a/assistant/src/daemon/session-memory.ts
+++ b/assistant/src/daemon/session-memory.ts
@@ -34,6 +34,7 @@ export interface MemoryPrepareContext {
   conflictGate: ConflictGate;
   scopeId: string;
   includeDefaultFallback: boolean;
+  guardianActorRole?: 'guardian' | 'non-guardian' | 'unverified_channel';
 }
 
 /**
@@ -48,6 +49,41 @@ export async function prepareMemoryContext(
   abortSignal: AbortSignal,
   onEvent: (msg: ServerMessage) => void,
 ): Promise<MemoryRecallResult & { conflictClarification: string | null }> {
+  // Provenance-based trust gating: untrusted actors skip all memory operations
+  // (recall, dynamic profile, conflict gate) to prevent untrusted content from
+  // influencing memory-augmented responses.
+  const isTrustedActor = ctx.guardianActorRole === 'guardian' || ctx.guardianActorRole === undefined;
+
+  if (!isTrustedActor) {
+    return {
+      runMessages: ctx.messages,
+      recall: {
+        enabled: false,
+        degraded: false,
+        injectedText: '',
+        lexicalHits: 0,
+        semanticHits: 0,
+        recencyHits: 0,
+        entityHits: 0,
+        relationSeedEntityCount: 0,
+        relationTraversedEdgeCount: 0,
+        relationNeighborEntityCount: 0,
+        relationExpandedItemCount: 0,
+        earlyTerminated: false,
+        mergedCount: 0,
+        selectedCount: 0,
+        rerankApplied: false,
+        injectedTokens: 0,
+        latencyMs: 0,
+        topCandidates: [],
+      } as Awaited<ReturnType<typeof buildMemoryRecall>>,
+      dynamicProfile: { text: '' },
+      softConflictInstruction: null,
+      recallInjectionStrategy: 'prepend_user_block',
+      conflictClarification: null,
+    };
+  }
+
   const runtimeConfig = getConfig();
   const memoryEnabled = runtimeConfig.memory?.enabled !== false;
 

--- a/assistant/src/daemon/session-messaging.ts
+++ b/assistant/src/daemon/session-messaging.ts
@@ -12,9 +12,11 @@ import { parseChannelId } from '../channels/types.js';
 import type { ServerMessage, UserMessageAttachment } from './ipc-protocol.js';
 import { createUserMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
+import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import type { SecretPrompter } from '../permissions/secret-prompter.js';
 import type { MessageQueue } from './session-queue-manager.js';
 import { getLogger } from '../util/logger.js';
+import type { GuardianRuntimeContext } from './session-runtime-assembly.js';
 
 const log = getLogger('session-messaging');
 
@@ -27,6 +29,7 @@ export interface MessagingSessionContext {
   abortController: AbortController | null;
   currentRequestId?: string;
   readonly queue: MessageQueue;
+  guardianContext?: GuardianRuntimeContext;
   getTurnChannelContext(): TurnChannelContext | null;
 }
 
@@ -105,13 +108,17 @@ export function persistUserMessage(
 
   try {
     const turnCtx = extractTurnChannelContext(metadata) ?? ctx.getTurnChannelContext();
-    const mergedMetadata = turnCtx
-      ? {
-          ...(metadata ?? {}),
-          userMessageChannel: turnCtx.userMessageChannel,
-          assistantMessageChannel: turnCtx.assistantMessageChannel,
-        }
-      : metadata;
+    const provenance = provenanceFromGuardianContext(ctx.guardianContext);
+    const mergedMetadata = {
+      ...(metadata ?? {}),
+      ...provenance,
+      ...(turnCtx
+        ? {
+            userMessageChannel: turnCtx.userMessageChannel,
+            assistantMessageChannel: turnCtx.assistantMessageChannel,
+          }
+        : {}),
+    };
 
     const persistedUserMessage = conversationStore.addMessage(
       ctx.conversationId,

--- a/assistant/src/daemon/session-notifiers.ts
+++ b/assistant/src/daemon/session-notifiers.ts
@@ -9,8 +9,10 @@
 
 import type { Message } from '../providers/types.js';
 import type { ServerMessage } from './ipc-protocol.js';
+import type { GuardianRuntimeContext } from './session-runtime-assembly.js';
 import { createAssistantMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
+import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import {
   registerWatchStartNotifier,
   unregisterWatchStartNotifier,
@@ -40,6 +42,7 @@ import { buildCallCompletionMessage } from '../calls/call-conversation-messages.
 export interface NotifierSessionContext {
   sendToClient: (msg: ServerMessage) => void;
   messages: Message[];
+  guardianContext?: GuardianRuntimeContext;
 }
 
 /**
@@ -102,7 +105,7 @@ export function registerSessionNotifiers(
       conversationId,
       'assistant',
       JSON.stringify([{ type: 'text', text: questionText }]),
-      { userMessageChannel: 'voice', assistantMessageChannel: 'voice' },
+      { ...provenanceFromGuardianContext(ctx.guardianContext), userMessageChannel: 'voice', assistantMessageChannel: 'voice' },
     );
 
     ctx.messages.push(createAssistantMessage(questionText));

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -10,12 +10,14 @@ import type { Message } from '../providers/types.js';
 import type { TurnChannelContext } from '../channels/types.js';
 import { parseChannelId } from '../channels/types.js';
 import type { ServerMessage, UserMessageAttachment } from './ipc-protocol.js';
+import type { GuardianRuntimeContext } from './session-runtime-assembly.js';
 import type { UsageStats } from './ipc-contract.js';
 import type { MessageQueue } from './session-queue-manager.js';
 import type { QueueDrainReason } from './session-queue-manager.js';
 import type { TraceEmitter } from './trace-emitter.js';
 import { createUserMessage, createAssistantMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
+import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import {
   getPendingDeliveryByConversation,
   getGuardianActionRequest,
@@ -72,6 +74,7 @@ export interface ProcessSessionContext {
   preactivatedSkillIds?: string[];
   /** Assistant identity — used for scoping notification preferences. */
   readonly assistantId?: string;
+  guardianContext?: GuardianRuntimeContext;
   persistUserMessage(content: string, attachments: UserMessageAttachment[], requestId?: string, metadata?: Record<string, unknown>): string;
   runAgentLoop(
     content: string,
@@ -154,9 +157,13 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
   // failed write never leaves an unpersisted message in memory.
   if (slashResult.kind === 'unknown') {
     try {
-      const drainChannelMeta = queuedTurnCtx
-        ? { userMessageChannel: queuedTurnCtx.userMessageChannel, assistantMessageChannel: queuedTurnCtx.assistantMessageChannel }
-        : undefined;
+      const drainProvenance = provenanceFromGuardianContext(session.guardianContext);
+      const drainChannelMeta = {
+        ...drainProvenance,
+        ...(queuedTurnCtx
+          ? { userMessageChannel: queuedTurnCtx.userMessageChannel, assistantMessageChannel: queuedTurnCtx.assistantMessageChannel }
+          : {}),
+      };
       const userMsg = createUserMessage(next.content, next.attachments);
       conversationStore.addMessage(
         session.conversationId,
@@ -293,7 +300,7 @@ export async function processMessage(
   if (guardianDelivery) {
     const guardianRequest = getGuardianActionRequest(guardianDelivery.requestId);
     if (guardianRequest && guardianRequest.status === 'pending') {
-      const guardianChannelMeta = { userMessageChannel: 'vellum' as const, assistantMessageChannel: 'vellum' as const };
+      const guardianChannelMeta = { userMessageChannel: 'vellum' as const, assistantMessageChannel: 'vellum' as const, provenanceActorRole: 'guardian' as const };
       const userMsg = createUserMessage(content, attachments);
       const persisted = conversationStore.addMessage(
         session.conversationId,
@@ -349,9 +356,13 @@ export async function processMessage(
   // so that a failed write never leaves an unpersisted message in memory.
   if (slashResult.kind === 'unknown') {
     const pmTurnCtx = session.getTurnChannelContext();
-    const pmChannelMeta = pmTurnCtx
-      ? { userMessageChannel: pmTurnCtx.userMessageChannel, assistantMessageChannel: pmTurnCtx.assistantMessageChannel }
-      : undefined;
+    const pmProvenance = provenanceFromGuardianContext(session.guardianContext);
+    const pmChannelMeta = {
+      ...pmProvenance,
+      ...(pmTurnCtx
+        ? { userMessageChannel: pmTurnCtx.userMessageChannel, assistantMessageChannel: pmTurnCtx.assistantMessageChannel }
+        : {}),
+    };
     const userMsg = createUserMessage(content, attachments);
     const persisted = conversationStore.addMessage(
       session.conversationId,

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -11,6 +11,7 @@ import { isChannelId, CHANNEL_IDS } from '../channels/types.js';
 import { getLogger } from '../util/logger.js';
 import { deleteOrphanAttachments } from './attachments-store.js';
 import { createRowMapper } from '../util/row-mapper.js';
+import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
 
 const log = getLogger('conversation-store');
 
@@ -32,9 +33,30 @@ export const messageMetadataSchema = z.object({
   userMessageChannel: channelIdSchema.optional(),
   assistantMessageChannel: channelIdSchema.optional(),
   subagentNotification: subagentNotificationSchema.optional(),
+  // Provenance fields for trust-aware memory gating (M3)
+  provenanceActorRole: z.enum(['guardian', 'non-guardian', 'unverified_channel']).optional(),
+  provenanceSourceChannel: channelIdSchema.optional(),
+  provenanceGuardianExternalUserId: z.string().optional(),
+  provenanceRequesterIdentifier: z.string().optional(),
 }).passthrough();
 
 export type MessageMetadata = z.infer<typeof messageMetadataSchema>;
+
+/**
+ * Extract provenance metadata fields from a GuardianRuntimeContext.
+ * When no guardian context is provided, defaults to 'unverified_channel'
+ * because the absence of guardian context means we cannot verify trust —
+ * callers with actual guardian trust should always supply a real context.
+ */
+export function provenanceFromGuardianContext(ctx: GuardianRuntimeContext | null | undefined): Record<string, unknown> {
+  if (!ctx) return { provenanceActorRole: 'unverified_channel' };
+  return {
+    provenanceActorRole: ctx.actorRole,
+    provenanceSourceChannel: ctx.sourceChannel,
+    provenanceGuardianExternalUserId: ctx.guardianExternalUserId,
+    provenanceRequesterIdentifier: ctx.requesterIdentifier,
+  };
+}
 
 export interface ConversationRow {
   id: string;
@@ -261,6 +283,8 @@ export function addMessage(conversationId: string, role: string, content: string
   try {
     const config = getConfig();
     const scopeId = getConversationMemoryScopeId(conversationId);
+    const parsed = metadata ? messageMetadataSchema.safeParse(metadata) : null;
+    const provenanceActorRole = parsed?.success ? parsed.data.provenanceActorRole : undefined;
     indexMessageNow({
       messageId: message.id,
       conversationId: message.conversationId,
@@ -268,6 +292,7 @@ export function addMessage(conversationId: string, role: string, content: string
       content: message.content,
       createdAt: message.createdAt,
       scopeId,
+      provenanceActorRole,
     }, config.memory);
   } catch (err) {
     log.warn({ err, conversationId, messageId: message.id }, 'Failed to index message for memory');

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -21,6 +21,8 @@ export interface IndexMessageInput {
   content: string;
   createdAt: number;
   scopeId?: string;
+  // Provenance for trust-aware extraction gating (M3)
+  provenanceActorRole?: 'guardian' | 'non-guardian' | 'unverified_channel';
 }
 
 export interface IndexMessageResult {

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -36,6 +36,10 @@ export function indexMessageNow(
 ): IndexMessageResult {
   if (!config.enabled) return { indexedSegments: 0, enqueuedJobs: 0 };
 
+  // Provenance-based trust gating: only guardian and legacy (undefined) actors
+  // are trusted for extraction and conflict resolution.
+  const isTrustedActor = input.provenanceActorRole === 'guardian' || input.provenanceActorRole === undefined;
+
   const text = extractTextFromStoredMessageContent(input.content);
   if (text.length === 0) {
     enqueueMemoryJob('build_conversation_summary', { conversationId: input.conversationId });
@@ -98,10 +102,10 @@ export function indexMessageNow(
       }
     }
 
-    if (shouldExtract) {
+    if (shouldExtract && isTrustedActor) {
       enqueueMemoryJob('extract_items', { messageId: input.messageId, scopeId: input.scopeId ?? 'default' }, Date.now(), tx);
     }
-    if (shouldResolveConflicts) {
+    if (shouldResolveConflicts && isTrustedActor) {
       enqueueResolvePendingConflictsForMessageJob(input.messageId, input.scopeId ?? 'default', tx);
     }
     enqueueMemoryJob('build_conversation_summary', { conversationId: input.conversationId }, Date.now(), tx);
@@ -111,10 +115,15 @@ export function indexMessageNow(
     log.debug(`Skipped ${skippedEmbedJobs}/${segments.length} embed_segment jobs (content unchanged)`);
   }
 
+  if (!isTrustedActor && (shouldExtract || shouldResolveConflicts)) {
+    log.info(`Skipping extraction/conflict jobs for untrusted actor (role=${input.provenanceActorRole})`);
+  }
+
   bumpMemoryVersion();
   enqueueSummaryRollupJobsIfDue();
 
-  const enqueuedJobs = (segments.length - skippedEmbedJobs) + (shouldExtract ? 2 : 1) + (shouldResolveConflicts ? 1 : 0);
+  const extractionGated = !isTrustedActor;
+  const enqueuedJobs = (segments.length - skippedEmbedJobs) + (shouldExtract && !extractionGated ? 2 : 1) + (shouldResolveConflicts && !extractionGated ? 1 : 0);
   return {
     indexedSegments: segments.length,
     enqueuedJobs,

--- a/assistant/src/memory/job-handlers/backfill.ts
+++ b/assistant/src/memory/job-handlers/backfill.ts
@@ -7,7 +7,7 @@ import {
   resetMessageCursorCheckpoint,
   writeMessageCursorCheckpoint,
 } from '../checkpoints.js';
-import { getConversationMemoryScopeId } from '../conversation-store.js';
+import { getConversationMemoryScopeId, messageMetadataSchema } from '../conversation-store.js';
 import { indexMessageNow } from '../indexer.js';
 import {
   enqueueBackfillEntityRelationsJob,
@@ -22,6 +22,23 @@ const BACKFILL_CHECKPOINT_KEY = 'memory:backfill:last_created_at';
 const BACKFILL_CHECKPOINT_ID_KEY = 'memory:backfill:last_message_id';
 const RELATION_BACKFILL_CHECKPOINT_KEY = 'memory:relation_backfill:last_created_at';
 const RELATION_BACKFILL_CHECKPOINT_ID_KEY = 'memory:relation_backfill:last_message_id';
+
+type ProvenanceActorRole = 'guardian' | 'non-guardian' | 'unverified_channel';
+
+function parseProvenanceActorRole(rawMetadata: string | null): ProvenanceActorRole | undefined {
+  if (!rawMetadata) return undefined;
+  try {
+    const parsedJson: unknown = JSON.parse(rawMetadata);
+    const parsed = messageMetadataSchema.safeParse(parsedJson);
+    return parsed.success ? parsed.data.provenanceActorRole : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isTrustedActorRole(actorRole: ProvenanceActorRole | undefined): boolean {
+  return actorRole === 'guardian' || actorRole === undefined;
+}
 
 export function backfillJob(job: MemoryJob, config: AssistantConfig): void {
   const db = getDb();
@@ -50,6 +67,7 @@ export function backfillJob(job: MemoryJob, config: AssistantConfig): void {
         scopeId = getConversationMemoryScopeId(message.conversationId);
         scopeCache.set(message.conversationId, scopeId);
       }
+      const provenanceActorRole = parseProvenanceActorRole(message.metadata ?? null);
       indexMessageNow({
         messageId: message.id,
         conversationId: message.conversationId,
@@ -57,6 +75,7 @@ export function backfillJob(job: MemoryJob, config: AssistantConfig): void {
         content: message.content,
         createdAt: message.createdAt,
         scopeId,
+        provenanceActorRole,
       }, config.memory);
     }
     const lastMessage = batch[batch.length - 1];
@@ -108,7 +127,7 @@ export function backfillEntityRelationsJob(job: MemoryJob, config: AssistantConf
     : afterCursor;
 
   const batch = db
-    .select({ id: messages.id, role: messages.role, createdAt: messages.createdAt })
+    .select({ id: messages.id, role: messages.role, createdAt: messages.createdAt, metadata: messages.metadata })
     .from(messages)
     .where(conditions)
     .orderBy(asc(messages.createdAt), asc(messages.id))
@@ -116,8 +135,16 @@ export function backfillEntityRelationsJob(job: MemoryJob, config: AssistantConf
     .all();
   if (batch.length === 0) return;
 
+  let queuedExtractEntityJobs = 0;
+  let skippedUntrusted = 0;
   for (const message of batch) {
+    const provenanceActorRole = parseProvenanceActorRole(message.metadata ?? null);
+    if (!isTrustedActorRole(provenanceActorRole)) {
+      skippedUntrusted += 1;
+      continue;
+    }
     enqueueMemoryJob('extract_entities', { messageId: message.id });
+    queuedExtractEntityJobs += 1;
   }
 
   const lastMessage = batch[batch.length - 1];
@@ -131,7 +158,8 @@ export function backfillEntityRelationsJob(job: MemoryJob, config: AssistantConf
   }
 
   log.debug({
-    queuedExtractEntityJobs: batch.length,
+    queuedExtractEntityJobs,
+    skippedUntrusted,
     batchSize,
     lastCreatedAt: lastMessage.createdAt,
     lastMessageId: lastMessage.id,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -323,7 +323,7 @@ export async function handleSendMessage(
       mapping.conversationId,
       content ?? '',
       hasAttachments ? attachmentIds : undefined,
-      undefined,
+      { guardianContext: { actorRole: 'guardian', sourceChannel } },
       sourceChannel,
     );
     return Response.json({ accepted: true, messageId: result.messageId }, { status: 202 });

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -273,6 +273,9 @@ export async function handleSendMessage(
   if (deps.sendMessageDeps) {
     const smDeps = deps.sendMessageDeps;
     const session = await smDeps.getOrCreateSession(mapping.conversationId);
+    // HTTP API is a trusted local ingress (same as IPC) — set guardian context
+    // so that memory extraction is not silently disabled by unverified provenance.
+    session.setGuardianContext({ actorRole: 'guardian', sourceChannel: sourceChannel ?? 'http' });
     const onEvent = makeHubPublisher(smDeps, mapping.conversationId, session);
 
     const attachments = hasAttachments


### PR DESCRIPTION
## Summary
Fix guardian escalation and memory contamination bugs with a channel-agnostic trust model. This prevents duplicate escalation while waiting for guardian input, prevents fabricated guardian approval, ensures non-guardian requests cannot poison long-term memory, and ensures untrusted actors do not receive internal memory-conflict disclosures — all consistently across every ingress channel.

## Changes
- **M1: Wait-State and Escalation Safety** — Guard `waiting_on_user` in call controller to prevent re-entrant turns, queue caller utterances during pending guardian answers, prevent duplicate escalation dispatch
- **M2: Provenance Plumbing** — Extend message metadata with provenance fields (actorRole, sourceChannel, etc.), propagate through all persistence paths, add `provenanceFromGuardianContext()` helper
- **M3: Trust-Aware Memory Write/Read Gating** — Gate extraction/conflict jobs by actor role in indexer, skip recall/profile/conflict for untrusted actors in session-memory, default IPC sessions to guardian
- **M4: Documentation** — Add provenance-aware memory pipeline section to ARCHITECTURE.md, add memory provenance invariant to AGENTS.md

## Milestone PRs (merged into feature branch)
- #8465: M1: Wait-State and Escalation Safety
- #8505: M2: Provenance Plumbing
- #8548: M3: Trust-Aware Memory Write/Read Gating
- #8562: M4: Cleanup, Backfill/Remediation, Docs

## Project issue
Closes #8459

## Test plan
- [ ] Verify duplicate escalation is prevented during `waiting_on_user` state
- [ ] Verify untrusted actor messages do not trigger `extract_items` jobs
- [ ] Verify desktop/IPC sessions retain memory extraction (guardian actor role)
- [ ] Verify untrusted actors get no recall/profile/conflict injection
- [ ] Verify legacy messages (no provenance) still work as trusted

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
