### PR TITLE
fix: align oauth2_connect service resolution with describe fallback

### DIFF
--- a/assistant/src/__tests__/task-memory-cleanup.test.ts
+++ b/assistant/src/__tests__/task-memory-cleanup.test.ts
@@ -1,0 +1,244 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { eq } from 'drizzle-orm';
+
+import { DEFAULT_CONFIG } from '../config/defaults.js';
+
+const testDir = mkdtempSync(join(tmpdir(), 'task-memory-cleanup-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../memory/qdrant-client.js', () => ({
+  getQdrantClient: () => ({
+    searchWithFilter: async () => [],
+    upsertPoints: async () => {},
+    deletePoints: async () => {},
+  }),
+  initQdrantClient: () => {},
+}));
+
+const TEST_CONFIG = {
+  ...DEFAULT_CONFIG,
+  memory: {
+    ...DEFAULT_CONFIG.memory,
+    extraction: {
+      ...DEFAULT_CONFIG.memory.extraction,
+      useLLM: false,
+    },
+  },
+};
+
+mock.module('../config/loader.js', () => ({
+  loadConfig: () => TEST_CONFIG,
+  getConfig: () => TEST_CONFIG,
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { conversations, memoryItems, memoryItemSources, messages } from '../memory/schema.js';
+import { invalidateAssistantInferredItemsForConversation } from '../memory/task-memory-cleanup.js';
+
+describe('invalidateAssistantInferredItemsForConversation', () => {
+  const now = 1_701_100_000_000;
+  const convId = 'conv-task-cleanup';
+  const otherConvId = 'conv-other';
+
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM memory_item_sources');
+    db.run('DELETE FROM memory_items');
+    db.run('DELETE FROM messages');
+    db.run('DELETE FROM conversations');
+  });
+
+  afterAll(() => {
+    resetDb();
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      // best effort
+    }
+  });
+
+  function seedConversations() {
+    const db = getDb();
+    for (const id of [convId, otherConvId]) {
+      db.insert(conversations).values({
+        id,
+        title: null,
+        createdAt: now,
+        updatedAt: now,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalEstimatedCost: 0,
+        contextSummary: null,
+        contextCompactedMessageCount: 0,
+        contextCompactedAt: null,
+      }).run();
+    }
+  }
+
+  function seedMessages() {
+    const db = getDb();
+    db.insert(messages).values([
+      { id: 'msg-task-1', conversationId: convId, role: 'assistant', content: '[]', createdAt: now + 10 },
+      { id: 'msg-task-2', conversationId: convId, role: 'user', content: '[]', createdAt: now + 20 },
+      { id: 'msg-other', conversationId: otherConvId, role: 'assistant', content: '[]', createdAt: now + 30 },
+    ]).run();
+  }
+
+  function seedMemoryItems() {
+    const db = getDb();
+    db.insert(memoryItems).values([
+      {
+        id: 'item-assistant-inferred',
+        kind: 'fact',
+        subject: 'DMV appointment',
+        statement: 'Booked a DMV appointment at 9 AM.',
+        status: 'active',
+        confidence: 0.8,
+        importance: 0.7,
+        fingerprint: 'fp-assistant-inferred',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now + 10,
+        lastSeenAt: now + 10,
+      },
+      {
+        id: 'item-user-reported',
+        kind: 'preference',
+        subject: 'notification pref',
+        statement: 'User prefers email notifications.',
+        status: 'active',
+        confidence: 0.9,
+        importance: 0.8,
+        fingerprint: 'fp-user-reported',
+        verificationState: 'user_reported',
+        scopeId: 'default',
+        firstSeenAt: now + 20,
+        lastSeenAt: now + 20,
+      },
+      {
+        id: 'item-other-conv',
+        kind: 'fact',
+        subject: 'weather check',
+        statement: 'Checked weather for tomorrow.',
+        status: 'active',
+        confidence: 0.7,
+        importance: 0.5,
+        fingerprint: 'fp-other-conv',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now + 30,
+        lastSeenAt: now + 30,
+      },
+      {
+        id: 'item-already-superseded',
+        kind: 'fact',
+        subject: 'old claim',
+        statement: 'Old assistant claim already superseded.',
+        status: 'superseded',
+        confidence: 0.6,
+        importance: 0.4,
+        fingerprint: 'fp-already-superseded',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now + 5,
+        lastSeenAt: now + 5,
+      },
+    ]).run();
+
+    db.insert(memoryItemSources).values([
+      { memoryItemId: 'item-assistant-inferred', messageId: 'msg-task-1', evidence: 'booking claim', createdAt: now + 10 },
+      { memoryItemId: 'item-user-reported', messageId: 'msg-task-2', evidence: 'user stated', createdAt: now + 20 },
+      { memoryItemId: 'item-other-conv', messageId: 'msg-other', evidence: 'weather', createdAt: now + 30 },
+      { memoryItemId: 'item-already-superseded', messageId: 'msg-task-1', evidence: 'old claim', createdAt: now + 5 },
+    ]).run();
+  }
+
+  test('only invalidates assistant_inferred items, not user_reported', () => {
+    seedConversations();
+    seedMessages();
+    seedMemoryItems();
+
+    const affected = invalidateAssistantInferredItemsForConversation(convId);
+
+    expect(affected).toBe(1);
+
+    const db = getDb();
+    const assistantItem = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-assistant-inferred')).get();
+    expect(assistantItem?.status).toBe('invalidated');
+    expect(assistantItem?.invalidAt).not.toBeNull();
+
+    const userItem = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-user-reported')).get();
+    expect(userItem?.status).toBe('active');
+    expect(userItem?.invalidAt).toBeNull();
+  });
+
+  test('does not affect items from other conversations', () => {
+    seedConversations();
+    seedMessages();
+    seedMemoryItems();
+
+    invalidateAssistantInferredItemsForConversation(convId);
+
+    const db = getDb();
+    const otherItem = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-other-conv')).get();
+    expect(otherItem?.status).toBe('active');
+    expect(otherItem?.invalidAt).toBeNull();
+  });
+
+  test('does not affect already-superseded items', () => {
+    seedConversations();
+    seedMessages();
+    seedMemoryItems();
+
+    invalidateAssistantInferredItemsForConversation(convId);
+
+    const db = getDb();
+    const supersededItem = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-already-superseded')).get();
+    expect(supersededItem?.status).toBe('superseded');
+  });
+
+  test('returns 0 when no matching items exist', () => {
+    seedConversations();
+    seedMessages();
+    // No memory items seeded
+
+    const affected = invalidateAssistantInferredItemsForConversation(convId);
+    expect(affected).toBe(0);
+  });
+
+  test('returns 0 for unknown conversation', () => {
+    seedConversations();
+    seedMessages();
+    seedMemoryItems();
+
+    const affected = invalidateAssistantInferredItemsForConversation('conv-nonexistent');
+    expect(affected).toBe(0);
+  });
+});

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -99,6 +99,7 @@ For each item, provide:
 Rules:
 - Only extract genuinely memorable information. Skip pleasantries, filler, and transient discussion.
 - Do NOT extract information about what tools the assistant used or what files it read — only extract substantive facts about the user, their projects, and their preferences.
+- Do NOT extract claims about actions the assistant performed, outcomes it achieved, or progress it reported (e.g., "I booked an appointment", "I sent the email"). Only extract facts stated by the user or from external sources — the assistant's self-reports are not reliable memory material.
 - Prefer fewer high-quality items over many low-quality ones.
 - If the message contains no memorable information, return an empty array.`;
 

--- a/assistant/src/memory/task-memory-cleanup.ts
+++ b/assistant/src/memory/task-memory-cleanup.ts
@@ -1,0 +1,36 @@
+import { getLogger } from '../util/logger.js';
+import { rawRun } from './raw-query.js';
+import { bumpMemoryVersion } from './recall-cache.js';
+
+const log = getLogger('task-memory-cleanup');
+
+/**
+ * Invalidate all `assistant_inferred` memory items sourced from messages
+ * in the given conversation. Called when a background task or schedule
+ * fails — the assistant's optimistic claims (e.g., "I booked an
+ * appointment") are not trustworthy if the task didn't complete.
+ */
+export function invalidateAssistantInferredItemsForConversation(conversationId: string): number {
+  const affected = rawRun(
+    `UPDATE memory_items
+        SET status = 'invalidated',
+            invalid_at = ?
+      WHERE verification_state = 'assistant_inferred'
+        AND status = 'active'
+        AND id IN (
+          SELECT mis.memory_item_id
+            FROM memory_item_sources mis
+            JOIN messages m ON m.id = mis.message_id
+           WHERE m.conversation_id = ?
+        )`,
+    Date.now(),
+    conversationId,
+  );
+
+  if (affected > 0) {
+    bumpMemoryVersion();
+    log.info({ conversationId, affected }, 'Invalidated assistant-inferred memory items after task failure');
+  }
+
+  return affected;
+}

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -122,9 +122,12 @@ const SERVICE_ALIASES: Record<string, string> = {
   notion: 'integration:notion',
 };
 
-/** Resolve a service name through aliases. */
+/** Resolve a service name through aliases, then fall back to integration: prefix
+ *  for providers registered in WELL_KNOWN_OAUTH without a SERVICE_ALIASES entry. */
 function resolveService(service: string): string {
-  return SERVICE_ALIASES[service] ?? service;
+  if (SERVICE_ALIASES[service]) return SERVICE_ALIASES[service];
+  if (!service.includes(':') && WELL_KNOWN_OAUTH[`integration:${service}`]) return `integration:${service}`;
+  return service;
 }
 
 /**
@@ -787,17 +790,11 @@ class CredentialStoreTool implements Tool {
 
       case 'describe': {
         const rawService = (input.service as string | undefined) ?? '';
-        const service = SERVICE_ALIASES[rawService] ?? rawService;
-        if (!service) {
+        if (!rawService) {
           return { content: 'Error: service is required for describe action', isError: true };
         }
-        // Try direct lookup, then fall back to integration: prefix for
-        // newly added providers that may not have a SERVICE_ALIASES entry yet.
-        const wellKnown = WELL_KNOWN_OAUTH[service]
-          ?? (!service.includes(':') ? WELL_KNOWN_OAUTH[`integration:${service}`] : undefined);
-        const resolvedService = WELL_KNOWN_OAUTH[service] ? service
-          : (!service.includes(':') && WELL_KNOWN_OAUTH[`integration:${service}`]) ? `integration:${service}`
-            : service;
+        const resolvedService = resolveService(rawService);
+        const wellKnown = WELL_KNOWN_OAUTH[resolvedService];
         if (!wellKnown) {
           return { content: `No well-known OAuth config found for "${rawService}". Available services: ${Object.keys(SERVICE_ALIASES).join(', ')}`, isError: false };
         }


### PR DESCRIPTION
Adds the same integration: prefix fallback to oauth2_connect that was added to describe in PR #8761, ensuring both actions resolve shorthand service names consistently. Without this fix, describe could report a service as supported while oauth2_connect would fail to resolve the same shorthand.

The fix centralizes the fallback logic in resolveService() so both actions share the same resolution path, and simplifies the describe action to use resolveService() instead of inline resolution.

Addresses review feedback from PR #8761.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
