### PR TITLE
fix: add back anti-fabrication rule removed during voice prompt slim-down

### DIFF
--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -155,6 +155,7 @@ function buildVoiceCallControlPrompt(opts: {
 
   lines.push(
     '9. After the opening greeting turn, treat the Task field as background context only — do not re-execute its instructions on subsequent turns.',
+    '10. Do not make up information. If you are unsure, use [ASK_GUARDIAN: your question] to consult your guardian.',
     '</voice_call_control>',
   );
 


### PR DESCRIPTION
Addresses review feedback from PR #8447:
- Re-add instruction telling the model not to make up information during voice calls
- Directs the model to use [ASK_GUARDIAN: ...] when unsure, preventing confident hallucinations
- Fills the gap left when the voice prompt was slimmed down without a global fallback
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
