### PR TITLE
feat: add loopback OAuth2 transport — no tunnel needed for Google OAuth

### DIFF
--- a/assistant/src/__tests__/oauth2-gateway-transport.test.ts
+++ b/assistant/src/__tests__/oauth2-gateway-transport.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
 
 // ---------------------------------------------------------------------------
 // Mocks — must be set up before importing the module under test
@@ -166,19 +166,38 @@ describe('OAuth2 gateway transport', () => {
       expect(result.tokens.accessToken).toBe('test-access-token');
     });
 
-    test('throws when ingress.publicBaseUrl is not configured', async () => {
+    test('falls back to loopback transport when ingress.publicBaseUrl is not configured', async () => {
       mockPublicBaseUrl = '';
 
-      // Without a public base URL, the flow should reject immediately
-      await expect(
-        startOAuth2Flow(BASE_OAUTH_CONFIG, { openUrl: () => {} }),
-      ).rejects.toThrow('OAuth requires a public ingress URL');
+      let capturedAuthUrl = '';
+      const flowPromise = startOAuth2Flow(BASE_OAUTH_CONFIG, {
+        openUrl: (url) => { capturedAuthUrl = url; },
+      });
+
+      // Give the loopback server time to start
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Auth URL should use a 127.0.0.1 redirect_uri
+      expect(capturedAuthUrl).toContain('redirect_uri=');
+      expect(capturedAuthUrl).toContain('127.0.0.1');
+      expect(capturedAuthUrl).toContain(encodeURIComponent('/oauth/callback'));
+
+      // Extract the redirect_uri and simulate the callback
+      const authUrl = new URL(capturedAuthUrl);
+      const redirectUri = authUrl.searchParams.get('redirect_uri')!;
+      const state = authUrl.searchParams.get('state')!;
+
+      // Make a request to the loopback server with the auth code
+      const callbackUrl = `${redirectUri}?code=loopback-auth-code&state=${state}`;
+      await fetch(callbackUrl);
+
+      const result = await flowPromise;
+      expect(result.tokens.accessToken).toBe('test-access-token');
     });
   });
 
   describe('explicit transport', () => {
     test('uses gateway transport when explicitly specified', async () => {
-      // Even with no publicBaseUrl, explicit gateway should work
       mockPublicBaseUrl = 'https://gw.example.com';
 
       let capturedAuthUrl = '';
@@ -200,8 +219,7 @@ describe('OAuth2 gateway transport', () => {
       expect(result.tokens.accessToken).toBe('test-access-token');
     });
 
-    test('ignores loopback transport option and uses gateway', async () => {
-      // Loopback transport was removed — gateway is always used
+    test('uses loopback transport when explicitly specified', async () => {
       mockPublicBaseUrl = 'https://gw.example.com';
 
       let capturedAuthUrl = '';
@@ -211,18 +229,32 @@ describe('OAuth2 gateway transport', () => {
         { callbackTransport: 'loopback' },
       );
 
-      await new Promise((r) => setTimeout(r, 10));
+      await new Promise((r) => setTimeout(r, 50));
 
-      // Should use gateway redirect, not loopback
-      expect(capturedAuthUrl).toContain(encodeURIComponent('https://gw.example.com'));
-      expect(capturedAuthUrl).not.toContain('127.0.0.1');
+      // Should use loopback redirect even though gateway URL is available
+      expect(capturedAuthUrl).toContain('127.0.0.1');
+      expect(capturedAuthUrl).not.toContain('gw.example.com');
 
-      const entries = Array.from(pendingCallbacks.entries());
-      expect(entries.length).toBe(1);
-      entries[0][1].resolve('gateway-code-despite-loopback-option');
+      // Simulate callback to loopback server
+      const authUrl = new URL(capturedAuthUrl);
+      const redirectUri = authUrl.searchParams.get('redirect_uri')!;
+      const state = authUrl.searchParams.get('state')!;
+      await fetch(`${redirectUri}?code=explicit-loopback-code&state=${state}`);
 
       const result = await flowPromise;
       expect(result.tokens.accessToken).toBe('test-access-token');
+    });
+
+    test('throws when gateway transport is explicitly requested without public URL', async () => {
+      mockPublicBaseUrl = '';
+
+      await expect(
+        startOAuth2Flow(
+          BASE_OAUTH_CONFIG,
+          { openUrl: () => {} },
+          { callbackTransport: 'gateway' },
+        ),
+      ).rejects.toThrow('Gateway transport requires a public ingress URL');
     });
   });
 
@@ -291,6 +323,105 @@ describe('OAuth2 gateway transport', () => {
 
       const entries = Array.from(pendingCallbacks.entries());
       entries[0][1].resolve('code-that-fails-exchange');
+
+      await expect(flowPromise).rejects.toThrow('OAuth2 token exchange failed');
+    });
+  });
+
+  describe('loopback transport flow', () => {
+    test('success: starts server, receives callback, exchanges for tokens', async () => {
+      let capturedAuthUrl = '';
+      const flowPromise = startOAuth2Flow(
+        BASE_OAUTH_CONFIG,
+        { openUrl: (url) => { capturedAuthUrl = url; } },
+        { callbackTransport: 'loopback' },
+      );
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(capturedAuthUrl).toContain('redirect_uri=');
+      expect(capturedAuthUrl).toContain('127.0.0.1');
+      expect(capturedAuthUrl).toContain('code_challenge=');
+      expect(capturedAuthUrl).toContain('code_challenge_method=S256');
+
+      const authUrl = new URL(capturedAuthUrl);
+      const redirectUri = authUrl.searchParams.get('redirect_uri')!;
+      const state = authUrl.searchParams.get('state')!;
+
+      const resp = await fetch(`${redirectUri}?code=loopback-code&state=${state}`);
+      expect(resp.status).toBe(200);
+      const html = await resp.text();
+      expect(html).toContain('Authorization Successful');
+
+      const result = await flowPromise;
+      expect(result.tokens.accessToken).toBe('test-access-token');
+      expect(result.tokens.refreshToken).toBe('test-refresh-token');
+    });
+
+    test('error: OAuth provider returns error parameter', async () => {
+      let capturedAuthUrl = '';
+      const flowPromise = startOAuth2Flow(
+        BASE_OAUTH_CONFIG,
+        { openUrl: (url) => { capturedAuthUrl = url; } },
+        { callbackTransport: 'loopback' },
+      );
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const authUrl = new URL(capturedAuthUrl);
+      const redirectUri = authUrl.searchParams.get('redirect_uri')!;
+      const state = authUrl.searchParams.get('state')!;
+
+      // Fire callback without awaiting — immediately check flowPromise rejection
+      fetch(`${redirectUri}?error=access_denied&state=${state}`).catch(() => {});
+
+      await expect(flowPromise).rejects.toThrow('OAuth2 authorization denied: access_denied');
+    });
+
+    test('rejects callback with wrong state parameter', async () => {
+      let capturedAuthUrl = '';
+      const flowPromise = startOAuth2Flow(
+        BASE_OAUTH_CONFIG,
+        { openUrl: (url) => { capturedAuthUrl = url; } },
+        { callbackTransport: 'loopback' },
+      );
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const authUrl = new URL(capturedAuthUrl);
+      const redirectUri = authUrl.searchParams.get('redirect_uri')!;
+
+      // Send callback with wrong state
+      const resp = await fetch(`${redirectUri}?code=bad-code&state=wrong-state`);
+      expect(resp.status).toBe(400);
+
+      // The flow should still be waiting (not resolved)
+      // Send the correct callback to clean up
+      const state = authUrl.searchParams.get('state')!;
+      await fetch(`${redirectUri}?code=correct-code&state=${state}`);
+
+      const result = await flowPromise;
+      expect(result.tokens.accessToken).toBe('test-access-token');
+    });
+
+    test('token exchange failure propagates error', async () => {
+      mockTokenResponse = { ok: false, status: 400, body: { error: 'invalid_grant' } };
+
+      let capturedAuthUrl = '';
+      const flowPromise = startOAuth2Flow(
+        BASE_OAUTH_CONFIG,
+        { openUrl: (url) => { capturedAuthUrl = url; } },
+        { callbackTransport: 'loopback' },
+      );
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const authUrl = new URL(capturedAuthUrl);
+      const redirectUri = authUrl.searchParams.get('redirect_uri')!;
+      const state = authUrl.searchParams.get('state')!;
+
+      // Fire callback without awaiting — immediately check flowPromise rejection
+      fetch(`${redirectUri}?code=code-that-fails&state=${state}`).catch(() => {});
 
       await expect(flowPromise).rejects.toThrow('OAuth2 token exchange failed');
     });

--- a/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: "Google OAuth Setup"
 description: "Set up Google Cloud OAuth credentials for Gmail and Calendar using browser automation"
 user-invocable: true
-includes: ["browser", "public-ingress"]
+includes: ["browser"]
 metadata: {"vellum": {"emoji": "\ud83d\udd11"}}
 ---
 
@@ -16,10 +16,6 @@ If the user is on Telegram (or any non-macOS client without browser automation):
 
 Stop here. Do not attempt a manual walkthrough.
 
-## Prerequisites
-
-Before starting, check that `ingress.publicBaseUrl` is configured (`INGRESS_PUBLIC_BASE_URL` env var or workspace config). If it is not set, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the public URL. The OAuth redirect URI depends on this value.
-
 ## Step 1: Single Upfront Confirmation
 
 Use `ui_show` with `surface_type: "confirmation"` and this message:
@@ -29,7 +25,7 @@ Use `ui_show` with `surface_type: "confirmation"` and this message:
 > Here's what will happen:
 > 1. **A browser opens** — you sign in to your Google account
 > 2. **I automate everything** — project creation, APIs, OAuth config, credentials
-> 3. **You enter credentials** from a downloaded file (secure prompt — I never see them)
+> 3. **You enter credentials** from the dialog (secure prompt — I never see them)
 > 4. **You authorize Vellum** with one click
 >
 > The whole thing takes 2-3 minutes. Ready?
@@ -122,32 +118,25 @@ Navigate to `https://console.cloud.google.com/apis/credentials?project=PROJECT_I
 Click "+ Create Credentials" then select "OAuth client ID".
 
 Take a `browser_snapshot` and fill in:
-1. **Application type:** Select "Web application"
+1. **Application type:** Select **"Desktop app"** from the dropdown
 2. **Name:** "Vellum Assistant"
-3. **Authorized redirect URIs:** Click "Add URI" and enter `${ingress.publicBaseUrl}/webhooks/oauth/callback`
+
+**Do NOT add any redirect URIs** — Desktop app credentials handle localhost redirects automatically.
 
 Click "Create".
 
-## Step 7: Download Credentials JSON
+## Step 7: Secure Credential Entry
 
-Tell the user: "Almost done — downloading credentials..."
+After the credentials dialog appears showing the client ID and client secret, tell the user:
 
-After the credentials dialog appears, click the "Download JSON" button (it may say "DOWNLOAD JSON" or show a download icon).
-
-Use `browser_wait_for_download` to wait for the file to download.
-
-Tell the user: "Credentials downloaded!"
-
-## Step 8: Secure Credential Entry
-
-Tell the user: "I've downloaded the credentials file. Please open it and enter the values below. I won't see what you type — these go directly to secure storage."
+"Credentials created! Please enter the values from the dialog below. I won't see what you type — these go directly to secure storage."
 
 ```
 credential_store prompt:
   service: "integration:gmail"
   field: "client_id"
   label: "Google OAuth Client ID"
-  description: "Open the downloaded JSON file and copy the client_id value"
+  description: "Copy the Client ID from the dialog that just appeared"
   placeholder: "123456789.apps.googleusercontent.com"
 ```
 
@@ -156,11 +145,11 @@ credential_store prompt:
   service: "integration:gmail"
   field: "client_secret"
   label: "Google OAuth Client Secret"
-  description: "Copy the client_secret value from the same JSON file"
+  description: "Copy the Client secret from the same dialog"
   placeholder: "GOCSPX-..."
 ```
 
-## Step 9: OAuth2 Authorization
+## Step 8: OAuth2 Authorization
 
 Tell the user: "Opening Google sign-in so you can authorize Vellum. Just click 'Allow' on the consent page."
 
@@ -171,11 +160,11 @@ action: "oauth2_connect"
 service: "integration:gmail"
 ```
 
-This auto-reads client_id/client_secret from the secure store and auto-fills auth_url, token_url, scopes, and extra_params from well-known config.
+This auto-reads client_id/client_secret from the secure store and auto-fills auth_url, token_url, scopes, and extra_params from well-known config. The OAuth flow uses a localhost callback — no public URL or tunnel is needed.
 
 **If the user sees a "This app isn't verified" warning:** Tell them this is normal for apps in testing mode. Click "Advanced" then "Go to Vellum Assistant (unsafe)" to proceed.
 
-## Step 10: Done!
+## Step 9: Done!
 
 "**Gmail and Calendar are connected!** You can now read, search, and send emails, plus view and manage your calendar. Try asking me to check your inbox or show your upcoming events!"
 

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -1,15 +1,23 @@
 /**
  * General-purpose OAuth2 Authorization Code flow with PKCE.
  *
- * Uses the gateway callback transport: OAuth callbacks route through the
- * gateway's OAuth callback route + in-memory registry (requires
- * ingress.publicBaseUrl to be configured).
+ * Supports two callback transports:
+ *
+ * 1. **Loopback** — starts a temporary HTTP server on localhost to receive the
+ *    callback directly. Works without any public URL or tunnel. Used by default
+ *    when no public ingress URL is configured, and preferred for providers like
+ *    Google that support localhost redirects.
+ *
+ * 2. **Gateway** — routes callbacks through the gateway's public OAuth route
+ *    + in-memory registry. Requires `ingress.publicBaseUrl` to be configured.
+ *    Used for providers that don't support localhost redirects (e.g. Slack).
  *
  * Moved from integrations/oauth2.ts. Types that were in integrations/types.ts
  * are now inlined here since the integration framework is removed.
  */
 
 import { randomBytes, createHash } from 'node:crypto';
+import { createServer, type Server } from 'node:http';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('oauth2');
@@ -197,26 +205,160 @@ async function runGatewayFlow(
 }
 
 // ---------------------------------------------------------------------------
+// Loopback transport
+// ---------------------------------------------------------------------------
+
+const LOOPBACK_CALLBACK_PATH = '/oauth/callback';
+const LOOPBACK_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+async function runLoopbackFlow(
+  config: OAuth2Config,
+  callbacks: OAuth2FlowCallbacks,
+  codeVerifier: string,
+  codeChallenge: string,
+  state: string,
+): Promise<OAuth2FlowResult> {
+  const { code, redirectUri } = await startLoopbackServerAndWaitForCode(
+    config, callbacks, codeChallenge, state,
+  );
+
+  return await exchangeCodeForTokens(config, code, redirectUri, codeVerifier);
+}
+
+/**
+ * Start a temporary HTTP server on a random port, build the auth URL with
+ * a localhost redirect_uri, open the browser, and wait for the callback.
+ */
+function startLoopbackServerAndWaitForCode(
+  config: OAuth2Config,
+  callbacks: OAuth2FlowCallbacks,
+  codeChallenge: string,
+  state: string,
+): Promise<{ code: string; redirectUri: string }> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let boundRedirectUri = '';
+
+    const server: Server = createServer((req, res) => {
+      if (settled) {
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end(renderLoopbackPage('Authorization already completed', false));
+        return;
+      }
+
+      const url = new URL(req.url ?? '/', `http://127.0.0.1`);
+
+      if (url.pathname !== LOOPBACK_CALLBACK_PATH) {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Not found');
+        return;
+      }
+
+      const callbackState = url.searchParams.get('state');
+      const code = url.searchParams.get('code');
+      const error = url.searchParams.get('error');
+
+      if (callbackState !== state) {
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end(renderLoopbackPage('Invalid state parameter', false));
+        return;
+      }
+
+      settled = true;
+
+      if (error) {
+        const errorDesc = url.searchParams.get('error_description') ?? error;
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(renderLoopbackPage(`Authorization failed: ${errorDesc}`, false));
+        cleanup();
+        reject(new Error(`OAuth2 authorization denied: ${error}`));
+        return;
+      }
+
+      if (!code) {
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end(renderLoopbackPage('Missing authorization code', false));
+        cleanup();
+        reject(new Error('OAuth2 callback missing authorization code'));
+        return;
+      }
+
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(renderLoopbackPage('Authorization successful! You can close this tab.', true));
+      cleanup();
+      resolve({ code, redirectUri: boundRedirectUri });
+    });
+
+    const timeout = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        cleanup();
+        reject(new Error('OAuth2 loopback callback timed out'));
+      }
+    }, LOOPBACK_TIMEOUT_MS);
+    if (typeof timeout === 'object' && 'unref' in timeout) timeout.unref();
+
+    function cleanup() {
+      clearTimeout(timeout);
+      server.close();
+    }
+
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as { port: number };
+      boundRedirectUri = `http://127.0.0.1:${addr.port}${LOOPBACK_CALLBACK_PATH}`;
+
+      const authParams = new URLSearchParams({
+        ...config.extraParams,
+        client_id: config.clientId,
+        redirect_uri: boundRedirectUri,
+        response_type: 'code',
+        scope: config.scopes.join(' '),
+        state,
+        code_challenge: codeChallenge,
+        code_challenge_method: 'S256',
+      });
+
+      const authUrl = `${config.authUrl}?${authParams}`;
+      callbacks.openUrl(authUrl);
+    });
+
+    server.on('error', (err) => {
+      if (!settled) {
+        settled = true;
+        cleanup();
+        reject(new Error(`OAuth2 loopback server error: ${err.message}`));
+      }
+    });
+  });
+}
+
+function renderLoopbackPage(message: string, success: boolean): string {
+  const title = success ? 'Authorization Successful' : 'Authorization Failed';
+  const color = success ? '#4CAF50' : '#f44336';
+  return `<!DOCTYPE html><html><head><title>${title}</title><style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0;background:#f5f5f5}div{text-align:center;padding:2rem;background:white;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,0.1)}h1{color:${color}}</style></head><body><div><h1>${title}</h1><p>${message}</p></div></body></html>`;
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
 /**
  * Run a full OAuth2 authorization code flow with PKCE support.
  *
- * Uses the gateway callback transport, which routes OAuth callbacks through
- * the gateway's OAuth route + in-memory registry. Requires a public ingress
- * URL to be configured.
+ * Transport selection:
+ * - If `callbackTransport` is explicitly set, that transport is used.
+ * - Otherwise, uses gateway transport when a public ingress URL is configured,
+ *   and falls back to loopback (localhost) when it is not.
  */
 export async function startOAuth2Flow(
   config: OAuth2Config,
   callbacks: OAuth2FlowCallbacks,
-  _options?: OAuth2FlowOptions,
+  options?: OAuth2FlowOptions,
 ): Promise<OAuth2FlowResult> {
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = generateCodeChallenge(codeVerifier);
   const state = generateState();
 
-  // Always enforce gateway transport and require a public ingress URL
   let hasPublicUrl = false;
   try {
     const { loadConfig } = await import('../config/loader.js');
@@ -227,15 +369,22 @@ export async function startOAuth2Flow(
     // No public URL configured
   }
 
-  if (!hasPublicUrl) {
-    throw new Error(
-      'OAuth requires a public ingress URL. Set ingress.publicBaseUrl or INGRESS_PUBLIC_BASE_URL so OAuth callbacks can route through the gateway.',
-    );
+  // Determine transport: explicit option > auto-detect from config
+  const transport = options?.callbackTransport
+    ?? (hasPublicUrl ? 'gateway' : 'loopback');
+
+  if (transport === 'gateway') {
+    if (!hasPublicUrl) {
+      throw new Error(
+        'Gateway transport requires a public ingress URL. Set ingress.publicBaseUrl or INGRESS_PUBLIC_BASE_URL, or use loopback transport.',
+      );
+    }
+    log.debug({ transport: 'gateway' }, 'OAuth2 flow starting');
+    return runGatewayFlow(config, callbacks, codeVerifier, codeChallenge, state);
   }
 
-  // Always use gateway transport — never fall back to loopback
-  log.debug({ transport: 'gateway' }, 'OAuth2 flow starting');
-  return runGatewayFlow(config, callbacks, codeVerifier, codeChallenge, state);
+  log.debug({ transport: 'loopback' }, 'OAuth2 flow starting');
+  return runLoopbackFlow(config, callbacks, codeVerifier, codeChallenge, state);
 }
 
 /**

--- a/skills/google-oauth-setup/SKILL.md
+++ b/skills/google-oauth-setup/SKILL.md
@@ -2,17 +2,13 @@
 name: "Google OAuth Setup"
 description: "Create Google Cloud OAuth credentials for Gmail integration using browser automation"
 user-invocable: true
-includes: ["browser", "public-ingress"]
+includes: ["browser"]
 metadata: {"vellum": {"emoji": "\ud83d\udd11"}}
 ---
 
 You are helping your user create Google Cloud OAuth credentials so the Gmail and Google Calendar integrations can connect. Walk through each step below using `browser_navigate`, `browser_snapshot`, `browser_screenshot`, `browser_click`, `browser_type`, and `browser_extract` tools.
 
 **Tone:** Be friendly and reassuring throughout. Narrate what you're doing in plain language so the user always knows what's happening. After each step, briefly confirm what was accomplished before moving on.
-
-## Prerequisites
-
-Before starting, check that `ingress.publicBaseUrl` is configured (Settings > Public Ingress, or `INGRESS_PUBLIC_BASE_URL` env var). If it is not set, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the public URL. The OAuth redirect URI depends on this value.
 
 ## Before You Start
 
@@ -128,7 +124,7 @@ Tell the user: "Consent screen is configured! Almost there — just need to crea
 
 > **Create OAuth Credentials**
 >
-> I'm about to create OAuth Web Application credentials for Vellum Assistant. This generates a client ID that Vellum uses to initiate the authorization flow. The redirect URI will point to the gateway's OAuth callback endpoint.
+> I'm about to create OAuth Desktop Application credentials for Vellum Assistant. This generates a client ID that Vellum uses to initiate the authorization flow. No redirect URIs are needed — desktop apps use a secure localhost callback automatically.
 
 Wait for the user to approve. If they decline, explain that credentials are the final step needed and offer to try again or cancel.
 
@@ -137,21 +133,38 @@ Once approved, navigate to `https://console.cloud.google.com/apis/credentials?pr
 Use `browser_click` on "+ Create Credentials" at the top, then select "OAuth client ID" from the dropdown.
 
 Take a `browser_snapshot` and fill in:
-1. **Application type:** Select "Web application" from the dropdown
+1. **Application type:** Select **"Desktop app"** from the dropdown
 2. **Name:** "Vellum Assistant"
-3. **Authorized redirect URIs:** Click "Add URI" and enter `${ingress.publicBaseUrl}/webhooks/oauth/callback` (e.g. `https://abc123.ngrok-free.app/webhooks/oauth/callback`). Read the `ingress.publicBaseUrl` value from the assistant's workspace config (Settings > Public Ingress) or the `INGRESS_PUBLIC_BASE_URL` environment variable.
+
+**Do NOT add any redirect URIs** — Desktop app credentials handle localhost redirects automatically.
 
 Use `browser_click` on the "Create" button.
 
-## Step 6: Extract and Store the Client ID
+## Step 6: Store Credentials
 
-After creation, a dialog should appear showing the client ID and client secret.
+After creation, a dialog appears showing the client ID and client secret.
 
-Use `browser_snapshot` or `browser_extract` to read the **Client ID** value from the dialog. The client ID looks like `NUMBERS-CHARS.apps.googleusercontent.com`.
+Tell the user: "Credentials created! Please enter the values from the dialog below — I won't see what you type, they go directly to secure storage."
 
-**Important:** You only need the Client ID, not the client secret (PKCE flow is used).
+Use `credential_store` to securely collect:
 
-Tell the user: "Credentials created! Now let's connect your Gmail account using the client ID."
+```
+credential_store prompt:
+  service: "integration:gmail"
+  field: "client_id"
+  label: "Google OAuth Client ID"
+  description: "Copy the Client ID from the dialog"
+  placeholder: "123456789.apps.googleusercontent.com"
+```
+
+```
+credential_store prompt:
+  service: "integration:gmail"
+  field: "client_secret"
+  label: "Google OAuth Client Secret"
+  description: "Copy the Client secret from the dialog"
+  placeholder: "GOCSPX-..."
+```
 
 ## Step 7: Connect Gmail
 
@@ -162,17 +175,13 @@ Use the `credential_store` tool to connect Gmail via OAuth2:
 ```
 action: "oauth2_connect"
 service: "integration:gmail"
-client_id: "<the extracted client ID>"
-auth_url: "https://accounts.google.com/o/oauth2/v2/auth"
-token_url: "https://oauth2.googleapis.com/token"
-scopes: ["https://www.googleapis.com/auth/gmail.readonly", "https://www.googleapis.com/auth/gmail.modify", "https://www.googleapis.com/auth/gmail.send", "https://www.googleapis.com/auth/calendar.readonly", "https://www.googleapis.com/auth/calendar.events", "https://www.googleapis.com/auth/userinfo.email"]
-userinfo_url: "https://www.googleapis.com/oauth2/v2/userinfo"
-extra_params: {"access_type": "offline", "prompt": "consent"}
 ```
 
-This will open the Google authorization page in the user's browser. Wait for the flow to complete.
+This auto-reads client_id/client_secret from the secure store and auto-fills endpoints, scopes, and params from well-known config. The OAuth flow uses a localhost callback — no public URL or tunnel is needed.
 
-**If the user sees a "This app isn't verified" warning:** Tell them this is normal for apps in testing mode. They should click "Advanced" → "Go to Vellum Assistant (unsafe)" to proceed. This warning appears because the app hasn't gone through Google's verification process, which is only needed for apps used by many people.
+Wait for the flow to complete.
+
+**If the user sees a "This app isn't verified" warning:** Tell them this is normal for apps in testing mode. They should click "Advanced" then "Go to Vellum Assistant (unsafe)" to proceed. This warning appears because the app hasn't gone through Google's verification process, which is only needed for apps used by many people.
 
 ## Step 8: Celebrate!
 
@@ -184,7 +193,7 @@ Summarize what was accomplished:
 - Created a Google Cloud project (or used an existing one)
 - Enabled the Gmail API and Google Calendar API
 - Configured the OAuth consent screen with appropriate scopes (including calendar)
-- Created OAuth Web Application credentials with gateway callback redirect URI
+- Created OAuth Desktop Application credentials
 - Connected your Gmail and Google Calendar accounts
 
 ## Error Handling
@@ -195,5 +204,5 @@ Summarize what was accomplished:
 - **Element not found for click/type:** Take a fresh `browser_snapshot` to re-assess the page layout. GCP UI may have changed; adapt your selectors. Tell the user what you're looking for if you get stuck.
 - **User declines an approval gate:** Don't push back aggressively. Explain briefly why the step matters, offer to try again, or offer to cancel the whole setup gracefully. Never proceed without approval.
 - **OAuth flow timeout or failure:** Tell the user what happened and offer to retry the connect step. The client ID is already stored, so they can also connect later from Settings.
-- **"This app isn't verified" warning:** Guide the user through clicking "Advanced" → "Go to Vellum Assistant (unsafe)". Reassure them this is expected for personal-use OAuth apps.
+- **"This app isn't verified" warning:** Guide the user through clicking "Advanced" then "Go to Vellum Assistant (unsafe)". Reassure them this is expected for personal-use OAuth apps.
 - **Any unexpected state:** Take a `browser_screenshot` and `browser_snapshot`, describe what you see, and ask the user for guidance rather than guessing.


### PR DESCRIPTION
## Summary

- Added loopback (localhost) OAuth2 callback transport that starts a temporary HTTP server to receive callbacks without requiring a public URL or ngrok tunnel
- Updated Google OAuth setup skill to create Desktop app credentials instead of Web application — removes the public-ingress prerequisite entirely
- Auto-detection: uses gateway transport when public URL is configured, falls back to loopback otherwise; explicit `callbackTransport` option overrides

## Original prompt

Resume interrupted Google OAuth2 task — add loopback transport so OAuth setup works without a public ingress URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
