### PR TITLE
fix: resolve type errors and lint failures breaking CI

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -211,6 +211,21 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'skills_inspect',
     slug: 'clawhub/my-skill',
   },
+  skills_draft: {
+    type: 'skills_draft',
+    sourceText: 'Create a weather skill',
+  },
+  skills_create: {
+    type: 'skills_create',
+    skillId: 'weather-skill',
+    name: 'Weather Skill',
+    description: 'Fetches current weather',
+    emoji: '🌤️',
+    bodyMarkdown: '# Weather\n\nFetches weather data.',
+    userInvocable: true,
+    disableModelInvocation: false,
+    overwrite: false,
+  },
   suggestion_request: {
     type: 'suggestion_request',
     sessionId: 'sess-001',
@@ -1040,6 +1055,18 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
       files: [{ path: 'SKILL.md', size: 1024 }],
       skillMdContent: '# My Skill\n\nDoes things.',
     },
+  },
+  skills_draft_response: {
+    type: 'skills_draft_response',
+    success: true,
+    draft: {
+      skillId: 'weather-skill',
+      name: 'Weather Skill',
+      description: 'Fetches current weather',
+      emoji: '🌤️',
+      bodyMarkdown: '# Weather\n\nFetches weather data.',
+    },
+    warnings: [],
   },
   suggestion_response: {
     type: 'suggestion_response',

--- a/assistant/src/__tests__/session-surfaces-task-progress.test.ts
+++ b/assistant/src/__tests__/session-surfaces-task-progress.test.ts
@@ -13,9 +13,13 @@ import {
   type SurfaceSessionContext,
 } from '../daemon/session-surfaces.js';
 
-function makeContext(sent: ServerMessage[] = []): SurfaceSessionContext {
+function makeContext(
+  sent: ServerMessage[] = [],
+  channelCapabilities?: SurfaceSessionContext['channelCapabilities'],
+): SurfaceSessionContext {
   return {
     conversationId: 'session-1',
+    channelCapabilities,
     traceEmitter: { emit: () => {} },
     sendToClient: (msg) => sent.push(msg),
     pendingSurfaceActions: new Map<string, { surfaceType: SurfaceType }>(),
@@ -34,8 +38,7 @@ function makeContext(sent: ServerMessage[] = []): SurfaceSessionContext {
 describe('task_progress surface compatibility', () => {
   test('blocks ui_show when channel lacks dynamic UI support', async () => {
     const sent: ServerMessage[] = [];
-    const ctx = makeContext(sent);
-    ctx.channelCapabilities = { channel: 'voice', supportsDynamicUi: false };
+    const ctx = makeContext(sent, { channel: 'voice', supportsDynamicUi: false });
 
     const result = await surfaceProxyResolver(ctx, 'ui_show', {
       surface_type: 'card',
@@ -49,8 +52,7 @@ describe('task_progress surface compatibility', () => {
 
   test('blocks ui_update when channel lacks dynamic UI support', async () => {
     const sent: ServerMessage[] = [];
-    const ctx = makeContext(sent);
-    ctx.channelCapabilities = { channel: 'telegram', supportsDynamicUi: false };
+    const ctx = makeContext(sent, { channel: 'telegram', supportsDynamicUi: false });
 
     const result = await surfaceProxyResolver(ctx, 'ui_update', {
       surface_id: 'surface-1',

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -263,6 +263,7 @@ export const AssistantConfigSchema = z.object({
       enqueueIntervalMs: 6 * 60 * 60 * 1000,
       resolvedConflictRetentionMs: 30 * 24 * 60 * 60 * 1000,
       supersededItemRetentionMs: 30 * 24 * 60 * 60 * 1000,
+      conversationRetentionDays: 90,
     },
     extraction: {
       useLLM: true,

--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -406,7 +406,7 @@ async function executeApprove(
   session.setAssistantId(assistantId);
   // Daemon inbox handler — the guardian approved this escalation, so tag as
   // guardian to avoid 'unverified_channel' blocking memory extraction.
-  session.setGuardianContext({ actorRole: 'guardian', sourceChannel: sourceChannel ?? 'macos' });
+  session.setGuardianContext({ actorRole: 'guardian', sourceChannel: sourceChannel ?? 'vellum' });
   session.setCommandIntent(null);
 
   // Process the message through the agent loop (no IPC event callback


### PR DESCRIPTION
## Summary
- Added missing `skills_draft`, `skills_create` (client), and `skills_draft_response` (server) entries to the IPC snapshot test
- Fixed `readonly channelCapabilities` assignment in `session-surfaces-task-progress.test.ts` by passing it through `makeContext()` parameter
- Added missing `conversationRetentionDays: 90` to the memory cleanup config default in `schema.ts`
- Replaced legacy `'macos'` channel literal with `'vellum'` in `config-inbox.ts` guardian context fallback

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22358705846

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
