### PR TITLE
Rename 'macos'/'ios' channel to 'vellum'

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -37,7 +37,7 @@ exports[`IPC message snapshots ClientMessage types session_create serializes to 
   "threadType": "standard",
   "title": "New session",
   "transport": {
-    "channelId": "macos",
+    "channelId": "vellum",
     "hints": [
       "dashboard-capable",
     ],

--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -635,7 +635,7 @@ describe('standalone approval endpoints — HTTP layer', () => {
       const res = await fetch(url('messages'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-        body: JSON.stringify({ conversationKey: 'conv-auto', content: 'Run ls', sourceChannel: 'macos' }),
+        body: JSON.stringify({ conversationKey: 'conv-auto', content: 'Run ls', sourceChannel: 'vellum' }),
       });
       expect(res.status).toBe(202);
 

--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -541,8 +541,8 @@ describe('channelSupportsRichApprovalUI', () => {
     expect(channelSupportsRichApprovalUI('telegram')).toBe(true);
   });
 
-  test('returns false for macos', () => {
-    expect(channelSupportsRichApprovalUI('macos')).toBe(false);
+  test('returns false for vellum', () => {
+    expect(channelSupportsRichApprovalUI('vellum')).toBe(false);
   });
 
   test('returns false for sms', () => {

--- a/assistant/src/__tests__/guardian-action-store.test.ts
+++ b/assistant/src/__tests__/guardian-action-store.test.ts
@@ -97,7 +97,7 @@ describe('guardian-action-store', () => {
 
     const pendingDelivery = createGuardianActionDelivery({
       requestId: request.id,
-      destinationChannel: 'macos',
+      destinationChannel: 'vellum',
       destinationConversationId: 'conv-mac-guardian',
     });
     const sentDelivery = createGuardianActionDelivery({

--- a/assistant/src/__tests__/guardian-action-sweep.test.ts
+++ b/assistant/src/__tests__/guardian-action-sweep.test.ts
@@ -110,11 +110,11 @@ describe('guardian-action-sweep', () => {
     ensureConversation('conv-mac-1');
     createGuardianActionDelivery({
       requestId: request.id,
-      destinationChannel: 'macos',
+      destinationChannel: 'vellum',
       destinationConversationId: 'conv-mac-1',
     });
     updateDeliveryStatus(
-      getDeliveriesByRequestId(request.id).find(d => d.destinationChannel === 'macos')!.id,
+      getDeliveriesByRequestId(request.id).find(d => d.destinationChannel === 'vellum')!.id,
       'sent',
     );
 

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -160,7 +160,7 @@ describe('guardian-dispatch', () => {
 
     // Should have at least a mac delivery
     const deliveries = raw.query('SELECT * FROM guardian_action_deliveries WHERE request_id = ?').all(requests[0].id) as Array<{ destination_channel: string; status: string }>;
-    const macDelivery = deliveries.find(d => d.destination_channel === 'macos');
+    const macDelivery = deliveries.find(d => d.destination_channel === 'vellum');
     expect(macDelivery).toBeDefined();
     expect(macDelivery!.status).toBe('sent');
   });

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -41,7 +41,7 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     title: 'New session',
     correlationId: 'corr-001',
     transport: {
-      channelId: 'macos',
+      channelId: 'vellum',
       hints: ['dashboard-capable'],
       uxBrief: 'Prefer dashboard-first onboarding.',
     },

--- a/assistant/src/__tests__/run-orchestrator.test.ts
+++ b/assistant/src/__tests__/run-orchestrator.test.ts
@@ -305,10 +305,10 @@ describe('startRun channel capability resolution', () => {
     await new Promise((r) => setTimeout(r, 50));
 
     expect(capturedCapabilities).not.toBeNull();
-    expect(capturedCapabilities!.channel).toBe('macos');
+    expect(capturedCapabilities!.channel).toBe('vellum');
   });
 
-  test('defaults to macos (from http-api fallback) when options are provided without sourceChannel', async () => {
+  test('defaults to vellum when options are provided without sourceChannel', async () => {
     const conversation = createConversation('options no channel test');
     let capturedCapabilities: ChannelCapabilities | null = null;
 
@@ -342,7 +342,7 @@ describe('startRun channel capability resolution', () => {
     await new Promise((r) => setTimeout(r, 50));
 
     expect(capturedCapabilities).not.toBeNull();
-    expect(capturedCapabilities!.channel).toBe('macos');
+    expect(capturedCapabilities!.channel).toBe('vellum');
   });
 });
 

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -167,7 +167,7 @@ describe('POST /v1/messages — queue-if-busy and hub publishing', () => {
     const res = await fetch(messagesUrl(), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-      body: JSON.stringify({ conversationKey: 'conv-idle', content: 'Hello', sourceChannel: 'macos' }),
+      body: JSON.stringify({ conversationKey: 'conv-idle', content: 'Hello', sourceChannel: 'vellum' }),
     });
     const body = await res.json() as { accepted: boolean; messageId: string };
 
@@ -191,7 +191,7 @@ describe('POST /v1/messages — queue-if-busy and hub publishing', () => {
     const res = await fetch(messagesUrl(), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-      body: JSON.stringify({ conversationKey: 'conv-hub', content: 'Hello hub', sourceChannel: 'macos' }),
+      body: JSON.stringify({ conversationKey: 'conv-hub', content: 'Hello hub', sourceChannel: 'vellum' }),
     });
     expect(res.status).toBe(202);
 
@@ -216,7 +216,7 @@ describe('POST /v1/messages — queue-if-busy and hub publishing', () => {
     const res1 = await fetch(messagesUrl(), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-      body: JSON.stringify({ conversationKey: 'conv-busy', content: 'First', sourceChannel: 'macos' }),
+      body: JSON.stringify({ conversationKey: 'conv-busy', content: 'First', sourceChannel: 'vellum' }),
     });
     expect(res1.status).toBe(202);
     const body1 = await res1.json() as { accepted: boolean; messageId: string };
@@ -230,7 +230,7 @@ describe('POST /v1/messages — queue-if-busy and hub publishing', () => {
     const res2 = await fetch(messagesUrl(), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-      body: JSON.stringify({ conversationKey: 'conv-busy', content: 'Second', sourceChannel: 'macos' }),
+      body: JSON.stringify({ conversationKey: 'conv-busy', content: 'Second', sourceChannel: 'vellum' }),
     });
     const body2 = await res2.json() as { accepted: boolean; queued: boolean };
 
@@ -262,7 +262,7 @@ describe('POST /v1/messages — queue-if-busy and hub publishing', () => {
     const res = await fetch(messagesUrl(), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-      body: JSON.stringify({ conversationKey: 'conv-empty', content: '', sourceChannel: 'macos' }),
+      body: JSON.stringify({ conversationKey: 'conv-empty', content: '', sourceChannel: 'vellum' }),
     });
     expect(res.status).toBe(400);
 
@@ -275,7 +275,7 @@ describe('POST /v1/messages — queue-if-busy and hub publishing', () => {
     const res = await fetch(messagesUrl(), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
-      body: JSON.stringify({ content: 'Hello', sourceChannel: 'macos' }),
+      body: JSON.stringify({ content: 'Hello', sourceChannel: 'vellum' }),
     });
     expect(res.status).toBe(400);
 

--- a/assistant/src/__tests__/session-agent-loop.test.ts
+++ b/assistant/src/__tests__/session-agent-loop.test.ts
@@ -299,8 +299,8 @@ function makeCtx(overrides?: Partial<AgentLoopSessionContext> & { agentLoopRun?:
     canHandoffAtCheckpoint: () => false,
     drainQueue: () => {},
     getTurnChannelContext: () => ({
-      userMessageChannel: 'macos' as const,
-      assistantMessageChannel: 'macos' as const,
+      userMessageChannel: 'vellum' as const,
+      assistantMessageChannel: 'vellum' as const,
     }),
 
     ...overrides,

--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -21,39 +21,51 @@ import { buildChannelAwarenessSection } from '../config/system-prompt.js';
 // ---------------------------------------------------------------------------
 
 describe('resolveChannelCapabilities', () => {
-  test('defaults to macos when no source channel is provided', () => {
+  test('defaults to vellum when no source channel is provided', () => {
     const caps = resolveChannelCapabilities();
-    expect(caps.channel).toBe('macos');
+    expect(caps.channel).toBe('vellum');
     expect(caps.dashboardCapable).toBe(true);
     expect(caps.supportsDynamicUi).toBe(true);
     expect(caps.supportsVoiceInput).toBe(true);
   });
 
-  test('defaults to macos for null source channel', () => {
+  test('defaults to vellum for null source channel', () => {
     const caps = resolveChannelCapabilities(null);
-    expect(caps.channel).toBe('macos');
+    expect(caps.channel).toBe('vellum');
     expect(caps.dashboardCapable).toBe(true);
   });
 
-  test('normalises "dashboard" to "macos"', () => {
+  test('normalises "dashboard" to "vellum"', () => {
     const caps = resolveChannelCapabilities('dashboard');
-    expect(caps.channel).toBe('macos');
+    expect(caps.channel).toBe('vellum');
     expect(caps.dashboardCapable).toBe(true);
     expect(caps.supportsDynamicUi).toBe(true);
     expect(caps.supportsVoiceInput).toBe(true);
   });
 
-  test('normalises "http-api" to "macos"', () => {
+  test('normalises "http-api" to "vellum"', () => {
     const caps = resolveChannelCapabilities('http-api');
-    expect(caps.channel).toBe('macos');
+    expect(caps.channel).toBe('vellum');
     expect(caps.dashboardCapable).toBe(true);
     expect(caps.supportsDynamicUi).toBe(true);
     expect(caps.supportsVoiceInput).toBe(true);
   });
 
-  test('normalises "mac" to "macos"', () => {
+  test('normalises "mac" to "vellum"', () => {
     const caps = resolveChannelCapabilities('mac');
-    expect(caps.channel).toBe('macos');
+    expect(caps.channel).toBe('vellum');
+    expect(caps.dashboardCapable).toBe(true);
+  });
+
+  test('normalises "macos" to "vellum"', () => {
+    const caps = resolveChannelCapabilities('macos');
+    expect(caps.channel).toBe('vellum');
+    expect(caps.dashboardCapable).toBe(true);
+  });
+
+  test('normalises "ios" to "vellum"', () => {
+    const caps = resolveChannelCapabilities('ios');
+    expect(caps.channel).toBe('vellum');
     expect(caps.dashboardCapable).toBe(true);
   });
 
@@ -63,14 +75,6 @@ describe('resolveChannelCapabilities', () => {
     expect(caps.dashboardCapable).toBe(false);
     expect(caps.supportsDynamicUi).toBe(false);
     expect(caps.supportsVoiceInput).toBe(false);
-  });
-
-  test('resolves "ios" with voice but no dashboard/dynamic-ui', () => {
-    const caps = resolveChannelCapabilities('ios');
-    expect(caps.channel).toBe('ios');
-    expect(caps.dashboardCapable).toBe(false);
-    expect(caps.supportsDynamicUi).toBe(false);
-    expect(caps.supportsVoiceInput).toBe(true);
   });
 
   test('resolves "whatsapp" as all-capabilities-false', () => {
@@ -118,7 +122,7 @@ describe('injectChannelCapabilityContext', () => {
 
   test('injects channel capabilities block for dashboard channel', () => {
     const caps: ChannelCapabilities = {
-      channel: 'macos',
+      channel: 'vellum',
       dashboardCapable: true,
       supportsDynamicUi: true,
       supportsVoiceInput: true,
@@ -341,8 +345,8 @@ describe('buildChannelAwarenessSection', () => {
 // ---------------------------------------------------------------------------
 
 describe('trust-gating via channel capabilities', () => {
-  test('macos channel does not add constraint rules', () => {
-    const caps = resolveChannelCapabilities('macos');
+  test('vellum channel does not add constraint rules', () => {
+    const caps = resolveChannelCapabilities('vellum');
     const message: Message = {
       role: 'user',
       content: [{ type: 'text', text: 'Enable my microphone' }],
@@ -629,7 +633,7 @@ describe('buildChannelTurnContextBlock', () => {
 
   test('uses "unknown" when conversationOriginChannel is null', () => {
     const block = buildChannelTurnContextBlock({
-      turnContext: { userMessageChannel: 'macos', assistantMessageChannel: 'macos' },
+      turnContext: { userMessageChannel: 'vellum', assistantMessageChannel: 'vellum' },
       conversationOriginChannel: null,
     });
     expect(block).toContain('conversation_origin_channel: unknown');
@@ -637,12 +641,12 @@ describe('buildChannelTurnContextBlock', () => {
 
   test('handles mixed channels', () => {
     const block = buildChannelTurnContextBlock({
-      turnContext: { userMessageChannel: 'telegram', assistantMessageChannel: 'macos' },
-      conversationOriginChannel: 'ios',
+      turnContext: { userMessageChannel: 'telegram', assistantMessageChannel: 'vellum' },
+      conversationOriginChannel: 'vellum',
     });
     expect(block).toContain('user_message_channel: telegram');
-    expect(block).toContain('assistant_message_channel: macos');
-    expect(block).toContain('conversation_origin_channel: ios');
+    expect(block).toContain('assistant_message_channel: vellum');
+    expect(block).toContain('conversation_origin_channel: vellum');
   });
 });
 
@@ -673,8 +677,8 @@ describe('injectChannelTurnContext', () => {
 
   test('preserves original message content', () => {
     const params: ChannelTurnContextParams = {
-      turnContext: { userMessageChannel: 'macos', assistantMessageChannel: 'macos' },
-      conversationOriginChannel: 'macos',
+      turnContext: { userMessageChannel: 'vellum', assistantMessageChannel: 'vellum' },
+      conversationOriginChannel: 'vellum',
     };
     const result = injectChannelTurnContext(baseUserMessage, params);
     const lastBlock = result.content[result.content.length - 1];

--- a/assistant/src/calls/guardian-action-sweep.ts
+++ b/assistant/src/calls/guardian-action-sweep.ts
@@ -53,13 +53,13 @@ export function sweepExpiredGuardianActions(
     for (const delivery of deliveries) {
       if (delivery.status !== 'sent' && delivery.status !== 'pending') continue;
 
-      if ((delivery.destinationChannel === 'macos' || delivery.destinationChannel === 'mac') && delivery.destinationConversationId) {
-        // Add expiry message to mac guardian thread
+      if ((delivery.destinationChannel === 'vellum' || delivery.destinationChannel === 'macos' || delivery.destinationChannel === 'mac') && delivery.destinationConversationId) {
+        // Add expiry message to vellum guardian thread
         addMessage(
           delivery.destinationConversationId,
           'assistant',
           JSON.stringify([{ type: 'text', text: 'This guardian question has expired without a response.' }]),
-          { userMessageChannel: 'voice', assistantMessageChannel: 'macos' },
+          { userMessageChannel: 'voice', assistantMessageChannel: 'vellum' },
         );
       } else if (delivery.destinationChatId) {
         // External channel — send expiry notice

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -79,7 +79,7 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
 
     // Emit notification signal through the unified pipeline (fire-and-forget).
     // The existing guardian dispatch logic below handles the actual delivery
-    // to specific channels (telegram, sms, macos), so this signal is
+    // to specific channels (telegram, sms, vellum), so this signal is
     // supplementary — it lets the decision engine log and potentially route
     // to additional channels in the future.
     void emitNotificationSignal({
@@ -137,10 +137,10 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
       });
     }
 
-    // Mac (internal) delivery — always created
-    destinations.push({ channel: 'macos' });
+    // Vellum (internal) delivery — always created
+    destinations.push({ channel: 'vellum' });
 
-    // Start LLM copy generation concurrently — only awaited in the macOS branch
+    // Start LLM copy generation concurrently — only awaited in the vellum branch
     // so external channels (Telegram, SMS) dispatch without LLM latency.
     const guardianCopyPromise = generateGuardianCopy(
       pendingQuestion.questionText,
@@ -149,16 +149,16 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
 
     // Create delivery rows and dispatch
     for (const dest of destinations) {
-      if (dest.channel === 'macos') {
+      if (dest.channel === 'vellum') {
         // Create conversation and delivery row synchronously so they exist
         // before awaiting LLM copy — prevents a race where an external channel
-        // reply resolves the request before the macOS delivery is created.
+        // reply resolves the request before the vellum delivery is created.
         const macConvKey = `asst:${assistantId}:guardian:request:${request.id}`;
         const { conversationId: macConversationId } = getOrCreateConversation(macConvKey);
 
         const delivery = createGuardianActionDelivery({
           requestId: request.id,
-          destinationChannel: 'macos',
+          destinationChannel: 'vellum',
           destinationConversationId: macConversationId,
         });
 
@@ -174,10 +174,10 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
           macConversationId,
           'assistant',
           JSON.stringify([{ type: 'text', text: guardianCopy.initialMessage }]),
-          { userMessageChannel: 'voice', assistantMessageChannel: 'macos' },
+          { userMessageChannel: 'voice', assistantMessageChannel: 'vellum' },
         );
 
-        // Emit IPC event for the mac client with the server-created conversation
+        // Emit IPC event for the vellum client with the server-created conversation
         if (broadcast) {
           broadcast({
             type: 'guardian_request_thread_created',
@@ -189,7 +189,7 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
           } as ServerMessage);
         }
         updateDeliveryStatus(delivery.id, 'sent');
-        log.info({ deliveryId: delivery.id, channel: 'macos', macConversationId }, 'Mac guardian delivery emitted');
+        log.info({ deliveryId: delivery.id, channel: 'vellum', macConversationId }, 'Vellum guardian delivery emitted');
       } else {
         const delivery = createGuardianActionDelivery({
           requestId: request.id,

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -1,5 +1,5 @@
 export const CHANNEL_IDS = [
-  'telegram', 'sms', 'voice', 'macos', 'ios', 'whatsapp', 'slack', 'email',
+  'telegram', 'sms', 'voice', 'vellum', 'whatsapp', 'slack', 'email',
 ] as const;
 
 export type ChannelId = (typeof CHANNEL_IDS)[number];

--- a/assistant/src/config/vellum-skills/chatgpt-import/tools/chatgpt-import.ts
+++ b/assistant/src/config/vellum-skills/chatgpt-import/tools/chatgpt-import.ts
@@ -101,8 +101,8 @@ export async function run(
 
     const conversation = createConversation(conv.title);
     const importChannelMetadata = {
-      userMessageChannel: 'macos',
-      assistantMessageChannel: 'macos',
+      userMessageChannel: 'vellum',
+      assistantMessageChannel: 'vellum',
     } as const;
 
     for (const msg of conv.messages) {

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -85,7 +85,7 @@ export async function handleUserMessage(
       attributes: { source: 'user_message' },
     });
 
-    const ipcChannel = parseChannelId(msg.channel) ?? 'macos';
+    const ipcChannel = parseChannelId(msg.channel) ?? 'vellum';
     const queuedChannelMetadata = {
       userMessageChannel: ipcChannel,
       assistantMessageChannel: ipcChannel,
@@ -303,7 +303,7 @@ export async function handleSessionCreate(
     ctx.socketToSession.set(socket, conversation.id);
     const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
     const requestId = uuid();
-    const transportChannel = parseChannelId(msg.transport?.channelId) ?? 'macos';
+    const transportChannel = parseChannelId(msg.transport?.channelId) ?? 'vellum';
     session.setTurnChannelContext({
       userMessageChannel: transportChannel,
       assistantMessageChannel: transportChannel,

--- a/assistant/src/daemon/ipc-contract/messages.ts
+++ b/assistant/src/daemon/ipc-contract/messages.ts
@@ -15,7 +15,7 @@ export interface UserMessage {
   currentPage?: string;
   /** When true, skip the secret-ingress check. Set by the client when the user clicks "Send Anyway". */
   bypassSecretCheck?: boolean;
-  /** Originating channel identifier (e.g. 'macos', 'ios'). Defaults to 'macos' when absent. */
+  /** Originating channel identifier (e.g. 'vellum'). Defaults to 'vellum' when absent. */
   channel?: ChannelId;
 }
 

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -68,7 +68,7 @@ function resolveTurnChannel(sourceChannel?: string, transportChannelId?: string)
     }
     return parsed;
   }
-  return 'macos';
+  return 'vellum';
 }
 
 export class DaemonServer {

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -160,7 +160,7 @@ export async function runAgentLoopImpl(
     if (live) return live;
     const origin = getConversationOriginChannel(ctx.conversationId);
     if (origin) return { userMessageChannel: origin, assistantMessageChannel: origin };
-    return { userMessageChannel: 'macos' as ChannelId, assistantMessageChannel: 'macos' as ChannelId };
+    return { userMessageChannel: 'vellum' as ChannelId, assistantMessageChannel: 'vellum' as ChannelId };
   })();
 
   ctx.lastAssistantAttachments = [];

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -293,7 +293,7 @@ export async function processMessage(
   if (guardianDelivery) {
     const guardianRequest = getGuardianActionRequest(guardianDelivery.requestId);
     if (guardianRequest && guardianRequest.status === 'pending') {
-      const guardianChannelMeta = { userMessageChannel: 'macos' as const, assistantMessageChannel: 'macos' as const };
+      const guardianChannelMeta = { userMessageChannel: 'vellum' as const, assistantMessageChannel: 'vellum' as const };
       const userMsg = createUserMessage(content, attachments);
       const persisted = conversationStore.addMessage(
         session.conversationId,
@@ -310,7 +310,7 @@ export async function processMessage(
       const answerResult = await answerCall({ callSessionId: guardianRequest.callSessionId, answer: content });
 
       if ('ok' in answerResult && answerResult.ok) {
-        const resolved = resolveGuardianActionRequest(guardianRequest.id, content, 'macos');
+        const resolved = resolveGuardianActionRequest(guardianRequest.id, content, 'vellum');
         const replyText = resolved
           ? 'Your answer has been relayed to the call.'
           : 'This question has already been answered from another channel.';

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -16,7 +16,7 @@ import { join } from 'node:path';
  * interacting.  Used to gate UI-specific references and permission asks.
  */
 export interface ChannelCapabilities {
-  /** The raw channel identifier (e.g. "macos", "telegram", "sms"). */
+  /** The raw channel identifier (e.g. "vellum", "telegram", "sms"). */
   channel: string;
   /** Whether this channel can render the dashboard UI (apps, dynamic pages). */
   dashboardCapable: boolean;
@@ -48,17 +48,17 @@ export function resolveChannelCapabilities(sourceChannel?: string | null): Chann
     case 'dashboard':
     case 'http-api':
     case 'mac':
-      channel = 'macos';
+    case 'macos':
+    case 'ios':
+      channel = 'vellum';
       break;
     default:
       channel = sourceChannel;
   }
 
   switch (channel) {
-    case 'macos':
+    case 'vellum':
       return { channel, dashboardCapable: true, supportsDynamicUi: true, supportsVoiceInput: true };
-    case 'ios':
-      return { channel, dashboardCapable: false, supportsDynamicUi: false, supportsVoiceInput: true };
     case 'telegram':
     case 'sms':
     case 'voice':

--- a/assistant/src/memory/migrations/020-rename-macos-ios-channel-to-vellum.ts
+++ b/assistant/src/memory/migrations/020-rename-macos-ios-channel-to-vellum.ts
@@ -1,0 +1,98 @@
+import { getSqliteFrom, type DrizzleDb } from '../db-connection.js';
+
+/**
+ * One-shot migration: rename 'macos' and 'ios' channel identifiers to 'vellum'
+ * across all tables that store channel values.
+ *
+ * Uses a checkpoint key for idempotency.
+ */
+export function migrateRenameChannelToVellum(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  const checkpointKey = 'migration_rename_macos_ios_channel_to_vellum_v1';
+  const checkpoint = raw.query(
+    `SELECT 1 FROM memory_checkpoints WHERE key = ?`,
+  ).get(checkpointKey);
+  if (checkpoint) return;
+
+  try {
+    raw.exec('BEGIN');
+
+    // guardian_action_deliveries.destination_channel
+    const gadExists = raw.query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'guardian_action_deliveries'`,
+    ).get();
+    if (gadExists) {
+      raw.query(
+        `UPDATE guardian_action_deliveries SET destination_channel = 'vellum' WHERE destination_channel IN ('macos', 'ios')`,
+      ).run();
+    }
+
+    // messages.user_message_channel / assistant_message_channel
+    const msgsExists = raw.query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'messages'`,
+    ).get();
+    if (msgsExists) {
+      // Check if columns exist before updating
+      const hasUserMsgChannel = raw.query(
+        `SELECT 1 FROM pragma_table_info('messages') WHERE name = 'user_message_channel'`,
+      ).get();
+      if (hasUserMsgChannel) {
+        raw.query(
+          `UPDATE messages SET user_message_channel = 'vellum' WHERE user_message_channel IN ('macos', 'ios')`,
+        ).run();
+      }
+      const hasAssistantMsgChannel = raw.query(
+        `SELECT 1 FROM pragma_table_info('messages') WHERE name = 'assistant_message_channel'`,
+      ).get();
+      if (hasAssistantMsgChannel) {
+        raw.query(
+          `UPDATE messages SET assistant_message_channel = 'vellum' WHERE assistant_message_channel IN ('macos', 'ios')`,
+        ).run();
+      }
+    }
+
+    // external_conversation_bindings.source_channel
+    const ecbExists = raw.query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'external_conversation_bindings'`,
+    ).get();
+    if (ecbExists) {
+      raw.query(
+        `UPDATE external_conversation_bindings SET source_channel = 'vellum' WHERE source_channel IN ('macos', 'ios')`,
+      ).run();
+    }
+
+    // assistant_inbox_thread_state.source_channel
+    const aitsExists = raw.query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'assistant_inbox_thread_state'`,
+    ).get();
+    if (aitsExists) {
+      raw.query(
+        `UPDATE assistant_inbox_thread_state SET source_channel = 'vellum' WHERE source_channel IN ('macos', 'ios')`,
+      ).run();
+    }
+
+    // conversations.origin_channel
+    const convExists = raw.query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'conversations'`,
+    ).get();
+    if (convExists) {
+      const hasOriginChannel = raw.query(
+        `SELECT 1 FROM pragma_table_info('conversations') WHERE name = 'origin_channel'`,
+      ).get();
+      if (hasOriginChannel) {
+        raw.query(
+          `UPDATE conversations SET origin_channel = 'vellum' WHERE origin_channel IN ('macos', 'ios')`,
+        ).run();
+      }
+    }
+
+    raw.query(
+      `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,
+    ).run(checkpointKey, Date.now());
+
+    raw.exec('COMMIT');
+  } catch (e) {
+    try { raw.exec('ROLLBACK'); } catch { /* no active transaction */ }
+    throw e;
+  }
+}

--- a/assistant/src/memory/migrations/113-late-migrations.ts
+++ b/assistant/src/memory/migrations/113-late-migrations.ts
@@ -4,10 +4,11 @@ import { migrateMemoryFtsBackfill } from './003-memory-fts-backfill.js';
 import { migrateMemorySegmentsIndexes } from './016-memory-segments-indexes.js';
 import { migrateMemoryItemsIndexes } from './017-memory-items-indexes.js';
 import { migrateRemainingTableIndexes } from './018-remaining-table-indexes.js';
+import { migrateRenameChannelToVellum } from './020-rename-macos-ios-channel-to-vellum.js';
 
 /**
  * Late-stage migrations that must run after all tables and indexes exist:
- * guardian action tables, FTS backfill, and index migrations.
+ * guardian action tables, FTS backfill, index migrations, and channel renames.
  */
 export function runLateMigrations(database: DrizzleDb): void {
   migrateGuardianActionTables(database);
@@ -15,4 +16,5 @@ export function runLateMigrations(database: DrizzleDb): void {
   migrateMemorySegmentsIndexes(database);
   migrateMemoryItemsIndexes(database);
   migrateRemainingTableIndexes(database);
+  migrateRenameChannelToVellum(database);
 }

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -23,6 +23,7 @@ export { migrateMemorySegmentsIndexes } from './016-memory-segments-indexes.js';
 export { migrateMemoryItemsIndexes } from './017-memory-items-indexes.js';
 export { migrateRemainingTableIndexes } from './018-remaining-table-indexes.js';
 export { migrateNotificationTablesSchema } from './019-notification-tables-schema-migration.js';
+export { migrateRenameChannelToVellum } from './020-rename-macos-ios-channel-to-vellum.js';
 export { createCoreTables } from './100-core-tables.js';
 export { createWatchersAndLogsTables } from './101-watchers-and-logs.js';
 export { addCoreColumns } from './102-alter-table-columns.js';

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -74,6 +74,11 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     version: 10,
     description: 'Drop legacy enum-based notification tables so they can be recreated with the new signal-contract schema',
   },
+  {
+    key: 'migration_rename_macos_ios_channel_to_vellum_v1',
+    version: 11,
+    description: 'Rename macos and ios channel identifiers to vellum across all tables',
+  },
 ];
 
 export interface MigrationValidationResult {

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -829,7 +829,7 @@ export const guardianActionDeliveries = sqliteTable('guardian_action_deliveries'
   requestId: text('request_id')
     .notNull()
     .references(() => guardianActionRequests.id, { onDelete: 'cascade' }),
-  destinationChannel: text('destination_channel').notNull(),       // 'telegram' | 'sms' | 'macos'
+  destinationChannel: text('destination_channel').notNull(),       // 'telegram' | 'sms' | 'vellum'
   destinationConversationId: text('destination_conversation_id'),
   destinationChatId: text('destination_chat_id'),
   destinationExternalUserId: text('destination_external_user_id'),

--- a/assistant/src/notifications/adapters/macos.ts
+++ b/assistant/src/notifications/adapters/macos.ts
@@ -1,8 +1,8 @@
 /**
- * macOS channel adapter — delivers notifications to connected desktop
- * clients via the daemon's IPC broadcast mechanism.
+ * Vellum channel adapter — delivers notifications to connected desktop
+ * and mobile clients via the daemon's IPC broadcast mechanism.
  *
- * The adapter broadcasts a `notification_intent` message that the macOS
+ * The adapter broadcasts a `notification_intent` message that the Vellum
  * client can use to display a native notification (e.g. NSUserNotification
  * or UNUserNotificationCenter).
  */
@@ -17,12 +17,12 @@ import type {
   DeliveryResult,
 } from '../types.js';
 
-const log = getLogger('notif-adapter-macos');
+const log = getLogger('notif-adapter-vellum');
 
 export type BroadcastFn = (msg: ServerMessage) => void;
 
-export class MacOSAdapter implements ChannelAdapter {
-  readonly channel: NotificationChannel = 'macos';
+export class VellumAdapter implements ChannelAdapter {
+  readonly channel: NotificationChannel = 'vellum';
 
   private broadcast: BroadcastFn;
 
@@ -42,13 +42,13 @@ export class MacOSAdapter implements ChannelAdapter {
 
       log.info(
         { sourceEventName: payload.sourceEventName, title: payload.copy.title },
-        'macOS notification intent broadcast',
+        'Vellum notification intent broadcast',
       );
 
       return { success: true };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      log.error({ err, sourceEventName: payload.sourceEventName }, 'Failed to broadcast macOS notification intent');
+      log.error({ err, sourceEventName: payload.sourceEventName }, 'Failed to broadcast Vellum notification intent');
       return { success: false, error: message };
     }
   }

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -189,7 +189,7 @@ function buildFallbackDecision(
 
 // ── Validation ─────────────────────────────────────────────────────────
 
-const VALID_CHANNELS = new Set<string>(['macos', 'telegram']);
+const VALID_CHANNELS = new Set<string>(['vellum', 'telegram']);
 
 function validateDecisionOutput(
   input: Record<string, unknown>,

--- a/assistant/src/notifications/destination-resolver.ts
+++ b/assistant/src/notifications/destination-resolver.ts
@@ -1,8 +1,8 @@
 /**
  * Resolves per-channel destination endpoints for notification delivery.
  *
- * - macOS: no external endpoint needed — delivery goes through the IPC
- *   broadcast mechanism to connected desktop clients.
+ * - Vellum: no external endpoint needed — delivery goes through the IPC
+ *   broadcast mechanism to connected desktop/mobile clients.
  * - Telegram: requires a chat ID sourced from the guardian binding for the
  *   assistant.
  */
@@ -24,9 +24,9 @@ export function resolveDestinations(
 
   for (const channel of channels) {
     switch (channel) {
-      case 'macos': {
-        // macOS delivery is local IPC — no external endpoint required.
-        result.set('macos', { channel: 'macos' });
+      case 'vellum': {
+        // Vellum delivery is local IPC — no external endpoint required.
+        result.set('vellum', { channel: 'vellum' });
         break;
       }
       case 'telegram': {

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -18,7 +18,7 @@ import { evaluateSignal } from './decision-engine.js';
 import { runDeterministicChecks, type DeterministicCheckContext } from './deterministic-checks.js';
 import { dispatchDecision } from './runtime-dispatch.js';
 import { NotificationBroadcaster } from './broadcaster.js';
-import { MacOSAdapter, type BroadcastFn } from './adapters/macos.js';
+import { VellumAdapter, type BroadcastFn } from './adapters/macos.js';
 import { TelegramAdapter } from './adapters/telegram.js';
 import type { NotificationSignal, AttentionHints } from './signal.js';
 import type { NotificationChannel } from './types.js';
@@ -31,7 +31,7 @@ let broadcasterInstance: NotificationBroadcaster | null = null;
 let registeredBroadcastFn: BroadcastFn | null = null;
 
 /**
- * Register the IPC broadcast function so the macOS adapter can deliver
+ * Register the IPC broadcast function so the vellum adapter can deliver
  * notifications through the daemon's IPC socket. Must be called once
  * during daemon startup (before any signals are emitted).
  */
@@ -47,7 +47,7 @@ function getBroadcaster(): NotificationBroadcaster {
       new TelegramAdapter(),
     ];
     if (registeredBroadcastFn) {
-      adapters.unshift(new MacOSAdapter(registeredBroadcastFn));
+      adapters.unshift(new VellumAdapter(registeredBroadcastFn));
     }
     broadcasterInstance = new NotificationBroadcaster(adapters);
   }
@@ -57,9 +57,9 @@ function getBroadcaster(): NotificationBroadcaster {
 // ── Connected channels resolution ──────────────────────────────────────
 
 function getConnectedChannels(assistantId: string): NotificationChannel[] {
-  // macOS is always considered connected (IPC socket is always available
+  // Vellum is always considered connected (IPC socket is always available
   // when the daemon is running).
-  const channels: NotificationChannel[] = ['macos'];
+  const channels: NotificationChannel[] = ['vellum'];
   // Only report Telegram as connected when there is an active guardian
   // binding for this assistant. Without a binding, the destination
   // resolver will fail to resolve a chat ID and dispatch will silently

--- a/assistant/src/notifications/preferences-store.ts
+++ b/assistant/src/notifications/preferences-store.ts
@@ -40,7 +40,7 @@ function rowToPreference(row: typeof notificationPreferences.$inferSelect): Noti
 
 export interface AppliesWhenConditions {
   timeRange?: { after?: string; before?: string }; // e.g. "22:00", "06:00"
-  channels?: string[];        // e.g. ["telegram", "macos"]
+  channels?: string[];        // e.g. ["telegram", "vellum"]
   urgencyLevels?: string[];   // e.g. ["high", "critical"]
   contexts?: string[];        // e.g. ["work_calls", "meetings"]
   [key: string]: unknown;

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -16,7 +16,7 @@ export interface NotificationSignal {
   signalId: string;
   assistantId: string;
   createdAt: number; // epoch ms
-  sourceChannel: string; // free-form: 'macos', 'telegram', 'voice', 'scheduler', etc.
+  sourceChannel: string; // free-form: 'vellum', 'telegram', 'voice', 'scheduler', etc.
   sourceSessionId: string;
   sourceEventName: string; // free-form: 'reminder_fired', 'schedule_complete', 'guardian_question', etc.
   contextPayload: Record<string, unknown>;

--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -5,7 +5,7 @@
  * depend on, plus the decision engine output contract.
  */
 
-export type NotificationChannel = 'macos' | 'telegram';
+export type NotificationChannel = 'vellum' | 'telegram';
 
 export type NotificationDeliveryStatus = 'pending' | 'sent' | 'failed' | 'skipped';
 

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -94,7 +94,7 @@ export interface RunStartOptions {
   /**
    * The originating channel (e.g. 'telegram', 'slack'). When provided,
    * channel capabilities are resolved for this channel instead of the
-   * default 'macos'.
+   * default 'vellum'.
    */
   sourceChannel?: ChannelId;
   /**
@@ -227,8 +227,8 @@ export class RunOrchestrator {
     session.setGuardianContext(options?.guardianContext ?? null);
     session.setCommandIntent(options?.commandIntent ?? null);
     session.setTurnChannelContext(options?.turnChannelContext ?? {
-      userMessageChannel: parseChannelId(options?.sourceChannel) ?? 'macos',
-      assistantMessageChannel: parseChannelId(options?.sourceChannel) ?? 'macos',
+      userMessageChannel: parseChannelId(options?.sourceChannel) ?? 'vellum',
+      assistantMessageChannel: parseChannelId(options?.sourceChannel) ?? 'vellum',
     });
 
     const attachments = attachmentIds
@@ -241,8 +241,8 @@ export class RunOrchestrator {
 
     // Set channel capabilities based on the originating channel so capabilities
     // (e.g. attachment scope) match the actual transport rather than always
-    // defaulting to 'macos'.
-    session.setChannelCapabilities(resolveChannelCapabilities(options?.sourceChannel ?? 'macos'));
+    // defaulting to 'vellum'.
+    session.setChannelCapabilities(resolveChannelCapabilities(options?.sourceChannel ?? 'vellum'));
     session.setVoiceCallControlPrompt(options?.voiceCallControlPrompt ?? null);
 
     // Serialized publish chain so hub subscribers observe events in order.

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingIntroductionViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingIntroductionViewModel.swift
@@ -69,7 +69,7 @@ final class FirstMeetingIntroductionViewModel {
                 try self.daemonClient.send(SessionCreateMessage(
                     title: "First meeting",
                     maxResponseTokens: 220,
-                    transportChannelId: "macos",
+                    transportChannelId: "vellum",
                     transportHints: [
                         "onboarding-active",
                         "onboarding-phase:post_hatch",

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
@@ -76,7 +76,7 @@ final class InterviewViewModel {
                 try self.daemonClient.send(SessionCreateMessage(
                     title: "Getting to know you",
                     maxResponseTokens: 220,
-                    transportChannelId: "macos",
+                    transportChannelId: "vellum",
                     transportHints: hints,
                     transportUxBrief: "Onboarding conversation after hatch. Follow the channel playbook and update USER.md directly."
                 ))

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -5293,7 +5293,7 @@ public struct IPCUserMessage: Codable, Sendable {
     public let currentPage: String?
     /// When true, skip the secret-ingress check. Set by the client when the user clicks "Send Anyway".
     public let bypassSecretCheck: Bool?
-    /// Originating channel identifier (e.g. 'macos', 'ios'). Defaults to 'macos' when absent.
+    /// Originating channel identifier (e.g. 'vellum'). Defaults to 'vellum' when absent.
     public let channel: String?
 
     public init(type: String, sessionId: String, content: String? = nil, attachments: [IPCUserMessageAttachment]? = nil, activeSurfaceId: String? = nil, currentPage: String? = nil, bypassSecretCheck: Bool? = nil, channel: String? = nil) {

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -51,11 +51,7 @@ final class HTTPTransport {
     private let sourceChannel: String
 
     private static var defaultSourceChannel: String {
-        #if os(iOS)
-        return "ios"
-        #else
-        return "macos"
-        #endif
+        return "vellum"
     }
 
     /// Currently active SSE task.

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -293,11 +293,7 @@ public typealias UserMessageMessage = IPCUserMessage
 extension IPCUserMessage {
     /// Platform-derived default channel identifier.
     private static var defaultChannel: String {
-        #if os(iOS)
-        return "ios"
-        #else
-        return "macos"
-        #endif
+        return "vellum"
     }
 
     public init(sessionId: String, content: String, attachments: [IPCAttachment]?, activeSurfaceId: String? = nil, currentPage: String? = nil, bypassSecretCheck: Bool? = nil, channel: String? = nil) {

--- a/gateway/src/channels/types.ts
+++ b/gateway/src/channels/types.ts
@@ -1,5 +1,5 @@
 export const CHANNEL_IDS = [
-  'telegram', 'sms', 'voice', 'macos', 'ios', 'whatsapp', 'slack', 'email',
+  'telegram', 'sms', 'voice', 'vellum', 'whatsapp', 'slack', 'email',
 ] as const;
 
 export type ChannelId = (typeof CHANNEL_IDS)[number];


### PR DESCRIPTION
## Summary
- Consolidate `'macos'` and `'ios'` channel identifiers into a single `'vellum'` channel across the entire codebase (assistant, gateway, Swift clients)
- Add legacy normalization in `resolveChannelCapabilities` so old channel values (`'macos'`, `'ios'`, `'mac'`, `'dashboard'`, `'http-api'`) map to `'vellum'`
- Add data migration (020) to convert existing `'macos'`/`'ios'` values to `'vellum'` in all DB tables that store channel identifiers

## Original prompt
We have a union of string literals somewhere representing our canonical "channels". Right now one of them is "macos". Lets rename this to be "vellum". If we already have ios as a channel, then that should also be "vellum". If easy, do a data migration to convert stateful data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
