### PR TITLE
feat: reply with rejection message on ACL denial

### DIFF
--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -163,19 +163,50 @@ export async function handleChannelInbound(
 
     if (!resolvedMember && !isGuardianVerifyCommand) {
       log.info({ sourceChannel, externalUserId: body.senderExternalUserId }, 'Ingress ACL: no member record, denying');
+      if (body.replyCallbackUrl) {
+        try {
+          await deliverChannelReply(body.replyCallbackUrl, {
+            chatId: externalChatId,
+            text: "Sorry, you haven't been approved to message this assistant. You can ask its Guardian for an invite.",
+            assistantId,
+          }, bearerToken);
+        } catch (err) {
+          log.error({ err, externalChatId }, 'Failed to deliver ACL rejection reply');
+        }
+      }
       return Response.json({ accepted: true, denied: true, reason: 'not_a_member' });
     }
 
     if (resolvedMember) {
       if (resolvedMember.status !== 'active') {
         log.info({ sourceChannel, memberId: resolvedMember.id, status: resolvedMember.status }, 'Ingress ACL: member not active, denying');
+        if (body.replyCallbackUrl) {
+          try {
+            await deliverChannelReply(body.replyCallbackUrl, {
+              chatId: externalChatId,
+              text: "Sorry, you haven't been approved to message this assistant. You can ask its Guardian for an invite.",
+              assistantId,
+            }, bearerToken);
+          } catch (err) {
+            log.error({ err, externalChatId }, 'Failed to deliver ACL rejection reply');
+          }
+        }
         return Response.json({ accepted: true, denied: true, reason: `member_${resolvedMember.status}` });
       }
 
       if (resolvedMember.policy === 'deny') {
         log.info({ sourceChannel, memberId: resolvedMember.id }, 'Ingress ACL: member policy deny');
-        return Response.json({ accepted: true, denied: true, reason: 'policy_deny' });
-      }
+        if (body.replyCallbackUrl) {
+          try {
+            await deliverChannelReply(body.replyCallbackUrl, {
+              chatId: externalChatId,
+              text: "Sorry, you haven't been approved to message this assistant. You can ask its Guardian for an invite.",
+              assistantId,
+            }, bearerToken);
+          } catch (err) {
+            log.error({ err, externalChatId }, 'Failed to deliver ACL rejection reply');
+          }
+        }
 
       // 'allow' or 'escalate' — update last seen and continue
       updateLastSeen(resolvedMember.id);


### PR DESCRIPTION
## Summary
- When an inbound message is denied by the ingress ACL (no member record, inactive member, or deny policy), delivers a user-facing reply on the channel: "Sorry, you haven't been approved to message this assistant. You can ask its Guardian for an invite."
- Previously, denied users saw no response at all on Telegram/other channels — now they get clear feedback about why their message wasn't processed and what to do about it.
- Reply delivery failures are caught and logged without affecting the denial response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
