### PR TITLE
M1: Add canonical InterfaceId types and helpers

### DIFF
--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -23,3 +23,30 @@ export interface TurnChannelContext {
   userMessageChannel: ChannelId;
   assistantMessageChannel: ChannelId;
 }
+
+export const INTERFACE_IDS = [
+  'macos', 'ios', 'cli',
+  'telegram', 'sms', 'voice', 'vellum', 'whatsapp', 'slack', 'email',
+] as const;
+
+export type InterfaceId = (typeof INTERFACE_IDS)[number];
+
+export function isInterfaceId(value: unknown): value is InterfaceId {
+  return typeof value === 'string' && (INTERFACE_IDS as readonly string[]).includes(value);
+}
+
+export function parseInterfaceId(value: unknown): InterfaceId | null {
+  return isInterfaceId(value) ? value : null;
+}
+
+export function assertInterfaceId(value: unknown, field: string): InterfaceId {
+  if (!isInterfaceId(value)) {
+    throw new Error(`Invalid interface ID for ${field}: ${String(value)}. Valid values: ${INTERFACE_IDS.join(', ')}`);
+  }
+  return value;
+}
+
+export interface TurnInterfaceContext {
+  userMessageInterface: InterfaceId;
+  assistantMessageInterface: InterfaceId;
+}

--- a/gateway/src/channels/types.ts
+++ b/gateway/src/channels/types.ts
@@ -18,3 +18,30 @@ export function assertChannelId(value: unknown, field: string): ChannelId {
   }
   return value;
 }
+
+export const INTERFACE_IDS = [
+  'macos', 'ios', 'cli',
+  'telegram', 'sms', 'voice', 'vellum', 'whatsapp', 'slack', 'email',
+] as const;
+
+export type InterfaceId = (typeof INTERFACE_IDS)[number];
+
+export function isInterfaceId(value: unknown): value is InterfaceId {
+  return typeof value === 'string' && (INTERFACE_IDS as readonly string[]).includes(value);
+}
+
+export function parseInterfaceId(value: unknown): InterfaceId | null {
+  return isInterfaceId(value) ? value : null;
+}
+
+export function assertInterfaceId(value: unknown, field: string): InterfaceId {
+  if (!isInterfaceId(value)) {
+    throw new Error(`Invalid interface ID for ${field}: ${String(value)}. Valid values: ${INTERFACE_IDS.join(', ')}`);
+  }
+  return value;
+}
+
+export interface TurnInterfaceContext {
+  userMessageInterface: InterfaceId;
+  assistantMessageInterface: InterfaceId;
+}


### PR DESCRIPTION
Add INTERFACE_IDS tuple, InterfaceId union type, isInterfaceId/parseInterfaceId/assertInterfaceId guard functions, and TurnInterfaceContext interface in both assistant and gateway type modules. Mirrors the existing ChannelId pattern for orthogonal interface context tracking. Part of #8611.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
