### PR TITLE
fix: add per-call retry opt-in for idempotent POST endpoints in Gmail client

### DIFF
--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -45,9 +45,14 @@ function isIdempotent(options?: RequestInit): boolean {
   return IDEMPOTENT_METHODS.has(method);
 }
 
-async function request<T>(token: string, path: string, options?: RequestInit): Promise<T> {
+interface GmailRequestOptions extends RequestInit {
+  /** Override method-based retry eligibility. When true, retries on 429/5xx even for POST requests. */
+  retryable?: boolean;
+}
+
+async function request<T>(token: string, path: string, options?: GmailRequestOptions): Promise<T> {
   const url = `${GMAIL_API_BASE}${path}`;
-  const canRetry = isIdempotent(options);
+  const canRetry = options?.retryable ?? isIdempotent(options);
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     const resp = await fetch(url, {
@@ -145,6 +150,7 @@ export async function modifyMessage(
   return request<GmailMessage>(token, `/messages/${messageId}/modify`, {
     method: 'POST',
     body: JSON.stringify(modifications),
+    retryable: true,
   });
 }
 
@@ -157,6 +163,7 @@ export async function batchModifyMessages(
   await request<void>(token, '/messages/batchModify', {
     method: 'POST',
     body: JSON.stringify({ ids: messageIds, ...modifications }),
+    retryable: true,
   });
 }
 
@@ -167,6 +174,7 @@ export async function trashMessage(
 ): Promise<GmailMessage> {
   return request<GmailMessage>(token, `/messages/${messageId}/trash`, {
     method: 'POST',
+    retryable: true,
   });
 }
 


### PR DESCRIPTION
Addresses review feedback on #8793. The blanket POST exclusion from retries also blocked idempotent POST endpoints like batchModifyMessages. Added a retryable option that allows callers to opt-in to retries for specific POST calls, and enabled it for batchModifyMessages, modifyMessage, and trashMessage which are all idempotent (label mutations / trash operations).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
