### PR TITLE
feat: wire rebind intent through guardian challenge clients

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -972,6 +972,14 @@ struct SettingsConnectTab: View {
             default: return nil
             }
         }()
+        let alreadyBound: Bool = {
+            switch channel {
+            case "telegram": return store.telegramGuardianAlreadyBound
+            case "sms": return store.smsGuardianAlreadyBound
+            case "voice": return store.voiceGuardianAlreadyBound
+            default: return false
+            }
+        }()
         let primaryIdentity = guardianPrimaryIdentity(channel: channel, identity: identity)
         let secondaryIdentity = guardianSecondaryIdentity(primary: primaryIdentity, identity: identity)
         let telegramProfileURL: URL? = channel == "telegram"
@@ -1049,10 +1057,17 @@ struct SettingsConnectTab: View {
             }
 
             if let error {
-                Text(error)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.error)
-                    .padding(.leading, 90 + VSpacing.sm)
+                HStack(spacing: VSpacing.sm) {
+                    Text(error)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.error)
+                    if alreadyBound {
+                        VButton(label: "Replace", style: .secondary) {
+                            store.startChannelGuardianVerification(channel: channel, rebind: true)
+                        }
+                    }
+                }
+                .padding(.leading, 90 + VSpacing.sm)
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -103,6 +103,7 @@ public final class SettingsStore: ObservableObject {
     @Published var telegramGuardianVerificationInProgress: Bool = false
     @Published var telegramGuardianInstruction: String?
     @Published var telegramGuardianError: String?
+    @Published var telegramGuardianAlreadyBound: Bool = false
 
     // MARK: - Channel Guardian State (SMS)
 
@@ -113,6 +114,7 @@ public final class SettingsStore: ObservableObject {
     @Published var smsGuardianVerificationInProgress: Bool = false
     @Published var smsGuardianInstruction: String?
     @Published var smsGuardianError: String?
+    @Published var smsGuardianAlreadyBound: Bool = false
 
     // MARK: - Channel Guardian State (Voice)
 
@@ -123,6 +125,7 @@ public final class SettingsStore: ObservableObject {
     @Published var voiceGuardianVerificationInProgress: Bool = false
     @Published var voiceGuardianInstruction: String?
     @Published var voiceGuardianError: String?
+    @Published var voiceGuardianAlreadyBound: Bool = false
 
     // MARK: - Email Integration State
 
@@ -448,8 +451,13 @@ public final class SettingsStore: ObservableObject {
                         self.telegramGuardianInstruction = instruction
                     }
                     self.telegramGuardianError = nil
+                    self.telegramGuardianAlreadyBound = false
                 } else {
-                    self.telegramGuardianError = response.error
+                    let isAlreadyBound = response.error == "already_bound"
+                    self.telegramGuardianAlreadyBound = isAlreadyBound
+                    self.telegramGuardianError = isAlreadyBound
+                        ? "A guardian is already bound. Revoke it first or replace it."
+                        : response.error
                 }
             case "sms":
                 self.smsGuardianVerificationInProgress = false
@@ -465,8 +473,13 @@ public final class SettingsStore: ObservableObject {
                         self.smsGuardianInstruction = instruction
                     }
                     self.smsGuardianError = nil
+                    self.smsGuardianAlreadyBound = false
                 } else {
-                    self.smsGuardianError = response.error
+                    let isAlreadyBound = response.error == "already_bound"
+                    self.smsGuardianAlreadyBound = isAlreadyBound
+                    self.smsGuardianError = isAlreadyBound
+                        ? "A guardian is already bound. Revoke it first or replace it."
+                        : response.error
                 }
             case "voice":
                 self.voiceGuardianVerificationInProgress = false
@@ -482,8 +495,13 @@ public final class SettingsStore: ObservableObject {
                         self.voiceGuardianInstruction = instruction
                     }
                     self.voiceGuardianError = nil
+                    self.voiceGuardianAlreadyBound = false
                 } else {
-                    self.voiceGuardianError = response.error
+                    let isAlreadyBound = response.error == "already_bound"
+                    self.voiceGuardianAlreadyBound = isAlreadyBound
+                    self.voiceGuardianError = isAlreadyBound
+                        ? "A guardian is already bound. Revoke it first or replace it."
+                        : response.error
                 }
             default:
                 break
@@ -913,20 +931,23 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    func startChannelGuardianVerification(channel: String) {
+    func startChannelGuardianVerification(channel: String, rebind: Bool = false) {
         stopGuardianStatusPolling(for: channel)
         switch channel {
         case "telegram":
             telegramGuardianVerificationInProgress = true
             telegramGuardianError = nil
+            telegramGuardianAlreadyBound = false
             telegramGuardianInstruction = nil
         case "sms":
             smsGuardianVerificationInProgress = true
             smsGuardianError = nil
+            smsGuardianAlreadyBound = false
             smsGuardianInstruction = nil
         case "voice":
             voiceGuardianVerificationInProgress = true
             voiceGuardianError = nil
+            voiceGuardianAlreadyBound = false
             voiceGuardianInstruction = nil
         default:
             return
@@ -951,7 +972,12 @@ public final class SettingsStore: ObservableObject {
             }
             pendingGuardianChallengeChannel = channel
             armGuardianChallengeTimeout(for: channel)
-            try daemonClient.sendGuardianVerification(action: "create_challenge", channel: channel, assistantId: guardianAssistantScope)
+            try daemonClient.sendGuardianVerification(
+                action: "create_challenge",
+                channel: channel,
+                assistantId: guardianAssistantScope,
+                rebind: rebind ? true : nil
+            )
         } catch {
             log.error("Failed to start \(channel) guardian verification: \(error)")
             clearGuardianChallengePending(for: channel)

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1038,13 +1038,15 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         action: String,
         channel: String? = nil,
         sessionId: String? = nil,
-        assistantId: String? = nil
+        assistantId: String? = nil,
+        rebind: Bool? = nil
     ) throws {
         try send(GuardianVerificationRequestMessage(
             action: action,
             channel: channel,
             sessionId: sessionId,
-            assistantId: assistantId
+            assistantId: assistantId,
+            rebind: rebind
         ))
     }
 

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1931,13 +1931,15 @@ public struct IPCGuardianVerificationRequest: Codable, Sendable {
     public let channel: String?
     public let sessionId: String?
     public let assistantId: String?
+    public let rebind: Bool?
 
-    public init(type: String, action: String, channel: String? = nil, sessionId: String? = nil, assistantId: String? = nil) {
+    public init(type: String, action: String, channel: String? = nil, sessionId: String? = nil, assistantId: String? = nil, rebind: Bool? = nil) {
         self.type = type
         self.action = action
         self.channel = channel
         self.sessionId = sessionId
         self.assistantId = assistantId
+        self.rebind = rebind
     }
 }
 

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1946,14 +1946,16 @@ extension IPCGuardianVerificationRequest {
         action: String,
         channel: String? = nil,
         sessionId: String? = nil,
-        assistantId: String? = nil
+        assistantId: String? = nil,
+        rebind: Bool? = nil
     ) {
         self.init(
             type: "guardian_verification",
             action: action,
             channel: channel,
             sessionId: sessionId,
-            assistantId: assistantId
+            assistantId: assistantId,
+            rebind: rebind
         )
     }
 }


### PR DESCRIPTION
## Summary

- Regenerates IPC contract types to include the new `rebind?: boolean` field on `GuardianVerificationRequest`
- Updates the Swift convenience initializer and `DaemonClient.sendGuardianVerification()` to pass through the `rebind` parameter
- Handles the `already_bound` error response in `SettingsStore`: translates the error code into a user-friendly message and sets an `alreadyBound` flag per channel
- Shows a "Replace" button in the guardian status row (Settings > Connect) when the daemon returns `already_bound`, letting users explicitly opt into rebinding
- No pre-emptive friction: the normal flow sends `create_challenge` without `rebind`; only after the daemon rejects with `already_bound` does the UI offer the replace option

## Test plan

- [ ] Verify that creating a guardian challenge on a channel with no existing binding works as before
- [ ] Verify that creating a challenge when a binding already exists returns `already_bound` error with clear message and "Replace" button
- [ ] Verify that clicking "Replace" sends `create_challenge` with `rebind: true` and proceeds normally
- [ ] Verify that the `alreadyBound` state clears when a successful response arrives or when starting a new verification
- [ ] Test across all three channels: Telegram, SMS, Voice

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
