### PR TITLE
feat: channel-compatible Gmail OAuth2 flow

### DIFF
--- a/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
@@ -10,11 +10,171 @@ You are helping your user set up Google Cloud OAuth credentials so Gmail and Goo
 
 ## Client Check
 
-If the user is on Telegram (or any non-macOS client without browser automation):
+Determine whether the user has browser automation available (macOS desktop app) or is on a non-interactive channel (Telegram, SMS, etc.).
 
-> "Gmail setup requires browser automation, which is available on the macOS app. Please open the Vellum app on your Mac and ask me to connect Gmail there — I'll handle the rest automatically."
+- **macOS desktop app**: Follow the **Automated Setup** path below (Steps 1-9).
+- **Telegram or other channel** (no browser automation): Follow the **Manual Setup for Channels** path below.
 
-Stop here. Do not attempt a manual walkthrough.
+---
+
+# Path A: Manual Setup for Channels (Telegram, SMS, etc.)
+
+When the user is on Telegram or any non-macOS client, walk them through a text-based setup. No browser automation is used — the user follows links and performs each action manually.
+
+### Channel Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Gmail & Calendar from Telegram**
+>
+> Since I can't automate the browser from here, I'll walk you through each step with direct links. You'll need:
+> 1. A Google account with access to Google Cloud Console
+> 2. About 5 minutes
+>
+> Ready to start?
+
+If the user declines, acknowledge and stop.
+
+### Channel Step 2: Create a Google Cloud Project
+
+Tell the user:
+
+> **Step 1: Create a Google Cloud project**
+>
+> Open this link to create a new project:
+> https://console.cloud.google.com/projectcreate
+>
+> Set the project name to **"Vellum Assistant"** and click **Create**.
+>
+> Let me know when it's done (or if you already have a project you'd like to use — just tell me the project ID).
+
+Wait for confirmation. Note the project ID for subsequent steps.
+
+### Channel Step 3: Enable APIs
+
+Tell the user:
+
+> **Step 2: Enable Gmail and Calendar APIs**
+>
+> Open each link below and click **Enable**:
+>
+> 1. Gmail API: `https://console.cloud.google.com/apis/library/gmail.googleapis.com?project=PROJECT_ID`
+> 2. Calendar API: `https://console.cloud.google.com/apis/library/calendar-json.googleapis.com?project=PROJECT_ID`
+>
+> Let me know when both are enabled.
+
+(Substitute the actual project ID into the URLs.)
+
+### Channel Step 4: Configure OAuth Consent Screen
+
+Tell the user:
+
+> **Step 3: Configure the OAuth consent screen**
+>
+> Open: `https://console.cloud.google.com/apis/credentials/consent?project=PROJECT_ID`
+>
+> 1. Select **"External"** user type, click **Create**
+> 2. Fill in:
+>    - App name: **Vellum Assistant**
+>    - User support email: **your email**
+>    - Developer contact email: **your email**
+> 3. Click **Save and Continue**
+> 4. On the Scopes page, click **Add or Remove Scopes** and add these:
+>    - `https://www.googleapis.com/auth/gmail.readonly`
+>    - `https://www.googleapis.com/auth/gmail.modify`
+>    - `https://www.googleapis.com/auth/gmail.send`
+>    - `https://www.googleapis.com/auth/calendar.readonly`
+>    - `https://www.googleapis.com/auth/calendar.events`
+>    - `https://www.googleapis.com/auth/userinfo.email`
+>    - Click **Update**, then **Save and Continue**
+> 5. On the Test users page, add **your email**, click **Save and Continue**
+> 6. On the Summary page, click **Back to Dashboard**
+>
+> Let me know when the consent screen is configured.
+
+### Channel Step 5: Create OAuth Credentials (Web Application)
+
+Tell the user:
+
+> **Step 4: Create OAuth credentials**
+>
+> Open: `https://console.cloud.google.com/apis/credentials?project=PROJECT_ID`
+>
+> 1. Click **+ Create Credentials** → **OAuth client ID**
+> 2. Application type: Select **"Web application"** (not Desktop app)
+> 3. Name: **Vellum Assistant**
+> 4. Under **Authorized redirect URIs**, click **Add URI** and enter:
+>    `GATEWAY_OAUTH_CALLBACK_URL`
+> 5. Click **Create**
+>
+> A dialog will show your **Client ID** and **Client Secret**. Copy both values — you'll need them in the next step.
+
+(Substitute the actual gateway OAuth callback URL. This is obtained from `getOAuthCallbackUrl(loadConfig())` — the skill should compute and insert this URL.)
+
+**Important:** Channel users must use **"Web application"** credentials (not Desktop app) because the OAuth callback goes through the gateway's public URL, not localhost.
+
+### Channel Step 6: Store Credentials
+
+Tell the user to send the Client ID first:
+
+> **Step 5: Store your credentials**
+>
+> Please send me the **Client ID** from the dialog (it looks like `123456789-xxxxx.apps.googleusercontent.com`).
+
+When the user provides the Client ID, store it:
+
+```
+credential_store store:
+  service: "integration:gmail"
+  field: "client_id"
+  value: "<the value the user sent>"
+```
+
+Then ask for the Client Secret:
+
+> Now send me the **Client Secret** (it starts with `GOCSPX-...`).
+
+When the user provides it, store it:
+
+```
+credential_store store:
+  service: "integration:gmail"
+  field: "client_secret"
+  value: "<the value the user sent>"
+```
+
+**Note:** These values are stored securely in the vault and are not logged or exposed after storage. However, since the user sent them in chat, advise them that the credentials were visible in the conversation and they can revoke/regenerate them in GCP if concerned.
+
+### Channel Step 7: Authorize
+
+Tell the user:
+
+> **Step 6: Authorize access**
+>
+> I'll now generate an authorization link for you.
+
+Use `credential_store` with:
+
+```
+action: "oauth2_connect"
+service: "integration:gmail"
+```
+
+This will return an auth URL (since the session is non-interactive). Send the URL to the user:
+
+> Open this link to authorize Vellum to access your Gmail and Calendar. After you click **Allow**, the connection will be set up automatically.
+
+**If the user sees a "This app isn't verified" warning:** Tell them this is normal for apps in testing mode. Click "Advanced" then "Go to Vellum Assistant (unsafe)" to proceed.
+
+### Channel Step 8: Done!
+
+After the user authorizes (they'll come back and say so, or you can suggest they verify):
+
+> **Gmail and Calendar are connected!** Try asking me to check your inbox or show your upcoming events to verify everything is working.
+
+---
+
+# Path B: Automated Setup (macOS Desktop App)
 
 ## Step 1: Single Upfront Confirmation
 

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -346,6 +346,60 @@ function renderLoopbackPage(message: string, success: boolean): string {
 // Public API
 // ---------------------------------------------------------------------------
 
+export interface OAuth2PreparedFlow {
+  authUrl: string;
+  state: string;
+  /** Resolves when the user completes authorization and tokens are exchanged. */
+  completion: Promise<OAuth2FlowResult>;
+}
+
+/**
+ * Build an OAuth2 auth URL and register a pending callback, without opening
+ * the URL or blocking. Used by channel sessions where the LLM sends the auth
+ * URL directly in chat and the callback arrives asynchronously via the gateway.
+ *
+ * Requires a public ingress URL (gateway transport).
+ */
+export async function prepareOAuth2Flow(
+  config: OAuth2Config,
+): Promise<OAuth2PreparedFlow> {
+  const { loadConfig } = await import('../config/loader.js');
+  const { getOAuthCallbackUrl } = await import('../inbound/public-ingress-urls.js');
+  const { registerPendingCallback } = await import('./oauth-callback-registry.js');
+
+  const appConfig = loadConfig();
+  const redirectUri = getOAuthCallbackUrl(appConfig);
+
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = generateCodeChallenge(codeVerifier);
+  const state = generateState();
+
+  const codePromise = new Promise<string>((resolve, reject) => {
+    registerPendingCallback(state, resolve, reject);
+  });
+
+  const authParams = new URLSearchParams({
+    ...config.extraParams,
+    client_id: config.clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    scope: config.scopes.join(' '),
+    state,
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
+  });
+
+  const authUrl = `${config.authUrl}?${authParams}`;
+
+  const completion = codePromise.then(async (code) => {
+    return await exchangeCodeForTokens(config, code, redirectUri, codeVerifier);
+  });
+
+  log.debug({ transport: 'gateway', state }, 'Prepared deferred OAuth2 flow');
+
+  return { authUrl, state, completion };
+}
+
 /**
  * Run a full OAuth2 authorization code flow with PKCE support.
  *

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -13,7 +13,7 @@ import { upsertCredentialMetadata, deleteCredentialMetadata, getCredentialMetada
 import { validatePolicyInput, toPolicyFromInput } from './policy-validate.js';
 import type { CredentialPolicyInput, CredentialInjectionTemplate } from './policy-types.js';
 import { credentialBroker } from './broker.js';
-import { startOAuth2Flow, type TokenEndpointAuthMethod } from '../../security/oauth2.js';
+import { startOAuth2Flow, prepareOAuth2Flow, type OAuth2FlowResult, type TokenEndpointAuthMethod } from '../../security/oauth2.js';
 import { runPostConnectHook } from './post-connect-hooks.js';
 import { getConfig } from '../../config/loader.js';
 import { getLogger } from '../../util/logger.js';
@@ -141,6 +141,87 @@ function findStoredOAuthField(service: string, fieldNames: string[]): string | u
   }
 
   return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Shared helper: store OAuth2 tokens + metadata after a successful flow.
+// Used by both the interactive (desktop) and deferred (channel) paths.
+// ---------------------------------------------------------------------------
+
+interface StoreOAuth2TokensParams {
+  service: string;
+  tokens: OAuth2FlowResult['tokens'];
+  grantedScopes: string[];
+  rawTokenResponse: Record<string, unknown>;
+  clientId: string;
+  clientSecret?: string;
+  tokenUrl: string;
+  tokenEndpointAuthMethod?: TokenEndpointAuthMethod;
+  userinfoUrl?: string;
+  allowedTools?: string[];
+  wellKnownInjectionTemplates?: CredentialInjectionTemplate[];
+}
+
+async function storeOAuth2Tokens(params: StoreOAuth2TokensParams): Promise<{ accountInfo?: string }> {
+  const { service, tokens, grantedScopes, rawTokenResponse, clientId, clientSecret, tokenUrl, tokenEndpointAuthMethod, userinfoUrl, allowedTools, wellKnownInjectionTemplates } = params;
+
+  const tokenStored = setSecureKey(`credential:${service}:access_token`, tokens.accessToken);
+  if (!tokenStored) {
+    throw new Error('Failed to store access token in secure storage');
+  }
+
+  const expiresAt = tokens.expiresIn ? Date.now() + tokens.expiresIn * 1000 : null;
+
+  let accountInfo: string | undefined;
+  if (userinfoUrl && grantedScopes.some((s) => s.includes('userinfo'))) {
+    try {
+      const resp = await fetch(userinfoUrl, {
+        headers: { Authorization: `Bearer ${tokens.accessToken}` },
+      });
+      if (resp.ok) {
+        const info = await resp.json() as { email?: string };
+        accountInfo = info.email;
+      }
+    } catch {
+      // Non-fatal
+    }
+  }
+
+  // Persist client credentials in keychain for defense in depth
+  const clientIdStored = setSecureKey(`credential:${service}:client_id`, clientId);
+  if (!clientIdStored) {
+    throw new Error('Failed to store client_id in secure storage');
+  }
+  if (clientSecret) {
+    const clientSecretStored = setSecureKey(`credential:${service}:client_secret`, clientSecret);
+    if (!clientSecretStored) {
+      throw new Error('Failed to store client_secret in secure storage');
+    }
+  }
+
+  upsertCredentialMetadata(service, 'access_token', {
+    allowedTools: allowedTools ?? [],
+    expiresAt,
+    grantedScopes,
+    accountInfo: accountInfo ?? null,
+    oauth2TokenUrl: tokenUrl,
+    oauth2ClientId: clientId,
+    ...(clientSecret ? { oauth2ClientSecret: clientSecret } : {}),
+    ...(tokenEndpointAuthMethod ? { oauth2TokenEndpointAuthMethod: tokenEndpointAuthMethod } : {}),
+    ...(wellKnownInjectionTemplates ? { injectionTemplates: wellKnownInjectionTemplates } : {}),
+  });
+
+  if (tokens.refreshToken) {
+    const refreshStored = setSecureKey(`credential:${service}:refresh_token`, tokens.refreshToken);
+    if (refreshStored) {
+      upsertCredentialMetadata(service, 'refresh_token', {});
+    }
+  }
+
+  // Run any provider-specific post-connect actions (e.g. Slack welcome DM)
+  await runPostConnectHook({ service, rawTokenResponse });
+
+  return { accountInfo };
 }
 
 class CredentialStoreTool implements Tool {
@@ -586,21 +667,68 @@ class CredentialStoreTool implements Tool {
         if (!scopes) return { content: 'Error: scopes is required for oauth2_connect action (no well-known config for this service)', isError: true };
         if (!clientId) return { content: 'Error: client_id is required for oauth2_connect action. Provide it directly or store it first with credential_store.', isError: true };
 
-        if (!context.isInteractive) {
-          return { content: 'Error: oauth2_connect action requires an interactive client session', isError: true };
-        }
-
         try {
           assertMetadataWritable();
         } catch {
           return { content: 'Error: credential metadata file has an unrecognized version; cannot store credentials', isError: true };
         }
 
-        try {
-          const allowedTools = input.allowed_tools as string[] | undefined;
+        const allowedTools = input.allowed_tools as string[] | undefined;
+        const wellKnownInjectionTemplates = wellKnown?.injectionTemplates;
+        const oauthConfig = { authUrl, tokenUrl, scopes, clientId, clientSecret, extraParams, userinfoUrl, tokenEndpointAuthMethod };
+        const storageParams = {
+          service, clientId, clientSecret, tokenUrl, tokenEndpointAuthMethod,
+          userinfoUrl, allowedTools, wellKnownInjectionTemplates,
+        };
 
+        if (!context.isInteractive) {
+          // Channel path: return the auth URL as text for the user to open manually.
+          // Token storage happens asynchronously when the callback arrives.
+          try {
+            const { loadConfig } = await import('../../config/loader.js');
+            const { getPublicBaseUrl } = await import('../../inbound/public-ingress-urls.js');
+            try {
+              getPublicBaseUrl(loadConfig());
+            } catch {
+              return {
+                content: 'Error: oauth2_connect from a non-interactive session requires a public ingress URL. Configure ingress.publicBaseUrl first.',
+                isError: true,
+              };
+            }
+
+            const prepared = await prepareOAuth2Flow(oauthConfig);
+
+            // Fire-and-forget: when the callback arrives, store tokens in the background
+            prepared.completion.then(async (result) => {
+              try {
+                const { accountInfo } = await storeOAuth2Tokens({
+                  ...storageParams,
+                  tokens: result.tokens,
+                  grantedScopes: result.grantedScopes,
+                  rawTokenResponse: result.rawTokenResponse,
+                });
+                log.info({ service, accountInfo }, 'Deferred OAuth2 flow completed — tokens stored');
+              } catch (err) {
+                log.error({ err, service }, 'Failed to store tokens from deferred OAuth2 flow');
+              }
+            }).catch((err) => {
+              log.error({ err, service }, 'Deferred OAuth2 flow failed');
+            });
+
+            return {
+              content: `To connect ${rawService}, open this link and authorize access:\n\n${prepared.authUrl}\n\nOnce you authorize, the connection will be set up automatically. You can verify by asking me to check your inbox.`,
+              isError: false,
+            };
+          } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : 'Unknown error preparing OAuth flow';
+            return { content: `Error connecting "${service}": ${message}`, isError: true };
+          }
+        }
+
+        // Interactive path (desktop): open browser and wait for completion
+        try {
           const { tokens, grantedScopes, rawTokenResponse } = await startOAuth2Flow(
-            { authUrl, tokenUrl, scopes, clientId, clientSecret, extraParams, userinfoUrl, tokenEndpointAuthMethod },
+            oauthConfig,
             {
               openUrl: (url) => {
                 context.sendToClient?.({ type: 'open_url', url, title: `Connect ${service}` });
@@ -609,65 +737,12 @@ class CredentialStoreTool implements Tool {
             wellKnown?.callbackTransport ? { callbackTransport: wellKnown.callbackTransport } : undefined,
           );
 
-          const tokenStored = setSecureKey(`credential:${service}:access_token`, tokens.accessToken);
-          if (!tokenStored) {
-            return { content: 'Error: failed to store access token in secure storage', isError: true };
-          }
-
-          const expiresAt = tokens.expiresIn ? Date.now() + tokens.expiresIn * 1000 : null;
-
-          let accountInfo: string | undefined;
-          if (userinfoUrl && grantedScopes.some((s) => s.includes('userinfo'))) {
-            try {
-              const resp = await fetch(userinfoUrl, {
-                headers: { Authorization: `Bearer ${tokens.accessToken}` },
-              });
-              if (resp.ok) {
-                const info = await resp.json() as { email?: string };
-                accountInfo = info.email;
-              }
-            } catch {
-              // Non-fatal
-            }
-          }
-
-          // Persist client credentials in keychain for defense in depth
-          const clientIdStored = setSecureKey(`credential:${service}:client_id`, clientId);
-          if (!clientIdStored) {
-            return { content: 'Error: failed to store client_id in secure storage', isError: true };
-          }
-          if (clientSecret) {
-            const clientSecretStored = setSecureKey(`credential:${service}:client_secret`, clientSecret);
-            if (!clientSecretStored) {
-              return { content: 'Error: failed to store client_secret in secure storage', isError: true };
-            }
-          }
-
-          // Well-known configs may supply injection templates (e.g. auto-inject Bearer header for
-          // api.notion.com) so that bash/network_mode=proxied works without manual setup.
-          const wellKnownInjectionTemplates = wellKnown?.injectionTemplates;
-
-          upsertCredentialMetadata(service, 'access_token', {
-            allowedTools: allowedTools ?? [],
-            expiresAt,
+          const { accountInfo } = await storeOAuth2Tokens({
+            ...storageParams,
+            tokens,
             grantedScopes,
-            accountInfo: accountInfo ?? null,
-            oauth2TokenUrl: tokenUrl,
-            oauth2ClientId: clientId,
-            ...(clientSecret ? { oauth2ClientSecret: clientSecret } : {}),
-            ...(tokenEndpointAuthMethod ? { oauth2TokenEndpointAuthMethod: tokenEndpointAuthMethod } : {}),
-            ...(wellKnownInjectionTemplates ? { injectionTemplates: wellKnownInjectionTemplates } : {}),
+            rawTokenResponse,
           });
-
-          if (tokens.refreshToken) {
-            const refreshStored = setSecureKey(`credential:${service}:refresh_token`, tokens.refreshToken);
-            if (refreshStored) {
-              upsertCredentialMetadata(service, 'refresh_token', {});
-            }
-          }
-
-          // Run any provider-specific post-connect actions (e.g. Slack welcome DM)
-          await runPostConnectHook({ service, rawTokenResponse });
 
           return {
             content: `Successfully connected "${service}"${accountInfo ? ` as ${accountInfo}` : ''}. The service is now ready to use.`,


### PR DESCRIPTION
## Summary

- Add `prepareOAuth2Flow()` to `oauth2.ts` — builds auth URL via gateway transport and returns a completion promise without blocking or opening a browser
- Extract `storeOAuth2Tokens()` helper in `vault.ts` to DRY the token storage logic; branch `oauth2_connect` on `isInteractive` so channels get the auth URL as text with fire-and-forget token storage on callback
- Update `google-oauth-setup` SKILL.md with a full text-based setup path for Telegram/channel users (Web application credentials, gateway callback URL, manual walkthrough)

## Original prompt
Make oauth2_connect work from Telegram/channels by returning the auth URL as tool output and handling the callback asynchronously. Add prepareOAuth2Flow, extract storeOAuth2Tokens, branch on isInteractive, update SKILL.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
