### PR TITLE
fix: add setTurnChannelContext in handleSendMessage idle path

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -329,6 +329,10 @@ export async function handleSendMessage(
     }
 
     // Session is idle — persist and fire agent loop immediately
+    session.setTurnChannelContext({
+      userMessageChannel: sourceChannel,
+      assistantMessageChannel: sourceChannel,
+    });
     session.setTurnInterfaceContext({
       userMessageInterface: sourceInterface,
       assistantMessageInterface: sourceInterface,


### PR DESCRIPTION
Adds missing setTurnChannelContext call alongside setTurnInterfaceContext in the handleSendMessage idle-session path, matching all other message-processing paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
