### PR TITLE
fix: skip non-existent deps in detectCycles to prevent false cycle reports (#8511)

### DIFF
--- a/assistant/src/swarm/graph-utils.ts
+++ b/assistant/src/swarm/graph-utils.ts
@@ -22,8 +22,10 @@ export function detectCycles(nodes: GraphNode[]): string[] | null {
 
   for (const node of nodes) {
     for (const dep of node.dependencies) {
-      adj.get(dep)?.push(node.id);
-      inDegree.set(node.id, (inDegree.get(node.id) ?? 0) + 1);
+      if (adj.has(dep)) {
+        adj.get(dep)!.push(node.id);
+        inDegree.set(node.id, (inDegree.get(node.id) ?? 0) + 1);
+      }
     }
   }
 


### PR DESCRIPTION
Addresses review feedback from PR #8511. The shared detectCycles function was incrementing in-degree for dependencies referencing non-existent node IDs, causing valid acyclic plans with dangling dependencies to be falsely reported as cycles. Now skips unknown deps so only real graph edges affect cycle detection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
