### PR TITLE
Change user bubble background from green to neutral dark

### DIFF
--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -160,7 +160,7 @@ public enum VColor {
     public static let warning = adaptiveColor(light: Amber._700, dark: Amber._600)
 
     // Chat
-    public static let userBubble = adaptiveColor(light: Moss._200, dark: Forest._900)
+    public static let userBubble = adaptiveColor(light: Moss._200, dark: Moss._950)
     public static let userBubbleText = adaptiveColor(light: Stone._900, dark: Moss._50)
     public static let userBubbleTextSecondary = adaptiveColor(light: Stone._600, dark: Moss._50.opacity(0.8))
 


### PR DESCRIPTION
## Summary
- Switch dark mode user bubble background from `Forest._900` (#2A3825, green) to `Moss._950` (#20201E, neutral dark matching sidebar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
