### PR TITLE
fix: emit initial selection state on table/list widget appear

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineListWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineListWidget.swift
@@ -20,6 +20,9 @@ public struct InlineListWidget: View {
         }
         .onAppear {
             selectedIds = Set(data.items.filter(\.selected).map(\.id))
+            if data.selectionMode != .none {
+                onAction("selection_changed", ["selectedIds": AnyCodable(Array(selectedIds))])
+            }
         }
     }
 

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -46,8 +46,13 @@ public struct InlineTableWidget: View {
             }
         }
         .onAppear {
-            // Initialize selection from data
+            // Initialize selection from data and notify the parent so action
+            // buttons always carry the current selection — even if the user
+            // never toggles a checkbox.
             selectedIds = Set(data.rows.filter(\.selected).map(\.id))
+            if data.selectionMode != .none {
+                onAction("selection_changed", ["selectedIds": AnyCodable(Array(selectedIds))])
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- **Bug**: When a table/list widget had pre-selected rows and the user clicked an action button without toggling any checkboxes, `selectionPayload` was `nil` — the backend received no `selectedIds` and the LLM misinterpreted the selection as "everything selected"
- **Fix**: Both `InlineTableWidget` and `InlineListWidget` now fire `selection_changed` on `.onAppear` with the initial selection state, so `InlineSurfaceRouter` always has the current selection ready for action buttons

## Original prompt
fix: emit initial selection state on table/list widget appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
