### PR TITLE
fix: add durable failed-conversation tracking and pre-upsert guard

### DIFF
--- a/assistant/src/__tests__/task-memory-cleanup.test.ts
+++ b/assistant/src/__tests__/task-memory-cleanup.test.ts
@@ -56,7 +56,7 @@ mock.module('../config/loader.js', () => ({
 
 import { getDb, initializeDb, resetDb } from '../memory/db.js';
 import { conversations, cronJobs, cronRuns, memoryItems, memoryItemSources, memoryJobs, messages, taskRuns, tasks } from '../memory/schema.js';
-import { invalidateAssistantInferredItemsForConversation, isConversationFailed, clearAllFailedConversations } from '../memory/task-memory-cleanup.js';
+import { invalidateAssistantInferredItemsForConversation, isConversationFailed } from '../memory/task-memory-cleanup.js';
 import { enqueueMemoryJob } from '../memory/jobs-store.js';
 
 describe('invalidateAssistantInferredItemsForConversation', () => {
@@ -79,7 +79,6 @@ describe('invalidateAssistantInferredItemsForConversation', () => {
     db.run('DELETE FROM task_runs');
     db.run('DELETE FROM tasks');
     db.run('DELETE FROM conversations');
-    clearAllFailedConversations();
   });
 
   afterAll(() => {
@@ -481,17 +480,70 @@ describe('invalidateAssistantInferredItemsForConversation', () => {
     expect(item?.status).toBe('active');
   });
 
-  test('marks conversation as failed after invalidation', () => {
+  test('isConversationFailed derives state from durable task_runs/cron_runs', () => {
     seedConversations();
     seedMessages();
-    seedMemoryItems();
+
+    const db = getDb();
+
+    // No failure records yet — should be false
+    expect(isConversationFailed(convId)).toBe(false);
+    expect(isConversationFailed(otherConvId)).toBe(false);
+
+    // Insert a failed task run for convId
+    db.insert(tasks).values({
+      id: 'task-durable',
+      title: 'Durable test',
+      template: 'template',
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+    }).run();
+
+    db.insert(taskRuns).values({
+      id: 'run-durable',
+      taskId: 'task-durable',
+      conversationId: convId,
+      status: 'failed',
+      createdAt: now + 50,
+    }).run();
+
+    // Now convId should be detected as failed via the DB
+    expect(isConversationFailed(convId)).toBe(true);
+    // Other conversations remain unaffected
+    expect(isConversationFailed(otherConvId)).toBe(false);
+  });
+
+  test('isConversationFailed detects failed schedule runs', () => {
+    seedConversations();
+    seedMessages();
+
+    const db = getDb();
 
     expect(isConversationFailed(convId)).toBe(false);
 
-    invalidateAssistantInferredItemsForConversation(convId);
+    // Insert a failed schedule run for convId
+    db.insert(cronJobs).values({
+      id: 'cron-durable',
+      name: 'Durable schedule test',
+      cronExpression: '0 9 * * *',
+      message: 'test',
+      nextRunAt: now + 100_000,
+      createdBy: 'agent',
+      createdAt: now,
+      updatedAt: now,
+    }).run();
+
+    db.insert(cronRuns).values({
+      id: 'cron-run-durable',
+      jobId: 'cron-durable',
+      status: 'error',
+      conversationId: convId,
+      startedAt: now + 50,
+      createdAt: now + 50,
+    }).run();
 
     expect(isConversationFailed(convId)).toBe(true);
-    // Other conversations remain unaffected
     expect(isConversationFailed(otherConvId)).toBe(false);
   });
 

--- a/assistant/src/memory/job-handlers/extraction.ts
+++ b/assistant/src/memory/job-handlers/extraction.ts
@@ -41,6 +41,14 @@ export async function extractItemsJob(job: MemoryJob): Promise<void> {
   const scopeId = typeof job.payload.scopeId === 'string' && job.payload.scopeId
     ? job.payload.scopeId
     : 'default';
+
+  // Re-check right before the write to close the race window: the conversation
+  // may have been marked failed while this job was doing preliminary work.
+  if (msg && isConversationFailed(msg.conversationId)) {
+    log.info({ messageId, conversationId: msg.conversationId }, 'Skipping extraction for failed conversation (pre-upsert guard)');
+    return;
+  }
+
   await extractAndUpsertMemoryItemsForMessage(messageId, scopeId);
   // Queue entity extraction for this message after items are extracted
   const config = getConfig();

--- a/assistant/src/memory/task-memory-cleanup.ts
+++ b/assistant/src/memory/task-memory-cleanup.ts
@@ -1,33 +1,27 @@
 import { getLogger } from '../util/logger.js';
-import { rawRun } from './raw-query.js';
+import { rawGet, rawRun } from './raw-query.js';
 import { bumpMemoryVersion } from './recall-cache.js';
 
 const log = getLogger('task-memory-cleanup');
 
-// Conversations whose task/schedule execution failed. Memory extraction
-// jobs that arrive after the one-shot invalidation must not create new
-// `assistant_inferred` items for these conversations. The set is checked
-// at extraction time in the extraction job handler.
-const failedConversationIds = new Set<string>();
-
-/** Mark a conversation as failed so future extraction jobs skip it. */
-export function markConversationFailed(conversationId: string): void {
-  failedConversationIds.add(conversationId);
-}
-
-/** Check whether a conversation has been marked as failed. */
+/**
+ * Check whether a conversation belongs to a failed task run or failed
+ * schedule run. Derived from durable storage (task_runs / cron_runs)
+ * so the check survives daemon restarts.
+ */
 export function isConversationFailed(conversationId: string): boolean {
-  return failedConversationIds.has(conversationId);
-}
-
-/** Remove a conversation from the failed set (used in tests). */
-export function clearFailedConversation(conversationId: string): void {
-  failedConversationIds.delete(conversationId);
-}
-
-/** Clear all failed conversation markers (used in tests). */
-export function clearAllFailedConversations(): void {
-  failedConversationIds.clear();
+  const row = rawGet<{ found: number }>(
+    `SELECT 1 AS found
+       FROM (
+         SELECT 1 FROM task_runs WHERE conversation_id = ? AND status = 'failed'
+         UNION ALL
+         SELECT 1 FROM cron_runs WHERE conversation_id = ? AND status = 'error'
+       )
+      LIMIT 1`,
+    conversationId,
+    conversationId,
+  );
+  return row !== null;
 }
 
 /**
@@ -36,9 +30,9 @@ export function clearAllFailedConversations(): void {
  * schedule fails — the assistant's optimistic claims (e.g., "I booked an
  * appointment") are not trustworthy if the task didn't complete.
  *
- * Also marks the conversation as failed so that any pending or future
- * extraction jobs for this conversation are blocked from creating new
- * `assistant_inferred` items.
+ * The failed state is derived from durable storage (task_runs / cron_runs),
+ * so any pending or future extraction jobs for this conversation are blocked
+ * from creating new `assistant_inferred` items — even after daemon restarts.
  *
  * Items that also have sources from other conversations are left alone
  * only when those conversations come from non-failed task/schedule runs
@@ -47,10 +41,6 @@ export function clearAllFailedConversations(): void {
  * a memory item and both fail, the item is correctly invalidated.
  */
 export function invalidateAssistantInferredItemsForConversation(conversationId: string): number {
-  // Mark failed *before* the UPDATE so concurrent extraction jobs
-  // that are already running see the flag immediately.
-  markConversationFailed(conversationId);
-
   // Cancel pending extract_items jobs for this conversation's messages
   // so the worker never processes them. Jobs already running will be
   // caught by the isConversationFailed check in the extraction handler.


### PR DESCRIPTION
Addresses Codex feedback on #8774:

1. **Pre-upsert guard**: Added a second `isConversationFailed` check immediately before `extractAndUpsertMemoryItemsForMessage` to close the race window where an in-flight extraction job passes the initial check before invalidation runs.

2. **Durable failed-conversation tracking**: Replaced the in-memory `Set` with a database query against `task_runs` and `cron_runs` tables, so failed-conversation markers survive daemon restarts. The failure state was already persisted durably by the task runner and scheduler before `invalidateAssistantInferredItemsForConversation` is called -- this change derives the check from that existing durable state rather than maintaining a redundant in-memory copy.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
