### PR TITLE
Switch VButton font from DM Mono to Inter

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -74,9 +74,9 @@ public struct VButton: View {
 
     private var labelFont: Font {
         switch size {
-        case .small: return VFont.monoSmall
-        case .medium: return VFont.monoBodyMedium
-        case .large: return VFont.monoMedium
+        case .small: return VFont.caption
+        case .medium: return VFont.bodyMedium
+        case .large: return VFont.cardTitle
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace DM Mono (monospaced) with Inter for all VButton label sizes
- Small: `VFont.caption` (Inter 11pt), Medium: `VFont.bodyMedium` (Inter-Medium 13pt), Large: `VFont.cardTitle` (Inter-Medium 17pt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
