### PR TITLE
fix: handle commas in function names in FNDA output (#8600)

### DIFF
--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -256,10 +256,11 @@ if [[ "${COVERAGE}" == "true" ]]; then
         fnf = 0; fnh = 0
         for (i = 2; i <= n; i++) {
           key = sf SUBSEP fn_entries[i]
-          # fn_entries[i] is "line,name" — extract just the name for FNDA output
-          split(fn_entries[i], fnda_parts, ",")
-          fname_out = fnda_parts[2]
-          if (fname_out == "") fname_out = fn_entries[i]
+          # fn_entries[i] is "line,name" — strip leading "line," to get the name
+          # Uses sub() instead of split() so commas in function names are preserved
+          fname_out = fn_entries[i]
+          sub(/^[^,]*,/, "", fname_out)
+          if (fname_out == "" || fname_out == fn_entries[i]) fname_out = fn_entries[i]
           print "FNDA:" fnda[key] "," fname_out
           fnf++
           if (fnda[key] > 0) fnh++


### PR DESCRIPTION
Addresses Devin feedback on #8600. Uses sub() to strip the leading line number prefix instead of splitting on all commas, so function names containing commas (e.g., C++ template names) are preserved intact.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
