### PR TITLE
fix: wire analytics event recording and cap event log

### DIFF
--- a/assistant/src/sequence/analytics.ts
+++ b/assistant/src/sequence/analytics.ts
@@ -30,6 +30,11 @@ export interface SequenceEvent {
 let eventCounter = 0;
 const eventLog: SequenceEvent[] = [];
 
+/** Hard cap to prevent unbounded memory growth. When exceeded, the oldest
+ *  half of events is discarded. 10 000 events is enough for dashboard
+ *  metrics while keeping memory usage predictable. */
+const MAX_EVENT_LOG_SIZE = 10_000;
+
 export function recordEvent(
   sequenceId: string,
   enrollmentId: string,
@@ -47,6 +52,12 @@ export function recordEvent(
     createdAt: Date.now(),
   };
   eventLog.push(event);
+
+  // Evict the oldest half when the log exceeds the cap
+  if (eventLog.length > MAX_EVENT_LOG_SIZE) {
+    eventLog.splice(0, eventLog.length - Math.floor(MAX_EVENT_LOG_SIZE / 2));
+  }
+
   return event;
 }
 

--- a/assistant/src/sequence/engine.ts
+++ b/assistant/src/sequence/engine.ts
@@ -20,6 +20,7 @@ import {
   updateEnrollmentThreadId,
 } from './store.js';
 import { checkAllPreSend, recordSend } from './guardrails.js';
+import { recordEvent } from './analytics.js';
 import type { Sequence, SequenceEnrollment, SequenceStep } from './types.js';
 
 const log = getLogger('sequence-engine');
@@ -79,6 +80,7 @@ async function processEnrollment(
   const sequence = getSequence(enrollment.sequenceId);
   if (!sequence) {
     log.warn({ enrollmentId: enrollment.id, sequenceId: enrollment.sequenceId }, 'Sequence not found, cancelling enrollment');
+    recordEvent(enrollment.sequenceId, enrollment.id, 'fail', undefined, { reason: 'sequence_not_found' });
     exitEnrollment(enrollment.id, 'failed');
     return;
   }
@@ -93,6 +95,7 @@ async function processEnrollment(
   const step = sequence.steps[enrollment.currentStep];
   if (!step) {
     log.info({ enrollmentId: enrollment.id, step: enrollment.currentStep }, 'No more steps, marking completed');
+    recordEvent(sequence.id, enrollment.id, 'complete');
     exitEnrollment(enrollment.id, 'completed');
     return;
   }
@@ -130,8 +133,9 @@ async function processEnrollment(
 
   await processMessage(conversation.id, prompt);
 
-  // Track the send for rate-limiting guardrails
+  // Track the send for rate-limiting guardrails and analytics
   recordSend(sequence.id);
+  recordEvent(sequence.id, enrollment.id, 'send', step.index);
 
   // Try to extract the email thread ID from conversation tool results so
   // subsequent steps can reply in the same thread.
@@ -159,6 +163,7 @@ async function processEnrollment(
   if (nextStepIndex >= sequence.steps.length) {
     // This was the final step
     advanceEnrollment(enrollment.id, threadId, null);
+    recordEvent(sequence.id, enrollment.id, 'complete', step.index);
     exitEnrollment(enrollment.id, 'completed');
     log.info({ enrollmentId: enrollment.id, sequenceId: sequence.id }, 'Sequence completed');
   } else {

--- a/assistant/src/sequence/reply-matcher.ts
+++ b/assistant/src/sequence/reply-matcher.ts
@@ -9,6 +9,7 @@
 
 import { getLogger } from '../util/logger.js';
 import { findActiveEnrollmentsByEmail, exitEnrollment, getSequence } from './store.js';
+import { recordEvent } from './analytics.js';
 
 const log = getLogger('sequence:reply-matcher');
 
@@ -66,6 +67,10 @@ export function checkForSequenceReplies(
 
       if (!threadMatch) continue;
 
+      recordEvent(enrollment.sequenceId, enrollment.id, 'reply', enrollment.currentStep, {
+        senderEmail,
+        threadId: payload.threadId,
+      });
       exitEnrollment(enrollment.id, 'replied');
 
       log.info(


### PR DESCRIPTION
Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/8736

## Summary
- Wire `recordEvent` from `analytics.ts` into `engine.ts` (send, complete, fail events) and `reply-matcher.ts` (reply events) so analytics actually tracks sequence lifecycle events
- Cap `eventLog` at 10,000 entries to prevent unbounded memory growth — evicts the oldest half when the cap is exceeded

## Feedback addressed
- **Codex P1:** recordEvent never called from runtime
- **Devin BUG:** recordEvent never called
- **Devin BUG:** Unbounded eventLog array
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
