### PR TITLE
fix: scope Gmail retry to idempotent requests and surface archive truncation

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/gmail-archive-by-query.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/gmail-archive-by-query.ts
@@ -20,6 +20,7 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
       // Paginate through matching messages, capped to prevent unbounded API/memory usage
       const allMessageIds: string[] = [];
       let pageToken: string | undefined;
+      let truncated = false;
 
       while (allMessageIds.length < MAX_MESSAGES) {
         const listResp = await listMessages(token, query, Math.min(500, MAX_MESSAGES - allMessageIds.length), pageToken);
@@ -28,6 +29,11 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         allMessageIds.push(...ids);
         pageToken = listResp.nextPageToken ?? undefined;
         if (!pageToken) break;
+      }
+
+      // If we stopped because we hit the cap while more pages existed, flag truncation
+      if (allMessageIds.length >= MAX_MESSAGES && pageToken) {
+        truncated = true;
       }
 
       if (allMessageIds.length === 0) {
@@ -40,7 +46,11 @@ export async function run(input: Record<string, unknown>, _context: ToolContext)
         await batchModifyMessages(token, chunk, { removeLabelIds: ['INBOX'] });
       }
 
-      return ok(`Archived ${allMessageIds.length} message(s) matching query: ${query}`);
+      const summary = `Archived ${allMessageIds.length} message(s) matching query: ${query}`;
+      if (truncated) {
+        return ok(`${summary}\n\nNote: this operation was capped at ${MAX_MESSAGES} messages. Additional messages matching the query may remain in the inbox. Run the command again to archive more.`);
+      }
+      return ok(summary);
     });
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));

--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -38,8 +38,16 @@ function isRetryable(status: number): boolean {
   return status === 429 || (status >= 500 && status < 600);
 }
 
+const IDEMPOTENT_METHODS = new Set(['GET', 'HEAD', 'PUT', 'DELETE', 'OPTIONS']);
+
+function isIdempotent(options?: RequestInit): boolean {
+  const method = (options?.method ?? 'GET').toUpperCase();
+  return IDEMPOTENT_METHODS.has(method);
+}
+
 async function request<T>(token: string, path: string, options?: RequestInit): Promise<T> {
   const url = `${GMAIL_API_BASE}${path}`;
+  const canRetry = isIdempotent(options);
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     const resp = await fetch(url, {
@@ -52,7 +60,7 @@ async function request<T>(token: string, path: string, options?: RequestInit): P
     });
 
     if (!resp.ok) {
-      if (isRetryable(resp.status) && attempt < MAX_RETRIES) {
+      if (canRetry && isRetryable(resp.status) && attempt < MAX_RETRIES) {
         const retryAfter = resp.headers.get('retry-after');
         const delayMs = retryAfter
           ? parseInt(retryAfter, 10) * 1000


### PR DESCRIPTION
Addresses reviewer feedback on PR #8791:

1. **Retry only idempotent requests**: The retry loop in the Gmail client now only retries GET requests (and other safe methods). Non-idempotent POST operations like sendMessage are not retried to avoid duplicate side effects.

2. **Surface archive truncation**: When the archive-by-query tool hits the 5,000 message cap, the result now explicitly reports that the operation was truncated and more messages may remain.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
