### PR TITLE
fix: scope browser_click dropdown guidance to ARIA dropdowns and add native select fallback

### DIFF
--- a/assistant/src/config/bundled-skills/browser/TOOLS.json
+++ b/assistant/src/config/bundled-skills/browser/TOOLS.json
@@ -71,7 +71,7 @@
     },
     {
       "name": "browser_click",
-      "description": "Click an element on the page. Always use element_id from browser_snapshot — do not fabricate CSS selectors. For dropdowns (including Angular Material mat-select), click to open, take a new browser_snapshot to see the options (role=\"option\" elements), then click the desired option by element_id. For autocomplete inputs where options don't appear in the snapshot, use browser_press_key with ArrowDown/ArrowUp + Enter.",
+      "description": "Click an element on the page. Always use element_id from browser_snapshot — do not fabricate CSS selectors. For ARIA/custom dropdowns (mat-select, role=listbox, or any dropdown whose options appear as role=\"option\" in browser_snapshot), click to open, take a new browser_snapshot, then click the desired option by element_id. For native <select> elements (whose <option> children do NOT appear in browser_snapshot), use browser_press_key with ArrowDown/ArrowUp + Enter to navigate and select. For autocomplete inputs where options don't appear in the snapshot, also use browser_press_key with ArrowDown/ArrowUp + Enter.",
       "category": "browser",
       "risk": "low",
       "input_schema": {


### PR DESCRIPTION
Addresses Codex feedback on #8664. The browser_click tool description now explicitly scopes the open-snapshot-click flow to ARIA/custom dropdowns (role=option) and adds a fallback path for native select elements using ArrowDown/ArrowUp + Enter.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
