### PR TITLE
fix: address review feedback on swarm stack traces (#8496)

### DIFF
--- a/assistant/src/swarm/orchestrator.ts
+++ b/assistant/src/swarm/orchestrator.ts
@@ -173,10 +173,11 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
       })
       .filter((d): d is { taskId: string; summary: string } => d != null);
 
+    let result: SwarmTaskResult;
     try {
       const taskTimeoutMs = getTimeoutForRole(limits, task.role) * 1000;
 
-      let result = await runWorkerTask({
+      result = await runWorkerTask({
         task,
         upstreamContext: plan.objective,
         dependencyOutputs: depOutputs,
@@ -211,12 +212,10 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
       if (result.status === 'failed') {
         log.error({ taskId: task.id, error: result.summary, retries }, 'Swarm task execution failed');
       }
-
-      processResult(result);
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
       log.error({ taskId: task.id, error: error.message, stack: error.stack }, 'Swarm task execution failed unexpectedly');
-      processResult({
+      result = {
         taskId: task.id,
         status: 'failed',
         summary: `Unexpected error: ${error.message}`,
@@ -226,8 +225,10 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
         rawOutput: '',
         durationMs: 0,
         retryCount: 0,
-      });
+      };
     }
+
+    processResult(result);
   }
 
   while (ready.length > 0 || activeCount > 0) {


### PR DESCRIPTION
Addresses review feedback from PR #8496 (error stack trace capture in swarm orchestrator).

Moves processResult() outside the try-catch in runTask() so that observer callback errors (e.g. onStatus throwing) don't get caught and rewritten as synthetic failed results. Previously, a throwing onStatus callback could overwrite an already-completed task with a failed status, corrupting swarm execution stats and blocking downstream dependencies.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
