### PR TITLE
fix: address review feedback on skills tests (#8515)

### DIFF
--- a/assistant/src/__tests__/clawhub.test.ts
+++ b/assistant/src/__tests__/clawhub.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, test, spyOn } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { mock } from 'bun:test';
@@ -104,33 +104,70 @@ describe('clawhubInspect slug validation', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Integrity manifest edge cases (via filesystem)
+// Integrity manifest edge cases — mock Bun.spawn so install succeeds and
+// verifyAndRecordSkillHash actually runs.
 // ---------------------------------------------------------------------------
 
+/** Mock Bun.spawn to simulate a successful clawhub install (exit code 0). */
+function mockSuccessfulSpawn(): ReturnType<typeof spyOn> {
+  return spyOn(Bun, 'spawn').mockImplementation((() => {
+    const emptyStream = new ReadableStream({ start(c) { c.close(); } });
+    return {
+      stdout: emptyStream,
+      stderr: new ReadableStream({ start(c) { c.close(); } }),
+      exited: Promise.resolve(0),
+      kill: () => {},
+      pid: 0,
+    };
+  }) as Parameters<typeof Bun.spawn>[0] as never);
+}
+
 describe('integrity manifest', () => {
-  test('malformed integrity JSON is handled gracefully on next install', async () => {
-    // Write corrupted integrity manifest
+  test('malformed integrity JSON is replaced with fresh manifest on install', async () => {
     const integrityPath = join(TEST_DIR, 'skills', '.integrity.json');
     writeFileSync(integrityPath, '{not valid json!!!', 'utf-8');
 
-    // clawhubInstall will fail because npx clawhub is not available,
-    // but it should not crash on malformed manifest. The slug validation
-    // passes so it proceeds to runClawhub which will fail.
-    const result = await clawhubInstall('valid-slug');
-    // Should fail due to subprocess failure, not manifest parse error
-    expect(result.success).toBe(false);
-    // The error should be about the command failing, not JSON parsing
-    expect(result.error).toBeDefined();
-    expect(result.error).not.toContain('JSON');
+    // Create a skill directory so computeSkillHash produces a real hash
+    const skillDir = join(TEST_DIR, 'skills', 'valid-slug');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), '# Test Skill', 'utf-8');
+
+    const spy = mockSuccessfulSpawn();
+    try {
+      const result = await clawhubInstall('valid-slug');
+      expect(result.success).toBe(true);
+
+      // The malformed manifest should have been replaced with a valid one
+      const manifest = JSON.parse(readFileSync(integrityPath, 'utf-8'));
+      expect(manifest['valid-slug']).toBeDefined();
+      expect(manifest['valid-slug'].sha256).toMatch(/^v2:[0-9a-f]{64}$/);
+      expect(manifest['valid-slug'].installedAt).toBeDefined();
+    } finally {
+      spy.mockRestore();
+    }
   });
 
-  test('missing integrity manifest file does not block install', async () => {
+  test('missing integrity manifest is created on first install', async () => {
     const integrityPath = join(TEST_DIR, 'skills', '.integrity.json');
     expect(existsSync(integrityPath)).toBe(false);
 
-    // Will fail on subprocess, but should not fail on missing manifest
-    const result = await clawhubInstall('valid-slug');
-    expect(result.success).toBe(false);
-    expect(result.error).not.toContain('integrity');
+    // Create a skill directory so computeSkillHash produces a real hash
+    const skillDir = join(TEST_DIR, 'skills', 'new-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'index.js'), 'console.log("hi")', 'utf-8');
+
+    const spy = mockSuccessfulSpawn();
+    try {
+      const result = await clawhubInstall('new-skill');
+      expect(result.success).toBe(true);
+
+      // Manifest should now exist with the skill's hash
+      expect(existsSync(integrityPath)).toBe(true);
+      const manifest = JSON.parse(readFileSync(integrityPath, 'utf-8'));
+      expect(manifest['new-skill']).toBeDefined();
+      expect(manifest['new-skill'].sha256).toMatch(/^v2:[0-9a-f]{64}$/);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
Addresses review feedback from PR #8515 (tests for skills subsystem).

The Codex review pointed out that the integrity manifest tests never exercised the actual manifest parsing code path because clawhubInstall returned early on subprocess failure before reaching verifyAndRecordSkillHash. Fixed by mocking Bun.spawn to simulate a successful install, creating skill directories with files, and asserting that the manifest is correctly written/replaced.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
