### PR TITLE
feat: add sequence engine with scheduler integration

### DIFF
--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -30,6 +30,7 @@ export type TitleOrigin =
   | 'task'
   | 'watcher'
   | 'subagent'
+  | 'sequence'
   | 'heartbeat'
   | 'ipc'
   | 'task_submit'

--- a/assistant/src/messaging/outreach-classifier.ts
+++ b/assistant/src/messaging/outreach-classifier.ts
@@ -1,0 +1,140 @@
+/**
+ * LLM-powered classifier for cold outreach emails (sales, recruiting, marketing).
+ * Works with metadata only (from, subject) to keep token usage low.
+ */
+
+import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/provider-send-message.js';
+import type { EmailMetadata } from './email-classifier.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('outreach-classifier');
+
+const MODEL_INTENT = 'latency-optimized' as const;
+const TIMEOUT_MS = 30_000;
+const BATCH_SIZE = 100;
+
+export type OutreachType = 'sales' | 'recruiting' | 'marketing' | 'other';
+
+export interface OutreachClassification {
+  id: string;
+  isOutreach: boolean;
+  outreachType: OutreachType;
+  confidence: number; // 0-1
+  reasoning: string;
+}
+
+const VALID_OUTREACH_TYPES = new Set<OutreachType>(['sales', 'recruiting', 'marketing', 'other']);
+
+const SYSTEM_PROMPT = 'You are a cold outreach detection system. Given email metadata (sender, subject), classify each email as outreach or not.\n\nOutreach signals to look for:\n- Generic greetings (\"Hi there\", \"Hope this finds you well\")\n- Scheduling links (Calendly, Chili Piper, cal.com)\n- Pitch language (\"quick chat\", \"15 minutes\", \"love to connect\", \"touching base\")\n- Recruiting templates (\"exciting opportunity\", \"your background\", \"perfect fit\")\n- Product/service promotion from unknown senders\n- Cold intro patterns (\"I came across your profile\", \"saw your company\")\n\nExplicitly NOT outreach (classify as other with isOutreach=false):\n- Personal emails from known contacts\n- Transactional emails (receipts, shipping, password resets)\n- Newsletters (these are already filtered out by query)\n- Calendar invites and event notifications\n\nFor each email, provide:\n- isOutreach: true if this is cold outreach, false otherwise\n- outreachType: \"sales\" (product/service pitch), \"recruiting\" (job opportunity), \"marketing\" (promotional from unknown sender), or \"other\" (not outreach)\n- confidence: 0.0 (uncertain) to 1.0 (certain)\n- reasoning: Brief explanation (1 sentence)\n\nYou MUST respond using the `store_outreach_classifications` tool. Do not respond with text.';
+
+const STORE_OUTREACH_TOOL = {
+  name: 'store_outreach_classifications',
+  description: 'Store outreach classification results',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      classifications: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', description: 'Email ID' },
+            is_outreach: { type: 'boolean', description: 'Whether this is cold outreach' },
+            outreach_type: {
+              type: 'string',
+              enum: ['sales', 'recruiting', 'marketing', 'other'],
+            },
+            confidence: { type: 'number', description: 'Confidence score 0-1' },
+            reasoning: { type: 'string', description: 'Brief classification reasoning' },
+          },
+          required: ['id', 'is_outreach', 'outreach_type', 'confidence', 'reasoning'],
+        },
+      },
+    },
+    required: ['classifications'],
+  },
+};
+
+function formatEmailsForPrompt(emails: EmailMetadata[]): string {
+  return emails
+    .map((e, i) => [
+      '--- Email ' + (i + 1) + ' (ID: ' + e.id + ') ---',
+      'From: ' + e.from,
+      'Subject: ' + e.subject,
+    ].join('\n'))
+    .join('\n\n');
+}
+
+async function classifyBatch(emails: EmailMetadata[]): Promise<OutreachClassification[]> {
+  const provider = getConfiguredProvider();
+  if (!provider) {
+    log.warn('Configured provider unavailable for outreach classification');
+    return [];
+  }
+
+  const prompt = 'Classify these ' + emails.length + ' emails as outreach or not:\n\n' + formatEmailsForPrompt(emails);
+  const { signal, cleanup } = createTimeout(TIMEOUT_MS);
+
+  try {
+    const response = await provider.sendMessage(
+      [userMessage(prompt)],
+      [STORE_OUTREACH_TOOL],
+      SYSTEM_PROMPT,
+      {
+        config: {
+          modelIntent: MODEL_INTENT,
+          max_tokens: 4096,
+          tool_choice: { type: 'tool' as const, name: 'store_outreach_classifications' },
+        },
+        signal,
+      },
+    );
+    cleanup();
+
+    const toolBlock = extractToolUse(response);
+    if (!toolBlock) {
+      log.warn('No tool_use block in outreach classification response');
+      return [];
+    }
+
+    const input = toolBlock.input as {
+      classifications?: Array<{
+        id: string;
+        is_outreach: boolean;
+        outreach_type: string;
+        confidence: number;
+        reasoning: string;
+      }>;
+    };
+
+    return (input.classifications ?? []).map((c) => ({
+      id: c.id,
+      isOutreach: Boolean(c.is_outreach),
+      outreachType: VALID_OUTREACH_TYPES.has(c.outreach_type as OutreachType)
+        ? (c.outreach_type as OutreachType)
+        : 'other',
+      confidence: Math.max(0, Math.min(1, c.confidence)),
+      reasoning: c.reasoning,
+    }));
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    log.warn({ err: message }, 'Outreach classification LLM call failed');
+    return [];
+  } finally {
+    cleanup();
+  }
+}
+
+export async function classifyOutreach(emails: EmailMetadata[]): Promise<OutreachClassification[]> {
+  if (emails.length === 0) return [];
+
+  const results: OutreachClassification[] = [];
+
+  for (let i = 0; i < emails.length; i += BATCH_SIZE) {
+    const batch = emails.slice(i, i + BATCH_SIZE);
+    const batchResults = await classifyBatch(batch);
+    results.push(...batchResults);
+  }
+
+  return results;
+}

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -9,6 +9,7 @@ import {
 import { hasSetConstructs } from './recurrence-engine.js';
 import { claimDueReminders, completeReminder, failReminder, setReminderConversationId } from '../tools/reminder/reminder-store.js';
 import { runWatchersOnce, type WatcherNotifier, type WatcherEscalator } from '../watcher/engine.js';
+import { runSequencesOnce } from '../sequence/engine.js';
 
 const log = getLogger('scheduler');
 
@@ -175,6 +176,14 @@ async function runScheduleOnce(
     } catch (err) {
       log.error({ err }, 'Watcher tick failed');
     }
+  }
+
+  // ── Sequences (multi-step outreach) ──────────────────────────────
+  try {
+    const sequenceProcessed = await runSequencesOnce(processMessage);
+    processed += sequenceProcessed;
+  } catch (err) {
+    log.error({ err }, 'Sequence engine tick failed');
   }
 
   if (processed > 0) {

--- a/assistant/src/sequence/engine.ts
+++ b/assistant/src/sequence/engine.ts
@@ -1,0 +1,164 @@
+/**
+ * Sequence engine — processes due enrollments on each scheduler tick.
+ *
+ * Runs as a phase in the scheduler's 15-second tick loop. Claims due
+ * enrollments, generates personalized content via the assistant, and
+ * sends through the messaging layer.
+ */
+
+import { getLogger } from '../util/logger.js';
+import { createConversation } from '../memory/conversation-store.js';
+import { GENERATING_TITLE, queueGenerateConversationTitle } from '../memory/conversation-title-service.js';
+import type { ScheduleMessageProcessor } from '../schedule/scheduler.js';
+import {
+  claimDueEnrollments,
+  advanceEnrollment,
+  exitEnrollment,
+  getSequence,
+  rescheduleEnrollment,
+} from './store.js';
+import type { Sequence, SequenceEnrollment, SequenceStep } from './types.js';
+
+const log = getLogger('sequence-engine');
+
+const MAX_RETRIES = 3;
+const BATCH_SIZE = 10;
+
+/**
+ * Process due sequence enrollments. Called by the scheduler on each tick.
+ * Returns the number of enrollments processed.
+ */
+export async function runSequencesOnce(
+  processMessage: ScheduleMessageProcessor,
+): Promise<number> {
+  const now = Date.now();
+  const claimed = claimDueEnrollments(now, BATCH_SIZE);
+  if (claimed.length === 0) return 0;
+
+  let processed = 0;
+  for (const enrollment of claimed) {
+    try {
+      await processEnrollment(enrollment, processMessage);
+      processed += 1;
+    } catch (err) {
+      log.error(
+        { err, enrollmentId: enrollment.id, sequenceId: enrollment.sequenceId },
+        'Sequence enrollment processing failed',
+      );
+    }
+  }
+  return processed;
+}
+
+async function processEnrollment(
+  enrollment: SequenceEnrollment,
+  processMessage: ScheduleMessageProcessor,
+): Promise<void> {
+  const sequence = getSequence(enrollment.sequenceId);
+  if (!sequence) {
+    log.warn({ enrollmentId: enrollment.id, sequenceId: enrollment.sequenceId }, 'Sequence not found, cancelling enrollment');
+    exitEnrollment(enrollment.id, 'failed');
+    return;
+  }
+
+  if (sequence.status !== 'active') {
+    log.info({ enrollmentId: enrollment.id, sequenceId: enrollment.sequenceId, status: sequence.status }, 'Sequence not active, skipping');
+    // Re-set nextStepAt so it can be picked up when the sequence resumes
+    advanceEnrollmentToCurrentStep(enrollment, sequence);
+    return;
+  }
+
+  const step = sequence.steps[enrollment.currentStep];
+  if (!step) {
+    log.info({ enrollmentId: enrollment.id, step: enrollment.currentStep }, 'No more steps, marking completed');
+    exitEnrollment(enrollment.id, 'completed');
+    return;
+  }
+
+  // Build the prompt for the assistant to generate and send the email
+  const prompt = buildStepPrompt(enrollment, sequence, step);
+
+  // Create a conversation for this step execution
+  const conversation = createConversation({ title: GENERATING_TITLE, source: 'sequence' });
+  queueGenerateConversationTitle({
+    conversationId: conversation.id,
+    context: { origin: 'sequence', systemHint: `Sequence: ${sequence.name} — Step ${step.index + 1}` },
+  });
+
+  log.info({
+    enrollmentId: enrollment.id,
+    sequenceId: sequence.id,
+    step: step.index,
+    contactEmail: enrollment.contactEmail,
+    conversationId: conversation.id,
+  }, 'Processing sequence step');
+
+  await processMessage(conversation.id, prompt);
+
+  // Advance to the next step
+  const nextStepIndex = enrollment.currentStep + 1;
+  if (nextStepIndex >= sequence.steps.length) {
+    // This was the final step
+    advanceEnrollment(enrollment.id, undefined, null);
+    exitEnrollment(enrollment.id, 'completed');
+    log.info({ enrollmentId: enrollment.id, sequenceId: sequence.id }, 'Sequence completed');
+  } else {
+    const nextStep = sequence.steps[nextStepIndex];
+    const nextStepAt = Date.now() + (nextStep.delaySeconds * 1000);
+    advanceEnrollment(enrollment.id, undefined, nextStepAt);
+    log.info({
+      enrollmentId: enrollment.id,
+      nextStep: nextStepIndex,
+      nextStepAt: new Date(nextStepAt).toISOString(),
+    }, 'Advanced to next step');
+  }
+}
+
+function buildStepPrompt(
+  enrollment: SequenceEnrollment,
+  sequence: Sequence,
+  step: SequenceStep,
+): string {
+  const parts: string[] = [];
+
+  parts.push(`You are executing step ${step.index + 1} of ${sequence.steps.length} in the "${sequence.name}" email sequence.`);
+  parts.push('');
+  parts.push(`Recipient: ${enrollment.contactEmail}${enrollment.contactName ? ` (${enrollment.contactName})` : ''}`);
+  parts.push(`Channel: ${sequence.channel}`);
+
+  if (enrollment.context) {
+    parts.push('');
+    parts.push('Contact context:');
+    for (const [key, value] of Object.entries(enrollment.context)) {
+      parts.push(`- ${key}: ${value}`);
+    }
+  }
+
+  parts.push('');
+
+  if (step.requireApproval) {
+    parts.push(`Create a DRAFT email (do not send) with subject "${step.subjectTemplate}".`);
+    parts.push('The user will review and approve before sending.');
+  } else {
+    parts.push(`Send an email with subject "${step.subjectTemplate}".`);
+  }
+
+  if (step.replyToThread && enrollment.threadId) {
+    parts.push(`Reply in the existing thread (thread ID: ${enrollment.threadId}).`);
+  }
+
+  parts.push('');
+  parts.push('Content instructions:');
+  parts.push(step.bodyPrompt);
+
+  return parts.join('\n');
+}
+
+/** Re-schedule the enrollment for the current step (used when sequence is paused). */
+function advanceEnrollmentToCurrentStep(
+  enrollment: SequenceEnrollment,
+  _sequence: Sequence,
+): void {
+  // Re-schedule 60 seconds from now so it gets picked up after the sequence resumes
+  rescheduleEnrollment(enrollment.id, Date.now() + 60_000);
+}

--- a/assistant/src/sequence/store.ts
+++ b/assistant/src/sequence/store.ts
@@ -276,6 +276,15 @@ export function countActiveEnrollments(sequenceId: string): number {
   return rows.length;
 }
 
+/** Re-set nextStepAt without advancing the step counter (e.g., when re-scheduling after a pause). */
+export function rescheduleEnrollment(id: string, nextStepAt: number): void {
+  const db = getDb();
+  db.update(sequenceEnrollments)
+    .set({ nextStepAt, updatedAt: Date.now() })
+    .where(eq(sequenceEnrollments.id, id))
+    .run();
+}
+
 // ── Aggregate export matching the SequenceStore interface ───────────
 
 export const sqliteSequenceStore: SequenceStore = {


### PR DESCRIPTION
## Summary
- Adds `sequence/engine.ts` — processes due enrollments on each scheduler tick, generates personalized content, sends via messaging provider
- Adds `rescheduleEnrollment` to store for pause/resume rescheduling
- Integrates as 4th phase in the scheduler's 15-second tick loop
- Adds 'sequence' to TitleOrigin for conversation title generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
