### PR TITLE
M6: Require interface on HTTP/runs/inbound ingress

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1,7 +1,8 @@
 /**
  * Route handlers for conversation messages and suggestions.
  */
-import { CHANNEL_IDS, parseChannelId } from '../../channels/types.js';
+import { CHANNEL_IDS, INTERFACE_IDS, parseChannelId, parseInterfaceId } from '../../channels/types.js';
+import type { InterfaceId } from '../../channels/types.js';
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import {
@@ -211,6 +212,7 @@ export async function handleSendMessage(
     content?: string;
     attachmentIds?: string[];
     sourceChannel?: string;
+    interface?: string;
   };
 
   const { conversationKey, content, attachmentIds } = body;
@@ -225,6 +227,21 @@ export async function handleSendMessage(
   if (!sourceChannel) {
     return Response.json(
       { error: `Invalid sourceChannel: ${body.sourceChannel}. Valid values: ${CHANNEL_IDS.join(', ')}` },
+      { status: 400 },
+    );
+  }
+
+  if (!body.interface || typeof body.interface !== 'string') {
+    return Response.json(
+      { error: 'interface is required' },
+      { status: 400 },
+    );
+  }
+  const sourceInterface: InterfaceId | null = parseInterfaceId(body.interface);
+
+  if (!sourceInterface) {
+    return Response.json(
+      { error: `Invalid interface: ${body.interface}. Valid values: ${INTERFACE_IDS.join(', ')}` },
       { status: 400 },
     );
   }
@@ -290,6 +307,14 @@ export async function handleSendMessage(
         attachments,
         onEvent,
         requestId,
+        undefined, // activeSurfaceId
+        undefined, // currentPage
+        {
+          userMessageChannel: sourceChannel,
+          assistantMessageChannel: sourceChannel,
+          userMessageInterface: sourceInterface,
+          assistantMessageInterface: sourceInterface,
+        },
       );
       if (result.rejected) {
         return Response.json(
@@ -301,6 +326,10 @@ export async function handleSendMessage(
     }
 
     // Session is idle — persist and fire agent loop immediately
+    session.setTurnInterfaceContext({
+      userMessageInterface: sourceInterface,
+      assistantMessageInterface: sourceInterface,
+    });
     const requestId = crypto.randomUUID();
     const messageId = session.persistUserMessage(content ?? '', attachments, requestId);
 
@@ -325,7 +354,7 @@ export async function handleSendMessage(
       hasAttachments ? attachmentIds : undefined,
       { guardianContext: { actorRole: 'guardian', sourceChannel } },
       sourceChannel,
-      sourceChannel, // HTTP POST /messages: interface matches channel
+      sourceInterface,
     );
     return Response.json({ accepted: true, messageId: result.messageId }, { status: 202 });
   } catch (err) {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -231,19 +231,22 @@ export async function handleSendMessage(
     );
   }
 
-  if (!body.interface || typeof body.interface !== 'string') {
-    return Response.json(
-      { error: 'interface is required' },
-      { status: 400 },
-    );
-  }
-  const sourceInterface: InterfaceId | null = parseInterfaceId(body.interface);
-
-  if (!sourceInterface) {
-    return Response.json(
-      { error: `Invalid interface: ${body.interface}. Valid values: ${INTERFACE_IDS.join(', ')}` },
-      { status: 400 },
-    );
+  // When `interface` is missing, fall back to deriving from sourceChannel
+  // (then to 'vellum') for backward compatibility with HTTP clients that
+  // don't send it yet (e.g. HTTPDaemonClient.swift before M8). Only reject
+  // when an explicit but invalid value is provided.
+  let sourceInterface: InterfaceId;
+  if (body.interface == null || body.interface === '') {
+    sourceInterface = parseInterfaceId(sourceChannel) ?? 'vellum';
+  } else {
+    const parsed = parseInterfaceId(body.interface);
+    if (!parsed) {
+      return Response.json(
+        { error: `Invalid interface: ${body.interface}. Valid values: ${INTERFACE_IDS.join(', ')}` },
+        { status: 400 },
+      );
+    }
+    sourceInterface = parsed;
   }
 
   if (!conversationKey) {

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -3,7 +3,7 @@
  * messages from all channels. Handles ingress ACL, edits, guardian
  * verification, guardian action answers, and approval interception.
  */
-import { isChannelId, CHANNEL_IDS, parseInterfaceId } from '../../channels/types.js';
+import { isChannelId, CHANNEL_IDS, INTERFACE_IDS, parseInterfaceId } from '../../channels/types.js';
 import type { ChannelId, InterfaceId } from '../../channels/types.js';
 import * as conversationStore from '../../memory/conversation-store.js';
 import * as attachmentsStore from '../../memory/attachments-store.js';
@@ -127,7 +127,21 @@ export async function handleChannelInbound(
 
   // Validate and narrow the interface field. Fall back to sourceChannel for
   // backward compatibility with gateway versions that don't send `interface`.
-  const sourceInterface: InterfaceId = parseInterfaceId(body.interface) ?? sourceChannel;
+  // When an explicit but invalid value is provided, reject with 400 to
+  // surface protocol regressions rather than silently masking them.
+  let sourceInterface: InterfaceId;
+  if (body.interface == null || body.interface === '') {
+    sourceInterface = sourceChannel;
+  } else {
+    const parsed = parseInterfaceId(body.interface);
+    if (!parsed) {
+      return Response.json(
+        { error: `Invalid interface: ${body.interface}. Valid values: ${INTERFACE_IDS.join(', ')}` },
+        { status: 400 },
+      );
+    }
+    sourceInterface = parsed;
+  }
 
   if (!externalChatId || typeof externalChatId !== 'string') {
     return Response.json({ error: 'externalChatId is required' }, { status: 400 });

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -3,8 +3,8 @@
  * messages from all channels. Handles ingress ACL, edits, guardian
  * verification, guardian action answers, and approval interception.
  */
-import { isChannelId, CHANNEL_IDS } from '../../channels/types.js';
-import type { ChannelId } from '../../channels/types.js';
+import { isChannelId, CHANNEL_IDS, parseInterfaceId } from '../../channels/types.js';
+import type { ChannelId, InterfaceId } from '../../channels/types.js';
 import * as conversationStore from '../../memory/conversation-store.js';
 import * as attachmentsStore from '../../memory/attachments-store.js';
 import * as channelDeliveryStore from '../../memory/channel-delivery-store.js';
@@ -87,6 +87,7 @@ export async function handleChannelInbound(
 
   const body = await req.json() as {
     sourceChannel?: string;
+    interface?: string;
     externalChatId?: string;
     externalMessageId?: string;
     content?: string;
@@ -123,6 +124,11 @@ export async function handleChannelInbound(
   }
 
   const sourceChannel = body.sourceChannel;
+
+  // Validate and narrow the interface field. Fall back to sourceChannel for
+  // backward compatibility with gateway versions that don't send `interface`.
+  const sourceInterface: InterfaceId = parseInterfaceId(body.interface) ?? sourceChannel;
+
   if (!externalChatId || typeof externalChatId !== 'string') {
     return Response.json({ error: 'externalChatId is required' }, { status: 400 });
   }
@@ -741,6 +747,7 @@ export async function handleChannelInbound(
         attachmentIds: hasAttachments ? attachmentIds : undefined,
         externalChatId,
         sourceChannel,
+        sourceInterface,
         replyCallbackUrl,
         bearerToken,
         guardianCtx,
@@ -761,6 +768,7 @@ export async function handleChannelInbound(
         content: content ?? '',
         attachmentIds: hasAttachments ? attachmentIds : undefined,
         sourceChannel,
+        sourceInterface,
         externalChatId,
         guardianCtx,
         metadataHints,
@@ -792,6 +800,7 @@ interface BackgroundProcessingParams {
   content: string;
   attachmentIds?: string[];
   sourceChannel: ChannelId;
+  sourceInterface: InterfaceId;
   externalChatId: string;
   guardianCtx: GuardianContext;
   metadataHints: string[];
@@ -811,6 +820,7 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
     content,
     attachmentIds,
     sourceChannel,
+    sourceInterface,
     externalChatId,
     guardianCtx,
     metadataHints,
@@ -842,7 +852,7 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
           ...(cmdIntent ? { commandIntent: cmdIntent } : {}),
         },
         sourceChannel,
-        sourceChannel, // Channel inbound: interface matches channel
+        sourceInterface,
       );
       channelDeliveryStore.linkMessage(eventId, userMessageId);
       channelDeliveryStore.markProcessed(eventId);
@@ -875,6 +885,7 @@ interface ApprovalProcessingParams {
   attachmentIds?: string[];
   externalChatId: string;
   sourceChannel: ChannelId;
+  sourceInterface: InterfaceId;
   replyCallbackUrl: string;
   bearerToken?: string;
   guardianCtx: GuardianContext;
@@ -907,6 +918,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
     attachmentIds,
     externalChatId,
     sourceChannel,
+    sourceInterface,
     replyCallbackUrl,
     bearerToken,
     guardianCtx,
@@ -939,6 +951,7 @@ function processChannelMessageWithApprovals(params: ApprovalProcessingParams): v
         {
           ...((isNonGuardian || isUnverifiedChannel) ? { forceStrictSideEffects: true } : {}),
           sourceChannel,
+          sourceInterface,
           hints: metadataHints.length > 0 ? metadataHints : undefined,
           uxBrief: metadataUxBrief,
           assistantId,

--- a/assistant/src/runtime/routes/run-routes.ts
+++ b/assistant/src/runtime/routes/run-routes.ts
@@ -4,7 +4,7 @@
 import { getOrCreateConversation } from '../../memory/conversation-key-store.js';
 import * as attachmentsStore from '../../memory/attachments-store.js';
 import * as runsStore from '../../memory/runs-store.js';
-import { CHANNEL_IDS, parseChannelId } from '../../channels/types.js';
+import { CHANNEL_IDS, INTERFACE_IDS, parseChannelId, parseInterfaceId } from '../../channels/types.js';
 import { addRule } from '../../permissions/trust-store.js';
 import { getTool } from '../../tools/registry.js';
 import { getLogger } from '../../util/logger.js';
@@ -21,6 +21,7 @@ export async function handleCreateRun(
     content?: string;
     attachmentIds?: string[];
     sourceChannel?: string;
+    interface?: string;
   };
 
   const { conversationKey, content, attachmentIds } = body;
@@ -32,6 +33,18 @@ export async function handleCreateRun(
   if (!sourceChannel) {
     return Response.json(
       { error: `Invalid sourceChannel: ${body.sourceChannel}. Valid values: ${CHANNEL_IDS.join(', ')}` },
+      { status: 400 },
+    );
+  }
+
+  if (!body.interface || typeof body.interface !== 'string') {
+    return Response.json({ error: 'interface is required' }, { status: 400 });
+  }
+  const sourceInterface = parseInterfaceId(body.interface);
+
+  if (!sourceInterface) {
+    return Response.json(
+      { error: `Invalid interface: ${body.interface}. Valid values: ${INTERFACE_IDS.join(', ')}` },
       { status: 400 },
     );
   }
@@ -70,7 +83,7 @@ export async function handleCreateRun(
       mapping.conversationId,
       content ?? '',
       hasAttachments ? attachmentIds : undefined,
-      { sourceChannel },
+      { sourceChannel, sourceInterface },
     );
     return Response.json({
       id: run.id,

--- a/assistant/src/runtime/routes/run-routes.ts
+++ b/assistant/src/runtime/routes/run-routes.ts
@@ -37,16 +37,22 @@ export async function handleCreateRun(
     );
   }
 
-  if (!body.interface || typeof body.interface !== 'string') {
-    return Response.json({ error: 'interface is required' }, { status: 400 });
-  }
-  const sourceInterface = parseInterfaceId(body.interface);
-
-  if (!sourceInterface) {
-    return Response.json(
-      { error: `Invalid interface: ${body.interface}. Valid values: ${INTERFACE_IDS.join(', ')}` },
-      { status: 400 },
-    );
+  // When `interface` is missing, fall back to deriving from sourceChannel
+  // (then to 'vellum') for backward compatibility with HTTP clients that
+  // don't send it yet (e.g. HTTPDaemonClient.swift before M8). Only reject
+  // when an explicit but invalid value is provided.
+  let sourceInterface: import('../../channels/types.js').InterfaceId;
+  if (body.interface == null || body.interface === '') {
+    sourceInterface = parseInterfaceId(sourceChannel) ?? 'vellum';
+  } else {
+    const parsed = parseInterfaceId(body.interface);
+    if (!parsed) {
+      return Response.json(
+        { error: `Invalid interface: ${body.interface}. Valid values: ${INTERFACE_IDS.join(', ')}` },
+        { status: 400 },
+      );
+    }
+    sourceInterface = parsed;
   }
 
   if (!conversationKey) {

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -13,8 +13,8 @@
  * status and submit a decision or secret via the respective endpoints.
  */
 
-import type { ChannelId, TurnChannelContext } from '../channels/types.js';
-import { parseChannelId } from '../channels/types.js';
+import type { ChannelId, InterfaceId, TurnChannelContext, TurnInterfaceContext } from '../channels/types.js';
+import { parseChannelId, parseInterfaceId } from '../channels/types.js';
 import * as runsStore from '../memory/runs-store.js';
 import type { Run } from '../memory/runs-store.js';
 import type { Session } from '../daemon/session.js';
@@ -97,6 +97,12 @@ export interface RunStartOptions {
    * default 'vellum'.
    */
   sourceChannel?: ChannelId;
+  /**
+   * The originating interface (e.g. 'macos', 'ios', 'telegram'). When
+   * provided, the session's turn interface context is set to this value
+   * so interface-aware metadata flows through the agent loop.
+   */
+  sourceInterface?: InterfaceId;
   /**
    * Transport hints from sourceMetadata (e.g. reply-context cues).
    * Forwarded to the session so the agent loop can incorporate them.
@@ -229,6 +235,12 @@ export class RunOrchestrator {
     session.setTurnChannelContext(options?.turnChannelContext ?? {
       userMessageChannel: parseChannelId(options?.sourceChannel) ?? 'vellum',
       assistantMessageChannel: parseChannelId(options?.sourceChannel) ?? 'vellum',
+    });
+    const resolvedInterface = parseInterfaceId(options?.sourceInterface)
+      ?? parseInterfaceId(options?.sourceChannel) ?? ('vellum' as InterfaceId);
+    session.setTurnInterfaceContext({
+      userMessageInterface: resolvedInterface,
+      assistantMessageInterface: resolvedInterface,
     });
 
     const attachments = attachmentIds
@@ -376,6 +388,12 @@ export class RunOrchestrator {
       session.setCommandIntent(null);
       session.setAssistantId('self');
       session.setVoiceCallControlPrompt(null);
+      // Reset turn interface context so a subsequent IPC/desktop session on the
+      // same conversation is not incorrectly treated as an HTTP-API interface.
+      session.setTurnInterfaceContext({
+        userMessageInterface: 'vellum' as InterfaceId,
+        assistantMessageInterface: 'vellum' as InterfaceId,
+      });
       // Reset the session's client callback to a no-op so the stale
       // closure doesn't intercept events from future runs on the same session.
       // Set hasNoClient=true here since the run is done and no HTTP caller


### PR DESCRIPTION
Add interface field to /v1/messages, /v1/runs, and channel inbound request bodies. Thread sourceInterface through run orchestrator and message processors. Ensure queue/idle path parity for interface metadata. Part of #8611.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
