### PR TITLE
fix: address M3 PR #8699 review feedback

### DIFF
--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -11,7 +11,7 @@ import { parseSlashCandidate } from '../../skills/slash-commands.js';
 import { classifySessionError, buildSessionErrorMessage } from '../session-error.js';
 import { resolveBlobPath, deleteBlob, isValidBlobId } from '../ipc-blob-store.js';
 import { getConfig } from '../../config/loader.js';
-import { isRecordingOnly, detectStopRecordingIntent } from '../recording-intent.js';
+import { isRecordingOnly, isStopRecordingOnly } from '../recording-intent.js';
 import { handleRecordingStart, handleRecordingStop } from './recording.js';
 import type {
   TaskSubmit,
@@ -72,16 +72,20 @@ export async function handleTaskSubmit(
     // session and routes it to the standalone recording flow instead.
     const config = getConfig();
     if (config.daemon.standaloneRecording) {
-      if (detectStopRecordingIntent(msg.task)) {
+      if (isStopRecordingOnly(msg.task)) {
         // Find the active session for this socket so we can resolve the
         // conversation that owns the recording.
         const activeSessionId = ctx.socketToSession.get(socket);
+        let stopped = false;
         if (activeSessionId) {
-          handleRecordingStop(activeSessionId, ctx);
+          stopped = handleRecordingStop(activeSessionId, ctx) !== undefined;
         }
         rlog.info('Recording stop intent intercepted');
-        ctx.send(socket, { type: 'assistant_text_delta', text: 'Stopping the recording.' });
-        ctx.send(socket, { type: 'message_complete' });
+        ctx.send(socket, {
+          type: 'assistant_text_delta',
+          text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',
+        });
+        ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
         return;
       }
 
@@ -99,7 +103,7 @@ export async function handleTaskSubmit(
         });
         rlog.info({ sessionId: conversation.id }, 'Recording-only intent intercepted — routed to standalone recording');
         ctx.send(socket, { type: 'assistant_text_delta', text: 'Starting screen recording.' });
-        ctx.send(socket, { type: 'message_complete' });
+        ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
         return;
       }
     }

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -10,7 +10,7 @@ import { getAttachmentsForMessage, setAttachmentThumbnail } from '../../memory/a
 import { generateVideoThumbnail } from '../video-thumbnail.js';
 import type { UserMessageAttachment } from '../ipc-contract.js';
 import { normalizeThreadType } from '../ipc-protocol.js';
-import { isRecordingOnly, detectStopRecordingIntent } from '../recording-intent.js';
+import { isRecordingOnly, isStopRecordingOnly } from '../recording-intent.js';
 import { handleRecordingStart, handleRecordingStop } from './recording.js';
 import type {
   UserMessage,
@@ -91,10 +91,13 @@ export async function handleUserMessage(
     const config = getConfig();
     const messageText = msg.content ?? '';
     if (config.daemon.standaloneRecording && messageText) {
-      if (detectStopRecordingIntent(messageText)) {
-        handleRecordingStop(msg.sessionId, ctx);
+      if (isStopRecordingOnly(messageText)) {
+        const stopped = handleRecordingStop(msg.sessionId, ctx) !== undefined;
         rlog.info('Recording stop intent intercepted in user_message');
-        ctx.send(socket, { type: 'assistant_text_delta', text: 'Stopping the recording.' });
+        ctx.send(socket, {
+          type: 'assistant_text_delta',
+          text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',
+        });
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
         return;
       }

--- a/assistant/src/daemon/recording-intent.ts
+++ b/assistant/src/daemon/recording-intent.ts
@@ -23,6 +23,15 @@ const STOP_RECORDING_PATTERNS: RegExp[] = [
   /\bhalt\s+(the\s+)?recording\b/i,
 ];
 
+// ─── Stop-recording clause removal for mixed-intent prompts ─────────────────
+
+const STOP_RECORDING_CLAUSE_PATTERNS: RegExp[] = [
+  /\b(and\s+)?(also\s+)?stop\s+(the\s+)?recording\b/i,
+  /\b(and\s+)?(also\s+)?end\s+(the\s+)?recording\b/i,
+  /\b(and\s+)?(also\s+)?finish\s+(the\s+)?recording\b/i,
+  /\b(and\s+)?(also\s+)?halt\s+(the\s+)?recording\b/i,
+];
+
 // ─── Clause removal for mixed-intent prompts ─────────────────────────────────
 
 const RECORDING_CLAUSE_PATTERNS: RegExp[] = [
@@ -83,4 +92,30 @@ export function stripRecordingIntent(taskText: string): string {
   }
   // Clean up any leftover double spaces or leading/trailing whitespace
   return result.replace(/\s{2,}/g, ' ').trim();
+}
+
+/**
+ * Removes stop-recording clauses from a message, returning the cleaned text.
+ * Analogous to stripRecordingIntent but for stop-recording phrases.
+ */
+export function stripStopRecordingIntent(taskText: string): string {
+  let result = taskText;
+  for (const pattern of STOP_RECORDING_CLAUSE_PATTERNS) {
+    result = result.replace(pattern, '');
+  }
+  return result.replace(/\s{2,}/g, ' ').trim();
+}
+
+/**
+ * Returns true if the prompt is purely about stopping recording with no
+ * additional task. Analogous to isRecordingOnly but for stop-recording.
+ * "stop recording" -> true
+ * "how do I stop recording?" -> false (has additional context)
+ * "stop recording and close the browser" -> false (has CU task component)
+ */
+export function isStopRecordingOnly(taskText: string): boolean {
+  if (!detectStopRecordingIntent(taskText)) return false;
+
+  const stripped = stripStopRecordingIntent(taskText);
+  return stripped.replace(/[.,;!?\s]+/g, '').length === 0;
 }

--- a/assistant/src/daemon/recording-intent.ts
+++ b/assistant/src/daemon/recording-intent.ts
@@ -45,6 +45,10 @@ const RECORDING_CLAUSE_PATTERNS: RegExp[] = [
   /\brecord\s+(my\s+|the\s+)?screen\s+while\b/i,
 ];
 
+/** Common polite/filler words stripped before checking intent-only status. */
+const FILLER_PATTERN =
+  /\b(please|pls|plz|can\s+you|could\s+you|would\s+you|now|right\s+now|thanks|thank\s+you|thx|ty|for\s+me|ok(ay)?|hey|hi|just)\b/gi;
+
 // ─── Public API ──────────────────────────────────────────────────────────────
 
 /**
@@ -66,9 +70,11 @@ export function isRecordingOnly(taskText: string): boolean {
 
   // Strip the recording clause and check if anything substantive remains
   const stripped = stripRecordingIntent(taskText);
-  // If after removing the recording clause, only whitespace/punctuation remains,
-  // this is a recording-only prompt.
-  return stripped.replace(/[.,;!?\s]+/g, '').length === 0;
+  // Also remove common polite/filler words that don't change the intent
+  const withoutFillers = stripped.replace(FILLER_PATTERN, '');
+  // If after removing the recording clause and fillers, only whitespace/punctuation
+  // remains, this is a recording-only prompt.
+  return withoutFillers.replace(/[.,;!?\s]+/g, '').length === 0;
 }
 
 /**
@@ -117,5 +123,7 @@ export function isStopRecordingOnly(taskText: string): boolean {
   if (!detectStopRecordingIntent(taskText)) return false;
 
   const stripped = stripStopRecordingIntent(taskText);
-  return stripped.replace(/[.,;!?\s]+/g, '').length === 0;
+  // Also remove common polite/filler words that don't change the intent
+  const withoutFillers = stripped.replace(FILLER_PATTERN, '');
+  return withoutFillers.replace(/[.,;!?\s]+/g, '').length === 0;
 }


### PR DESCRIPTION
Fixes 3 issues from Codex/Devin reviews on PR #8699:

1. **Stop recording guard**: Added `isStopRecordingOnly()` and `stripStopRecordingIntent()` to recording-intent.ts. Both misc.ts and sessions.ts now only intercept stop intent when the message is purely about stopping (prevents swallowing 'how do I stop recording?' queries).

2. **sessionId in message_complete**: misc.ts now includes sessionId in both stop and start intercept paths.

3. **handleRecordingStop return check**: Both handlers now check the return value of handleRecordingStop and send 'No active recording to stop.' when no recording was active.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
