### PR TITLE
fix: gate connection-error Retry button on having a resend payload (#8516)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -9,6 +9,7 @@ struct ChatErrorBanner: View {
     let isRetryableError: Bool
     let onRetryError: () -> Void
     let isConnectionError: Bool
+    var hasRetryPayload: Bool = true
     var connectionDiagnosticHint: String? = nil
     let onDismissError: () -> Void
 
@@ -44,7 +45,7 @@ struct ChatErrorBanner: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Send message anyway")
-            } else if isRetryableError || isConnectionError {
+            } else if isRetryableError || (isConnectionError && hasRetryPayload) {
                 Button(action: onRetryError) {
                     Text("Retry")
                         .font(VFont.captionMedium)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -21,6 +21,7 @@ struct ChatView: View {
     let isRetryableError: Bool
     let onRetryError: () -> Void
     let isConnectionError: Bool
+    var hasRetryPayload: Bool = true
     let isSecretBlockError: Bool
     let onSendAnyway: () -> Void
     let onAcceptSuggestion: () -> Void
@@ -192,6 +193,7 @@ struct ChatView: View {
                             isRetryableError: isRetryableError,
                             onRetryError: onRetryError,
                             isConnectionError: isConnectionError,
+                            hasRetryPayload: hasRetryPayload,
                             connectionDiagnosticHint: connectionDiagnosticHint,
                             onSend: onSend,
                             onStop: onStop,

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
@@ -16,6 +16,7 @@ struct ComposerSection: View {
     let isRetryableError: Bool
     let onRetryError: () -> Void
     let isConnectionError: Bool
+    var hasRetryPayload: Bool = true
     var connectionDiagnosticHint: String? = nil
     let onSend: () -> Void
     let onStop: () -> Void
@@ -50,6 +51,7 @@ struct ComposerSection: View {
                     isRetryableError: isRetryableError,
                     onRetryError: onRetryError,
                     isConnectionError: isConnectionError,
+                    hasRetryPayload: hasRetryPayload,
                     connectionDiagnosticHint: connectionDiagnosticHint,
                     onDismissError: onDismissError
                 )

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -590,6 +590,7 @@ struct ActiveChatViewWrapper: View {
             isRetryableError: viewModel.isRetryableError,
             onRetryError: { viewModel.retryLastMessage() },
             isConnectionError: viewModel.isConnectionError,
+            hasRetryPayload: viewModel.lastFailedMessageText != nil,
             isSecretBlockError: viewModel.isSecretBlockError,
             onSendAnyway: { viewModel.sendAnyway() },
             onAcceptSuggestion: viewModel.acceptSuggestion,


### PR DESCRIPTION
Addresses Codex review feedback from PR #8516. When a connection error occurs without a message to resend (e.g. during session bootstrapping), the Retry button was shown but was a silent no-op. Now the Retry button only appears for connection errors when lastFailedMessageText is non-nil, threaded through the view hierarchy as a hasRetryPayload boolean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
