### PR TITLE
feat: make Quick Input hotkey configurable via Settings

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -55,7 +55,7 @@ enum InteractionType {
     case textQA
 }
 
-/// Carbon event handler for the Quick Input hotkey (Cmd+/).
+/// Carbon event handler for the Quick Input hotkey (Cmd+Shift+/).
 /// Must be a free function because Carbon callbacks are C function pointers.
 private func quickInputHotKeyHandler(
     _: EventHandlerCallRef?,
@@ -94,6 +94,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var statusItem: NSStatusItem!
     private var hotKeyMonitor: Any?
     private var lastRegisteredGlobalHotkey: String?
+    private var lastRegisteredQuickInputHotkey: String?
     private var globalHotkeyObserver: AnyCancellable?
     private var escapeMonitor: Any?
     private var fnVGlobalMonitor: Any?
@@ -417,6 +418,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             quickInputWindow?.dismiss()
             quickInputWindow = nil
             lastRegisteredGlobalHotkey = nil
+            lastRegisteredQuickInputHotkey = nil
             globalHotkeyObserver?.cancel()
             globalHotkeyObserver = nil
             if let escapeMonitor {
@@ -1187,24 +1189,44 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 self?.registerGlobalHotkeyMonitor()
+                self?.registerQuickInputMonitor()
             }
     }
 
-    /// Registers a Carbon hotkey (Cmd+/) that intercepts system-wide,
+    /// Registers a Carbon hotkey for Quick Input that intercepts system-wide,
     /// before the frontmost app's menu system can consume it.
+    /// Reads the shortcut and key code from UserDefaults. Skips re-registration if unchanged.
     private func registerQuickInputMonitor() {
+        let shortcut = UserDefaults.standard.string(forKey: "quickInputHotkeyShortcut") ?? "cmd+shift+/"
+
+        if shortcut == lastRegisteredQuickInputHotkey { return }
+
+        // Tear down previous registration
+        if let ref = quickInputHotKeyRef {
+            UnregisterEventHotKey(ref)
+            quickInputHotKeyRef = nil
+        }
+        if let ref = quickInputEventHandlerRef {
+            RemoveEventHandler(ref)
+            quickInputEventHandlerRef = nil
+        }
+
+        let storedKeyCode = UserDefaults.standard.integer(forKey: "quickInputHotkeyKeyCode")
+        let keyCode = UInt32(storedKeyCode > 0 ? storedKeyCode : kVK_ANSI_Slash)
+        let (modifierFlags, _) = ShortcutHelper.parseShortcut(shortcut)
+        let carbonMods = ShortcutHelper.carbonModifiers(from: modifierFlags)
+
         // Install Carbon event handler for hotkey events
         var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
         var handlerRef: EventHandlerRef?
         InstallEventHandler(GetApplicationEventTarget(), quickInputHotKeyHandler, 1, &eventType, nil, &handlerRef)
         quickInputEventHandlerRef = handlerRef
 
-        // Register Cmd+/ (keyCode 44) as a system-wide hotkey
         let hotKeyID = EventHotKeyID(signature: OSType(0x564C_4D51), id: 1) // "VLMQ"
         var hotKeyRef: EventHotKeyRef?
         let status = RegisterEventHotKey(
-            UInt32(kVK_ANSI_Slash),
-            UInt32(cmdKey),
+            keyCode,
+            carbonMods,
             hotKeyID,
             GetApplicationEventTarget(),
             0,
@@ -1212,10 +1234,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         if status == noErr {
             quickInputHotKeyRef = hotKeyRef
-            log.info("Quick Input: Carbon hotkey Cmd+/ registered successfully")
+            log.info("Quick Input: Carbon hotkey \(ShortcutHelper.displayString(for: shortcut)) registered successfully")
         } else {
             log.error("Quick Input: Failed to register Carbon hotkey, status: \(status)")
         }
+
+        lastRegisteredQuickInputHotkey = shortcut
     }
 
     /// Removes the Carbon hotkey and event handler registrations.

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -7,6 +7,7 @@ struct SettingsAppearanceTab: View {
     @AppStorage("themePreference") private var themePreference: String = "system"
     @State private var newAllowlistDomain = ""
     @State private var isRecordingGlobalHotkey = false
+    @State private var isRecordingQuickInputHotkey = false
     @State private var shortcutMonitor: Any?
     @State private var shortcutConflictWarning: String?
 
@@ -83,7 +84,34 @@ struct SettingsAppearanceTab: View {
                         .foregroundColor(VColor.warning)
                 }
 
-                ShortcutRow(label: "Quick Input", shortcut: "⌘⇧V")
+                // Quick Input (configurable)
+                HStack {
+                    Text("Quick Input")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Spacer()
+                    Text(ShortcutHelper.displayString(for: store.quickInputHotkeyShortcut))
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textPrimary)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(VColor.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.sm)
+                                .stroke(VColor.surfaceBorder, lineWidth: 1)
+                        )
+
+                    if isRecordingQuickInputHotkey {
+                        VButton(label: "Press shortcut...", style: .tertiary) {
+                            stopRecording()
+                        }
+                    } else {
+                        VButton(label: "Record", style: .tertiary) {
+                            startRecordingQuickInput()
+                        }
+                    }
+                }
                 ShortcutRow(label: "Start voice input", shortcut: "Hold Fn")
             }
             .padding(VSpacing.lg)
@@ -175,7 +203,23 @@ struct SettingsAppearanceTab: View {
     // MARK: - Shortcut Recording
 
     private func startRecording() {
+        startRecordingShortcut { shortcut, _ in
+            store.globalHotkeyShortcut = shortcut
+        }
         isRecordingGlobalHotkey = true
+    }
+
+    private func startRecordingQuickInput() {
+        startRecordingShortcut { shortcut, keyCode in
+            store.quickInputHotkeyShortcut = shortcut
+            store.quickInputHotkeyKeyCode = Int(keyCode)
+        }
+        isRecordingQuickInputHotkey = true
+    }
+
+    /// Shared recording logic. The callback receives the shortcut string and the raw NSEvent key code.
+    private func startRecordingShortcut(onRecord: @escaping (String, UInt16) -> Void) {
+        stopRecording()
         shortcutConflictWarning = nil
 
         shortcutMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
@@ -198,7 +242,7 @@ struct SettingsAppearanceTab: View {
             )
 
             shortcutConflictWarning = nil
-            store.globalHotkeyShortcut = shortcut
+            onRecord(shortcut, event.keyCode)
             stopRecording()
             return nil
         }
@@ -206,6 +250,7 @@ struct SettingsAppearanceTab: View {
 
     private func stopRecording() {
         isRecordingGlobalHotkey = false
+        isRecordingQuickInputHotkey = false
         if let monitor = shortcutMonitor {
             NSEvent.removeMonitor(monitor)
             shortcutMonitor = nil

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1,3 +1,4 @@
+import Carbon.HIToolbox
 import Combine
 import Foundation
 import os
@@ -58,6 +59,8 @@ public final class SettingsStore: ObservableObject {
     @Published var maxSteps: Double
     @Published var activityNotificationsEnabled: Bool
     @Published var globalHotkeyShortcut: String
+    @Published var quickInputHotkeyShortcut: String
+    @Published var quickInputHotkeyKeyCode: Int
 
     // MARK: - Media Embed Settings
 
@@ -251,6 +254,9 @@ public final class SettingsStore: ObservableObject {
         self.activityNotificationsEnabled = UserDefaults.standard.object(forKey: "activityNotificationsEnabled") as? Bool ?? true
 
         self.globalHotkeyShortcut = UserDefaults.standard.string(forKey: "globalHotkeyShortcut") ?? "cmd+shift+g"
+        self.quickInputHotkeyShortcut = UserDefaults.standard.string(forKey: "quickInputHotkeyShortcut") ?? "cmd+shift+/"
+        let storedQIKeyCode = UserDefaults.standard.integer(forKey: "quickInputHotkeyKeyCode")
+        self.quickInputHotkeyKeyCode = storedQIKeyCode > 0 ? storedQIKeyCode : kVK_ANSI_Slash
 
         #if DEBUG
         self.isDevMode = UserDefaults.standard.object(forKey: "devModeEnabled") as? Bool ?? true
@@ -299,6 +305,16 @@ public final class SettingsStore: ObservableObject {
         $globalHotkeyShortcut
             .dropFirst()
             .sink { value in UserDefaults.standard.set(value, forKey: "globalHotkeyShortcut") }
+            .store(in: &cancellables)
+
+        $quickInputHotkeyShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "quickInputHotkeyShortcut") }
+            .store(in: &cancellables)
+
+        $quickInputHotkeyKeyCode
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "quickInputHotkeyKeyCode") }
             .store(in: &cancellables)
 
         $isDevMode

--- a/clients/macos/vellum-assistant/Features/Settings/ShortcutHelper.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ShortcutHelper.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Carbon.HIToolbox
 
 /// Utilities for converting between the string shortcut representation
 /// (e.g. "cmd+shift+space") and macOS modifier flags / display symbols.
@@ -63,6 +64,16 @@ enum ShortcutHelper {
     /// produce {"shift", "cmd", "g"}).
     static func normalizeShortcut(_ shortcut: String) -> Set<String> {
         Set(shortcut.lowercased().split(separator: "+").map(String.init))
+    }
+
+    /// Converts NSEvent modifier flags to the Carbon modifier mask used by `RegisterEventHotKey`.
+    static func carbonModifiers(from flags: NSEvent.ModifierFlags) -> UInt32 {
+        var mods: UInt32 = 0
+        if flags.contains(.command) { mods |= UInt32(cmdKey) }
+        if flags.contains(.shift) { mods |= UInt32(shiftKey) }
+        if flags.contains(.option) { mods |= UInt32(optionKey) }
+        if flags.contains(.control) { mods |= UInt32(controlKey) }
+        return mods
     }
 
     // MARK: - Private


### PR DESCRIPTION
## Summary
- Change the default Quick Input shortcut from Cmd+/ to Cmd+Shift+/ to avoid conflicts with app menu shortcuts
- Add a Record button next to Quick Input in Settings > Keyboard Shortcuts so users can customize the hotkey
- Store the raw NSEvent key code during recording so Carbon's `RegisterEventHotKey` can use it directly — no hardcoded character-to-keycode mapping needed
- Add `carbonModifiers(from:)` helper to ShortcutHelper for converting NSEvent modifier flags to Carbon modifier masks

## Test plan
- [ ] Verify Cmd+Shift+/ opens Quick Input from any app
- [ ] Open Settings > Keyboard Shortcuts, click Record next to Quick Input, press a new shortcut
- [ ] Verify the new shortcut works system-wide after recording
- [ ] Verify Open Vellum Record button still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
