### PR TITLE
fix: address review feedback on swarm truncation warning (#8480)

### DIFF
--- a/assistant/src/swarm/plan-validator.ts
+++ b/assistant/src/swarm/plan-validator.ts
@@ -41,7 +41,7 @@ export function validateAndNormalizePlan(
 
   // --- Task count limit ---
   if (tasks.length > limits.maxTasks) {
-    issues.push(`Plan truncated from ${tasks.length} tasks to ${limits.maxTasks}`);
+    console.warn(`Plan truncated from ${tasks.length} tasks to ${limits.maxTasks}`);
     tasks = tasks.slice(0, limits.maxTasks);
   }
 


### PR DESCRIPTION
Addresses review feedback from PR #8480 (swarm plan task truncation warning).

Both Codex and Devin identified that pushing the truncation message into the `issues` array causes `validateAndNormalizePlan` to throw a `SwarmPlanValidationError` whenever tasks exceed `maxTasks`. This broke the intended truncation behavior — the caller in `router-planner.ts` catches validation errors and falls back to a single-task plan, so over-limit plans were silently discarded instead of being truncated and executed.

Fix: use `console.warn()` instead of `issues.push()` so the truncation is logged but the validated (truncated) plan is still returned successfully.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
