### PR TITLE
fix: add macOS OS gate to screen-recording skill

### DIFF
--- a/assistant/src/config/bundled-skills/screen-recording/SKILL.md
+++ b/assistant/src/config/bundled-skills/screen-recording/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "Screen Recording"
 description: "Record the user's screen as a video file"
-metadata: {"vellum": {"emoji": "🎬"}, "os": ["darwin"]}
+metadata: {"vellum": {"emoji": "🎬", "os": ["darwin"]}}
 ---
 
 Capture screen recordings as video files attached to the conversation.

--- a/assistant/src/config/bundled-skills/screen-recording/SKILL.md
+++ b/assistant/src/config/bundled-skills/screen-recording/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "Screen Recording"
 description: "Record the user's screen as a video file"
-metadata: {"vellum": {"emoji": "🎬"}}
+metadata: {"vellum": {"emoji": "🎬"}, "os": ["darwin"]}
 ---
 
 Capture screen recordings as video files attached to the conversation.


### PR DESCRIPTION
Adds "os": ["darwin"] to the screen-recording skill metadata so it's only surfaced on macOS. The recording implementation is macOS-client-specific.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
