### PR TITLE
fix: expose hasRetryPayload on ChatViewModel for cross-module access

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -590,7 +590,7 @@ struct ActiveChatViewWrapper: View {
             isRetryableError: viewModel.isRetryableError,
             onRetryError: { viewModel.retryLastMessage() },
             isConnectionError: viewModel.isConnectionError,
-            hasRetryPayload: viewModel.lastFailedMessageText != nil,
+            hasRetryPayload: viewModel.hasRetryPayload,
             isSecretBlockError: viewModel.isSecretBlockError,
             onSendAnyway: { viewModel.sendAnyway() },
             onAcceptSuggestion: viewModel.acceptSuggestion,

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1308,6 +1308,8 @@ public final class ChatViewModel: ObservableObject {
     /// button to actual send failures and prevents unrelated errors (attachment
     /// validation, confirmation response failures, regenerate errors) from
     /// offering to resend a stale cached message.
+    public var hasRetryPayload: Bool { lastFailedMessageText != nil }
+
     public var isRetryableError: Bool {
         lastFailedMessageText != nil && lastFailedSendError != nil && !isConnectionError
     }


### PR DESCRIPTION
## Summary
- Added `public var hasRetryPayload: Bool` computed property on `ChatViewModel` to expose retry state across module boundaries
- Replaced direct access to `private(set) lastFailedMessageText` in `PanelCoordinator.swift` with `viewModel.hasRetryPayload`
- Fixes Swift module access control failure where macOS code couldn't read the `private(set)` property from the shared module

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
