### PR TITLE
fix: clarify anti-loop fallback wording to avoid OAuth type mismatch

### DIFF
--- a/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
@@ -208,7 +208,7 @@ Each step has a **retry budget of 3 attempts**. An attempt is one try at the ste
 2. **Fall back to manual.** Tell the user what you were trying to do and ask them to complete that step manually in the browser. Give them the direct URL and clear text instructions.
 3. **Resume automation** at the next step once the user confirms the manual step is done.
 
-If **two or more steps** require manual fallback, abandon the automated flow entirely and switch to giving the user the remaining steps as text instructions with links (same format as Path A).
+If **two or more steps** require manual fallback, abandon the automated flow entirely and switch to giving the user the remaining steps as clear text instructions with links — using the correct OAuth type for the current flow (Desktop app for macOS, Web application for channels).
 
 ## Things That Do Not Work — Do Not Attempt
 


### PR DESCRIPTION
The anti-loop guardrail in the Google OAuth setup skill referenced 'Path A' format for manual fallback, but Path A creates a Web application OAuth client. For desktop/loopback flows, this would cause redirect URI mismatch. Changed the wording to be flow-agnostic.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
