### PR TITLE
Revert stale-start cancel guard to !state.isActive

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/RecordingManager.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/RecordingManager.swift
@@ -88,7 +88,7 @@ final class RecordingManager: ObservableObject {
                 // Only cancel if no other session has taken ownership of the recorder.
                 // If ownerSessionId points to a different session and the state is active,
                 // that session now owns the recorder — cancelling would tear down its recording.
-                if ownerSessionId == nil || state != .recording {
+                if ownerSessionId == nil || !state.isActive {
                     recorder.cancelRecording()
                 }
                 return false


### PR DESCRIPTION
Reverts the change from PR #8692 which changed !state.isActive to state != .recording. Both Codex and Devin confirmed this was a regression — it cancels during .stopping (data loss on finalization) and .starting (tears down new session). The original !state.isActive correctly protects active/starting/stopping states. Part of #8672.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
