### PR TITLE
fix: add positive assertion to stored client_id test

### DIFF
--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -508,7 +508,9 @@ describe('credential_store tool — oauth2_connect error paths', () => {
 
     // Should pass client_id and client_secret checks — the flow proceeds
     // through the channel path (gmail uses loopback transport so no
-    // public ingress URL is needed).
+    // public ingress URL is needed) and returns the authorization URL.
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('To connect gmail, open this link');
     expect(result.content).not.toContain('client_id is required');
     expect(result.content).not.toContain('client_secret is required');
   });


### PR DESCRIPTION
Addresses Codex feedback on PR #8783. Adds a positive assertion to the 'uses stored client_id from secure storage' test so it verifies the expected outcome rather than only checking for the absence of error strings.

The test now asserts:
- `result.isError` is `false` (the flow succeeded past credential checks)
- `result.content` contains the expected auth URL prompt text
- Retains the negative assertions as secondary guards
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
