### PR TITLE
fix: include both reason and command in shell confirmation notifications

### DIFF
--- a/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
@@ -108,12 +108,15 @@ public final class ToolConfirmationNotificationService {
     }
 
     private func formatBody(_ message: ConfirmationRequestMessage) -> String {
-        // For shell commands, prefer the human-readable reason over the raw command
+        // For shell commands, show both the human-readable reason and the raw command
         if message.toolName == "bash" || message.toolName == "host_bash" {
+            let command = commandPreview(toolName: message.toolName, input: message.input)
             if let reason = message.input["reason"]?.value as? String, !reason.isEmpty {
-                let body = reason.prefix(1).uppercased() + reason.dropFirst()
+                let capitalizedReason = reason.prefix(1).uppercased() + reason.dropFirst()
+                let body = "\(capitalizedReason)\n$ \(command)"
                 return body.count > 200 ? String(body.prefix(197)) + "..." : body
             }
+            return command.count > 200 ? String(command.prefix(197)) + "..." : command
         }
         let preview = commandPreview(toolName: message.toolName, input: message.input)
         if preview.count > 200 {


### PR DESCRIPTION
Addresses Codex feedback on #8665. The macOS notification body for bash/host_bash confirmations now shows both the human-readable reason AND the raw command text, so users can make informed approval decisions from notifications.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
