### PR TITLE
Show clicked state on inline surface action buttons

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -6,6 +6,7 @@ public struct InlineSurfaceRouter: View {
     public let onAction: (String, String, [String: AnyCodable]?) -> Void
 
     @State private var selectionPayload: [String: AnyCodable]?
+    @State private var clickedActionLabel: String?
 
     public init(surface: InlineSurfaceData, onAction: @escaping (String, String, [String: AnyCodable]?) -> Void) {
         self.surface = surface
@@ -197,24 +198,46 @@ public struct InlineSurfaceRouter: View {
         }
     }
 
+    @ViewBuilder
     private var actionButtons: some View {
-        HStack(spacing: VSpacing.sm) {
-            Spacer()
-            ForEach(surface.actions) { action in
-                Button {
-                    onAction(surface.id, action.id, selectionPayload)
-                } label: {
-                    Text(action.label)
-                        .font(VFont.bodyMedium)
-                        .foregroundColor(buttonForeground(action.style))
-                        .padding(.horizontal, VSpacing.lg)
-                        .padding(.vertical, VSpacing.sm)
-                        .background(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .fill(buttonBackground(action.style))
-                        )
+        if let label = clickedActionLabel {
+            HStack(spacing: VSpacing.sm) {
+                Spacer()
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.success)
+                    Text(label)
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textPrimary)
                 }
-                .buttonStyle(.plain)
+                .padding(.horizontal, VSpacing.md)
+                .padding(.vertical, VSpacing.sm)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .fill(VColor.backgroundSubtle.opacity(0.5))
+                )
+            }
+        } else {
+            HStack(spacing: VSpacing.sm) {
+                Spacer()
+                ForEach(surface.actions) { action in
+                    Button {
+                        clickedActionLabel = action.label
+                        onAction(surface.id, action.id, selectionPayload)
+                    } label: {
+                        Text(action.label)
+                            .font(VFont.bodyMedium)
+                            .foregroundColor(buttonForeground(action.style))
+                            .padding(.horizontal, VSpacing.lg)
+                            .padding(.vertical, VSpacing.sm)
+                            .background(
+                                RoundedRectangle(cornerRadius: VRadius.md)
+                                    .fill(buttonBackground(action.style))
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- After tapping an action button (e.g. "Archive & Unsubscribe Selected"), the buttons are replaced with a green checkmark chip showing which action was selected
- Follows the same feedback pattern used by ConfirmationSurfaceView
- Prevents accidental double-clicks by removing the buttons immediately

## Original prompt
Show clicked state on inline surface action buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
