### PR TITLE
feat: auto-exit sequences on recipient reply

### DIFF
--- a/assistant/src/sequence/reply-matcher.ts
+++ b/assistant/src/sequence/reply-matcher.ts
@@ -1,0 +1,87 @@
+/**
+ * Reply matcher — detects incoming messages that are replies to active
+ * sequence enrollments and auto-exits them.
+ *
+ * Called from the watcher engine after new events are stored.
+ * Matches by sender email against active enrollment contact_email,
+ * with thread_id confirmation when available.
+ */
+
+import { getLogger } from '../util/logger.js';
+import { findActiveEnrollmentsByEmail, exitEnrollment, getSequence } from './store.js';
+
+const log = getLogger('sequence:reply-matcher');
+
+interface WatcherEventPayload {
+  id?: string;
+  threadId?: string;
+  from?: string;
+  subject?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Extract a bare email address from a "Name <email>" or plain "email" string.
+ */
+function extractEmail(from: string): string | undefined {
+  const match = from.match(/<([^>]+)>/);
+  if (match) return match[1].toLowerCase();
+  if (from.includes('@')) return from.trim().toLowerCase();
+  return undefined;
+}
+
+export interface ReplyMatchResult {
+  enrollmentId: string;
+  contactEmail: string;
+  sequenceId: string;
+  sequenceName: string;
+  threadId?: string;
+}
+
+/**
+ * Check a batch of watcher event payloads for replies to active
+ * sequence enrollments. Returns matched enrollments that were exited.
+ */
+export function checkForSequenceReplies(
+  payloads: WatcherEventPayload[],
+): ReplyMatchResult[] {
+  const results: ReplyMatchResult[] = [];
+
+  for (const payload of payloads) {
+    const senderEmail = extractEmail(payload.from ?? '');
+    if (!senderEmail) continue;
+
+    const enrollments = findActiveEnrollmentsByEmail(senderEmail);
+    if (enrollments.length === 0) continue;
+
+    for (const enrollment of enrollments) {
+      const seq = getSequence(enrollment.sequenceId);
+      if (!seq || !seq.exitOnReply) continue;
+
+      // Primary match: thread ID matches enrollment's thread.
+      // Fallback: if no thread ID is set on the enrollment yet (first step
+      // hasn't been sent), match by email alone.
+      const threadMatch = !enrollment.threadId
+        || enrollment.threadId === payload.threadId;
+
+      if (!threadMatch) continue;
+
+      exitEnrollment(enrollment.id, 'replied');
+
+      log.info(
+        { enrollmentId: enrollment.id, senderEmail, threadId: payload.threadId },
+        'Sequence enrollment exited on reply',
+      );
+
+      results.push({
+        enrollmentId: enrollment.id,
+        contactEmail: enrollment.contactEmail,
+        sequenceId: enrollment.sequenceId,
+        sequenceName: seq.name,
+        threadId: payload.threadId,
+      });
+    }
+  }
+
+  return results;
+}

--- a/assistant/src/watcher/engine.ts
+++ b/assistant/src/watcher/engine.ts
@@ -21,6 +21,7 @@ import {
   setWatcherConversationId,
 } from './watcher-store.js';
 import { MAX_CONSECUTIVE_ERRORS } from './constants.js';
+import { checkForSequenceReplies } from '../sequence/reply-matcher.js';
 
 const log = getLogger('watcher-engine');
 
@@ -90,6 +91,7 @@ export async function runWatchersOnce(
 
       // Store new events with dedup
       let newEvents = 0;
+      const newPayloads: Array<Record<string, unknown>> = [];
       for (const item of result.items) {
         const inserted = insertWatcherEvent({
           watcherId: watcher.id,
@@ -98,11 +100,29 @@ export async function runWatchersOnce(
           summary: item.summary,
           payloadJson: JSON.stringify(item.payload),
         });
-        if (inserted) newEvents++;
+        if (inserted) {
+          newEvents++;
+          newPayloads.push(item.payload);
+        }
       }
 
       if (newEvents > 0) {
         log.info({ watcherId: watcher.id, name: watcher.name, newEvents }, 'Detected new events');
+      }
+
+      // Check new events for replies to active sequence enrollments
+      if (newPayloads.length > 0) {
+        try {
+          const replyMatches = checkForSequenceReplies(newPayloads);
+          for (const match of replyMatches) {
+            notify({
+              title: `Sequence reply: ${match.sequenceName}`,
+              body: `${match.contactEmail} replied — enrollment auto-exited.`,
+            });
+          }
+        } catch (replyErr) {
+          log.warn({ err: replyErr, watcherId: watcher.id }, 'Reply matcher failed');
+        }
       }
 
       completeWatcherPoll(watcher.id, {


### PR DESCRIPTION
## Summary
- Adds `sequence/reply-matcher.ts` — matches incoming watcher events to active sequence enrollments by sender email + thread ID
- Integrates into watcher engine Phase 1: after storing events, checks for sequence replies
- Auto-exits enrollments with status 'replied' and sends a notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
