### PR TITLE
fix: compact post-action surfaces to match chip style

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -33,9 +33,29 @@ public struct InlineSurfaceRouter: View {
         return false
     }
 
+    /// Whether the surface renders as a lightweight chip without card chrome.
+    /// Surfaces that don't have a dedicated inline widget (e.g. browser_view, file_upload)
+    /// render as compact fallback chips — no need for the full card wrapper.
+    private var isChipOnlySurface: Bool {
+        switch surface.data {
+        case .browserView, .fileUpload:
+            return true
+        default:
+            return false
+        }
+    }
+
     public var body: some View {
         if let completion = surface.completionState {
             CompletedSurfaceChip(title: surface.title, summary: completion.summary)
+        } else if case .confirmation(let data) = surface.data {
+            // Confirmations manage their own card chrome — collapse to a chip after user acts
+            ConfirmationSurfaceView(data: data, actions: surface.actions) { actionId in
+                onAction(surface.id, actionId, nil)
+            }
+            .frame(maxWidth: 540, alignment: .leading)
+        } else if isChipOnlySurface {
+            surfaceContent
         } else {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             // Template cards and dynamic page previews handle their own header

--- a/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
@@ -42,6 +42,8 @@ public struct ConfirmationSurfaceView: View {
                 selectedActionFeedback(selectedAction)
             } else {
                 pendingContent
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .inlineWidgetCard()
             }
         }
         .onChange(of: data) { _, _ in


### PR DESCRIPTION
## Summary
- Confirmation surfaces now manage their own card chrome — full card while pending, compact chip after user confirms/cancels
- Fallback surfaces (browser_view, file_upload) render as standalone chips without the oversized card wrapper
- Both post-action states now visually match the 'Completed X steps' chip style

## Original prompt
let's make the size of these big white boxes smaller once user gives permission. they should be stylistically similar to 'completed x steps' right below that so it looks consistent for user

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
