### PR TITLE
fix: address review feedback on OAuth state rollback (#8575)

### DIFF
--- a/gateway/src/__tests__/oauth-callback.test.ts
+++ b/gateway/src/__tests__/oauth-callback.test.ts
@@ -203,12 +203,39 @@ describe("OAuth callback handler", () => {
     expect(sentBody.code).toBeUndefined();
   });
 
-  test("runtime returning 404 (unknown state) shows error page and allows retry", async () => {
+  test("runtime returning 404 (deterministic rejection) keeps state consumed", async () => {
+    fetchMock = mock(async () =>
+      Response.json({ error: "Unknown state" }, { status: 404 }),
+    );
+
+    const handler = createOAuthCallbackHandler(makeConfig());
+    const req1 = new Request(
+      `http://localhost:7830/webhooks/oauth/callback?state=${VALID_STATE}&code=code`,
+      { method: "GET" },
+    );
+
+    const res1 = await handler(req1);
+    expect(res1.status).toBe(400);
+    expect(await res1.text()).toContain("Authorization Failed");
+
+    // State stays consumed — replay is blocked even after a 4xx rejection
+    const req2 = new Request(
+      `http://localhost:7830/webhooks/oauth/callback?state=${VALID_STATE}&code=code`,
+      { method: "GET" },
+    );
+    const res2 = await handler(req2);
+    expect(res2.status).toBe(400);
+    expect(await res2.text()).toContain("State parameter already used");
+    // Only the first request should have been forwarded to the runtime
+    expect(fetchMock.mock.calls.length).toBe(1);
+  });
+
+  test("runtime returning 5xx allows retry", async () => {
     let callCount = 0;
     fetchMock = mock(async () => {
       callCount++;
       if (callCount === 1) {
-        return Response.json({ error: "Unknown state" }, { status: 404 });
+        return Response.json({ error: "Internal error" }, { status: 500 });
       }
       return Response.json({ ok: true }, { status: 200 });
     });
@@ -223,7 +250,7 @@ describe("OAuth callback handler", () => {
     expect(res1.status).toBe(400);
     expect(await res1.text()).toContain("Authorization Failed");
 
-    // State should be rolled back so a retry succeeds
+    // State should be rolled back on 5xx so a retry succeeds
     const req2 = new Request(
       `http://localhost:7830/webhooks/oauth/callback?state=${VALID_STATE}&code=code`,
       { method: "GET" },

--- a/gateway/src/http/routes/oauth-callback.ts
+++ b/gateway/src/http/routes/oauth-callback.ts
@@ -67,8 +67,9 @@ export function createOAuthCallbackHandler(config: GatewayConfig) {
     }
 
     // Optimistically mark consumed so concurrent duplicate callbacks are
-    // blocked while the runtime processes this one. Rolled back on failure
-    // so transient errors don't permanently block retries.
+    // blocked while the runtime processes this one. Only rolled back on
+    // transient failures (5xx / transport errors) — deterministic rejections
+    // (4xx) keep state consumed to prevent replay attacks.
     markStateConsumed(state);
 
     try {
@@ -86,12 +87,18 @@ export function createOAuthCallbackHandler(config: GatewayConfig) {
         });
       }
 
-      rollBackConsumedState(state);
+      // Only roll back consumed state for transient failures (5xx) so the user
+      // can retry. Deterministic rejections (4xx) keep state consumed to prevent
+      // replay/spam — the runtime already rejected the callback definitively.
+      if (response.status >= 500) {
+        rollBackConsumedState(state);
+      }
       return new Response(
         renderErrorPage("Authorization failed. Please try again."),
         { status: 400, headers: { "Content-Type": "text/html" } },
       );
     } catch (err) {
+      // Transport errors are transient — roll back so the callback can be retried.
       rollBackConsumedState(state);
       log.error({ err }, "Failed to forward OAuth callback to runtime");
       return new Response(


### PR DESCRIPTION
Addresses review feedback from PR #8575 (OAuth state rollback on failure).

Only roll back consumed OAuth state on transient failures (5xx responses and transport errors). Deterministic rejections (4xx) now keep state consumed to prevent replay attacks and reduce unnecessary runtime load.

Changes:
- gateway/src/http/routes/oauth-callback.ts: gate rollback on response.status >= 500 instead of all non-2xx
- gateway/src/__tests__/oauth-callback.test.ts: update 404 test to verify state stays consumed; add new 5xx retry test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
