### PR TITLE
Fix recording handler map leaks: duplicate start + missing socket cleanup

### DIFF
--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -29,6 +29,12 @@ export function handleRecordingStart(
 ): string {
   const recordingId = uuid();
 
+  const existingRecordingId = recordingOwnerByConversation.get(conversationId);
+  if (existingRecordingId) {
+    log.warn({ conversationId, existingRecordingId }, 'Overwriting active recording for conversation');
+    standaloneRecordingConversationId.delete(existingRecordingId);
+  }
+
   standaloneRecordingConversationId.set(recordingId, conversationId);
   recordingOwnerByConversation.set(conversationId, recordingId);
 
@@ -68,6 +74,8 @@ export function handleRecordingStop(
   const socket = findSocketForSession(conversationId, ctx);
   if (!socket) {
     log.warn({ conversationId, recordingId }, 'Cannot send recording_stop: no socket bound to conversation');
+    standaloneRecordingConversationId.delete(recordingId);
+    recordingOwnerByConversation.delete(conversationId);
     return undefined;
   }
 


### PR DESCRIPTION
Addresses 2 review issues on PR #8696: (1) handleRecordingStart now cleans up old recording mapping before overwriting when duplicate start for same conversation, (2) handleRecordingStop now cleans up both maps when socket not found. Part of #8672.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
