### PR TITLE
M3: Add session state and queue propagation plumbing

### DIFF
--- a/assistant/src/daemon/session-messaging.ts
+++ b/assistant/src/daemon/session-messaging.ts
@@ -7,8 +7,8 @@
 
 import { v4 as uuid } from 'uuid';
 import type { Message } from '../providers/types.js';
-import type { TurnChannelContext } from '../channels/types.js';
-import { parseChannelId } from '../channels/types.js';
+import type { TurnChannelContext, TurnInterfaceContext } from '../channels/types.js';
+import { parseChannelId, parseInterfaceId } from '../channels/types.js';
 import type { ServerMessage, UserMessageAttachment } from './ipc-protocol.js';
 import { createUserMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
@@ -31,6 +31,7 @@ export interface MessagingSessionContext {
   readonly queue: MessageQueue;
   guardianContext?: GuardianRuntimeContext;
   getTurnChannelContext(): TurnChannelContext | null;
+  getTurnInterfaceContext(): TurnInterfaceContext | null;
 }
 
 function extractTurnChannelContext(metadata?: Record<string, unknown>): TurnChannelContext | null {
@@ -39,6 +40,14 @@ function extractTurnChannelContext(metadata?: Record<string, unknown>): TurnChan
   const assistantMessageChannel = parseChannelId(metadata.assistantMessageChannel);
   if (!userMessageChannel || !assistantMessageChannel) return null;
   return { userMessageChannel, assistantMessageChannel };
+}
+
+function extractTurnInterfaceContext(metadata?: Record<string, unknown>): TurnInterfaceContext | null {
+  if (!metadata) return null;
+  const userMessageInterface = parseInterfaceId(metadata.userMessageInterface);
+  const assistantMessageInterface = parseInterfaceId(metadata.assistantMessageInterface);
+  if (!userMessageInterface || !assistantMessageInterface) return null;
+  return { userMessageInterface, assistantMessageInterface };
 }
 
 // ── enqueueMessage ───────────────────────────────────────────────────
@@ -58,6 +67,7 @@ export function enqueueMessage(
   }
 
   const turnChannelContext = extractTurnChannelContext(metadata) ?? ctx.getTurnChannelContext() ?? undefined;
+  const turnInterfaceContext = extractTurnInterfaceContext(metadata) ?? ctx.getTurnInterfaceContext() ?? undefined;
   const pushed = ctx.queue.push({
     content,
     attachments,
@@ -67,6 +77,7 @@ export function enqueueMessage(
     currentPage,
     metadata,
     turnChannelContext,
+    turnInterfaceContext,
     queuedAt: Date.now(),
   });
   if (!pushed) {

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -7,8 +7,8 @@
  */
 
 import type { Message } from '../providers/types.js';
-import type { TurnChannelContext } from '../channels/types.js';
-import { parseChannelId } from '../channels/types.js';
+import type { TurnChannelContext, TurnInterfaceContext } from '../channels/types.js';
+import { parseChannelId, parseInterfaceId } from '../channels/types.js';
 import type { ServerMessage, UserMessageAttachment } from './ipc-protocol.js';
 import type { GuardianRuntimeContext } from './session-runtime-assembly.js';
 import type { UsageStats } from './ipc-contract.js';
@@ -84,6 +84,8 @@ export interface ProcessSessionContext {
   ): Promise<void>;
   getTurnChannelContext(): TurnChannelContext | null;
   setTurnChannelContext(ctx: TurnChannelContext): void;
+  getTurnInterfaceContext(): TurnInterfaceContext | null;
+  setTurnInterfaceContext(ctx: TurnInterfaceContext): void;
 }
 
 function resolveQueuedTurnContext(
@@ -97,6 +99,22 @@ function resolveQueuedTurnContext(
     const assistantMessageChannel = parseChannelId(metadata.assistantMessageChannel);
     if (userMessageChannel && assistantMessageChannel) {
       return { userMessageChannel, assistantMessageChannel };
+    }
+  }
+  return fallback;
+}
+
+function resolveQueuedTurnInterfaceContext(
+  queued: { turnInterfaceContext?: TurnInterfaceContext; metadata?: Record<string, unknown> },
+  fallback: TurnInterfaceContext | null,
+): TurnInterfaceContext | null {
+  if (queued.turnInterfaceContext) return queued.turnInterfaceContext;
+  const metadata = queued.metadata;
+  if (metadata) {
+    const userMessageInterface = parseInterfaceId(metadata.userMessageInterface);
+    const assistantMessageInterface = parseInterfaceId(metadata.assistantMessageInterface);
+    if (userMessageInterface && assistantMessageInterface) {
+      return { userMessageInterface, assistantMessageInterface };
     }
   }
   return fallback;
@@ -147,6 +165,11 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
   const queuedTurnCtx = resolveQueuedTurnContext(next, session.getTurnChannelContext());
   if (queuedTurnCtx) {
     session.setTurnChannelContext(queuedTurnCtx);
+  }
+
+  const queuedInterfaceCtx = resolveQueuedTurnInterfaceContext(next, session.getTurnInterfaceContext());
+  if (queuedInterfaceCtx) {
+    session.setTurnInterfaceContext(queuedInterfaceCtx);
   }
 
   // Resolve slash commands for queued messages

--- a/assistant/src/daemon/session-queue-manager.ts
+++ b/assistant/src/daemon/session-queue-manager.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ServerMessage, UserMessageAttachment } from './ipc-protocol.js';
-import type { TurnChannelContext } from '../channels/types.js';
+import type { TurnChannelContext, TurnInterfaceContext } from '../channels/types.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('session-queue');
@@ -20,6 +20,7 @@ export interface QueuedMessage {
   currentPage?: string;
   metadata?: Record<string, unknown>;
   turnChannelContext?: TurnChannelContext;
+  turnInterfaceContext?: TurnInterfaceContext;
   /** Timestamp (ms) when the message was enqueued. */
   queuedAt: number;
 }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -16,7 +16,7 @@
  */
 
 import type { Message } from '../providers/types.js';
-import type { TurnChannelContext } from '../channels/types.js';
+import type { TurnChannelContext, TurnInterfaceContext } from '../channels/types.js';
 import type { ServerMessage, UsageStats, UserMessageAttachment, SurfaceType, SurfaceData } from './ipc-protocol.js';
 import { AgentLoop } from '../agent/loop.js';
 import type { Provider } from '../providers/types.js';
@@ -149,6 +149,7 @@ export class Session {
   public lastAssistantAttachments: AssistantAttachmentDraft[] = [];
   public lastAttachmentWarnings: string[] = [];
   /** @internal */ currentTurnChannelContext: TurnChannelContext | null = null;
+  /** @internal */ currentTurnInterfaceContext: TurnInterfaceContext | null = null;
 
   constructor(
     conversationId: string,
@@ -363,6 +364,14 @@ export class Session {
 
   getTurnChannelContext(): TurnChannelContext | null {
     return this.currentTurnChannelContext;
+  }
+
+  setTurnInterfaceContext(ctx: TurnInterfaceContext): void {
+    this.currentTurnInterfaceContext = ctx;
+  }
+
+  getTurnInterfaceContext(): TurnInterfaceContext | null {
+    return this.currentTurnInterfaceContext;
   }
 
   persistUserMessage(


### PR DESCRIPTION
Add currentTurnInterfaceContext to session state, TurnInterfaceContext to queue propagation, extractTurnInterfaceContext helper, and resolveQueuedTurnInterfaceContext helper. Mirrors existing channel context patterns. Part of #8611.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
