### PR TITLE
M2: Add DB schema/migration and conversation store helpers

### DIFF
--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -5,9 +5,9 @@ import { getDb, rawGet, rawExec } from './db.js';
 import { conversations, messages, toolInvocations, messageRuns, channelInboundEvents, memoryItemSources, memoryItems, memoryEmbeddings, memoryItemEntities, memorySegments, messageAttachments, llmRequestLogs } from './schema.js';
 import { getConfig } from '../config/loader.js';
 import { indexMessageNow } from './indexer.js';
-import { parseChannelId } from '../channels/types.js';
-import type { ChannelId } from '../channels/types.js';
-import { isChannelId, CHANNEL_IDS } from '../channels/types.js';
+import { parseChannelId, parseInterfaceId } from '../channels/types.js';
+import type { ChannelId, InterfaceId } from '../channels/types.js';
+import { isChannelId, CHANNEL_IDS, isInterfaceId, INTERFACE_IDS } from '../channels/types.js';
 import { getLogger } from '../util/logger.js';
 import { deleteOrphanAttachments } from './attachments-store.js';
 import { createRowMapper } from '../util/row-mapper.js';
@@ -20,6 +20,7 @@ const log = getLogger('conversation-store');
 // extra keys are allowed via passthrough so callers can attach ad-hoc data.
 
 const channelIdSchema = z.enum(CHANNEL_IDS);
+const interfaceIdSchema = z.enum(INTERFACE_IDS);
 
 const subagentNotificationSchema = z.object({
   subagentId: z.string(),
@@ -32,6 +33,8 @@ const subagentNotificationSchema = z.object({
 export const messageMetadataSchema = z.object({
   userMessageChannel: channelIdSchema.optional(),
   assistantMessageChannel: channelIdSchema.optional(),
+  userMessageInterface: interfaceIdSchema.optional(),
+  assistantMessageInterface: interfaceIdSchema.optional(),
   subagentNotification: subagentNotificationSchema.optional(),
   // Provenance fields for trust-aware memory gating (M3)
   provenanceActorRole: z.enum(['guardian', 'non-guardian', 'unverified_channel']).optional(),
@@ -73,6 +76,7 @@ export interface ConversationRow {
   source: string;
   memoryScopeId: string;
   originChannel: string | null;
+  originInterface: string | null;
 }
 
 const parseConversation = createRowMapper<typeof conversations.$inferSelect, ConversationRow>({
@@ -90,6 +94,7 @@ const parseConversation = createRowMapper<typeof conversations.$inferSelect, Con
   source: 'source',
   memoryScopeId: 'memoryScopeId',
   originChannel: 'originChannel',
+  originInterface: 'originInterface',
 });
 
 export interface MessageRow {
@@ -788,4 +793,21 @@ export function getConversationOriginChannel(conversationId: string): ChannelId 
     .where(eq(conversations.id, conversationId))
     .get();
   return parseChannelId(row?.originChannel) ?? null;
+}
+
+export function setConversationOriginInterfaceIfUnset(conversationId: string, interfaceId: InterfaceId): void {
+  const db = getDb();
+  db.update(conversations)
+    .set({ originInterface: interfaceId })
+    .where(and(eq(conversations.id, conversationId), isNull(conversations.originInterface)))
+    .run();
+}
+
+export function getConversationOriginInterface(conversationId: string): InterfaceId | null {
+  const db = getDb();
+  const row = db.select({ originInterface: conversations.originInterface })
+    .from(conversations)
+    .where(eq(conversations.id, conversationId))
+    .get();
+  return parseInterfaceId(row?.originInterface) ?? null;
 }

--- a/assistant/src/memory/migrations/021-add-origin-interface.ts
+++ b/assistant/src/memory/migrations/021-add-origin-interface.ts
@@ -1,0 +1,16 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Add the `origin_interface` text column to `conversations` — nullable,
+ * mirroring the existing `origin_channel` column.
+ *
+ * Uses ALTER TABLE ADD COLUMN which is a no-op if the column already
+ * exists (caught via try/catch, matching the existing migration pattern).
+ */
+export function migrateAddOriginInterface(database: DrizzleDb): void {
+  try {
+    database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN origin_interface TEXT`);
+  } catch {
+    // Column already exists — nothing to do.
+  }
+}

--- a/assistant/src/memory/migrations/113-late-migrations.ts
+++ b/assistant/src/memory/migrations/113-late-migrations.ts
@@ -5,6 +5,7 @@ import { migrateMemorySegmentsIndexes } from './016-memory-segments-indexes.js';
 import { migrateMemoryItemsIndexes } from './017-memory-items-indexes.js';
 import { migrateRemainingTableIndexes } from './018-remaining-table-indexes.js';
 import { migrateRenameChannelToVellum } from './020-rename-macos-ios-channel-to-vellum.js';
+import { migrateAddOriginInterface } from './021-add-origin-interface.js';
 
 /**
  * Late-stage migrations that must run after all tables and indexes exist:
@@ -17,4 +18,5 @@ export function runLateMigrations(database: DrizzleDb): void {
   migrateMemoryItemsIndexes(database);
   migrateRemainingTableIndexes(database);
   migrateRenameChannelToVellum(database);
+  migrateAddOriginInterface(database);
 }

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -24,6 +24,7 @@ export { migrateMemoryItemsIndexes } from './017-memory-items-indexes.js';
 export { migrateRemainingTableIndexes } from './018-remaining-table-indexes.js';
 export { migrateNotificationTablesSchema } from './019-notification-tables-schema-migration.js';
 export { migrateRenameChannelToVellum } from './020-rename-macos-ios-channel-to-vellum.js';
+export { migrateAddOriginInterface } from './021-add-origin-interface.js';
 export { createCoreTables } from './100-core-tables.js';
 export { createWatchersAndLogsTables } from './101-watchers-and-logs.js';
 export { addCoreColumns } from './102-alter-table-columns.js';

--- a/assistant/src/memory/schema-migration.ts
+++ b/assistant/src/memory/schema-migration.ts
@@ -23,4 +23,5 @@ export {
   migrateMemorySegmentsIndexes,
   migrateMemoryItemsIndexes,
   migrateRemainingTableIndexes,
+  migrateAddOriginInterface,
 } from './migrations/index.js';

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -15,6 +15,7 @@ export const conversations = sqliteTable('conversations', {
   source: text('source').notNull().default('user'),
   memoryScopeId: text('memory_scope_id').notNull().default('default'),
   originChannel: text('origin_channel'),
+  originInterface: text('origin_interface'),
 });
 
 export const messages = sqliteTable('messages', {


### PR DESCRIPTION
Add origin_interface column to conversations table with migration, extend messageMetadataSchema with interface fields, and add setConversationOriginInterfaceIfUnset/getConversationOriginInterface store helpers. Mirrors existing channel pattern. Part of #8611.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
