### PR TITLE
fix: restore missing closing brace in inbound-message-handler

### DIFF
--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -207,6 +207,8 @@ export async function handleChannelInbound(
             log.error({ err, externalChatId }, 'Failed to deliver ACL rejection reply');
           }
         }
+        return Response.json({ accepted: true, denied: true, reason: 'policy_deny' });
+      }
 
       // 'allow' or 'escalate' — update last seen and continue
       updateLastSeen(resolvedMember.id);


### PR DESCRIPTION
## Summary
- Restored the missing closing `}` and `return Response.json(...)` for the `policy === 'deny'` block in `inbound-message-handler.ts`
- The previous ACL rejection reply PR (#8592) accidentally dropped these when adding the reply delivery code, leaving the deny block unclosed
- Fixes TS1005 "'}' expected" at EOF

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
