### PR TITLE
fix: scope memory invalidation to items sourced only from failed conversation

### DIFF
--- a/assistant/src/__tests__/task-memory-cleanup.test.ts
+++ b/assistant/src/__tests__/task-memory-cleanup.test.ts
@@ -212,6 +212,31 @@ describe('invalidateAssistantInferredItemsForConversation', () => {
     expect(otherItem?.invalidAt).toBeNull();
   });
 
+  test('does not invalidate items also sourced from another conversation', () => {
+    seedConversations();
+    seedMessages();
+    seedMemoryItems();
+
+    // Add a second source from the other conversation to the assistant-inferred item.
+    // This simulates deduplication: the same fact was extracted from both conversations.
+    const db = getDb();
+    db.insert(memoryItemSources).values({
+      memoryItemId: 'item-assistant-inferred',
+      messageId: 'msg-other',
+      evidence: 'corroborating source from other conversation',
+      createdAt: now + 40,
+    }).run();
+
+    const affected = invalidateAssistantInferredItemsForConversation(convId);
+
+    // The item has sources from both conversations, so it should NOT be invalidated.
+    expect(affected).toBe(0);
+
+    const item = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-assistant-inferred')).get();
+    expect(item?.status).toBe('active');
+    expect(item?.invalidAt).toBeNull();
+  });
+
   test('does not affect already-superseded items', () => {
     seedConversations();
     seedMessages();

--- a/assistant/src/memory/task-memory-cleanup.ts
+++ b/assistant/src/memory/task-memory-cleanup.ts
@@ -5,10 +5,13 @@ import { bumpMemoryVersion } from './recall-cache.js';
 const log = getLogger('task-memory-cleanup');
 
 /**
- * Invalidate all `assistant_inferred` memory items sourced from messages
- * in the given conversation. Called when a background task or schedule
- * fails — the assistant's optimistic claims (e.g., "I booked an
+ * Invalidate `assistant_inferred` memory items sourced *exclusively* from
+ * messages in the given conversation. Called when a background task or
+ * schedule fails — the assistant's optimistic claims (e.g., "I booked an
  * appointment") are not trustworthy if the task didn't complete.
+ *
+ * Items that also have sources from other conversations are left alone
+ * because those other conversations still corroborate the claim.
  */
 export function invalidateAssistantInferredItemsForConversation(conversationId: string): number {
   const affected = rawRun(
@@ -22,8 +25,16 @@ export function invalidateAssistantInferredItemsForConversation(conversationId: 
             FROM memory_item_sources mis
             JOIN messages m ON m.id = mis.message_id
            WHERE m.conversation_id = ?
+        )
+        AND NOT EXISTS (
+          SELECT 1
+            FROM memory_item_sources mis2
+            JOIN messages m2 ON m2.id = mis2.message_id
+           WHERE mis2.memory_item_id = memory_items.id
+             AND m2.conversation_id != ?
         )`,
     Date.now(),
+    conversationId,
     conversationId,
   );
 


### PR DESCRIPTION
Address Codex feedback on PR #8766: prevent over-invalidation of memory items that have sources from other healthy conversations by adding a NOT EXISTS guard.

## Changes

- **`assistant/src/memory/task-memory-cleanup.ts`**: Added a `NOT EXISTS` subquery to the invalidation SQL so that memory items with sources from other conversations are preserved. Previously, any `assistant_inferred` item with at least one source in the failed conversation would be invalidated — even if it also had corroborating sources from other healthy conversations.

- **`assistant/src/__tests__/task-memory-cleanup.test.ts`**: Added a test case verifying that an `assistant_inferred` memory item with sources from both the failed conversation and another conversation is NOT invalidated.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
