### PR TITLE
fix: avoid duplicated prompt text in SMS approval messages (#8530)

### DIFF
--- a/gateway/src/http/routes/sms-deliver.ts
+++ b/gateway/src/http/routes/sms-deliver.ts
@@ -142,10 +142,10 @@ export function createSmsDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "text is required" }, { status: 400 });
     }
 
-    // When an approval payload is present with a plainTextFallback, append it
-    // to the SMS body so the recipient knows how to approve/reject via text.
+    // plainTextFallback already includes the full prompt text plus reply
+    // instructions, so use it as the entire SMS body to avoid duplication.
     const smsBody = approval?.plainTextFallback && typeof approval.plainTextFallback === "string"
-      ? `${effectiveText}\n\n${approval.plainTextFallback}`
+      ? approval.plainTextFallback
       : effectiveText;
 
     const from = resolveFromNumber(config, assistantId);


### PR DESCRIPTION
Addresses Codex review feedback from PR #8530. The plainTextFallback already includes the full prompt text plus reply instructions, so using it as the entire SMS body instead of appending it to effectiveText avoids sending duplicated content that wastes SMS segments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
