### PR TITLE
fix: address review feedback on WhatsApp media (#8566)

### DIFF
--- a/gateway/src/http/routes/whatsapp-deliver.ts
+++ b/gateway/src/http/routes/whatsapp-deliver.ts
@@ -117,17 +117,30 @@ export function createWhatsAppDeliverHandler(config: GatewayConfig) {
       }
     }
 
+    let textSent = false;
+
     try {
       if (text) {
         await sendWhatsAppReply(config, to, text, approval);
-      }
-
-      if (attachments && attachments.length > 0) {
-        await sendWhatsAppAttachments(config, to, assistantId, attachments);
+        textSent = true;
       }
     } catch (err) {
-      tlog.error({ err, to }, "Failed to deliver WhatsApp reply");
+      tlog.error({ err, to }, "Failed to deliver WhatsApp text");
       return Response.json({ error: "Delivery failed" }, { status: 502 });
+    }
+
+    if (attachments && attachments.length > 0) {
+      const result = await sendWhatsAppAttachments(config, to, assistantId, attachments);
+
+      if (result.allFailed && !textSent) {
+        // Nothing was delivered at all -- signal failure so the caller can retry
+        tlog.error({ to, failureCount: result.failureCount }, "All attachments failed and no text was sent");
+        return Response.json({ error: "Delivery failed" }, { status: 502 });
+      }
+
+      if (result.failureCount > 0) {
+        tlog.warn({ to, failureCount: result.failureCount, totalCount: result.totalCount }, "Partial attachment delivery failure");
+      }
     }
 
     tlog.info({ to, hasText: !!text, attachmentCount: attachments?.length ?? 0, hasApproval: !!approval }, "WhatsApp reply sent");

--- a/gateway/src/whatsapp/send.ts
+++ b/gateway/src/whatsapp/send.ts
@@ -77,12 +77,18 @@ export async function sendWhatsAppReply(
   log.debug({ to, chunks: chunks.length }, "WhatsApp reply sent");
 }
 
+export type AttachmentResult = {
+  allFailed: boolean;
+  failureCount: number;
+  totalCount: number;
+};
+
 export async function sendWhatsAppAttachments(
   config: GatewayConfig,
   to: string,
   assistantId: string | undefined,
   attachments: RuntimeAttachmentMeta[],
-): Promise<void> {
+): Promise<AttachmentResult> {
   const failures: string[] = [];
 
   for (const meta of attachments) {
@@ -130,8 +136,11 @@ export async function sendWhatsAppAttachments(
       log.error({ err, to }, "Failed to send attachment failure notice");
     }
 
-    if (failures.length === attachments.length) {
-      throw new Error(`All ${failures.length} attachment(s) failed to deliver`);
-    }
   }
+
+  return {
+    allFailed: failures.length === attachments.length,
+    failureCount: failures.length,
+    totalCount: attachments.length,
+  };
 }


### PR DESCRIPTION
Addresses review feedback from PR #8566

Both Codex and Devin flagged the same issue: when a request contains both text and attachments, the throw in sendWhatsAppAttachments when all attachments fail propagates up through the shared try/catch in the deliver handler, returning 502 even though text was already successfully delivered. This causes duplicate text messages on retry.

Fix: change sendWhatsAppAttachments to return an AttachmentResult object instead of throwing. The deliver handler now separates text and attachment error handling -- only returning 502 when nothing was delivered at all (no text sent AND all attachments failed). When text was sent but attachments failed, returns 200 to prevent retries and logs a warning about partial delivery failure.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
