### PR TITLE
Make shell command permission prompts accessible to non-technical users

### DIFF
--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -65,7 +65,8 @@ class ShellTool implements Tool {
           },
           reason: {
             type: 'string',
-            description: 'Brief human-readable explanation of what this command does and why, shown to the user in the permission prompt (e.g. "to find available location services")',
+            description:
+              'Brief non-technical explanation of what this command does and why, shown to a non-technical user in the permission prompt. Avoid jargon and technical terms. Good: "to check if a required program is installed on your computer". Bad: "to check if gcloud CLI is installed". Good: "to download a helper program". Bad: "to run npm install".',
           },
           timeout_seconds: {
             type: 'number',

--- a/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
@@ -141,7 +141,7 @@ public final class ToolConfirmationNotificationService {
 
     private func commandPreview(toolName: String, input: [String: AnyCodable]) -> String {
         switch toolName {
-        case "bash":
+        case "bash", "host_bash":
             return (input["command"]?.value as? String) ?? ""
         case "file_read":
             return "read \((input["path"]?.value as? String) ?? "")"

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -21,6 +21,7 @@ public struct ToolConfirmationBubble: View {
     @State private var showScopePickerMenu = false
     @State private var keyboardModel: ToolConfirmationKeyboardModel?
     @State private var popoverKeyboardModel: ToolConfirmationPopoverKeyboardModel?
+    @AppStorage("hasSeenCommandExplanation") private var hasSeenCommandExplanation = false
     #if os(macOS)
     @State private var keyMonitor: Any?
     #endif
@@ -39,6 +40,10 @@ public struct ToolConfirmationBubble: View {
 
     private var needsScopeChoice: Bool {
         !confirmation.scopeOptions.isEmpty
+    }
+
+    private var isCommandTool: Bool {
+        confirmation.toolName == "bash" || confirmation.toolName == "host_bash"
     }
 
     private var isDecided: Bool {
@@ -167,12 +172,47 @@ public struct ToolConfirmationBubble: View {
     // MARK: - Tool Permission (pending)
 
     @ViewBuilder
+    private var commandExplanationBanner: some View {
+        HStack(alignment: .top, spacing: VSpacing.sm) {
+            Image(systemName: "info.circle.fill")
+                .font(.system(size: 14))
+                .foregroundColor(VColor.accent)
+                .padding(.top, 1)
+
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("What is this?")
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.textPrimary)
+
+                Text("Sometimes your assistant needs to run commands on your computer to complete tasks \u{2014} like installing software, checking settings, or organizing files. You\u{2019}ll always be asked for permission first, and nothing runs without your approval.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(VSpacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .fill(VColor.accent.opacity(0.08))
+        )
+        .onDisappear {
+            hasSeenCommandExplanation = true
+        }
+    }
+
+    @ViewBuilder
     private var pendingContent: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             // Bold non-technical question
             Text(confirmation.humanDescription)
                 .font(VFont.bodyBold)
                 .foregroundColor(VColor.textPrimary)
+
+            // First-time educational banner for command confirmations
+            if isCommandTool && !hasSeenCommandExplanation {
+                commandExplanationBanner
+            }
 
             // Action buttons at top
             buttonRow


### PR DESCRIPTION
## Summary
- Update the `reason` field description in `shell.ts` bash tool definition to guide the LLM toward writing non-technical, jargon-free reasons (with good/bad examples)
- Add a one-time educational banner in `ToolConfirmationBubble` that explains what command permissions are for first-time users, persisted via `@AppStorage`
- Update `ToolConfirmationNotificationService` to prefer the human-readable `reason` over raw command text in notification body, and add missing `host_bash` to display name and preview switches

## Test plan
- [ ] Trigger a bash confirmation — verify the prompt says "Allow running a command on your computer to..." (already shipped in prior PR)
- [ ] Clear UserDefaults `hasSeenCommandExplanation`, trigger a bash confirmation — verify educational banner appears
- [ ] Dismiss the confirmation, trigger another — verify banner is gone
- [ ] Trigger a bash confirmation while chat is in background — verify notification body shows the reason, not the raw command
- [ ] Verify `host_bash` notifications show "Run Command" title instead of "Host Bash"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
