### PR TITLE
fix: guard memory extraction against failed conversations

### DIFF
--- a/assistant/src/memory/failed-conversations.ts
+++ b/assistant/src/memory/failed-conversations.ts
@@ -1,0 +1,27 @@
+/**
+ * In-memory registry of conversation IDs whose owning task or schedule has
+ * failed. The memory extraction worker checks this before processing
+ * `extract_items` jobs — if the conversation is marked as failed, extraction
+ * is skipped to prevent stale `assistant_inferred` items from being created
+ * after the one-shot invalidation in `task-memory-cleanup.ts` has already run.
+ *
+ * This is intentionally in-memory: on process restart, the set is empty, which
+ * is safe because any pending extraction jobs are also reset. The persistent
+ * invalidation in `task-memory-cleanup.ts` remains as the belt-and-suspenders
+ * safety net.
+ */
+
+const failedConversationIds = new Set<string>();
+
+export function markConversationFailed(conversationId: string): void {
+  failedConversationIds.add(conversationId);
+}
+
+export function isConversationFailed(conversationId: string): boolean {
+  return failedConversationIds.has(conversationId);
+}
+
+/** Clear all entries — exposed for testing only. */
+export function resetFailedConversations(): void {
+  failedConversationIds.clear();
+}

--- a/assistant/src/memory/job-handlers/extraction.ts
+++ b/assistant/src/memory/job-handlers/extraction.ts
@@ -10,6 +10,7 @@ import {
   upsertEntity,
   upsertEntityRelation,
 } from '../entity-extractor.js';
+import { isConversationFailed } from '../failed-conversations.js';
 import { extractAndUpsertMemoryItemsForMessage } from '../items-extractor.js';
 import { enqueueMemoryJob, type MemoryJob } from '../jobs-store.js';
 import { asString } from '../job-utils.js';
@@ -21,6 +22,22 @@ const log = getLogger('memory-jobs-worker');
 export async function extractItemsJob(job: MemoryJob): Promise<void> {
   const messageId = asString(job.payload.messageId);
   if (!messageId) return;
+
+  // Guard: skip extraction for messages belonging to failed conversations.
+  // The owning task/schedule marks the conversation as failed before the
+  // one-shot invalidation runs, so any extraction jobs still in the queue
+  // (or retrying) are caught here and silently dropped.
+  const db = getDb();
+  const msg = db
+    .select({ conversationId: messages.conversationId })
+    .from(messages)
+    .where(eq(messages.id, messageId))
+    .get();
+  if (msg && isConversationFailed(msg.conversationId)) {
+    log.debug({ messageId, conversationId: msg.conversationId }, 'Skipping extraction — conversation marked as failed');
+    return;
+  }
+
   // Backward compat: old payloads may lack scopeId — default to 'default'
   const scopeId = typeof job.payload.scopeId === 'string' && job.payload.scopeId
     ? job.payload.scopeId
@@ -38,6 +55,19 @@ export async function extractEntitiesJob(job: MemoryJob, config: AssistantConfig
   if (!messageId) return;
 
   const db = getDb();
+
+  // Guard: skip entity extraction for failed conversations (same rationale
+  // as extractItemsJob — entities linked to failed task output are stale).
+  const msgRow = db
+    .select({ conversationId: messages.conversationId })
+    .from(messages)
+    .where(eq(messages.id, messageId))
+    .get();
+  if (msgRow && isConversationFailed(msgRow.conversationId)) {
+    log.debug({ messageId, conversationId: msgRow.conversationId }, 'Skipping entity extraction — conversation marked as failed');
+    return;
+  }
+
   const message = db
     .select({
       id: messages.id,

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -1,6 +1,7 @@
 import { getLogger } from '../util/logger.js';
 import { createConversation } from '../memory/conversation-store.js';
 import { GENERATING_TITLE, queueGenerateConversationTitle } from '../memory/conversation-title-service.js';
+import { markConversationFailed } from '../memory/failed-conversations.js';
 import { invalidateAssistantInferredItemsForConversation } from '../memory/task-memory-cleanup.js';
 import {
   claimDueSchedules,
@@ -135,6 +136,8 @@ async function runScheduleOnce(
       const message = err instanceof Error ? err.message : String(err);
       log.warn({ err, jobId: job.id, name: job.name, syntax: job.syntax, expression: job.expression, isRruleSet: isRruleSetMsg }, 'Schedule execution failed');
       completeScheduleRun(runId, { status: 'error', error: message });
+
+      markConversationFailed(conversation.id);
 
       try {
         invalidateAssistantInferredItemsForConversation(conversation.id);

--- a/assistant/src/tasks/task-runner.ts
+++ b/assistant/src/tasks/task-runner.ts
@@ -1,6 +1,7 @@
 import { getLogger } from '../util/logger.js';
 import { createConversation } from '../memory/conversation-store.js';
 import { GENERATING_TITLE, queueGenerateConversationTitle } from '../memory/conversation-title-service.js';
+import { markConversationFailed } from '../memory/failed-conversations.js';
 import { invalidateAssistantInferredItemsForConversation } from '../memory/task-memory-cleanup.js';
 import { getTask, createTaskRun, updateTaskRun } from './task-store.js';
 import { buildTaskRules, setTaskRunRules, clearTaskRunRules } from './ephemeral-permissions.js';
@@ -83,6 +84,10 @@ export async function runTask(
     log.warn({ err, taskId: task.id, taskRunId: run.id }, 'Task execution failed');
 
     updateTaskRun(run.id, { status: 'failed', error: errorMessage, finishedAt: Date.now() });
+
+    // Mark before invalidation so any in-flight or future extraction jobs
+    // for this conversation are skipped by the memory worker.
+    markConversationFailed(conversation.id);
 
     try {
       invalidateAssistantInferredItemsForConversation(conversation.id);


### PR DESCRIPTION
Address Codex feedback on PR #8764: prevent async memory extraction from creating new assistant_inferred items after a task/schedule failure by tracking failed conversations and skipping extraction for them.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
