### PR TITLE
fix: wire all guardrails into checkAllPreSend and fix CLI input validation

### DIFF
--- a/assistant/src/cli/sequence.ts
+++ b/assistant/src/cli/sequence.ts
@@ -247,18 +247,22 @@ export function registerSequenceCommand(program: Command): void {
       switch (key) {
         case 'dailySendCap':
         case 'daily_send_cap':
+          if (!Number.isFinite(numVal)) return exitError(`Invalid numeric value for ${key}: ${value}`);
           patch.dailySendCap = numVal;
           break;
         case 'perSequenceHourlyRate':
         case 'hourly_rate':
+          if (!Number.isFinite(numVal)) return exitError(`Invalid numeric value for ${key}: ${value}`);
           patch.perSequenceHourlyRate = numVal;
           break;
         case 'minimumStepDelaySec':
         case 'min_delay':
+          if (!Number.isFinite(numVal)) return exitError(`Invalid numeric value for ${key}: ${value}`);
           patch.minimumStepDelaySec = numVal;
           break;
         case 'maxActiveEnrollments':
         case 'max_enrollments':
+          if (!Number.isFinite(numVal)) return exitError(`Invalid numeric value for ${key}: ${value}`);
           patch.maxActiveEnrollments = numVal;
           break;
         case 'duplicateEnrollmentCheck':
@@ -267,9 +271,12 @@ export function registerSequenceCommand(program: Command): void {
           patch.duplicateEnrollmentCheck = boolVal;
           break;
         case 'cooldownPeriodMs':
+          if (!Number.isFinite(numVal)) return exitError(`Invalid numeric value for ${key}: ${value}`);
+          patch.cooldownPeriodMs = numVal;
+          break;
         case 'cooldown_days': {
-          const days = numVal;
-          patch.cooldownPeriodMs = days * 24 * 60 * 60 * 1000;
+          if (!Number.isFinite(numVal)) return exitError(`Invalid numeric value for ${key}: ${value}`);
+          patch.cooldownPeriodMs = numVal * 24 * 60 * 60 * 1000;
           break;
         }
         default:

--- a/assistant/src/sequence/guardrails.ts
+++ b/assistant/src/sequence/guardrails.ts
@@ -180,10 +180,15 @@ export function checkCooldown(
 export function checkAllPreSend(
   sequenceId: string,
   enrollment: SequenceEnrollment,
+  stepDelaySec: number,
 ): GuardrailResult {
   const checks: GuardrailResult[] = [
     checkDailyCap(),
     checkHourlyRate(sequenceId),
+    checkMinDelay(stepDelaySec),
+    checkEnrollmentCap(sequenceId),
+    checkDuplicateEnrollment(sequenceId, enrollment.contactEmail),
+    checkCooldown(sequenceId, enrollment.contactEmail),
   ];
 
   for (const check of checks) {


### PR DESCRIPTION
Address review feedback on PR #8734:

- Include all 6 guardrail checks in checkAllPreSend (was only running 2)
- Validate numeric input with Number.isFinite() before applying
- Separate cooldownPeriodMs (raw ms) from cooldown_days (days-to-ms conversion)

Addresses feedback from: https://github.com/vellum-ai/vellum-assistant/pull/8734
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
