### PR TITLE
fix: restore collision-free scroll trigger in MessageListView (#8510)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -29,14 +29,13 @@ struct MessageListView: View {
     @State private var appearance = AvatarAppearanceManager.shared
 
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
-    /// Only inspects segment count and the last segment's length — O(1) instead of O(segments).
-    /// During streaming only the last segment grows; previous segments are immutable once a new
-    /// one starts after a tool call, so checking just the last segment captures all streaming deltas.
+    /// Uses total text length (monotonically increasing) so the trigger never produces the same
+    /// value when a new text segment starts after a tool call — unlike a hash of segment count +
+    /// last segment length, which can collide and miss scroll events.
     private var streamingScrollTrigger: Int {
         let last = messages.last(where: { if case .queued = $0.status { return false }; return true })
-        let segments = last?.textSegments ?? []
-        let lastSegmentLen = segments.last?.utf8.count ?? 0
-        return segments.count &* 31 &+ lastSegmentLen &+ (last?.toolCalls.count ?? 0) &+ (last?.inlineSurfaces.count ?? 0)
+        let textLen = last?.textSegments.reduce(0) { $0 + $1.utf8.count } ?? 0
+        return textLen + (last?.toolCalls.count ?? 0) + (last?.inlineSurfaces.count ?? 0)
     }
 
     private func shouldShowTimestamp(at index: Int, in list: [ChatMessage]) -> Bool {


### PR DESCRIPTION
Addresses review feedback from PR #8510 (cache streaming scroll trigger in ChatView).

Both Codex and Devin identified the same bug: the optimized hash formula `segments.count * 31 + lastSegmentLen` can produce collisions when a new text segment starts after a tool call, causing missed auto-scroll events. For example, if the previous segment was 32 bytes and the first delta of the new segment is 1 byte, both states produce the same trigger value.

Restores the original `reduce`-based total text length, which is monotonically increasing and collision-free by design. The performance cost is negligible since `utf8.count` is O(1) for contiguous Swift strings and segment counts are small.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
