### PR TITLE
feat: enrich inbound call title generation with guardian context and timestamp

### DIFF
--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -33,6 +33,7 @@ import { getOrCreateConversation } from '../memory/conversation-key-store.js';
 import { queueGenerateConversationTitle } from '../memory/conversation-title-service.js';
 import { upsertBinding } from '../memory/external-conversation-store.js';
 import { addPointerMessage } from './call-pointer-messages.js';
+import { isGuardian } from '../runtime/channel-guardian-service.js';
 
 const log = getLogger('call-domain');
 
@@ -237,6 +238,12 @@ export function createInboundVoiceSession(
   updateCallSession(session.id, { providerCallSid: callSid });
   session.providerCallSid = callSid;
 
+  const callerIsGuardian = isGuardian(assistantId, 'voice', fromNumber);
+  const metadataHints: string[] = [
+    callerIsGuardian ? 'Caller is the guardian' : 'Caller is not the guardian (external caller)',
+    `Timestamp: ${new Date().toLocaleString('en-US', { weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}`,
+  ];
+
   queueGenerateConversationTitle({
     conversationId: voiceConversationId,
     context: {
@@ -244,6 +251,7 @@ export function createInboundVoiceSession(
       sourceChannel: 'voice',
       assistantId,
       systemHint: `Inbound call from ${fromNumber}`,
+      metadataHints,
     },
   });
 
@@ -338,6 +346,9 @@ export async function startCall(input: StartCallInput): Promise<StartCallResult 
         assistantId,
         systemHint: `Outbound call to ${phoneNumber}`,
         triggerTextSnippet: task,
+        metadataHints: [
+          `Timestamp: ${new Date().toLocaleString('en-US', { weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}`,
+        ],
       },
     });
 


### PR DESCRIPTION
## Summary
- Pass guardian context (caller is/isn't the guardian) and timestamp as metadata hints to the title generation LLM for inbound voice calls, enabling more distinctive titles instead of repeated "Inbound Call From Hawaii"
- Also add timestamp hint to outbound call title generation for consistency
- No prompt changes — just additional context via existing `metadataHints` field

## Original prompt
for conversation title generation, we should pass in more context so that we can produce better titles for inbound phone calls (see screenshot showing redundant bad titles). We should pass guardian context (so the llm knows whether the conversation was initiated by their guardian or someone else) as well as timestamp, so that the llm can include the day if it chooses to. We don't need to make forceful prompt udpates – simply include a bit more context

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
