### PR TITLE
fix: disambiguate OAuth client selection in Gmail setup

### DIFF
--- a/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
@@ -304,7 +304,7 @@ Close the creation dialog. Do NOT try to read the client secret from this dialog
 
 **Important context:** Google's Cloud Console no longer displays client secret values after initial creation, and "Download JSON" does not work in headless/automated browsers. The reliable approach is to generate a new secret, which Google shows exactly once.
 
-Navigate to the credential detail page. From the credentials list (`https://console.cloud.google.com/apis/credentials?project=PROJECT_ID`), click on the "Vellum Assistant" OAuth client you just created.
+Navigate to the credential detail page. From the credentials list (`https://console.cloud.google.com/apis/credentials?project=PROJECT_ID`), find the OAuth client whose **Client ID** matches the one you captured and stored in Step 6 (e.g., `123456789-xxxxx.apps.googleusercontent.com`). Click on that client to open its detail page. Do not rely on the display name alone — there may be multiple clients named "Vellum Assistant".
 
 Tell the user:
 


### PR DESCRIPTION
Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/8737

## Summary
- Updated Step 7 in Google OAuth setup SKILL.md to reference the captured Client ID when navigating to the credential detail page, instead of relying solely on the display name "Vellum Assistant"
- This prevents mismatches when multiple OAuth clients share the same name in the same project

## Original prompt
Address Codex P2 feedback: disambiguate OAuth client by referencing client ID instead of just display name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
