### PR TITLE
fix: preserve legacy macos/ios channel parsing and update stale references

### DIFF
--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -8,15 +8,26 @@ export function isChannelId(value: unknown): value is ChannelId {
   return typeof value === 'string' && (CHANNEL_IDS as readonly string[]).includes(value);
 }
 
+/** Legacy channel IDs that were renamed but may still arrive from pre-rename clients. */
+const LEGACY_CHANNEL_ALIASES: Record<string, ChannelId> = {
+  macos: 'vellum',
+  ios: 'vellum',
+};
+
 export function parseChannelId(value: unknown): ChannelId | null {
-  return isChannelId(value) ? value : null;
+  if (isChannelId(value)) return value;
+  if (typeof value === 'string' && value in LEGACY_CHANNEL_ALIASES) {
+    return LEGACY_CHANNEL_ALIASES[value]!;
+  }
+  return null;
 }
 
 export function assertChannelId(value: unknown, field: string): ChannelId {
-  if (!isChannelId(value)) {
+  const parsed = parseChannelId(value);
+  if (parsed === null) {
     throw new Error(`Invalid channel ID for ${field}: ${String(value)}. Valid values: ${CHANNEL_IDS.join(', ')}`);
   }
-  return value;
+  return parsed;
 }
 
 export interface TurnChannelContext {

--- a/assistant/src/notifications/preference-extractor.ts
+++ b/assistant/src/notifications/preference-extractor.ts
@@ -41,7 +41,7 @@ Notification preferences are statements about HOW, WHEN, or WHERE the user wants
 - "Use Telegram for urgent alerts"
 - "Don't notify me on desktop during work calls"
 - "Weeknights after 10pm: only critical notifications"
-- "Send me everything on macOS"
+- "Send me everything on the desktop app"
 - "Only bug me for high priority stuff"
 - "Mute notifications between 11pm and 7am"
 - "I prefer Telegram over desktop notifications"
@@ -91,7 +91,7 @@ const EXTRACTION_TOOL = {
                 channels: {
                   type: 'array',
                   items: { type: 'string' },
-                  description: 'Channels this preference applies to (e.g. telegram, macos)',
+                  description: 'Channels this preference applies to (e.g. telegram, vellum)',
                 },
                 urgencyLevels: {
                   type: 'array',


### PR DESCRIPTION
Addresses review feedback from PR #8591:
- Keep 'macos' and 'ios' parseable in parseChannelId, mapping them to 'vellum' so pre-rename clients still work
- Update LLM tool description in preference-extractor.ts to reference 'vellum' instead of 'macos'
- Update stale 'macos' reference in preferences-store.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
