### PR TITLE
fix: add Gmail API retry logic and cap archive-by-query pagination

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-archive-by-query.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-archive-by-query.ts
@@ -5,6 +5,7 @@ import { listMessages, batchModifyMessages } from '../../../../messaging/provide
 import { ok, err } from './shared.js';
 
 const BATCH_MODIFY_LIMIT = 1000;
+const MAX_MESSAGES = 5000;
 
 export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
   const query = input.query as string;
@@ -16,12 +17,12 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
   try {
     const provider = getMessagingProvider('gmail');
     return withValidToken(provider.credentialService, async (token) => {
-      // Paginate through all matching messages
+      // Paginate through matching messages, capped to prevent unbounded API/memory usage
       const allMessageIds: string[] = [];
       let pageToken: string | undefined;
 
-      while (true) {
-        const listResp = await listMessages(token, query, 500, pageToken);
+      while (allMessageIds.length < MAX_MESSAGES) {
+        const listResp = await listMessages(token, query, Math.min(500, MAX_MESSAGES - allMessageIds.length), pageToken);
         const ids = (listResp.messages ?? []).map((m) => m.id);
         if (ids.length === 0) break;
         allMessageIds.push(...ids);

--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -31,28 +31,51 @@ export class GmailApiError extends Error {
   }
 }
 
+const MAX_RETRIES = 3;
+const INITIAL_BACKOFF_MS = 1000;
+
+function isRetryable(status: number): boolean {
+  return status === 429 || (status >= 500 && status < 600);
+}
+
 async function request<T>(token: string, path: string, options?: RequestInit): Promise<T> {
   const url = `${GMAIL_API_BASE}${path}`;
-  const resp = await fetch(url, {
-    ...options,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-      ...options?.headers,
-    },
-  });
-  if (!resp.ok) {
-    const body = await resp.text().catch(() => '');
-    throw new GmailApiError(resp.status, resp.statusText, `Gmail API ${resp.status}: ${body}`);
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const resp = await fetch(url, {
+      ...options,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        ...options?.headers,
+      },
+    });
+
+    if (!resp.ok) {
+      if (isRetryable(resp.status) && attempt < MAX_RETRIES) {
+        const retryAfter = resp.headers.get('retry-after');
+        const delayMs = retryAfter
+          ? parseInt(retryAfter, 10) * 1000
+          : INITIAL_BACKOFF_MS * Math.pow(2, attempt);
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        continue;
+      }
+      const body = await resp.text().catch(() => '');
+      throw new GmailApiError(resp.status, resp.statusText, `Gmail API ${resp.status}: ${body}`);
+    }
+
+    // Some endpoints (e.g. batchModify) return empty success responses
+    const contentLength = resp.headers.get('content-length');
+    if (resp.status === 204 || contentLength === '0') {
+      return undefined as T;
+    }
+    const text = await resp.text();
+    if (!text) return undefined as T;
+    return JSON.parse(text) as T;
   }
-  // Some endpoints (e.g. batchModify) return empty success responses
-  const contentLength = resp.headers.get('content-length');
-  if (resp.status === 204 || contentLength === '0') {
-    return undefined as T;
-  }
-  const text = await resp.text();
-  if (!text) return undefined as T;
-  return JSON.parse(text) as T;
+
+  // Unreachable — the loop always returns or throws — but TypeScript needs this
+  throw new Error('Unreachable: retry loop exited without returning or throwing');
 }
 
 /** List messages matching a query. */


### PR DESCRIPTION
Addresses feedback on #8786:

1. **Retry with exponential backoff**: Added retry logic to the Gmail client `request()` function for 429/5xx responses. Checks Retry-After header, falls back to exponential backoff (1s, 2s, 4s), retries up to 3 times. This makes all Gmail API calls resilient at BATCH_CONCURRENCY=50.

2. **Pagination cap**: Added MAX_MESSAGES=5000 to gmail_archive_by_query to prevent unbounded memory and API usage, consistent with caps in other tools.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
