### PR TITLE
fix: add confirmedLabel field for post-confirmation status text

### DIFF
--- a/assistant/src/daemon/ipc-contract/surfaces.ts
+++ b/assistant/src/daemon/ipc-contract/surfaces.ts
@@ -65,6 +65,7 @@ export interface ConfirmationSurfaceData {
   message: string;
   detail?: string;
   confirmLabel?: string;
+  confirmedLabel?: string;
   cancelLabel?: string;
   destructive?: boolean;
 }

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -46,7 +46,7 @@ export const uiShowTool: Tool = {
     '- list: Selectable list of items. ' +
     'data shape: { items: Array<{ id: string, title: string, subtitle?: string, icon?: string, selected?: boolean }>, selectionMode: "single"|"multiple"|"none" }\n' +
     '- confirmation: Yes/no confirmation dialog. ' +
-    'data shape: { message: string, detail?: string, confirmLabel?: string, cancelLabel?: string, destructive?: boolean }\n' +
+    'data shape: { message: string, detail?: string, confirmLabel?: string, confirmedLabel?: string, cancelLabel?: string, destructive?: boolean }\n' +
     '- dynamic_page: Custom HTML page rendered in a sandboxed container. ' +
     'data shape: { html: string, width?: number, height?: number, preview?: { title: string, subtitle?: string, description?: string, icon?: string (emoji), metrics?: Array<{ label: string, value: string }> } }. ' +
     'When preview is provided, a compact preview card is shown inline in chat with the title, subtitle, description, metric pills, and a "View Output" button that opens the full page.\n' +

--- a/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
@@ -101,7 +101,7 @@ public struct ConfirmationSurfaceView: View {
                 Image(systemName: "checkmark.circle.fill")
                     .font(VFont.caption)
                     .foregroundColor(VColor.success)
-                Text(data.confirmLabel ?? "Done")
+                Text(data.confirmedLabel ?? "Done")
                     .font(VFont.captionMedium)
                     .foregroundColor(VColor.textPrimary)
             case .cancelled:

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -192,13 +192,15 @@ public struct ConfirmationSurfaceData: Sendable, Equatable {
     public let message: String
     public let detail: String?
     public let confirmLabel: String?
+    public let confirmedLabel: String?
     public let cancelLabel: String?
     public let destructive: Bool
 
-    public init(message: String, detail: String? = nil, confirmLabel: String? = nil, cancelLabel: String? = nil, destructive: Bool) {
+    public init(message: String, detail: String? = nil, confirmLabel: String? = nil, confirmedLabel: String? = nil, cancelLabel: String? = nil, destructive: Bool) {
         self.message = message
         self.detail = detail
         self.confirmLabel = confirmLabel
+        self.confirmedLabel = confirmedLabel
         self.cancelLabel = cancelLabel
         self.destructive = destructive
     }
@@ -653,6 +655,8 @@ public extension Surface {
         let detail: String? = update.keys.contains("detail") ? (update["detail"] as? String) : existing.detail
         let confirmLabel: String? = update.keys.contains("confirmLabel")
             ? (update["confirmLabel"] as? String) : existing.confirmLabel
+        let confirmedLabel: String? = update.keys.contains("confirmedLabel")
+            ? (update["confirmedLabel"] as? String) : existing.confirmedLabel
         let cancelLabel: String? = update.keys.contains("cancelLabel")
             ? (update["cancelLabel"] as? String) : existing.cancelLabel
         let destructive: Bool = (update["destructive"] as? Bool) ?? existing.destructive
@@ -661,6 +665,7 @@ public extension Surface {
             message: message,
             detail: detail,
             confirmLabel: confirmLabel,
+            confirmedLabel: confirmedLabel,
             cancelLabel: cancelLabel,
             destructive: destructive
         )
@@ -826,6 +831,7 @@ public extension Surface {
             message: message,
             detail: dict["detail"] as? String,
             confirmLabel: dict["confirmLabel"] as? String,
+            confirmedLabel: dict["confirmedLabel"] as? String,
             cancelLabel: dict["cancelLabel"] as? String,
             destructive: dict["destructive"] as? Bool ?? false
         )

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1109,13 +1109,15 @@ public struct IPCConfirmationSurfaceData: Codable, Sendable {
     public let message: String
     public let detail: String?
     public let confirmLabel: String?
+    public let confirmedLabel: String?
     public let cancelLabel: String?
     public let destructive: Bool?
 
-    public init(message: String, detail: String? = nil, confirmLabel: String? = nil, cancelLabel: String? = nil, destructive: Bool? = nil) {
+    public init(message: String, detail: String? = nil, confirmLabel: String? = nil, confirmedLabel: String? = nil, cancelLabel: String? = nil, destructive: Bool? = nil) {
         self.message = message
         self.detail = detail
         self.confirmLabel = confirmLabel
+        self.confirmedLabel = confirmedLabel
         self.cancelLabel = cancelLabel
         self.destructive = destructive
     }


### PR DESCRIPTION
Addresses review feedback on PR #8658:

Introduces a separate `confirmedLabel` field for post-confirmation feedback text instead of reusing the button label (`confirmLabel`). The button label is imperative ("Get Started"), while post-action feedback should indicate completion ("Done"). Falls back to "Done" when `confirmedLabel` is not set.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
