### PR TITLE
Fix: accept CRLF line endings in skills frontmatter parsing

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -519,7 +519,7 @@ export async function handleSkillDetail(
 
 // ─── Frontmatter parsing ─────────────────────────────────────────────────────
 
-const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/;
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
 
 interface ParsedFrontmatter {
   skillId?: string;
@@ -534,12 +534,12 @@ function parseFrontmatter(sourceText: string): ParsedFrontmatter {
   if (!match) return { body: sourceText };
 
   const yamlBlock = match[1];
-  const body = match[2];
+  const body = match[2].replace(/\r\n/g, '\n');
 
   const result: ParsedFrontmatter = { body };
 
   // Simple YAML key-value extraction (handles quoted and unquoted values)
-  for (const line of yamlBlock.split('\n')) {
+  for (const line of yamlBlock.split(/\r?\n/)) {
     const kvMatch = /^(\w[\w-]*):\s*(.+)$/.exec(line.trim());
     if (!kvMatch) continue;
     const key = kvMatch[1];


### PR DESCRIPTION
Update frontmatter regex and line splitting to handle \r\n Windows line endings. Normalize body markdown to Unix line endings. Addresses Codex feedback on #8601. Part of #8549.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
