### PR TITLE
fix: conditionally apply inlineWidgetCard to avoid double chrome in floating panel

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -50,7 +50,7 @@ public struct InlineSurfaceRouter: View {
             CompletedSurfaceChip(title: surface.title, summary: completion.summary)
         } else if case .confirmation(let data) = surface.data {
             // Confirmations manage their own card chrome — collapse to a chip after user acts
-            ConfirmationSurfaceView(data: data, actions: surface.actions) { actionId in
+            ConfirmationSurfaceView(data: data, actions: surface.actions, showCardChrome: true) { actionId in
                 onAction(surface.id, actionId, nil)
             }
             .frame(maxWidth: 540, alignment: .leading)

--- a/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 public struct ConfirmationSurfaceView: View {
     public let data: ConfirmationSurfaceData
     public let actions: [SurfaceActionButton]
+    public let showCardChrome: Bool
     public let onAction: (String) -> Void
 
     private enum SelectedAction {
@@ -12,9 +13,10 @@ public struct ConfirmationSurfaceView: View {
 
     @State private var selectedAction: SelectedAction?
 
-    public init(data: ConfirmationSurfaceData, actions: [SurfaceActionButton], onAction: @escaping (String) -> Void) {
+    public init(data: ConfirmationSurfaceData, actions: [SurfaceActionButton], showCardChrome: Bool = false, onAction: @escaping (String) -> Void) {
         self.data = data
         self.actions = actions
+        self.showCardChrome = showCardChrome
         self.onAction = onAction
     }
 
@@ -40,10 +42,13 @@ public struct ConfirmationSurfaceView: View {
         Group {
             if let selectedAction {
                 selectedActionFeedback(selectedAction)
-            } else {
+            } else if showCardChrome {
                 pendingContent
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .inlineWidgetCard()
+            } else {
+                pendingContent
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
         .onChange(of: data) { _, _ in


### PR DESCRIPTION
Addresses review feedback on PR #8661:

Adds a `showCardChrome` parameter to `ConfirmationSurfaceView` (default `false`) so `.inlineWidgetCard()` is only applied when the view is used inline (`InlineSurfaceRouter` passes `true`). This prevents double card chrome when the view is rendered in the floating panel context (`SurfaceContainerView`), which already provides its own panel chrome.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
