### PR TITLE
fix: wire pre-send guardrails and send tracking into sequence engine

### DIFF
--- a/assistant/src/sequence/engine.ts
+++ b/assistant/src/sequence/engine.ts
@@ -19,6 +19,7 @@ import {
   rescheduleEnrollment,
   updateEnrollmentThreadId,
 } from './store.js';
+import { checkAllPreSend, recordSend } from './guardrails.js';
 import type { Sequence, SequenceEnrollment, SequenceStep } from './types.js';
 
 const log = getLogger('sequence-engine');
@@ -96,6 +97,19 @@ async function processEnrollment(
     return;
   }
 
+  // Enforce guardrails before allocating resources for the send
+  const guardrailResult = checkAllPreSend(sequence.id, enrollment, step.delaySeconds);
+  if (!guardrailResult.ok) {
+    log.info({
+      enrollmentId: enrollment.id,
+      sequenceId: sequence.id,
+      guardrail: guardrailResult.guardrail,
+      reason: guardrailResult.reason,
+    }, 'Guardrail blocked sequence step — rescheduling');
+    rescheduleEnrollment(enrollment.id, Date.now() + ERROR_RETRY_DELAY_MS);
+    return;
+  }
+
   // Build the prompt for the assistant to generate and send the email
   const prompt = buildStepPrompt(enrollment, sequence, step);
 
@@ -115,6 +129,9 @@ async function processEnrollment(
   }, 'Processing sequence step');
 
   await processMessage(conversation.id, prompt);
+
+  // Track the send for rate-limiting guardrails
+  recordSend(sequence.id);
 
   // Try to extract the email thread ID from conversation tool results so
   // subsequent steps can reply in the same thread.


### PR DESCRIPTION
## Summary
- Wire `checkAllPreSend()` into the sequence engine before step processing so configured daily/hourly limits, enrollment caps, cooldowns, duplicate checks, and minimum delays are actually enforced
- Call `recordSend()` after `processMessage()` so the in-memory send log tracks sends for rate-limiting guardrails
- When a guardrail blocks a step, reschedule the enrollment (60s retry) instead of silently dropping it

This was the one remaining unaddressed feedback item from PR #8725. The guardrails functions existed in `guardrails.ts` (and were completed by PR #8742 to include all 6 checks) but were never called from the engine.

## Context
Addresses **Codex P1: Apply pre-send guardrails** from [PR #8725](https://github.com/vellum-ai/vellum-assistant/pull/8725).

All other feedback items from #8725 were already addressed by follow-up PRs:
- **Codex P1: Requeue enrollment on failure** -- PR #8738, #8743
- **Codex P2: Persist thread ID** -- PR #8743
- **Devin BUG: Stuck enrollments** -- PR #8738, #8743
- **Devin BUG: cooldownPeriodMs treated as days** -- PR #8742
- **Devin: filter(Boolean) removes separators** -- PR #8741

## Test plan
- [ ] Verify `checkAllPreSend` is called before conversation/prompt allocation
- [ ] Verify `recordSend` is called after successful `processMessage`
- [ ] Verify guardrail-blocked steps are rescheduled (not dropped)
- [ ] Verify type-checking passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
