### PR TITLE
fix: add role=option/combobox/listbox to browser snapshot for dropdown support

### DIFF
--- a/assistant/src/config/bundled-skills/browser/TOOLS.json
+++ b/assistant/src/config/bundled-skills/browser/TOOLS.json
@@ -71,7 +71,7 @@
     },
     {
       "name": "browser_click",
-      "description": "Click an element on the page. Always use element_id from browser_snapshot — do not fabricate CSS selectors. For autocomplete dropdowns, search suggestion lists, or address pickers, prefer browser_press_key with ArrowDown/ArrowUp + Enter instead of clicking dropdown items.",
+      "description": "Click an element on the page. Always use element_id from browser_snapshot — do not fabricate CSS selectors. For dropdowns (including Angular Material mat-select), click to open, take a new browser_snapshot to see the options (role=\"option\" elements), then click the desired option by element_id. For autocomplete inputs where options don't appear in the snapshot, use browser_press_key with ArrowDown/ArrowUp + Enter.",
       "category": "browser",
       "risk": "low",
       "input_schema": {

--- a/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
@@ -88,13 +88,13 @@ Take a `browser_snapshot`:
 
 Fill in the consent screen form:
 1. **App name:** "Vellum Assistant"
-2. **User support email:** This is an Angular Material dropdown that doesn't work well with direct clicks. Use this approach:
-   - Take a `browser_snapshot` to find the dropdown element (it may appear as a `mat-select` or a div with "User support email" label)
+2. **User support email:** This is an Angular Material dropdown. Use this approach:
+   - Take a `browser_snapshot` to find the dropdown element (look for a `mat-select` or element with "User support email" label)
    - Click the dropdown element_id to open it
-   - Wait briefly (`browser_wait_for` with duration 500ms) for the overlay to render
-   - Use `browser_press_key` with `ArrowDown` to highlight the email option
-   - Use `browser_press_key` with `Enter` to select it
-   - If the dropdown didn't open on click, try: focus the element with `browser_click`, then press `Space` to open it, then ArrowDown + Enter
+   - Wait briefly (`browser_wait_for` with duration 1000ms) for the overlay to render
+   - Take a **new** `browser_snapshot` — the dropdown options now appear as `[role="option"]` elements with the email addresses as text
+   - Click the element_id of the desired email option (the user's own email, e.g. the first option)
+   - If the dropdown didn't open on click, try: focus the element with `browser_click`, then press `Space` to open it, then take another snapshot and click the option
 3. **Developer contact email:** Type the user's email address
 4. Leave other fields as defaults
 

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -46,6 +46,9 @@ export const INTERACTIVE_SELECTOR = [
   '[role="radio"]',
   '[role="tab"]',
   '[role="menuitem"]',
+  '[role="option"]',
+  '[role="combobox"]',
+  '[role="listbox"]',
   '[contenteditable="true"]',
 ].join(', ');
 


### PR DESCRIPTION
## Summary
- Added `[role="option"]`, `[role="combobox"]`, and `[role="listbox"]` to `INTERACTIVE_SELECTOR` in `browser-execution.ts` so dropdown options from Angular Material (and similar frameworks) appear in `browser_snapshot` results
- Updated Google OAuth setup skill to use the reliable open → snapshot → click flow instead of fragile ArrowDown/Enter keyboard navigation
- Updated `browser_click` tool description to guide the model toward snapshot-then-click pattern for dropdowns

## Context
The Google OAuth consent screen has a "User support email" dropdown using Angular Material's `mat-select`. When opened, options render in a CDK overlay as `mat-option` elements with `role="option"` — but this role wasn't in the snapshot selector list, so the assistant literally couldn't see the options. The previous fix tried ArrowDown/Enter workarounds but those were unreliable due to overlay focus management.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
