### PR TITLE
feat: add channel tracking to Slack watcher

### DIFF
--- a/assistant/src/watcher/providers/slack.ts
+++ b/assistant/src/watcher/providers/slack.ts
@@ -1,10 +1,10 @@
 /**
- * Slack watcher provider — polls for new DMs, mentions, and thread replies.
+ * Slack watcher provider — polls for new DMs, mentions, and channel messages.
  *
  * Uses the conversations.history API with a timestamp watermark.
  * On first poll, captures the current time as the watermark (start from "now").
- * Subsequent polls fetch messages newer than the watermark across DM channels
- * and member channels, filtering to relevant events.
+ * Subsequent polls fetch messages newer than the watermark across configured
+ * channels, DM channels, and member channels.
  */
 
 import { withValidToken } from '../../security/token-manager.js';
@@ -14,6 +14,21 @@ import type { WatcherProvider, WatcherItem, FetchResult } from '../provider-type
 import { getLogger } from '../../util/logger.js';
 
 const log = getLogger('watcher:slack');
+
+/**
+ * Provider-specific configuration for the Slack watcher.
+ *
+ * When `channels` is specified, those channels are monitored for ALL messages
+ * (not just mentions). When omitted or empty, the legacy behavior applies:
+ * @mentions in the top 20 member channels.
+ */
+interface SlackWatcherConfig {
+  /** Channel IDs to watch for all messages (e.g. ["C01234ABCDE"]).
+   *  When non-empty, replaces the default "top 20 member channels for mentions" behavior. */
+  channels?: string[];
+  /** When true, also monitor DMs and group DMs (default: true). */
+  includeDMs?: boolean;
+}
 
 function messageToItem(
   msg: { ts: string; text: string; user?: string; channel: string },
@@ -35,6 +50,40 @@ function messageToItem(
   };
 }
 
+/**
+ * Poll a single channel for new messages since the watermark, paginating
+ * through all results. Returns items and the latest timestamp seen.
+ */
+async function pollChannel(
+  token: string,
+  channelId: string,
+  channelName: string,
+  eventType: string,
+  watermark: string,
+  userId: string,
+): Promise<{ items: WatcherItem[]; latestTs: string }> {
+  const items: WatcherItem[] = [];
+  let channelLatestTs = watermark;
+  let cursor: string | undefined;
+
+  do {
+    const histResp = await slack.conversationHistory(token, channelId, 100, undefined, watermark, cursor);
+    for (const msg of histResp.messages) {
+      if (msg.user === userId) continue;
+      if (parseFloat(msg.ts) <= parseFloat(watermark)) continue;
+
+      items.push(messageToItem({ ...msg, channel: channelId }, eventType, channelName));
+
+      if (parseFloat(msg.ts) > parseFloat(channelLatestTs)) {
+        channelLatestTs = msg.ts;
+      }
+    }
+    cursor = histResp.has_more ? histResp.response_metadata?.next_cursor : undefined;
+  } while (cursor);
+
+  return { items, latestTs: channelLatestTs };
+}
+
 export const slackProvider: WatcherProvider = {
   id: 'slack',
   displayName: 'Slack',
@@ -48,7 +97,7 @@ export const slackProvider: WatcherProvider = {
   async fetchNew(
     credentialService: string,
     watermark: string | null,
-    _config: Record<string, unknown>,
+    config: Record<string, unknown>,
     _watcherKey: string,
   ): Promise<FetchResult> {
     return withValidToken(credentialService, async (token) => {
@@ -56,70 +105,65 @@ export const slackProvider: WatcherProvider = {
         return { items: [], watermark: String(Date.now() / 1000) };
       }
 
-      // Get the authenticated user's ID to detect mentions
+      const slackConfig = config as SlackWatcherConfig;
+      const watchChannels = slackConfig.channels ?? [];
+      const includeDMs = slackConfig.includeDMs ?? true;
+
       const authResp = await slack.authTest(token);
       const userId = authResp.user_id;
-
-      // List DM and group DM channels to poll
-      const convResp = await slack.listConversations(token, 'im,mpim', false, 100);
-      const dmChannels = convResp.channels;
 
       const items: WatcherItem[] = [];
       let latestTs = watermark;
 
-      // Poll each DM channel for new messages, paginating to fetch all.
-      // We track a per-channel watermark candidate and only merge it into the
-      // global watermark after the entire pagination loop succeeds. This prevents
-      // advancing past unread messages when a later page fails (rate limit, etc.).
-      for (const channel of dmChannels) {
-        try {
-          let channelLatestTs = watermark;
-          let cursor: string | undefined;
-          do {
-            const histResp = await slack.conversationHistory(token, channel.id, 100, undefined, watermark, cursor);
-            for (const msg of histResp.messages) {
-              // Skip our own messages
-              if (msg.user === userId) continue;
-              // Skip messages older than watermark (shouldn't happen but guard)
-              if (parseFloat(msg.ts) <= parseFloat(watermark)) continue;
-
-              const channelName = channel.name ?? channel.user ?? channel.id;
-              const eventType = channel.is_im ? 'slack_dm' : 'slack_group_dm';
-              items.push(messageToItem({ ...msg, channel: channel.id }, eventType, channelName));
-
-              if (parseFloat(msg.ts) > parseFloat(channelLatestTs)) {
-                channelLatestTs = msg.ts;
-              }
+      // ── DM / Group DM polling ──────────────────────────────────────
+      if (includeDMs) {
+        const convResp = await slack.listConversations(token, 'im,mpim', false, 100);
+        for (const channel of convResp.channels) {
+          try {
+            const channelName = channel.name ?? channel.user ?? channel.id;
+            const eventType = channel.is_im ? 'slack_dm' : 'slack_group_dm';
+            const result = await pollChannel(token, channel.id, channelName, eventType, watermark, userId);
+            items.push(...result.items);
+            if (parseFloat(result.latestTs) > parseFloat(latestTs)) {
+              latestTs = result.latestTs;
             }
-            cursor = histResp.has_more ? histResp.response_metadata?.next_cursor : undefined;
-          } while (cursor);
-          // Only advance after all pages for this channel succeeded
-          if (parseFloat(channelLatestTs) > parseFloat(latestTs)) {
-            latestTs = channelLatestTs;
+          } catch (err) {
+            log.debug({ channelId: channel.id, err }, 'Skipping channel in Slack watcher');
           }
-        } catch (err) {
-          // Skip channels we can't read (archived, permissions, etc.)
-          log.debug({ channelId: channel.id, err }, 'Skipping channel in Slack watcher');
         }
       }
 
-      // Also check a few active member channels for @mentions
-      const memberConvResp = await slack.listConversations(token, 'public_channel,private_channel', true, 50);
-      for (const channel of memberConvResp.channels.slice(0, 20)) {
-        try {
-          const histResp = await slack.conversationHistory(token, channel.id, 5, undefined, watermark);
-          for (const msg of histResp.messages) {
-            if (parseFloat(msg.ts) <= parseFloat(watermark)) continue;
-            // Check for @mention
-            if (msg.text.includes(`<@${userId}>`)) {
-              items.push(messageToItem({ ...msg, channel: channel.id }, 'slack_mention', channel.name ?? channel.id));
-              if (parseFloat(msg.ts) > parseFloat(latestTs)) {
-                latestTs = msg.ts;
+      // ── Configured channel polling (all messages) ──────────────────
+      if (watchChannels.length > 0) {
+        for (const channelId of watchChannels) {
+          try {
+            const result = await pollChannel(token, channelId, channelId, 'slack_channel_message', watermark, userId);
+            items.push(...result.items);
+            if (parseFloat(result.latestTs) > parseFloat(latestTs)) {
+              latestTs = result.latestTs;
+            }
+          } catch (err) {
+            log.debug({ channelId, err }, 'Skipping configured channel in Slack watcher');
+          }
+        }
+      } else {
+        // Legacy behavior: check top 20 member channels for @mentions only
+        const memberConvResp = await slack.listConversations(token, 'public_channel,private_channel', true, 50);
+        for (const channel of memberConvResp.channels.slice(0, 20)) {
+          try {
+            const histResp = await slack.conversationHistory(token, channel.id, 5, undefined, watermark);
+            for (const msg of histResp.messages) {
+              if (parseFloat(msg.ts) <= parseFloat(watermark)) continue;
+              if (msg.text.includes(`<@${userId}>`)) {
+                items.push(messageToItem({ ...msg, channel: channel.id }, 'slack_mention', channel.name ?? channel.id));
+                if (parseFloat(msg.ts) > parseFloat(latestTs)) {
+                  latestTs = msg.ts;
+                }
               }
             }
+          } catch {
+            // Skip unreadable channels
           }
-        } catch {
-          // Skip unreadable channels
         }
       }
 


### PR DESCRIPTION
## Summary
- Add `SlackWatcherConfig` type with `channels` (channel IDs to watch for all messages) and `includeDMs` (toggle DM monitoring)
- When `channels` is configured, poll those channels for ALL messages with full pagination (new event type `slack_channel_message`)
- When no channels configured, preserve existing behavior (all DMs + top-20 channels for @mentions only)
- Extract shared `pollChannel` helper to reduce duplication

## Original prompt
PR 3: Channel-aware Slack watcher — let users specify which channels to monitor via watcher config and fetch all messages from those channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
