### PR TITLE
fix: prevent async memory extraction from re-adding items after task failure

### DIFF
--- a/assistant/src/__tests__/task-memory-cleanup.test.ts
+++ b/assistant/src/__tests__/task-memory-cleanup.test.ts
@@ -55,8 +55,9 @@ mock.module('../config/loader.js', () => ({
 }));
 
 import { getDb, initializeDb, resetDb } from '../memory/db.js';
-import { conversations, cronJobs, cronRuns, memoryItems, memoryItemSources, messages, taskRuns, tasks } from '../memory/schema.js';
-import { invalidateAssistantInferredItemsForConversation } from '../memory/task-memory-cleanup.js';
+import { conversations, cronJobs, cronRuns, memoryItems, memoryItemSources, memoryJobs, messages, taskRuns, tasks } from '../memory/schema.js';
+import { invalidateAssistantInferredItemsForConversation, isConversationFailed, clearAllFailedConversations } from '../memory/task-memory-cleanup.js';
+import { enqueueMemoryJob } from '../memory/jobs-store.js';
 
 describe('invalidateAssistantInferredItemsForConversation', () => {
   const now = 1_701_100_000_000;
@@ -71,12 +72,14 @@ describe('invalidateAssistantInferredItemsForConversation', () => {
     const db = getDb();
     db.run('DELETE FROM memory_item_sources');
     db.run('DELETE FROM memory_items');
+    db.run('DELETE FROM memory_jobs');
     db.run('DELETE FROM messages');
     db.run('DELETE FROM cron_runs');
     db.run('DELETE FROM cron_jobs');
     db.run('DELETE FROM task_runs');
     db.run('DELETE FROM tasks');
     db.run('DELETE FROM conversations');
+    clearAllFailedConversations();
   });
 
   afterAll(() => {
@@ -476,5 +479,58 @@ describe('invalidateAssistantInferredItemsForConversation', () => {
 
     const item = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-with-good-corroboration')).get();
     expect(item?.status).toBe('active');
+  });
+
+  test('marks conversation as failed after invalidation', () => {
+    seedConversations();
+    seedMessages();
+    seedMemoryItems();
+
+    expect(isConversationFailed(convId)).toBe(false);
+
+    invalidateAssistantInferredItemsForConversation(convId);
+
+    expect(isConversationFailed(convId)).toBe(true);
+    // Other conversations remain unaffected
+    expect(isConversationFailed(otherConvId)).toBe(false);
+  });
+
+  test('cancels pending extract_items jobs for the failed conversation', () => {
+    seedConversations();
+    seedMessages();
+
+    const db = getDb();
+
+    // Enqueue extract_items jobs for messages in the target conversation
+    enqueueMemoryJob('extract_items', { messageId: 'msg-task-1', scopeId: 'default' });
+    enqueueMemoryJob('extract_items', { messageId: 'msg-task-2', scopeId: 'default' });
+    // Enqueue an extract_items job for a message in a different conversation
+    enqueueMemoryJob('extract_items', { messageId: 'msg-other', scopeId: 'default' });
+
+    // Verify all jobs are pending
+    const pendingBefore = db.select().from(memoryJobs)
+      .where(eq(memoryJobs.type, 'extract_items'))
+      .all();
+    expect(pendingBefore.filter((j) => j.status === 'pending')).toHaveLength(3);
+
+    invalidateAssistantInferredItemsForConversation(convId);
+
+    // Jobs for the failed conversation should be cancelled (failed)
+    const allJobs = db.select().from(memoryJobs)
+      .where(eq(memoryJobs.type, 'extract_items'))
+      .all();
+    const failedJobs = allJobs.filter((j) => j.status === 'failed');
+    const pendingJobs = allJobs.filter((j) => j.status === 'pending');
+
+    // Two jobs for the failed conversation should be cancelled
+    expect(failedJobs).toHaveLength(2);
+    for (const j of failedJobs) {
+      expect(j.lastError).toBe('conversation_failed');
+    }
+
+    // The job for the other conversation should remain pending
+    expect(pendingJobs).toHaveLength(1);
+    const payload = JSON.parse(pendingJobs[0].payload);
+    expect(payload.messageId).toBe('msg-other');
   });
 });

--- a/assistant/src/memory/job-handlers/extraction.ts
+++ b/assistant/src/memory/job-handlers/extraction.ts
@@ -14,6 +14,7 @@ import { extractAndUpsertMemoryItemsForMessage } from '../items-extractor.js';
 import { enqueueMemoryJob, type MemoryJob } from '../jobs-store.js';
 import { asString } from '../job-utils.js';
 import { extractTextFromStoredMessageContent } from '../message-content.js';
+import { isConversationFailed } from '../task-memory-cleanup.js';
 import { memoryItemSources, messages } from '../schema.js';
 
 const log = getLogger('memory-jobs-worker');
@@ -21,6 +22,21 @@ const log = getLogger('memory-jobs-worker');
 export async function extractItemsJob(job: MemoryJob): Promise<void> {
   const messageId = asString(job.payload.messageId);
   if (!messageId) return;
+
+  // If the conversation that owns this message has been marked as failed,
+  // skip extraction entirely. This prevents async extraction jobs from
+  // re-creating assistant_inferred items after the one-shot invalidation.
+  const db = getDb();
+  const msg = db
+    .select({ conversationId: messages.conversationId })
+    .from(messages)
+    .where(eq(messages.id, messageId))
+    .get();
+  if (msg && isConversationFailed(msg.conversationId)) {
+    log.info({ messageId, conversationId: msg.conversationId }, 'Skipping extraction for failed conversation');
+    return;
+  }
+
   // Backward compat: old payloads may lack scopeId — default to 'default'
   const scopeId = typeof job.payload.scopeId === 'string' && job.payload.scopeId
     ? job.payload.scopeId

--- a/assistant/src/memory/task-memory-cleanup.ts
+++ b/assistant/src/memory/task-memory-cleanup.ts
@@ -4,11 +4,41 @@ import { bumpMemoryVersion } from './recall-cache.js';
 
 const log = getLogger('task-memory-cleanup');
 
+// Conversations whose task/schedule execution failed. Memory extraction
+// jobs that arrive after the one-shot invalidation must not create new
+// `assistant_inferred` items for these conversations. The set is checked
+// at extraction time in the extraction job handler.
+const failedConversationIds = new Set<string>();
+
+/** Mark a conversation as failed so future extraction jobs skip it. */
+export function markConversationFailed(conversationId: string): void {
+  failedConversationIds.add(conversationId);
+}
+
+/** Check whether a conversation has been marked as failed. */
+export function isConversationFailed(conversationId: string): boolean {
+  return failedConversationIds.has(conversationId);
+}
+
+/** Remove a conversation from the failed set (used in tests). */
+export function clearFailedConversation(conversationId: string): void {
+  failedConversationIds.delete(conversationId);
+}
+
+/** Clear all failed conversation markers (used in tests). */
+export function clearAllFailedConversations(): void {
+  failedConversationIds.clear();
+}
+
 /**
  * Invalidate `assistant_inferred` memory items sourced *exclusively* from
  * messages in the given conversation. Called when a background task or
  * schedule fails — the assistant's optimistic claims (e.g., "I booked an
  * appointment") are not trustworthy if the task didn't complete.
+ *
+ * Also marks the conversation as failed so that any pending or future
+ * extraction jobs for this conversation are blocked from creating new
+ * `assistant_inferred` items.
  *
  * Items that also have sources from other conversations are left alone
  * only when those conversations come from non-failed task/schedule runs
@@ -17,6 +47,15 @@ const log = getLogger('task-memory-cleanup');
  * a memory item and both fail, the item is correctly invalidated.
  */
 export function invalidateAssistantInferredItemsForConversation(conversationId: string): number {
+  // Mark failed *before* the UPDATE so concurrent extraction jobs
+  // that are already running see the flag immediately.
+  markConversationFailed(conversationId);
+
+  // Cancel pending extract_items jobs for this conversation's messages
+  // so the worker never processes them. Jobs already running will be
+  // caught by the isConversationFailed check in the extraction handler.
+  cancelPendingExtractionJobsForConversation(conversationId);
+
   const affected = rawRun(
     `UPDATE memory_items
         SET status = 'invalidated',
@@ -59,4 +98,31 @@ export function invalidateAssistantInferredItemsForConversation(conversationId: 
   }
 
   return affected;
+}
+
+/**
+ * Cancel pending `extract_items` jobs whose messageId belongs to the
+ * given conversation. This drains the queue so the worker never processes
+ * them, complementing the runtime check in the extraction handler.
+ */
+function cancelPendingExtractionJobsForConversation(conversationId: string): number {
+  const cancelled = rawRun(
+    `UPDATE memory_jobs
+        SET status = 'failed',
+            last_error = 'conversation_failed',
+            updated_at = ?
+      WHERE type = 'extract_items'
+        AND status IN ('pending', 'running')
+        AND json_extract(payload, '$.messageId') IN (
+          SELECT id FROM messages WHERE conversation_id = ?
+        )`,
+    Date.now(),
+    conversationId,
+  );
+
+  if (cancelled > 0) {
+    log.info({ conversationId, cancelled }, 'Cancelled pending extraction jobs for failed conversation');
+  }
+
+  return cancelled;
 }


### PR DESCRIPTION
When a task/schedule fails, memory extraction jobs that are still pending can create new assistant_inferred rows after the one-shot invalidation runs. This fix ensures the failure state is enforced at extraction time, preventing stale memories from being created after a task failure.

The fix has three layers of defense:

1. **Failed conversation registry**: `invalidateAssistantInferredItemsForConversation` now marks the conversation ID in an in-memory `Set` before running the invalidation UPDATE. This flag persists for the process lifetime.

2. **Pending job cancellation**: When a conversation is marked as failed, all pending `extract_items` jobs whose `messageId` belongs to that conversation are immediately marked as `failed` with error `conversation_failed`. This drains the queue so the worker never picks them up.

3. **Runtime extraction gate**: The `extractItemsJob` handler now looks up the conversation ID for the message and checks `isConversationFailed()` before proceeding. This catches any jobs that were already claimed by the worker (status `running`) at the time of invalidation, as well as any hypothetical future jobs.

Together, these three mechanisms ensure that no `assistant_inferred` memory items can be created from a failed conversation's messages, regardless of timing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
