### PR TITLE
fix: show checkmark instead of spinner after confirmation action

### DIFF
--- a/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
@@ -96,9 +96,10 @@ public struct ConfirmationSurfaceView: View {
         HStack(spacing: VSpacing.sm) {
             switch action {
             case .confirmed:
-                ProgressView()
-                    .controlSize(.small)
-                Text(data.confirmLabel.map { "\($0)..." } ?? "In progress...")
+                Image(systemName: "checkmark.circle.fill")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.success)
+                Text("Started")
                     .font(VFont.captionMedium)
                     .foregroundColor(VColor.textPrimary)
             case .cancelled:


### PR DESCRIPTION
## Summary
- Replace indefinite `ProgressView()` spinner with a green checkmark (`checkmark.circle.fill`) in `ConfirmationSurfaceView` after the user clicks a confirm action
- Change feedback text from `"{label}..."` to `"Started"` to clearly indicate the action was dispatched

## Original prompt
Update the confirmation surface UI so that once a confirm action (e.g., "Get Started") is clicked, the action bar shows "Started" with a checkmark instead of an indefinite spinner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
