### PR TITLE
M4: Add runtime injection block and agent loop capture

### DIFF
--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -10,6 +10,7 @@
 import { v4 as uuid } from 'uuid';
 import type { Message, ContentBlock } from '../providers/types.js';
 import type { ChannelId, TurnChannelContext, InterfaceId, TurnInterfaceContext } from '../channels/types.js';
+import { parseInterfaceId } from '../channels/types.js';
 import type { ServerMessage, UsageStats, SurfaceType, SurfaceData, DynamicPageSurfaceData } from './ipc-protocol.js';
 import type { AgentLoop, CheckpointDecision, AgentEvent } from '../agent/loop.js';
 import type { Provider } from '../providers/types.js';
@@ -165,12 +166,18 @@ export async function runAgentLoopImpl(
   })();
 
   // Capture interface context with the same anti-race snapshot pattern.
+  // When interface context is missing, derive it from the captured channel
+  // context — channel IDs like 'telegram', 'sms', 'voice' are also valid
+  // InterfaceIds, so this avoids hardcoding 'vellum' for non-vellum traffic.
   const capturedTurnInterfaceContext: TurnInterfaceContext = (() => {
     const live = ctx.getTurnInterfaceContext();
     if (live) return live;
     const origin = getConversationOriginInterface(ctx.conversationId);
     if (origin) return { userMessageInterface: origin, assistantMessageInterface: origin };
-    return { userMessageInterface: 'vellum' as InterfaceId, assistantMessageInterface: 'vellum' as InterfaceId };
+    return {
+      userMessageInterface: parseInterfaceId(capturedTurnChannelContext.userMessageChannel) ?? 'vellum' as InterfaceId,
+      assistantMessageInterface: parseInterfaceId(capturedTurnChannelContext.assistantMessageChannel) ?? 'vellum' as InterfaceId,
+    };
   })();
 
   ctx.lastAssistantAttachments = [];
@@ -328,7 +335,9 @@ export async function runAgentLoopImpl(
 
     const interfaceTurnContext: InterfaceTurnContextParams = {
       turnContext: capturedTurnInterfaceContext,
-      conversationOriginInterface: getConversationOriginInterface(ctx.conversationId),
+      conversationOriginInterface:
+        getConversationOriginInterface(ctx.conversationId)
+        ?? parseInterfaceId(getConversationOriginChannel(ctx.conversationId)),
     };
 
     runMessages = applyRuntimeInjections(runMessages, {

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -9,13 +9,13 @@
 
 import { v4 as uuid } from 'uuid';
 import type { Message, ContentBlock } from '../providers/types.js';
-import type { ChannelId, TurnChannelContext } from '../channels/types.js';
+import type { ChannelId, TurnChannelContext, InterfaceId, TurnInterfaceContext } from '../channels/types.js';
 import type { ServerMessage, UsageStats, SurfaceType, SurfaceData, DynamicPageSurfaceData } from './ipc-protocol.js';
 import type { AgentLoop, CheckpointDecision, AgentEvent } from '../agent/loop.js';
 import type { Provider } from '../providers/types.js';
 import { createAssistantMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
-import { getConversationOriginChannel, provenanceFromGuardianContext } from '../memory/conversation-store.js';
+import { getConversationOriginChannel, getConversationOriginInterface, provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import type { PermissionPrompter } from '../permissions/prompter.js';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
@@ -37,7 +37,7 @@ import {
   stripInjectedContext,
 } from './session-runtime-assembly.js';
 import { buildTemporalContext } from './date-context.js';
-import type { ActiveSurfaceContext, ChannelCapabilities, ChannelTurnContextParams, GuardianRuntimeContext } from './session-runtime-assembly.js';
+import type { ActiveSurfaceContext, ChannelCapabilities, ChannelTurnContextParams, InterfaceTurnContextParams, GuardianRuntimeContext } from './session-runtime-assembly.js';
 import {
   cleanAssistantContent,
   type AssistantAttachmentDraft,
@@ -132,6 +132,7 @@ export interface AgentLoopSessionContext {
   canHandoffAtCheckpoint(): boolean;
   drainQueue(reason: QueueDrainReason): void;
   getTurnChannelContext(): TurnChannelContext | null;
+  getTurnInterfaceContext(): TurnInterfaceContext | null;
 }
 
 // ── runAgentLoop ─────────────────────────────────────────────────────
@@ -161,6 +162,15 @@ export async function runAgentLoopImpl(
     const origin = getConversationOriginChannel(ctx.conversationId);
     if (origin) return { userMessageChannel: origin, assistantMessageChannel: origin };
     return { userMessageChannel: 'vellum' as ChannelId, assistantMessageChannel: 'vellum' as ChannelId };
+  })();
+
+  // Capture interface context with the same anti-race snapshot pattern.
+  const capturedTurnInterfaceContext: TurnInterfaceContext = (() => {
+    const live = ctx.getTurnInterfaceContext();
+    if (live) return live;
+    const origin = getConversationOriginInterface(ctx.conversationId);
+    if (origin) return { userMessageInterface: origin, assistantMessageInterface: origin };
+    return { userMessageInterface: 'vellum' as InterfaceId, assistantMessageInterface: 'vellum' as InterfaceId };
   })();
 
   ctx.lastAssistantAttachments = [];
@@ -308,12 +318,17 @@ export async function runAgentLoopImpl(
       timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     });
 
-    // Use the channel context captured at the top of this function so it
-    // reflects the channel that originally sent *this* turn's message,
-    // even if a newer message from a different channel arrived since.
+    // Use the channel/interface context captured at the top of this function
+    // so it reflects the channel/interface that originally sent *this* turn's
+    // message, even if a newer message from a different channel arrived since.
     const channelTurnContext: ChannelTurnContextParams = {
       turnContext: capturedTurnChannelContext,
       conversationOriginChannel: getConversationOriginChannel(ctx.conversationId),
+    };
+
+    const interfaceTurnContext: InterfaceTurnContextParams = {
+      turnContext: capturedTurnInterfaceContext,
+      conversationOriginInterface: getConversationOriginInterface(ctx.conversationId),
     };
 
     runMessages = applyRuntimeInjections(runMessages, {
@@ -323,6 +338,7 @@ export async function runAgentLoopImpl(
       channelCapabilities: ctx.channelCapabilities ?? null,
       channelCommandContext: ctx.commandIntent ?? null,
       channelTurnContext,
+      interfaceTurnContext,
       guardianContext: ctx.guardianContext ?? null,
       temporalContext,
       voiceCallControlPrompt: ctx.voiceCallControlPrompt ?? null,
@@ -439,6 +455,7 @@ export async function runAgentLoopImpl(
           channelCapabilities: ctx.channelCapabilities ?? null,
           channelCommandContext: ctx.commandIntent ?? null,
           channelTurnContext,
+          interfaceTurnContext,
           guardianContext: ctx.guardianContext ?? null,
           temporalContext,
           voiceCallControlPrompt: ctx.voiceCallControlPrompt ?? null,
@@ -475,6 +492,7 @@ export async function runAgentLoopImpl(
             channelCapabilities: ctx.channelCapabilities ?? null,
             channelCommandContext: ctx.commandIntent ?? null,
             channelTurnContext,
+            interfaceTurnContext,
             guardianContext: ctx.guardianContext ?? null,
             temporalContext,
             voiceCallControlPrompt: ctx.voiceCallControlPrompt ?? null,

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -5,7 +5,7 @@
  * before it is sent to the provider.  They are pure (no side effects).
  */
 
-import type { ChannelId, TurnChannelContext } from '../channels/types.js';
+import type { ChannelId, TurnChannelContext, InterfaceId, TurnInterfaceContext } from '../channels/types.js';
 import type { Message } from '../providers/types.js';
 import { listAppFiles, getAppsDir } from '../memory/app-store.js';
 import { statSync } from 'node:fs';
@@ -528,12 +528,58 @@ export function stripChannelTurnContext(messages: Message[]): Message[] {
   return stripUserTextBlocksByPrefix(messages, ['<channel_turn_context>']);
 }
 
+// ---------------------------------------------------------------------------
+// Interface turn context injection
+// ---------------------------------------------------------------------------
+
+/** Parameters for building the interface turn context block. */
+export interface InterfaceTurnContextParams {
+  turnContext: TurnInterfaceContext;
+  conversationOriginInterface: InterfaceId | null;
+}
+
+/**
+ * Build the `<interface_turn_context>` text block that informs the model
+ * which interfaces are active for the current turn and the conversation's
+ * origin interface.
+ */
+export function buildInterfaceTurnContextBlock(params: InterfaceTurnContextParams): string {
+  const { turnContext, conversationOriginInterface } = params;
+  const lines: string[] = ['<interface_turn_context>'];
+  lines.push(`user_message_interface: ${turnContext.userMessageInterface}`);
+  lines.push(`assistant_message_interface: ${turnContext.assistantMessageInterface}`);
+  lines.push(`conversation_origin_interface: ${conversationOriginInterface ?? 'unknown'}`);
+  lines.push('</interface_turn_context>');
+  return lines.join('\n');
+}
+
+/**
+ * Prepend interface turn context to the last user message so the model
+ * knows which interfaces are involved in this turn.
+ */
+export function injectInterfaceTurnContext(message: Message, params: InterfaceTurnContextParams): Message {
+  const block = buildInterfaceTurnContextBlock(params);
+  return {
+    ...message,
+    content: [
+      { type: 'text', text: block },
+      ...message.content,
+    ],
+  };
+}
+
+/** Strip `<interface_turn_context>` blocks injected by `injectInterfaceTurnContext`. */
+export function stripInterfaceTurnContext(messages: Message[]): Message[] {
+  return stripUserTextBlocksByPrefix(messages, ['<interface_turn_context>']);
+}
+
 /** Prefixes stripped by the pipeline (order doesn't matter — single pass). */
 const RUNTIME_INJECTION_PREFIXES = [
   '<channel_capabilities>',
   '<channel_command_context>',
   '<channel_turn_context>',
   '<guardian_context>',
+  '<interface_turn_context>',
   '<voice_call_control>',
   '<workspace_top_level>',
   TEMPORAL_INJECTED_PREFIX,
@@ -577,6 +623,7 @@ export function applyRuntimeInjections(
     channelCapabilities?: ChannelCapabilities | null;
     channelCommandContext?: ChannelCommandContext | null;
     channelTurnContext?: ChannelTurnContextParams | null;
+    interfaceTurnContext?: InterfaceTurnContextParams | null;
     guardianContext?: GuardianRuntimeContext | null;
     temporalContext?: string | null;
     voiceCallControlPrompt?: string | null;
@@ -640,6 +687,16 @@ export function applyRuntimeInjections(
       result = [
         ...result.slice(0, -1),
         injectChannelTurnContext(userTail, options.channelTurnContext),
+      ];
+    }
+  }
+
+  if (options.interfaceTurnContext) {
+    const userTail = result[result.length - 1];
+    if (userTail && userTail.role === 'user') {
+      result = [
+        ...result.slice(0, -1),
+        injectInterfaceTurnContext(userTail, options.interfaceTurnContext),
       ];
     }
   }


### PR DESCRIPTION
Add InterfaceTurnContextParams, buildInterfaceTurnContextBlock, injectInterfaceTurnContext, stripInterfaceTurnContext functions and integrate into applyRuntimeInjections. Capture interface context in agent loop with fallback sequence. Part of #8611.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
