### PR TITLE
fix: set origin interface during ChatGPT import

### DIFF
--- a/assistant/src/config/vellum-skills/chatgpt-import/tools/chatgpt-import.ts
+++ b/assistant/src/config/vellum-skills/chatgpt-import/tools/chatgpt-import.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
-import { createConversation, addMessage } from '../../../../memory/conversation-store.js';
+import { createConversation, addMessage, setConversationOriginInterfaceIfUnset } from '../../../../memory/conversation-store.js';
 import { getDb } from '../../../../memory/db.js';
 import { conversations, messages as messagesTable, conversationKeys } from '../../../../memory/schema.js';
 
@@ -110,6 +110,9 @@ export async function run(
     for (const msg of conv.messages) {
       addMessage(conversation.id, msg.role, JSON.stringify(msg.content), importChannelMetadata);
     }
+
+    // addMessage auto-fills originChannel but not originInterface, so set it explicitly
+    setConversationOriginInterfaceIfUnset(conversation.id, 'vellum');
 
     // Override timestamps to match ChatGPT originals
     db.update(conversations)


### PR DESCRIPTION
Adds setConversationOriginInterfaceIfUnset call during ChatGPT import loop so imported conversations have their origin_interface set.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
