### PR TITLE
fix: settle and clean up on pre-startup loopback errors

### DIFF
--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -556,6 +556,8 @@ function startLoopbackServerForPreparedFlow(
       if (!listening) {
         // Pre-startup error (e.g. port in use): resolveSetup was never called,
         // so codePromise has no consumer — only reject the setup promise.
+        settled = true;
+        cleanup();
         rejectSetup(new Error(message));
       } else if (!settled) {
         // Post-startup error: setup promise already resolved, reject codePromise


### PR DESCRIPTION
When a pre-startup server error occurs (e.g. EADDRINUSE), the error handler now sets settled=true and calls cleanup() before rejecting the setup promise. This prevents the 5-minute timeout from firing and calling codeReject() on an unobserved codePromise, which would cause the unhandled promise rejection that PR #8771 was trying to fix.

Addresses review feedback from Codex and Devin on #8771.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
