### PR TITLE
fix: address review feedback on swarm checkpoint (#8574)

### DIFF
--- a/assistant/src/swarm/checkpoint.ts
+++ b/assistant/src/swarm/checkpoint.ts
@@ -43,7 +43,7 @@ function getCheckpointPath(runId: string): string {
  * identical and safe to resume from.
  */
 function computePlanHash(plan: SwarmPlan): string {
-  const parts = plan.tasks.map((t) => `${t.id}:${t.role}:${t.dependencies.sort().join(',')}`);
+  const parts = plan.tasks.map((t) => `${t.id}:${t.role}:${[...t.dependencies].sort().join(',')}`);
   return `${plan.objective}|${parts.sort().join('|')}`;
 }
 
@@ -54,18 +54,18 @@ export function writeCheckpoint(
   results: Map<string, SwarmTaskResult>,
   blockedTaskIds: Set<string>,
 ): void {
-  const path = getCheckpointPath(runId);
-  const checkpoint: SwarmCheckpoint = {
-    runId,
-    objective: plan.objective,
-    planTaskIds: plan.tasks.map((t) => t.id),
-    planHash: computePlanHash(plan),
-    results: Array.from(results.values()),
-    blockedTaskIds: Array.from(blockedTaskIds),
-    updatedAt: new Date().toISOString(),
-  };
-
   try {
+    const path = getCheckpointPath(runId);
+    const checkpoint: SwarmCheckpoint = {
+      runId,
+      objective: plan.objective,
+      planTaskIds: plan.tasks.map((t) => t.id),
+      planHash: computePlanHash(plan),
+      results: Array.from(results.values()),
+      blockedTaskIds: Array.from(blockedTaskIds),
+      updatedAt: new Date().toISOString(),
+    };
+
     mkdirSync(dirname(path), { recursive: true });
     // Atomic-ish write: write to temp then rename to avoid partial reads
     const tmpPath = path + '.tmp';


### PR DESCRIPTION
Addresses review feedback from PR #8574 (swarm checkpoint persistence):

- Use non-mutating sort in computePlanHash to avoid reordering plan dependencies in-place (Devin yellow + Codex P2)
- Move getCheckpointPath inside try/catch in writeCheckpoint so invalid runId validation errors degrade gracefully instead of crashing (Codex P1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
