### PR TITLE
M5: Bundled Recording Skill (Activation Rules Only)

### DIFF
--- a/assistant/src/config/bundled-skills/screen-recording/SKILL.md
+++ b/assistant/src/config/bundled-skills/screen-recording/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "Screen Recording"
 description: "Record the user's screen as a video file"
-metadata: {"vellum": {"emoji": "🎬"}}
+metadata: {"vellum": {"emoji": "🎬", "os": ["darwin"]}}
 ---
 
 Capture screen recordings as video files attached to the conversation.

--- a/assistant/src/config/bundled-skills/screen-recording/SKILL.md
+++ b/assistant/src/config/bundled-skills/screen-recording/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: "Screen Recording"
+description: "Record the user's screen as a video file"
+metadata: {"vellum": {"emoji": "🎬"}}
+---
+
+Capture screen recordings as video files attached to the conversation.
+
+## Activation
+
+This skill activates when the user asks to record their screen. Common phrases:
+
+**Start recording:**
+- "record my screen"
+- "start recording"
+- "begin recording"
+- "capture my screen"
+- "capture my display"
+- "make a recording"
+
+**Stop recording:**
+- "stop recording"
+- "end recording"
+- "finish recording"
+- "halt recording"
+
+## Routing
+
+Recording-only requests are handled by the **standalone recording route** — they do NOT create a computer-use session.
+
+- When the user says "record my screen" (with no other task), the daemon intercepts this and starts a standalone recording directly.
+- When the user says "stop recording", the daemon intercepts and stops the active recording for the current conversation.
+- The recording is saved as a video file and attached to the conversation thread.
+
+## Behavior Rules
+
+1. **Do not invoke computer use** for recording-only requests. The daemon handles these directly.
+2. **One recording at a time.** If a recording is already active, starting another returns an "already recording" message.
+3. **Conversation-scoped.** Each recording is linked to the conversation that started it. Stopping in a different thread does not affect unrelated recordings.
+4. **Permission required.** Screen recording requires macOS Screen Recording permission. If denied, the user sees actionable guidance to enable it in System Settings.
+
+## What This Skill Does NOT Do
+
+- This skill does not contain recorder logic — the `RecordingManager` and `ScreenRecorder` in the macOS app handle the actual recording.
+- This skill does not provide shell commands or scripts for recording.
+- This skill does not fall back to computer use for recording tasks.


### PR DESCRIPTION
Adds a bundled screen-recording SKILL.md that defines activation rules for the standalone recording feature:

- Start phrases: record my screen, start recording, capture my display, etc.
- Stop phrases: stop recording, end recording, finish recording
- Explicitly states recording-only requests use standalone route (no CU)
- Thin skill: no shell recorder instructions, no CU fallback
- Auto-discovered by skill loader via bundled-skills directory convention

Closes #8677
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
