### PR TITLE
feat: add sequence analytics with send tracking and dashboard

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/TOOLS.json
+++ b/assistant/src/config/bundled-skills/messaging/TOOLS.json
@@ -1466,6 +1466,23 @@
       },
       "executor": "tools/sequence-import.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "sequence_analytics",
+      "description": "View sequence analytics dashboard with send/reply/completion metrics, per-step funnel, and recent activity.",
+      "category": "messaging",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "sequence_id": {
+            "type": "string",
+            "description": "Optional sequence ID for detailed step funnel view"
+          }
+        }
+      },
+      "executor": "tools/sequence-analytics.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/messaging/tools/sequence-analytics.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/sequence-analytics.ts
@@ -1,0 +1,64 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { getDashboardData, getStepMetrics } from '../../../../sequence/analytics.js';
+import { ok } from './shared.js';
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const sequenceId = input.sequence_id as string | undefined;
+
+  const data = getDashboardData();
+
+  const lines: string[] = [];
+
+  // ── Summary ─────────────────────────────────────────────────────
+  lines.push('=== Sequence Analytics Dashboard ===');
+  lines.push('');
+  lines.push(`Total sequences:     ${data.summary.totalSequences}`);
+  lines.push(`Active sequences:    ${data.summary.activeSequences}`);
+  lines.push(`Active enrollments:  ${data.summary.activeEnrollments}`);
+  lines.push(`Sends today:         ${data.summary.sendsToday}`);
+  lines.push(`Overall reply rate:  ${(data.summary.overallReplyRate * 100).toFixed(1)}%`);
+
+  // ── Per-sequence table ──────────────────────────────────────────
+  if (data.sequences.length > 0) {
+    lines.push('');
+    lines.push('--- Per-Sequence Metrics ---');
+    for (const m of data.sequences) {
+      lines.push('');
+      lines.push(`  ${m.sequenceName} (${m.status})`);
+      lines.push(`    Enrolled: ${m.totalEnrollments}  Active: ${m.activeEnrollments}  Sends: ${m.sends}`);
+      lines.push(`    Replied: ${m.replies}  Completed: ${m.completions}  Failed: ${m.failures}  Cancelled: ${m.cancellations}`);
+      lines.push(`    Reply rate: ${(m.replyRate * 100).toFixed(1)}%  Completion rate: ${(m.completionRate * 100).toFixed(1)}%`);
+      if (m.avgTimeToReplyMs !== null) {
+        const hours = Math.round(m.avgTimeToReplyMs / (1000 * 60 * 60));
+        lines.push(`    Avg time to reply: ${hours}h`);
+      }
+    }
+  }
+
+  // ── Step funnel (if specific sequence requested) ────────────────
+  if (sequenceId) {
+    const steps = getStepMetrics(sequenceId);
+    if (steps.length > 0) {
+      lines.push('');
+      lines.push('--- Step Funnel ---');
+      for (const s of steps) {
+        const bar = '#'.repeat(Math.max(1, Math.round(s.enrollmentsReached / Math.max(1, steps[0].enrollmentsReached) * 20)));
+        lines.push(`  Step ${s.stepIndex + 1}: "${s.subject}" — ${s.sends} sends, ${s.enrollmentsReached} reached, ${(s.dropOff * 100).toFixed(0)}% drop-off`);
+        lines.push(`    ${bar}`);
+      }
+    }
+  }
+
+  // ── Recent activity ─────────────────────────────────────────────
+  if (data.recentEvents.length > 0) {
+    lines.push('');
+    lines.push('--- Recent Activity ---');
+    for (const e of data.recentEvents.slice(0, 10)) {
+      const time = new Date(e.createdAt).toISOString();
+      const step = e.stepIndex !== undefined ? ` step ${e.stepIndex + 1}` : '';
+      lines.push(`  [${time}] ${e.eventType}${step} — enrollment ${e.enrollmentId.slice(0, 8)}...`);
+    }
+  }
+
+  return ok(lines.join('\n'));
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -134,6 +134,7 @@ import * as sequencePause from './bundled-skills/messaging/tools/sequence-pause.
 import * as sequenceResume from './bundled-skills/messaging/tools/sequence-resume.js';
 import * as sequenceCancel from './bundled-skills/messaging/tools/sequence-cancel.js';
 import * as sequenceImport from './bundled-skills/messaging/tools/sequence-import.js';
+import * as sequenceAnalytics from './bundled-skills/messaging/tools/sequence-analytics.js';
 
 // ── playbooks ────────────────────────────────────────────────────────────────
 import * as playbookCreate from './bundled-skills/playbooks/tools/playbook-create.js';
@@ -307,6 +308,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ['messaging:tools/sequence-resume.ts', sequenceResume],
   ['messaging:tools/sequence-cancel.ts', sequenceCancel],
   ['messaging:tools/sequence-import.ts', sequenceImport],
+  ['messaging:tools/sequence-analytics.ts', sequenceAnalytics],
 
   // playbooks
   ['playbooks:tools/playbook-create.ts', playbookCreate],

--- a/assistant/src/sequence/analytics.ts
+++ b/assistant/src/sequence/analytics.ts
@@ -1,0 +1,218 @@
+/**
+ * Sequence analytics — tracks send events and computes metrics.
+ *
+ * Uses an in-memory event log (will be backed by sequence_events table
+ * when the analytics migration is added). Provides per-sequence and
+ * per-step metrics for dashboard rendering.
+ */
+
+import {
+  listSequences,
+  listEnrollments,
+  countActiveEnrollments,
+} from './store.js';
+import type { Sequence, SequenceEnrollment } from './types.js';
+
+// ── Event tracking ──────────────────────────────────────────────────
+
+export type SequenceEventType = 'send' | 'reply' | 'complete' | 'fail' | 'cancel' | 'pause' | 'resume';
+
+export interface SequenceEvent {
+  id: string;
+  sequenceId: string;
+  enrollmentId: string;
+  eventType: SequenceEventType;
+  stepIndex?: number;
+  metadata?: Record<string, unknown>;
+  createdAt: number;
+}
+
+let eventCounter = 0;
+const eventLog: SequenceEvent[] = [];
+
+export function recordEvent(
+  sequenceId: string,
+  enrollmentId: string,
+  eventType: SequenceEventType,
+  stepIndex?: number,
+  metadata?: Record<string, unknown>,
+): SequenceEvent {
+  const event: SequenceEvent = {
+    id: `evt_${++eventCounter}`,
+    sequenceId,
+    enrollmentId,
+    eventType,
+    stepIndex,
+    metadata,
+    createdAt: Date.now(),
+  };
+  eventLog.push(event);
+  return event;
+}
+
+export function getRecentEvents(limit = 20): SequenceEvent[] {
+  return eventLog.slice(-limit).reverse();
+}
+
+// ── Metrics ─────────────────────────────────────────────────────────
+
+export interface SequenceMetrics {
+  sequenceId: string;
+  sequenceName: string;
+  status: string;
+  totalEnrollments: number;
+  activeEnrollments: number;
+  sends: number;
+  replies: number;
+  completions: number;
+  failures: number;
+  cancellations: number;
+  replyRate: number;
+  completionRate: number;
+  avgTimeToReplyMs: number | null;
+}
+
+export interface StepMetrics {
+  stepIndex: number;
+  subject: string;
+  sends: number;
+  enrollmentsReached: number;
+  dropOff: number;
+}
+
+export interface DashboardData {
+  summary: {
+    totalSequences: number;
+    activeSequences: number;
+    activeEnrollments: number;
+    sendsToday: number;
+    overallReplyRate: number;
+  };
+  sequences: SequenceMetrics[];
+  recentEvents: SequenceEvent[];
+}
+
+function computeSequenceMetrics(seq: Sequence): SequenceMetrics {
+  const enrollments = listEnrollments({ sequenceId: seq.id });
+  const active = countActiveEnrollments(seq.id);
+
+  const statusCounts = enrollments.reduce((acc, e) => {
+    acc[e.status] = (acc[e.status] || 0) + 1;
+    return acc;
+  }, {} as Record<string, number>);
+
+  const replies = statusCounts['replied'] ?? 0;
+  const completions = statusCounts['completed'] ?? 0;
+  const failures = statusCounts['failed'] ?? 0;
+  const cancellations = statusCounts['cancelled'] ?? 0;
+
+  const total = enrollments.length;
+  const replyRate = total > 0 ? replies / total : 0;
+  const completionRate = total > 0 ? completions / total : 0;
+
+  // Compute average time to reply from event log
+  const replyEvents = eventLog.filter(
+    (e) => e.sequenceId === seq.id && e.eventType === 'reply',
+  );
+  let avgTimeToReplyMs: number | null = null;
+  if (replyEvents.length > 0) {
+    const firstSendTimes = new Map<string, number>();
+    for (const e of eventLog) {
+      if (e.sequenceId === seq.id && e.eventType === 'send' && e.stepIndex === 0) {
+        if (!firstSendTimes.has(e.enrollmentId)) {
+          firstSendTimes.set(e.enrollmentId, e.createdAt);
+        }
+      }
+    }
+    let totalTime = 0;
+    let count = 0;
+    for (const re of replyEvents) {
+      const sendTime = firstSendTimes.get(re.enrollmentId);
+      if (sendTime) {
+        totalTime += re.createdAt - sendTime;
+        count++;
+      }
+    }
+    if (count > 0) avgTimeToReplyMs = totalTime / count;
+  }
+
+  // Count sends from event log
+  const sends = eventLog.filter(
+    (e) => e.sequenceId === seq.id && e.eventType === 'send',
+  ).length;
+
+  return {
+    sequenceId: seq.id,
+    sequenceName: seq.name,
+    status: seq.status,
+    totalEnrollments: total,
+    activeEnrollments: active,
+    sends,
+    replies,
+    completions,
+    failures,
+    cancellations,
+    replyRate,
+    completionRate,
+    avgTimeToReplyMs,
+  };
+}
+
+export function getStepMetrics(sequenceId: string): StepMetrics[] {
+  const seq = listSequences({ status: 'active' }).find((s) => s.id === sequenceId)
+    ?? listSequences().find((s) => s.id === sequenceId);
+  if (!seq) return [];
+
+  const enrollments = listEnrollments({ sequenceId });
+  const sendEvents = eventLog.filter(
+    (e) => e.sequenceId === sequenceId && e.eventType === 'send',
+  );
+
+  return seq.steps.map((step) => {
+    const sends = sendEvents.filter((e) => e.stepIndex === step.index).length;
+    const reached = enrollments.filter((e) => e.currentStep >= step.index).length;
+    const prevReached = step.index === 0
+      ? enrollments.length
+      : enrollments.filter((e) => e.currentStep >= step.index - 1).length;
+    const dropOff = prevReached > 0 ? 1 - (reached / prevReached) : 0;
+
+    return {
+      stepIndex: step.index,
+      subject: step.subjectTemplate,
+      sends,
+      enrollmentsReached: reached,
+      dropOff,
+    };
+  });
+}
+
+export function getDashboardData(): DashboardData {
+  const seqs = listSequences();
+  const activeSeqs = seqs.filter((s) => s.status === 'active');
+
+  const sequenceMetrics = seqs.map(computeSequenceMetrics);
+
+  const startOfDay = new Date();
+  startOfDay.setHours(0, 0, 0, 0);
+  const sendsToday = eventLog.filter(
+    (e) => e.eventType === 'send' && e.createdAt >= startOfDay.getTime(),
+  ).length;
+
+  const totalEnrollments = sequenceMetrics.reduce((s, m) => s + m.totalEnrollments, 0);
+  const totalReplies = sequenceMetrics.reduce((s, m) => s + m.replies, 0);
+  const overallReplyRate = totalEnrollments > 0 ? totalReplies / totalEnrollments : 0;
+
+  const totalActive = sequenceMetrics.reduce((s, m) => s + m.activeEnrollments, 0);
+
+  return {
+    summary: {
+      totalSequences: seqs.length,
+      activeSequences: activeSeqs.length,
+      activeEnrollments: totalActive,
+      sendsToday,
+      overallReplyRate,
+    },
+    sequences: sequenceMetrics,
+    recentEvents: getRecentEvents(20),
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `sequence/analytics.ts` — in-memory event tracking, per-sequence metrics (reply rate, completion rate, avg time to reply), step funnel analysis
- Adds `sequence-analytics.ts` tool — text-based dashboard with summary cards, per-sequence table, step funnel (ASCII bars), recent activity feed
- Registers tool in TOOLS.json and bundled-tool-registry.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
