### PR TITLE
feat: add integration status probing for schedule creation

### DIFF
--- a/assistant/src/__tests__/integration-status.test.ts
+++ b/assistant/src/__tests__/integration-status.test.ts
@@ -1,0 +1,101 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+const secureKeyValues = new Map<string, string>();
+
+mock.module('../security/secure-keys.js', () => ({
+  getSecureKey: (account: string) => secureKeyValues.get(account),
+}));
+
+const { getIntegrationSummary, formatIntegrationSummary, hasCapability } = await import(
+  '../schedule/integration-status.js'
+);
+
+describe('integration-status', () => {
+  beforeEach(() => {
+    secureKeyValues.clear();
+  });
+
+  describe('getIntegrationSummary', () => {
+    test('returns all disconnected when no keys are set', () => {
+      const summary = getIntegrationSummary();
+      expect(summary).toEqual([
+        { name: 'Gmail', category: 'email', connected: false },
+        { name: 'Twitter', category: 'social', connected: false },
+        { name: 'Slack', category: 'messaging', connected: false },
+        { name: 'SMS', category: 'messaging', connected: false },
+        { name: 'Telegram', category: 'messaging', connected: false },
+      ]);
+    });
+
+    test('returns all connected when all keys are set', () => {
+      secureKeyValues.set('credential:integration:gmail:access_token', 'tok');
+      secureKeyValues.set('credential:integration:twitter:access_token', 'tok');
+      secureKeyValues.set('credential:integration:slack:access_token', 'tok');
+      secureKeyValues.set('credential:twilio:account_sid', 'sid');
+      secureKeyValues.set('credential:telegram:bot_token', 'tok');
+
+      const summary = getIntegrationSummary();
+      expect(summary.every((s: { connected: boolean }) => s.connected)).toBe(true);
+    });
+
+    test('returns mixed status', () => {
+      secureKeyValues.set('credential:twilio:account_sid', 'sid');
+      secureKeyValues.set('credential:telegram:bot_token', 'tok');
+
+      const summary = getIntegrationSummary();
+      const connected = summary.filter((s: { connected: boolean }) => s.connected);
+      const disconnected = summary.filter((s: { connected: boolean }) => !s.connected);
+
+      expect(connected.map((s: { name: string }) => s.name)).toEqual(['SMS', 'Telegram']);
+      expect(disconnected.map((s: { name: string }) => s.name)).toEqual(['Gmail', 'Twitter', 'Slack']);
+    });
+  });
+
+  describe('formatIntegrationSummary', () => {
+    test('shows checkmarks and crosses', () => {
+      secureKeyValues.set('credential:twilio:account_sid', 'sid');
+      secureKeyValues.set('credential:telegram:bot_token', 'tok');
+
+      const result = formatIntegrationSummary();
+      expect(result).toBe('Gmail \u2717 | Twitter \u2717 | Slack \u2717 | SMS \u2713 | Telegram \u2713');
+    });
+
+    test('all disconnected', () => {
+      const result = formatIntegrationSummary();
+      expect(result).toBe('Gmail \u2717 | Twitter \u2717 | Slack \u2717 | SMS \u2717 | Telegram \u2717');
+    });
+
+    test('all connected', () => {
+      secureKeyValues.set('credential:integration:gmail:access_token', 'tok');
+      secureKeyValues.set('credential:integration:twitter:access_token', 'tok');
+      secureKeyValues.set('credential:integration:slack:access_token', 'tok');
+      secureKeyValues.set('credential:twilio:account_sid', 'sid');
+      secureKeyValues.set('credential:telegram:bot_token', 'tok');
+
+      const result = formatIntegrationSummary();
+      expect(result).toBe('Gmail \u2713 | Twitter \u2713 | Slack \u2713 | SMS \u2713 | Telegram \u2713');
+    });
+  });
+
+  describe('hasCapability', () => {
+    test('returns false when no integrations in category are connected', () => {
+      expect(hasCapability('email')).toBe(false);
+      expect(hasCapability('social')).toBe(false);
+      expect(hasCapability('messaging')).toBe(false);
+    });
+
+    test('returns true when any integration in category is connected', () => {
+      secureKeyValues.set('credential:telegram:bot_token', 'tok');
+      expect(hasCapability('messaging')).toBe(true);
+    });
+
+    test('returns false for unknown categories', () => {
+      expect(hasCapability('nonexistent')).toBe(false);
+    });
+
+    test('email category checks Gmail', () => {
+      secureKeyValues.set('credential:integration:gmail:access_token', 'tok');
+      expect(hasCapability('email')).toBe(true);
+    });
+  });
+});

--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -72,3 +72,20 @@ Use `syntax` + `expression` to specify the schedule type explicitly, or just `ex
 - Only use `schedule_create` when the user explicitly wants recurring automation (e.g. "every day at 9am", "weekly on Mondays"). For one-time tasks, use the task list instead.
 - Timezones default to the system timezone if omitted. Use IANA timezone identifiers (e.g. "America/Los_Angeles").
 - Prefer RRULE for complex patterns that cron cannot express (e.g. "every other Tuesday", "last weekday of the month").
+
+## Capability Preflight
+
+Before confirming a schedule to the user, you MUST verify that you have the capabilities needed to execute the scheduled message autonomously. Scheduled messages run without user interaction — if a required integration is missing, the schedule will fail silently.
+
+When `schedule_create` returns, it includes an integration status summary. Cross-reference the scheduled task's requirements against the available integrations:
+
+- If the task involves **email** (reading, sending, OTP verification): an email integration must be connected (check the "email" category)
+- If the task involves **tweeting or reading Twitter**: Twitter must be connected
+- If the task involves **sending SMS or making calls**: SMS/Twilio must be connected
+- If the task involves **web browsing or form-filling**: browser automation must be available (check client type)
+- If the task involves a **multi-step workflow** (e.g., book appointment → read confirmation email), trace the full dependency chain
+
+If any required capability is missing:
+1. **Do NOT tell the user the schedule is ready** — instead, explain what's missing and why the schedule won't work yet
+2. Offer to help set up the missing integration first
+3. The schedule is still created (so timing is preserved), but make it clear it won't execute successfully until dependencies are resolved

--- a/assistant/src/schedule/integration-status.ts
+++ b/assistant/src/schedule/integration-status.ts
@@ -1,0 +1,33 @@
+import { getSecureKey } from '../security/secure-keys.js';
+
+interface IntegrationProbe {
+  name: string;
+  category: string;
+  isConnected: () => boolean;
+}
+
+// Registry — add new integrations here:
+const INTEGRATION_PROBES: IntegrationProbe[] = [
+  { name: 'Gmail', category: 'email', isConnected: () => !!getSecureKey('credential:integration:gmail:access_token') },
+  { name: 'Twitter', category: 'social', isConnected: () => !!getSecureKey('credential:integration:twitter:access_token') },
+  { name: 'Slack', category: 'messaging', isConnected: () => !!getSecureKey('credential:integration:slack:access_token') },
+  { name: 'SMS', category: 'messaging', isConnected: () => !!getSecureKey('credential:twilio:account_sid') },
+  { name: 'Telegram', category: 'messaging', isConnected: () => !!getSecureKey('credential:telegram:bot_token') },
+];
+
+export function getIntegrationSummary(): Array<{ name: string; category: string; connected: boolean }> {
+  return INTEGRATION_PROBES.map((probe) => ({
+    name: probe.name,
+    category: probe.category,
+    connected: probe.isConnected(),
+  }));
+}
+
+export function formatIntegrationSummary(): string {
+  const summary = getIntegrationSummary();
+  return summary.map((s) => `${s.name} ${s.connected ? '\u2713' : '\u2717'}`).join(' | ');
+}
+
+export function hasCapability(category: string): boolean {
+  return INTEGRATION_PROBES.some((probe) => probe.category === category && probe.isConnected());
+}

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -2,6 +2,7 @@ import type { ToolContext, ToolExecutionResult } from '../types.js';
 import { createSchedule, isValidCronExpression, formatLocalDate, describeCronExpression } from '../../schedule/schedule-store.js';
 import { normalizeScheduleSyntax } from '../../schedule/recurrence-types.js';
 import { validateRruleSetLines } from '../../schedule/recurrence-engine.js';
+import { formatIntegrationSummary } from '../../schedule/integration-status.js';
 
 export async function executeScheduleCreate(
   input: Record<string, unknown>,
@@ -63,6 +64,7 @@ export async function executeScheduleCreate(
       : describeCronExpression(job.cronExpression);
 
     const nextRunDate = formatLocalDate(job.nextRunAt);
+    const integrations = formatIntegrationSummary();
     return {
       content: [
         `Schedule created successfully.`,
@@ -72,6 +74,9 @@ export async function executeScheduleCreate(
         `  Schedule: ${scheduleDescription}${job.timezone ? ` (${job.timezone})` : ''}`,
         `  Enabled: ${job.enabled}`,
         `  Next run: ${nextRunDate}`,
+        ``,
+        `Integrations: ${integrations}`,
+        `\u26a0 If this schedule requires an integration that isn't connected, it will fail at runtime. Warn the user about any missing capabilities before confirming the schedule is ready.`,
       ].join('\n'),
       isError: false,
     };


### PR DESCRIPTION
## Summary
- Add `integration-status.ts` with probes for Gmail, Twitter, Slack, SMS, and Telegram — checks secure key presence
- Surface integration summary (connected/disconnected) in `schedule_create` tool output
- Add capability preflight section to schedule skill docs so the assistant warns users about missing integrations
- Full test coverage (10 tests) for summary, formatting, and category-level capability checks

## Test plan
- [x] `bun test src/__tests__/integration-status.test.ts` passes (10/10)
- [x] `bunx tsc --noEmit` passes
- [ ] Manual: create a schedule requiring email, verify warning about disconnected Gmail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
