### PR TITLE
feat: prevent guardian takeover in validateAndConsumeChallenge

### DIFF
--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -197,7 +197,16 @@ export function validateAndConsumeChallenge(
   // Reset the rate-limit counter on success
   resetRateLimit(assistantId, channel, actorExternalUserId, actorChatId);
 
-  // Revoke any existing active binding before creating a new one
+  // Reject if a different user already holds the guardian binding
+  const existingBinding = getActiveBinding(assistantId, channel);
+  if (existingBinding && existingBinding.guardianExternalUserId !== actorExternalUserId) {
+    return {
+      success: false,
+      reason: 'A guardian is already bound for this channel. The existing guardian must be revoked before a new one can be verified.',
+    };
+  }
+
+  // Revoke any existing active binding before creating a new one (same-user re-verification)
   storeRevokeBinding(assistantId, channel);
 
   const metadata: Record<string, string> = {};


### PR DESCRIPTION
Rejects guardian verification when an active binding already exists for a different external user. The existing guardian must be explicitly revoked before a new one can verify. Same-user re-verification is still allowed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
