### PR TITLE
fix: remove browser_wait_for_download from SIDE_EFFECT_TOOLS

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -769,7 +769,6 @@ const SIDE_EFFECT_TOOLS: ReadonlySet<string> = new Set([
   'browser_scroll',
   'browser_select_option',
   'browser_hover',
-  'browser_wait_for_download',
   'browser_close',
   'browser_fill_credential',
   'document_create',


### PR DESCRIPTION
Addresses Codex review feedback on #8693. browser_wait_for_download is a passive operation (waits for download metadata) rather than a mutation, so it should not be gated as a side effect — doing so breaks automated flows in private threads.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
