### PR TITLE
fix: don't default to Gmail when user says 'manage my email'

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -66,6 +66,7 @@ The sms-setup skill also includes optional **guardian verification** for SMS (in
 - If the user specifies a platform (e.g., "check my Slack"), pass it as the `platform` parameter.
 - If only one platform is connected, it is auto-selected.
 - If multiple platforms are connected and the user doesn't specify, ask which platform they mean — or search across all of them.
+- **Do not assume a specific provider.** When the user says "email" or "manage my email" without naming a provider, call `messaging_auth_test` for each email-capable platform to discover what's connected — don't default to Gmail or any other specific provider. Present whatever is connected; if nothing is, ask the user which email service they use and offer to set it up.
 
 ## Capabilities
 


### PR DESCRIPTION
## Summary
- Added explicit guidance to the Messaging skill's Platform Selection section to not assume Gmail (or any specific provider) when the user mentions "email" generically
- The model should discover connected providers first via `messaging_auth_test`, then present options or offer setup

## Context
When a user says "lets manage my email", the assistant was immediately checking Gmail connectivity instead of discovering what email platforms are connected. The code logic (`resolveProvider()`) is actually platform-neutral, but the skill documentation is heavily Gmail-centric (18 Gmail-specific tools, detailed Gmail workflow guides), causing the model to infer email = Gmail.

## Test plan
- [ ] Send "lets manage my email" to the assistant and verify it checks connected providers generically instead of jumping to Gmail
- [ ] Verify that if only Gmail is connected, it still works correctly (auto-selects)
- [ ] Verify that if no email provider is connected, it asks which service the user uses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
