### PR TITLE
fix: address review feedback on Linear watcher cache (#8579)

### DIFF
--- a/assistant/src/watcher/providers/linear.ts
+++ b/assistant/src/watcher/providers/linear.ts
@@ -293,6 +293,16 @@ async function fetchAssignedIssueUpdates(
  */
 const knownIssueStateIdsByWatcher = new Map<string, Map<string, string>>();
 
+/**
+ * Tracks the set of assigned issue IDs returned by the previous poll, scoped
+ * by watcher key. Used to detect unassignment: if an issue was in the previous
+ * poll's assigned set but is absent from the current one, it has been
+ * unassigned and its cached state should be evicted. This prevents false
+ * `linear_status_changed` events when an issue is unassigned, changes state,
+ * and is later reassigned.
+ */
+const lastSeenAssignedIdsByWatcher = new Map<string, Set<string>>();
+
 /** Get (or lazily create) the per-watcher state map. */
 function getStateCache(watcherKey: string): Map<string, string> {
   let cache = knownIssueStateIdsByWatcher.get(watcherKey);
@@ -310,6 +320,7 @@ function getStateCache(watcherKey: string): Map<string, string> {
  */
 export function clearLinearStateCache(watcherKey: string): void {
   knownIssueStateIdsByWatcher.delete(watcherKey);
+  lastSeenAssignedIdsByWatcher.delete(watcherKey);
 }
 
 // ── Event type mapping ────────────────────────────────────────────────────────
@@ -439,14 +450,33 @@ export const linearProvider: WatcherProvider = {
       // credentialService so that multiple Linear watchers sharing the same credential
       // maintain independent baselines and cannot clobber each other's state.
       const stateCache = getStateCache(watcherKey);
+      const prevSeenIds = lastSeenAssignedIdsByWatcher.get(watcherKey);
+      const currentSeenIds = new Set<string>();
       for (const issue of assignedIssues) {
+        currentSeenIds.add(issue.id);
         const previousStateId = stateCache.get(issue.id);
-        if (previousStateId !== undefined && previousStateId !== issue.state.id) {
+        // Only emit a status change if the issue was also seen in the previous
+        // poll (continuously assigned). If it wasn't seen last time, it may have
+        // been unassigned and reassigned — the cached state is stale, so we
+        // re-seed instead of emitting a false event.
+        const wasPreviouslySeen = prevSeenIds === undefined || prevSeenIds.has(issue.id);
+        if (previousStateId !== undefined && previousStateId !== issue.state.id && wasPreviouslySeen) {
           items.push(issueToStatusChangeItem(issue, previousStateId));
         }
-        // Always update the map so the next poll has an accurate baseline.
         stateCache.set(issue.id, issue.state.id);
       }
+
+      // Evict cached state for issues that were seen last poll but not this one
+      // — they've been unassigned. This prevents stale entries from accumulating
+      // and avoids false-positive events if the issue is later reassigned.
+      if (prevSeenIds) {
+        for (const id of prevSeenIds) {
+          if (!currentSeenIds.has(id)) {
+            stateCache.delete(id);
+          }
+        }
+      }
+      lastSeenAssignedIdsByWatcher.set(watcherKey, currentSeenIds);
 
       const newWatermark = new Date().toISOString();
       log.info(


### PR DESCRIPTION
Addresses Codex P2 feedback from PR #8579: stateCache retained entries for unassigned issues, causing false linear_status_changed events when issues were unassigned, changed state, and reassigned.

Adds a lastSeenAssignedIds set per watcher to track which issue IDs were returned in the previous poll. On each poll:
- Only emits status change events for issues continuously seen across polls (prevents false events from stale cache entries after re-assignment)
- Evicts cache entries for issues that were in the previous poll but not the current one (clears state when issues are unassigned)
- Cleans up the tracking set in clearLinearStateCache
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
