### PR TITLE
M3: Navigation integration + Home Base in grid

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 // MARK: - Domain Types
 
 public enum NativePanelId: String, Codable, Equatable, Sendable {
-    case chat, threadList, settings, agent, debug, directory, generated, identity, avatarCustomization, voiceMode, assistantInbox
+    case chat, threadList, settings, agent, debug, directory, generated, identity, avatarCustomization, voiceMode, assistantInbox, apps
 }
 
 public enum SlotContent: Equatable, Sendable {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1042,7 +1042,7 @@ struct MainWindowView: View {
             Spacer().frame(height: 0)
 
             // MARK: Nav Items (fixed)
-            SidebarNavRow(icon: "square.grid.2x2", label: "Home Base", isActive: windowState.activePanel == .directory) {
+            SidebarNavRow(icon: "house.fill", label: "Home Base", isActive: windowState.activePanel == .directory) {
                 windowState.togglePanel(.directory)
             }
             SidebarNavRow(icon: "person.crop.circle", label: "Identity", isActive: windowState.activePanel == .identity) {
@@ -1053,6 +1053,9 @@ struct MainWindowView: View {
             }
             SidebarNavRow(icon: "tray.fill", label: "Inbox", isActive: windowState.activePanel == .assistantInbox) {
                 windowState.togglePanel(.assistantInbox)
+            }
+            SidebarNavRow(icon: "square.grid.2x2", label: "Apps", isActive: windowState.activePanel == .apps) {
+                windowState.togglePanel(.apps)
             }
 
             // Divider between nav items and threads
@@ -1154,7 +1157,7 @@ struct MainWindowView: View {
         VStack(spacing: VSpacing.sm) {
             Spacer().frame(height: 0)
 
-            SidebarNavRow(icon: "square.grid.2x2", label: "Home Base", isActive: windowState.activePanel == .directory, isExpanded: false) {
+            SidebarNavRow(icon: "house.fill", label: "Home Base", isActive: windowState.activePanel == .directory, isExpanded: false) {
                 windowState.togglePanel(.directory)
             }
             SidebarNavRow(icon: "person.crop.circle", label: "Identity", isActive: windowState.activePanel == .identity, isExpanded: false) {
@@ -1165,6 +1168,9 @@ struct MainWindowView: View {
             }
             SidebarNavRow(icon: "tray.fill", label: "Inbox", isActive: windowState.activePanel == .assistantInbox, isExpanded: false) {
                 windowState.togglePanel(.assistantInbox)
+            }
+            SidebarNavRow(icon: "square.grid.2x2", label: "Apps", isActive: windowState.activePanel == .apps, isExpanded: false) {
+                windowState.togglePanel(.apps)
             }
 
             VColor.divider

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -104,6 +104,18 @@ extension MainWindowView {
             )
         case .assistantInbox:
             AssistantInboxPanel(onClose: { windowState.selection = nil }, daemonClient: daemonClient)
+        case .apps:
+            AppsGridView(
+                appListManager: appListManager,
+                daemonClient: daemonClient,
+                onOpenApp: { appId in
+                    try? daemonClient.sendAppOpen(appId: appId)
+                    windowState.selection = .app(appId)
+                },
+                onOpenHomeBase: {
+                    windowState.selection = .panel(.directory)
+                }
+            )
         }
     }
 
@@ -294,6 +306,60 @@ extension MainWindowView {
                     .overlay(alignment: .topTrailing) { panelDismissButton }
                     .background(adaptiveColor(light: Moss._50, dark: Moss._950))
                 }
+            } else if panelType == .apps {
+                if isAppChatOpen {
+                    // VSplitView: ChatView (left) + Apps grid (right)
+                    let contentWidth = Double(geometry.size.width) / zoomManager.zoomLevel - Double(VSpacing.sm)
+                    let effectiveWidth = Binding<Double>(
+                        get: { appPanelWidth > 0 ? appPanelWidth : contentWidth * 0.7 },
+                        set: { appPanelWidth = $0 }
+                    )
+                    VSplitView(
+                        panelWidth: effectiveWidth,
+                        showPanel: true,
+                        main: {
+                            chatView
+                        },
+                        panel: {
+                            AppsGridView(
+                                appListManager: appListManager,
+                                daemonClient: daemonClient,
+                                onOpenApp: { appId in
+                                    try? daemonClient.sendAppOpen(appId: appId)
+                                    windowState.selection = .app(appId)
+                                },
+                                onOpenHomeBase: {
+                                    windowState.selection = .panel(.directory)
+                                }
+                            )
+                            .background(adaptiveColor(light: Moss._100, dark: Moss._900))
+                            .clipShape(UnevenRoundedRectangle(topLeadingRadius: VRadius.xl, bottomLeadingRadius: VRadius.xl))
+                        }
+                    )
+                    .onAppear {
+                        if threadManager.activeViewModel == nil {
+                            if let firstThread = threadManager.visibleThreads.first {
+                                threadManager.selectThread(id: firstThread.id)
+                            } else {
+                                threadManager.createThread()
+                            }
+                        }
+                    }
+                } else {
+                    AppsGridView(
+                        appListManager: appListManager,
+                        daemonClient: daemonClient,
+                        onOpenApp: { appId in
+                            try? daemonClient.sendAppOpen(appId: appId)
+                            windowState.selection = .app(appId)
+                        },
+                        onOpenHomeBase: {
+                            windowState.selection = .panel(.directory)
+                        }
+                    )
+                    .overlay(alignment: .topTrailing) { panelDismissButton }
+                    .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+                }
             } else if panelType == .documentEditor {
                 let config = windowState.layoutConfig
                 VSplitView(
@@ -462,6 +528,20 @@ extension MainWindowView {
             AssistantInboxPanel(onClose: { windowState.dismissOverlay() }, daemonClient: daemonClient)
                 .overlay(alignment: .topTrailing) { panelDismissButton }
                 .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+        case .apps:
+            AppsGridView(
+                appListManager: appListManager,
+                daemonClient: daemonClient,
+                onOpenApp: { appId in
+                    try? daemonClient.sendAppOpen(appId: appId)
+                    windowState.selection = .app(appId)
+                },
+                onOpenHomeBase: {
+                    windowState.selection = .panel(.directory)
+                }
+            )
+            .overlay(alignment: .topTrailing) { panelDismissButton }
+            .background(adaptiveColor(light: Moss._50, dark: Moss._950))
         default:
             EmptyView()
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -2,10 +2,12 @@ import SwiftUI
 import VellumAssistantShared
 
 /// Full-screen apps grid view showing all apps as an icon grid with search and pinned/recent sections.
+/// Home Base always appears as the first item in the Pinned section.
 struct AppsGridView: View {
     @ObservedObject var appListManager: AppListManager
     let daemonClient: DaemonClient
     let onOpenApp: (String) -> Void
+    var onOpenHomeBase: (() -> Void)?
 
     @State private var searchText = ""
     @State private var hoveredAppId: String?
@@ -13,44 +15,42 @@ struct AppsGridView: View {
 
     private let columns = Array(repeating: GridItem(.flexible(), spacing: VSpacing.xl), count: 5)
 
+    /// Whether "Home Base" matches the current search query.
+    private var homeBaseMatchesSearch: Bool {
+        guard !searchText.isEmpty else { return true }
+        return "Home Base".localizedCaseInsensitiveContains(searchText)
+    }
+
     var body: some View {
-        if appListManager.displayApps.isEmpty {
-            VEmptyState(
-                title: "No apps yet",
-                subtitle: "Apps you open will appear here",
-                icon: "square.grid.2x2"
-            )
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(VColor.backgroundSubtle)
-        } else {
-            ScrollView {
-                VStack(spacing: VSpacing.xl) {
-                    searchBar
-                        .padding(.top, VSpacing.xxl)
+        ScrollView {
+            VStack(spacing: VSpacing.xl) {
+                searchBar
+                    .padding(.top, VSpacing.xxl)
 
-                    if !filteredPinnedApps.isEmpty || !filteredRecentApps.isEmpty {
-                        if !filteredPinnedApps.isEmpty {
-                            sectionView(title: "PINNED", apps: filteredPinnedApps)
-                        }
-
-                        if !filteredRecentApps.isEmpty {
-                            recentSectionView
-                        }
-                    } else if !searchText.isEmpty {
-                        VEmptyState(
-                            title: "No apps matched",
-                            subtitle: "No apps matched \"\(searchText)\"",
-                            icon: "magnifyingglass"
-                        )
-                        .frame(maxWidth: .infinity)
-                        .padding(.top, VSpacing.xxxl)
-                    }
+                // Pinned section: Home Base is always the first item
+                let showPinned = homeBaseMatchesSearch || !filteredPinnedApps.isEmpty
+                if showPinned {
+                    pinnedSectionView
                 }
-                .padding(.horizontal, VSpacing.xxl)
-                .padding(.bottom, VSpacing.xxl)
+
+                if !filteredRecentApps.isEmpty {
+                    recentSectionView
+                }
+
+                if !showPinned && filteredRecentApps.isEmpty && !searchText.isEmpty {
+                    VEmptyState(
+                        title: "No apps matched",
+                        subtitle: "No apps matched \"\(searchText)\"",
+                        icon: "magnifyingglass"
+                    )
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, VSpacing.xxxl)
+                }
             }
-            .background(VColor.backgroundSubtle)
+            .padding(.horizontal, VSpacing.xxl)
+            .padding(.bottom, VSpacing.xxl)
         }
+        .background(VColor.backgroundSubtle)
     }
 
     // MARK: - Search Bar
@@ -95,6 +95,26 @@ struct AppsGridView: View {
     }
 
     // MARK: - Sections
+
+    /// Pinned section with Home Base as the first item followed by user-pinned apps.
+    private var pinnedSectionView: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            Text("PINNED")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .tracking(1.2)
+                .padding(.leading, VSpacing.xs)
+
+            LazyVGrid(columns: columns, spacing: VSpacing.xl) {
+                if homeBaseMatchesSearch {
+                    homeBaseGridItem
+                }
+                ForEach(filteredPinnedApps) { app in
+                    appGridItem(app)
+                }
+            }
+        }
+    }
 
     private func sectionView(title: String, apps: [AppListManager.AppItem]) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
@@ -195,6 +215,53 @@ struct AppsGridView: View {
         .accessibilityLabel(app.name)
     }
 
+    // MARK: - Home Base Item
+
+    private static let homeBaseId = "__home_base__"
+
+    private var homeBaseGridItem: some View {
+        let isHovered = hoveredAppId == Self.homeBaseId
+
+        return Button {
+            onOpenHomeBase?()
+        } label: {
+            VStack(spacing: VSpacing.sm) {
+                VAppIcon(
+                    sfSymbol: "house.fill",
+                    gradientColors: ["#7C3AED", "#4F46E5"],
+                    size: .medium
+                )
+                .overlay(alignment: .topTrailing) {
+                    // Small home badge in the top-right corner
+                    ZStack {
+                        Circle()
+                            .fill(Color(hexString: "#4F46E5"))
+                            .frame(width: 18, height: 18)
+                        Image(systemName: "house.fill")
+                            .font(.system(size: 9, weight: .bold))
+                            .foregroundColor(.white)
+                    }
+                    .offset(x: 4, y: -4)
+                }
+
+                Text("Home Base")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity)
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .buttonStyle(.plain)
+        .scaleEffect(isHovered ? 1.05 : 1.0)
+        .animation(VAnimation.fast, value: isHovered)
+        .onHover { hovering in
+            hoveredAppId = hovering ? Self.homeBaseId : nil
+        }
+        .accessibilityLabel("Home Base")
+    }
+
     // MARK: - Helpers
 
     private func resolvedIcon(for app: AppListManager.AppItem) -> (sfSymbol: String, colors: [String]) {
@@ -228,7 +295,8 @@ struct AppsGridView_Previews: PreviewProvider {
             AppsGridView(
                 appListManager: appListManager,
                 daemonClient: DaemonClient(),
-                onOpenApp: { _ in }
+                onOpenApp: { _ in },
+                onOpenHomeBase: {}
             )
             .onAppear {
                 appListManager.recordAppOpen(id: "1", name: "Weather", icon: nil, appType: "app")

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -274,7 +274,7 @@ struct AppsGridView: View {
     /// Exclude any app that is the Home Base from the regular sections
     /// (since Home Base is always shown as a dedicated synthetic first item).
     private func isHomeBaseApp(_ app: AppListManager.AppItem) -> Bool {
-        app.name.localizedCaseInsensitiveContains("home base")
+        app.name.caseInsensitiveCompare("Home Base") == .orderedSame
     }
 
     private var filteredPinnedApps: [AppListManager.AppItem] {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -271,14 +271,20 @@ struct AppsGridView: View {
         return VAppIconGenerator.generate(from: app.name, type: app.appType)
     }
 
+    /// Exclude any app that is the Home Base from the regular sections
+    /// (since Home Base is always shown as a dedicated synthetic first item).
+    private func isHomeBaseApp(_ app: AppListManager.AppItem) -> Bool {
+        app.name.localizedCaseInsensitiveContains("home base")
+    }
+
     private var filteredPinnedApps: [AppListManager.AppItem] {
-        let pinned = appListManager.displayApps.filter(\.isPinned)
+        let pinned = appListManager.displayApps.filter { $0.isPinned && !isHomeBaseApp($0) }
         guard !searchText.isEmpty else { return pinned }
         return pinned.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
     }
 
     private var filteredRecentApps: [AppListManager.AppItem] {
-        let unpinned = appListManager.displayApps.filter { !$0.isPinned }
+        let unpinned = appListManager.displayApps.filter { !$0.isPinned && !isHomeBaseApp($0) }
             .sorted { ($0.lastOpenedAt) > ($1.lastOpenedAt) }
         guard !searchText.isEmpty else { return unpinned }
         return unpinned.filter { $0.name.localizedCaseInsensitiveContains(searchText) }

--- a/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
@@ -9,6 +9,7 @@ enum SidePanelType: Hashable, CaseIterable {
     case avatarCustomization
     case voiceMode
     case assistantInbox
+    case apps
 
     init?(rawValue: String) {
         switch rawValue {
@@ -22,6 +23,7 @@ enum SidePanelType: Hashable, CaseIterable {
         case "avatarCustomization": self = .avatarCustomization
         case "voiceMode": self = .voiceMode
         case "assistantInbox": self = .assistantInbox
+        case "apps": self = .apps
         default: return nil
         }
     }


### PR DESCRIPTION
## Summary
- Added 'Apps' sidebar nav item (both expanded and collapsed)
- Changed Home Base icon from square.grid.2x2 to house.fill
- Added .apps case to SidePanelType
- Wired AppsGridView as main content when Apps panel is active
- Added Home Base as special first item in the Apps grid with home badge

Part of #8804
Closes #8807
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
