### PR TITLE
fix: add markCommandExplanationSeen to all Always Allow dropdown paths

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -512,6 +512,7 @@ public struct ToolConfirmationBubble: View {
 
     /// Activate the currently selected row in the nested popover.
     private func activatePopoverSelection() {
+        markCommandExplanationSeen()
         guard let model = popoverKeyboardModel else { return }
         let index = model.selectedIndex
 
@@ -746,6 +747,7 @@ public struct ToolConfirmationBubble: View {
                             label: scopeOption.label,
                             isKeyboardSelected: popoverKeyboardModel?.mode == .scopes && popoverKeyboardModel?.selectedIndex == index
                         ) {
+                            markCommandExplanationSeen()
                             showAlwaysAllowMenu = false
                             pendingPattern = nil
                             popoverKeyboardModel = nil
@@ -765,6 +767,7 @@ public struct ToolConfirmationBubble: View {
                             subtitle: option.description,
                             isKeyboardSelected: popoverKeyboardModel?.mode == .patterns && popoverKeyboardModel?.selectedIndex == index
                         ) {
+                            markCommandExplanationSeen()
                             if option.pattern.isEmpty {
                                 showAlwaysAllowMenu = false
                                 popoverKeyboardModel = nil
@@ -814,6 +817,7 @@ public struct ToolConfirmationBubble: View {
                     label: scopeOption.label,
                     isKeyboardSelected: popoverKeyboardModel?.mode == .scopes && popoverKeyboardModel?.selectedIndex == index
                 ) {
+                    markCommandExplanationSeen()
                     showScopePickerMenu = false
                     popoverKeyboardModel = nil
                     if let pattern = pendingPattern {


### PR DESCRIPTION
Adds markCommandExplanationSeen() calls to the multi-option Always Allow dropdown, scope picker, and popover selection paths that were missing them. Both Codex and Devin flagged this gap in PR #8683 — the banner dismissal was only persisted for direct button clicks and keyboard-driven flows, but not for mouse-driven dropdown completions.

Specifically adds calls to:
- activatePopoverSelection() — keyboard Enter in nested popovers
- ScopePickerRow action in alwaysAllowDropdown — mouse click on scope row
- AlwaysAllowRow action in alwaysAllowDropdown — mouse click on pattern row
- ScopePickerRow action in scopePickerContent — mouse click on inline scope picker
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
