### PR TITLE
fix: include thread ID in messaging send tool responses for reply matching

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-send-with-attachments.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-send-with-attachments.ts
@@ -69,7 +69,8 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
       const result = await sendMessageRaw(token, raw, threadId);
 
       const filenames = attachments.map((a) => a.filename).join(', ');
-      return ok(`Message sent with ${attachments.length} attachment(s): ${filenames} (ID: ${result.id}).`);
+      const threadSuffix = result.threadId ? `, "thread_id": "${result.threadId}"` : '';
+      return ok(`Message sent with ${attachments.length} attachment(s): ${filenames} (ID: ${result.id}${threadSuffix}).`);
     });
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -27,7 +27,8 @@ export async function run(input: Record<string, unknown>, context: ToolContext):
       if (provider.id === 'sms') {
         return ok(`SMS accepted by Twilio (ID: ${result.id}). Note: "accepted" means Twilio received it for delivery — it has not yet been confirmed as delivered to the handset.`);
       }
-      return ok(`Message sent (ID: ${result.id}).`);
+      const threadSuffix = result.threadId ? `, "thread_id": "${result.threadId}"` : '';
+      return ok(`Message sent (ID: ${result.id}${threadSuffix}).`);
     });
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));

--- a/assistant/src/messaging/provider-types.ts
+++ b/assistant/src/messaging/provider-types.ts
@@ -44,6 +44,7 @@ export interface SendResult {
   id: string;
   timestamp: number;
   conversationId: string;
+  threadId?: string;
 }
 
 export interface ConnectionInfo {

--- a/assistant/src/messaging/providers/gmail/adapter.ts
+++ b/assistant/src/messaging/providers/gmail/adapter.ts
@@ -167,6 +167,7 @@ export const gmailMessagingProvider: MessagingProvider = {
       id: msg.id,
       timestamp: msg.internalDate ? parseInt(msg.internalDate, 10) : Date.now(),
       conversationId: msg.threadId,
+      threadId: msg.threadId,
     };
   },
 


### PR DESCRIPTION
Addresses Codex review feedback on PR #8749. The messaging_send and gmail-send-with-attachments tools now include the thread_id in their response strings so that extractThreadIdFromConversation can capture it for reply matching. Without this, enrollments with exitOnReply enabled could never detect replies because the thread ID was never surfaced in the tool output.

Changes:
- Added optional threadId field to SendResult interface
- Gmail adapter now populates threadId on send responses
- messaging-send tool output includes thread_id when available
- gmail-send-with-attachments tool output includes thread_id when available

The output format uses the JSON pattern ("thread_id": "...") which matches the existing extractThreadIdFromContent regex in the sequence engine.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
