### PR TITLE
Add send_notification tool for unified notifications

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4684,6 +4684,7 @@ Producer → NotificationSignal → Decision Engine (LLM) → Deterministic Chec
 | `assistant/src/notifications/adapters/` | Per-channel delivery (macOS IPC, Telegram gateway) |
 | `assistant/src/notifications/preference-extractor.ts` | Detects preference statements in conversation messages |
 | `assistant/src/notifications/preferences-store.ts` | CRUD for user notification preferences |
+| `assistant/src/config/bundled-skills/messaging/tools/send-notification.ts` | Explicit producer tool for user-requested notifications; emits signals into the same routing pipeline |
 
 **Audit trail (SQLite):** `notification_events` → `notification_decisions` → `notification_deliveries`
 

--- a/assistant/src/__tests__/gmail-integration.test.ts
+++ b/assistant/src/__tests__/gmail-integration.test.ts
@@ -27,6 +27,7 @@ describe('Messaging tool contract', () => {
     'messaging_read',
     'messaging_search',
     'messaging_send',
+    'send_notification',
     'messaging_reply',
     'messaging_mark_read',
     'messaging_analyze_activity',

--- a/assistant/src/__tests__/send-notification-tool.test.ts
+++ b/assistant/src/__tests__/send-notification-tool.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const emitNotificationSignalMock = mock(async (_params: unknown) => {});
+const getConfigMock = mock(() => ({
+  notifications: {
+    enabled: true,
+    shadowMode: false,
+  },
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => getConfigMock() as any,
+}));
+
+mock.module('../notifications/emit-signal.js', () => ({
+  emitNotificationSignal: (params: unknown) => emitNotificationSignalMock(params),
+}));
+
+import { run } from '../config/bundled-skills/messaging/tools/send-notification.js';
+
+describe('send-notification tool', () => {
+  beforeEach(() => {
+    emitNotificationSignalMock.mockClear();
+    getConfigMock.mockClear();
+    getConfigMock.mockReturnValue({
+      notifications: {
+        enabled: true,
+        shadowMode: false,
+      },
+    });
+  });
+
+  test('emits a notification signal with normalized routing context', async () => {
+    const result = await run(
+      {
+        message: 'Your verification code is 123456',
+        title: 'Verification code',
+        urgency: 'high',
+        requires_action: true,
+        preferred_channels: ['vellum'],
+        deep_link_metadata: { conversationId: 'conv-deeplink' },
+        dedupe_key: 'voice-code-123456',
+      },
+      {
+        workingDir: '/tmp',
+        sessionId: 'sess-1',
+        conversationId: 'conv-1',
+        assistantId: 'ast-alpha',
+      },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(emitNotificationSignalMock).toHaveBeenCalledTimes(1);
+    expect(emitNotificationSignalMock).toHaveBeenCalledWith({
+      sourceEventName: 'user.send_notification',
+      sourceChannel: 'assistant_tool',
+      sourceSessionId: 'conv-1',
+      assistantId: 'ast-alpha',
+      attentionHints: {
+        requiresAction: true,
+        urgency: 'high',
+        deadlineAt: undefined,
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
+      contextPayload: {
+        requestedMessage: 'Your verification code is 123456',
+        requestedByTool: 'send_notification',
+        requestedBySessionId: 'sess-1',
+        requestedTitle: 'Verification code',
+        requestedByConversationId: 'conv-1',
+        preferredChannels: ['vellum'],
+        deepLinkMetadata: { conversationId: 'conv-deeplink' },
+      },
+      dedupeKey: 'voice-code-123456',
+    });
+  });
+
+  test('returns an error when notifications are disabled', async () => {
+    getConfigMock.mockReturnValue({
+      notifications: {
+        enabled: false,
+        shadowMode: false,
+      },
+    });
+
+    const result = await run(
+      { message: 'test notification' },
+      {
+        workingDir: '/tmp',
+        sessionId: 'sess-1',
+        conversationId: 'conv-1',
+        assistantId: 'ast-alpha',
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('disabled');
+    expect(emitNotificationSignalMock).not.toHaveBeenCalled();
+  });
+
+  test('returns an error when notifications are in shadow mode', async () => {
+    getConfigMock.mockReturnValue({
+      notifications: {
+        enabled: true,
+        shadowMode: true,
+      },
+    });
+
+    const result = await run(
+      { message: 'test notification' },
+      {
+        workingDir: '/tmp',
+        sessionId: 'sess-1',
+        conversationId: 'conv-1',
+        assistantId: 'ast-alpha',
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('shadow mode');
+    expect(emitNotificationSignalMock).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/__tests__/send-notification-tool.test.ts
+++ b/assistant/src/__tests__/send-notification-tool.test.ts
@@ -36,6 +36,7 @@ describe('send-notification tool', () => {
         message: 'Your verification code is 123456',
         title: 'Verification code',
         urgency: 'high',
+        conversation_id: 'conv-override',
         requires_action: true,
         preferred_channels: ['vellum'],
         deep_link_metadata: { conversationId: 'conv-deeplink' },
@@ -54,7 +55,7 @@ describe('send-notification tool', () => {
     expect(emitNotificationSignalMock).toHaveBeenCalledWith({
       sourceEventName: 'user.send_notification',
       sourceChannel: 'assistant_tool',
-      sourceSessionId: 'conv-1',
+      sourceSessionId: 'conv-override',
       assistantId: 'ast-alpha',
       attentionHints: {
         requiresAction: true,
@@ -68,11 +69,12 @@ describe('send-notification tool', () => {
         requestedByTool: 'send_notification',
         requestedBySessionId: 'sess-1',
         requestedTitle: 'Verification code',
-        requestedByConversationId: 'conv-1',
+        requestedByConversationId: 'conv-override',
         preferredChannels: ['vellum'],
         deepLinkMetadata: { conversationId: 'conv-deeplink' },
       },
       dedupeKey: 'voice-code-123456',
+      throwOnError: true,
     });
   });
 
@@ -120,5 +122,25 @@ describe('send-notification tool', () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain('shadow mode');
     expect(emitNotificationSignalMock).not.toHaveBeenCalled();
+  });
+
+  test('returns an error when the notification pipeline throws', async () => {
+    emitNotificationSignalMock.mockImplementationOnce(async () => {
+      throw new Error('database unavailable');
+    });
+
+    const result = await run(
+      { message: 'test notification' },
+      {
+        workingDir: '/tmp',
+        sessionId: 'sess-1',
+        conversationId: 'conv-1',
+        assistantId: 'ast-alpha',
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('database unavailable');
+    expect(emitNotificationSignalMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/assistant/src/__tests__/session-surfaces-task-progress.test.ts
+++ b/assistant/src/__tests__/session-surfaces-task-progress.test.ts
@@ -32,6 +32,36 @@ function makeContext(sent: ServerMessage[] = []): SurfaceSessionContext {
 }
 
 describe('task_progress surface compatibility', () => {
+  test('blocks ui_show when channel lacks dynamic UI support', async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+    ctx.channelCapabilities = { channel: 'voice', supportsDynamicUi: false };
+
+    const result = await surfaceProxyResolver(ctx, 'ui_show', {
+      surface_type: 'card',
+      data: { title: 'Blocked', body: 'blocked' },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('ui_show is unavailable on channel "voice"');
+    expect(sent).toHaveLength(0);
+  });
+
+  test('blocks ui_update when channel lacks dynamic UI support', async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+    ctx.channelCapabilities = { channel: 'telegram', supportsDynamicUi: false };
+
+    const result = await surfaceProxyResolver(ctx, 'ui_update', {
+      surface_id: 'surface-1',
+      data: { status: 'completed' },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('ui_update is unavailable on channel "telegram"');
+    expect(sent).toHaveLength(0);
+  });
+
   test('ui_show maps legacy top-level task_progress fields into card data', async () => {
     const sent: ServerMessage[] = [];
     const ctx = makeContext(sent);

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -75,6 +75,7 @@ The sms-setup skill also includes optional **guardian verification** for SMS (in
 - **Read Messages**: Read message history from a conversation
 - **Search**: Search messages with platform-appropriate query syntax
 - **Send**: Send a message (high risk — requires user approval)
+- **Send Notification**: Trigger a user notification through the unified notification router (medium risk)
 - **Reply**: Reply in a thread (medium risk)
 - **Mark Read**: Mark conversation as read
 
@@ -153,6 +154,12 @@ When searching Gmail, the query uses Gmail's search operators:
 - Default to drafting (local draft or Gmail native draft) when the user wants to compose.
 - Only send when the user explicitly requests it.
 - When uncertain, always default to drafting.
+
+## Notifications vs Messages
+
+- Use `send_notification` when the user asks for an alert/notification (for example "send this as a desktop notification").
+- Use `messaging_send` when the user asks to send a message into a specific chat/email/SMS destination.
+- `send_notification` channel routing is LLM-driven; `preferred_channels` are hints, not hard channel forcing.
 
 ## Personalized Drafting
 

--- a/assistant/src/config/bundled-skills/messaging/TOOLS.json
+++ b/assistant/src/config/bundled-skills/messaging/TOOLS.json
@@ -91,6 +91,37 @@
       "execution_target": "host"
     },
     {
+      "name": "send_notification",
+      "description": "Send a notification through the unified notification router. The router decides channels/copy from preferences and urgency hints. Include a confidence score (0-1).",
+      "category": "messaging",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message": { "type": "string", "description": "Notification message the user should receive" },
+          "title": { "type": "string", "description": "Optional notification title" },
+          "urgency": { "type": "string", "enum": ["low", "medium", "high"], "description": "Urgency hint (default: \"medium\")" },
+          "requires_action": { "type": "boolean", "description": "Whether the notification expects user action (default: true)" },
+          "is_async_background": { "type": "boolean", "description": "Whether the event is asynchronous/background work (default: false)" },
+          "visible_in_source_now": { "type": "boolean", "description": "Set true when user is already viewing the source context (default: false)" },
+          "deadline_at": { "type": "number", "description": "Optional deadline timestamp in epoch milliseconds" },
+          "preferred_channels": {
+            "type": "array",
+            "items": { "type": "string", "enum": ["vellum", "telegram"] },
+            "description": "Optional routing hints for preferred channels (not deterministic)"
+          },
+          "conversation_id": { "type": "string", "description": "Optional source conversation/session ID for notification context" },
+          "source_event_name": { "type": "string", "description": "Optional event name for audit and dedupe grouping (default: \"user.send_notification\")" },
+          "deep_link_metadata": { "type": "object", "description": "Optional metadata clients can use for deep linking" },
+          "dedupe_key": { "type": "string", "description": "Optional dedupe key to suppress duplicate notifications" },
+          "confidence": { "type": "number", "description": "Confidence score (0-1) for this action" }
+        },
+        "required": ["message", "confidence"]
+      },
+      "executor": "tools/send-notification.ts",
+      "execution_target": "host"
+    },
+    {
       "name": "messaging_reply",
       "description": "Reply in a thread. Medium-risk action. Include a confidence score (0-1).",
       "category": "messaging",

--- a/assistant/src/config/bundled-skills/messaging/tools/send-notification.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/send-notification.ts
@@ -1,0 +1,122 @@
+import { getConfig } from '../../../../config/loader.js';
+import { emitNotificationSignal } from '../../../../notifications/emit-signal.js';
+import type { AttentionHints } from '../../../../notifications/signal.js';
+import type { NotificationChannel } from '../../../../notifications/types.js';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { err, ok } from './shared.js';
+
+const VALID_URGENCY = new Set<AttentionHints['urgency']>(['low', 'medium', 'high']);
+const VALID_CHANNEL_HINTS = new Set<NotificationChannel>(['vellum', 'telegram']);
+
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseBool(value: unknown, defaultValue: boolean): boolean {
+  return typeof value === 'boolean' ? value : defaultValue;
+}
+
+function parseDeadlineAt(value: unknown): number | undefined | null {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'number' && Number.isFinite(value)) return Math.trunc(value);
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return Math.trunc(parsed);
+  }
+  return null;
+}
+
+function parseObject(value: unknown): Record<string, unknown> | undefined | null {
+  if (value === undefined) return undefined;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function parsePreferredChannels(value: unknown): NotificationChannel[] | undefined | null {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) return null;
+
+  const channels: NotificationChannel[] = [];
+  for (const item of value) {
+    if (typeof item !== 'string' || !VALID_CHANNEL_HINTS.has(item as NotificationChannel)) {
+      return null;
+    }
+    channels.push(item as NotificationChannel);
+  }
+  return [...new Set(channels)];
+}
+
+export async function run(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+  const message = asNonEmptyString(input.message);
+  if (!message) {
+    return err('message is required.');
+  }
+
+  const urgencyInput = asNonEmptyString(input.urgency)?.toLowerCase();
+  if (urgencyInput && !VALID_URGENCY.has(urgencyInput as AttentionHints['urgency'])) {
+    return err('urgency must be one of: low, medium, high.');
+  }
+  const urgency = (urgencyInput as AttentionHints['urgency'] | undefined) ?? 'medium';
+
+  const deadlineAt = parseDeadlineAt(input.deadline_at);
+  if (deadlineAt === null) {
+    return err('deadline_at must be a valid epoch timestamp (milliseconds).');
+  }
+
+  const deepLinkMetadata = parseObject(input.deep_link_metadata);
+  if (deepLinkMetadata === null) {
+    return err('deep_link_metadata must be an object.');
+  }
+
+  const preferredChannels = parsePreferredChannels(input.preferred_channels);
+  if (preferredChannels === null) {
+    return err('preferred_channels must be an array containing only "vellum" or "telegram".');
+  }
+
+  const config = getConfig();
+  if (!config.notifications?.enabled) {
+    return err('Notifications are disabled. Set notifications.enabled=true to deliver notifications.');
+  }
+  if (config.notifications.shadowMode) {
+    return err('Notifications are in shadow mode. Set notifications.shadowMode=false to deliver notifications.');
+  }
+
+  const sourceEventName = asNonEmptyString(input.source_event_name) ?? 'user.send_notification';
+  const sourceSessionId = asNonEmptyString(input.conversation_id) ?? context.conversationId ?? context.sessionId;
+  const title = asNonEmptyString(input.title);
+  const dedupeKey = asNonEmptyString(input.dedupe_key);
+
+  const contextPayload: Record<string, unknown> = {
+    requestedMessage: message,
+    requestedByTool: 'send_notification',
+    requestedBySessionId: context.sessionId,
+  };
+  if (title) contextPayload.requestedTitle = title;
+  if (context.conversationId) contextPayload.requestedByConversationId = context.conversationId;
+  if (preferredChannels && preferredChannels.length > 0) contextPayload.preferredChannels = preferredChannels;
+  if (deepLinkMetadata) contextPayload.deepLinkMetadata = deepLinkMetadata;
+
+  try {
+    await emitNotificationSignal({
+      sourceEventName,
+      sourceChannel: 'assistant_tool',
+      sourceSessionId,
+      assistantId: context.assistantId,
+      attentionHints: {
+        requiresAction: parseBool(input.requires_action, true),
+        urgency,
+        deadlineAt,
+        isAsyncBackground: parseBool(input.is_async_background, false),
+        visibleInSourceNow: parseBool(input.visible_in_source_now, false),
+      },
+      contextPayload,
+      dedupeKey,
+    });
+
+    return ok('Notification request queued. Channel selection and delivery are handled by the notification router.');
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/messaging/tools/send-notification.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/send-notification.ts
@@ -84,7 +84,8 @@ export async function run(input: Record<string, unknown>, context: ToolContext):
   }
 
   const sourceEventName = asNonEmptyString(input.source_event_name) ?? 'user.send_notification';
-  const sourceSessionId = asNonEmptyString(input.conversation_id) ?? context.conversationId ?? context.sessionId;
+  const requestedConversationId = asNonEmptyString(input.conversation_id) ?? context.conversationId;
+  const sourceSessionId = requestedConversationId ?? context.sessionId;
   const title = asNonEmptyString(input.title);
   const dedupeKey = asNonEmptyString(input.dedupe_key);
 
@@ -94,7 +95,7 @@ export async function run(input: Record<string, unknown>, context: ToolContext):
     requestedBySessionId: context.sessionId,
   };
   if (title) contextPayload.requestedTitle = title;
-  if (context.conversationId) contextPayload.requestedByConversationId = context.conversationId;
+  if (requestedConversationId) contextPayload.requestedByConversationId = requestedConversationId;
   if (preferredChannels && preferredChannels.length > 0) contextPayload.preferredChannels = preferredChannels;
   if (deepLinkMetadata) contextPayload.deepLinkMetadata = deepLinkMetadata;
 
@@ -113,6 +114,7 @@ export async function run(input: Record<string, unknown>, context: ToolContext):
       },
       contextPayload,
       dedupeKey,
+      throwOnError: true,
     });
 
     return ok('Notification request queued. Channel selection and delivery are handled by the notification router.');

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -96,6 +96,7 @@ import * as messagingListConversations from './bundled-skills/messaging/tools/me
 import * as messagingRead from './bundled-skills/messaging/tools/messaging-read.js';
 import * as messagingSearch from './bundled-skills/messaging/tools/messaging-search.js';
 import * as messagingSend from './bundled-skills/messaging/tools/messaging-send.js';
+import * as sendNotification from './bundled-skills/messaging/tools/send-notification.js';
 import * as messagingReply from './bundled-skills/messaging/tools/messaging-reply.js';
 import * as messagingMarkRead from './bundled-skills/messaging/tools/messaging-mark-read.js';
 import * as slackAddReaction from './bundled-skills/messaging/tools/slack-add-reaction.js';
@@ -245,6 +246,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ['messaging:tools/messaging-read.ts', messagingRead],
   ['messaging:tools/messaging-search.ts', messagingSearch],
   ['messaging:tools/messaging-send.ts', messagingSend],
+  ['messaging:tools/send-notification.ts', sendNotification],
   ['messaging:tools/messaging-reply.ts', messagingReply],
   ['messaging:tools/messaging-mark-read.ts', messagingMarkRead],
   ['messaging:tools/slack-add-reaction.ts', slackAddReaction],

--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -94,6 +94,10 @@ function normalizeTaskProgressCardPatch(existingCard: CardSurfaceData, patch: Re
  */
 export interface SurfaceSessionContext {
   readonly conversationId: string;
+  readonly channelCapabilities?: {
+    channel: string;
+    supportsDynamicUi: boolean;
+  };
   readonly traceEmitter: {
     emit(type: string, message: string, meta?: Record<string, unknown>): void;
   };
@@ -509,6 +513,20 @@ export async function surfaceProxyResolver(
   toolName: string,
   input: Record<string, unknown>,
 ): Promise<ToolExecutionResult> {
+  if (toolName === 'ui_show' || toolName === 'ui_update') {
+    const caps = ctx.channelCapabilities;
+    if (caps && !caps.supportsDynamicUi) {
+      log.info(
+        { toolName, channel: caps.channel, conversationId: ctx.conversationId },
+        'Blocked UI surface tool on channel without dynamic UI support',
+      );
+      return {
+        content: `${toolName} is unavailable on channel "${caps.channel}" because this channel cannot render dynamic UI surfaces. Use text responses or a messaging/notification tool instead.`,
+        isError: true,
+      };
+    }
+  }
+
   if (toolName === 'request_file') {
     const surfaceId = uuid();
     const prompt = typeof input.prompt === 'string' ? input.prompt : 'Please share a file';

--- a/assistant/src/notifications/README.md
+++ b/assistant/src/notifications/README.md
@@ -83,7 +83,7 @@ await emitNotificationSignal({
 
 3. Optionally add a fallback copy template in `copy-composer.ts` keyed by your `sourceEventName`. Without a template, the generic fallback produces a human-readable version of the event name.
 
-The call is fire-and-forget safe -- errors are caught and logged internally.
+The call is fire-and-forget safe by default -- errors are caught and logged internally unless you pass `throwOnError: true`.
 
 ## Audit Trail
 

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -5,8 +5,8 @@
  * and runs it through the decision engine + deterministic checks + dispatch
  * pipeline.
  *
- * Designed for fire-and-forget usage: errors are logged but never propagated
- * to the caller. The returned promise resolves even on failure.
+ * Designed for fire-and-forget usage by default: errors are logged and not
+ * propagated unless `throwOnError` is enabled.
  */
 
 import { v4 as uuid } from 'uuid';
@@ -89,14 +89,19 @@ export interface EmitSignalParams {
   contextPayload?: Record<string, unknown>;
   /** Optional deduplication key. */
   dedupeKey?: string;
+  /**
+   * When true, rethrow pipeline errors to the caller instead of only logging.
+   * Useful for direct user-invoked actions that must fail closed.
+   */
+  throwOnError?: boolean;
 }
 
 /**
  * Emit a notification signal through the full pipeline:
  * createEvent -> evaluateSignal -> runDeterministicChecks -> dispatchDecision.
  *
- * Fire-and-forget safe: all errors are caught and logged. The caller
- * should not await this in critical paths unless it needs the result.
+ * Fire-and-forget safe by default: errors are caught and logged unless
+ * `throwOnError` is enabled by the caller.
  */
 export async function emitNotificationSignal(params: EmitSignalParams): Promise<void> {
   const config = getConfig();
@@ -187,5 +192,8 @@ export async function emitNotificationSignal(params: EmitSignalParams): Promise<
       { err: errMsg, signalId, sourceEventName: params.sourceEventName },
       'Signal pipeline failed',
     );
+    if (params.throwOnError) {
+      throw err instanceof Error ? err : new Error(errMsg);
+    }
   }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -1,6 +1,7 @@
 import AppKit
 import UserNotifications
 import CoreText
+import VellumAssistantShared
 import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AppDelegate+Notifications")
@@ -84,7 +85,95 @@ extension AppDelegate {
             options: []
         )
 
-        center.setNotificationCategories([activityCategory, toolConfirmationCategory, rideShotgunCategory, voiceResponseCategory, guardianRequestCategory])
+        let viewNotificationIntentAction = UNNotificationAction(
+            identifier: "VIEW_NOTIFICATION_INTENT",
+            title: "View",
+            options: [.foreground]
+        )
+        let notificationIntentCategory = UNNotificationCategory(
+            identifier: "NOTIFICATION_INTENT",
+            actions: [viewNotificationIntentAction],
+            intentIdentifiers: [],
+            options: []
+        )
+
+        center.setNotificationCategories([
+            activityCategory,
+            toolConfirmationCategory,
+            rideShotgunCategory,
+            voiceResponseCategory,
+            guardianRequestCategory,
+            notificationIntentCategory,
+        ])
+    }
+
+    private func normalizeNotificationUserInfoValue(_ value: Any?) -> Any? {
+        switch value {
+        case nil:
+            return nil
+        case let v as String:
+            return v
+        case let v as Int:
+            return v
+        case let v as Double:
+            return v
+        case let v as Bool:
+            return v
+        case let v as [Any]:
+            return v.compactMap { normalizeNotificationUserInfoValue($0) }
+        case let v as [Any?]:
+            return v.compactMap { normalizeNotificationUserInfoValue($0) }
+        case let v as [String: Any]:
+            var out: [String: Any] = [:]
+            for (k, item) in v {
+                if let normalized = normalizeNotificationUserInfoValue(item) {
+                    out[k] = normalized
+                }
+            }
+            return out
+        case let v as [String: Any?]:
+            var out: [String: Any] = [:]
+            for (k, item) in v {
+                if let normalized = normalizeNotificationUserInfoValue(item) {
+                    out[k] = normalized
+                }
+            }
+            return out
+        default:
+            guard let value else { return nil }
+            return String(describing: value)
+        }
+    }
+
+    func deliverNotificationIntent(_ msg: NotificationIntentMessage) {
+        let content = UNMutableNotificationContent()
+        content.title = msg.title
+        content.body = msg.body
+        content.sound = .default
+        content.categoryIdentifier = "NOTIFICATION_INTENT"
+
+        var userInfo: [String: Any] = [
+            "sourceEventName": msg.sourceEventName,
+        ]
+        if let metadata = msg.deepLinkMetadata {
+            for (key, wrapped) in metadata {
+                if let normalized = normalizeNotificationUserInfoValue(wrapped.value) {
+                    userInfo[key] = normalized
+                }
+            }
+        }
+        content.userInfo = userInfo
+
+        let request = UNNotificationRequest(
+            identifier: "notification-intent-\(UUID().uuidString)",
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error {
+                log.error("Failed to post notification intent: \(error.localizedDescription)")
+            }
+        }
     }
 
     func registerBundledFonts() {
@@ -166,6 +255,21 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             await MainActor.run {
                 guard !self.isAwaitingFirstLaunchReady else { return }
                 self.openConversationThread(conversationId: conversationId)
+            }
+            return
+        }
+
+        if categoryId == "NOTIFICATION_INTENT" {
+            let conversationId =
+                response.notification.request.content.userInfo["conversationId"] as? String ??
+                response.notification.request.content.userInfo["conversation_id"] as? String
+            await MainActor.run {
+                guard !self.isAwaitingFirstLaunchReady else { return }
+                if let conversationId {
+                    self.openConversationThread(conversationId: conversationId)
+                } else {
+                    self.showMainWindow()
+                }
             }
             return
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -157,6 +157,10 @@ extension AppDelegate {
         ]
         if let metadata = msg.deepLinkMetadata {
             for (key, wrapped) in metadata {
+                // Keep sourceEventName authoritative from the daemon envelope.
+                if key == "sourceEventName" {
+                    continue
+                }
                 if let normalized = normalizeNotificationUserInfoValue(wrapped.value) {
                     userInfo[key] = normalized
                 }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -732,6 +732,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        daemonClient.onNotificationIntent = { [weak self] msg in
+            self?.deliverNotificationIntent(msg)
+        }
+
         // Handle open_bundle_response from the daemon
         daemonClient.onOpenBundleResponse = { [weak self] response in
             guard let self else { return }


### PR DESCRIPTION
## Summary
- add a new bundled messaging tool `send_notification` that emits `emitNotificationSignal` into the unified cross-channel notification pipeline
- keep channel selection LLM-routed (with optional `preferred_channels` hints), and return explicit tool errors when notifications are disabled or shadow mode is enabled
- register the new tool in messaging `TOOLS.json`, bundled tool registry, and messaging skill guidance
- wire macOS AppDelegate to handle `notification_intent` IPC messages by posting native notifications and handling click-through deep links (`conversationId` / `conversation_id`)
- add a hard runtime guard in `surfaceProxyResolver` that blocks `ui_show` and `ui_update` on channels without dynamic UI support (`supportsDynamicUi=false`)
- prevent deep-link metadata from overriding reserved `sourceEventName` in native notification payload assembly
- document the new notification producer path in `ARCHITECTURE.md`

## Testing
- `cd assistant && bun test src/__tests__/send-notification-tool.test.ts`
- `cd assistant && bun test src/__tests__/gmail-integration.test.ts`
- `cd assistant && bun test src/__tests__/session-surfaces-task-progress.test.ts`
- `cd clients && swift test --filter DaemonClientProbeTests`

## Notes
- full `cd assistant && bunx tsc --noEmit` currently fails due pre-existing unrelated TypeScript errors in:
  - `src/__tests__/ipc-snapshot.test.ts`
  - `src/config/schema.ts`
  - `src/daemon/handlers/config-inbox.ts`