### PR TITLE
fix: use confirmLabel for post-confirmation text instead of hardcoded Started

### DIFF
--- a/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
@@ -99,7 +99,7 @@ public struct ConfirmationSurfaceView: View {
                 Image(systemName: "checkmark.circle.fill")
                     .font(VFont.caption)
                     .foregroundColor(VColor.success)
-                Text("Started")
+                Text(data.confirmLabel ?? "Done")
                     .font(VFont.captionMedium)
                     .foregroundColor(VColor.textPrimary)
             case .cancelled:


### PR DESCRIPTION
Addresses Codex feedback on PR #8653. The confirmation surface was hardcoding 'Started' as post-confirmation text, but confirmLabel is configurable. Now uses the confirmLabel value (with fallback to 'Done') to preserve action-specific context.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
