### PR TITLE
fix: update credential vault test for requiresClientSecret guardrail

### DIFF
--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -494,19 +494,37 @@ describe('credential_store tool — oauth2_connect error paths', () => {
   });
 
   test('uses stored client_id from secure storage', async () => {
-    // Store a client_id for the service
+    // Store both client_id and client_secret for the service — the
+    // requiresClientSecret guardrail will short-circuit if client_secret
+    // is missing, so we need both to validate that stored client_id
+    // is resolved correctly.
     setSecureKey('credential:integration:gmail:client_id', 'stored-client-id-123');
+    setSecureKey('credential:integration:gmail:client_secret', 'test-secret');
 
     const result = await credentialStoreTool.execute({
       action: 'oauth2_connect',
       service: 'gmail',
     }, { ..._ctx, isInteractive: false });
 
-    // Should pass client_id check but fail on interactive check
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain('interactive client session');
-    // Does NOT contain client_id error
+    // Should pass client_id and client_secret checks — the flow proceeds
+    // through the channel path (gmail uses loopback transport so no
+    // public ingress URL is needed).
     expect(result.content).not.toContain('client_id is required');
+    expect(result.content).not.toContain('client_secret is required');
+  });
+
+  test('rejects when client_secret is missing for service that requires it', async () => {
+    // Store only client_id — client_secret is intentionally absent to
+    // validate the requiresClientSecret guardrail.
+    setSecureKey('credential:integration:gmail:client_id', 'stored-client-id-456');
+
+    const result = await credentialStoreTool.execute({
+      action: 'oauth2_connect',
+      service: 'gmail',
+    }, _ctx);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('client_secret is required for gmail');
   });
 });
 


### PR DESCRIPTION
Updates the 'uses stored client_id from secure storage' test to also store a client_secret so it proceeds past the new requiresClientSecret guardrail. Adds a new test validating the guardrail behavior when client_secret is missing.

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/8778
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
