### PR TITLE
fix: handle title generation edge cases (stuck placeholder, race condition, missing IPC queue)

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -28,7 +28,7 @@ import type {
   ConversationSearchRequest,
 } from '../ipc-protocol.js';
 import { getConfig } from '../../config/loader.js';
-import { GENERATING_TITLE } from '../../memory/conversation-title-service.js';
+import { GENERATING_TITLE, queueGenerateConversationTitle, isReplaceableTitle, UNTITLED_FALLBACK } from '../../memory/conversation-title-service.js';
 import { getSubagentManager } from '../../subagent/index.js';
 import {
   log,
@@ -302,6 +302,26 @@ export async function handleSessionCreate(
 
   // Auto-send the initial message if provided, kick-starting the skill.
   if (msg.initialMessage) {
+    // Queue title generation immediately (matches all other creation paths).
+    // The agent loop success path will also attempt title generation, but
+    // queueGenerateConversationTitle is safe to call redundantly — the
+    // replaceability check prevents double-writes. This ensures the title
+    // is generated even if the agent loop fails or is cancelled.
+    if (title === GENERATING_TITLE) {
+      queueGenerateConversationTitle({
+        conversationId: conversation.id,
+        context: { origin: 'ipc' },
+        userMessage: msg.initialMessage,
+        onTitleUpdated: (newTitle) => {
+          ctx.send(socket, {
+            type: 'session_title_updated',
+            sessionId: conversation.id,
+            title: newTitle,
+          });
+        },
+      });
+    }
+
     ctx.socketToSession.set(socket, conversation.id);
     const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
     const requestId = uuid();
@@ -314,6 +334,23 @@ export async function handleSessionCreate(
       const message = err instanceof Error ? err.message : String(err);
       log.error({ err, sessionId: conversation.id }, 'Error processing initial message');
       ctx.send(socket, { type: 'error', message: `Failed to process initial message: ${message}` });
+
+      // Replace stuck loading placeholder with a stable fallback title
+      // if title generation hasn't already completed or been renamed.
+      try {
+        const current = conversationStore.getConversation(conversation.id);
+        if (current && current.title === GENERATING_TITLE) {
+          const fallback = UNTITLED_FALLBACK;
+          conversationStore.updateConversationTitle(conversation.id, fallback);
+          ctx.send(socket, {
+            type: 'session_title_updated',
+            sessionId: conversation.id,
+            title: fallback,
+          });
+        }
+      } catch {
+        // Best-effort fallback
+      }
     });
   }
 }

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -150,6 +150,15 @@ export async function generateAndPersistConversationTitle(
   }
 
   // No text in response — use fallback
+  // Re-check replaceability before persisting (race guard — same as the
+  // text-response path above). A concurrent custom rename may have landed
+  // while the LLM request was in-flight; writing unconditionally would
+  // clobber the user's intent.
+  const currentForFallback = conversationStore.getConversation(conversationId);
+  if (currentForFallback && !isReplaceableTitle(currentForFallback.title)) {
+    return { title: currentForFallback.title!, updated: false };
+  }
+
   const fallback = deriveFallbackTitle(context) ?? UNTITLED_FALLBACK;
   conversationStore.updateConversationTitle(conversationId, fallback, 1);
   onTitleUpdated?.(fallback);


### PR DESCRIPTION
Addresses review feedback from PR #8542:
- Add fallback title on agent loop failure to prevent permanent 'Generating title...' state
- Re-check title replaceability before fallback writes to prevent race condition with concurrent renames
- Add queueGenerateConversationTitle call in handleSessionCreate for IPC sessions with initialMessage
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
