### PR TITLE
feat: add fixed loopback port for OAuth2, switch Slack to loopback

### DIFF
--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -63,6 +63,10 @@ export interface OAuth2FlowCallbacks {
 export interface OAuth2FlowOptions {
   /** Which callback transport to use. When omitted, auto-detected from config. */
   callbackTransport?: 'loopback' | 'gateway';
+  /** Fixed port for the loopback server. When set, the server binds to this port
+   *  instead of an OS-assigned random port. Required for providers like Slack that
+   *  need pre-registered redirect URIs. */
+  loopbackPort?: number;
 }
 
 export interface OAuth2FlowResult {
@@ -217,23 +221,27 @@ async function runLoopbackFlow(
   codeVerifier: string,
   codeChallenge: string,
   state: string,
+  loopbackPort?: number,
 ): Promise<OAuth2FlowResult> {
   const { code, redirectUri } = await startLoopbackServerAndWaitForCode(
-    config, callbacks, codeChallenge, state,
+    config, callbacks, codeChallenge, state, loopbackPort,
   );
 
   return await exchangeCodeForTokens(config, code, redirectUri, codeVerifier);
 }
 
 /**
- * Start a temporary HTTP server on a random port, build the auth URL with
+ * Start a temporary HTTP server on localhost, build the auth URL with
  * a localhost redirect_uri, open the browser, and wait for the callback.
+ * When `loopbackPort` is set, binds to that fixed port (for providers
+ * that require pre-registered redirect URIs); otherwise uses a random port.
  */
 function startLoopbackServerAndWaitForCode(
   config: OAuth2Config,
   callbacks: OAuth2FlowCallbacks,
   codeChallenge: string,
   state: string,
+  loopbackPort?: number,
 ): Promise<{ code: string; redirectUri: string }> {
   return new Promise((resolve, reject) => {
     let settled = false;
@@ -303,7 +311,7 @@ function startLoopbackServerAndWaitForCode(
       server.close();
     }
 
-    server.listen(0, '127.0.0.1', () => {
+    server.listen(loopbackPort ?? 0, '127.0.0.1', () => {
       const addr = server.address() as { port: number };
       boundRedirectUri = `http://127.0.0.1:${addr.port}${LOOPBACK_CALLBACK_PATH}`;
 
@@ -441,8 +449,8 @@ export async function startOAuth2Flow(
     return runGatewayFlow(config, callbacks, codeVerifier, codeChallenge, state);
   }
 
-  log.debug({ transport: 'loopback' }, 'OAuth2 flow starting');
-  return runLoopbackFlow(config, callbacks, codeVerifier, codeChallenge, state);
+  log.debug({ transport: 'loopback', loopbackPort: options?.loopbackPort }, 'OAuth2 flow starting');
+  return runLoopbackFlow(config, callbacks, codeVerifier, codeChallenge, state, options?.loopbackPort);
 }
 
 /**

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -38,6 +38,9 @@ interface WellKnownOAuthConfig {
   injectionTemplates?: CredentialInjectionTemplate[];
   /** Force a specific callback transport (e.g. 'loopback' for Desktop app credentials). */
   callbackTransport?: 'loopback' | 'gateway';
+  /** Fixed port for loopback transport. Required for providers like Slack that
+   *  need pre-registered redirect URIs and cannot use a random port. */
+  loopbackPort?: number;
 }
 
 const WELL_KNOWN_OAUTH: Record<string, WellKnownOAuthConfig> = {
@@ -71,6 +74,8 @@ const WELL_KNOWN_OAUTH: Record<string, WellKnownOAuthConfig> = {
     extraParams: {
       user_scope: 'channels:read,channels:history,groups:read,groups:history,im:read,im:history,mpim:read,mpim:history,users:read,chat:write,search:read,reactions:write',
     },
+    callbackTransport: 'loopback',
+    loopbackPort: 17322,
   },
   // Notion uses a simple OAuth2 flow with client_secret_basic auth at the token endpoint.
   // The access token is long-lived (no expiry) and scopes are configured per-integration in Notion
@@ -734,7 +739,7 @@ class CredentialStoreTool implements Tool {
                 context.sendToClient?.({ type: 'open_url', url, title: `Connect ${service}` });
               },
             },
-            wellKnown?.callbackTransport ? { callbackTransport: wellKnown.callbackTransport } : undefined,
+            wellKnown?.callbackTransport ? { callbackTransport: wellKnown.callbackTransport, loopbackPort: wellKnown.loopbackPort } : undefined,
           );
 
           const { accountInfo } = await storeOAuth2Tokens({


### PR DESCRIPTION
## Summary
- Add `loopbackPort` option to `OAuth2FlowOptions` and `WellKnownOAuthConfig` so providers that need pre-registered redirect URIs can use a fixed port instead of a random one
- Thread `loopbackPort` through `startOAuth2Flow` → `runLoopbackFlow` → `startLoopbackServerAndWaitForCode`
- Switch Slack's well-known OAuth config to `callbackTransport: 'loopback'` with `loopbackPort: 17322`, removing the need for a public tunnel

## Original prompt
PR 1: Loopback fixed port support + Slack OAuth switch — Add loopbackPort support to the OAuth2 loopback transport so providers like Slack that require pre-registered redirect URIs can use a deterministic port instead of a random one. Then switch Slack's well-known OAuth config to use loopback with port 17322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
