### PR TITLE
fix: lazily create MainWindow on quick input submit

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1343,7 +1343,24 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func handleQuickInputSubmit(_ message: String, imageData: Data?) {
-        showMainWindow()
+        // Ensure MainWindow exists without bringing it to the foreground.
+        // showMainWindow() would activate the app — instead, create the
+        // window lazily if needed, but don't call show().
+        if mainWindow == nil {
+            let main = MainWindow(services: services)
+            main.onMicrophoneToggle = { [weak self] in
+                self?.voiceInput?.toggleRecording()
+            }
+            main.threadManager.onInlineConfirmationResponse = { [weak self] requestId, decision in
+                guard let self else { return }
+                self.toolConfirmationNotificationService.handleInlineResponse(requestId: requestId)
+                UNUserNotificationCenter.current().removeDeliveredNotifications(
+                    withIdentifiers: ["tool-confirm-\(requestId)"]
+                )
+            }
+            mainWindow = main
+            observeAssistantStatus()
+        }
         guard let mainWindow else { return }
         mainWindow.threadManager.createThread()
         if let viewModel = mainWindow.activeViewModel {


### PR DESCRIPTION
## Summary
- Replace `showMainWindow()` with lazy MainWindow creation in `handleQuickInputSubmit` so quick input submissions don't steal focus from the user's current app
- The MainWindow is created in the background (without calling `show()`) and wired up with microphone toggle and inline confirmation handlers

## Test plan
- [ ] Submit a message via the quick input bar — verify the message is sent without the main window stealing focus
- [ ] Submit when no MainWindow exists yet — verify it's created lazily and the message still sends
- [ ] Verify microphone toggle and tool confirmation notifications still work after lazy creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
