### PR TITLE
Fix RecordingManager: stale recorder cleanup + forceStop status ordering

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/RecordingManager.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/RecordingManager.swift
@@ -84,7 +84,8 @@ final class RecordingManager: ObservableObject {
             // Guard against stale completion: if stop() or forceStop() was called
             // while we were awaiting recorder.start(), don't override the state.
             guard state == .starting, ownerSessionId == sessionId else {
-                log.info("Recording start completed but state changed during await — not overriding (state=\(String(describing: self.state)))")
+                log.info("Recording start completed but state changed during await — cancelling stale recorder (state=\(String(describing: self.state)))")
+                recorder.cancelRecording()
                 return false
             }
 
@@ -160,13 +161,13 @@ final class RecordingManager: ObservableObject {
         recorder.cancelRecording()
 
         let sessionId = ownerSessionId
-        state = .idle
-        ownerSessionId = nil
-        attachToConversationId = nil
-
         if let sessionId {
             sendStatus(sessionId: sessionId, status: "failed", error: "Recording cancelled during shutdown")
         }
+
+        state = .idle
+        ownerSessionId = nil
+        attachToConversationId = nil
         log.info("Force-stopped recording (synchronous cancel)")
     }
 


### PR DESCRIPTION
Addresses 2 review issues on PR #8686: (1) When start() detects stale state, cancel the now-active recorder to prevent untracked sessions, (2) Send status message before clearing attachToConversationId in forceStop() to preserve conversation association. Part of #8672.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
