### PR TITLE
fix: gate weather anti-loop notice on successful ui_show emission

### DIFF
--- a/assistant/src/tools/weather/service.ts
+++ b/assistant/src/tools/weather/service.ts
@@ -535,13 +535,14 @@ export async function executeGetWeather(
         surface_type: 'dynamic_page',
         data: uiShowData,
       });
+      // The trailing notice prevents the model from looping with web_search
+      // to "verify" or "improve" data that is already live and complete.
+      // Only added after a successful emit — if ui_show threw, the card
+      // was NOT rendered and the model should remain free to retry.
+      lines.push('', '[Live data from Open-Meteo Weather API. The weather card is already rendered. Respond with a brief summary — do NOT call web_search, ui_show, or ui_update.]');
     } catch (err) {
       log.warn({ err }, 'Failed to auto-emit weather surface');
     }
-    // Return concise result -- the surface is already displayed.
-    // The trailing notice prevents the model from looping with web_search
-    // to "verify" or "improve" data that is already live and complete.
-    lines.push('', '[Live data from Open-Meteo Weather API. The weather card is already rendered. Respond with a brief summary — do NOT call web_search, ui_show, or ui_update.]');
     return { content: lines.join('\n'), isError: false };
   }
 


### PR DESCRIPTION
The anti-loop notice claiming 'The weather card is already rendered' was appended unconditionally, even when proxyToolResolver('ui_show') threw an error. This prevented the model from retrying a failed render. Moved the notice inside the success path so it only appears when ui_show actually succeeds.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
