### PR TITLE
fix: preserve enrollment retryability and use typed errors in sequence store

### DIFF
--- a/assistant/src/sequence/engine.ts
+++ b/assistant/src/sequence/engine.ts
@@ -15,6 +15,7 @@ import {
   advanceEnrollment,
   exitEnrollment,
   getSequence,
+  getEnrollment,
   rescheduleEnrollment,
 } from './store.js';
 import type { Sequence, SequenceEnrollment, SequenceStep } from './types.js';
@@ -45,6 +46,25 @@ export async function runSequencesOnce(
         { err, enrollmentId: enrollment.id, sequenceId: enrollment.sequenceId },
         'Sequence enrollment processing failed',
       );
+      // Reschedule so the enrollment is retryable. claimDueEnrollments nulled
+      // nextStepAt to prevent concurrent claims; without restoring it the
+      // enrollment would be stranded as active with nextStepAt = null forever.
+      try {
+        const current = getEnrollment(enrollment.id);
+        if (current && current.status === 'active') {
+          const retryDelayMs = 60_000;
+          rescheduleEnrollment(enrollment.id, Date.now() + retryDelayMs);
+          log.info(
+            { enrollmentId: enrollment.id, retryAt: new Date(Date.now() + retryDelayMs).toISOString() },
+            'Rescheduled enrollment for retry after processing failure',
+          );
+        }
+      } catch (rescheduleErr) {
+        log.error(
+          { err: rescheduleErr, enrollmentId: enrollment.id },
+          'Failed to reschedule enrollment after processing failure',
+        );
+      }
     }
   }
   return processed;

--- a/assistant/src/sequence/store.ts
+++ b/assistant/src/sequence/store.ts
@@ -12,6 +12,7 @@ import { v4 as uuid } from 'uuid';
 import { getDb, rawChanges } from '../memory/db.js';
 import { sequences, sequenceEnrollments } from '../memory/schema.js';
 import { createRowMapper, cast, parseJson, parseJsonNullable } from '../util/row-mapper.js';
+import { AssistantError, ErrorCode } from '../util/errors.js';
 import type {
   Sequence,
   SequenceEnrollment,
@@ -125,8 +126,8 @@ export function enrollContact(input: EnrollContactInput): SequenceEnrollment {
 
   // Look up the sequence to compute initial nextStepAt
   const seq = getSequence(input.sequenceId);
-  if (!seq) throw new Error(`Sequence not found: ${input.sequenceId}`);
-  if (seq.steps.length === 0) throw new Error('Sequence has no steps');
+  if (!seq) throw new AssistantError(`Sequence not found: ${input.sequenceId}`, ErrorCode.INTERNAL_ERROR);
+  if (seq.steps.length === 0) throw new AssistantError('Sequence has no steps', ErrorCode.INTERNAL_ERROR);
 
   const firstStep = seq.steps[0];
   const nextStepAt = now + (firstStep.delaySeconds * 1000);


### PR DESCRIPTION
Address Codex review feedback on PR #8719:

- Add error recovery in sequence engine to reschedule enrollments on processing failure
- Replace bare Error throws with VellumError hierarchy for enrollment preconditions

Addresses feedback from: https://github.com/vellum-ai/vellum-assistant/pull/8719
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
