### PR TITLE
fix: handle cascading conversation failures in memory invalidation

### DIFF
--- a/assistant/src/__tests__/task-memory-cleanup.test.ts
+++ b/assistant/src/__tests__/task-memory-cleanup.test.ts
@@ -55,7 +55,7 @@ mock.module('../config/loader.js', () => ({
 }));
 
 import { getDb, initializeDb, resetDb } from '../memory/db.js';
-import { conversations, memoryItems, memoryItemSources, messages } from '../memory/schema.js';
+import { conversations, cronJobs, cronRuns, memoryItems, memoryItemSources, messages, taskRuns, tasks } from '../memory/schema.js';
 import { invalidateAssistantInferredItemsForConversation } from '../memory/task-memory-cleanup.js';
 
 describe('invalidateAssistantInferredItemsForConversation', () => {
@@ -72,6 +72,10 @@ describe('invalidateAssistantInferredItemsForConversation', () => {
     db.run('DELETE FROM memory_item_sources');
     db.run('DELETE FROM memory_items');
     db.run('DELETE FROM messages');
+    db.run('DELETE FROM cron_runs');
+    db.run('DELETE FROM cron_jobs');
+    db.run('DELETE FROM task_runs');
+    db.run('DELETE FROM tasks');
     db.run('DELETE FROM conversations');
   });
 
@@ -265,5 +269,212 @@ describe('invalidateAssistantInferredItemsForConversation', () => {
 
     const affected = invalidateAssistantInferredItemsForConversation('conv-nonexistent');
     expect(affected).toBe(0);
+  });
+
+  test('invalidates items when corroborating conversation is also from a failed task run', () => {
+    const db = getDb();
+    const convA = 'conv-failed-task-a';
+    const convB = 'conv-failed-task-b';
+
+    // Create two conversations, each from a failed task run
+    for (const id of [convA, convB]) {
+      db.insert(conversations).values({
+        id,
+        title: null,
+        createdAt: now,
+        updatedAt: now,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalEstimatedCost: 0,
+        contextSummary: null,
+        contextCompactedMessageCount: 0,
+        contextCompactedAt: null,
+      }).run();
+    }
+
+    db.insert(messages).values([
+      { id: 'msg-a', conversationId: convA, role: 'assistant', content: '[]', createdAt: now + 10 },
+      { id: 'msg-b', conversationId: convB, role: 'assistant', content: '[]', createdAt: now + 20 },
+    ]).run();
+
+    // Both conversations are from failed task runs
+    db.insert(tasks).values({
+      id: 'task-1',
+      title: 'Test task',
+      template: 'template',
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+    }).run();
+
+    db.insert(taskRuns).values([
+      { id: 'run-a', taskId: 'task-1', conversationId: convA, status: 'failed', createdAt: now + 10 },
+      { id: 'run-b', taskId: 'task-1', conversationId: convB, status: 'failed', createdAt: now + 20 },
+    ]).run();
+
+    // A memory item sourced from both conversations
+    db.insert(memoryItems).values({
+      id: 'item-cross-sourced',
+      kind: 'fact',
+      subject: 'cross-sourced claim',
+      statement: 'Claim from two failed tasks.',
+      status: 'active',
+      confidence: 0.8,
+      importance: 0.7,
+      fingerprint: 'fp-cross-sourced',
+      verificationState: 'assistant_inferred',
+      scopeId: 'default',
+      firstSeenAt: now + 10,
+      lastSeenAt: now + 20,
+    }).run();
+
+    db.insert(memoryItemSources).values([
+      { memoryItemId: 'item-cross-sourced', messageId: 'msg-a', evidence: 'claim from A', createdAt: now + 10 },
+      { memoryItemId: 'item-cross-sourced', messageId: 'msg-b', evidence: 'claim from B', createdAt: now + 20 },
+    ]).run();
+
+    // Invalidating for convA should succeed because convB is also from a failed task
+    const affected = invalidateAssistantInferredItemsForConversation(convA);
+    expect(affected).toBe(1);
+
+    const item = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-cross-sourced')).get();
+    expect(item?.status).toBe('invalidated');
+    expect(item?.invalidAt).not.toBeNull();
+  });
+
+  test('invalidates items when corroborating conversation is from a failed schedule run', () => {
+    const db = getDb();
+    const convA = 'conv-failed-sched-a';
+    const convB = 'conv-failed-sched-b';
+
+    for (const id of [convA, convB]) {
+      db.insert(conversations).values({
+        id,
+        title: null,
+        createdAt: now,
+        updatedAt: now,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalEstimatedCost: 0,
+        contextSummary: null,
+        contextCompactedMessageCount: 0,
+        contextCompactedAt: null,
+      }).run();
+    }
+
+    db.insert(messages).values([
+      { id: 'msg-sched-a', conversationId: convA, role: 'assistant', content: '[]', createdAt: now + 10 },
+      { id: 'msg-sched-b', conversationId: convB, role: 'assistant', content: '[]', createdAt: now + 20 },
+    ]).run();
+
+    // Both conversations are from failed schedule runs
+    db.insert(cronJobs).values({
+      id: 'cron-1',
+      name: 'Test schedule',
+      cronExpression: '0 9 * * *',
+      message: 'test',
+      nextRunAt: now + 100_000,
+      createdBy: 'agent',
+      createdAt: now,
+      updatedAt: now,
+    }).run();
+
+    db.insert(cronRuns).values([
+      { id: 'cron-run-a', jobId: 'cron-1', status: 'error', conversationId: convA, startedAt: now + 10, createdAt: now + 10 },
+      { id: 'cron-run-b', jobId: 'cron-1', status: 'error', conversationId: convB, startedAt: now + 20, createdAt: now + 20 },
+    ]).run();
+
+    db.insert(memoryItems).values({
+      id: 'item-cross-sched',
+      kind: 'fact',
+      subject: 'cross-sourced schedule claim',
+      statement: 'Claim from two failed schedules.',
+      status: 'active',
+      confidence: 0.8,
+      importance: 0.7,
+      fingerprint: 'fp-cross-sched',
+      verificationState: 'assistant_inferred',
+      scopeId: 'default',
+      firstSeenAt: now + 10,
+      lastSeenAt: now + 20,
+    }).run();
+
+    db.insert(memoryItemSources).values([
+      { memoryItemId: 'item-cross-sched', messageId: 'msg-sched-a', evidence: 'claim from A', createdAt: now + 10 },
+      { memoryItemId: 'item-cross-sched', messageId: 'msg-sched-b', evidence: 'claim from B', createdAt: now + 20 },
+    ]).run();
+
+    const affected = invalidateAssistantInferredItemsForConversation(convA);
+    expect(affected).toBe(1);
+
+    const item = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-cross-sched')).get();
+    expect(item?.status).toBe('invalidated');
+  });
+
+  test('preserves items when corroborating conversation is from a successful task run', () => {
+    const db = getDb();
+    const convFailed = 'conv-failed-task';
+    const convSuccess = 'conv-success-task';
+
+    for (const id of [convFailed, convSuccess]) {
+      db.insert(conversations).values({
+        id,
+        title: null,
+        createdAt: now,
+        updatedAt: now,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalEstimatedCost: 0,
+        contextSummary: null,
+        contextCompactedMessageCount: 0,
+        contextCompactedAt: null,
+      }).run();
+    }
+
+    db.insert(messages).values([
+      { id: 'msg-failed', conversationId: convFailed, role: 'assistant', content: '[]', createdAt: now + 10 },
+      { id: 'msg-success', conversationId: convSuccess, role: 'assistant', content: '[]', createdAt: now + 20 },
+    ]).run();
+
+    db.insert(tasks).values({
+      id: 'task-2',
+      title: 'Test task 2',
+      template: 'template',
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+    }).run();
+
+    db.insert(taskRuns).values([
+      { id: 'run-failed', taskId: 'task-2', conversationId: convFailed, status: 'failed', createdAt: now + 10 },
+      { id: 'run-success', taskId: 'task-2', conversationId: convSuccess, status: 'completed', createdAt: now + 20 },
+    ]).run();
+
+    db.insert(memoryItems).values({
+      id: 'item-with-good-corroboration',
+      kind: 'fact',
+      subject: 'corroborated claim',
+      statement: 'Claim corroborated by successful task.',
+      status: 'active',
+      confidence: 0.8,
+      importance: 0.7,
+      fingerprint: 'fp-good-corroboration',
+      verificationState: 'assistant_inferred',
+      scopeId: 'default',
+      firstSeenAt: now + 10,
+      lastSeenAt: now + 20,
+    }).run();
+
+    db.insert(memoryItemSources).values([
+      { memoryItemId: 'item-with-good-corroboration', messageId: 'msg-failed', evidence: 'claim from failed', createdAt: now + 10 },
+      { memoryItemId: 'item-with-good-corroboration', messageId: 'msg-success', evidence: 'claim from success', createdAt: now + 20 },
+    ]).run();
+
+    // The successful task run corroborates the claim, so it should NOT be invalidated
+    const affected = invalidateAssistantInferredItemsForConversation(convFailed);
+    expect(affected).toBe(0);
+
+    const item = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-with-good-corroboration')).get();
+    expect(item?.status).toBe('active');
   });
 });

--- a/assistant/src/memory/task-memory-cleanup.ts
+++ b/assistant/src/memory/task-memory-cleanup.ts
@@ -11,7 +11,10 @@ const log = getLogger('task-memory-cleanup');
  * appointment") are not trustworthy if the task didn't complete.
  *
  * Items that also have sources from other conversations are left alone
- * because those other conversations still corroborate the claim.
+ * only when those conversations come from non-failed task/schedule runs
+ * (or are ordinary user conversations). This prevents cascading failures
+ * from mutually protecting each other — if two conversations both source
+ * a memory item and both fail, the item is correctly invalidated.
  */
 export function invalidateAssistantInferredItemsForConversation(conversationId: string): number {
   const affected = rawRun(
@@ -32,6 +35,18 @@ export function invalidateAssistantInferredItemsForConversation(conversationId: 
             JOIN messages m2 ON m2.id = mis2.message_id
            WHERE mis2.memory_item_id = memory_items.id
              AND m2.conversation_id != ?
+             -- Only count as corroboration if the other conversation is NOT
+             -- from a failed task run or failed schedule run.
+             AND NOT EXISTS (
+               SELECT 1 FROM task_runs tr
+                WHERE tr.conversation_id = m2.conversation_id
+                  AND tr.status = 'failed'
+             )
+             AND NOT EXISTS (
+               SELECT 1 FROM cron_runs cr
+                WHERE cr.conversation_id = m2.conversation_id
+                  AND cr.status = 'error'
+             )
         )`,
     Date.now(),
     conversationId,


### PR DESCRIPTION
## Summary

Fixes the NOT EXISTS guard in task-memory-cleanup.ts to check whether corroborating conversations have also failed. Previously, if two conversations both sourced a memory item and both failed, the item stayed active forever because each failure saw the other as corroboration. Now the guard only preserves items when corroborating conversations are from non-failed tasks/schedules (or are ordinary user conversations).

Changes:
- Modified the NOT EXISTS subquery to add nested NOT EXISTS checks against task_runs (status='failed') and cron_runs (status='error')
- Added test: cascading task run failures correctly invalidate cross-sourced items
- Added test: cascading schedule run failures correctly invalidate cross-sourced items
- Added test: successful task run still corroborates and preserves items
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
