### PR TITLE
Make error messages more descriptive and wire up session error toast

### DIFF
--- a/assistant/src/__tests__/session-error.test.ts
+++ b/assistant/src/__tests__/session-error.test.ts
@@ -223,10 +223,11 @@ describe('classifySessionError', () => {
   });
 
   describe('generic errors', () => {
-    it('classifies unknown errors as SESSION_PROCESSING_FAILED', () => {
+    it('classifies unknown errors as SESSION_PROCESSING_FAILED with error summary', () => {
       const result = classifySessionError(new Error('something completely unexpected'), baseCtx);
       expect(result.code).toBe('SESSION_PROCESSING_FAILED');
       expect(result.retryable).toBe(false);
+      expect(result.userMessage).toContain('something completely unexpected');
     });
 
     it('includes debugDetails with stack trace', () => {
@@ -239,6 +240,7 @@ describe('classifySessionError', () => {
     it('handles non-Error values', () => {
       const result = classifySessionError('plain string error', baseCtx);
       expect(result.code).toBe('SESSION_PROCESSING_FAILED');
+      expect(result.userMessage).toContain('plain string error');
       expect(result.debugDetails).toBe('plain string error');
     });
   });

--- a/assistant/src/daemon/session-error.ts
+++ b/assistant/src/daemon/session-error.ts
@@ -264,10 +264,13 @@ function classifyByMessage(message: string): Omit<ClassifiedSessionError, 'debug
     }
   }
 
-  // Default: processing failure
+  // Default: processing failure — include the first line of the actual error
+  // so users know what went wrong instead of seeing a completely generic message.
+  const firstLine = message.split('\n')[0].trim();
+  const summary = firstLine.length > 150 ? firstLine.slice(0, 150) + '...' : firstLine;
   return {
     code: 'SESSION_PROCESSING_FAILED',
-    userMessage: 'Something went wrong processing your message. Please try again.',
+    userMessage: `Something went wrong: ${summary}`,
     retryable: false,
   };
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -84,7 +84,8 @@ struct ChatView: View {
         let base: CGFloat = VSpacing.sm + topPad + bottomPad + contentHeight + buttonRow
         let attachments: CGFloat = pendingAttachments.isEmpty ? 0 : 48
         let error: CGFloat = (sessionError == nil && errorText != nil) ? 36 : 0
-        return base + attachments + error
+        let sessionErrorToast: CGFloat = sessionError != nil ? 52 : 0
+        return base + attachments + error + sessionErrorToast
     }
 
     var body: some View {
@@ -203,6 +204,9 @@ struct ChatView: View {
                             onPaste: onPaste,
                             onMicrophoneToggle: onMicrophoneToggle,
                             onDismissError: onDismissError,
+                            onRetrySessionError: onRetry,
+                            onCopyDebugInfo: onCopyDebugInfo,
+                            onDismissSessionError: onDismissSessionError,
                             watchSession: watchSession,
                             onStopWatch: onStopWatch,
                             isLearnMode: isLearnMode,

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
@@ -26,6 +26,9 @@ struct ComposerSection: View {
     let onPaste: () -> Void
     let onMicrophoneToggle: () -> Void
     let onDismissError: () -> Void
+    let onRetrySessionError: () -> Void
+    let onCopyDebugInfo: () -> Void
+    let onDismissSessionError: () -> Void
     let watchSession: WatchSession?
     let onStopWatch: () -> Void
     var isLearnMode: Bool = false
@@ -41,6 +44,15 @@ struct ComposerSection: View {
                     .padding(.horizontal, VSpacing.lg)
                     .padding(.bottom, VSpacing.sm)
                     .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+
+            if let sessionError {
+                ChatSessionErrorToast(
+                    error: sessionError,
+                    onRetry: onRetrySessionError,
+                    onCopyDebugInfo: onCopyDebugInfo,
+                    onDismiss: onDismissSessionError
+                )
             }
 
             if let errorText, sessionError == nil {

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1254,8 +1254,6 @@ extension ChatViewModel {
                    messages.last?.toolCalls.isEmpty == true {
                     messages.removeAll(where: { $0.id == existingId })
                 }
-                let errorMsg = ChatMessage(role: .assistant, text: msg.userMessage, isError: true)
-                messages.append(errorMsg)
             }
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {


### PR DESCRIPTION
## Summary

- **Backend**: Default `SESSION_PROCESSING_FAILED` fallback now includes the first line of the actual error message (truncated to 150 chars) so users see what went wrong instead of a generic message
- **macOS**: Wired the existing `ChatSessionErrorToast` component into `ComposerSection` above the composer, with retry, copy debug info, and dismiss callbacks threaded from `ChatView`
- **Shared**: Removed the redundant inline `ChatMessage(isError: true)` append in the `sessionError` handler — the toast provides better UX (structured retry, copy debug info, dismiss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
