### PR TITLE
fix: handle empty command and smart truncation in shell notification body

### DIFF
--- a/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
@@ -113,8 +113,23 @@ public final class ToolConfirmationNotificationService {
             let command = commandPreview(toolName: message.toolName, input: message.input)
             if let reason = message.input["reason"]?.value as? String, !reason.isEmpty {
                 let capitalizedReason = reason.prefix(1).uppercased() + reason.dropFirst()
-                let body = "\(capitalizedReason)\n$ \(command)"
-                return body.count > 200 ? String(body.prefix(197)) + "..." : body
+                // Don't append a dangling "$ " when command is empty
+                guard !command.isEmpty else {
+                    return capitalizedReason.count > 200 ? String(capitalizedReason.prefix(197)) + "..." : capitalizedReason
+                }
+                let commandLine = "$ \(command)"
+                let body = "\(capitalizedReason)\n\(commandLine)"
+                if body.count <= 200 { return body }
+                // Truncate reason first to preserve the command
+                let commandBudget = min(commandLine.count, 200)
+                let reasonBudget = 200 - commandBudget - 1 // 1 for newline
+                if reasonBudget >= 4 {
+                    let truncatedReason = String(capitalizedReason.prefix(reasonBudget - 3)) + "..."
+                    let truncatedBody = "\(truncatedReason)\n\(commandLine)"
+                    if truncatedBody.count <= 200 { return truncatedBody }
+                }
+                // Command alone exceeds the limit — truncate it
+                return commandLine.count > 200 ? String(commandLine.prefix(197)) + "..." : commandLine
             }
             return command.count > 200 ? String(command.prefix(197)) + "..." : command
         }


### PR DESCRIPTION
Addresses Codex and Devin feedback on #8671. Fixes two issues: (1) dangling '$ ' prompt when command is empty, and (2) naive truncation that could hide the command when reason is long. Now guards against empty commands and truncates the reason first to preserve the command text.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
