### PR TITLE
fix: add im:write to Slack user_scope and fix non-interactive OAuth redirect

### DIFF
--- a/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/slack-oauth-setup/SKILL.md
@@ -123,7 +123,7 @@ client_secret: "<the extracted Client Secret>"
 auth_url: "https://slack.com/oauth/v2/authorize"
 token_url: "https://slack.com/api/oauth.v2.access"
 scopes: ["channels:read", "channels:history", "groups:read", "groups:history", "im:read", "im:history", "im:write", "mpim:read", "mpim:history", "users:read", "chat:write", "search:read", "reactions:write"]
-extra_params: {"user_scope": "channels:read,channels:history,groups:read,groups:history,im:read,im:history,mpim:read,mpim:history,users:read,chat:write,search:read,reactions:write"}
+extra_params: {"user_scope": "channels:read,channels:history,groups:read,groups:history,im:read,im:history,im:write,mpim:read,mpim:history,users:read,chat:write,search:read,reactions:write"}
 ```
 
 This will open the Slack authorization page in the user's browser. Wait for the flow to complete.

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -366,11 +366,24 @@ export interface OAuth2PreparedFlow {
  * the URL or blocking. Used by channel sessions where the LLM sends the auth
  * URL directly in chat and the callback arrives asynchronously via the gateway.
  *
- * Requires a public ingress URL (gateway transport).
+ * Supports two transports:
+ * - **gateway** (default): routes callbacks through the public ingress URL.
+ *   Requires `ingress.publicBaseUrl` to be configured.
+ * - **loopback**: starts a temporary localhost server to receive the callback.
+ *   Used for services like Slack that require pre-registered localhost redirect
+ *   URIs. The daemon is always local, so this works even in non-interactive
+ *   (channel) sessions.
  */
 export async function prepareOAuth2Flow(
   config: OAuth2Config,
+  options?: OAuth2FlowOptions,
 ): Promise<OAuth2PreparedFlow> {
+  const transport = options?.callbackTransport ?? 'gateway';
+
+  if (transport === 'loopback') {
+    return prepareLoopbackFlow(config, options?.loopbackPort);
+  }
+
   const { loadConfig } = await import('../config/loader.js');
   const { getOAuthCallbackUrl } = await import('../inbound/public-ingress-urls.js');
   const { registerPendingCallback } = await import('./oauth-callback-registry.js');
@@ -406,6 +419,140 @@ export async function prepareOAuth2Flow(
   log.debug({ transport: 'gateway', state }, 'Prepared deferred OAuth2 flow');
 
   return { authUrl, state, completion };
+}
+
+/**
+ * Prepare an OAuth2 flow using a loopback server. The server starts immediately
+ * and waits for the callback. The auth URL uses a localhost redirect URI
+ * matching the server's bound port.
+ */
+async function prepareLoopbackFlow(
+  config: OAuth2Config,
+  loopbackPort?: number,
+): Promise<OAuth2PreparedFlow> {
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = generateCodeChallenge(codeVerifier);
+  const state = generateState();
+
+  const { redirectUri, codePromise } = await startLoopbackServerForPreparedFlow(
+    state, loopbackPort,
+  );
+
+  const authParams = new URLSearchParams({
+    ...config.extraParams,
+    client_id: config.clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    scope: config.scopes.join(' '),
+    state,
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
+  });
+
+  const authUrl = `${config.authUrl}?${authParams}`;
+
+  const completion = codePromise.then(async (code) => {
+    return await exchangeCodeForTokens(config, code, redirectUri, codeVerifier);
+  });
+
+  log.debug({ transport: 'loopback', loopbackPort, state }, 'Prepared deferred OAuth2 flow (loopback)');
+
+  return { authUrl, state, completion };
+}
+
+/**
+ * Start a loopback server and return the redirect URI and a promise that
+ * resolves with the authorization code. Unlike startLoopbackServerAndWaitForCode,
+ * this does not open the browser — the caller is responsible for delivering
+ * the auth URL to the user.
+ */
+function startLoopbackServerForPreparedFlow(
+  state: string,
+  loopbackPort?: number,
+): Promise<{ redirectUri: string; codePromise: Promise<string> }> {
+  return new Promise((resolveSetup, rejectSetup) => {
+    let settled = false;
+    let codeResolve: (code: string) => void;
+    let codeReject: (err: Error) => void;
+    const codePromise = new Promise<string>((resolve, reject) => {
+      codeResolve = resolve;
+      codeReject = reject;
+    });
+
+    const server: Server = createServer((req, res) => {
+      if (settled) {
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end(renderLoopbackPage('Authorization already completed', false));
+        return;
+      }
+
+      const url = new URL(req.url ?? '/', `http://127.0.0.1`);
+
+      if (url.pathname !== LOOPBACK_CALLBACK_PATH) {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Not found');
+        return;
+      }
+
+      const callbackState = url.searchParams.get('state');
+      const code = url.searchParams.get('code');
+      const error = url.searchParams.get('error');
+
+      if (callbackState !== state) {
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end(renderLoopbackPage('Invalid state parameter', false));
+        return;
+      }
+
+      settled = true;
+
+      if (error) {
+        const errorDesc = url.searchParams.get('error_description') ?? error;
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(renderLoopbackPage(`Authorization failed: ${errorDesc}`, false));
+        cleanup();
+        codeReject(new Error(`OAuth2 authorization denied: ${error}`));
+        return;
+      }
+
+      if (!code) {
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end(renderLoopbackPage('Missing authorization code', false));
+        cleanup();
+        codeReject(new Error('OAuth2 callback missing authorization code'));
+        return;
+      }
+
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(renderLoopbackPage('Authorization successful! You can close this tab.', true));
+      cleanup();
+      codeResolve(code);
+    });
+
+    const timeout = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        cleanup();
+        codeReject(new Error('OAuth2 loopback callback timed out'));
+      }
+    }, LOOPBACK_TIMEOUT_MS);
+    if (typeof timeout === 'object' && 'unref' in timeout) timeout.unref();
+
+    function cleanup() {
+      clearTimeout(timeout);
+      server.close();
+    }
+
+    server.listen(loopbackPort ?? 0, '127.0.0.1', () => {
+      const addr = server.address() as { port: number };
+      const redirectUri = `http://127.0.0.1:${addr.port}${LOOPBACK_CALLBACK_PATH}`;
+      resolveSetup({ redirectUri, codePromise });
+    });
+
+    server.on('error', (err) => {
+      rejectSetup(new Error(`OAuth2 loopback server error: ${err.message}`));
+    });
+  });
 }
 
 /**

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -87,7 +87,7 @@ const WELL_KNOWN_OAUTH: Record<string, WellKnownOAuthConfig> = {
       'search:read', 'reactions:write',
     ],
     extraParams: {
-      user_scope: 'channels:read,channels:history,groups:read,groups:history,im:read,im:history,mpim:read,mpim:history,users:read,chat:write,search:read,reactions:write',
+      user_scope: 'channels:read,channels:history,groups:read,groups:history,im:read,im:history,im:write,mpim:read,mpim:history,users:read,chat:write,search:read,reactions:write',
     },
     callbackTransport: 'loopback',
     loopbackPort: 17322,
@@ -705,18 +705,29 @@ class CredentialStoreTool implements Tool {
           // Channel path: return the auth URL as text for the user to open manually.
           // Token storage happens asynchronously when the callback arrives.
           try {
-            const { loadConfig } = await import('../../config/loader.js');
-            const { getPublicBaseUrl } = await import('../../inbound/public-ingress-urls.js');
-            try {
-              getPublicBaseUrl(loadConfig());
-            } catch {
-              return {
-                content: 'Error: oauth2_connect from a non-interactive session requires a public ingress URL. Configure ingress.publicBaseUrl first.',
-                isError: true,
-              };
+            const callbackTransport = wellKnown?.callbackTransport ?? 'gateway';
+
+            // Gateway transport needs a public ingress URL; loopback runs locally
+            // on the daemon so it works regardless of ingress configuration.
+            if (callbackTransport !== 'loopback') {
+              const { loadConfig } = await import('../../config/loader.js');
+              const { getPublicBaseUrl } = await import('../../inbound/public-ingress-urls.js');
+              try {
+                getPublicBaseUrl(loadConfig());
+              } catch {
+                return {
+                  content: 'Error: oauth2_connect from a non-interactive session requires a public ingress URL. Configure ingress.publicBaseUrl first.',
+                  isError: true,
+                };
+              }
             }
 
-            const prepared = await prepareOAuth2Flow(oauthConfig);
+            const prepared = await prepareOAuth2Flow(
+              oauthConfig,
+              callbackTransport === 'loopback'
+                ? { callbackTransport, loopbackPort: wellKnown?.loopbackPort }
+                : undefined,
+            );
 
             // Fire-and-forget: when the callback arrives, store tokens in the background
             prepared.completion.then(async (result) => {

--- a/skills/slack-oauth-setup/SKILL.md
+++ b/skills/slack-oauth-setup/SKILL.md
@@ -123,7 +123,7 @@ client_secret: "<the extracted Client Secret>"
 auth_url: "https://slack.com/oauth/v2/authorize"
 token_url: "https://slack.com/api/oauth.v2.access"
 scopes: ["channels:read", "channels:history", "groups:read", "groups:history", "im:read", "im:history", "im:write", "mpim:read", "mpim:history", "users:read", "chat:write", "search:read", "reactions:write"]
-extra_params: {"user_scope": "channels:read,channels:history,groups:read,groups:history,im:read,im:history,mpim:read,mpim:history,users:read,chat:write,search:read,reactions:write"}
+extra_params: {"user_scope": "channels:read,channels:history,groups:read,groups:history,im:read,im:history,im:write,mpim:read,mpim:history,users:read,chat:write,search:read,reactions:write"}
 ```
 
 This will open the Slack authorization page in the user's browser. Wait for the flow to complete.


### PR DESCRIPTION
Addresses review feedback from PR #8753:

1. Added im:write to extra_params.user_scope in both copies of the Slack OAuth setup skill and in the well-known config in vault.ts. Without this, the user token wouldn't get DM write permission even though the scope was listed in the setup instructions.

2. Fixed non-interactive OAuth flow to respect loopback transport — when a service uses callbackTransport: 'loopback', prepareOAuth2Flow now uses the localhost redirect URI instead of the gateway callback URL. This prevents redirect URI mismatches for services like Slack that only allow localhost callbacks.

Original prompt: Address the feedback on #8753
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
