### PR TITLE
fix: use category:promotions for gmail newsletter scan

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -215,7 +215,7 @@ Use `gmail_sender_digest` to help users identify and clean up high-volume sender
 
 ### Workflow
 
-1. **Scan**: Call `gmail_sender_digest` (default query targets emails with unsubscribe headers from the last 90 days)
+1. **Scan**: Call `gmail_sender_digest` (default query targets Gmail's promotions category from the last 90 days)
 2. **Present**: Show results as a `ui_show` table with `selectionMode: "multiple"`:
    - Columns: Sender, Email Count, Unsubscribable, Date Range, Sample Subject
    - Action buttons: "Archive & Unsubscribe" (primary), "Archive Only" (secondary)
@@ -227,7 +227,7 @@ Use `gmail_sender_digest` to help users identify and clean up high-volume sender
 
 ### Edge Cases
 
-- **Zero results**: Tell the user "No newsletter emails found" and suggest broadening the query (e.g. removing `has:unsubscribe` or extending the date range)
+- **Zero results**: Tell the user "No newsletter emails found" and suggest broadening the query (e.g. removing the category filter or extending the date range)
 - **Unsubscribe failures**: Report per-sender success/failure; the existing `gmail_unsubscribe` tool handles edge cases
 - **Large sender counts**: The `has_more` flag indicates a sender had more messages than collected — use `search_query` for follow-up archiving
 

--- a/assistant/src/config/bundled-skills/messaging/TOOLS.json
+++ b/assistant/src/config/bundled-skills/messaging/TOOLS.json
@@ -1028,7 +1028,7 @@
         "properties": {
           "query": {
             "type": "string",
-            "description": "Gmail search query (default 'has:unsubscribe newer_than:90d')"
+            "description": "Gmail search query (default 'category:promotions newer_than:90d')"
           },
           "max_messages": {
             "type": "number",

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
@@ -35,7 +35,7 @@ function parseFrom(from: string): { displayName: string; email: string } {
 }
 
 export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-  const query = (input.query as string) ?? 'has:unsubscribe newer_than:90d';
+  const query = (input.query as string) ?? 'category:promotions newer_than:90d';
   const maxMessages = Math.min((input.max_messages as number) ?? 500, MAX_MESSAGES_CAP);
   const maxSenders = (input.max_senders as number) ?? 30;
 
@@ -57,7 +57,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
       }
 
       if (allMessageIds.length === 0) {
-        return ok(JSON.stringify({ senders: [], total_scanned: 0, message: 'No newsletter emails found matching the query.' }));
+        return ok(JSON.stringify({ senders: [], total_scanned: 0, message: 'No emails found matching the query. Try broadening the search (e.g. remove category filter or extend date range).' }));
       }
 
       // Batch-fetch metadata headers


### PR DESCRIPTION
## Summary

- Replace `has:unsubscribe` with `category:promotions` in the default gmail_sender_digest query — the former is a Gmail web UI operator that doesn't work reliably via the REST API, causing scans to return empty
- Update SKILL.md and TOOLS.json docs to reflect the new default query
- Improve the empty-results message to suggest actionable next steps

## Original prompt

why did the newsletter scan come out empty?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
