### PR TITLE
M8: Update clients/gateway producers and session API exposure

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -244,6 +244,7 @@ export function handleSessionList(socket: net.Socket, ctx: HandlerContext, offse
     sessions: conversations.map((c) => {
       const binding = bindings.get(c.id);
       const originChannel = parseChannelId(c.originChannel);
+      const originInterface = parseInterfaceId(c.originInterface);
       return {
         id: c.id,
         title: c.title ?? 'Untitled',
@@ -260,6 +261,7 @@ export function handleSessionList(socket: net.Socket, ctx: HandlerContext, offse
           },
         } : {}),
         ...(originChannel ? { conversationOriginChannel: originChannel } : {}),
+        ...(originInterface ? { conversationOriginInterface: originInterface } : {}),
       };
     }),
     hasMore: offset + conversations.length < totalCount,

--- a/assistant/src/daemon/ipc-contract/sessions.ts
+++ b/assistant/src/daemon/ipc-contract/sessions.ts
@@ -1,6 +1,6 @@
 // Session lifecycle, auth, model config, and history types.
 
-import type { ChannelId } from '../../channels/types.js';
+import type { ChannelId, InterfaceId } from '../../channels/types.js';
 import type { ThreadType } from './shared.js';
 import type { UserMessageAttachment } from './shared.js';
 
@@ -170,7 +170,7 @@ export interface ChannelBinding {
 
 export interface SessionListResponse {
   type: 'session_list_response';
-  sessions: Array<{ id: string; title: string; updatedAt: number; threadType?: ThreadType; source?: string; channelBinding?: ChannelBinding; conversationOriginChannel?: ChannelId }>;
+  sessions: Array<{ id: string; title: string; updatedAt: number; threadType?: ThreadType; source?: string; channelBinding?: ChannelBinding; conversationOriginChannel?: ChannelId; conversationOriginInterface?: InterfaceId }>;
   /** Whether more sessions exist beyond the returned page. */
   hasMore?: boolean;
 }

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -157,7 +157,7 @@ async function sendMessage(
     "/messages",
     {
       method: "POST",
-      body: JSON.stringify({ conversationKey: assistantId, content }),
+      body: JSON.stringify({ conversationKey: assistantId, content, sourceChannel: "vellum", interface: "cli" }),
       signal,
     },
     bearerToken,

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -2323,6 +2323,8 @@ public struct IPCIngressInviteResponseInvite: Codable, Sendable {
 public struct IPCIngressMemberRequest: Codable, Sendable {
     public let type: String
     public let action: String
+    /// Assistant ID for scoping member operations (defaults to 'self').
+    public let assistantId: String?
     /// Source channel (required for upsert, optional filter for list).
     public let sourceChannel: String?
     /// External user ID (upsert only).
@@ -2342,9 +2344,10 @@ public struct IPCIngressMemberRequest: Codable, Sendable {
     /// Reason for revoke or block (revoke and block only).
     public let reason: String?
 
-    public init(type: String, action: String, sourceChannel: String? = nil, externalUserId: String? = nil, externalChatId: String? = nil, displayName: String? = nil, username: String? = nil, policy: String? = nil, status: String? = nil, memberId: String? = nil, reason: String? = nil) {
+    public init(type: String, action: String, assistantId: String? = nil, sourceChannel: String? = nil, externalUserId: String? = nil, externalChatId: String? = nil, displayName: String? = nil, username: String? = nil, policy: String? = nil, status: String? = nil, memberId: String? = nil, reason: String? = nil) {
         self.type = type
         self.action = action
+        self.assistantId = assistantId
         self.sourceChannel = sourceChannel
         self.externalUserId = externalUserId
         self.externalChatId = externalChatId
@@ -3443,8 +3446,9 @@ public struct IPCSessionListResponseSession: Codable, Sendable {
     /// Channel binding metadata exposed in session/conversation list APIs.
     public let channelBinding: IPCChannelBinding?
     public let conversationOriginChannel: String?
+    public let conversationOriginInterface: String?
 
-    public init(id: String, title: String, updatedAt: Int, threadType: String? = nil, source: String? = nil, channelBinding: IPCChannelBinding? = nil, conversationOriginChannel: String? = nil) {
+    public init(id: String, title: String, updatedAt: Int, threadType: String? = nil, source: String? = nil, channelBinding: IPCChannelBinding? = nil, conversationOriginChannel: String? = nil, conversationOriginInterface: String? = nil) {
         self.id = id
         self.title = title
         self.updatedAt = updatedAt
@@ -3452,6 +3456,7 @@ public struct IPCSessionListResponseSession: Codable, Sendable {
         self.source = source
         self.channelBinding = channelBinding
         self.conversationOriginChannel = conversationOriginChannel
+        self.conversationOriginInterface = conversationOriginInterface
     }
 }
 
@@ -5296,14 +5301,9 @@ public struct IPCUserMessage: Codable, Sendable {
     /// Originating channel identifier (e.g. 'vellum'). Defaults to 'vellum' when absent.
     public let channel: String?
     /// Originating interface identifier (e.g. 'macos'). Falls back to channel when absent.
-    public let interface_: String?
+    public let interface: String?
 
-    enum CodingKeys: String, CodingKey {
-        case type, sessionId, content, attachments, activeSurfaceId, currentPage, bypassSecretCheck, channel
-        case interface_ = "interface"
-    }
-
-    public init(type: String, sessionId: String, content: String? = nil, attachments: [IPCUserMessageAttachment]? = nil, activeSurfaceId: String? = nil, currentPage: String? = nil, bypassSecretCheck: Bool? = nil, channel: String? = nil, interface_: String? = nil) {
+    public init(type: String, sessionId: String, content: String? = nil, attachments: [IPCUserMessageAttachment]? = nil, activeSurfaceId: String? = nil, currentPage: String? = nil, bypassSecretCheck: Bool? = nil, channel: String? = nil, interface: String? = nil) {
         self.type = type
         self.sessionId = sessionId
         self.content = content
@@ -5312,7 +5312,7 @@ public struct IPCUserMessage: Codable, Sendable {
         self.currentPage = currentPage
         self.bypassSecretCheck = bypassSecretCheck
         self.channel = channel
-        self.interface_ = interface_
+        self.interface = interface
     }
 }
 

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -26,6 +26,7 @@ struct ConversationsListResponse: Decodable {
         let source: String?
         let channelBinding: IPCChannelBinding?
         let conversationOriginChannel: String?
+        let conversationOriginInterface: String?
     }
     let sessions: [Session]
     let hasMore: Bool?
@@ -307,7 +308,8 @@ final class HTTPTransport {
 
         var body: [String: Any] = [
             "conversationKey": conversationKey,
-            "sourceChannel": sourceChannel
+            "sourceChannel": sourceChannel,
+            "interface": "macos"
         ]
         if let content, !content.isEmpty {
             body["content"] = content
@@ -410,7 +412,7 @@ final class HTTPTransport {
             do {
                 let decoded = try decoder.decode(ConversationsListResponse.self, from: data)
                 let sessions = decoded.sessions.map {
-                    IPCSessionListResponseSession(id: $0.id, title: $0.title, updatedAt: $0.updatedAt, threadType: $0.threadType, source: $0.source, channelBinding: $0.channelBinding, conversationOriginChannel: $0.conversationOriginChannel)
+                    IPCSessionListResponseSession(id: $0.id, title: $0.title, updatedAt: $0.updatedAt, threadType: $0.threadType, source: $0.source, channelBinding: $0.channelBinding, conversationOriginChannel: $0.conversationOriginChannel, conversationOriginInterface: $0.conversationOriginInterface)
                 }
                 onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: sessions, hasMore: decoded.hasMore)))
             } catch {

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -55,6 +55,17 @@ final class HTTPTransport {
         return "vellum"
     }
 
+    /// Platform-derived default interface identifier.
+    private static var defaultInterface: String {
+        #if os(macOS)
+        return "macos"
+        #elseif os(iOS)
+        return "ios"
+        #else
+        return "vellum"
+        #endif
+    }
+
     /// Currently active SSE task.
     private var sseTask: Task<Void, Never>?
 
@@ -309,7 +320,7 @@ final class HTTPTransport {
         var body: [String: Any] = [
             "conversationKey": conversationKey,
             "sourceChannel": sourceChannel,
-            "interface": "macos"
+            "interface": Self.defaultInterface
         ]
         if let content, !content.isEmpty {
             body["content"] = content

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -296,8 +296,19 @@ extension IPCUserMessage {
         return "vellum"
     }
 
-    public init(sessionId: String, content: String, attachments: [IPCAttachment]?, activeSurfaceId: String? = nil, currentPage: String? = nil, bypassSecretCheck: Bool? = nil, channel: String? = nil) {
-        self.init(type: "user_message", sessionId: sessionId, content: content, attachments: attachments, activeSurfaceId: activeSurfaceId, currentPage: currentPage, bypassSecretCheck: bypassSecretCheck, channel: channel ?? Self.defaultChannel)
+    /// Platform-derived default interface identifier.
+    private static var defaultInterface: String {
+        #if os(macOS)
+        return "macos"
+        #elseif os(iOS)
+        return "ios"
+        #else
+        return "vellum"
+        #endif
+    }
+
+    public init(sessionId: String, content: String, attachments: [IPCAttachment]?, activeSurfaceId: String? = nil, currentPage: String? = nil, bypassSecretCheck: Bool? = nil, channel: String? = nil, interface: String? = nil) {
+        self.init(type: "user_message", sessionId: sessionId, content: content, attachments: attachments, activeSurfaceId: activeSurfaceId, currentPage: currentPage, bypassSecretCheck: bypassSecretCheck, channel: channel ?? Self.defaultChannel, interface: interface ?? Self.defaultInterface)
     }
 }
 

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -73,6 +73,7 @@ export async function handleInbound(
       routing.assistantId,
       {
         sourceChannel: event.sourceChannel,
+        interface: event.sourceChannel,
         externalChatId: event.message.externalChatId,
         externalMessageId: event.message.externalMessageId,
         content: event.message.content,

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -1,4 +1,4 @@
-import type { ChannelId } from '../channels/types.js';
+import type { ChannelId, InterfaceId } from '../channels/types.js';
 import type { GatewayConfig } from "../config.js";
 import { fetchImpl } from "../fetch.js";
 import { getLogger } from "../logger.js";
@@ -130,6 +130,8 @@ export class AttachmentValidationError extends Error {
 
 export type RuntimeInboundPayload = {
   sourceChannel: ChannelId;
+  /** Explicit interface identifier forwarded to the assistant. */
+  interface?: InterfaceId;
   externalChatId: string;
   externalMessageId: string;
   content: string;


### PR DESCRIPTION
Updates client producers (macOS, iOS, CLI) to emit interface field in outbound payloads. Adds gateway forwarding of interface. Exposes conversationOriginInterface in session list API. Regenerates Swift IPC contract.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
