### PR TITLE
M5: Require interface on IPC and server processing paths

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -1,5 +1,5 @@
 import * as net from 'node:net';
-import { isChannelId, parseChannelId } from '../../channels/types.js';
+import { isChannelId, parseChannelId, parseInterfaceId, type InterfaceId } from '../../channels/types.js';
 import { silentlyWithLog } from '../../util/silently.js';
 import { v4 as uuid } from 'uuid';
 import * as conversationStore from '../../memory/conversation-store.js';
@@ -86,9 +86,12 @@ export async function handleUserMessage(
     });
 
     const ipcChannel = parseChannelId(msg.channel) ?? 'vellum';
+    const ipcInterfaceForQueue: InterfaceId = parseInterfaceId(msg.interface) ?? ipcChannel;
     const queuedChannelMetadata = {
       userMessageChannel: ipcChannel,
       assistantMessageChannel: ipcChannel,
+      userMessageInterface: ipcInterfaceForQueue,
+      assistantMessageInterface: ipcInterfaceForQueue,
     };
     const result = session.enqueueMessage(
       msg.content ?? '',
@@ -135,6 +138,11 @@ export async function handleUserMessage(
     session.setTurnChannelContext({
       userMessageChannel: ipcChannel,
       assistantMessageChannel: ipcChannel,
+    });
+    const ipcInterface: InterfaceId = parseInterfaceId(msg.interface) ?? ipcChannel;
+    session.setTurnInterfaceContext({
+      userMessageInterface: ipcInterface,
+      assistantMessageInterface: ipcInterface,
     });
     session.setAssistantId('self');
     // IPC/desktop user IS the guardian — default to guardian role so messages
@@ -309,6 +317,11 @@ export async function handleSessionCreate(
     session.setTurnChannelContext({
       userMessageChannel: transportChannel,
       assistantMessageChannel: transportChannel,
+    });
+    const transportInterface: InterfaceId = transportChannel;
+    session.setTurnInterfaceContext({
+      userMessageInterface: transportInterface,
+      assistantMessageInterface: transportInterface,
     });
     session.processMessage(msg.initialMessage, [], sendEvent, requestId).catch((err) => {
       const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/ipc-contract/messages.ts
+++ b/assistant/src/daemon/ipc-contract/messages.ts
@@ -1,6 +1,6 @@
 // User/assistant messages, tool results, confirmations, secrets, errors, and generation lifecycle.
 
-import type { ChannelId } from '../../channels/types.js';
+import type { ChannelId, InterfaceId } from '../../channels/types.js';
 import type { UserMessageAttachment } from './shared.js';
 
 // === Client → Server ===
@@ -17,6 +17,8 @@ export interface UserMessage {
   bypassSecretCheck?: boolean;
   /** Originating channel identifier (e.g. 'vellum'). Defaults to 'vellum' when absent. */
   channel?: ChannelId;
+  /** Originating interface identifier (e.g. 'macos'). Falls back to channel when absent. */
+  interface?: InterfaceId;
 }
 
 export interface ConfirmationResponse {

--- a/assistant/src/daemon/ipc-validate.ts
+++ b/assistant/src/daemon/ipc-validate.ts
@@ -1,4 +1,4 @@
-import { isChannelId } from '../channels/types.js';
+import { isChannelId, isInterfaceId } from '../channels/types.js';
 import type { ClientMessage } from './ipc-contract.js';
 import inventory from './ipc-contract-inventory.json' with { type: 'json' };
 
@@ -85,6 +85,9 @@ const HIGH_RISK_VALIDATORS: Record<string, PropertyValidator> = {
     }
     if (obj.channel !== undefined && !isChannelId(obj.channel)) {
       return 'user_message "channel" must be a valid channel ID when present';
+    }
+    if (obj.interface !== undefined && !isInterfaceId(obj.interface)) {
+      return 'user_message "interface" must be a valid interface ID when present';
     }
     return null;
   },

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -332,10 +332,10 @@ export async function runDaemon(): Promise<void> {
     port: httpPort,
     hostname,
     bearerToken,
-    processMessage: (conversationId, content, attachmentIds, options, sourceChannel) =>
-      server.processMessage(conversationId, content, attachmentIds, options, sourceChannel),
-    persistAndProcessMessage: (conversationId, content, attachmentIds, options, sourceChannel) =>
-      server.persistAndProcessMessage(conversationId, content, attachmentIds, options, sourceChannel),
+    processMessage: (conversationId, content, attachmentIds, options, sourceChannel, sourceInterface) =>
+      server.processMessage(conversationId, content, attachmentIds, options, sourceChannel, sourceInterface),
+    persistAndProcessMessage: (conversationId, content, attachmentIds, options, sourceChannel, sourceInterface) =>
+      server.persistAndProcessMessage(conversationId, content, attachmentIds, options, sourceChannel, sourceInterface),
     runOrchestrator,
     interfacesDir: getInterfacesDir(),
     approvalCopyGenerator: createApprovalCopyGenerator(),

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -16,7 +16,7 @@ import * as conversationStore from '../memory/conversation-store.js';
 import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import * as attachmentsStore from '../memory/attachments-store.js';
 import { Session, DEFAULT_MEMORY_POLICY, type SessionMemoryPolicy } from './session.js';
-import { parseChannelId, type ChannelId } from '../channels/types.js';
+import { parseChannelId, parseInterfaceId, type ChannelId, type InterfaceId } from '../channels/types.js';
 import { resolveChannelCapabilities } from './session-runtime-assembly.js';
 import { ComputerUseSession } from './computer-use-session.js';
 import {
@@ -70,6 +70,18 @@ function resolveTurnChannel(sourceChannel?: string, transportChannelId?: string)
     return parsed;
   }
   return 'vellum';
+}
+
+function resolveTurnInterface(sourceInterface?: string, resolvedChannel?: ChannelId): InterfaceId {
+  if (sourceInterface != null) {
+    const parsed = parseInterfaceId(sourceInterface);
+    if (!parsed) {
+      throw new Error(`Invalid sourceInterface: ${sourceInterface}`);
+    }
+    return parsed;
+  }
+  // Fall back to the resolved channel — every ChannelId is also a valid InterfaceId.
+  return resolvedChannel ?? 'vellum';
 }
 
 export class DaemonServer {
@@ -687,6 +699,7 @@ export class DaemonServer {
     attachmentIds?: string[],
     options?: SessionCreateOptions,
     sourceChannel?: string,
+    sourceInterface?: string,
   ): Promise<{ messageId: string }> {
     const ingressCheck = checkIngressForSecrets(content);
     if (ingressCheck.blocked) {
@@ -700,6 +713,7 @@ export class DaemonServer {
     }
 
     const resolvedChannel = resolveTurnChannel(sourceChannel, options?.transport?.channelId);
+    const resolvedInterface = resolveTurnInterface(sourceInterface, resolvedChannel);
     session.setAssistantId(options?.assistantId ?? 'self');
     session.setGuardianContext(options?.guardianContext ?? null);
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
@@ -707,6 +721,10 @@ export class DaemonServer {
     session.setTurnChannelContext({
       userMessageChannel: resolvedChannel,
       assistantMessageChannel: resolvedChannel,
+    });
+    session.setTurnInterfaceContext({
+      userMessageInterface: resolvedInterface,
+      assistantMessageInterface: resolvedInterface,
     });
 
     const attachments = attachmentIds
@@ -734,6 +752,7 @@ export class DaemonServer {
     attachmentIds?: string[],
     options?: SessionCreateOptions,
     sourceChannel?: string,
+    sourceInterface?: string,
   ): Promise<{ messageId: string }> {
     const ingressCheck = checkIngressForSecrets(content);
     if (ingressCheck.blocked) {
@@ -747,6 +766,7 @@ export class DaemonServer {
     }
 
     const resolvedChannel2 = resolveTurnChannel(sourceChannel, options?.transport?.channelId);
+    const resolvedInterface2 = resolveTurnInterface(sourceInterface, resolvedChannel2);
     session.setAssistantId(options?.assistantId ?? 'self');
     session.setGuardianContext(options?.guardianContext ?? null);
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel));
@@ -754,6 +774,10 @@ export class DaemonServer {
     session.setTurnChannelContext({
       userMessageChannel: resolvedChannel2,
       assistantMessageChannel: resolvedChannel2,
+    });
+    session.setTurnInterfaceContext({
+      userMessageInterface: resolvedInterface2,
+      assistantMessageInterface: resolvedInterface2,
     });
 
     const attachments = attachmentIds

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -118,6 +118,8 @@ export async function sweepFailedEvents(
           assistantId,
           guardianContext,
         },
+        sourceChannel,
+        sourceChannel, // Retry sweep: interface matches channel
       );
       channelDeliveryStore.linkMessage(event.id, userMessageId);
       channelDeliveryStore.markProcessed(event.id);

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -1,7 +1,7 @@
 /**
  * Shared types for the runtime HTTP server and its route handlers.
  */
-import type { ChannelId } from '../channels/types.js';
+import type { ChannelId, InterfaceId } from '../channels/types.js';
 import type { RunOrchestrator } from './run-orchestrator.js';
 import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
 import type { ApprovalMessageContext, ComposeApprovalMessageGenerativeOptions } from './approval-message-composer.js';
@@ -71,6 +71,7 @@ export type MessageProcessor = (
   attachmentIds?: string[],
   options?: RuntimeMessageSessionOptions,
   sourceChannel?: ChannelId,
+  sourceInterface?: InterfaceId,
 ) => Promise<{ messageId: string }>;
 
 /**
@@ -84,6 +85,7 @@ export type NonBlockingMessageProcessor = (
   attachmentIds?: string[],
   options?: RuntimeMessageSessionOptions,
   sourceChannel?: ChannelId,
+  sourceInterface?: InterfaceId,
 ) => Promise<{ messageId: string }>;
 
 /**

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -325,6 +325,7 @@ export async function handleSendMessage(
       hasAttachments ? attachmentIds : undefined,
       { guardianContext: { actorRole: 'guardian', sourceChannel } },
       sourceChannel,
+      sourceChannel, // HTTP POST /messages: interface matches channel
     );
     return Response.json({ accepted: true, messageId: result.messageId }, { status: 202 });
   } catch (err) {

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -842,6 +842,7 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
           ...(cmdIntent ? { commandIntent: cmdIntent } : {}),
         },
         sourceChannel,
+        sourceChannel, // Channel inbound: interface matches channel
       );
       channelDeliveryStore.linkMessage(eventId, userMessageId);
       channelDeliveryStore.markProcessed(eventId);

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -5295,8 +5295,15 @@ public struct IPCUserMessage: Codable, Sendable {
     public let bypassSecretCheck: Bool?
     /// Originating channel identifier (e.g. 'vellum'). Defaults to 'vellum' when absent.
     public let channel: String?
+    /// Originating interface identifier (e.g. 'macos'). Falls back to channel when absent.
+    public let interface_: String?
 
-    public init(type: String, sessionId: String, content: String? = nil, attachments: [IPCUserMessageAttachment]? = nil, activeSurfaceId: String? = nil, currentPage: String? = nil, bypassSecretCheck: Bool? = nil, channel: String? = nil) {
+    enum CodingKeys: String, CodingKey {
+        case type, sessionId, content, attachments, activeSurfaceId, currentPage, bypassSecretCheck, channel
+        case interface_ = "interface"
+    }
+
+    public init(type: String, sessionId: String, content: String? = nil, attachments: [IPCUserMessageAttachment]? = nil, activeSurfaceId: String? = nil, currentPage: String? = nil, bypassSecretCheck: Bool? = nil, channel: String? = nil, interface_: String? = nil) {
         self.type = type
         self.sessionId = sessionId
         self.content = content
@@ -5305,6 +5312,7 @@ public struct IPCUserMessage: Codable, Sendable {
         self.currentPage = currentPage
         self.bypassSecretCheck = bypassSecretCheck
         self.channel = channel
+        self.interface_ = interface_
     }
 }
 


### PR DESCRIPTION
Add interface field to IPC user_message contract, validate in ipc-validate, set turn interface context in session handlers, and thread through server processMessage/persistAndProcessMessage. Updates Swift IPC contract. Part of #8611.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
