### PR TITLE
fix: prioritize most recent screenshots in attachment selection

### DIFF
--- a/assistant/src/__tests__/assistant-attachments.test.ts
+++ b/assistant/src/__tests__/assistant-attachments.test.ts
@@ -375,6 +375,40 @@ describe('contentBlocksToDrafts', () => {
 // deduplicateDrafts
 // ---------------------------------------------------------------------------
 
+describe('validateDrafts with reversed tool drafts', () => {
+  test('most recent tool screenshots win the attachment cap when reversed before validation', () => {
+    // Simulate a browser session producing many screenshots chronologically.
+    // After reversing, the most recent (highest index) should appear first
+    // and win the MAX_ASSISTANT_ATTACHMENTS cap.
+    const totalScreenshots = MAX_ASSISTANT_ATTACHMENTS + 3;
+    const toolDrafts = Array.from({ length: totalScreenshots }, (_, i) =>
+      makeDraft({
+        sourceType: 'tool_block',
+        filename: `screenshot-step-${i}.png`,
+        mimeType: 'image/png',
+        kind: 'image',
+        dataBase64: `data${i}`,
+      }),
+    );
+
+    // Reverse to prioritize most recent
+    toolDrafts.reverse();
+
+    const result = validateDrafts(toolDrafts);
+    expect(result.accepted).toHaveLength(MAX_ASSISTANT_ATTACHMENTS);
+
+    // The accepted drafts should be the most recent screenshots (highest step numbers)
+    const acceptedFilenames = result.accepted.map(d => d.filename);
+    for (let i = 0; i < MAX_ASSISTANT_ATTACHMENTS; i++) {
+      expect(acceptedFilenames[i]).toBe(`screenshot-step-${totalScreenshots - 1 - i}.png`);
+    }
+
+    // The oldest screenshots should be dropped
+    expect(result.warnings).toHaveLength(3);
+    expect(result.warnings[0]).toContain('screenshot-step-2.png');
+  });
+});
+
 describe('deduplicateDrafts', () => {
   test('removes exact duplicates with same filename and content', () => {
     const d = makeDraft({ filename: 'same.txt', dataBase64: 'AAAA'.repeat(20) });

--- a/assistant/src/daemon/session-attachments.ts
+++ b/assistant/src/daemon/session-attachments.ts
@@ -117,7 +117,9 @@ export async function resolveAssistantAttachments(
     );
 
     const toolDrafts = contentBlocksToDrafts(accumulatedToolContentBlocks);
-
+    // Most recent tool outputs (e.g., final browser screenshot) should win
+    // the MAX_ASSISTANT_ATTACHMENTS cap over older intermediate screenshots.
+    toolDrafts.reverse();
     const merged = deduplicateDrafts([...directiveDrafts.drafts, ...toolDrafts]);
     const validated = validateDrafts(merged);
     directiveWarnings.push(...validated.warnings);


### PR DESCRIPTION
## Summary

- Reverse `toolDrafts` in `session-attachments.ts` before merging with directive drafts, so the most recent tool outputs (e.g., final browser screenshot) win the `MAX_ASSISTANT_ATTACHMENTS` cap over older intermediate screenshots
- Add test verifying that reversed tool drafts correctly prioritize the most recent screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
