### PR TITLE
fix: validate Slack watcher channels config before use

### DIFF
--- a/assistant/src/watcher/providers/slack.ts
+++ b/assistant/src/watcher/providers/slack.ts
@@ -106,8 +106,18 @@ export const slackProvider: WatcherProvider = {
       }
 
       const slackConfig = config as SlackWatcherConfig;
-      const watchChannels = slackConfig.channels ?? [];
-      const includeDMs = slackConfig.includeDMs ?? true;
+
+      // Normalize channels: config is persisted as untyped JSON, so a caller
+      // could provide a bare string instead of an array. Coerce to string[]
+      // and filter out any non-string entries to prevent iterating characters.
+      const rawChannels = slackConfig.channels;
+      const watchChannels: string[] = Array.isArray(rawChannels)
+        ? rawChannels.filter((ch): ch is string => typeof ch === 'string')
+        : typeof rawChannels === 'string'
+          ? [rawChannels]
+          : [];
+
+      const includeDMs = typeof slackConfig.includeDMs === 'boolean' ? slackConfig.includeDMs : true;
 
       const authResp = await slack.authTest(token);
       const userId = authResp.user_id;


### PR DESCRIPTION
Addresses review feedback from PR #8755:

Normalizes and validates the channels and includeDMs config fields in the Slack watcher before use. If channels is provided as a single string instead of an array, it's wrapped in an array. Non-array/non-string values default to []. Non-boolean includeDMs defaults to true. This prevents silent failures when config is malformed.

Original prompt: Address the feedback on #8755
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
