### PR TITLE
fix: sync browser TOOLS.json dropdown guidance and add consent screen dropdown instructions

### DIFF
--- a/assistant/src/config/bundled-skills/browser/TOOLS.json
+++ b/assistant/src/config/bundled-skills/browser/TOOLS.json
@@ -71,7 +71,7 @@
     },
     {
       "name": "browser_click",
-      "description": "Click an element on the page. Target the element by element_id (from browser_snapshot) or a CSS selector.",
+      "description": "Click an element on the page. Always use element_id from browser_snapshot — do not fabricate CSS selectors. For autocomplete dropdowns, search suggestion lists, or address pickers, prefer browser_press_key with ArrowDown/ArrowUp + Enter instead of clicking dropdown items.",
       "category": "browser",
       "risk": "low",
       "input_schema": {
@@ -126,7 +126,7 @@
     },
     {
       "name": "browser_press_key",
-      "description": "Press a keyboard key, optionally targeting a specific element. Use for Enter, Escape, Tab, arrow keys, etc.",
+      "description": "Press a keyboard key, optionally targeting a specific element. Use for Enter, Escape, Tab, arrow keys, etc. Preferred method for navigating autocomplete dropdowns and search suggestion lists: use ArrowDown/ArrowUp to move through options, then Enter to select.",
       "category": "browser",
       "risk": "low",
       "input_schema": {

--- a/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
@@ -88,7 +88,13 @@ Take a `browser_snapshot`:
 
 Fill in the consent screen form:
 1. **App name:** "Vellum Assistant"
-2. **User support email:** Select the user's email from the dropdown
+2. **User support email:** This is an Angular Material dropdown that doesn't work well with direct clicks. Use this approach:
+   - Take a `browser_snapshot` to find the dropdown element (it may appear as a `mat-select` or a div with "User support email" label)
+   - Click the dropdown element_id to open it
+   - Wait briefly (`browser_wait_for` with duration 500ms) for the overlay to render
+   - Use `browser_press_key` with `ArrowDown` to highlight the email option
+   - Use `browser_press_key` with `Enter` to select it
+   - If the dropdown didn't open on click, try: focus the element with `browser_click`, then press `Space` to open it, then ArrowDown + Enter
 3. **Developer contact email:** Type the user's email address
 4. Leave other fields as defaults
 


### PR DESCRIPTION
## Summary

- Synced `browser_click` and `browser_press_key` descriptions in bundled `TOOLS.json` to match the updated tool classes in `headless-browser.ts` — adds explicit guidance to use ArrowDown/ArrowUp + Enter for dropdown navigation instead of clicking dynamic overlay items
- Added step-by-step instructions in the Google OAuth setup skill (Step 5) for interacting with the Angular Material "User support email" dropdown, including a fallback approach if the initial click doesn't open it

## Original prompt

The assistant was getting stuck during Google OAuth consent screen setup because (1) TOOLS.json lacked dropdown navigation hints that were added to headless-browser.ts, and (2) the skill instructions were too vague about how to interact with the Angular Material dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
