### PR TITLE
fix: handle polite filler words in recording intent detection

### DIFF
--- a/assistant/src/daemon/recording-intent.ts
+++ b/assistant/src/daemon/recording-intent.ts
@@ -45,6 +45,10 @@ const RECORDING_CLAUSE_PATTERNS: RegExp[] = [
   /\brecord\s+(my\s+|the\s+)?screen\s+while\b/i,
 ];
 
+/** Common polite/filler words stripped before checking intent-only status. */
+const FILLER_PATTERN =
+  /\b(please|pls|plz|can\s+you|could\s+you|would\s+you|now|right\s+now|thanks|thank\s+you|thx|ty|for\s+me|ok(ay)?|hey|hi|just)\b/gi;
+
 // ─── Public API ──────────────────────────────────────────────────────────────
 
 /**
@@ -66,9 +70,11 @@ export function isRecordingOnly(taskText: string): boolean {
 
   // Strip the recording clause and check if anything substantive remains
   const stripped = stripRecordingIntent(taskText);
-  // If after removing the recording clause, only whitespace/punctuation remains,
-  // this is a recording-only prompt.
-  return stripped.replace(/[.,;!?\s]+/g, '').length === 0;
+  // Also remove common polite/filler words that don't change the intent
+  const withoutFillers = stripped.replace(FILLER_PATTERN, '');
+  // If after removing the recording clause and fillers, only whitespace/punctuation
+  // remains, this is a recording-only prompt.
+  return withoutFillers.replace(/[.,;!?\s]+/g, '').length === 0;
 }
 
 /**
@@ -117,5 +123,7 @@ export function isStopRecordingOnly(taskText: string): boolean {
   if (!detectStopRecordingIntent(taskText)) return false;
 
   const stripped = stripStopRecordingIntent(taskText);
-  return stripped.replace(/[.,;!?\s]+/g, '').length === 0;
+  // Also remove common polite/filler words that don't change the intent
+  const withoutFillers = stripped.replace(FILLER_PATTERN, '');
+  return withoutFillers.replace(/[.,;!?\s]+/g, '').length === 0;
 }


### PR DESCRIPTION
Fixes Codex P2 on PR #8700: isStopRecordingOnly was too strict — polite forms like 'please stop recording', 'can you stop recording?', 'stop recording now' were not intercepted because filler text remained after stripping the stop clause.

Added a shared FILLER_PATTERN that strips common polite/filler words (please, can you, could you, now, thanks, etc.) before checking if the remainder is empty. Applied to both isStopRecordingOnly() and isRecordingOnly() for consistency.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
