### PR TITLE
fix: use CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE for GCP hatch

### DIFF
--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -192,8 +192,8 @@ final class AssistantCli {
             ]
             for key in ["ANTHROPIC_API_KEY", "BASE_DATA_DIR", "VELLUM_DEBUG",
                         "SENTRY_DSN", "TMPDIR", "USER", "LANG",
-                        "CLOUDSDK_CONFIG", "GOOGLE_APPLICATION_CREDENTIALS",
-                        "GCP_ACCOUNT_EMAIL",
+                        "CLOUDSDK_CONFIG", "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+                        "GOOGLE_APPLICATION_CREDENTIALS", "GCP_ACCOUNT_EMAIL",
                         "AWS_PROFILE", "AWS_DEFAULT_REGION",
                         "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"] {
                 if let val = fullEnv[key] { env[key] = val }
@@ -383,6 +383,7 @@ final class AssistantCli {
                     .appendingPathComponent("vellum-sa-key-\(ProcessInfo.processInfo.processIdentifier).json")
                 try config.gcpServiceAccountKey.write(to: tmpKeyPath, atomically: true, encoding: .utf8)
                 env["GOOGLE_APPLICATION_CREDENTIALS"] = tmpKeyPath.path
+                env["CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE"] = tmpKeyPath.path
 
                 if let data = config.gcpServiceAccountKey.data(using: .utf8) {
                     do {


### PR DESCRIPTION
## Summary
- Sets `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE` env var alongside `GOOGLE_APPLICATION_CREDENTIALS` when hatching a GCP assistant from the desktop app
- `GOOGLE_APPLICATION_CREDENTIALS` is a Google client library convention — gcloud CLI ignores it and requires either pre-activated credentials or `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE`
- Also forwards `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE` in the retire command's env allowlist for consistency

## Test plan
- [ ] Open the desktop app and start a new GCP hatch flow
- [ ] Provide a GCP service account JSON key file during onboarding
- [ ] Confirm the hatch completes without "does not have any valid credentials" error
- [ ] Confirm the `--account` flag still works correctly (gcloud uses the credential file to authenticate as the service account)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
