### PR TITLE
M7: Persist interface metadata on all message writes

### DIFF
--- a/assistant/src/calls/call-conversation-messages.ts
+++ b/assistant/src/calls/call-conversation-messages.ts
@@ -27,7 +27,7 @@ export function persistCallCompletionMessage(conversationId: string, callSession
     conversationId,
     'assistant',
     JSON.stringify([{ type: 'text', text: summaryText }]),
-    { userMessageChannel: 'voice', assistantMessageChannel: 'voice' },
+    { userMessageChannel: 'voice', assistantMessageChannel: 'voice', userMessageInterface: 'voice', assistantMessageInterface: 'voice' },
   );
   return summaryText;
 }

--- a/assistant/src/calls/call-pointer-messages.ts
+++ b/assistant/src/calls/call-pointer-messages.ts
@@ -37,7 +37,7 @@ export function addPointerMessage(
     conversationId,
     'assistant',
     JSON.stringify([{ type: 'text', text }]),
-    { userMessageChannel: 'voice', assistantMessageChannel: 'voice' },
+    { userMessageChannel: 'voice', assistantMessageChannel: 'voice', userMessageInterface: 'voice', assistantMessageInterface: 'voice' },
   );
 }
 

--- a/assistant/src/calls/guardian-action-sweep.ts
+++ b/assistant/src/calls/guardian-action-sweep.ts
@@ -59,7 +59,7 @@ export function sweepExpiredGuardianActions(
           delivery.destinationConversationId,
           'assistant',
           JSON.stringify([{ type: 'text', text: 'This guardian question has expired without a response.' }]),
-          { userMessageChannel: 'voice', assistantMessageChannel: 'vellum' },
+          { userMessageChannel: 'voice', assistantMessageChannel: 'vellum', userMessageInterface: 'voice', assistantMessageInterface: 'vellum' },
         );
       } else if (delivery.destinationChatId) {
         // External channel — send expiry notice

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -174,7 +174,7 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
           macConversationId,
           'assistant',
           JSON.stringify([{ type: 'text', text: guardianCopy.initialMessage }]),
-          { userMessageChannel: 'voice', assistantMessageChannel: 'vellum' },
+          { userMessageChannel: 'voice', assistantMessageChannel: 'vellum', userMessageInterface: 'voice', assistantMessageInterface: 'vellum' },
         );
 
         // Emit IPC event for the vellum client with the server-created conversation

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -458,7 +458,7 @@ export class RelayConnection {
         session.initiatedFromConversationId,
         'assistant',
         JSON.stringify([{ type: 'text', text: codeMsg }]),
-        { userMessageChannel: 'voice', assistantMessageChannel: 'voice' },
+        { userMessageChannel: 'voice', assistantMessageChannel: 'voice', userMessageInterface: 'voice', assistantMessageInterface: 'voice' },
       );
     }
 
@@ -722,7 +722,7 @@ export class RelayConnection {
           session.conversationId,
           'user',
           JSON.stringify([{ type: 'text', text: msg.voicePrompt }]),
-          { userMessageChannel: 'voice', assistantMessageChannel: 'voice' },
+          { userMessageChannel: 'voice', assistantMessageChannel: 'voice', userMessageInterface: 'voice', assistantMessageInterface: 'voice' },
         );
       }
       this.sendTextToken('I\'m still setting up. Please hold.', true);

--- a/assistant/src/config/vellum-skills/chatgpt-import/tools/chatgpt-import.ts
+++ b/assistant/src/config/vellum-skills/chatgpt-import/tools/chatgpt-import.ts
@@ -103,6 +103,8 @@ export async function run(
     const importChannelMetadata = {
       userMessageChannel: 'vellum',
       assistantMessageChannel: 'vellum',
+      userMessageInterface: 'vellum',
+      assistantMessageInterface: 'vellum',
     } as const;
 
     for (const msg of conv.messages) {

--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -1,7 +1,7 @@
 import * as net from 'node:net';
 import type { IngressInviteRequest, IngressMemberRequest, AssistantInboxEscalationRequest, AssistantInboxReplyRequest } from '../ipc-protocol.js';
 import type { ChannelId } from '../../channels/types.js';
-import { isChannelId } from '../../channels/types.js';
+import { isChannelId, isInterfaceId } from '../../channels/types.js';
 import { log, defineHandlers, type HandlerContext } from './shared.js';
 import {
   createInvite,
@@ -402,6 +402,13 @@ async function executeApprove(
       userMessageChannel: sourceChannel,
       assistantMessageChannel: sourceChannel,
     });
+    const sourceInterface = isInterfaceId(sourceChannel) ? sourceChannel : undefined;
+    if (sourceInterface) {
+      session.setTurnInterfaceContext({
+        userMessageInterface: sourceInterface,
+        assistantMessageInterface: sourceInterface,
+      });
+    }
   }
   session.setAssistantId(assistantId);
   // Daemon inbox handler — the guardian approved this escalation, so tag as
@@ -481,10 +488,12 @@ async function executeDeny(
   }, bearerToken);
 
   // Store a system note about the denial in the conversation
+  const denialInterface = isInterfaceId(sourceChannel) ? sourceChannel : undefined;
   addMessage(conversationId, 'assistant', denialText, {
     provenanceActorRole: 'guardian' as const,
     userMessageChannel: sourceChannel,
     assistantMessageChannel: sourceChannel,
+    ...(denialInterface ? { userMessageInterface: denialInterface, assistantMessageInterface: denialInterface } : {}),
   });
   updateThreadActivity(conversationId, 'outbound');
 
@@ -513,6 +522,7 @@ export function handleAssistantInboxReply(
 
     // Store the reply as an assistant message
     const bindingChannel = isChannelId(binding.sourceChannel) ? binding.sourceChannel : null;
+    const bindingInterface = isInterfaceId(binding.sourceChannel) ? binding.sourceChannel : null;
     const message = addMessage(
       conversationId,
       'assistant',
@@ -521,6 +531,9 @@ export function handleAssistantInboxReply(
         provenanceActorRole: 'guardian' as const,
         ...(bindingChannel
           ? { userMessageChannel: bindingChannel, assistantMessageChannel: bindingChannel }
+          : {}),
+        ...(bindingInterface
+          ? { userMessageInterface: bindingInterface, assistantMessageInterface: bindingInterface }
           : {}),
       },
     );

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -793,11 +793,15 @@ export class DaemonServer {
 
     if (slashResult.kind === 'unknown') {
       const serverTurnCtx = session.getTurnChannelContext();
+      const serverInterfaceCtx = session.getTurnInterfaceContext();
       const serverProvenance = provenanceFromGuardianContext(session.guardianContext);
       const serverChannelMeta = {
         ...serverProvenance,
         ...(serverTurnCtx
           ? { userMessageChannel: serverTurnCtx.userMessageChannel, assistantMessageChannel: serverTurnCtx.assistantMessageChannel }
+          : {}),
+        ...(serverInterfaceCtx
+          ? { userMessageInterface: serverInterfaceCtx.userMessageInterface, assistantMessageInterface: serverInterfaceCtx.assistantMessageInterface }
           : {}),
       };
       const userMsg = createUserMessage(content, attachments);
@@ -814,6 +818,13 @@ export class DaemonServer {
           conversationStore.setConversationOriginChannelIfUnset(conversationId, serverTurnCtx.userMessageChannel);
         } catch (err) {
           log.warn({ err, conversationId }, 'Failed to set origin channel (best-effort)');
+        }
+      }
+      if (serverInterfaceCtx) {
+        try {
+          conversationStore.setConversationOriginInterfaceIfUnset(conversationId, serverInterfaceCtx.userMessageInterface);
+        } catch (err) {
+          log.warn({ err, conversationId }, 'Failed to set origin interface (best-effort)');
         }
       }
 

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -8,7 +8,7 @@
 
 import type pino from 'pino';
 import type { ContentBlock, ImageContent } from '../providers/types.js';
-import type { TurnChannelContext } from '../channels/types.js';
+import type { TurnChannelContext, TurnInterfaceContext } from '../channels/types.js';
 import type { ServerMessage } from './ipc-protocol.js';
 import type { AgentEvent } from '../agent/loop.js';
 import type { AgentLoopSessionContext } from './session-agent-loop.js';
@@ -60,6 +60,7 @@ export interface EventHandlerDeps {
   readonly shouldGenerateTitle: boolean;
   readonly rlog: pino.Logger;
   readonly turnChannelContext: TurnChannelContext;
+  readonly turnInterfaceContext: TurnInterfaceContext;
 }
 
 // ── Factory ──────────────────────────────────────────────────────────
@@ -281,6 +282,8 @@ export function handleMessageComplete(
       ...provenanceFromGuardianContext(deps.ctx.guardianContext),
       userMessageChannel: deps.turnChannelContext.userMessageChannel,
       assistantMessageChannel: deps.turnChannelContext.assistantMessageChannel,
+      userMessageInterface: deps.turnInterfaceContext.userMessageInterface,
+      assistantMessageInterface: deps.turnInterfaceContext.assistantMessageInterface,
     };
     conversationStore.addMessage(
       deps.ctx.conversationId,
@@ -324,6 +327,8 @@ export function handleMessageComplete(
     ...provenanceFromGuardianContext(deps.ctx.guardianContext),
     userMessageChannel: deps.turnChannelContext.userMessageChannel,
     assistantMessageChannel: deps.turnChannelContext.assistantMessageChannel,
+    userMessageInterface: deps.turnInterfaceContext.userMessageInterface,
+    assistantMessageInterface: deps.turnInterfaceContext.assistantMessageInterface,
   };
   const assistantMsg = conversationStore.addMessage(
     deps.ctx.conversationId,

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -266,6 +266,8 @@ export async function runAgentLoopImpl(
         ...provenanceFromGuardianContext(ctx.guardianContext),
         userMessageChannel: capturedTurnChannelContext.userMessageChannel,
         assistantMessageChannel: capturedTurnChannelContext.assistantMessageChannel,
+        userMessageInterface: capturedTurnInterfaceContext.userMessageInterface,
+        assistantMessageInterface: capturedTurnInterfaceContext.assistantMessageInterface,
       };
       const assistantMessage = createAssistantMessage(memoryResult.conflictClarification);
       conversationStore.addMessage(
@@ -375,6 +377,7 @@ export async function runAgentLoopImpl(
       shouldGenerateTitle,
       rlog,
       turnChannelContext: capturedTurnChannelContext,
+      turnInterfaceContext: capturedTurnInterfaceContext,
     };
     const eventHandler = (event: AgentEvent) => dispatchAgentEvent(state, deps, event);
 
@@ -564,6 +567,8 @@ export async function runAgentLoopImpl(
         ...provenanceFromGuardianContext(ctx.guardianContext),
         userMessageChannel: capturedTurnChannelContext.userMessageChannel,
         assistantMessageChannel: capturedTurnChannelContext.assistantMessageChannel,
+        userMessageInterface: capturedTurnInterfaceContext.userMessageInterface,
+        assistantMessageInterface: capturedTurnInterfaceContext.assistantMessageInterface,
       };
       conversationStore.addMessage(
         ctx.conversationId,
@@ -587,6 +592,8 @@ export async function runAgentLoopImpl(
         ...provenanceFromGuardianContext(ctx.guardianContext),
         userMessageChannel: capturedTurnChannelContext.userMessageChannel,
         assistantMessageChannel: capturedTurnChannelContext.assistantMessageChannel,
+        userMessageInterface: capturedTurnInterfaceContext.userMessageInterface,
+        assistantMessageInterface: capturedTurnInterfaceContext.assistantMessageInterface,
       };
       const errorAssistantMessage = createAssistantMessage(state.providerErrorUserMessage);
       conversationStore.addMessage(

--- a/assistant/src/daemon/session-messaging.ts
+++ b/assistant/src/daemon/session-messaging.ts
@@ -119,6 +119,7 @@ export function persistUserMessage(
 
   try {
     const turnCtx = extractTurnChannelContext(metadata) ?? ctx.getTurnChannelContext();
+    const turnIfCtx = extractTurnInterfaceContext(metadata) ?? ctx.getTurnInterfaceContext();
     const provenance = provenanceFromGuardianContext(ctx.guardianContext);
     const mergedMetadata = {
       ...(metadata ?? {}),
@@ -127,6 +128,12 @@ export function persistUserMessage(
         ? {
             userMessageChannel: turnCtx.userMessageChannel,
             assistantMessageChannel: turnCtx.assistantMessageChannel,
+          }
+        : {}),
+      ...(turnIfCtx
+        ? {
+            userMessageInterface: turnIfCtx.userMessageInterface,
+            assistantMessageInterface: turnIfCtx.assistantMessageInterface,
           }
         : {}),
     };
@@ -140,6 +147,9 @@ export function persistUserMessage(
 
     if (turnCtx) {
       conversationStore.setConversationOriginChannelIfUnset(ctx.conversationId, turnCtx.userMessageChannel);
+    }
+    if (turnIfCtx) {
+      conversationStore.setConversationOriginInterfaceIfUnset(ctx.conversationId, turnIfCtx.userMessageInterface);
     }
 
     if (!persistedUserMessage.id) {

--- a/assistant/src/daemon/session-notifiers.ts
+++ b/assistant/src/daemon/session-notifiers.ts
@@ -105,7 +105,7 @@ export function registerSessionNotifiers(
       conversationId,
       'assistant',
       JSON.stringify([{ type: 'text', text: questionText }]),
-      { ...provenanceFromGuardianContext(ctx.guardianContext), userMessageChannel: 'voice', assistantMessageChannel: 'voice' },
+      { ...provenanceFromGuardianContext(ctx.guardianContext), userMessageChannel: 'voice', assistantMessageChannel: 'voice', userMessageInterface: 'voice', assistantMessageInterface: 'voice' },
     );
 
     ctx.messages.push(createAssistantMessage(questionText));

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -186,6 +186,9 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
         ...(queuedTurnCtx
           ? { userMessageChannel: queuedTurnCtx.userMessageChannel, assistantMessageChannel: queuedTurnCtx.assistantMessageChannel }
           : {}),
+        ...(queuedInterfaceCtx
+          ? { userMessageInterface: queuedInterfaceCtx.userMessageInterface, assistantMessageInterface: queuedInterfaceCtx.assistantMessageInterface }
+          : {}),
       };
       const userMsg = createUserMessage(next.content, next.attachments);
       conversationStore.addMessage(
@@ -323,7 +326,7 @@ export async function processMessage(
   if (guardianDelivery) {
     const guardianRequest = getGuardianActionRequest(guardianDelivery.requestId);
     if (guardianRequest && guardianRequest.status === 'pending') {
-      const guardianChannelMeta = { userMessageChannel: 'vellum' as const, assistantMessageChannel: 'vellum' as const, provenanceActorRole: 'guardian' as const };
+      const guardianChannelMeta = { userMessageChannel: 'vellum' as const, assistantMessageChannel: 'vellum' as const, userMessageInterface: 'vellum' as const, assistantMessageInterface: 'vellum' as const, provenanceActorRole: 'guardian' as const };
       const userMsg = createUserMessage(content, attachments);
       const persisted = conversationStore.addMessage(
         session.conversationId,
@@ -379,11 +382,15 @@ export async function processMessage(
   // so that a failed write never leaves an unpersisted message in memory.
   if (slashResult.kind === 'unknown') {
     const pmTurnCtx = session.getTurnChannelContext();
+    const pmInterfaceCtx = session.getTurnInterfaceContext();
     const pmProvenance = provenanceFromGuardianContext(session.guardianContext);
     const pmChannelMeta = {
       ...pmProvenance,
       ...(pmTurnCtx
         ? { userMessageChannel: pmTurnCtx.userMessageChannel, assistantMessageChannel: pmTurnCtx.assistantMessageChannel }
+        : {}),
+      ...(pmInterfaceCtx
+        ? { userMessageInterface: pmInterfaceCtx.userMessageInterface, assistantMessageInterface: pmInterfaceCtx.assistantMessageInterface }
         : {}),
     };
     const userMsg = createUserMessage(content, attachments);

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -208,6 +208,13 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
       );
       session.messages.push(assistantMsg);
 
+      if (queuedTurnCtx) {
+        conversationStore.setConversationOriginChannelIfUnset(session.conversationId, queuedTurnCtx.userMessageChannel);
+      }
+      if (queuedInterfaceCtx) {
+        conversationStore.setConversationOriginInterfaceIfUnset(session.conversationId, queuedInterfaceCtx.userMessageInterface);
+      }
+
       // Emit fresh model info before the text delta so the client has
       // up-to-date configuredProviders when rendering /model or /models UI.
       if (isModelSlashCommand(next.content)) {
@@ -326,7 +333,8 @@ export async function processMessage(
   if (guardianDelivery) {
     const guardianRequest = getGuardianActionRequest(guardianDelivery.requestId);
     if (guardianRequest && guardianRequest.status === 'pending') {
-      const guardianChannelMeta = { userMessageChannel: 'vellum' as const, assistantMessageChannel: 'vellum' as const, userMessageInterface: 'vellum' as const, assistantMessageInterface: 'vellum' as const, provenanceActorRole: 'guardian' as const };
+      const guardianIfCtx = session.getTurnInterfaceContext();
+      const guardianChannelMeta = { userMessageChannel: 'vellum' as const, assistantMessageChannel: 'vellum' as const, userMessageInterface: guardianIfCtx?.userMessageInterface ?? 'vellum', assistantMessageInterface: guardianIfCtx?.assistantMessageInterface ?? 'vellum', provenanceActorRole: 'guardian' as const };
       const userMsg = createUserMessage(content, attachments);
       const persisted = conversationStore.addMessage(
         session.conversationId,
@@ -410,6 +418,13 @@ export async function processMessage(
       pmChannelMeta,
     );
     session.messages.push(assistantMsg);
+
+    if (pmTurnCtx) {
+      conversationStore.setConversationOriginChannelIfUnset(session.conversationId, pmTurnCtx.userMessageChannel);
+    }
+    if (pmInterfaceCtx) {
+      conversationStore.setConversationOriginInterfaceIfUnset(session.conversationId, pmInterfaceCtx.userMessageInterface);
+    }
 
     // Emit fresh model info before the text delta so the client has
     // up-to-date configuredProviders when rendering /model or /models UI.


### PR DESCRIPTION
Add userMessageInterface/assistantMessageInterface to all message persistence paths (user, assistant, tool-result, queue drain, slash commands, guardian replies). Set conversationOriginInterfaceIfUnset on first user turn. Part of #8611.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
