### PR TITLE
fix: remove incorrect eviction loop in Linear watcher state cache (#8492)

### DIFF
--- a/assistant/src/watcher/providers/linear.ts
+++ b/assistant/src/watcher/providers/linear.ts
@@ -439,23 +439,13 @@ export const linearProvider: WatcherProvider = {
       // credentialService so that multiple Linear watchers sharing the same credential
       // maintain independent baselines and cannot clobber each other's state.
       const stateCache = getStateCache(watcherKey);
-      const currentIssueIds = new Set<string>();
       for (const issue of assignedIssues) {
-        currentIssueIds.add(issue.id);
         const previousStateId = stateCache.get(issue.id);
         if (previousStateId !== undefined && previousStateId !== issue.state.id) {
           items.push(issueToStatusChangeItem(issue, previousStateId));
         }
         // Always update the map so the next poll has an accurate baseline.
         stateCache.set(issue.id, issue.state.id);
-      }
-
-      // Evict issues no longer returned by the assigned-issues query (unassigned,
-      // completed, archived) so the cache doesn't grow without bound.
-      for (const issueId of stateCache.keys()) {
-        if (!currentIssueIds.has(issueId)) {
-          stateCache.delete(issueId);
-        }
       }
 
       const newWatermark = new Date().toISOString();


### PR DESCRIPTION
Addresses review feedback from PR #8492 (prevent unbounded Set growth in Linear watcher).

Both Codex and Devin identified that the eviction loop incorrectly treated the result of fetchAssignedIssueUpdates (filtered by updatedAt >= watermark) as the full set of assigned issues. This caused legitimate status transitions to be silently missed whenever an issue had a quiet poll cycle.

Removes the eviction loop and the currentIssueIds Set. The cache growth is bounded by the number of issues ever assigned to the user (inherently finite), and watcher-level cleanup already handles eviction when watchers are removed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
