### PR TITLE
fix: extend failed-conversation guard to entity extraction jobs

### DIFF
--- a/assistant/src/memory/job-handlers/extraction.ts
+++ b/assistant/src/memory/job-handlers/extraction.ts
@@ -54,6 +54,21 @@ export async function extractEntitiesJob(job: MemoryJob, config: AssistantConfig
   if (!messageId) return;
 
   const db = getDb();
+
+  // Guard: skip entity extraction for failed conversations. Entity extraction
+  // jobs are enqueued by extractItemsJob after items are extracted; while new
+  // jobs won't be queued (extractItemsJob returns early for failed convos),
+  // any entity jobs enqueued before the failure marker was set must be caught.
+  const msgRow = db
+    .select({ conversationId: messages.conversationId })
+    .from(messages)
+    .where(eq(messages.id, messageId))
+    .get();
+  if (msgRow && isConversationFailed(msgRow.conversationId)) {
+    log.info({ messageId, conversationId: msgRow.conversationId }, 'Skipping entity extraction for failed conversation');
+    return;
+  }
+
   const message = db
     .select({
       id: messages.id,

--- a/assistant/src/memory/task-memory-cleanup.ts
+++ b/assistant/src/memory/task-memory-cleanup.ts
@@ -101,22 +101,23 @@ export function invalidateAssistantInferredItemsForConversation(conversationId: 
 }
 
 /**
- * Cancel pending `extract_items` jobs whose messageId belongs to the
- * given conversation. This drains the queue so the worker never processes
- * them, complementing the runtime check in the extraction handler.
+ * Cancel pending `extract_items` and `extract_entities` jobs whose messageId
+ * belongs to the given conversation. This drains the queue so the worker never
+ * processes them, complementing the runtime check in the extraction handler.
  */
 function cancelPendingExtractionJobsForConversation(conversationId: string): number {
+  const now = Date.now();
   const cancelled = rawRun(
     `UPDATE memory_jobs
         SET status = 'failed',
             last_error = 'conversation_failed',
             updated_at = ?
-      WHERE type = 'extract_items'
+      WHERE type IN ('extract_items', 'extract_entities')
         AND status IN ('pending', 'running')
         AND json_extract(payload, '$.messageId') IN (
           SELECT id FROM messages WHERE conversation_id = ?
         )`,
-    Date.now(),
+    now,
     conversationId,
   );
 


### PR DESCRIPTION
Follow-up to PR #8774: the failed-conversation guard was applied to extract_items jobs but not extract_entities jobs. This extends the guard to also skip entity extraction for messages from failed conversations, and updates cancelPendingExtractionJobsForConversation to cancel both extract_items and extract_entities pending jobs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
