### PR TITLE
Add shortcuts reference to Settings > Appearance

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -82,6 +82,9 @@ struct SettingsAppearanceTab: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.warning)
                 }
+
+                ShortcutRow(label: "Quick Input", shortcut: "⌘⇧V")
+                ShortcutRow(label: "Start voice input", shortcut: "Hold Fn")
             }
             .padding(VSpacing.lg)
             .vCard(background: VColor.surfaceSubtle)
@@ -206,6 +209,32 @@ struct SettingsAppearanceTab: View {
         if let monitor = shortcutMonitor {
             NSEvent.removeMonitor(monitor)
             shortcutMonitor = nil
+        }
+    }
+}
+
+/// A read-only row displaying a keyboard shortcut and its description.
+private struct ShortcutRow: View {
+    let label: String
+    let shortcut: String
+
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+            Spacer()
+            Text(shortcut)
+                .font(VFont.mono)
+                .foregroundColor(VColor.textPrimary)
+                .padding(.horizontal, VSpacing.sm)
+                .padding(.vertical, VSpacing.xs)
+                .background(VColor.surface)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.sm)
+                        .stroke(VColor.surfaceBorder, lineWidth: 1)
+                )
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add read-only shortcut rows for Quick Input (⌘⇧V) and Start voice input (Hold Fn) to the Keyboard Shortcuts section in Settings > Appearance
- Extract reusable `ShortcutRow` helper view matching existing shortcut badge styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
