### PR TITLE
Fix: correlate draft/create responses with generation counters

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -47,6 +47,8 @@ final class SkillsManager: ObservableObject {
     private var lastSearchQuery: String?
     private var draftTask: Task<Void, Never>?
     private var createTask: Task<Void, Never>?
+    private var draftGeneration: Int = 0
+    private var createGeneration: Int = 0
 
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
@@ -276,6 +278,8 @@ final class SkillsManager: ObservableObject {
         isDrafting = true
         draftError = nil
         draftResult = nil
+        draftGeneration += 1
+        let generation = draftGeneration
 
         draftTask = Task {
             let stream = daemonClient.subscribe()
@@ -290,6 +294,7 @@ final class SkillsManager: ObservableObject {
 
             for await message in stream {
                 guard !Task.isCancelled else { break }
+                guard generation == self.draftGeneration else { break }
                 if case .skillsDraftResponse(let response) = message {
                     if response.success, let draft = response.draft {
                         draftResult = SkillDraftResult(
@@ -315,6 +320,8 @@ final class SkillsManager: ObservableObject {
         guard !isCreating else { return }
         isCreating = true
         createError = nil
+        createGeneration += 1
+        let generation = createGeneration
 
         createTask = Task {
             let stream = daemonClient.subscribe()
@@ -335,6 +342,7 @@ final class SkillsManager: ObservableObject {
 
             for await message in stream {
                 guard !Task.isCancelled else { break }
+                guard generation == self.createGeneration else { break }
                 if case .skillsOperationResponse(let response) = message,
                    response.operation == "create" {
                     if !response.success {
@@ -360,5 +368,7 @@ final class SkillsManager: ObservableObject {
         draftError = nil
         isCreating = false
         createError = nil
+        draftGeneration += 1
+        createGeneration += 1
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -287,8 +287,10 @@ final class SkillsManager: ObservableObject {
             do {
                 try daemonClient.draftSkill(sourceText: sourceText)
             } catch {
-                isDrafting = false
-                draftError = "Failed to send draft request"
+                if generation == self.draftGeneration {
+                    isDrafting = false
+                    draftError = "Failed to send draft request"
+                }
                 return
             }
 
@@ -312,7 +314,9 @@ final class SkillsManager: ObservableObject {
                     return
                 }
             }
-            isDrafting = false
+            if generation == self.draftGeneration {
+                isDrafting = false
+            }
         }
     }
 
@@ -335,8 +339,10 @@ final class SkillsManager: ObservableObject {
                     bodyMarkdown: bodyMarkdown
                 )
             } catch {
-                isCreating = false
-                createError = "Failed to send create request"
+                if generation == self.createGeneration {
+                    isCreating = false
+                    createError = "Failed to send create request"
+                }
                 return
             }
 
@@ -354,7 +360,9 @@ final class SkillsManager: ObservableObject {
                     return
                 }
             }
-            isCreating = false
+            if generation == self.createGeneration {
+                isCreating = false
+            }
         }
     }
 


### PR DESCRIPTION
Add generation counters to SkillsManager.draftSkill() and createSkillFromDraft() to prevent stale daemon responses from overwriting newer attempts after sheet close/reopen. Addresses Codex feedback on #8601. Part of #8549.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
