### PR TITLE
feat: generic OAuth setup skill with describe action

### DIFF
--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -41,6 +41,21 @@ interface WellKnownOAuthConfig {
   /** Fixed port for loopback transport. Required for providers like Slack that
    *  need pre-registered redirect URIs and cannot use a random port. */
   loopbackPort?: number;
+  /** Metadata for the generic OAuth setup skill. When present, the assistant
+   *  can guide users through app creation and OAuth connection without a
+   *  provider-specific setup skill. */
+  setup?: {
+    /** Human-readable provider name (e.g., "Discord", "Linear") */
+    displayName: string;
+    /** URL of the developer dashboard where the user creates an app */
+    dashboardUrl: string;
+    /** What the provider calls its apps (e.g., "Discord Application", "Linear OAuth App") */
+    appType: string;
+    /** Whether the provider requires a client_secret for token exchange */
+    requiresClientSecret: boolean;
+    /** Provider-specific notes the LLM should follow during setup */
+    notes?: string[];
+  };
 }
 
 const WELL_KNOWN_OAUTH: Record<string, WellKnownOAuthConfig> = {
@@ -244,8 +259,8 @@ class CredentialStoreTool implements Tool {
         properties: {
           action: {
             type: 'string',
-            enum: ['store', 'list', 'delete', 'prompt', 'oauth2_connect'],
-            description: 'The operation to perform. Use "prompt" to ask the user for a secret via secure UI — the value never enters the conversation. Use "oauth2_connect" to connect an OAuth2 service via browser authorization. For well-known services (gmail, slack), only the service name is required — endpoints, scopes, and stored client credentials are resolved automatically.',
+            enum: ['store', 'list', 'delete', 'prompt', 'oauth2_connect', 'describe'],
+            description: 'The operation to perform. Use "prompt" to ask the user for a secret via secure UI — the value never enters the conversation. Use "oauth2_connect" to connect an OAuth2 service via browser authorization. Use "describe" to get setup metadata for a well-known OAuth service (dashboard URL, scopes, redirect URI, etc.). For well-known services (gmail, slack), only the service name is required — endpoints, scopes, and stored client credentials are resolved automatically.',
           },
           service: {
             type: 'string',
@@ -757,6 +772,43 @@ class CredentialStoreTool implements Tool {
           const message = err instanceof Error ? err.message : 'Unknown error during OAuth flow';
           return { content: `Error connecting "${service}": ${message}`, isError: true };
         }
+      }
+
+      case 'describe': {
+        const rawService = (input.service as string | undefined) ?? '';
+        const service = SERVICE_ALIASES[rawService] ?? rawService;
+        if (!service) {
+          return { content: 'Error: service is required for describe action', isError: true };
+        }
+        const wellKnown = WELL_KNOWN_OAUTH[service];
+        if (!wellKnown) {
+          return { content: `No well-known OAuth config found for "${rawService}". Available services: ${Object.keys(SERVICE_ALIASES).join(', ')}`, isError: false };
+        }
+
+        // Compute the redirect URI based on callback transport
+        let redirectUri: string;
+        const transport = wellKnown.callbackTransport ?? 'gateway';
+        if (transport === 'loopback' && wellKnown.loopbackPort) {
+          redirectUri = `http://127.0.0.1:${wellKnown.loopbackPort}/oauth/callback`;
+        } else if (transport === 'loopback') {
+          redirectUri = '(automatic — no redirect URI needed, uses random localhost port)';
+        } else {
+          redirectUri = '${ingress.publicBaseUrl}/webhooks/oauth/callback (requires public ingress URL)';
+        }
+
+        const info: Record<string, unknown> = {
+          service,
+          authUrl: wellKnown.authUrl,
+          tokenUrl: wellKnown.tokenUrl,
+          scopes: wellKnown.scopes,
+          callbackTransport: transport,
+          redirectUri,
+          requiresClientSecret: !!(wellKnown.tokenEndpointAuthMethod || wellKnown.extraParams),
+        };
+        if (wellKnown.setup) info.setup = wellKnown.setup;
+        if (wellKnown.extraParams) info.extraParams = wellKnown.extraParams;
+
+        return { content: JSON.stringify(info, null, 2), isError: false };
       }
 
       default:

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -32,7 +32,7 @@
       "name": "Slack OAuth Setup",
       "description": "Create Slack App and OAuth credentials for Slack integration using browser automation",
       "emoji": "\ud83d\udd11",
-      "includes": ["browser", "public-ingress"]
+      "includes": ["browser"]
     },
     {
       "id": "telegram-setup",
@@ -66,6 +66,13 @@
       "name": "Notion",
       "description": "Read and write Notion pages and databases using the Notion API",
       "emoji": "\ud83d\udcdd"
+    },
+    {
+      "id": "oauth-setup",
+      "name": "OAuth Setup",
+      "description": "Connect any OAuth service — create app credentials and authorize via browser automation. Works for any provider with a well-known config.",
+      "emoji": "\ud83d\udd11",
+      "includes": ["browser"]
     }
   ]
 }

--- a/skills/oauth-setup/SKILL.md
+++ b/skills/oauth-setup/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: "OAuth Setup"
+description: "Connect any OAuth service — create app credentials and authorize via browser automation"
+user-invocable: true
+includes: ["browser"]
+metadata: {"vellum": {"emoji": "🔑"}}
+---
+
+You are helping the user connect an OAuth-based service to Vellum. This is a generic setup flow that works for any provider with a well-known OAuth config and setup metadata.
+
+**Tone:** Be friendly and reassuring throughout. Narrate what you're doing in plain language so the user always knows what's happening. After each step, briefly confirm what was accomplished before moving on.
+
+## Input
+
+You will be given a `service` name (e.g., "discord", "linear", "spotify"). If not provided, ask the user which service they want to connect.
+
+## Step 1: Read the service config
+
+Use `credential_store` with `action: "describe"` and `service: "<name>"` to get the well-known OAuth config. This returns:
+- `setup.displayName` — the provider's name
+- `setup.dashboardUrl` — where to create the app
+- `setup.appType` — what kind of app to create
+- `setup.requiresClientSecret` — whether a client secret is needed
+- `setup.notes` — provider-specific guidance
+- `scopes` — permissions to request
+- `redirectUri` — the callback URL to register
+- `callbackTransport` — loopback or gateway
+
+If no config is found, tell the user this service doesn't have a pre-configured setup and offer to help them configure it manually via `oauth2_connect`.
+
+## Step 2: Tell the user what's happening
+
+Tell the user:
+- "I'll walk you through creating a {setup.appType} so Vellum can connect to {setup.displayName}. The whole process takes a few minutes."
+- "I'll be automating the {setup.displayName} developer dashboard in the browser — you'll be able to see everything I'm doing."
+- "I'll ask for your approval before each major step, so nothing happens without your say-so."
+
+## Step 3: Navigate to the developer dashboard
+
+Use `browser_navigate` to go to `setup.dashboardUrl`.
+
+Take a `browser_screenshot` and `browser_snapshot`:
+- **If a sign-in page appears:** Tell the user to sign in and wait for confirmation.
+- **If the dashboard loads:** Continue to Step 4.
+
+## Step 4: Create an app
+
+**Ask for approval before proceeding.** Use `ui_show` with `surface_type: "confirmation"` explaining what you're about to create.
+
+Once approved:
+1. Find and click the "Create App" / "New Application" / "New Integration" button (adapt to the provider's UI)
+2. Name it "Vellum Assistant"
+3. Follow any guidance from `setup.notes`
+4. Complete the creation flow
+
+Take a `browser_screenshot` to confirm.
+
+## Step 5: Configure scopes/permissions
+
+**Ask for approval before proceeding.** List the `scopes` from the config and explain what each grants.
+
+Once approved, navigate to the OAuth/permissions section and add each scope. Follow `setup.notes` for any provider-specific guidance (e.g., "User Token Scopes" vs "Bot Token Scopes").
+
+Take a `browser_screenshot` after adding all scopes.
+
+## Step 6: Set redirect URL
+
+Check the `redirectUri` from the config:
+- If it starts with `http://127.0.0.1:` — tell the user "This uses a local callback, no public URL needed" and enter the URL in the redirect URL field.
+- If it mentions `ingress.publicBaseUrl` — the user needs a public URL configured. Check if one is set; if not, load the `public-ingress` skill first.
+- If it says "automatic" — skip this step entirely (no redirect URI needed).
+
+Take a `browser_snapshot` to confirm.
+
+## Step 7: Extract credentials
+
+Navigate to the app's credentials/settings section.
+
+Use `browser_extract` to read:
+1. **Client ID** (or equivalent)
+2. **Client Secret** (if `setup.requiresClientSecret` is true) — click "Show"/"Reveal" first if needed
+
+## Step 8: Connect
+
+Tell the user you're opening the authorization page.
+
+Use `credential_store` with:
+```
+action: "oauth2_connect"
+service: "<service name>"
+client_id: "<extracted client ID>"
+client_secret: "<extracted client secret>"  (if required)
+```
+
+Everything else (endpoints, scopes, params) is auto-filled from the well-known config. Wait for the flow to complete.
+
+## Step 9: Celebrate!
+
+Once connected, tell the user:
+"**{setup.displayName} is connected!** You're all set."
+
+Summarize what was accomplished.
+
+## Error Handling
+
+- **Page load failures:** Retry once. If it still fails, ask the user to check their connection.
+- **Element not found:** Take a fresh `browser_snapshot`. The provider's UI may have changed — adapt dynamically.
+- **User declines an approval gate:** Don't push back. Explain why it matters, offer to retry or cancel.
+- **OAuth flow timeout or failure:** Offer to retry. The app is already created, so only the connect step needs to be re-run.
+- **Any unexpected state:** Take a `browser_screenshot` and `browser_snapshot`, describe what you see, and ask for guidance.


### PR DESCRIPTION
## Summary
- Add `setup` metadata field to `WellKnownOAuthConfig` (displayName, dashboardUrl, appType, requiresClientSecret, notes) for self-describing OAuth providers
- Add `describe` action to `credential_store` tool — returns setup metadata, scopes, computed redirect URI for any well-known service
- Create generic `oauth-setup` skill that reads config via `describe` and guides browser automation for any provider
- Fix Slack OAuth catalog entry to remove stale `public-ingress` include

## How to add a new OAuth provider

Just add a `WELL_KNOWN_OAUTH` entry with a `setup` field — no new skill needed:
```typescript
'integration:discord': {
  authUrl: '...', tokenUrl: '...', scopes: [...],
  callbackTransport: 'loopback', loopbackPort: 17324,
  setup: {
    displayName: 'Discord',
    dashboardUrl: 'https://discord.com/developers/applications',
    appType: 'Discord Application',
    requiresClientSecret: true,
    notes: ['Create OAuth2 redirect under "OAuth2" tab'],
  },
},
```

## Original prompt
PR 4: Generic OAuth setup for future providers — enrich well-known config with setup metadata, add describe action to credential_store, create a single generic OAuth setup skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
