### PR TITLE
fix: sequence tool improvements — pause, validation, counts, and formatting

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-outreach-scan.ts
@@ -182,15 +182,17 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
       }
 
       // Sort by message count desc, filter by confidence, take top N
-      const sorted = [...senderMap.values()]
+      const qualified = [...senderMap.values()]
         .map((s) => ({
           ...s,
           avgConfidence: s.messageCount > 0 ? s.confidenceSum / s.messageCount : 0,
           outreachType: mostCommon(s.outreachTypes),
         }))
         .filter((s) => s.avgConfidence >= minConfidence)
-        .sort((a, b) => b.messageCount - a.messageCount)
-        .slice(0, maxSenders);
+        .sort((a, b) => b.messageCount - a.messageCount);
+
+      const totalOutreachDetected = qualified.length;
+      const sorted = qualified.slice(0, maxSenders);
 
       const senders = sorted.map((s) => ({
         id: Buffer.from(s.email).toString('base64url'),
@@ -212,7 +214,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
       return ok(JSON.stringify({
         senders,
         total_scanned: allMessageIds.length,
-        outreach_detected: senders.length,
+        outreach_detected: totalOutreachDetected,
       }));
     });
   } catch (e) {

--- a/assistant/src/config/bundled-skills/messaging/tools/sequence-enroll.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/sequence-enroll.ts
@@ -22,16 +22,18 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
     if (emailList.length === 0) return err('No valid emails provided.');
 
     const results: string[] = [];
+    let successCount = 0;
     for (const email of emailList) {
       try {
         const enrollment = enrollContact({ sequenceId, contactEmail: email, context });
         results.push(`  ${email} — enrolled (ID: ${enrollment.id})`);
+        successCount++;
       } catch (e) {
         results.push(`  ${email} — failed: ${e instanceof Error ? e.message : String(e)}`);
       }
     }
 
-    return ok(`Enrolled ${emailList.length} contact(s) in "${seq.name}":\n${results.join('\n')}`);
+    return ok(`Enrolled ${successCount}/${emailList.length} contact(s) in "${seq.name}":\n${results.join('\n')}`);
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/messaging/tools/sequence-get.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/sequence-get.ts
@@ -30,7 +30,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
       '',
       `Enrollments: ${allEnrollments.length} total, ${activeCount} active`,
       ...Object.entries(statusCounts).map(([k, v]) => `  ${k}: ${v}`),
-    ].filter(Boolean);
+    ].filter((line): line is string => line !== null);
 
     return ok(lines.join('\n'));
   } catch (e) {

--- a/assistant/src/config/bundled-skills/messaging/tools/sequence-pause.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/sequence-pause.ts
@@ -1,5 +1,5 @@
 import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
-import { updateSequence, getSequence, getEnrollment, exitEnrollment } from '../../../../sequence/store.js';
+import { updateSequence, getSequence, getEnrollment, pauseEnrollment } from '../../../../sequence/store.js';
 import { ok, err } from './shared.js';
 
 export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
@@ -13,8 +13,8 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
       const enrollment = getEnrollment(enrollmentId);
       if (!enrollment) return err(`Enrollment not found: ${enrollmentId}`);
       if (enrollment.status !== 'active') return err(`Enrollment is not active (status: ${enrollment.status}).`);
-      exitEnrollment(enrollmentId, 'cancelled');
-      return ok(`Enrollment ${enrollmentId} paused (status set to cancelled).`);
+      pauseEnrollment(enrollmentId);
+      return ok(`Enrollment ${enrollmentId} paused. Resume it later to continue from step ${enrollment.currentStep + 1}.`);
     }
 
     const seq = getSequence(sequenceId!);

--- a/assistant/src/config/bundled-skills/messaging/tools/sequence-update.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/sequence-update.ts
@@ -23,6 +23,10 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
       requireApproval: (s.require_approval as boolean) ?? false,
     }));
 
+    if (steps !== undefined && steps.length === 0) {
+      return err('steps must not be empty. A sequence requires at least one step.');
+    }
+
     const updated = updateSequence(id, { name, description, status, exitOnReply, steps });
     if (!updated) return err(`Sequence not found: ${id}`);
 

--- a/assistant/src/sequence/store.ts
+++ b/assistant/src/sequence/store.ts
@@ -248,6 +248,15 @@ export function exitEnrollment(id: string, reason: EnrollmentExitReason): void {
     .run();
 }
 
+/** Pause an active enrollment — preserves current step so it can be resumed later. */
+export function pauseEnrollment(id: string): void {
+  const db = getDb();
+  db.update(sequenceEnrollments)
+    .set({ status: 'paused', nextStepAt: null, updatedAt: Date.now() })
+    .where(eq(sequenceEnrollments.id, id))
+    .run();
+}
+
 // ── Query Helpers ───────────────────────────────────────────────────
 
 export function findActiveEnrollmentsByEmail(email: string): SequenceEnrollment[] {


### PR DESCRIPTION
Address review feedback on PR #8731:

- Implement proper enrollment pause (not cancel) in sequence-pause tool
- Validate non-empty steps in sequence-update
- Count outreach senders before max_senders truncation
- Fix filter(Boolean) removing blank-line separators in sequence-get
- Report accurate enrolled count in sequence-enroll

Addresses feedback from: https://github.com/vellum-ai/vellum-assistant/pull/8731
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
