### PR TITLE
fix: resolve lint errors breaking CI

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-vacation.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-vacation.ts
@@ -41,7 +41,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         }
 
         case 'disable': {
-          const updated = await updateVacation(token, { enableAutoReply: false });
+          await updateVacation(token, { enableAutoReply: false });
           return ok('Vacation responder disabled.');
         }
 

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -40,7 +40,7 @@ export function handleGuardianVerification(
           error: 'already_bound',
           message: 'A guardian is already bound for this channel. Revoke the existing binding first, or set rebind: true to replace.',
           channel,
-        } as any);
+        });
         return;
       }
 

--- a/assistant/src/daemon/ipc-contract/integrations.ts
+++ b/assistant/src/daemon/ipc-contract/integrations.ts
@@ -238,6 +238,8 @@ export interface GuardianVerificationResponse {
   /** Whether a pending verification challenge exists for this (assistantId, channel). Used by relay setup to detect active voice verification sessions. */
   hasPendingChallenge?: boolean;
   error?: string;
+  /** Human-readable error detail (e.g. for already_bound failures). */
+  message?: string;
 }
 
 export interface TwitterAuthResult {

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -70,11 +70,11 @@ const log = getLogger('runtime-http');
  * Parse a `/guardian_verify` command from message content.
  * Supports `/guardian_verify <code>`, `/guardian_verify@BotName <code>`,
  * and normalized whitespace.
- * Returns the verification code if the message is a verify command, or null otherwise.
+ * Returns the verification code if the message is a verify command, or undefined otherwise.
  */
-function parseGuardianVerifyCommand(content: string): string | null {
+function parseGuardianVerifyCommand(content: string): string | undefined {
   const match = content.match(/^\/guardian_verify(?:@\S+)?\s+(\S+)/);
-  return match ? match[1] : null;
+  return match?.[1];
 }
 
 export async function handleChannelInbound(
@@ -172,7 +172,7 @@ export async function handleChannelInbound(
   // /guardian_verify must bypass the ACL membership check — users without a
   // member record need to verify before they can be recognized as members.
   const guardianVerifyCode = parseGuardianVerifyCommand(trimmedContent);
-  const isGuardianVerifyCommand = guardianVerifyCode !== null;
+  const isGuardianVerifyCommand = guardianVerifyCode !== undefined;
 
   if (body.senderExternalUserId) {
     resolvedMember = findMember({
@@ -490,7 +490,7 @@ export async function handleChannelInbound(
   // Handled before normal message processing so it never enters the agent loop.
   if (
     !result.duplicate &&
-    guardianVerifyCode !== null &&
+    guardianVerifyCode !== undefined &&
     replyCallbackUrl &&
     body.senderExternalUserId
   ) {


### PR DESCRIPTION
## Summary
- Fix 5 lint errors on main: unused import, unused variable, `as any` cast, and two `!== null` violations
- Add `message` field to `GuardianVerificationResponse` IPC contract to replace `as any` workaround
- Change `parseGuardianVerifyCommand` to return `undefined` instead of `null` per project lint rules

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22358705846

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
