### PR TITLE
fix: restore focus to previous app after quick input submit

### DIFF
--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
@@ -148,7 +148,7 @@ final class QuickInputWindow {
                 } else {
                     self?.onSubmit?(message, self?.attachedImageData)
                 }
-                self?.dismiss(restorePreviousApp: false)
+                self?.dismiss(restorePreviousApp: true)
             },
             onDismiss: { [weak self] in
                 self?.dismiss()
@@ -218,7 +218,7 @@ final class QuickInputWindow {
             Task { @MainActor in
                 // Don't dismiss while screen capture is in progress
                 guard self?.isCapturingScreen != true else { return }
-                self?.dismiss(restorePreviousApp: false)
+                self?.dismiss(restorePreviousApp: true)
             }
         }
 


### PR DESCRIPTION
## Summary
- After submitting from the quick input bar, `dismiss(restorePreviousApp: false)` left Vellum as the active app instead of returning focus to the user's previous app
- Changed both call sites to `dismiss(restorePreviousApp: true)` so the previous app regains focus after submit

## Test plan
- [ ] Open quick input from another app (e.g. browser), type a message, submit
- [ ] Verify the browser regains focus after submit (Vellum does not steal focus)
- [ ] Verify dismissing quick input with Escape also restores focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
