### PR TITLE
feat: invalidate assistant-inferred memory on task/schedule failure

### DIFF
--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -1,6 +1,7 @@
 import { getLogger } from '../util/logger.js';
 import { createConversation } from '../memory/conversation-store.js';
 import { GENERATING_TITLE, queueGenerateConversationTitle } from '../memory/conversation-title-service.js';
+import { invalidateAssistantInferredItemsForConversation } from '../memory/task-memory-cleanup.js';
 import {
   claimDueSchedules,
   createScheduleRun,
@@ -134,6 +135,12 @@ async function runScheduleOnce(
       const message = err instanceof Error ? err.message : String(err);
       log.warn({ err, jobId: job.id, name: job.name, syntax: job.syntax, expression: job.expression, isRruleSet: isRruleSetMsg }, 'Schedule execution failed');
       completeScheduleRun(runId, { status: 'error', error: message });
+
+      try {
+        invalidateAssistantInferredItemsForConversation(conversation.id);
+      } catch (cleanupErr) {
+        log.warn({ err: cleanupErr, conversationId: conversation.id }, 'Failed to invalidate assistant-inferred memory items');
+      }
     }
   }
 

--- a/assistant/src/tasks/task-runner.ts
+++ b/assistant/src/tasks/task-runner.ts
@@ -1,6 +1,7 @@
 import { getLogger } from '../util/logger.js';
 import { createConversation } from '../memory/conversation-store.js';
 import { GENERATING_TITLE, queueGenerateConversationTitle } from '../memory/conversation-title-service.js';
+import { invalidateAssistantInferredItemsForConversation } from '../memory/task-memory-cleanup.js';
 import { getTask, createTaskRun, updateTaskRun } from './task-store.js';
 import { buildTaskRules, setTaskRunRules, clearTaskRunRules } from './ephemeral-permissions.js';
 import { sanitizeToolList } from './tool-sanitizer.js';
@@ -82,6 +83,12 @@ export async function runTask(
     log.warn({ err, taskId: task.id, taskRunId: run.id }, 'Task execution failed');
 
     updateTaskRun(run.id, { status: 'failed', error: errorMessage, finishedAt: Date.now() });
+
+    try {
+      invalidateAssistantInferredItemsForConversation(conversation.id);
+    } catch (cleanupErr) {
+      log.warn({ err: cleanupErr, conversationId: conversation.id }, 'Failed to invalidate assistant-inferred memory items');
+    }
 
     return {
       taskRunId: run.id,


### PR DESCRIPTION
## Summary
- Wire `invalidateAssistantInferredItemsForConversation` into `scheduler.ts` catch block for failed schedule executions
- Wire it into `task-runner.ts` catch block for failed task runs
- Both call sites wrap cleanup in try/catch to avoid masking the original error

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] Cleanup utility already tested in PR #8763
- [ ] Manual verification: create a schedule that fails, confirm `assistant_inferred` items are invalidated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
