### PR TITLE
feat: simplify Slack OAuth setup to use localhost callback

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -30,7 +30,7 @@ Gmail, Slack, and Telegram setup all require a publicly reachable URL for OAuth 
 
 ### Slack
 1. **Try connecting directly first.** Call `credential_store` with `action: "oauth2_connect"` and `service: "slack"`. The tool auto-fills Slack's OAuth endpoints and looks up any previously stored client credentials.
-2. **If it fails because no client_id is found:** The user needs to create a Slack App first. Install and load the **slack-oauth-setup** skill (which depends on **public-ingress** for the redirect URI):
+2. **If it fails because no client_id is found:** The user needs to create a Slack App first. Install and load the **slack-oauth-setup** skill:
    - Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "slack-oauth-setup"`.
    - Then call `skill_load` with `skill: "slack-oauth-setup"`.
    - Tell the user Slack isn't connected yet and briefly explain what the setup involves, then use `ui_show` with `surface_type: "confirmation"` to ask for permission to start:

--- a/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
@@ -2,17 +2,13 @@
 name: "Slack OAuth Setup"
 description: "Create Slack App and OAuth credentials for Slack integration using browser automation"
 user-invocable: true
-includes: ["browser", "public-ingress"]
+includes: ["browser"]
 metadata: {"vellum": {"emoji": "🔑"}}
 ---
 
 You are helping your user create a Slack App and OAuth credentials so the Messaging integration can connect to their Slack workspace. Walk through each step below using `browser_navigate`, `browser_snapshot`, `browser_screenshot`, `browser_click`, `browser_type`, and `browser_extract` tools.
 
 **Tone:** Be friendly and reassuring throughout. Narrate what you're doing in plain language so the user always knows what's happening. After each step, briefly confirm what was accomplished before moving on.
-
-## Prerequisites
-
-Before starting, check that `ingress.publicBaseUrl` is configured (`INGRESS_PUBLIC_BASE_URL` env var or workspace config). If it is not set, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the public URL. The OAuth redirect URI depends on this value.
 
 ## Before You Start
 
@@ -90,16 +86,16 @@ Tell the user: "Permissions configured! Now let's set up the redirect URL and ge
 
 Navigate to the "OAuth & Permissions" page if not already there.
 
-The redirect URL must point to the gateway's OAuth callback endpoint. Determine the URL by reading the `ingress.publicBaseUrl` value from the assistant's workspace config or the `INGRESS_PUBLIC_BASE_URL` environment variable. The callback path is `/webhooks/oauth/callback`.
+The redirect URL uses a localhost callback — no public URL or tunnel is needed.
 
 In the "Redirect URLs" section:
 1. Click "Add New Redirect URL"
-2. Enter `${ingress.publicBaseUrl}/webhooks/oauth/callback` (e.g. `https://abc123.ngrok-free.app/webhooks/oauth/callback`)
+2. Enter `http://127.0.0.1:17322/oauth/callback`
 3. Click "Add" then "Save URLs"
 
 Take a `browser_snapshot` to confirm.
 
-Tell the user: "Redirect URL configured. Make sure your tunnel is running and `ingress.publicBaseUrl` is set so the callback can reach the gateway. You can always check or update this from the Settings page."
+Tell the user: "Redirect URL configured. This uses a local callback so no tunnel or public URL is needed."
 
 ## Step 5: Extract Client ID and Client Secret
 
@@ -141,7 +137,7 @@ Once connected, tell the user:
 Summarize what was accomplished:
 - Created a Slack App called "Vellum Assistant"
 - Configured User Token Scopes for reading, writing, and searching
-- Set up the OAuth redirect URL
+- Set up the OAuth redirect URL (localhost callback — no tunnel needed)
 - Connected your Slack workspace
 
 ## Error Handling

--- a/skills/slack-oauth-setup/SKILL.md
+++ b/skills/slack-oauth-setup/SKILL.md
@@ -2,17 +2,13 @@
 name: "Slack OAuth Setup"
 description: "Create Slack App and OAuth credentials for Slack integration using browser automation"
 user-invocable: true
-includes: ["browser", "public-ingress"]
+includes: ["browser"]
 metadata: {"vellum": {"emoji": "🔑"}}
 ---
 
 You are helping your user create a Slack App and OAuth credentials so the Messaging integration can connect to their Slack workspace. Walk through each step below using `browser_navigate`, `browser_snapshot`, `browser_screenshot`, `browser_click`, `browser_type`, and `browser_extract` tools.
 
 **Tone:** Be friendly and reassuring throughout. Narrate what you're doing in plain language so the user always knows what's happening. After each step, briefly confirm what was accomplished before moving on.
-
-## Prerequisites
-
-Before starting, check that `ingress.publicBaseUrl` is configured (Settings > Public Ingress, or `INGRESS_PUBLIC_BASE_URL` env var). If it is not set, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the public URL. The OAuth redirect URI depends on this value.
 
 ## Before You Start
 
@@ -67,6 +63,7 @@ Tell the user: "App created! Now let's configure the permissions it needs."
 > - `groups:history` — Read message history in private channels
 > - `im:read` — View direct message info
 > - `im:history` — Read direct message history
+> - `im:write` — Open and send direct messages
 > - `mpim:read` — View group DM info
 > - `mpim:history` — Read group DM history
 > - `users:read` — View user profiles
@@ -89,16 +86,16 @@ Tell the user: "Permissions configured! Now let's set up the redirect URL and ge
 
 Navigate to the "OAuth & Permissions" page if not already there.
 
-The redirect URL must point to the gateway's OAuth callback endpoint. Determine the URL by reading the `ingress.publicBaseUrl` value from the assistant's workspace config (Settings > Public Ingress) or the `INGRESS_PUBLIC_BASE_URL` environment variable. The callback path is `/webhooks/oauth/callback`.
+The redirect URL uses a localhost callback — no public URL or tunnel is needed.
 
 In the "Redirect URLs" section:
 1. Click "Add New Redirect URL"
-2. Enter `${ingress.publicBaseUrl}/webhooks/oauth/callback` (e.g. `https://abc123.ngrok-free.app/webhooks/oauth/callback`)
+2. Enter `http://127.0.0.1:17322/oauth/callback`
 3. Click "Add" then "Save URLs"
 
 Take a `browser_snapshot` to confirm.
 
-Tell the user: "Redirect URL configured. Make sure your tunnel is running and `ingress.publicBaseUrl` is set in Settings so the callback can reach the gateway."
+Tell the user: "Redirect URL configured. This uses a local callback so no tunnel or public URL is needed."
 
 ## Step 5: Extract Client ID and Client Secret
 
@@ -140,7 +137,7 @@ Once connected, tell the user:
 Summarize what was accomplished:
 - Created a Slack App called "Vellum Assistant"
 - Configured User Token Scopes for reading, writing, and searching
-- Set up the OAuth redirect URL
+- Set up the OAuth redirect URL (localhost callback — no tunnel needed)
 - Connected your Slack workspace
 
 ## Error Handling


### PR DESCRIPTION
## Summary
- Remove `public-ingress` dependency from the Slack OAuth setup skill — no ngrok tunnel needed
- Replace the dynamic redirect URL (`${ingress.publicBaseUrl}/webhooks/oauth/callback`) with a fixed localhost callback (`http://127.0.0.1:17322/oauth/callback`)
- Update both the main and bundled copies of the skill, plus the messaging skill's Slack setup reference

## Original prompt
PR 2: Simplify Slack OAuth setup skill — remove public-ingress prerequisite, use fixed localhost redirect URL from PR 1's loopback port support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
