### PR TITLE
fix: preserve filters and track unsubscribable message in sender digest

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
@@ -14,6 +14,8 @@ interface SenderAggregation {
   messageCount: number;
   hasUnsubscribe: boolean;
   newestMessageId: string;
+  newestUnsubscribableMessageId: string | null;
+  newestUnsubscribableEpoch: number;
   oldestDate: string;
   newestDate: string;
   messageIds: string[];
@@ -84,6 +86,8 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
             messageCount: 0,
             hasUnsubscribe: false,
             newestMessageId: msg.id,
+            newestUnsubscribableMessageId: null,
+            newestUnsubscribableEpoch: 0,
             oldestDate: dateStr,
             newestDate: dateStr,
             messageIds: [],
@@ -120,6 +124,13 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
           agg.newestMessageId = msg.id;
         }
 
+        // Track the newest message that actually has List-Unsubscribe so
+        // gmail_unsubscribe() is called with a message that carries the header
+        if (listUnsub && msgEpoch >= agg.newestUnsubscribableEpoch) {
+          agg.newestUnsubscribableMessageId = msg.id;
+          agg.newestUnsubscribableEpoch = msgEpoch;
+        }
+
         // Collect sample subjects
         if (subject && agg.sampleSubjects.length < MAX_SAMPLE_SUBJECTS) {
           agg.sampleSubjects.push(subject);
@@ -137,12 +148,16 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         email: s.email,
         message_count: s.messageCount,
         has_unsubscribe: s.hasUnsubscribe,
-        newest_message_id: s.newestMessageId,
+        // When unsubscribe is available, point to a message that carries the header
+        newest_message_id: (s.hasUnsubscribe && s.newestUnsubscribableMessageId)
+          ? s.newestUnsubscribableMessageId
+          : s.newestMessageId,
         oldest_date: s.oldestDate,
         newest_date: s.newestDate,
         message_ids: s.messageIds,
         has_more: s.hasMore,
-        search_query: `from:${s.email}`,
+        // Preserve original query filters so follow-up searches stay scoped
+        search_query: `from:${s.email} ${query}`,
         sample_subjects: s.sampleSubjects,
       }));
 


### PR DESCRIPTION
## Summary

Address Codex review feedback on PR #8721:

- **Preserve original query filters in follow-up `search_query` field** — Previously `search_query` only contained `from:<sender>`, dropping the caller's original query constraints. When the skill followed the `has_more` flow, this could archive messages outside the scanned set. Now appends the original query to the `from:` filter.
- **Track newest message with `List-Unsubscribe` header for reliable unsubscribe** — Previously `newest_message_id` pointed to the newest message regardless of whether it had a `List-Unsubscribe` header. If the latest message lacked unsubscribe metadata, `gmail_unsubscribe(newest_message_id)` would fail. Now tracks the newest unsubscribable message separately and uses that ID when `has_unsubscribe` is true.

Addresses feedback from: https://github.com/vellum-ai/vellum-assistant/pull/8721

## Test plan

- [ ] Verify `search_query` output includes original query filters (e.g., `from:sender@example.com has:unsubscribe newer_than:90d`)
- [ ] Verify `newest_message_id` points to a message with `List-Unsubscribe` header when `has_unsubscribe` is true
- [ ] Verify `newest_message_id` falls back to the overall newest message when no unsubscribe headers exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
