### PR TITLE
fix: exclude current enrollment from duplicate check and move recordSend after approval gate

### DIFF
--- a/assistant/src/sequence/engine.ts
+++ b/assistant/src/sequence/engine.ts
@@ -133,10 +133,6 @@ async function processEnrollment(
 
   await processMessage(conversation.id, prompt);
 
-  // Track the send for rate-limiting guardrails and analytics
-  recordSend(sequence.id);
-  recordEvent(sequence.id, enrollment.id, 'send', step.index);
-
   // Try to extract the email thread ID from conversation tool results so
   // subsequent steps can reply in the same thread.
   const threadId = extractThreadIdFromConversation(conversation.id) ?? undefined;
@@ -157,6 +153,12 @@ async function processEnrollment(
     }, 'Step requires approval — pausing advancement until draft is approved');
     return;
   }
+
+  // Track the send for rate-limiting guardrails and analytics.
+  // Placed after the requireApproval gate so draft-only steps don't inflate
+  // rate-limit counters — only actual sends are counted.
+  recordSend(sequence.id);
+  recordEvent(sequence.id, enrollment.id, 'send', step.index);
 
   // Advance to the next step
   const nextStepIndex = enrollment.currentStep + 1;

--- a/assistant/src/sequence/guardrails.ts
+++ b/assistant/src/sequence/guardrails.ts
@@ -182,12 +182,15 @@ export function checkAllPreSend(
   enrollment: SequenceEnrollment,
   stepDelaySec: number,
 ): GuardrailResult {
+  // checkDuplicateEnrollment is intentionally excluded here — it's an
+  // enrollment-time guard, not a per-step guard. During step processing the
+  // current enrollment is still status='active', so it would always find
+  // itself and block every step.
   const checks: GuardrailResult[] = [
     checkDailyCap(),
     checkHourlyRate(sequenceId),
     checkMinDelay(stepDelaySec),
     checkEnrollmentCap(sequenceId),
-    checkDuplicateEnrollment(sequenceId, enrollment.contactEmail),
     checkCooldown(sequenceId, enrollment.contactEmail),
   ];
 


### PR DESCRIPTION
Addresses review feedback from PR #8746. Two fixes:

1. **checkDuplicateEnrollment self-blocking**: The duplicate enrollment guardrail was running during step processing via checkAllPreSend, but the current enrollment is still status='active' in the DB, so it always found itself and blocked — creating an infinite retry loop. Fixed by removing it from checkAllPreSend (it's an enrollment-time check, not a per-step check).

2. **recordSend for draft steps**: recordSend was called before the requireApproval check, so approval-only steps that create drafts (not actual sends) were counted toward daily/hourly rate limits. Moved recordSend to after the approval gate so only actual sends are counted.

Feedback from: https://github.com/vellum-ai/vellum-assistant/pull/8746
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
