### PR TITLE
fix: prevent weather tool from spinning in a web_search loop

### DIFF
--- a/assistant/src/config/bundled-skills/weather/SKILL.md
+++ b/assistant/src/config/bundled-skills/weather/SKILL.md
@@ -35,3 +35,4 @@ The tool returns:
 
 - If the user provides an ambiguous location (e.g. "Springfield"), the geocoding API picks the most prominent match. If the result seems wrong, suggest the user be more specific (e.g. "Springfield, IL").
 - The tool auto-renders a rich weather card with hourly and daily forecasts — you don't need to reformat the data as text unless the user explicitly asks for a text summary.
+- The tool fetches **live data** from the Open-Meteo Weather API. Do NOT follow up with `web_search`, `ui_show`, or `ui_update` to verify, supplement, or re-render the data — the card is already accurate and complete. Just respond with a brief conversational summary.

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -58,7 +58,7 @@ export const uiShowTool: Tool = {
     'Presenting choices: When the user needs to make a choice or provide structured input, prefer interactive surfaces over plain text. ' +
     'Use list (2-8 options, single select), form (structured input with typed fields), confirmation (destructive/important actions), or table (data review with selectable rows).\n\n' +
     'Tool chaining: After gathering data via tools (web search, browser, APIs), synthesize results into a visual output. ' +
-    'Exception: get_weather automatically renders its own surface — do NOT call ui_show or app_create after get_weather, just respond with a brief summary.\n\n' +
+    'Exception: get_weather automatically renders its own surface with live API data — do NOT call ui_show, ui_update, app_create, or web_search after get_weather. Just respond with a brief summary.\n\n' +
     'Task progress for multi-step workflows: Create a card with template "task_progress" and templateData containing steps. ' +
     'As each step completes, call ui_update to patch data.templateData (not top-level fields). ' +
     'Set templateData.status to "completed" or "failed" when done.',

--- a/assistant/src/tools/weather/service.ts
+++ b/assistant/src/tools/weather/service.ts
@@ -538,7 +538,10 @@ export async function executeGetWeather(
     } catch (err) {
       log.warn({ err }, 'Failed to auto-emit weather surface');
     }
-    // Return concise result -- the surface is already displayed
+    // Return concise result -- the surface is already displayed.
+    // The trailing notice prevents the model from looping with web_search
+    // to "verify" or "improve" data that is already live and complete.
+    lines.push('', '[Live data from Open-Meteo Weather API. The weather card is already rendered. Respond with a brief summary — do NOT call web_search, ui_show, or ui_update.]');
     return { content: lines.join('\n'), isError: false };
   }
 


### PR DESCRIPTION
## Summary

- Add trailing notice to weather tool result text telling the model the data is live API data and no verification/supplementation via `web_search`, `ui_show`, or `ui_update` is needed
- Update weather SKILL.md to explicitly prohibit follow-up web searches after the card renders
- Expand the `ui_show` tool description exception to include `web_search` and `ui_update` in the post-`get_weather` prohibition list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
