### PR TITLE
Gmail declutter performance improvements

### DIFF
--- a/assistant/src/__tests__/gmail-integration.test.ts
+++ b/assistant/src/__tests__/gmail-integration.test.ts
@@ -14,6 +14,7 @@ describe('Messaging tool contract', () => {
   const expectedGmailToolNames = [
     'gmail_archive',
     'gmail_batch_archive',
+    'gmail_archive_by_query',
     'gmail_label',
     'gmail_batch_label',
     'gmail_trash',

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -220,8 +220,8 @@ Use `gmail_sender_digest` to help users identify and clean up high-volume sender
    - Columns: Sender, Email Count, Unsubscribable, Date Range, Sample Subject
    - Action buttons: "Archive & Unsubscribe" (primary), "Archive Only" (secondary)
 3. **Act on selection**: For each selected sender:
-   - Call `gmail_batch_archive` with the sender's `message_ids`
-   - If `has_more` is true, use the sender's `search_query` to find and archive remaining messages
+   - Prefer `gmail_archive_by_query` with the sender's `search_query` — this archives all matching messages in one call, regardless of volume
+   - Alternatively, use `gmail_batch_archive` with the sender's `message_ids` for smaller senders where all IDs are already collected
    - If the action is "Archive & Unsubscribe" and `has_unsubscribe` is true, call `gmail_unsubscribe` with the sender's `newest_message_id`
 4. **Report**: Summarize results — e.g. "Archived 247 messages from 8 senders. Unsubscribed from 6."
 

--- a/assistant/src/config/bundled-skills/messaging/TOOLS.json
+++ b/assistant/src/config/bundled-skills/messaging/TOOLS.json
@@ -507,6 +507,31 @@
       "execution_target": "host"
     },
     {
+      "name": "gmail_archive_by_query",
+      "description": "Archive ALL Gmail messages matching a search query. Paginates through all results and archives in bulk. Ideal for high-volume senders where message IDs are not pre-collected. Include a confidence score (0-1).",
+      "category": "messaging",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Gmail search query (e.g. \"from:marketing@example.com category:promotions newer_than:90d\")"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          }
+        },
+        "required": [
+          "query",
+          "confidence"
+        ]
+      },
+      "executor": "tools/gmail-archive-by-query.ts",
+      "execution_target": "host"
+    },
+    {
       "name": "gmail_label",
       "description": "Add or remove labels on a Gmail message. Include a confidence score (0-1).",
       "category": "messaging",

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-archive-by-query.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-archive-by-query.ts
@@ -1,0 +1,47 @@
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { withValidToken } from '../../../../security/token-manager.js';
+import { getMessagingProvider } from '../../../../messaging/registry.js';
+import { listMessages, batchModifyMessages } from '../../../../messaging/providers/gmail/client.js';
+import { ok, err } from './shared.js';
+
+const BATCH_MODIFY_LIMIT = 1000;
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const query = input.query as string;
+
+  if (!query) {
+    return err('query is required.');
+  }
+
+  try {
+    const provider = getMessagingProvider('gmail');
+    return withValidToken(provider.credentialService, async (token) => {
+      // Paginate through all matching messages
+      const allMessageIds: string[] = [];
+      let pageToken: string | undefined;
+
+      while (true) {
+        const listResp = await listMessages(token, query, 500, pageToken);
+        const ids = (listResp.messages ?? []).map((m) => m.id);
+        if (ids.length === 0) break;
+        allMessageIds.push(...ids);
+        pageToken = listResp.nextPageToken ?? undefined;
+        if (!pageToken) break;
+      }
+
+      if (allMessageIds.length === 0) {
+        return ok('No messages matched the query. Nothing archived.');
+      }
+
+      // Archive in chunks of BATCH_MODIFY_LIMIT (Gmail's per-call limit)
+      for (let i = 0; i < allMessageIds.length; i += BATCH_MODIFY_LIMIT) {
+        const chunk = allMessageIds.slice(i, i + BATCH_MODIFY_LIMIT);
+        await batchModifyMessages(token, chunk, { removeLabelIds: ['INBOX'] });
+      }
+
+      return ok(`Archived ${allMessageIds.length} message(s) matching query: ${query}`);
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-outreach-scan.ts
@@ -7,7 +7,7 @@ import type { EmailMetadata } from '../../../../messaging/email-classifier.js';
 import { ok, err } from './shared.js';
 
 const MAX_MESSAGES_CAP = 2000;
-const MAX_IDS_PER_SENDER = 100;
+const MAX_IDS_PER_SENDER = 1000;
 const MAX_SAMPLE_SUBJECTS = 3;
 
 interface OutreachSenderAggregation {

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-sender-digest.ts
@@ -5,7 +5,7 @@ import { listMessages, batchGetMessages } from '../../../../messaging/providers/
 import { ok, err } from './shared.js';
 
 const MAX_MESSAGES_CAP = 2000;
-const MAX_IDS_PER_SENDER = 100;
+const MAX_IDS_PER_SENDER = 1000;
 const MAX_SAMPLE_SUBJECTS = 3;
 
 interface SenderAggregation {

--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-triage.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-triage.ts
@@ -4,7 +4,7 @@ import { getMessagingProvider } from '../../../../messaging/registry.js';
 import {
   listMessages,
   batchGetMessages,
-  modifyMessage,
+  batchModifyMessages,
   listLabels,
   createLabel,
 } from '../../../../messaging/providers/gmail/client.js';
@@ -68,10 +68,8 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
       if (autoApply) {
         // Archive can_archive emails
         const archivable = groups['can_archive'] ?? [];
-        for (const c of archivable) {
-          await modifyMessage(token, c.id, { removeLabelIds: ['INBOX'] });
-        }
         if (archivable.length > 0) {
+          await batchModifyMessages(token, archivable.map(c => c.id), { removeLabelIds: ['INBOX'] });
           actions.push(`Archived ${archivable.length} message(s)`);
         }
 
@@ -79,9 +77,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         const needsReply = groups['needs_reply'] ?? [];
         if (needsReply.length > 0) {
           const followUpLabelId = await getOrCreateLabel(token, FOLLOW_UP_LABEL_NAME);
-          for (const c of needsReply) {
-            await modifyMessage(token, c.id, { addLabelIds: [followUpLabelId] });
-          }
+          await batchModifyMessages(token, needsReply.map(c => c.id), { addLabelIds: [followUpLabelId] });
           actions.push(`Labeled ${needsReply.length} message(s) as Follow-up`);
         }
       }

--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -18,7 +18,7 @@ import type {
 const GMAIL_API_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
 
 /** Max concurrent requests for batch operations */
-const BATCH_CONCURRENCY = 5;
+const BATCH_CONCURRENCY = 50;
 
 export class GmailApiError extends Error {
   constructor(


### PR DESCRIPTION
## Summary
- Increase `BATCH_CONCURRENCY` from 5 to 50 for ~10x faster metadata scan phase
- Add `gmail_archive_by_query` tool that archives all messages matching a Gmail search query in bulk, eliminating `has_more` round-trips for high-volume senders
- Increase `MAX_IDS_PER_SENDER` from 100 to 1000 in sender digest and outreach scan, matching Gmail's `batchModify` per-call limit
- Replace sequential `modifyMessage` loops with single `batchModifyMessages` calls in `gmail_triage` for faster auto-apply

## Original prompt
Gmail declutter performance improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
