### PR TITLE
feat: add gmail_sender_digest tool for newsletter decluttering

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -208,6 +208,28 @@ Medium and high risk tools require a confidence score between 0 and 1:
 
 Use `messaging_analyze_activity` to classify channels or conversations by activity level (high, medium, low, dead). Useful for decluttering — suggest leaving dead channels or archiving old emails.
 
+## Newsletter Decluttering
+
+Use `gmail_sender_digest` to help users identify and clean up high-volume senders like newsletters, marketing emails, and automated notifications.
+
+### Workflow
+
+1. **Scan**: Call `gmail_sender_digest` (default query targets emails with unsubscribe headers from the last 90 days)
+2. **Present**: Show results as a `ui_show` table with `selectionMode: "multiple"`:
+   - Columns: Sender, Email Count, Unsubscribable, Date Range, Sample Subject
+   - Action buttons: "Archive & Unsubscribe" (primary), "Archive Only" (secondary)
+3. **Act on selection**: For each selected sender:
+   - Call `gmail_batch_archive` with the sender's `message_ids`
+   - If `has_more` is true, use the sender's `search_query` to find and archive remaining messages
+   - If the action is "Archive & Unsubscribe" and `has_unsubscribe` is true, call `gmail_unsubscribe` with the sender's `newest_message_id`
+4. **Report**: Summarize results — e.g. "Archived 247 messages from 8 senders. Unsubscribed from 6."
+
+### Edge Cases
+
+- **Zero results**: Tell the user "No newsletter emails found" and suggest broadening the query (e.g. removing `has:unsubscribe` or extending the date range)
+- **Unsubscribe failures**: Report per-sender success/failure; the existing `gmail_unsubscribe` tool handles edge cases
+- **Large sender counts**: The `has_more` flag indicates a sender had more messages than collected — use `search_query` for follow-up archiving
+
 ## Batch Operations
 
 - Gmail batch tools (`gmail_batch_archive`, `gmail_batch_label`) accept arrays of message IDs.

--- a/assistant/src/config/bundled-skills/messaging/TOOLS.json
+++ b/assistant/src/config/bundled-skills/messaging/TOOLS.json
@@ -565,6 +565,22 @@
       "execution_target": "host"
     },
     {
+      "name": "gmail_sender_digest",
+      "description": "Scan Gmail and group messages by sender to identify high-volume senders (e.g. newsletters). Returns top senders sorted by message count with metadata for bulk cleanup.",
+      "category": "messaging",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query": { "type": "string", "description": "Gmail search query (default 'has:unsubscribe newer_than:90d')" },
+          "max_messages": { "type": "number", "description": "Maximum messages to scan (default 500, cap 2000)" },
+          "max_senders": { "type": "number", "description": "Maximum senders to return (default 30)" }
+        }
+      },
+      "executor": "tools/gmail-sender-digest.ts",
+      "execution_target": "host"
+    },
+    {
       "name": "google_contacts",
       "description": "List or search Google Contacts. Requires contacts.readonly scope (re-authorization may be needed).",
       "category": "messaging",

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
@@ -1,0 +1,154 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { getMessagingProvider } from '../../../../messaging/registry.js';
+import { withValidToken } from '../../../../security/token-manager.js';
+import { listMessages, batchGetMessages } from '../../../../messaging/providers/gmail/client.js';
+import { ok, err } from './shared.js';
+
+const MAX_MESSAGES_CAP = 2000;
+const MAX_IDS_PER_SENDER = 100;
+const MAX_SAMPLE_SUBJECTS = 3;
+
+interface SenderAggregation {
+  displayName: string;
+  email: string;
+  messageCount: number;
+  hasUnsubscribe: boolean;
+  newestMessageId: string;
+  oldestDate: string;
+  newestDate: string;
+  messageIds: string[];
+  hasMore: boolean;
+  sampleSubjects: string[];
+}
+
+/** Parse "Display Name <email@example.com>" into parts. */
+function parseFrom(from: string): { displayName: string; email: string } {
+  const match = from.match(/^(.+?)\s*<([^>]+)>$/);
+  if (match) {
+    return { displayName: match[1].replace(/^["']|["']$/g, '').trim(), email: match[2].toLowerCase() };
+  }
+  // Bare email address
+  const bare = from.trim().toLowerCase();
+  return { displayName: '', email: bare };
+}
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const query = (input.query as string) ?? 'has:unsubscribe newer_than:90d';
+  const maxMessages = Math.min((input.max_messages as number) ?? 500, MAX_MESSAGES_CAP);
+  const maxSenders = (input.max_senders as number) ?? 30;
+
+  try {
+    const provider = getMessagingProvider('gmail');
+    return withValidToken(provider.credentialService, async (token) => {
+      // Paginate through listMessages to collect up to maxMessages IDs
+      const allMessageIds: string[] = [];
+      let pageToken: string | undefined;
+
+      while (allMessageIds.length < maxMessages) {
+        const pageSize = Math.min(100, maxMessages - allMessageIds.length);
+        const listResp = await listMessages(token, query, pageSize, pageToken);
+        const ids = (listResp.messages ?? []).map((m) => m.id);
+        if (ids.length === 0) break;
+        allMessageIds.push(...ids);
+        pageToken = listResp.nextPageToken ?? undefined;
+        if (!pageToken) break;
+      }
+
+      if (allMessageIds.length === 0) {
+        return ok(JSON.stringify({ senders: [], total_scanned: 0, message: 'No newsletter emails found matching the query.' }));
+      }
+
+      // Batch-fetch metadata headers
+      const messages = await batchGetMessages(token, allMessageIds, 'metadata', [
+        'From', 'List-Unsubscribe', 'Subject', 'Date',
+      ]);
+
+      // Group by sender email
+      const senderMap = new Map<string, SenderAggregation>();
+
+      for (const msg of messages) {
+        const headers = msg.payload?.headers ?? [];
+        const fromHeader = headers.find((h) => h.name.toLowerCase() === 'from')?.value ?? '';
+        const subject = headers.find((h) => h.name.toLowerCase() === 'subject')?.value ?? '';
+        const dateStr = headers.find((h) => h.name.toLowerCase() === 'date')?.value ?? '';
+        const listUnsub = headers.find((h) => h.name.toLowerCase() === 'list-unsubscribe')?.value;
+
+        const { displayName, email } = parseFrom(fromHeader);
+        if (!email) continue;
+
+        let agg = senderMap.get(email);
+        if (!agg) {
+          agg = {
+            displayName,
+            email,
+            messageCount: 0,
+            hasUnsubscribe: false,
+            newestMessageId: msg.id,
+            oldestDate: dateStr,
+            newestDate: dateStr,
+            messageIds: [],
+            hasMore: false,
+            sampleSubjects: [],
+          };
+          senderMap.set(email, agg);
+        }
+
+        agg.messageCount++;
+
+        if (listUnsub) agg.hasUnsubscribe = true;
+
+        // Use displayName from earliest message that has one
+        if (!agg.displayName && displayName) agg.displayName = displayName;
+
+        // Track message IDs (cap at MAX_IDS_PER_SENDER)
+        if (agg.messageIds.length < MAX_IDS_PER_SENDER) {
+          agg.messageIds.push(msg.id);
+        } else {
+          agg.hasMore = true;
+        }
+
+        // Track date range — compare using internalDate (epoch ms) for reliability
+        const msgEpoch = msg.internalDate ? Number(msg.internalDate) : 0;
+        const oldestEpoch = agg.oldestDate ? new Date(agg.oldestDate).getTime() : Infinity;
+        const newestEpoch = agg.newestDate ? new Date(agg.newestDate).getTime() : 0;
+
+        if (msgEpoch > 0 && msgEpoch < oldestEpoch) {
+          agg.oldestDate = dateStr || agg.oldestDate;
+        }
+        if (msgEpoch > newestEpoch) {
+          agg.newestDate = dateStr || agg.newestDate;
+          agg.newestMessageId = msg.id;
+        }
+
+        // Collect sample subjects
+        if (subject && agg.sampleSubjects.length < MAX_SAMPLE_SUBJECTS) {
+          agg.sampleSubjects.push(subject);
+        }
+      }
+
+      // Sort by message count descending, take top N
+      const sorted = [...senderMap.values()]
+        .sort((a, b) => b.messageCount - a.messageCount)
+        .slice(0, maxSenders);
+
+      const result = sorted.map((s) => ({
+        id: Buffer.from(s.email).toString('base64url'),
+        display_name: s.displayName || s.email.split('@')[0],
+        email: s.email,
+        message_count: s.messageCount,
+        has_unsubscribe: s.hasUnsubscribe,
+        newest_message_id: s.newestMessageId,
+        oldest_date: s.oldestDate,
+        newest_date: s.newestDate,
+        message_ids: s.messageIds,
+        has_more: s.hasMore,
+        search_query: `from:${s.email}`,
+        sample_subjects: s.sampleSubjects,
+      }));
+
+      return ok(JSON.stringify({ senders: result, total_scanned: allMessageIds.length }));
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}


### PR DESCRIPTION
## Summary

- Add `gmail_sender_digest` read-only tool that scans Gmail, groups messages by sender, and returns top senders sorted by message count — designed for identifying high-volume newsletter senders for bulk cleanup
- Register the tool in `TOOLS.json` with configurable query, max_messages, and max_senders inputs
- Add "Newsletter Decluttering" section to `SKILL.md` with orchestration instructions for the full scan → present → archive/unsubscribe flow using existing action tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
