### PR TITLE
fix: filter empty string channel IDs in Slack watcher config normalization

### DIFF
--- a/assistant/src/watcher/providers/slack.ts
+++ b/assistant/src/watcher/providers/slack.ts
@@ -111,11 +111,13 @@ export const slackProvider: WatcherProvider = {
       // could provide a bare string instead of an array. Coerce to string[]
       // and filter out any non-string entries to prevent iterating characters.
       const rawChannels = slackConfig.channels;
-      const watchChannels: string[] = Array.isArray(rawChannels)
-        ? rawChannels.filter((ch): ch is string => typeof ch === 'string')
-        : typeof rawChannels === 'string'
-          ? [rawChannels]
-          : [];
+      const watchChannels: string[] = (
+        Array.isArray(rawChannels)
+          ? rawChannels.filter((ch): ch is string => typeof ch === 'string')
+          : typeof rawChannels === 'string'
+            ? [rawChannels]
+            : []
+      ).filter((ch) => ch.trim().length > 0);
 
       const includeDMs = typeof slackConfig.includeDMs === 'boolean' ? slackConfig.includeDMs : true;
 


### PR DESCRIPTION
Addresses Codex review feedback on #8758. When channels config is an empty string, the coercion produced [""] instead of treating it as unset. This caused watchChannels.length > 0, skipping legacy mention polling and attempting to poll an invalid channel ID. Fix: filter out empty/whitespace-only strings after coercion.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
