### PR TITLE
fix: address review feedback on OAuth2 loopback transport (#8702)

### DIFF
--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -332,10 +332,14 @@ function startLoopbackServerAndWaitForCode(
   });
 }
 
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
 function renderLoopbackPage(message: string, success: boolean): string {
   const title = success ? 'Authorization Successful' : 'Authorization Failed';
   const color = success ? '#4CAF50' : '#f44336';
-  return `<!DOCTYPE html><html><head><title>${title}</title><style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0;background:#f5f5f5}div{text-align:center;padding:2rem;background:white;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,0.1)}h1{color:${color}}</style></head><body><div><h1>${title}</h1><p>${message}</p></div></body></html>`;
+  return `<!DOCTYPE html><html><head><title>${escapeHtml(title)}</title><style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0;background:#f5f5f5}div{text-align:center;padding:2rem;background:white;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,0.1)}h1{color:${color}}</style></head><body><div><h1>${escapeHtml(title)}</h1><p>${escapeHtml(message)}</p></div></body></html>`;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -36,6 +36,8 @@ interface WellKnownOAuthConfig {
   tokenEndpointAuthMethod?: TokenEndpointAuthMethod;
   /** Injection templates auto-applied to the access_token credential after a successful OAuth2 connect. */
   injectionTemplates?: CredentialInjectionTemplate[];
+  /** Force a specific callback transport (e.g. 'loopback' for Desktop app credentials). */
+  callbackTransport?: 'loopback' | 'gateway';
 }
 
 const WELL_KNOWN_OAUTH: Record<string, WellKnownOAuthConfig> = {
@@ -52,6 +54,7 @@ const WELL_KNOWN_OAUTH: Record<string, WellKnownOAuthConfig> = {
     ],
     userinfoUrl: 'https://www.googleapis.com/oauth2/v2/userinfo',
     extraParams: { access_type: 'offline', prompt: 'consent' },
+    callbackTransport: 'loopback',
   },
   'integration:slack': {
     authUrl: 'https://slack.com/oauth/v2/authorize',
@@ -602,6 +605,7 @@ class CredentialStoreTool implements Tool {
                 context.sendToClient?.({ type: 'open_url', url, title: `Connect ${service}` });
               },
             },
+            wellKnown?.callbackTransport ? { callbackTransport: wellKnown.callbackTransport } : undefined,
           );
 
           const tokenStored = setSecureKey(`credential:${service}:access_token`, tokens.accessToken);


### PR DESCRIPTION
Addresses reviewer feedback from PR #8702:

1. **Codex (P1):** Make transport selection provider-aware — Gmail's well-known OAuth config now specifies `callbackTransport: 'loopback'` so Desktop app credentials always use localhost redirects, even when a public ingress URL is configured. The `callbackTransport` field is passed through from the well-known config to `startOAuth2Flow`.

2. **Devin (XSS):** Add HTML entity escaping in `renderLoopbackPage` to prevent reflected XSS via `error_description` query parameter. Both `title` and `message` are now escaped before interpolation into HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
