### PR TITLE
Re-generate conversation titles after multiple turns

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -367,7 +367,7 @@ export function handleSessionRename(
     ctx.send(socket, { type: 'error', message: `Session ${msg.sessionId} not found` });
     return;
   }
-  conversationStore.updateConversationTitle(msg.sessionId, msg.title);
+  conversationStore.updateConversationTitle(msg.sessionId, msg.title, 0);
   ctx.send(socket, {
     type: 'session_title_updated',
     sessionId: msg.sessionId,

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -25,7 +25,7 @@ import type { ToolProfiler } from '../events/tool-profiling-listener.js';
 import type { ContextWindowManager } from '../context/window-manager.js';
 import { getHookManager } from '../hooks/manager.js';
 import { truncate } from '../util/truncate.js';
-import { isReplaceableTitle, queueGenerateConversationTitle } from '../memory/conversation-title-service.js';
+import { isReplaceableTitle, queueGenerateConversationTitle, queueRegenerateConversationTitle } from '../memory/conversation-title-service.js';
 import { stripMemoryRecallMessages } from '../memory/retriever.js';
 import { getApp, listAppFiles } from '../memory/app-store.js';
 import type { ConflictGate } from './session-conflict-gate.js';
@@ -649,6 +649,24 @@ export async function runAgentLoopImpl(
         provider: ctx.provider,
         userMessage: content,
         assistantResponse: state.firstAssistantText || undefined,
+        onTitleUpdated: (title) => {
+          onEvent({
+            type: 'session_title_updated',
+            sessionId: ctx.conversationId,
+            title,
+          });
+        },
+        signal: abortController.signal,
+      });
+    }
+
+    // Second title pass: after 3 completed turns, re-generate the title
+    // using the last 3 messages for better context. Only fires when the
+    // current title was auto-generated (isAutoTitle = 1).
+    if (ctx.turnCount === 2) { // turnCount is 0-indexed, incremented in finally; 2 = about to become 3rd turn
+      queueRegenerateConversationTitle({
+        conversationId: ctx.conversationId,
+        provider: ctx.provider,
         onTitleUpdated: (title) => {
           onEvent({
             type: 'session_title_updated',

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -73,6 +73,7 @@ export interface ConversationRow {
   source: string;
   memoryScopeId: string;
   originChannel: string | null;
+  isAutoTitle: number;
 }
 
 const parseConversation = createRowMapper<typeof conversations.$inferSelect, ConversationRow>({
@@ -90,6 +91,7 @@ const parseConversation = createRowMapper<typeof conversations.$inferSelect, Con
   source: 'source',
   memoryScopeId: 'memoryScopeId',
   originChannel: 'originChannel',
+  isAutoTitle: 'isAutoTitle',
 });
 
 export interface MessageRow {
@@ -312,10 +314,12 @@ export function getMessages(conversationId: string): MessageRow[] {
     .map(parseMessage);
 }
 
-export function updateConversationTitle(id: string, title: string): void {
+export function updateConversationTitle(id: string, title: string, isAutoTitle?: number): void {
   const db = getDb();
+  const set: Record<string, unknown> = { title, updatedAt: Date.now() };
+  if (isAutoTitle !== undefined) set.isAutoTitle = isAutoTitle;
   db.update(conversations)
-    .set({ title, updatedAt: Date.now() })
+    .set(set)
     .where(eq(conversations.id, id))
     .run();
 }

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -8,6 +8,7 @@
  */
 
 import * as conversationStore from './conversation-store.js';
+import type { MessageRow } from './conversation-store.js';
 import { getConfiguredProvider } from '../providers/provider-send-message.js';
 import { getConfig } from '../config/loader.js';
 import { truncate } from '../util/truncate.js';
@@ -110,7 +111,7 @@ export async function generateAndPersistConversationTitle(
   if (!provider) {
     // No provider available — fall back to context-derived title or untitled
     const fallback = deriveFallbackTitle(context) ?? UNTITLED_FALLBACK;
-    conversationStore.updateConversationTitle(conversationId, fallback);
+    conversationStore.updateConversationTitle(conversationId, fallback, 1);
     onTitleUpdated?.(fallback);
     return { title: fallback, updated: true };
   }
@@ -142,7 +143,7 @@ export async function generateAndPersistConversationTitle(
       return { title: current.title!, updated: false };
     }
 
-    conversationStore.updateConversationTitle(conversationId, title);
+    conversationStore.updateConversationTitle(conversationId, title, 1);
     onTitleUpdated?.(title);
     log.info({ conversationId, title }, 'Auto-generated conversation title');
     return { title, updated: true };
@@ -150,7 +151,7 @@ export async function generateAndPersistConversationTitle(
 
   // No text in response — use fallback
   const fallback = deriveFallbackTitle(context) ?? UNTITLED_FALLBACK;
-  conversationStore.updateConversationTitle(conversationId, fallback);
+  conversationStore.updateConversationTitle(conversationId, fallback, 1);
   onTitleUpdated?.(fallback);
   return { title: fallback, updated: true };
 }
@@ -179,6 +180,91 @@ export function queueGenerateConversationTitle(
     } catch {
       // Best-effort
     }
+  });
+}
+
+// ── Title regeneration (second pass) ─────────────────────────────────
+
+export interface RegenerateTitleParams {
+  conversationId: string;
+  provider?: Provider;
+  onTitleUpdated?: (title: string) => void;
+  signal?: AbortSignal;
+}
+
+/**
+ * Re-generate a conversation title using the last 3 stored messages.
+ * Only fires when the current title was auto-generated (isAutoTitle = 1).
+ * Skips if the user has manually renamed the conversation.
+ */
+export async function regenerateConversationTitle(
+  params: RegenerateTitleParams,
+): Promise<{ title: string; updated: boolean }> {
+  const { conversationId, onTitleUpdated, signal } = params;
+
+  const conversation = conversationStore.getConversation(conversationId);
+  if (!conversation || !conversation.isAutoTitle) {
+    return { title: conversation?.title ?? UNTITLED_FALLBACK, updated: false };
+  }
+
+  const provider = params.provider ?? getConfiguredProvider();
+  if (!provider) {
+    return { title: conversation.title ?? UNTITLED_FALLBACK, updated: false };
+  }
+
+  const allMessages = conversationStore.getMessages(conversationId);
+  const recentMessages = allMessages.slice(-3);
+  if (recentMessages.length === 0) {
+    return { title: conversation.title ?? UNTITLED_FALLBACK, updated: false };
+  }
+
+  const prompt = buildRegenerationPrompt(recentMessages);
+  const config = getConfig();
+  const timeoutSignal = AbortSignal.timeout(10_000);
+  const combinedSignal = signal
+    ? AbortSignal.any([signal, timeoutSignal])
+    : timeoutSignal;
+
+  const response = await provider.sendMessage(
+    [{ role: 'user', content: [{ type: 'text', text: prompt }] }],
+    [],
+    undefined,
+    { config: { max_tokens: config.daemon.titleGenerationMaxTokens }, signal: combinedSignal },
+  );
+
+  const textBlock = response.content.find((b) => b.type === 'text');
+  if (textBlock && textBlock.type === 'text') {
+    let title = normalizeTitle(textBlock.text);
+    if (!title) {
+      return { title: conversation.title ?? UNTITLED_FALLBACK, updated: false };
+    }
+
+    // Re-check isAutoTitle before persisting (race guard against manual rename)
+    const current = conversationStore.getConversation(conversationId);
+    if (!current || !current.isAutoTitle) {
+      return { title: current?.title ?? UNTITLED_FALLBACK, updated: false };
+    }
+
+    conversationStore.updateConversationTitle(conversationId, title, 1);
+    onTitleUpdated?.(title);
+    log.info({ conversationId, title }, 'Re-generated conversation title (second pass)');
+    return { title, updated: true };
+  }
+
+  return { title: conversation.title ?? UNTITLED_FALLBACK, updated: false };
+}
+
+/**
+ * Fire-and-forget wrapper for title regeneration.
+ */
+export function queueRegenerateConversationTitle(
+  params: RegenerateTitleParams,
+): void {
+  regenerateConversationTitle(params).catch((err) => {
+    log.warn(
+      { err, conversationId: params.conversationId },
+      'Failed to regenerate conversation title (non-fatal)',
+    );
   });
 }
 
@@ -228,4 +314,19 @@ function deriveFallbackTitle(context?: TitleContext): string | null {
   if (context.systemHint) return truncate(context.systemHint, 40, '');
   if (context.uxBrief) return truncate(context.uxBrief, 40, '');
   return null;
+}
+
+function buildRegenerationPrompt(recentMessages: MessageRow[]): string {
+  const parts: string[] = [
+    'Generate a very short title for this conversation based on the recent messages below. Rules: at most 5 words, at most 40 characters, no quotes.',
+    '',
+    'Recent messages:',
+  ];
+
+  for (const msg of recentMessages) {
+    const role = msg.role === 'user' ? 'User' : 'Assistant';
+    parts.push(`${role}: ${truncate(msg.content, 200, '')}`);
+  }
+
+  return parts.join('\n');
 }

--- a/assistant/src/memory/migrations/102-alter-table-columns.ts
+++ b/assistant/src/memory/migrations/102-alter-table-columns.ts
@@ -26,6 +26,7 @@ export function addCoreColumns(database: DrizzleDb): void {
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN source TEXT NOT NULL DEFAULT 'user'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN memory_scope_id TEXT NOT NULL DEFAULT 'default'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN origin_channel TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN is_auto_title INTEGER NOT NULL DEFAULT 1`); } catch { /* already exists */ }
 
   // memory_items
   try { database.run(/*sql*/ `ALTER TABLE memory_items ADD COLUMN importance REAL`); } catch { /* already exists */ }

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -15,6 +15,7 @@ export const conversations = sqliteTable('conversations', {
   source: text('source').notNull().default('user'),
   memoryScopeId: text('memory_scope_id').notNull().default('default'),
   originChannel: text('origin_channel'),
+  isAutoTitle: integer('is_auto_title').notNull().default(1),
 });
 
 export const messages = sqliteTable('messages', {


### PR DESCRIPTION
## Summary
- Add a second title generation pass after 3 completed turns, using the last 3 messages for better context instead of just the initial greeting
- Track auto-generated vs user-renamed titles via `is_auto_title` column so manual renames are never overwritten
- Add `regenerateConversationTitle()` service function with race-guard checks and fire-and-forget wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
