### PR TITLE
fix: reset clickedActionLabel on surface data change in InlineSurfaceRouter

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -47,6 +47,7 @@ public struct InlineSurfaceRouter: View {
     }
 
     public var body: some View {
+        Group {
         if let completion = surface.completionState {
             CompletedSurfaceChip(title: surface.title, summary: completion.summary)
         } else if case .confirmation(let data) = surface.data {
@@ -121,6 +122,10 @@ public struct InlineSurfaceRouter: View {
         }
         // Consistent width for all widget cards; dynamic page previews and document previews are more compact.
         .frame(maxWidth: isDynamicPreview || isDocumentPreview ? 350 : 540, alignment: .leading)
+        }
+        }
+        .onChange(of: surface) { _, _ in
+            clickedActionLabel = nil
         }
     }
 


### PR DESCRIPTION
Addresses review feedback on #8781. Adds .onChange modifier to reset clickedActionLabel when surface data changes, following the same pattern used in ConfirmationSurfaceView. This ensures that if the server sends a uiSurfaceUpdate (e.g., after a failure or with new actions), the clicked state is cleared and the user can interact with the updated buttons.