### PR TITLE
fix: skip ASK_GUARDIAN dispatch when caller is the guardian

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -504,58 +504,67 @@ export class CallController {
       const askMatch = responseText.match(ASK_GUARDIAN_CAPTURE_REGEX);
       if (askMatch) {
         const questionText = askMatch[1];
-        const pendingQuestion = createPendingQuestion(this.callSessionId, questionText);
-        this.state = 'waiting_on_user';
-        updateCallSession(this.callSessionId, { status: 'waiting_on_user' });
-        recordCallEvent(this.callSessionId, 'user_question_asked', { question: questionText });
 
-        // Notify the conversation that a question was asked
-        const session = getCallSession(this.callSessionId);
-        if (session) {
-          fireCallQuestionNotifier(session.conversationId, this.callSessionId, questionText);
+        if (this.isCallerGuardian()) {
+          // Caller IS the guardian — don't dispatch cross-channel.
+          // Queue an instruction so the next turn asks them directly.
+          log.info({ callSessionId: this.callSessionId }, 'Caller is guardian — skipping ASK_GUARDIAN dispatch, asking directly');
+          this.pendingInstructions.push(`You just tried to use [ASK_GUARDIAN] but the person on the phone IS your guardian. Ask them directly: "${questionText}"`);
+          // Fall through to normal turn completion (idle + flushPendingInstructions)
+        } else {
+          const pendingQuestion = createPendingQuestion(this.callSessionId, questionText);
+          this.state = 'waiting_on_user';
+          updateCallSession(this.callSessionId, { status: 'waiting_on_user' });
+          recordCallEvent(this.callSessionId, 'user_question_asked', { question: questionText });
 
-          // Dispatch guardian action request to all configured channels
-          void dispatchGuardianQuestion({
-            callSessionId: this.callSessionId,
-            conversationId: session.conversationId,
-            assistantId: this.assistantId,
-            pendingQuestion,
-            broadcast: this.broadcast,
-          });
-        }
+          // Notify the conversation that a question was asked
+          const session = getCallSession(this.callSessionId);
+          if (session) {
+            fireCallQuestionNotifier(session.conversationId, this.callSessionId, questionText);
 
-        // Set a consultation timeout
-        this.consultationTimer = setTimeout(() => {
-          if (this.state === 'waiting_on_user') {
-            log.info({ callSessionId: this.callSessionId }, 'User consultation timed out');
-            this.relay.sendTextToken(
-              'I\'m sorry, I wasn\'t able to get that information in time. Let me move on.',
-              true,
-            );
-            this.state = 'idle';
-            updateCallSession(this.callSessionId, { status: 'in_progress' });
-            expirePendingQuestions(this.callSessionId);
-
-            const hasInstructions = this.pendingInstructions.length > 0;
-            const hasUtterances = this.pendingCallerUtterances.length > 0;
-
-            if (hasInstructions && hasUtterances) {
-              // Merge both queues into a single turn to avoid the race where
-              // flushPendingInstructions fires a turn that gets aborted by
-              // drainPendingCallerUtterances, losing the instructions.
-              const instructionPrefix = this.pendingInstructions
-                .map((instr) => `[USER_INSTRUCTION: ${instr}]`)
-                .join('\n');
-              this.pendingInstructions = [];
-              this.drainPendingCallerUtterances(instructionPrefix);
-            } else if (hasInstructions) {
-              this.flushPendingInstructions();
-            } else if (hasUtterances) {
-              this.drainPendingCallerUtterances();
-            }
+            // Dispatch guardian action request to all configured channels
+            void dispatchGuardianQuestion({
+              callSessionId: this.callSessionId,
+              conversationId: session.conversationId,
+              assistantId: this.assistantId,
+              pendingQuestion,
+              broadcast: this.broadcast,
+            });
           }
-        }, getUserConsultationTimeoutMs());
-        return;
+
+          // Set a consultation timeout
+          this.consultationTimer = setTimeout(() => {
+            if (this.state === 'waiting_on_user') {
+              log.info({ callSessionId: this.callSessionId }, 'User consultation timed out');
+              this.relay.sendTextToken(
+                'I\'m sorry, I wasn\'t able to get that information in time. Let me move on.',
+                true,
+              );
+              this.state = 'idle';
+              updateCallSession(this.callSessionId, { status: 'in_progress' });
+              expirePendingQuestions(this.callSessionId);
+
+              const hasInstructions = this.pendingInstructions.length > 0;
+              const hasUtterances = this.pendingCallerUtterances.length > 0;
+
+              if (hasInstructions && hasUtterances) {
+                // Merge both queues into a single turn to avoid the race where
+                // flushPendingInstructions fires a turn that gets aborted by
+                // drainPendingCallerUtterances, losing the instructions.
+                const instructionPrefix = this.pendingInstructions
+                  .map((instr) => `[USER_INSTRUCTION: ${instr}]`)
+                  .join('\n');
+                this.pendingInstructions = [];
+                this.drainPendingCallerUtterances(instructionPrefix);
+              } else if (hasInstructions) {
+                this.flushPendingInstructions();
+              } else if (hasUtterances) {
+                this.drainPendingCallerUtterances();
+              }
+            }
+          }, getUserConsultationTimeoutMs());
+          return;
+        }
       }
 
       // Check for END_CALL marker
@@ -634,6 +643,10 @@ export class CallController {
 
   private isCurrentRun(runVersion: number): boolean {
     return runVersion === this.llmRunVersion;
+  }
+
+  private isCallerGuardian(): boolean {
+    return this.guardianContext?.actorRole === 'guardian';
   }
 
   /**

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -109,7 +109,10 @@ function buildVoiceCallControlPrompt(opts: {
     'CALL PROTOCOL RULES:',
     disclosureRule,
     '1. Be concise — keep responses to 1-3 sentences. Phone conversations should be brief and natural.',
-    '2. You can consult your guardian at any time by including [ASK_GUARDIAN: your question here] in your response. When you do, add a natural hold message like "Let me check on that for you."',
+    ...(opts.isCallerGuardian
+      ? ['2. You are speaking directly with your guardian (your user). Do NOT use [ASK_GUARDIAN:]. If you need permission, information, or confirmation, ask them directly in the conversation. They can answer you right now.']
+      : ['2. You can consult your guardian at any time by including [ASK_GUARDIAN: your question here] in your response. When you do, add a natural hold message like "Let me check on that for you."']
+    ),
   );
 
   if (opts.isInbound) {


### PR DESCRIPTION
## Summary
- **voice-session-bridge.ts**: Made rule #2 in the call-control prompt conditional on `isCallerGuardian` — when the guardian is on the call, the LLM is told to ask them directly instead of using `[ASK_GUARDIAN:]` markers.
- **call-controller.ts**: Added a safety-net guard in the `[ASK_GUARDIAN:]` handler — if the caller is the guardian, the dispatch is skipped and the question is queued as a `pendingInstruction` so the LLM asks it directly on the next turn. Added `isCallerGuardian()` helper method.

## Original prompt

### Bug: Voice LLM Uses `[ASK_GUARDIAN:]` When Speaking Directly to the Guardian

When the guardian is on the phone (either inbound or outbound), the voice LLM still emits `[ASK_GUARDIAN:]` markers to "consult" the guardian. This triggers the full guardian dispatch system (cross-channel notification to Vellum desktop, Telegram, SMS), even though the guardian is right there on the call. The correct behavior is to just ask the question directly in the voice conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
