### PR TITLE
fix: don't restore previous app when quick input loses focus via click

### DIFF
--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
@@ -218,7 +218,7 @@ final class QuickInputWindow {
             Task { @MainActor in
                 // Don't dismiss while screen capture is in progress
                 guard self?.isCapturingScreen != true else { return }
-                self?.dismiss(restorePreviousApp: true)
+                self?.dismiss(restorePreviousApp: false)
             }
         }
 


### PR DESCRIPTION
## Summary
- Revert the resign-key dismissal back to `restorePreviousApp: false` — when the user clicks another app to dismiss quick input, that app already has focus and shouldn't be overridden
- Keep `restorePreviousApp: true` only for the submit path where the user expects to return to their previous app

## Original prompt
Addresses feedback from PR #8733.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
