### PR TITLE
fix: preserve null elements in unwrapOptionalsInArray using NSNull

### DIFF
--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -49,9 +49,11 @@ private func unwrapOptionals(_ dict: [String: Any?]) -> [String: Any] {
 }
 
 /// Recursively strip Optional boxing from array elements.
+/// nil elements are preserved as NSNull() so that positional nulls affect equality
+/// (e.g., [1, nil, 3] is not equal to [1, 3]).
 private func unwrapOptionalsInArray(_ array: [Any?]) -> [Any] {
-    return array.compactMap { element -> Any? in
-        guard let element = element else { return nil }
+    return array.map { element -> Any in
+        guard let element = element else { return NSNull() }
         if let nested = element as? [String: Any?] {
             return unwrapOptionals(nested)
         } else if let nestedArray = element as? [Any?] {


### PR DESCRIPTION
Addresses review feedback on #8790. The original compactMap implementation dropped nil elements from arrays, causing [1, null, 3] and [1, 3] to falsely compare as equal. Changed to map + NSNull() to preserve null semantics in array equality comparison.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
