### PR TITLE
fix: preserve confirmation action IDs in surface message forwarding

### DIFF
--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -496,7 +496,11 @@ export function refreshSurfacesForApp(ctx: SurfaceSessionContext, appId: string,
 
 export function buildCompletionSummary(surfaceType: string | undefined, actionId: string, data?: Record<string, unknown>): string {
   if (surfaceType === 'confirmation') {
-    return actionId === 'cancel' ? 'Cancelled' : 'Confirmed';
+    if (actionId === 'cancel') return 'Cancelled';
+    if (actionId === 'confirm') return 'Confirmed';
+    // Preserve the actual action ID so the LLM knows the user's exact choice
+    // (e.g. "deny", "no", "reject") rather than misreporting it as confirmed.
+    return `User selected: ${actionId}`;
   }
   if (surfaceType === 'form') {
     return 'Submitted';


### PR DESCRIPTION
Address Codex review feedback on PR #8726:

- Fix buildCompletionSummary to preserve actual action IDs instead of mapping all non-cancel to 'Confirmed'
- Ensures decline/deny actions are not misinterpreted as confirmations
- Only 'cancel' maps to 'Cancelled' and 'confirm' maps to 'Confirmed'; all other action IDs are forwarded as 'User selected: <actionId>'

Addresses feedback from: https://github.com/vellum-ai/vellum-assistant/pull/8726
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
