### PR TITLE
fix: tasks column alignment and composer placeholder wrapping

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -769,6 +769,10 @@ private final class ComposerNativeTextView: NSTextView {
         let x = textContainerInset.width + linePadding
         let width = max(0, bounds.width - x - textContainerInset.width - linePadding)
 
+        // Skip placeholder if it would wrap to a second line.
+        let placeholderWidth = (placeholderText as NSString).size(withAttributes: attributes).width
+        if placeholderWidth > width { return }
+
         // Draw at the standard text insertion position and let
         // CenteringClipView handle vertical centering of the whole
         // scroll content — avoids double-centering misalignment.
@@ -924,23 +928,21 @@ private final class CenteringClipView: NSClipView {
             layoutManager.ensureLayout(for: textContainer)
             var usedHeight = layoutManager.usedRect(for: textContainer).height
 
-            // When placeholder text is visible, use its rendered height instead
-            // of the (empty) layout manager height so the cursor stays aligned
-            // with the first line of placeholder text that may wrap.
+            // When placeholder text is visible and fits on one line, use its
+            // height so the cursor stays vertically centered with it.
             if textView.string.isEmpty,
                let placeholder = textView.placeholderText,
                !placeholder.isEmpty {
                 let font = textView.font ?? NSFont.systemFont(ofSize: 13)
-                let paragraph = NSMutableParagraphStyle()
-                paragraph.lineBreakMode = .byTruncatingTail
                 let linePadding = textContainer.lineFragmentPadding
                 let availableWidth = max(0, textView.bounds.width - textView.textContainerInset.width * 2 - linePadding * 2)
-                let placeholderSize = (placeholder as NSString).boundingRect(
-                    with: NSSize(width: availableWidth, height: .greatestFiniteMagnitude),
-                    options: [.usesLineFragmentOrigin],
-                    attributes: [.font: font, .paragraphStyle: paragraph]
-                )
-                usedHeight = max(usedHeight, placeholderSize.height)
+                // Only account for placeholder height when it fits on one line
+                // (draw() hides the placeholder when it would wrap).
+                let placeholderWidth = (placeholder as NSString).size(withAttributes: [.font: font]).width
+                if placeholderWidth <= availableWidth {
+                    let singleLineHeight = ceil(font.ascender - font.descender + font.leading)
+                    usedHeight = max(usedHeight, singleLineHeight)
+                }
             }
 
             // Include the textContainerInset in the total content height so

--- a/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/Tasks/TasksWindowView.swift
@@ -11,35 +11,8 @@ struct TasksWindowView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Column headers — fixed above the scrollable list
-            HStack(alignment: .center, spacing: 0) {
-                Text("Task Description")
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                Text("Priority")
-                    .frame(width: TasksTableContract.priorityWidth)
-
-                Text("Status")
-                    .frame(width: TasksTableContract.statusWidth)
-
-                Text("Actions")
-                    .frame(width: TasksTableContract.actionsWidth)
-            }
-            .font(VFont.captionMedium)
-            .foregroundColor(VColor.textMuted)
-            .padding(.top, VSpacing.lg)
-            .padding(.bottom, VSpacing.sm)
-            .padding(.horizontal, VSpacing.lg)
-            // Inner horizontal padding matches row padding so labels sit
-            // directly above their respective columns.
-            .padding(.horizontal, VSpacing.md)
-
-            Rectangle()
-                .fill(VColor.surfaceBorder)
-                .frame(height: 1)
-
-            // Content
             if viewModel.isLoading {
+                columnHeaderBar
                 VStack {
                     Spacer()
                     ProgressView()
@@ -48,6 +21,7 @@ struct TasksWindowView: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let error = viewModel.errorMessage {
+                columnHeaderBar
                 VStack(spacing: VSpacing.md) {
                     Spacer()
                     Image(systemName: "exclamationmark.triangle")
@@ -66,6 +40,7 @@ struct TasksWindowView: View {
                 .frame(maxWidth: .infinity)
                 .padding(VSpacing.lg)
             } else if viewModel.items.isEmpty {
+                columnHeaderBar
                 VEmptyState(
                     title: "No tasks",
                     subtitle: "Your tasks will appear here",
@@ -73,22 +48,35 @@ struct TasksWindowView: View {
                 )
             } else {
                 ScrollView {
-                    LazyVStack(spacing: VSpacing.xs) {
-                        ForEach(viewModel.items, id: \.id) { item in
-                            TasksWindowRow(
-                                item: item,
-                                hasOutput: viewModel.taskHasOutput(item),
-                                runningIds: viewModel.runInFlightIds,
-                                timeoutIds: viewModel.runTimeoutIds,
-                                cancelInFlightIds: viewModel.cancelInFlightIds,
-                                onTap: { viewModel.fetchOutput(for: item) },
-                                onRun: { viewModel.initiateRun(item: item) },
-                                onCancel: { viewModel.cancelTask(id: item.id) },
-                                onRemove: { viewModel.removeTask(id: item.id) },
-                                onPriorityChange: { newTier in
-                                    viewModel.updatePriority(id: item.id, tier: newTier)
+                    LazyVStack(spacing: VSpacing.xs, pinnedViews: [.sectionHeaders]) {
+                        Section {
+                            ForEach(viewModel.items, id: \.id) { item in
+                                TasksWindowRow(
+                                    item: item,
+                                    hasOutput: viewModel.taskHasOutput(item),
+                                    runningIds: viewModel.runInFlightIds,
+                                    timeoutIds: viewModel.runTimeoutIds,
+                                    cancelInFlightIds: viewModel.cancelInFlightIds,
+                                    onTap: { viewModel.fetchOutput(for: item) },
+                                    onRun: { viewModel.initiateRun(item: item) },
+                                    onCancel: { viewModel.cancelTask(id: item.id) },
+                                    onRemove: { viewModel.removeTask(id: item.id) },
+                                    onPriorityChange: { newTier in
+                                        viewModel.updatePriority(id: item.id, tier: newTier)
+                                    }
+                                )
+                            }
+                        } header: {
+                            columnHeaderLabels
+                                .padding(.horizontal, VSpacing.md)
+                                .padding(.top, VSpacing.lg)
+                                .padding(.bottom, VSpacing.sm)
+                                .background(VColor.background)
+                                .overlay(alignment: .bottom) {
+                                    Rectangle()
+                                        .fill(VColor.surfaceBorder)
+                                        .frame(height: 1)
                                 }
-                            )
                         }
                     }
                     .padding(.horizontal, VSpacing.lg)
@@ -127,6 +115,44 @@ struct TasksWindowView: View {
                     onDismiss: { viewModel.dismissPreflight() }
                 )
             }
+        }
+    }
+}
+
+// MARK: - Column Header Helpers
+
+extension TasksWindowView {
+    /// Column header labels shared between standalone and scroll-pinned headers.
+    fileprivate var columnHeaderLabels: some View {
+        HStack(alignment: .center, spacing: 0) {
+            Text("Task Description")
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Text("Priority")
+                .frame(width: TasksTableContract.priorityWidth)
+
+            Text("Status")
+                .frame(width: TasksTableContract.statusWidth)
+
+            Text("Actions")
+                .frame(width: TasksTableContract.actionsWidth)
+        }
+        .font(VFont.captionMedium)
+        .foregroundColor(VColor.textMuted)
+    }
+
+    /// Standalone column header bar for non-scrolling states (loading/error/empty).
+    fileprivate var columnHeaderBar: some View {
+        VStack(spacing: 0) {
+            columnHeaderLabels
+                .padding(.top, VSpacing.lg)
+                .padding(.bottom, VSpacing.sm)
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.horizontal, VSpacing.md)
+
+            Rectangle()
+                .fill(VColor.surfaceBorder)
+                .frame(height: 1)
         }
     }
 }
@@ -228,6 +254,7 @@ private struct TasksWindowRow: View {
         }
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
+        .fixedSize()
         .accessibilityLabel("Priority \(style.label)")
         .accessibilityHint("Double-click to change priority")
     }


### PR DESCRIPTION
## Summary
- Fix Tasks window column header misalignment by using pinned section headers inside ScrollView, ensuring headers and rows share the same layout context
- Add `.fixedSize()` to priority Menu to prevent macOS borderless button style from expanding and misaligning content
- Fix composer placeholder text wrapping: skip drawing when placeholder would wrap to a second line, simplify height calculation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
