### PR TITLE
fix: restore duplicate enrollment check with self-exclusion

### DIFF
--- a/assistant/src/sequence/guardrails.ts
+++ b/assistant/src/sequence/guardrails.ts
@@ -133,11 +133,15 @@ export function checkEnrollmentCap(sequenceId: string): GuardrailResult {
 export function checkDuplicateEnrollment(
   sequenceId: string,
   email: string,
+  excludeEnrollmentId?: string,
 ): GuardrailResult {
   if (!config.duplicateEnrollmentCheck) return { ok: true };
 
   const existing = listEnrollments({ sequenceId, contactEmail: email, status: 'active' });
-  if (existing.length > 0) {
+  const duplicates = excludeEnrollmentId
+    ? existing.filter((e) => e.id !== excludeEnrollmentId)
+    : existing;
+  if (duplicates.length > 0) {
     return {
       ok: false,
       reason: `${email} is already enrolled in this sequence.`,
@@ -182,15 +186,12 @@ export function checkAllPreSend(
   enrollment: SequenceEnrollment,
   stepDelaySec: number,
 ): GuardrailResult {
-  // checkDuplicateEnrollment is intentionally excluded here — it's an
-  // enrollment-time guard, not a per-step guard. During step processing the
-  // current enrollment is still status='active', so it would always find
-  // itself and block every step.
   const checks: GuardrailResult[] = [
     checkDailyCap(),
     checkHourlyRate(sequenceId),
     checkMinDelay(stepDelaySec),
     checkEnrollmentCap(sequenceId),
+    checkDuplicateEnrollment(sequenceId, enrollment.contactEmail, enrollment.id),
     checkCooldown(sequenceId, enrollment.contactEmail),
   ];
 


### PR DESCRIPTION
Addresses review feedback from PR #8754:

PR #8754 removed checkDuplicateEnrollment from checkAllPreSend because the current enrollment (still active) would always find itself and block every step. But removing the check entirely disabled duplicate protection.

This fix restores the check but modifies it to exclude the current enrollment's own record, so it only catches genuinely duplicate enrollments for the same contact.

Original prompt: Address the feedback on #8754
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
