### PR TITLE
M2: AppsGridView — full-screen apps grid view

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -1,0 +1,252 @@
+import SwiftUI
+
+/// Full-screen apps grid view showing all apps as an icon grid with search and pinned/recent sections.
+struct AppsGridView: View {
+    @ObservedObject var appListManager: AppListManager
+    let daemonClient: DaemonClient
+    let onOpenApp: (String) -> Void
+
+    @State private var searchText = ""
+    @State private var hoveredAppId: String?
+    @State private var recentVisibleCount = 10
+
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: VSpacing.xl), count: 5)
+
+    var body: some View {
+        if appListManager.displayApps.isEmpty {
+            VEmptyState(
+                title: "No apps yet",
+                subtitle: "Apps you open will appear here",
+                icon: "square.grid.2x2"
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(VColor.backgroundSubtle)
+        } else {
+            ScrollView {
+                VStack(spacing: VSpacing.xl) {
+                    searchBar
+                        .padding(.top, VSpacing.xxl)
+
+                    if !filteredPinnedApps.isEmpty || !filteredRecentApps.isEmpty {
+                        if !filteredPinnedApps.isEmpty {
+                            sectionView(title: "PINNED", apps: filteredPinnedApps)
+                        }
+
+                        if !filteredRecentApps.isEmpty {
+                            recentSectionView
+                        }
+                    } else if !searchText.isEmpty {
+                        VEmptyState(
+                            title: "No apps matched",
+                            subtitle: "No apps matched \"\(searchText)\"",
+                            icon: "magnifyingglass"
+                        )
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, VSpacing.xxxl)
+                    }
+                }
+                .padding(.horizontal, VSpacing.xxl)
+                .padding(.bottom, VSpacing.xxl)
+            }
+            .background(VColor.backgroundSubtle)
+        }
+    }
+
+    // MARK: - Search Bar
+
+    private var searchBar: some View {
+        GeometryReader { geometry in
+            HStack {
+                Spacer()
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "magnifyingglass")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(VColor.textMuted)
+
+                    TextField("Search apps...", text: $searchText)
+                        .textFieldStyle(.plain)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+
+                    if !searchText.isEmpty {
+                        Button(action: { searchText = "" }) {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.system(size: 12))
+                                .foregroundColor(VColor.textMuted)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Clear search")
+                    }
+                }
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.vertical, VSpacing.sm)
+                .background(VColor.surface)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.pill)
+                        .stroke(VColor.surfaceBorder, lineWidth: 1)
+                )
+                .frame(maxWidth: geometry.size.width * 0.6)
+                Spacer()
+            }
+        }
+        .frame(height: 36)
+    }
+
+    // MARK: - Sections
+
+    private func sectionView(title: String, apps: [AppListManager.AppItem]) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            Text(title)
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .tracking(1.2)
+                .padding(.leading, VSpacing.xs)
+
+            LazyVGrid(columns: columns, spacing: VSpacing.xl) {
+                ForEach(apps) { app in
+                    appGridItem(app)
+                }
+            }
+        }
+    }
+
+    private var recentSectionView: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            Text("RECENT")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .tracking(1.2)
+                .padding(.leading, VSpacing.xs)
+
+            let visibleRecent = Array(filteredRecentApps.prefix(recentVisibleCount))
+
+            LazyVGrid(columns: columns, spacing: VSpacing.xl) {
+                ForEach(visibleRecent) { app in
+                    appGridItem(app)
+                }
+            }
+
+            if filteredRecentApps.count > recentVisibleCount {
+                HStack {
+                    Spacer()
+                    Button {
+                        withAnimation(VAnimation.standard) {
+                            recentVisibleCount += 10
+                        }
+                    } label: {
+                        Text("Show more")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.accent)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Show more recent apps")
+                    Spacer()
+                }
+                .padding(.top, VSpacing.sm)
+            }
+        }
+    }
+
+    // MARK: - Grid Item
+
+    private func appGridItem(_ app: AppListManager.AppItem) -> some View {
+        let isHovered = hoveredAppId == app.id
+        let iconInfo = resolvedIcon(for: app)
+
+        return Button {
+            onOpenApp(app.id)
+        } label: {
+            VStack(spacing: VSpacing.sm) {
+                VAppIcon(
+                    sfSymbol: iconInfo.sfSymbol,
+                    gradientColors: iconInfo.colors,
+                    size: .medium
+                )
+
+                Text(app.name)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity)
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .buttonStyle(.plain)
+        .scaleEffect(isHovered ? 1.05 : 1.0)
+        .animation(VAnimation.fast, value: isHovered)
+        .onHover { hovering in
+            hoveredAppId = hovering ? app.id : nil
+        }
+        .contextMenu {
+            Button("Open") {
+                onOpenApp(app.id)
+            }
+            Button(app.isPinned ? "Unpin" : "Pin") {
+                if app.isPinned {
+                    appListManager.unpinApp(id: app.id)
+                } else {
+                    appListManager.pinApp(id: app.id)
+                }
+            }
+        }
+        .accessibilityLabel(app.name)
+    }
+
+    // MARK: - Helpers
+
+    private func resolvedIcon(for app: AppListManager.AppItem) -> (sfSymbol: String, colors: [String]) {
+        if let symbol = app.sfSymbol, let colors = app.iconBackground, !colors.isEmpty {
+            return (sfSymbol: symbol, colors: colors)
+        }
+        return VAppIconGenerator.generate(from: app.name, type: app.appType)
+    }
+
+    private var filteredPinnedApps: [AppListManager.AppItem] {
+        let pinned = appListManager.displayApps.filter(\.isPinned)
+        guard !searchText.isEmpty else { return pinned }
+        return pinned.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+    }
+
+    private var filteredRecentApps: [AppListManager.AppItem] {
+        let unpinned = appListManager.displayApps.filter { !$0.isPinned }
+            .sorted { ($0.lastOpenedAt) > ($1.lastOpenedAt) }
+        guard !searchText.isEmpty else { return unpinned }
+        return unpinned.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+    }
+}
+
+// MARK: - Preview
+
+struct AppsGridView_Previews: PreviewProvider {
+    struct PreviewWrapper: View {
+        @StateObject private var appListManager = AppListManager()
+
+        var body: some View {
+            AppsGridView(
+                appListManager: appListManager,
+                daemonClient: DaemonClient(),
+                onOpenApp: { _ in }
+            )
+            .onAppear {
+                appListManager.recordAppOpen(id: "1", name: "Weather", icon: nil, appType: "app")
+                appListManager.recordAppOpen(id: "2", name: "Notes", icon: nil, appType: "app")
+                appListManager.recordAppOpen(id: "3", name: "Calendar", icon: nil, appType: "app")
+                appListManager.recordAppOpen(id: "4", name: "Music", icon: nil, appType: "app")
+                appListManager.recordAppOpen(id: "5", name: "Photos", icon: nil, appType: "site")
+                appListManager.recordAppOpen(id: "6", name: "Maps", icon: nil, appType: "app")
+                appListManager.pinApp(id: "1")
+                appListManager.pinApp(id: "2")
+            }
+        }
+    }
+
+    static var previews: some View {
+        ZStack {
+            VColor.background.ignoresSafeArea()
+            PreviewWrapper()
+        }
+        .frame(width: 800, height: 600)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import VellumAssistantShared
 
 /// Full-screen apps grid view showing all apps as an icon grid with search and pinned/recent sections.
 struct AppsGridView: View {


### PR DESCRIPTION
## Summary
- Created AppsGridView showing all apps as icon grid with VAppIcon components
- Search bar at top for filtering apps by name
- Pinned and Recent sections with pagination
- Hover effects, right-click context menu for pin/unpin
- Empty states for no apps and no search results

Part of #8804
Closes #8806
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
