### PR TITLE
fix: handle empty error messages and restore iOS inline error fallback

### DIFF
--- a/assistant/src/__tests__/session-error.test.ts
+++ b/assistant/src/__tests__/session-error.test.ts
@@ -243,6 +243,18 @@ describe('classifySessionError', () => {
       expect(result.userMessage).toContain('plain string error');
       expect(result.debugDetails).toBe('plain string error');
     });
+
+    it('falls back to generic message for empty error', () => {
+      const result = classifySessionError(new Error(''), baseCtx);
+      expect(result.code).toBe('SESSION_PROCESSING_FAILED');
+      expect(result.userMessage).toBe('Something went wrong processing your message. Please try again.');
+    });
+
+    it('skips leading newlines to find first non-empty line', () => {
+      const result = classifySessionError(new Error('\n\nactual error on line 3'), baseCtx);
+      expect(result.code).toBe('SESSION_PROCESSING_FAILED');
+      expect(result.userMessage).toContain('actual error on line 3');
+    });
   });
 
   describe('ProviderError with statusCode (deterministic classification)', () => {

--- a/assistant/src/daemon/session-error.ts
+++ b/assistant/src/daemon/session-error.ts
@@ -264,13 +264,16 @@ function classifyByMessage(message: string): Omit<ClassifiedSessionError, 'debug
     }
   }
 
-  // Default: processing failure — include the first line of the actual error
+  // Default: processing failure — include the first non-empty line of the actual error
   // so users know what went wrong instead of seeing a completely generic message.
-  const firstLine = message.split('\n')[0].trim();
+  const firstLine = message.split('\n').map(l => l.trim()).find(l => l.length > 0) ?? '';
   const summary = firstLine.length > 150 ? firstLine.slice(0, 150) + '...' : firstLine;
+  const userMessage = summary
+    ? `Processing failed: ${summary}`
+    : 'Something went wrong processing your message. Please try again.';
   return {
     code: 'SESSION_PROCESSING_FAILED',
-    userMessage: `Processing failed: ${summary}`,
+    userMessage,
     retryable: false,
   };
 }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1254,6 +1254,9 @@ extension ChatViewModel {
                    messages.last?.toolCalls.isEmpty == true {
                     messages.removeAll(where: { $0.id == existingId })
                 }
+                // Keep inline error message as fallback for platforms without the session error toast
+                let errorMsg = ChatMessage(role: .assistant, text: msg.userMessage, isError: true)
+                messages.append(errorMsg)
             }
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {


### PR DESCRIPTION
Addresses review feedback on PR #8657:

1. Fix empty/newline-prefixed error messages producing 'Something went wrong: ' with no content — now finds the first non-empty line and falls back to a generic message (Devin feedback)
2. Restore inline error message append in ChatViewModel for iOS compatibility (Codex feedback)
3. Add test cases for empty and newline-prefixed error edge cases
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
