### PR TITLE
fix: handle key code 0 (kVK_ANSI_A) correctly for Quick Input hotkey

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1211,8 +1211,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             quickInputEventHandlerRef = nil
         }
 
-        let storedKeyCode = UserDefaults.standard.integer(forKey: "quickInputHotkeyKeyCode")
-        let keyCode = UInt32(storedKeyCode > 0 ? storedKeyCode : kVK_ANSI_Slash)
+        let storedKeyCode = UserDefaults.standard.object(forKey: "quickInputHotkeyKeyCode") as? Int
+        let keyCode = UInt32(storedKeyCode ?? Int(kVK_ANSI_Slash))
         let (modifierFlags, _) = ShortcutHelper.parseShortcut(shortcut)
         let carbonMods = ShortcutHelper.carbonModifiers(from: modifierFlags)
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -255,8 +255,8 @@ public final class SettingsStore: ObservableObject {
 
         self.globalHotkeyShortcut = UserDefaults.standard.string(forKey: "globalHotkeyShortcut") ?? "cmd+shift+g"
         self.quickInputHotkeyShortcut = UserDefaults.standard.string(forKey: "quickInputHotkeyShortcut") ?? "cmd+shift+/"
-        let storedQIKeyCode = UserDefaults.standard.integer(forKey: "quickInputHotkeyKeyCode")
-        self.quickInputHotkeyKeyCode = storedQIKeyCode > 0 ? storedQIKeyCode : kVK_ANSI_Slash
+        let storedQIKeyCode = UserDefaults.standard.object(forKey: "quickInputHotkeyKeyCode") as? Int
+        self.quickInputHotkeyKeyCode = storedQIKeyCode ?? kVK_ANSI_Slash
 
         #if DEBUG
         self.isDevMode = UserDefaults.standard.object(forKey: "devModeEnabled") as? Bool ?? true


### PR DESCRIPTION
## Summary
- Use `UserDefaults.object(forKey:) as? Int` instead of `integer(forKey:)` to distinguish missing keys from key code 0 (`kVK_ANSI_A`)
- Previously, recording Cmd+A as Quick Input shortcut would silently register Cmd+/ instead
- Fixed in both `AppDelegate.swift` and `SettingsStore.swift`

## Original prompt
Addresses review feedback from #8729.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
