### PR TITLE
fix: custom skill emoji, label, and duplicate ID validation

### DIFF
--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -317,6 +317,16 @@ function parseFrontmatter(content: string, skillFilePath: string): ParsedFrontma
     }
   }
 
+  // Read standalone emoji frontmatter field (written by buildSkillMarkdown)
+  const emojiField = fields.emoji?.trim() || undefined;
+
+  // If metadata doesn't already have an emoji, inject the standalone field value
+  if (emojiField && metadata && !metadata.emoji) {
+    metadata.emoji = emojiField;
+  } else if (emojiField && !metadata) {
+    metadata = { emoji: emojiField };
+  }
+
   const includes = parseIncludes(fields.includes, skillFilePath);
 
   return {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -943,7 +943,7 @@ struct AgentPanelContent: View {
         case "bundled":
             return "Bundled"
         case "managed":
-            return "Managed"
+            return "Custom"
         case "workspace":
             return "Workspace"
         case "clawhub":

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/NewSkillSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/NewSkillSheet.swift
@@ -202,7 +202,7 @@ struct NewSkillSheet: View {
                 }
             }
 
-            formField(label: "Skill ID", text: $skillId, placeholder: "my-skill-id")
+            formField(label: "Skill ID", text: $skillId, placeholder: "my-skill-id", error: skillIdError)
             formField(label: "Name", text: $name, placeholder: "My Skill")
             formField(label: "Description", text: $description, placeholder: "A short description")
             formField(label: "Emoji", text: $emoji, placeholder: "")
@@ -330,11 +330,21 @@ struct NewSkillSheet: View {
 
     // MARK: - Helpers
 
+    private var skillIdError: String? {
+        let trimmed = skillId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if skillsManager.skills.contains(where: { $0.id == trimmed }) {
+            return "A skill with this ID already exists"
+        }
+        return nil
+    }
+
     private var isFormValid: Bool {
         !skillId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
         !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
         !description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
-        !bodyMarkdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        !bodyMarkdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        skillIdError == nil
     }
 
     private func errorLabel(_ text: String) -> some View {
@@ -348,7 +358,7 @@ struct NewSkillSheet: View {
         }
     }
 
-    private func formField(label: String, text: Binding<String>, placeholder: String) -> some View {
+    private func formField(label: String, text: Binding<String>, placeholder: String, error: String? = nil) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
             Text(label)
                 .font(VFont.caption)
@@ -362,8 +372,11 @@ struct NewSkillSheet: View {
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.sm)
-                        .stroke(VColor.surfaceBorder, lineWidth: 1)
+                        .stroke(error != nil ? VColor.error : VColor.surfaceBorder, lineWidth: 1)
                 )
+            if let error {
+                errorLabel(error)
+            }
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
@@ -178,7 +178,7 @@ struct SkillsSettingsView: View {
                 List {
                     // Managed skills section
                     if !managedSkills.isEmpty {
-                        Section("Managed Skills") {
+                        Section("Custom Skills") {
                             ForEach(managedSkills) { skill in
                                 SkillRow(
                                     skill: skill,


### PR DESCRIPTION
## Summary
- Fixed emoji not appearing in skill list for custom skills — `buildSkillMarkdown` writes `emoji:` as a standalone frontmatter field, but `parseFrontmatter` only read it from the `metadata` JSON object. Now reads both.
- Changed "Managed" label to "Custom" for user-created skills in the agent panel and settings views
- Added inline validation on the Skill ID field in New Skill sheet that checks against existing skills and shows an error with red border when a duplicate is detected, also disabling the Create button

## Original prompt
lets add more improvements to custom new skills:
1. The emoji we set should be used in the skill list (right now it shows the default lightning bolt icon)
2. Custom skills are currently shown as "Managed" but should show as "Custom"
3. If you try to save a new skill with the same id as an existing skill, nothing happens. We should have an error snackbar or toast, or show an error validation message in the id field

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
