### PR TITLE
Fix M1 review feedback: forceStop, start race, HUD timing, picker close

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Recording.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Recording.swift
@@ -74,31 +74,33 @@ extension AppDelegate {
         )
     }
 
-    /// Start recording and show the recording HUD.
+    /// Start recording and show the recording HUD only after recording is confirmed.
     private func startRecording(
         recordingId: String,
         options: IPCRecordingOptions?,
         attachToConversationId: String?
     ) {
-        let started = recordingManager.start(
-            sessionId: recordingId,
-            options: options,
-            attachToConversationId: attachToConversationId
-        )
+        Task {
+            let started = await recordingManager.start(
+                sessionId: recordingId,
+                options: options,
+                attachToConversationId: attachToConversationId
+            )
 
-        guard started else { return }
+            guard started else { return }
 
-        // Show the recording HUD
-        if recordingHUDWindow == nil {
-            recordingHUDWindow = RecordingHUDWindow()
-        }
-
-        recordingHUDWindow?.show(onStop: { [weak self] in
-            guard let self else { return }
-            Task {
-                _ = await self.recordingManager.stop(sessionId: recordingId)
-                self.recordingHUDWindow?.dismiss()
+            // Show the recording HUD only after recording is confirmed
+            if recordingHUDWindow == nil {
+                recordingHUDWindow = RecordingHUDWindow()
             }
-        })
+
+            recordingHUDWindow?.show(onStop: { [weak self] in
+                guard let self else { return }
+                Task {
+                    _ = await self.recordingManager.stop(sessionId: recordingId)
+                    self.recordingHUDWindow?.dismiss()
+                }
+            })
+        }
     }
 }

--- a/clients/macos/vellum-assistant/ComputerUse/RecordingManager.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/RecordingManager.swift
@@ -52,13 +52,17 @@ final class RecordingManager: ObservableObject {
 
     /// Start a new recording.
     ///
+    /// This method is async — it awaits the actual recorder start and only
+    /// returns `true` after the recording has been confirmed. Callers should
+    /// await the result before showing UI (e.g., the recording HUD).
+    ///
     /// - Parameters:
     ///   - sessionId: The recording session ID (matches `recordingId` from `RecordingStart`).
     ///   - options: Recording options (capture scope, display/window, audio).
     ///   - attachToConversationId: Optional conversation ID to attach the recording to.
-    /// - Returns: `true` if the recording started successfully, `false` if already recording.
+    /// - Returns: `true` if the recording started successfully, `false` otherwise.
     @discardableResult
-    func start(sessionId: String, options: IPCRecordingOptions? = nil, attachToConversationId: String? = nil) -> Bool {
+    func start(sessionId: String, options: IPCRecordingOptions? = nil, attachToConversationId: String? = nil) async -> Bool {
         guard !state.isActive else {
             log.warning("Cannot start recording — already active (state=\(String(describing: self.state)), owner=\(self.ownerSessionId ?? "nil"))")
             sendStatus(sessionId: sessionId, status: "failed", error: "Another recording is already active")
@@ -69,26 +73,35 @@ final class RecordingManager: ObservableObject {
         self.attachToConversationId = attachToConversationId
         self.state = .starting
 
-        Task {
-            do {
-                try await recorder.start(
-                    captureScope: options?.captureScope ?? "display",
-                    displayId: options?.displayId,
-                    windowId: options?.windowId.flatMap { Int(exactly: $0) },
-                    includeAudio: options?.includeAudio ?? false
-                )
-                state = .recording
-                sendStatus(sessionId: sessionId, status: "started")
-                log.info("Recording started for session \(sessionId, privacy: .public)")
-            } catch {
+        do {
+            try await recorder.start(
+                captureScope: options?.captureScope ?? "display",
+                displayId: options?.displayId,
+                windowId: options?.windowId.flatMap { Int(exactly: $0) },
+                includeAudio: options?.includeAudio ?? false
+            )
+
+            // Guard against stale completion: if stop() or forceStop() was called
+            // while we were awaiting recorder.start(), don't override the state.
+            guard state == .starting, ownerSessionId == sessionId else {
+                log.info("Recording start completed but state changed during await — not overriding (state=\(String(describing: self.state)))")
+                return false
+            }
+
+            state = .recording
+            sendStatus(sessionId: sessionId, status: "started")
+            log.info("Recording started for session \(sessionId, privacy: .public)")
+            return true
+        } catch {
+            // Only update state if we're still the active start attempt
+            if state == .starting, ownerSessionId == sessionId {
                 let message = error.localizedDescription
                 state = .failed(message)
                 sendStatus(sessionId: sessionId, status: "failed", error: message)
                 log.error("Recording failed to start: \(message, privacy: .public)")
             }
+            return false
         }
-
-        return true
     }
 
     // MARK: - Stop
@@ -137,12 +150,24 @@ final class RecordingManager: ObservableObject {
     // MARK: - Force Stop
 
     /// Force-stop any active recording, regardless of owner. Used during app shutdown.
+    ///
+    /// This method is synchronous and safe to call from `applicationWillTerminate`
+    /// where async work cannot complete before the process exits.
+    /// It discards the recording rather than trying to finalize the file.
     func forceStop() {
-        guard state.isActive, let sessionId = ownerSessionId else { return }
+        guard state.isActive else { return }
 
-        Task {
-            _ = await stop(sessionId: sessionId)
+        recorder.cancelRecording()
+
+        let sessionId = ownerSessionId
+        state = .idle
+        ownerSessionId = nil
+        attachToConversationId = nil
+
+        if let sessionId {
+            sendStatus(sessionId: sessionId, status: "failed", error: "Recording cancelled during shutdown")
         }
+        log.info("Force-stopped recording (synchronous cancel)")
     }
 
     // MARK: - IPC

--- a/clients/macos/vellum-assistant/ComputerUse/RecordingSourcePickerWindow.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/RecordingSourcePickerWindow.swift
@@ -7,9 +7,13 @@ import VellumAssistantShared
 /// Creates an NSWindow hosting `RecordingSourcePickerView` and centers it
 /// on the main screen.
 @MainActor
-final class RecordingSourcePickerWindow {
+final class RecordingSourcePickerWindow: NSObject, NSWindowDelegate {
     private var window: NSWindow?
     private var viewModel: RecordingSourcePickerViewModel?
+    private var onCancelCallback: (() -> Void)?
+    /// Guards against double-invocation of the cancel callback (e.g., if
+    /// the Cancel button is pressed and then the window also closes).
+    private var cancelFired = false
 
     /// Show the source picker window.
     ///
@@ -20,17 +24,24 @@ final class RecordingSourcePickerWindow {
         // Dismiss any existing picker window
         dismiss()
 
+        self.onCancelCallback = onCancel
+        self.cancelFired = false
+
         let vm = RecordingSourcePickerViewModel()
         self.viewModel = vm
 
         let pickerView = RecordingSourcePickerView(
             viewModel: vm,
             onStart: { [weak self] options in
+                // Start was chosen — clear the cancel callback so closing
+                // the window doesn't also fire cancel.
+                self?.onCancelCallback = nil
+                self?.cancelFired = true
                 onStart(options)
                 self?.dismiss()
             },
             onCancel: { [weak self] in
-                onCancel()
+                self?.fireCancel()
                 self?.dismiss()
             }
         )
@@ -50,6 +61,7 @@ final class RecordingSourcePickerWindow {
         newWindow.isReleasedWhenClosed = false
         newWindow.level = .floating
         newWindow.center()
+        newWindow.delegate = self
 
         newWindow.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
@@ -59,8 +71,29 @@ final class RecordingSourcePickerWindow {
 
     /// Dismiss the picker window.
     func dismiss() {
+        window?.delegate = nil
         window?.close()
         window = nil
         viewModel = nil
+    }
+
+    // MARK: - NSWindowDelegate
+
+    /// Handles the window being closed via the title bar close button or Cmd+W.
+    nonisolated func windowWillClose(_ notification: Notification) {
+        Task { @MainActor in
+            fireCancel()
+            window = nil
+            viewModel = nil
+        }
+    }
+
+    // MARK: - Private
+
+    private func fireCancel() {
+        guard !cancelFired else { return }
+        cancelFired = true
+        onCancelCallback?()
+        onCancelCallback = nil
     }
 }

--- a/clients/macos/vellum-assistant/ComputerUse/ScreenRecorder.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ScreenRecorder.swift
@@ -290,6 +290,28 @@ final class ScreenRecorder: NSObject {
         }
     }
 
+    /// Cancel the active recording synchronously, discarding the output file.
+    ///
+    /// Uses `AVAssetWriter.cancelWriting()` which is synchronous and safe to
+    /// call during `applicationWillTerminate` where async work cannot complete.
+    func cancelRecording() {
+        guard isRecordingActive else { return }
+
+        // Stop the stream synchronously (best-effort — stopCapture is async but
+        // we nil it out so no more buffers arrive).
+        stream = nil
+
+        assetWriter?.cancelWriting()
+
+        // Remove the partial file to avoid leaving corrupted output
+        if let outputURL = assetWriter?.outputURL {
+            try? FileManager.default.removeItem(at: outputURL)
+            log.info("Cancelled recording — removed partial file \(outputURL.path, privacy: .public)")
+        }
+
+        cleanUpWriter()
+    }
+
     private func cleanUpWriter() {
         isRecordingActive = false
         assetWriter = nil


### PR DESCRIPTION
Addresses 4 review issues on PR #8684: (1) forceStop() now uses synchronous cancelWriting() to prevent corrupted files during app termination, (2) start() completion guards against stale state to prevent race with stop(), (3) start() is now async so HUD only shows after recording confirmed, (4) picker window close via title bar now invokes cancel callback. Part of #8672.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
