### PR TITLE
fix: gate inline error fallback to iOS only

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1254,9 +1254,11 @@ extension ChatViewModel {
                    messages.last?.toolCalls.isEmpty == true {
                     messages.removeAll(where: { $0.id == existingId })
                 }
-                // Keep inline error message as fallback for platforms without the session error toast
+                // macOS shows ChatSessionErrorToast; only append inline error on iOS where the toast is unavailable
+                #if os(iOS)
                 let errorMsg = ChatMessage(role: .assistant, text: msg.userMessage, isError: true)
                 messages.append(errorMsg)
+                #endif
             }
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {


### PR DESCRIPTION
Addresses Codex feedback on #8666. The inline error message append was running on all platforms, but macOS already shows ChatSessionErrorToast, creating duplicate error surfaces. Wraps the inline fallback in a platform guard so it only runs on iOS.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
