### PR TITLE
feat: add Gmail management improvements — attachments, triage, filters, contacts

### DIFF
--- a/assistant/src/__tests__/email-classifier.test.ts
+++ b/assistant/src/__tests__/email-classifier.test.ts
@@ -1,0 +1,21 @@
+import { describe, test, expect } from 'bun:test';
+import { classifyEmails, type EmailMetadata } from '../messaging/email-classifier.js';
+
+describe('classifyEmails', () => {
+  test('returns empty classifications for empty input', async () => {
+    const result = await classifyEmails([]);
+    expect(result.classifications).toEqual([]);
+  });
+
+  test('accepts well-formed email metadata', () => {
+    const email: EmailMetadata = {
+      id: 'msg-1',
+      from: 'test@example.com',
+      subject: 'Test Subject',
+      snippet: 'This is a test email snippet',
+      labels: ['INBOX', 'UNREAD'],
+    };
+    expect(email.id).toBe('msg-1');
+    expect(email.labels).toContain('INBOX');
+  });
+});

--- a/assistant/src/__tests__/gmail-integration.test.ts
+++ b/assistant/src/__tests__/gmail-integration.test.ts
@@ -19,6 +19,16 @@ describe('Messaging tool contract', () => {
     'gmail_trash',
     'gmail_draft',
     'gmail_unsubscribe',
+    'gmail_list_attachments',
+    'gmail_download_attachment',
+    'gmail_send_with_attachments',
+    'gmail_forward',
+    'gmail_summarize_thread',
+    'gmail_follow_up',
+    'gmail_triage',
+    'gmail_filters',
+    'gmail_vacation',
+    'google_contacts',
   ];
 
   const expectedMessagingToolNames = [

--- a/assistant/src/__tests__/mime-builder.test.ts
+++ b/assistant/src/__tests__/mime-builder.test.ts
@@ -1,0 +1,60 @@
+import { describe, test, expect } from 'bun:test';
+import { buildMultipartMime } from '../messaging/providers/gmail/mime-builder.js';
+
+describe('buildMultipartMime', () => {
+  test('produces valid base64url output', () => {
+    const result = buildMultipartMime({
+      to: 'test@example.com',
+      subject: 'Test',
+      body: 'Hello',
+      attachments: [
+        { filename: 'doc.txt', mimeType: 'text/plain', data: Buffer.from('file content') },
+      ],
+    });
+
+    // base64url: no +, /, or = characters
+    expect(result).not.toMatch(/[+/=]/);
+
+    // Decode and verify structure
+    const decoded = Buffer.from(result.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf-8');
+    expect(decoded).toContain('To: test@example.com');
+    expect(decoded).toContain('Subject: Test');
+    expect(decoded).toContain('MIME-Version: 1.0');
+    expect(decoded).toContain('Content-Type: multipart/mixed');
+    expect(decoded).toContain('Hello');
+    expect(decoded).toContain('Content-Disposition: attachment; filename="doc.txt"');
+  });
+
+  test('includes In-Reply-To and References headers when inReplyTo is set', () => {
+    const result = buildMultipartMime({
+      to: 'test@example.com',
+      subject: 'Re: Test',
+      body: 'Reply',
+      inReplyTo: '<msg-id@example.com>',
+      attachments: [
+        { filename: 'a.pdf', mimeType: 'application/pdf', data: Buffer.from('pdf') },
+      ],
+    });
+
+    const decoded = Buffer.from(result.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf-8');
+    expect(decoded).toContain('In-Reply-To: <msg-id@example.com>');
+    expect(decoded).toContain('References: <msg-id@example.com>');
+  });
+
+  test('handles multiple attachments', () => {
+    const result = buildMultipartMime({
+      to: 'test@example.com',
+      subject: 'Multi',
+      body: 'Body',
+      attachments: [
+        { filename: 'a.txt', mimeType: 'text/plain', data: Buffer.from('aaa') },
+        { filename: 'b.png', mimeType: 'image/png', data: Buffer.from('png-data') },
+      ],
+    });
+
+    const decoded = Buffer.from(result.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf-8');
+    expect(decoded).toContain('filename="a.txt"');
+    expect(decoded).toContain('filename="b.png"');
+    expect(decoded).toContain('Content-Type: image/png');
+  });
+});

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -120,6 +120,32 @@ SMS is supported as a messaging provider with limited capabilities. The conversa
 - **Unsubscribe**: Unsubscribe via List-Unsubscribe header
 - **Draft (native)**: Create a draft in Gmail's Drafts folder
 
+### Attachments (Gmail)
+- **List Attachments**: `gmail_list_attachments` — list all attachments on a message with filename, MIME type, size, and attachment ID
+- **Download Attachment**: `gmail_download_attachment` — download an attachment to the working directory by message ID + attachment ID
+- **Send with Attachments**: `gmail_send_with_attachments` — send an email with file attachments (reads files from disk, builds multipart MIME)
+
+Workflow: use `gmail_list_attachments` to discover attachments, then `gmail_download_attachment` to save them locally.
+
+### Forward & Thread Operations (Gmail)
+- **Forward**: `gmail_forward` — forward a message to another recipient, preserving all attachments. Optionally prepend your own text
+- **Summarize Thread**: `gmail_summarize_thread` — LLM-powered thread summary with participants, decisions, open questions, and sentiment
+- **Follow-up Tracking**: `gmail_follow_up` — track/untrack messages for follow-up using a dedicated "Follow-up" label, or list all tracked messages
+
+### Smart Triage (Gmail)
+- **Triage**: `gmail_triage` — LLM-powered inbox classification of unread emails into categories: `needs_reply`, `fyi_only`, `can_archive`, `urgent`, `newsletter`, `promotional`
+  - Returns grouped report with reasoning and suggested actions per email
+  - Set `auto_apply: true` to auto-archive `can_archive` emails and label `needs_reply` as "Follow-up"
+  - Custom query support (default: `is:unread in:inbox`)
+
+### Inbox Automation (Gmail)
+- **Filters**: `gmail_filters` — list, create, or delete Gmail filters. Filter criteria include from, to, subject, query, has_attachment. Actions include adding/removing labels and forwarding
+- **Vacation Responder**: `gmail_vacation` — get, enable, or disable the vacation auto-responder with custom message, date range, and domain/contact restrictions
+
+### Google Contacts
+- **Contacts**: `google_contacts` — list or search Google Contacts by name or email. Returns name, email, phone, and organization
+  - Requires the `contacts.readonly` scope — users may need to re-authorize Gmail to grant this additional permission
+
 ## Slack Search Syntax
 
 When searching Slack, the query is passed directly to Slack's search API:

--- a/assistant/src/config/bundled-skills/messaging/TOOLS.json
+++ b/assistant/src/config/bundled-skills/messaging/TOOLS.json
@@ -383,6 +383,204 @@
       },
       "executor": "tools/gmail-draft.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "gmail_list_attachments",
+      "description": "List attachments on a Gmail message with filename, MIME type, size, and attachment ID.",
+      "category": "messaging",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_id": { "type": "string", "description": "Gmail message ID to list attachments for" }
+        },
+        "required": ["message_id"]
+      },
+      "executor": "tools/gmail-list-attachments.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_download_attachment",
+      "description": "Download a Gmail attachment to the working directory.",
+      "category": "messaging",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_id": { "type": "string", "description": "Gmail message ID" },
+          "attachment_id": { "type": "string", "description": "Attachment ID from gmail_list_attachments" },
+          "filename": { "type": "string", "description": "Filename to save as" }
+        },
+        "required": ["message_id", "attachment_id", "filename"]
+      },
+      "executor": "tools/gmail-download-attachment.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_send_with_attachments",
+      "description": "Send an email with file attachments. High-risk action requiring user approval. Include a confidence score (0-1).",
+      "category": "messaging",
+      "risk": "high",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "to": { "type": "string", "description": "Recipient email address" },
+          "subject": { "type": "string", "description": "Email subject line" },
+          "body": { "type": "string", "description": "Email body (plain text)" },
+          "attachment_paths": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Absolute file paths of attachments to include"
+          },
+          "in_reply_to": { "type": "string", "description": "Message-ID header for replies" },
+          "thread_id": { "type": "string", "description": "Thread ID to continue an existing thread" },
+          "confidence": { "type": "number", "description": "Confidence score (0-1) for this action" }
+        },
+        "required": ["to", "subject", "body", "attachment_paths", "confidence"]
+      },
+      "executor": "tools/gmail-send-with-attachments.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_forward",
+      "description": "Forward a Gmail message to another recipient, preserving attachments. Include a confidence score (0-1).",
+      "category": "messaging",
+      "risk": "high",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_id": { "type": "string", "description": "Gmail message ID to forward" },
+          "to": { "type": "string", "description": "Recipient email address" },
+          "text": { "type": "string", "description": "Optional text to prepend to the forwarded message" },
+          "confidence": { "type": "number", "description": "Confidence score (0-1) for this action" }
+        },
+        "required": ["message_id", "to", "confidence"]
+      },
+      "executor": "tools/gmail-forward.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_summarize_thread",
+      "description": "Summarize a Gmail thread using LLM analysis. Returns participants, key decisions, open questions, and sentiment.",
+      "category": "messaging",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "thread_id": { "type": "string", "description": "Gmail thread ID to summarize" }
+        },
+        "required": ["thread_id"]
+      },
+      "executor": "tools/gmail-summarize-thread.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_follow_up",
+      "description": "Track, list, or untrack Gmail messages for follow-up using a dedicated label. Include a confidence score (0-1).",
+      "category": "messaging",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "action": { "type": "string", "enum": ["track", "list", "untrack"], "description": "Follow-up action" },
+          "message_id": { "type": "string", "description": "Gmail message ID (required for track/untrack)" },
+          "confidence": { "type": "number", "description": "Confidence score (0-1) for this action" }
+        },
+        "required": ["action", "confidence"]
+      },
+      "executor": "tools/gmail-follow-up.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_triage",
+      "description": "LLM-powered inbox triage: classify unread emails by urgency and type, optionally auto-apply actions. Include a confidence score (0-1).",
+      "category": "messaging",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "max_results": { "type": "number", "description": "Maximum emails to triage (default 20)" },
+          "auto_apply": { "type": "boolean", "description": "Auto-archive can_archive and label needs_reply as Follow-up (default false)" },
+          "query": { "type": "string", "description": "Gmail search query (default 'is:unread in:inbox')" },
+          "confidence": { "type": "number", "description": "Confidence score (0-1) for this action" }
+        },
+        "required": ["confidence"]
+      },
+      "executor": "tools/gmail-triage.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_filters",
+      "description": "List, create, or delete Gmail filters for inbox automation. Include a confidence score (0-1).",
+      "category": "messaging",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "action": { "type": "string", "enum": ["list", "create", "delete"], "description": "Filter action" },
+          "from": { "type": "string", "description": "Filter criteria: sender (for create)" },
+          "to": { "type": "string", "description": "Filter criteria: recipient (for create)" },
+          "subject": { "type": "string", "description": "Filter criteria: subject contains (for create)" },
+          "query": { "type": "string", "description": "Filter criteria: Gmail query (for create)" },
+          "has_attachment": { "type": "boolean", "description": "Filter criteria: has attachment (for create)" },
+          "add_label_ids": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Filter action: label IDs to add (for create)"
+          },
+          "remove_label_ids": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Filter action: label IDs to remove (for create)"
+          },
+          "forward": { "type": "string", "description": "Filter action: forward to email (for create)" },
+          "filter_id": { "type": "string", "description": "Filter ID (for delete)" },
+          "confidence": { "type": "number", "description": "Confidence score (0-1) for this action" }
+        },
+        "required": ["action", "confidence"]
+      },
+      "executor": "tools/gmail-filters.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_vacation",
+      "description": "Get, enable, or disable Gmail vacation auto-responder. Include a confidence score (0-1).",
+      "category": "messaging",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "action": { "type": "string", "enum": ["get", "enable", "disable"], "description": "Vacation action" },
+          "message": { "type": "string", "description": "Auto-reply message body (required for enable)" },
+          "subject": { "type": "string", "description": "Auto-reply subject (default 'Out of Office')" },
+          "start_time": { "type": "number", "description": "Start time in epoch milliseconds" },
+          "end_time": { "type": "number", "description": "End time in epoch milliseconds" },
+          "restrict_to_contacts": { "type": "boolean", "description": "Only auto-reply to contacts (default false)" },
+          "restrict_to_domain": { "type": "boolean", "description": "Only auto-reply to same domain (default false)" },
+          "confidence": { "type": "number", "description": "Confidence score (0-1) for this action" }
+        },
+        "required": ["action", "confidence"]
+      },
+      "executor": "tools/gmail-vacation.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "google_contacts",
+      "description": "List or search Google Contacts. Requires contacts.readonly scope (re-authorization may be needed).",
+      "category": "messaging",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "action": { "type": "string", "enum": ["list", "search"], "description": "Contacts action" },
+          "query": { "type": "string", "description": "Search query (for search action)" },
+          "page_size": { "type": "number", "description": "Number of contacts to return (default 50, for list)" },
+          "page_token": { "type": "string", "description": "Pagination token (for list)" }
+        },
+        "required": ["action"]
+      },
+      "executor": "tools/google-contacts.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-download-attachment.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-download-attachment.ts
@@ -1,0 +1,36 @@
+import { writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { withValidToken } from '../../../../security/token-manager.js';
+import { getMessagingProvider } from '../../../../messaging/registry.js';
+import { getAttachment } from '../../../../messaging/providers/gmail/client.js';
+import { ok, err } from './shared.js';
+
+export async function run(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+  const messageId = input.message_id as string;
+  const attachmentId = input.attachment_id as string;
+  const filename = input.filename as string;
+
+  if (!messageId) return err('message_id is required.');
+  if (!attachmentId) return err('attachment_id is required.');
+  if (!filename) return err('filename is required.');
+
+  try {
+    const provider = getMessagingProvider('gmail');
+    return withValidToken(provider.credentialService, async (token) => {
+      const attachment = await getAttachment(token, messageId, attachmentId);
+
+      // Gmail returns base64url; convert to standard base64 then to Buffer
+      const base64 = attachment.data.replace(/-/g, '+').replace(/_/g, '/');
+      const buffer = Buffer.from(base64, 'base64');
+
+      const outputDir = context.workingDir ?? process.cwd();
+      const outputPath = resolve(outputDir, filename);
+      await writeFile(outputPath, buffer);
+
+      return ok(`Attachment saved to ${outputPath} (${buffer.length} bytes).`);
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-filters.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-filters.ts
@@ -1,0 +1,63 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { withValidToken } from '../../../../security/token-manager.js';
+import { getMessagingProvider } from '../../../../messaging/registry.js';
+import { listFilters, createFilter, deleteFilter } from '../../../../messaging/providers/gmail/client.js';
+import type { GmailFilterCriteria, GmailFilterAction } from '../../../../messaging/providers/gmail/types.js';
+import { ok, err } from './shared.js';
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const action = input.action as string;
+
+  if (!action) {
+    return err('action is required (list, create, or delete).');
+  }
+
+  try {
+    const provider = getMessagingProvider('gmail');
+    return withValidToken(provider.credentialService, async (token) => {
+      switch (action) {
+        case 'list': {
+          const filters = await listFilters(token);
+          if (filters.length === 0) {
+            return ok('No filters configured.');
+          }
+          return ok(JSON.stringify(filters, null, 2));
+        }
+
+        case 'create': {
+          const criteria: GmailFilterCriteria = {};
+          if (input.from) criteria.from = input.from as string;
+          if (input.to) criteria.to = input.to as string;
+          if (input.subject) criteria.subject = input.subject as string;
+          if (input.query) criteria.query = input.query as string;
+          if (input.has_attachment !== undefined) criteria.hasAttachment = input.has_attachment as boolean;
+
+          const filterAction: GmailFilterAction = {};
+          if (input.add_label_ids) filterAction.addLabelIds = input.add_label_ids as string[];
+          if (input.remove_label_ids) filterAction.removeLabelIds = input.remove_label_ids as string[];
+          if (input.forward) filterAction.forward = input.forward as string;
+
+          if (Object.keys(criteria).length === 0) {
+            return err('At least one filter criteria is required (from, to, subject, query, or has_attachment).');
+          }
+
+          const filter = await createFilter(token, criteria, filterAction);
+          return ok(`Filter created (ID: ${filter.id}).`);
+        }
+
+        case 'delete': {
+          const filterId = input.filter_id as string;
+          if (!filterId) return err('filter_id is required for delete action.');
+
+          await deleteFilter(token, filterId);
+          return ok('Filter deleted.');
+        }
+
+        default:
+          return err(`Unknown action "${action}". Use list, create, or delete.`);
+      }
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-follow-up.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-follow-up.ts
@@ -1,0 +1,81 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { withValidToken } from '../../../../security/token-manager.js';
+import { getMessagingProvider } from '../../../../messaging/registry.js';
+import {
+  listLabels,
+  createLabel,
+  modifyMessage,
+  listMessages,
+  batchGetMessages,
+} from '../../../../messaging/providers/gmail/client.js';
+import { ok, err } from './shared.js';
+
+const FOLLOW_UP_LABEL_NAME = 'Follow-up';
+
+async function getOrCreateFollowUpLabel(token: string): Promise<string> {
+  const labels = await listLabels(token);
+  const existing = labels.find((l) => l.name === FOLLOW_UP_LABEL_NAME);
+  if (existing) return existing.id;
+
+  const created = await createLabel(token, FOLLOW_UP_LABEL_NAME);
+  return created.id;
+}
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const action = input.action as string;
+
+  if (!action) {
+    return err('action is required (track, list, or untrack).');
+  }
+
+  try {
+    const provider = getMessagingProvider('gmail');
+    return withValidToken(provider.credentialService, async (token) => {
+      switch (action) {
+        case 'track': {
+          const messageId = input.message_id as string;
+          if (!messageId) return err('message_id is required for track action.');
+
+          const labelId = await getOrCreateFollowUpLabel(token);
+          await modifyMessage(token, messageId, { addLabelIds: [labelId] });
+          return ok('Message marked for follow-up.');
+        }
+
+        case 'list': {
+          const labelId = await getOrCreateFollowUpLabel(token);
+          const listResp = await listMessages(token, undefined, 50, undefined, [labelId]);
+          const messageIds = (listResp.messages ?? []).map((m) => m.id);
+
+          if (messageIds.length === 0) {
+            return ok('No messages are currently tracked for follow-up.');
+          }
+
+          const messages = await batchGetMessages(token, messageIds, 'metadata', ['From', 'Subject', 'Date']);
+          const items = messages.map((m) => {
+            const headers = m.payload?.headers ?? [];
+            const from = headers.find((h) => h.name.toLowerCase() === 'from')?.value ?? '';
+            const subject = headers.find((h) => h.name.toLowerCase() === 'subject')?.value ?? '';
+            const date = headers.find((h) => h.name.toLowerCase() === 'date')?.value ?? '';
+            return { id: m.id, threadId: m.threadId, from, subject, date };
+          });
+
+          return ok(JSON.stringify(items, null, 2));
+        }
+
+        case 'untrack': {
+          const messageId = input.message_id as string;
+          if (!messageId) return err('message_id is required for untrack action.');
+
+          const labelId = await getOrCreateFollowUpLabel(token);
+          await modifyMessage(token, messageId, { removeLabelIds: [labelId] });
+          return ok('Follow-up tracking removed from message.');
+        }
+
+        default:
+          return err(`Unknown action "${action}". Use track, list, or untrack.`);
+      }
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-forward.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-forward.ts
@@ -1,0 +1,103 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { withValidToken } from '../../../../security/token-manager.js';
+import { getMessagingProvider } from '../../../../messaging/registry.js';
+import { getMessage, getAttachment, sendMessageRaw } from '../../../../messaging/providers/gmail/client.js';
+import { buildMultipartMime } from '../../../../messaging/providers/gmail/mime-builder.js';
+import type { GmailMessagePart } from '../../../../messaging/providers/gmail/types.js';
+import { ok, err } from './shared.js';
+
+function extractHeader(headers: Array<{ name: string; value: string }> | undefined, name: string): string {
+  return headers?.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value ?? '';
+}
+
+function extractPlainTextBody(part: GmailMessagePart | undefined): string {
+  if (!part) return '';
+  if (part.mimeType === 'text/plain' && part.body?.data) {
+    return Buffer.from(part.body.data.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf-8');
+  }
+  if (part.parts) {
+    for (const child of part.parts) {
+      const text = extractPlainTextBody(child);
+      if (text) return text;
+    }
+  }
+  return '';
+}
+
+interface AttachmentRef {
+  attachmentId: string;
+  filename: string;
+  mimeType: string;
+}
+
+function collectAttachmentRefs(parts: GmailMessagePart[] | undefined): AttachmentRef[] {
+  if (!parts) return [];
+  const result: AttachmentRef[] = [];
+  for (const part of parts) {
+    if (part.filename && part.body?.attachmentId) {
+      result.push({
+        attachmentId: part.body.attachmentId,
+        filename: part.filename,
+        mimeType: part.mimeType ?? 'application/octet-stream',
+      });
+    }
+    if (part.parts) result.push(...collectAttachmentRefs(part.parts));
+  }
+  return result;
+}
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const messageId = input.message_id as string;
+  const forwardTo = input.to as string;
+  const additionalText = input.text as string | undefined;
+
+  if (!messageId) return err('message_id is required.');
+  if (!forwardTo) return err('to is required.');
+
+  try {
+    const provider = getMessagingProvider('gmail');
+    return withValidToken(provider.credentialService, async (token) => {
+      const message = await getMessage(token, messageId, 'full');
+      const headers = message.payload?.headers ?? [];
+      const originalFrom = extractHeader(headers, 'From');
+      const originalDate = extractHeader(headers, 'Date');
+      const originalSubject = extractHeader(headers, 'Subject');
+      const originalBody = extractPlainTextBody(message.payload);
+
+      const forwardHeader = [
+        additionalText ? `${additionalText}\n\n` : '',
+        '---------- Forwarded message ----------',
+        `From: ${originalFrom}`,
+        `Date: ${originalDate}`,
+        `Subject: ${originalSubject}`,
+        '',
+        originalBody,
+      ].join('\n');
+
+      const subject = originalSubject.startsWith('Fwd:') ? originalSubject : `Fwd: ${originalSubject}`;
+
+      // Collect and download attachments from the original message
+      const attachmentRefs = collectAttachmentRefs(message.payload?.parts);
+      const attachments = await Promise.all(
+        attachmentRefs.map(async (ref) => {
+          const att = await getAttachment(token, messageId, ref.attachmentId);
+          const data = Buffer.from(att.data.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
+          return { filename: ref.filename, mimeType: ref.mimeType, data };
+        }),
+      );
+
+      if (attachments.length > 0) {
+        const raw = buildMultipartMime({ to: forwardTo, subject, body: forwardHeader, attachments });
+        const result = await sendMessageRaw(token, raw);
+        return ok(`Message forwarded to ${forwardTo} with ${attachments.length} attachment(s) (ID: ${result.id}).`);
+      }
+
+      // No attachments — use sendMessageRaw with a simple text MIME
+      const raw = buildMultipartMime({ to: forwardTo, subject, body: forwardHeader, attachments: [] });
+      const result = await sendMessageRaw(token, raw);
+      return ok(`Message forwarded to ${forwardTo} (ID: ${result.id}).`);
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-list-attachments.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-list-attachments.ts
@@ -1,0 +1,59 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { withValidToken } from '../../../../security/token-manager.js';
+import { getMessagingProvider } from '../../../../messaging/registry.js';
+import { getMessage } from '../../../../messaging/providers/gmail/client.js';
+import type { GmailMessagePart } from '../../../../messaging/providers/gmail/types.js';
+import { ok, err } from './shared.js';
+
+interface AttachmentInfo {
+  partId: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+  attachmentId: string;
+}
+
+/** Recursively walk the MIME parts tree to find attachments. */
+function collectAttachments(parts: GmailMessagePart[] | undefined): AttachmentInfo[] {
+  if (!parts) return [];
+  const result: AttachmentInfo[] = [];
+  for (const part of parts) {
+    if (part.filename && part.body?.attachmentId) {
+      result.push({
+        partId: part.partId ?? '',
+        filename: part.filename,
+        mimeType: part.mimeType ?? 'application/octet-stream',
+        size: part.body.size ?? 0,
+        attachmentId: part.body.attachmentId,
+      });
+    }
+    if (part.parts) {
+      result.push(...collectAttachments(part.parts));
+    }
+  }
+  return result;
+}
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const messageId = input.message_id as string;
+
+  if (!messageId) {
+    return err('message_id is required.');
+  }
+
+  try {
+    const provider = getMessagingProvider('gmail');
+    return withValidToken(provider.credentialService, async (token) => {
+      const message = await getMessage(token, messageId, 'full');
+      const attachments = collectAttachments(message.payload?.parts);
+
+      if (attachments.length === 0) {
+        return ok('No attachments found on this message.');
+      }
+
+      return ok(JSON.stringify(attachments, null, 2));
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-send-with-attachments.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-send-with-attachments.ts
@@ -1,0 +1,77 @@
+import { readFile } from 'node:fs/promises';
+import { basename, extname } from 'node:path';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { withValidToken } from '../../../../security/token-manager.js';
+import { getMessagingProvider } from '../../../../messaging/registry.js';
+import { sendMessageRaw } from '../../../../messaging/providers/gmail/client.js';
+import { buildMultipartMime } from '../../../../messaging/providers/gmail/mime-builder.js';
+import { ok, err } from './shared.js';
+
+const MIME_MAP: Record<string, string> = {
+  '.pdf': 'application/pdf',
+  '.zip': 'application/zip',
+  '.gz': 'application/gzip',
+  '.tar': 'application/x-tar',
+  '.doc': 'application/msword',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.xls': 'application/vnd.ms-excel',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.ppt': 'application/vnd.ms-powerpoint',
+  '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.mp3': 'audio/mpeg',
+  '.mp4': 'video/mp4',
+  '.wav': 'audio/wav',
+  '.txt': 'text/plain',
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'text/javascript',
+  '.json': 'application/json',
+  '.xml': 'application/xml',
+  '.csv': 'text/csv',
+};
+
+function guessMimeType(filePath: string): string {
+  return MIME_MAP[extname(filePath).toLowerCase()] ?? 'application/octet-stream';
+}
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const to = input.to as string;
+  const subject = input.subject as string;
+  const body = input.body as string;
+  const attachmentPaths = input.attachment_paths as string[];
+  const inReplyTo = input.in_reply_to as string | undefined;
+  const threadId = input.thread_id as string | undefined;
+
+  if (!to) return err('to is required.');
+  if (!subject) return err('subject is required.');
+  if (!body) return err('body is required.');
+  if (!attachmentPaths?.length) return err('attachment_paths is required and must not be empty.');
+
+  try {
+    const provider = getMessagingProvider('gmail');
+    return withValidToken(provider.credentialService, async (token) => {
+      const attachments = await Promise.all(
+        attachmentPaths.map(async (filePath) => {
+          const data = await readFile(filePath);
+          const filename = basename(filePath);
+          const mimeType = guessMimeType(filePath);
+          return { filename, mimeType, data };
+        }),
+      );
+
+      const raw = buildMultipartMime({ to, subject, body, inReplyTo, attachments });
+      const result = await sendMessageRaw(token, raw, threadId);
+
+      const filenames = attachments.map((a) => a.filename).join(', ');
+      return ok(`Message sent with ${attachments.length} attachment(s): ${filenames} (ID: ${result.id}).`);
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-summarize-thread.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-summarize-thread.ts
@@ -1,0 +1,66 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { withValidToken } from '../../../../security/token-manager.js';
+import { getMessagingProvider } from '../../../../messaging/registry.js';
+import { listMessages, batchGetMessages } from '../../../../messaging/providers/gmail/client.js';
+import type { GmailMessage, GmailMessagePart } from '../../../../messaging/providers/gmail/types.js';
+import { summarizeThread } from '../../../../messaging/thread-summarizer.js';
+import type { ThreadMessage } from '../../../../messaging/types.js';
+import { ok, err } from './shared.js';
+
+function extractHeader(headers: Array<{ name: string; value: string }> | undefined, name: string): string {
+  return headers?.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value ?? '';
+}
+
+function extractPlainTextBody(part: GmailMessagePart | undefined): string {
+  if (!part) return '';
+  if (part.mimeType === 'text/plain' && part.body?.data) {
+    return Buffer.from(part.body.data.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf-8');
+  }
+  if (part.parts) {
+    for (const child of part.parts) {
+      const text = extractPlainTextBody(child);
+      if (text) return text;
+    }
+  }
+  return '';
+}
+
+function gmailToThreadMessage(msg: GmailMessage): ThreadMessage {
+  const from = extractHeader(msg.payload?.headers, 'From');
+  const senderName = from.replace(/<[^>]+>/, '').trim() || from;
+  return {
+    id: msg.id,
+    sender: senderName,
+    body: extractPlainTextBody(msg.payload),
+    timestamp: Number(msg.internalDate ?? 0),
+    channel: 'email',
+  };
+}
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const threadId = input.thread_id as string;
+
+  if (!threadId) {
+    return err('thread_id is required.');
+  }
+
+  try {
+    const provider = getMessagingProvider('gmail');
+    return withValidToken(provider.credentialService, async (token) => {
+      const listResp = await listMessages(token, `thread:${threadId}`, 50);
+      const messageIds = (listResp.messages ?? []).map((m) => m.id);
+
+      if (messageIds.length === 0) {
+        return err('No messages found in this thread.');
+      }
+
+      const messages = await batchGetMessages(token, messageIds, 'full');
+      const threadMessages = messages.map(gmailToThreadMessage);
+      const summary = await summarizeThread(threadMessages);
+
+      return ok(JSON.stringify(summary, null, 2));
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-triage.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-triage.ts
@@ -1,0 +1,110 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { withValidToken } from '../../../../security/token-manager.js';
+import { getMessagingProvider } from '../../../../messaging/registry.js';
+import {
+  listMessages,
+  batchGetMessages,
+  modifyMessage,
+  listLabels,
+  createLabel,
+} from '../../../../messaging/providers/gmail/client.js';
+import { classifyEmails, type EmailMetadata, type ClassifiedEmail } from '../../../../messaging/email-classifier.js';
+import { ok, err } from './shared.js';
+
+const FOLLOW_UP_LABEL_NAME = 'Follow-up';
+
+async function getOrCreateLabel(token: string, name: string): Promise<string> {
+  const labels = await listLabels(token);
+  const existing = labels.find((l) => l.name === name);
+  if (existing) return existing.id;
+  const created = await createLabel(token, name);
+  return created.id;
+}
+
+function groupByCategory(classifications: ClassifiedEmail[]): Record<string, ClassifiedEmail[]> {
+  const groups: Record<string, ClassifiedEmail[]> = {};
+  for (const c of classifications) {
+    (groups[c.category] ??= []).push(c);
+  }
+  return groups;
+}
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const maxResults = (input.max_results as number) ?? 20;
+  const autoApply = (input.auto_apply as boolean) ?? false;
+  const query = (input.query as string) ?? 'is:unread in:inbox';
+
+  try {
+    const provider = getMessagingProvider('gmail');
+    return withValidToken(provider.credentialService, async (token) => {
+      const listResp = await listMessages(token, query, maxResults);
+      const messageIds = (listResp.messages ?? []).map((m) => m.id);
+
+      if (messageIds.length === 0) {
+        return ok('No messages to triage.');
+      }
+
+      const messages = await batchGetMessages(token, messageIds, 'metadata', ['From', 'Subject']);
+      const emailMetadata: EmailMetadata[] = messages.map((m) => {
+        const headers = m.payload?.headers ?? [];
+        return {
+          id: m.id,
+          from: headers.find((h) => h.name.toLowerCase() === 'from')?.value ?? '',
+          subject: headers.find((h) => h.name.toLowerCase() === 'subject')?.value ?? '',
+          snippet: m.snippet ?? '',
+          labels: m.labelIds ?? [],
+        };
+      });
+
+      const result = await classifyEmails(emailMetadata);
+
+      if (result.classifications.length === 0) {
+        return ok('Classification unavailable. Try again later.');
+      }
+
+      const groups = groupByCategory(result.classifications);
+      const actions: string[] = [];
+
+      if (autoApply) {
+        // Archive can_archive emails
+        const archivable = groups['can_archive'] ?? [];
+        for (const c of archivable) {
+          await modifyMessage(token, c.id, { removeLabelIds: ['INBOX'] });
+        }
+        if (archivable.length > 0) {
+          actions.push(`Archived ${archivable.length} message(s)`);
+        }
+
+        // Label needs_reply as Follow-up
+        const needsReply = groups['needs_reply'] ?? [];
+        if (needsReply.length > 0) {
+          const followUpLabelId = await getOrCreateLabel(token, FOLLOW_UP_LABEL_NAME);
+          for (const c of needsReply) {
+            await modifyMessage(token, c.id, { addLabelIds: [followUpLabelId] });
+          }
+          actions.push(`Labeled ${needsReply.length} message(s) as Follow-up`);
+        }
+      }
+
+      const report = {
+        total: result.classifications.length,
+        groups: Object.fromEntries(
+          Object.entries(groups).map(([cat, items]) => [
+            cat,
+            items.map((c) => ({
+              id: c.id,
+              reasoning: c.reasoning,
+              suggestedAction: c.suggestedAction,
+              urgencyScore: c.urgencyScore,
+            })),
+          ]),
+        ),
+        actionsApplied: actions,
+      };
+
+      return ok(JSON.stringify(report, null, 2));
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-vacation.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-vacation.ts
@@ -1,0 +1,55 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { withValidToken } from '../../../../security/token-manager.js';
+import { getMessagingProvider } from '../../../../messaging/registry.js';
+import { getVacation, updateVacation } from '../../../../messaging/providers/gmail/client.js';
+import type { GmailVacationSettings } from '../../../../messaging/providers/gmail/types.js';
+import { ok, err } from './shared.js';
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const action = input.action as string;
+
+  if (!action) {
+    return err('action is required (get, enable, or disable).');
+  }
+
+  try {
+    const provider = getMessagingProvider('gmail');
+    return withValidToken(provider.credentialService, async (token) => {
+      switch (action) {
+        case 'get': {
+          const settings = await getVacation(token);
+          return ok(JSON.stringify(settings, null, 2));
+        }
+
+        case 'enable': {
+          const message = input.message as string;
+          if (!message) return err('message is required when enabling vacation responder.');
+
+          const settings: GmailVacationSettings = {
+            enableAutoReply: true,
+            responseSubject: (input.subject as string) ?? 'Out of Office',
+            responseBodyPlainText: message,
+            restrictToContacts: (input.restrict_to_contacts as boolean) ?? false,
+            restrictToDomain: (input.restrict_to_domain as boolean) ?? false,
+          };
+
+          if (input.start_time) settings.startTime = String(input.start_time);
+          if (input.end_time) settings.endTime = String(input.end_time);
+
+          const updated = await updateVacation(token, settings);
+          return ok(`Vacation responder enabled.\n${JSON.stringify(updated, null, 2)}`);
+        }
+
+        case 'disable': {
+          const updated = await updateVacation(token, { enableAutoReply: false });
+          return ok('Vacation responder disabled.');
+        }
+
+        default:
+          return err(`Unknown action "${action}". Use get, enable, or disable.`);
+      }
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/messaging/tools/google-contacts.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/google-contacts.ts
@@ -1,0 +1,64 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { withValidToken } from '../../../../security/token-manager.js';
+import { getMessagingProvider } from '../../../../messaging/registry.js';
+import { listContacts, searchContacts } from '../../../../messaging/providers/gmail/people-client.js';
+import type { Person } from '../../../../messaging/providers/gmail/people-types.js';
+import { ok, err } from './shared.js';
+
+function formatContact(person: Person): Record<string, unknown> {
+  const name = person.names?.[0];
+  const email = person.emailAddresses?.[0];
+  const phone = person.phoneNumbers?.[0];
+  const org = person.organizations?.[0];
+
+  return {
+    name: name?.displayName ?? 'Unknown',
+    email: email?.value ?? null,
+    phone: phone?.value ?? null,
+    organization: org?.name ?? null,
+    title: org?.title ?? null,
+  };
+}
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const action = input.action as string;
+
+  if (!action) {
+    return err('action is required (list or search).');
+  }
+
+  try {
+    const provider = getMessagingProvider('gmail');
+    return withValidToken(provider.credentialService, async (token) => {
+      switch (action) {
+        case 'list': {
+          const pageSize = (input.page_size as number) ?? 50;
+          const pageToken = input.page_token as string | undefined;
+
+          const resp = await listContacts(token, pageSize, pageToken);
+          const contacts = (resp.connections ?? []).map(formatContact);
+
+          const result: Record<string, unknown> = { contacts, total: resp.totalPeople ?? contacts.length };
+          if (resp.nextPageToken) result.nextPageToken = resp.nextPageToken;
+
+          return ok(JSON.stringify(result, null, 2));
+        }
+
+        case 'search': {
+          const query = input.query as string;
+          if (!query) return err('query is required for search action.');
+
+          const resp = await searchContacts(token, query);
+          const contacts = (resp.results ?? []).map((r) => formatContact(r.person));
+
+          return ok(JSON.stringify({ contacts, total: contacts.length }, null, 2));
+        }
+
+        default:
+          return err(`Unknown action "${action}". Use list or search.`);
+      }
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/messaging/email-classifier.ts
+++ b/assistant/src/messaging/email-classifier.ts
@@ -1,0 +1,172 @@
+/**
+ * LLM-powered email classification for inbox triage.
+ * Works with metadata only (from, subject, snippet, labels) to keep token usage low.
+ */
+
+import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/provider-send-message.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('email-classifier');
+
+const CLASSIFICATION_MODEL_INTENT = 'latency-optimized' as const;
+const CLASSIFICATION_TIMEOUT_MS = 30_000;
+
+export type EmailCategory =
+  | 'needs_reply'
+  | 'fyi_only'
+  | 'can_archive'
+  | 'urgent'
+  | 'newsletter'
+  | 'promotional';
+
+export interface EmailMetadata {
+  id: string;
+  from: string;
+  subject: string;
+  snippet: string;
+  labels: string[];
+}
+
+export interface ClassifiedEmail {
+  id: string;
+  category: EmailCategory;
+  reasoning: string;
+  suggestedAction: string;
+  urgencyScore: number; // 0-1
+}
+
+export interface ClassificationResult {
+  classifications: ClassifiedEmail[];
+}
+
+const VALID_CATEGORIES = new Set<EmailCategory>([
+  'needs_reply', 'fyi_only', 'can_archive', 'urgent', 'newsletter', 'promotional',
+]);
+
+const SYSTEM_PROMPT = `You are an email triage system. Given email metadata (sender, subject, snippet, labels), classify each email into exactly one category:
+
+- needs_reply: Requires a personal response from the user
+- fyi_only: Informational, no action needed but worth reading
+- can_archive: Safe to archive without reading (automated notifications, receipts, etc.)
+- urgent: Time-sensitive and requires immediate attention
+- newsletter: Regular newsletter or digest
+- promotional: Marketing, sales, or promotional content
+
+For each email, provide:
+- category: One of the categories above
+- reasoning: Brief explanation of the classification (1 sentence)
+- suggestedAction: What the user should do (e.g., "Reply to confirm", "Archive", "Read later")
+- urgencyScore: 0.0 (not urgent) to 1.0 (extremely urgent)
+
+You MUST respond using the \`store_classifications\` tool. Do not respond with text.`;
+
+const STORE_CLASSIFICATIONS_TOOL = {
+  name: 'store_classifications',
+  description: 'Store email classification results',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      classifications: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', description: 'Email ID' },
+            category: {
+              type: 'string',
+              enum: ['needs_reply', 'fyi_only', 'can_archive', 'urgent', 'newsletter', 'promotional'],
+            },
+            reasoning: { type: 'string', description: 'Brief classification reasoning' },
+            suggested_action: { type: 'string', description: 'Suggested action for the user' },
+            urgency_score: { type: 'number', description: 'Urgency score 0-1' },
+          },
+          required: ['id', 'category', 'reasoning', 'suggested_action', 'urgency_score'],
+        },
+      },
+    },
+    required: ['classifications'],
+  },
+};
+
+function formatEmailsForPrompt(emails: EmailMetadata[]): string {
+  return emails
+    .map((e, i) => [
+      `--- Email ${i + 1} (ID: ${e.id}) ---`,
+      `From: ${e.from}`,
+      `Subject: ${e.subject}`,
+      `Snippet: ${e.snippet}`,
+      `Labels: ${e.labels.join(', ') || 'none'}`,
+    ].join('\n'))
+    .join('\n\n');
+}
+
+export async function classifyEmails(
+  emails: EmailMetadata[],
+): Promise<ClassificationResult> {
+  if (emails.length === 0) {
+    return { classifications: [] };
+  }
+
+  const provider = getConfiguredProvider();
+  if (!provider) {
+    log.warn('Configured provider unavailable for email classification');
+    return { classifications: [] };
+  }
+
+  const prompt = `Classify these ${emails.length} emails:\n\n${formatEmailsForPrompt(emails)}`;
+
+  try {
+    const { signal, cleanup } = createTimeout(CLASSIFICATION_TIMEOUT_MS);
+
+    try {
+      const response = await provider.sendMessage(
+        [userMessage(prompt)],
+        [STORE_CLASSIFICATIONS_TOOL],
+        SYSTEM_PROMPT,
+        {
+          config: {
+            modelIntent: CLASSIFICATION_MODEL_INTENT,
+            max_tokens: 2048,
+            tool_choice: { type: 'tool' as const, name: 'store_classifications' },
+          },
+          signal,
+        },
+      );
+      cleanup();
+
+      const toolBlock = extractToolUse(response);
+      if (!toolBlock) {
+        log.warn('No tool_use block in classification response');
+        return { classifications: [] };
+      }
+
+      const input = toolBlock.input as {
+        classifications?: Array<{
+          id: string;
+          category: string;
+          reasoning: string;
+          suggested_action: string;
+          urgency_score: number;
+        }>;
+      };
+
+      const classifications: ClassifiedEmail[] = (input.classifications ?? [])
+        .filter((c) => VALID_CATEGORIES.has(c.category as EmailCategory))
+        .map((c) => ({
+          id: c.id,
+          category: c.category as EmailCategory,
+          reasoning: c.reasoning,
+          suggestedAction: c.suggested_action,
+          urgencyScore: Math.max(0, Math.min(1, c.urgency_score)),
+        }));
+
+      return { classifications };
+    } finally {
+      cleanup();
+    }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    log.warn({ err: message }, 'Email classification LLM call failed');
+    return { classifications: [] };
+  }
+}

--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -7,6 +7,12 @@ import type {
   GmailDraft,
   GmailModifyRequest,
   GmailMessageFormat,
+  GmailAttachment,
+  GmailFilter,
+  GmailFilterCriteria,
+  GmailFilterAction,
+  GmailFiltersListResponse,
+  GmailVacationSettings,
 } from './types.js';
 
 const GMAIL_API_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
@@ -201,4 +207,78 @@ export async function sendMessage(
 /** Get the authenticated user's profile (email address). */
 export async function getProfile(token: string): Promise<GmailProfile> {
   return request<GmailProfile>(token, '/profile');
+}
+
+/** Get attachment data for a message. */
+export async function getAttachment(
+  token: string,
+  messageId: string,
+  attachmentId: string,
+): Promise<GmailAttachment> {
+  return request<GmailAttachment>(token, `/messages/${messageId}/attachments/${attachmentId}`);
+}
+
+/** Send an email with a pre-built raw MIME payload (for multipart/attachments). */
+export async function sendMessageRaw(
+  token: string,
+  raw: string,
+  threadId?: string,
+): Promise<GmailMessage> {
+  const payload: Record<string, unknown> = { raw };
+  if (threadId) payload.threadId = threadId;
+  return request<GmailMessage>(token, '/messages/send', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+/** Create a user label. */
+export async function createLabel(
+  token: string,
+  name: string,
+  opts?: { messageListVisibility?: 'show' | 'hide'; labelListVisibility?: 'labelShow' | 'labelShowIfUnread' | 'labelHide' },
+): Promise<GmailLabel> {
+  return request<GmailLabel>(token, '/labels', {
+    method: 'POST',
+    body: JSON.stringify({ name, ...opts }),
+  });
+}
+
+/** List all Gmail filters. */
+export async function listFilters(token: string): Promise<GmailFilter[]> {
+  const resp = await request<GmailFiltersListResponse>(token, '/settings/filters');
+  return resp.filter ?? [];
+}
+
+/** Create a Gmail filter. */
+export async function createFilter(
+  token: string,
+  criteria: GmailFilterCriteria,
+  action: GmailFilterAction,
+): Promise<GmailFilter> {
+  return request<GmailFilter>(token, '/settings/filters', {
+    method: 'POST',
+    body: JSON.stringify({ criteria, action }),
+  });
+}
+
+/** Delete a Gmail filter. */
+export async function deleteFilter(token: string, filterId: string): Promise<void> {
+  await request<void>(token, `/settings/filters/${filterId}`, { method: 'DELETE' });
+}
+
+/** Get vacation auto-reply settings. */
+export async function getVacation(token: string): Promise<GmailVacationSettings> {
+  return request<GmailVacationSettings>(token, '/settings/vacation');
+}
+
+/** Update vacation auto-reply settings. */
+export async function updateVacation(
+  token: string,
+  settings: GmailVacationSettings,
+): Promise<GmailVacationSettings> {
+  return request<GmailVacationSettings>(token, '/settings/vacation', {
+    method: 'PUT',
+    body: JSON.stringify(settings),
+  });
 }

--- a/assistant/src/messaging/providers/gmail/mime-builder.ts
+++ b/assistant/src/messaging/providers/gmail/mime-builder.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure-function MIME builder for multipart messages with attachments.
+ * Returns a base64url-encoded string suitable for the Gmail API's `raw` field.
+ */
+
+import { randomBytes } from 'node:crypto';
+
+export interface MimeAttachment {
+  filename: string;
+  mimeType: string;
+  data: Buffer;
+}
+
+export interface MimeMessageOptions {
+  to: string;
+  subject: string;
+  body: string;
+  inReplyTo?: string;
+  attachments: MimeAttachment[];
+}
+
+function toBase64Url(input: Buffer): string {
+  return input
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+/**
+ * Build a multipart/mixed MIME message with attachments.
+ * Returns a base64url-encoded string ready for Gmail's messages.send `raw` field.
+ */
+export function buildMultipartMime(options: MimeMessageOptions): string {
+  const { to, subject, body, inReplyTo, attachments } = options;
+  const boundary = `----=_Part_${randomBytes(16).toString('hex')}`;
+
+  const headers = [
+    `To: ${to}`,
+    `Subject: ${subject}`,
+    'MIME-Version: 1.0',
+    `Content-Type: multipart/mixed; boundary="${boundary}"`,
+  ];
+  if (inReplyTo) {
+    headers.push(`In-Reply-To: ${inReplyTo}`);
+    headers.push(`References: ${inReplyTo}`);
+  }
+
+  const parts: string[] = [];
+
+  // Text body part
+  parts.push(
+    `--${boundary}\r\n` +
+    'Content-Type: text/plain; charset=utf-8\r\n' +
+    'Content-Transfer-Encoding: 7bit\r\n' +
+    '\r\n' +
+    body,
+  );
+
+  // Attachment parts
+  for (const att of attachments) {
+    const b64 = att.data.toString('base64');
+    parts.push(
+      `--${boundary}\r\n` +
+      `Content-Type: ${att.mimeType}; name="${att.filename}"\r\n` +
+      'Content-Transfer-Encoding: base64\r\n' +
+      `Content-Disposition: attachment; filename="${att.filename}"\r\n` +
+      '\r\n' +
+      b64,
+    );
+  }
+
+  const mimeMessage = `${headers.join('\r\n')}\r\n\r\n${parts.join('\r\n')}\r\n--${boundary}--`;
+  return toBase64Url(Buffer.from(mimeMessage, 'utf-8'));
+}

--- a/assistant/src/messaging/providers/gmail/people-client.ts
+++ b/assistant/src/messaging/providers/gmail/people-client.ts
@@ -1,0 +1,50 @@
+/**
+ * Google People API client for contact search and listing.
+ * Separate from the Gmail client due to a different base URL.
+ */
+
+import type { PeopleConnectionsResponse, PeopleSearchResponse } from './people-types.js';
+import { GmailApiError } from './client.js';
+
+const PEOPLE_API_BASE = 'https://people.googleapis.com/v1';
+
+const PERSON_FIELDS = 'names,emailAddresses,phoneNumbers,organizations';
+
+async function request<T>(token: string, url: string): Promise<T> {
+  const resp = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '');
+    throw new GmailApiError(resp.status, resp.statusText, `People API ${resp.status}: ${body}`);
+  }
+  return resp.json() as Promise<T>;
+}
+
+/** List the user's contacts with pagination. */
+export async function listContacts(
+  token: string,
+  pageSize = 50,
+  pageToken?: string,
+): Promise<PeopleConnectionsResponse> {
+  const params = new URLSearchParams({
+    personFields: PERSON_FIELDS,
+    pageSize: String(pageSize),
+  });
+  if (pageToken) params.set('pageToken', pageToken);
+  return request<PeopleConnectionsResponse>(token, `${PEOPLE_API_BASE}/people/me/connections?${params}`);
+}
+
+/** Search contacts by name or email. */
+export async function searchContacts(
+  token: string,
+  query: string,
+): Promise<PeopleSearchResponse> {
+  const params = new URLSearchParams({
+    query,
+    readMask: PERSON_FIELDS,
+  });
+  return request<PeopleSearchResponse>(token, `${PEOPLE_API_BASE}/people:searchContacts?${params}`);
+}

--- a/assistant/src/messaging/providers/gmail/people-types.ts
+++ b/assistant/src/messaging/providers/gmail/people-types.ts
@@ -1,0 +1,41 @@
+/** Types for the Google People API (Contacts). */
+
+export interface PersonName {
+  displayName?: string;
+  givenName?: string;
+  familyName?: string;
+}
+
+export interface PersonEmail {
+  value?: string;
+  type?: string;
+}
+
+export interface PersonPhone {
+  value?: string;
+  type?: string;
+}
+
+export interface PersonOrganization {
+  name?: string;
+  title?: string;
+}
+
+export interface Person {
+  resourceName: string;
+  names?: PersonName[];
+  emailAddresses?: PersonEmail[];
+  phoneNumbers?: PersonPhone[];
+  organizations?: PersonOrganization[];
+}
+
+export interface PeopleConnectionsResponse {
+  connections?: Person[];
+  nextPageToken?: string;
+  totalPeople?: number;
+  totalItems?: number;
+}
+
+export interface PeopleSearchResponse {
+  results?: Array<{ person: Person }>;
+}

--- a/assistant/src/messaging/providers/gmail/types.ts
+++ b/assistant/src/messaging/providers/gmail/types.ts
@@ -88,3 +88,52 @@ export interface GmailModifyRequest {
 
 /** Message format for GET requests */
 export type GmailMessageFormat = 'minimal' | 'full' | 'raw' | 'metadata';
+
+/** Attachment data from the Gmail API */
+export interface GmailAttachment {
+  size: number;
+  data: string; // base64url-encoded
+}
+
+/** Gmail filter criteria */
+export interface GmailFilterCriteria {
+  from?: string;
+  to?: string;
+  subject?: string;
+  query?: string;
+  hasAttachment?: boolean;
+  excludeChats?: boolean;
+  size?: number;
+  sizeComparison?: 'larger' | 'smaller';
+}
+
+/** Gmail filter action */
+export interface GmailFilterAction {
+  addLabelIds?: string[];
+  removeLabelIds?: string[];
+  forward?: string;
+}
+
+/** Gmail filter */
+export interface GmailFilter {
+  id: string;
+  criteria: GmailFilterCriteria;
+  action: GmailFilterAction;
+}
+
+/** Gmail filters list response */
+export interface GmailFiltersListResponse {
+  filter?: GmailFilter[];
+}
+
+/** Gmail vacation auto-reply settings */
+export interface GmailVacationSettings {
+  enableAutoReply: boolean;
+  responseSubject?: string;
+  responseBodyPlainText?: string;
+  responseBodyHtml?: string;
+  restrictToContacts?: boolean;
+  restrictToDomain?: boolean;
+  startTime?: string; // epoch ms as string
+  endTime?: string;   // epoch ms as string
+}

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -51,6 +51,7 @@ const WELL_KNOWN_OAUTH: Record<string, WellKnownOAuthConfig> = {
       'https://www.googleapis.com/auth/calendar.readonly',
       'https://www.googleapis.com/auth/calendar.events',
       'https://www.googleapis.com/auth/userinfo.email',
+      'https://www.googleapis.com/auth/contacts.readonly',
     ],
     userinfoUrl: 'https://www.googleapis.com/oauth2/v2/userinfo',
     extraParams: { access_type: 'offline', prompt: 'consent' },


### PR DESCRIPTION
## Summary

- **Attachments**: 3 new tools (`gmail_list_attachments`, `gmail_download_attachment`, `gmail_send_with_attachments`) with a pure-function MIME builder for multipart messages
- **Forward & Thread Ops**: `gmail_forward` (preserves attachments), `gmail_summarize_thread` (LLM-powered via existing thread-summarizer), `gmail_follow_up` (track/untrack/list with auto-created Follow-up label)
- **Smart Triage**: `gmail_triage` with LLM classifier (`email-classifier.ts`) that categorizes unread emails as needs_reply/fyi_only/can_archive/urgent/newsletter/promotional; optional `auto_apply` mode
- **Inbox Automation**: `gmail_filters` (list/create/delete) and `gmail_vacation` (get/enable/disable auto-responder)
- **Google Contacts**: `google_contacts` (list/search via People API) with new `contacts.readonly` OAuth scope
- Updated TOOLS.json (10 new tools), SKILL.md (5 new subsections), and gmail-integration.test.ts (30 total tools)

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] `bun test` — all new/modified tests pass (mime-builder, email-classifier, gmail-integration)
- [ ] Manual: connect Gmail via OAuth2, exercise attachment download/send, forward, triage, filter CRUD, vacation toggle, and contacts search

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
