### PR TITLE
fix: gate codeReject to post-startup errors in OAuth2 loopback

### DIFF
--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -472,6 +472,7 @@ function startLoopbackServerForPreparedFlow(
 ): Promise<{ redirectUri: string; codePromise: Promise<string> }> {
   return new Promise((resolveSetup, rejectSetup) => {
     let settled = false;
+    let listening = false;
     let codeResolve: (code: string) => void;
     let codeReject: (err: Error) => void;
     const codePromise = new Promise<string>((resolve, reject) => {
@@ -546,16 +547,23 @@ function startLoopbackServerForPreparedFlow(
     server.listen(loopbackPort ?? 0, '127.0.0.1', () => {
       const addr = server.address() as { port: number };
       const redirectUri = `http://127.0.0.1:${addr.port}${LOOPBACK_CALLBACK_PATH}`;
+      listening = true;
       resolveSetup({ redirectUri, codePromise });
     });
 
     server.on('error', (err) => {
-      if (!settled) {
+      const message = `OAuth2 loopback server error: ${err.message}`;
+      if (!listening) {
+        // Pre-startup error (e.g. port in use): resolveSetup was never called,
+        // so codePromise has no consumer — only reject the setup promise.
+        rejectSetup(new Error(message));
+      } else if (!settled) {
+        // Post-startup error: setup promise already resolved, reject codePromise
+        // so the caller waiting on it receives the error.
         settled = true;
         cleanup();
-        codeReject(new Error(`OAuth2 loopback server error: ${err.message}`));
+        codeReject(new Error(message));
       }
-      rejectSetup(new Error(`OAuth2 loopback server error: ${err.message}`));
     });
   });
 }


### PR DESCRIPTION
Address Codex+Devin feedback on PR #8765: distinguish pre-startup vs post-startup server errors to prevent unhandled promise rejection when codePromise has no consumer.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
