### PR TITLE
fix: move pre-upsert guard into extractAndUpsertMemoryItemsForMessage and add conversation_id indexes

### DIFF
--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -10,6 +10,7 @@ import { enqueueMemoryJob } from './jobs-store.js';
 import { extractTextFromStoredMessageContent } from './message-content.js';
 import { getDb } from './db.js';
 import { memoryItemConflicts, memoryItems, memoryItemSources, messages } from './schema.js';
+import { isConversationFailed } from './task-memory-cleanup.js';
 import { clampUnitInterval } from './validation.js';
 
 const log = getLogger('memory-items-extractor');
@@ -224,7 +225,7 @@ async function extractItemsWithLLM(
 
 // ── Public API ─────────────────────────────────────────────────────────
 
-export async function extractAndUpsertMemoryItemsForMessage(messageId: string, scopeId?: string): Promise<number> {
+export async function extractAndUpsertMemoryItemsForMessage(messageId: string, scopeId?: string, conversationId?: string): Promise<number> {
   const db = getDb();
   const message = db
     .select({
@@ -253,6 +254,14 @@ export async function extractAndUpsertMemoryItemsForMessage(messageId: string, s
     : extractItemsPatternBased(text, effectiveScopeId);
 
   if (extracted.length === 0) return 0;
+
+  // Guard: re-check after the async LLM call. The event loop yields during
+  // extractItemsWithLLM, so another task could have marked the conversation
+  // as failed in the meantime. Bail before writing to the DB.
+  if (conversationId && isConversationFailed(conversationId)) {
+    log.info({ messageId, conversationId }, 'Skipping upsert — conversation marked failed during extraction');
+    return 0;
+  }
 
   // Determine verification state from message role
   const verificationState = message.role === 'user' ? 'user_reported' : 'assistant_inferred';

--- a/assistant/src/memory/job-handlers/extraction.ts
+++ b/assistant/src/memory/job-handlers/extraction.ts
@@ -42,14 +42,7 @@ export async function extractItemsJob(job: MemoryJob): Promise<void> {
     ? job.payload.scopeId
     : 'default';
 
-  // Re-check right before the write to close the race window: the conversation
-  // may have been marked failed while this job was doing preliminary work.
-  if (msg && isConversationFailed(msg.conversationId)) {
-    log.info({ messageId, conversationId: msg.conversationId }, 'Skipping extraction for failed conversation (pre-upsert guard)');
-    return;
-  }
-
-  await extractAndUpsertMemoryItemsForMessage(messageId, scopeId);
+  await extractAndUpsertMemoryItemsForMessage(messageId, scopeId, msg?.conversationId);
   // Queue entity extraction for this message after items are extracted
   const config = getConfig();
   if (config.memory.entity.enabled) {

--- a/assistant/src/memory/migrations/021-conversation-status-indexes.ts
+++ b/assistant/src/memory/migrations/021-conversation-status-indexes.ts
@@ -1,0 +1,11 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Add composite indexes on (conversation_id, status) for task_runs and
+ * cron_runs. The isConversationFailed query filters on both columns via a
+ * UNION ALL — without these indexes each branch requires a full table scan.
+ */
+export function migrateConversationStatusIndexes(database: DrizzleDb): void {
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_task_runs_conversation_status ON task_runs(conversation_id, status)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_cron_runs_conversation_status ON cron_runs(conversation_id, status)`);
+}

--- a/assistant/src/memory/migrations/113-late-migrations.ts
+++ b/assistant/src/memory/migrations/113-late-migrations.ts
@@ -5,6 +5,7 @@ import { migrateMemorySegmentsIndexes } from './016-memory-segments-indexes.js';
 import { migrateMemoryItemsIndexes } from './017-memory-items-indexes.js';
 import { migrateRemainingTableIndexes } from './018-remaining-table-indexes.js';
 import { migrateRenameChannelToVellum } from './020-rename-macos-ios-channel-to-vellum.js';
+import { migrateConversationStatusIndexes } from './021-conversation-status-indexes.js';
 
 /**
  * Late-stage migrations that must run after all tables and indexes exist:
@@ -17,4 +18,5 @@ export function runLateMigrations(database: DrizzleDb): void {
   migrateMemoryItemsIndexes(database);
   migrateRemainingTableIndexes(database);
   migrateRenameChannelToVellum(database);
+  migrateConversationStatusIndexes(database);
 }

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -24,6 +24,7 @@ export { migrateMemoryItemsIndexes } from './017-memory-items-indexes.js';
 export { migrateRemainingTableIndexes } from './018-remaining-table-indexes.js';
 export { migrateNotificationTablesSchema } from './019-notification-tables-schema-migration.js';
 export { migrateRenameChannelToVellum } from './020-rename-macos-ios-channel-to-vellum.js';
+export { migrateConversationStatusIndexes } from './021-conversation-status-indexes.js';
 export { createCoreTables } from './100-core-tables.js';
 export { createWatchersAndLogsTables } from './101-watchers-and-logs.js';
 export { addCoreColumns } from './102-alter-table-columns.js';


### PR DESCRIPTION
Addresses review feedback on #8792. Moves the isConversationFailed check from between synchronous code (where it was redundant) to after the async LLM extraction but before DB writes (where the actual race window exists). Also adds indexes on (conversation_id, status) for task_runs and cron_runs tables to support the new durable query pattern.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
