### PR TITLE
M3: Add basic new-skill authoring sheet with daemon-generated drafts

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -16,6 +16,7 @@ struct AgentPanelContent: View {
     @State private var selectedSkillSlug: String?
     @State private var selectedInstalledSkillId: String?
     @State private var skillToDelete: SkillInfo?
+    @State private var showNewSkillSheet = false
 
     private enum SkillsTab {
         case installed, available
@@ -61,6 +62,18 @@ struct AgentPanelContent: View {
                     tabButton(installedTabTitle, tab: .installed)
                     tabButton(availableTabTitle, tab: .available)
                     Spacer()
+                    Button {
+                        showNewSkillSheet = true
+                    } label: {
+                        HStack(spacing: VSpacing.xs) {
+                            Image(systemName: "plus")
+                            Text("New Skill")
+                        }
+                        .font(VFont.body)
+                        .foregroundColor(VColor.accent)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("New Skill")
                 }
 
                 Divider().background(VColor.surfaceBorder)
@@ -112,6 +125,9 @@ struct AgentPanelContent: View {
                     skillToDelete = nil
                 }
             )
+        }
+        .sheet(isPresented: $showNewSkillSheet) {
+            NewSkillSheet(skillsManager: skillsManager)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/NewSkillSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/NewSkillSheet.swift
@@ -1,0 +1,221 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct NewSkillSheet: View {
+    @ObservedObject var skillsManager: SkillsManager
+    @Environment(\.dismiss) var dismiss
+
+    // Input state
+    @State private var sourceText = ""
+
+    // Editable draft fields (populated after draft generation)
+    @State private var skillId = ""
+    @State private var name = ""
+    @State private var description = ""
+    @State private var emoji = ""
+    @State private var bodyMarkdown = ""
+    @State private var hasDraft = false
+    @State private var warnings: [String] = []
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            Divider().background(VColor.surfaceBorder)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    if !hasDraft {
+                        inputSection
+                    } else {
+                        editSection
+                    }
+                }
+                .padding(VSpacing.xl)
+            }
+
+            Divider().background(VColor.surfaceBorder)
+
+            footer
+        }
+        .frame(width: 560, height: 520)
+        .background(VColor.background)
+        .onChange(of: skillsManager.draftResult?.skillId) {
+            if let result = skillsManager.draftResult {
+                skillId = result.skillId
+                name = result.name
+                description = result.description
+                emoji = result.emoji ?? ""
+                bodyMarkdown = result.bodyMarkdown
+                warnings = result.warnings
+                hasDraft = true
+            }
+        }
+        .onChange(of: skillsManager.isCreating) {
+            if !skillsManager.isCreating && skillsManager.createError == nil && hasDraft {
+                dismiss()
+            }
+        }
+        .onDisappear {
+            skillsManager.resetDraftState()
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            Text("New Skill")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textPrimary)
+            Spacer()
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .foregroundColor(VColor.textMuted)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close")
+        }
+        .padding(VSpacing.xl)
+    }
+
+    // MARK: - Input Section (paste text)
+
+    private var inputSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("Paste your skill text or SKILL.md content below:")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+
+            TextEditor(text: $sourceText)
+                .font(VFont.mono)
+                .foregroundColor(VColor.textPrimary)
+                .scrollContentBackground(.hidden)
+                .background(VColor.surfaceSubtle)
+                .cornerRadius(VRadius.md)
+                .frame(minHeight: 240)
+
+            if let error = skillsManager.draftError {
+                Text(error)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
+            }
+        }
+    }
+
+    // MARK: - Edit Section (after draft)
+
+    private var editSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            if !warnings.isEmpty {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    ForEach(warnings, id: \.self) { warning in
+                        HStack(spacing: VSpacing.xs) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundColor(VColor.warning)
+                                .font(.caption)
+                            Text(warning)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textSecondary)
+                        }
+                    }
+                }
+            }
+
+            formField(label: "Skill ID", text: $skillId, placeholder: "my-skill-id")
+            formField(label: "Name", text: $name, placeholder: "My Skill")
+            formField(label: "Description", text: $description, placeholder: "A short description")
+            formField(label: "Emoji", text: $emoji, placeholder: "")
+
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Body")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                TextEditor(text: $bodyMarkdown)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.textPrimary)
+                    .scrollContentBackground(.hidden)
+                    .background(VColor.surfaceSubtle)
+                    .cornerRadius(VRadius.md)
+                    .frame(minHeight: 200)
+            }
+
+            if let error = skillsManager.createError {
+                Text(error)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
+            }
+        }
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        HStack {
+            if hasDraft {
+                Button {
+                    hasDraft = false
+                    skillsManager.resetDraftState()
+                } label: {
+                    Text("Back")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                }
+                .buttonStyle(.plain)
+            }
+
+            Spacer()
+
+            if !hasDraft {
+                VButton(
+                    label: skillsManager.isDrafting ? "Generating..." : "Generate Draft",
+                    style: .primary,
+                    isDisabled: sourceText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || skillsManager.isDrafting
+                ) {
+                    skillsManager.draftSkill(sourceText: sourceText)
+                }
+            } else {
+                VButton(
+                    label: skillsManager.isCreating ? "Creating..." : "Create Skill",
+                    style: .primary,
+                    isDisabled: !isFormValid || skillsManager.isCreating
+                ) {
+                    skillsManager.createSkillFromDraft(
+                        skillId: skillId.trimmingCharacters(in: .whitespacesAndNewlines),
+                        name: name.trimmingCharacters(in: .whitespacesAndNewlines),
+                        description: description.trimmingCharacters(in: .whitespacesAndNewlines),
+                        emoji: emoji.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : emoji.trimmingCharacters(in: .whitespacesAndNewlines),
+                        bodyMarkdown: bodyMarkdown
+                    )
+                }
+            }
+        }
+        .padding(VSpacing.xl)
+    }
+
+    // MARK: - Helpers
+
+    private var isFormValid: Bool {
+        !skillId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !bodyMarkdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func formField(label: String, text: Binding<String>, placeholder: String) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text(label)
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+            TextField(placeholder, text: text)
+                .textFieldStyle(.plain)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .padding(VSpacing.sm)
+                .background(VColor.surfaceSubtle)
+                .cornerRadius(VRadius.sm)
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -45,6 +45,8 @@ final class SkillsManager: ObservableObject {
     private let daemonClient: DaemonClient
     private var currentInspectSlug: String?
     private var lastSearchQuery: String?
+    private var draftTask: Task<Void, Never>?
+    private var createTask: Task<Void, Never>?
 
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
@@ -275,7 +277,7 @@ final class SkillsManager: ObservableObject {
         draftError = nil
         draftResult = nil
 
-        Task {
+        draftTask = Task {
             let stream = daemonClient.subscribe()
 
             do {
@@ -287,6 +289,7 @@ final class SkillsManager: ObservableObject {
             }
 
             for await message in stream {
+                guard !Task.isCancelled else { break }
                 if case .skillsDraftResponse(let response) = message {
                     if response.success, let draft = response.draft {
                         draftResult = SkillDraftResult(
@@ -313,7 +316,7 @@ final class SkillsManager: ObservableObject {
         isCreating = true
         createError = nil
 
-        Task {
+        createTask = Task {
             let stream = daemonClient.subscribe()
 
             do {
@@ -331,6 +334,7 @@ final class SkillsManager: ObservableObject {
             }
 
             for await message in stream {
+                guard !Task.isCancelled else { break }
                 if case .skillsOperationResponse(let response) = message,
                    response.operation == "create" {
                     if !response.success {
@@ -347,6 +351,10 @@ final class SkillsManager: ObservableObject {
     }
 
     func resetDraftState() {
+        draftTask?.cancel()
+        createTask?.cancel()
+        draftTask = nil
+        createTask = nil
         draftResult = nil
         isDrafting = false
         draftError = nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -15,6 +15,11 @@ final class SkillsManager: ObservableObject {
     @Published var installResult: InstallResult?
     @Published var uninstallResult: UninstallResult?
     @Published var isUninstalling = false
+    @Published var draftResult: SkillDraftResult?
+    @Published var isDrafting = false
+    @Published var draftError: String?
+    @Published var isCreating = false
+    @Published var createError: String?
 
     struct InstallResult {
         let slug: String
@@ -26,6 +31,15 @@ final class SkillsManager: ObservableObject {
         let id: String
         let success: Bool
         let error: String?
+    }
+
+    struct SkillDraftResult {
+        let skillId: String
+        let name: String
+        let description: String
+        let emoji: String?
+        let bodyMarkdown: String
+        let warnings: [String]
     }
 
     private let daemonClient: DaemonClient
@@ -251,5 +265,92 @@ final class SkillsManager: ObservableObject {
         inspectedSkill = nil
         isInspecting = false
         inspectError = nil
+    }
+
+    // MARK: - Skill Drafting & Creation
+
+    func draftSkill(sourceText: String) {
+        guard !isDrafting else { return }
+        isDrafting = true
+        draftError = nil
+        draftResult = nil
+
+        Task {
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.draftSkill(sourceText: sourceText)
+            } catch {
+                isDrafting = false
+                draftError = "Failed to send draft request"
+                return
+            }
+
+            for await message in stream {
+                if case .skillsDraftResponse(let response) = message {
+                    if response.success, let draft = response.draft {
+                        draftResult = SkillDraftResult(
+                            skillId: draft.skillId,
+                            name: draft.name,
+                            description: draft.description,
+                            emoji: draft.emoji,
+                            bodyMarkdown: draft.bodyMarkdown,
+                            warnings: response.warnings ?? []
+                        )
+                    } else {
+                        draftError = response.error ?? "Draft generation failed"
+                    }
+                    isDrafting = false
+                    return
+                }
+            }
+            isDrafting = false
+        }
+    }
+
+    func createSkillFromDraft(skillId: String, name: String, description: String, emoji: String?, bodyMarkdown: String) {
+        guard !isCreating else { return }
+        isCreating = true
+        createError = nil
+
+        Task {
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.createSkill(
+                    skillId: skillId,
+                    name: name,
+                    description: description,
+                    emoji: emoji,
+                    bodyMarkdown: bodyMarkdown
+                )
+            } catch {
+                isCreating = false
+                createError = "Failed to send create request"
+                return
+            }
+
+            for await message in stream {
+                if case .skillsOperationResponse(let response) = message,
+                   response.operation == "create" {
+                    if !response.success {
+                        createError = response.error ?? "Failed to create skill"
+                    } else {
+                        fetchSkills(force: true)
+                    }
+                    isCreating = false
+                    return
+                }
+            }
+            isCreating = false
+        }
+    }
+
+    func resetDraftState() {
+        draftResult = nil
+        isDrafting = false
+        draftError = nil
+        isCreating = false
+        createError = nil
     }
 }


### PR DESCRIPTION
Add New Skill button to Skills page and authoring sheet with paste/draft/edit/create flow. Draft generation routes through daemon IPC. User can edit all fields before creating. Part of #8549.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
