### PR TITLE
Fix RecordingManager: gate stale recorder cancel to original session

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/RecordingManager.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/RecordingManager.swift
@@ -84,8 +84,13 @@ final class RecordingManager: ObservableObject {
             // Guard against stale completion: if stop() or forceStop() was called
             // while we were awaiting recorder.start(), don't override the state.
             guard state == .starting, ownerSessionId == sessionId else {
-                log.info("Recording start completed but state changed during await — cancelling stale recorder (state=\(String(describing: self.state)))")
-                recorder.cancelRecording()
+                log.info("Recording start completed but state changed during await — checking ownership before cancelling (state=\(String(describing: self.state)), owner=\(self.ownerSessionId ?? "nil"))")
+                // Only cancel if no other session has taken ownership of the recorder.
+                // If ownerSessionId points to a different session and the state is active,
+                // that session now owns the recorder — cancelling would tear down its recording.
+                if ownerSessionId == nil || !state.isActive {
+                    recorder.cancelRecording()
+                }
                 return false
             }
 


### PR DESCRIPTION
Only cancel the recorder on stale start completion if no other session has taken ownership. Prevents cross-session cancellation where session A's stale completion would tear down session B's active recording. Addresses review feedback on PR #8688. Part of #8672.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
