### PR TITLE
fix: require full credential sets for SMS and Telegram probes

### DIFF
--- a/assistant/src/__tests__/integration-status.test.ts
+++ b/assistant/src/__tests__/integration-status.test.ts
@@ -32,7 +32,9 @@ describe('integration-status', () => {
       secureKeyValues.set('credential:integration:twitter:access_token', 'tok');
       secureKeyValues.set('credential:integration:slack:access_token', 'tok');
       secureKeyValues.set('credential:twilio:account_sid', 'sid');
+      secureKeyValues.set('credential:twilio:auth_token', 'auth');
       secureKeyValues.set('credential:telegram:bot_token', 'tok');
+      secureKeyValues.set('credential:telegram:webhook_secret', 'secret');
 
       const summary = getIntegrationSummary();
       expect(summary.every((s: { connected: boolean }) => s.connected)).toBe(true);
@@ -40,7 +42,9 @@ describe('integration-status', () => {
 
     test('returns mixed status', () => {
       secureKeyValues.set('credential:twilio:account_sid', 'sid');
+      secureKeyValues.set('credential:twilio:auth_token', 'auth');
       secureKeyValues.set('credential:telegram:bot_token', 'tok');
+      secureKeyValues.set('credential:telegram:webhook_secret', 'secret');
 
       const summary = getIntegrationSummary();
       const connected = summary.filter((s: { connected: boolean }) => s.connected);
@@ -49,12 +53,30 @@ describe('integration-status', () => {
       expect(connected.map((s: { name: string }) => s.name)).toEqual(['SMS', 'Telegram']);
       expect(disconnected.map((s: { name: string }) => s.name)).toEqual(['Gmail', 'Twitter', 'Slack']);
     });
+
+    test('SMS disconnected when only account_sid is set (missing auth_token)', () => {
+      secureKeyValues.set('credential:twilio:account_sid', 'sid');
+
+      const summary = getIntegrationSummary();
+      const sms = summary.find((s: { name: string }) => s.name === 'SMS');
+      expect(sms?.connected).toBe(false);
+    });
+
+    test('Telegram disconnected when only bot_token is set (missing webhook_secret)', () => {
+      secureKeyValues.set('credential:telegram:bot_token', 'tok');
+
+      const summary = getIntegrationSummary();
+      const telegram = summary.find((s: { name: string }) => s.name === 'Telegram');
+      expect(telegram?.connected).toBe(false);
+    });
   });
 
   describe('formatIntegrationSummary', () => {
     test('shows checkmarks and crosses', () => {
       secureKeyValues.set('credential:twilio:account_sid', 'sid');
+      secureKeyValues.set('credential:twilio:auth_token', 'auth');
       secureKeyValues.set('credential:telegram:bot_token', 'tok');
+      secureKeyValues.set('credential:telegram:webhook_secret', 'secret');
 
       const result = formatIntegrationSummary();
       expect(result).toBe('Gmail \u2717 | Twitter \u2717 | Slack \u2717 | SMS \u2713 | Telegram \u2713');
@@ -70,7 +92,9 @@ describe('integration-status', () => {
       secureKeyValues.set('credential:integration:twitter:access_token', 'tok');
       secureKeyValues.set('credential:integration:slack:access_token', 'tok');
       secureKeyValues.set('credential:twilio:account_sid', 'sid');
+      secureKeyValues.set('credential:twilio:auth_token', 'auth');
       secureKeyValues.set('credential:telegram:bot_token', 'tok');
+      secureKeyValues.set('credential:telegram:webhook_secret', 'secret');
 
       const result = formatIntegrationSummary();
       expect(result).toBe('Gmail \u2713 | Twitter \u2713 | Slack \u2713 | SMS \u2713 | Telegram \u2713');
@@ -86,7 +110,14 @@ describe('integration-status', () => {
 
     test('returns true when any integration in category is connected', () => {
       secureKeyValues.set('credential:telegram:bot_token', 'tok');
+      secureKeyValues.set('credential:telegram:webhook_secret', 'secret');
       expect(hasCapability('messaging')).toBe(true);
+    });
+
+    test('returns false when only partial credentials exist for category integrations', () => {
+      secureKeyValues.set('credential:telegram:bot_token', 'tok');
+      // Missing webhook_secret — Telegram should not count as connected
+      expect(hasCapability('messaging')).toBe(false);
     });
 
     test('returns false for unknown categories', () => {

--- a/assistant/src/schedule/integration-status.ts
+++ b/assistant/src/schedule/integration-status.ts
@@ -11,8 +11,8 @@ const INTEGRATION_PROBES: IntegrationProbe[] = [
   { name: 'Gmail', category: 'email', isConnected: () => !!getSecureKey('credential:integration:gmail:access_token') },
   { name: 'Twitter', category: 'social', isConnected: () => !!getSecureKey('credential:integration:twitter:access_token') },
   { name: 'Slack', category: 'messaging', isConnected: () => !!getSecureKey('credential:integration:slack:access_token') },
-  { name: 'SMS', category: 'messaging', isConnected: () => !!getSecureKey('credential:twilio:account_sid') },
-  { name: 'Telegram', category: 'messaging', isConnected: () => !!getSecureKey('credential:telegram:bot_token') },
+  { name: 'SMS', category: 'messaging', isConnected: () => !!getSecureKey('credential:twilio:account_sid') && !!getSecureKey('credential:twilio:auth_token') },
+  { name: 'Telegram', category: 'messaging', isConnected: () => !!getSecureKey('credential:telegram:bot_token') && !!getSecureKey('credential:telegram:webhook_secret') },
 ];
 
 export function getIntegrationSummary(): Array<{ name: string; category: string; connected: boolean }> {


### PR DESCRIPTION
Address Codex feedback on PR #8767: SMS probe now checks both account_sid and auth_token, Telegram probe checks both bot_token and webhook_secret, matching the actual runtime requirements.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
