### PR TITLE
feat: explicit rebind semantics for guardian challenge creation

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -30,6 +30,20 @@ export function handleGuardianVerification(
 
   try {
     if (msg.action === 'create_challenge') {
+      // Fail by default if a guardian is already bound, unless the caller
+      // explicitly opts in to rebinding by setting rebind: true.
+      const existingBinding = getGuardianBinding(assistantId, channel);
+      if (existingBinding && !msg.rebind) {
+        ctx.send(socket, {
+          type: 'guardian_verification_response',
+          success: false,
+          error: 'already_bound',
+          message: 'A guardian is already bound for this channel. Revoke the existing binding first, or set rebind: true to replace.',
+          channel,
+        } as any);
+        return;
+      }
+
       const result = createVerificationChallenge(assistantId, channel, msg.sessionId);
 
       ctx.send(socket, {

--- a/assistant/src/daemon/ipc-contract/integrations.ts
+++ b/assistant/src/daemon/ipc-contract/integrations.ts
@@ -82,6 +82,7 @@ export interface GuardianVerificationRequest {
   channel?: ChannelId;  // Defaults to 'telegram'
   sessionId?: string;
   assistantId?: string;  // Defaults to 'self'
+  rebind?: boolean;  // When true, allows creating a challenge even if a binding already exists
 }
 
 export interface TwitterAuthStartRequest {


### PR DESCRIPTION
When an active guardian binding exists, create_challenge now fails by default with 'already_bound' error. Callers must set rebind: true to explicitly opt in to replacing the existing guardian. Keeps backward-compatible for unbound setups.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
