### PR TITLE
fix: use non-greedy JSON regex in skills draft handler

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -646,7 +646,7 @@ export async function handleSkillsDraft(
 
             const responseText = extractText(response);
             // Extract JSON from response (handle markdown code fences)
-            const jsonMatch = /\{[\s\S]*\}/.exec(responseText);
+            const jsonMatch = /\{[\s\S]*?\}/.exec(responseText);
             if (jsonMatch) {
               const generated = JSON.parse(jsonMatch[0]);
               if (typeof generated === 'object' && generated !== null) {


### PR DESCRIPTION
The greedy regex `/\{[\s\S]*\}/` could match across multiple JSON objects if the LLM response contains explanatory text with braces. Switch to non-greedy `/\{[\s\S]*?\}/` to match only the first JSON object.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
