### PR TITLE
Fix stale-start cancel: only skip when state is .recording

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/RecordingManager.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/RecordingManager.swift
@@ -88,7 +88,7 @@ final class RecordingManager: ObservableObject {
                 // Only cancel if no other session has taken ownership of the recorder.
                 // If ownerSessionId points to a different session and the state is active,
                 // that session now owns the recorder — cancelling would tear down its recording.
-                if ownerSessionId == nil || !state.isActive {
+                if ownerSessionId == nil || state != .recording {
                     recorder.cancelRecording()
                 }
                 return false


### PR DESCRIPTION
Narrows the stale-start cancel guard — only skip cancelRecording() when another session is confirmed .recording, not when .starting. Prevents orphaned recorders when the replacing session fails during startup. Addresses Codex P1 on PR #8691. Part of #8672.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
