### PR TITLE
fix: use Equatable conformance for ConfirmationSurfaceData identity (PR #8426)

### DIFF
--- a/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
@@ -36,11 +36,6 @@ public struct ConfirmationSurfaceView: View {
         return "confirm"
     }
 
-    /// Composite identity for detecting data changes from surface updates.
-    private var dataIdentity: String {
-        "\(data.message)|\(data.detail ?? "")|\(data.confirmLabel ?? "")|\(data.cancelLabel ?? "")|\(data.destructive)"
-    }
-
     public var body: some View {
         Group {
             if let selectedAction {
@@ -49,7 +44,7 @@ public struct ConfirmationSurfaceView: View {
                 pendingContent
             }
         }
-        .onChange(of: dataIdentity) { _, _ in
+        .onChange(of: data) { _, _ in
             selectedAction = nil
         }
     }

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -188,7 +188,7 @@ public struct ListSurfaceData: Sendable {
     }
 }
 
-public struct ConfirmationSurfaceData: Sendable {
+public struct ConfirmationSurfaceData: Sendable, Equatable {
     public let message: String
     public let detail: String?
     public let confirmLabel: String?


### PR DESCRIPTION
Both Codex and Devin flagged a separator collision issue in the dataIdentity computed property added in PR #8426. The | separator could cause two different ConfirmationSurfaceData values to produce the same identity string, preventing onChange from firing. Fix: make ConfirmationSurfaceData conform to Equatable and use onChange(of: data) directly instead of the string-based identity hack.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
