### PR TITLE
fix: resolve guardian context for outbound voice calls

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -382,20 +382,21 @@ export class RelayConnection {
     const assistantId = normalizeAssistantId(session?.assistantId ?? 'self');
     const isInbound = session?.initiatedFromConversationId == null;
 
-    // Create and attach the session-backed voice controller. For inbound voice,
-    // seed guardian actor context from caller identity + active binding so
-    // first-turn behavior matches channel ingress semantics.
-    const initialGuardianContext = isInbound
-      ? toGuardianRuntimeContext(
-        'voice',
-        resolveGuardianContext({
-          assistantId,
-          sourceChannel: 'voice',
-          externalChatId: msg.from,
-          senderExternalUserId: msg.from || undefined,
-        }),
-      )
-      : undefined;
+    // Create and attach the session-backed voice controller. Seed guardian
+    // actor context from the other party's identity + active binding so
+    // first-turn behavior matches channel ingress semantics. For inbound
+    // calls msg.from is the caller; for outbound calls msg.to is the
+    // recipient (msg.from is the assistant's Twilio number).
+    const otherPartyNumber = isInbound ? msg.from : msg.to;
+    const initialGuardianContext = toGuardianRuntimeContext(
+      'voice',
+      resolveGuardianContext({
+        assistantId,
+        sourceChannel: 'voice',
+        externalChatId: otherPartyNumber,
+        senderExternalUserId: otherPartyNumber || undefined,
+      }),
+    );
 
     const controller = new CallController(this.callSessionId, this, session?.task ?? null, {
       broadcast: globalBroadcast,


### PR DESCRIPTION
## Summary
- Outbound voice calls now resolve guardian context using the recipient's phone number (`msg.to`) instead of getting `undefined`
- Previously, outbound calls always had `guardianContext: undefined`, causing fail-closed permissions (`forceStrictSideEffects=true`, `voiceAutoDenyConfirmations=true`, `isCallerGuardian=false`)
- The fix unifies inbound/outbound guardian resolution: inbound uses `msg.from` (caller), outbound uses `msg.to` (recipient)

## Original prompt
Fix: Outbound voice calls skip guardian context resolution, treating the recipient as non-guardian even when initiated by the guardian from chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8623" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
