### PR TITLE
M4: Auto-icon assignment + icon editing

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import os
+import VellumAssistantShared
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AppListManager")
 
@@ -57,8 +58,15 @@ final class AppListManager: ObservableObject {
             if let icon { apps[index].icon = icon }
             if let previewBase64 { apps[index].previewBase64 = previewBase64 }
             if let appType { apps[index].appType = appType }
+            // Auto-assign icon if this app doesn't have one yet
+            if apps[index].sfSymbol == nil {
+                let generated = VAppIconGenerator.generate(from: name, type: appType ?? apps[index].appType)
+                apps[index].sfSymbol = generated.sfSymbol
+                apps[index].iconBackground = generated.colors
+            }
         } else {
-            let item = AppItem(
+            let generated = VAppIconGenerator.generate(from: name, type: appType)
+            var item = AppItem(
                 id: id,
                 name: name,
                 icon: icon,
@@ -66,6 +74,8 @@ final class AppListManager: ObservableObject {
                 appType: appType,
                 lastOpenedAt: Date()
             )
+            item.sfSymbol = generated.sfSymbol
+            item.iconBackground = generated.colors
             apps.append(item)
         }
         save()
@@ -100,6 +110,13 @@ final class AppListManager: ObservableObject {
 
     func removeApp(id: String) {
         apps.removeAll { $0.id == id }
+        save()
+    }
+
+    func updateAppIcon(id: String, sfSymbol: String, iconBackground: [String]) {
+        guard let index = apps.firstIndex(where: { $0.id == id }) else { return }
+        apps[index].sfSymbol = sfSymbol
+        apps[index].iconBackground = iconBackground
         save()
     }
 
@@ -150,6 +167,19 @@ final class AppListManager: ObservableObject {
             decoder.dateDecodingStrategy = .iso8601
             apps = try decoder.decode([AppItem].self, from: data)
             log.info("Loaded \(self.apps.count) app list entries")
+
+            // Migrate existing apps that don't have icons assigned yet
+            var didMigrate = false
+            for index in apps.indices where apps[index].sfSymbol == nil {
+                let generated = VAppIconGenerator.generate(from: apps[index].name, type: apps[index].appType)
+                apps[index].sfSymbol = generated.sfSymbol
+                apps[index].iconBackground = generated.colors
+                didMigrate = true
+            }
+            if didMigrate {
+                save()
+                log.info("Migrated app icons for existing entries")
+            }
         } catch {
             log.error("Failed to load app list: \(error.localizedDescription)")
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppIconPickerSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppIconPickerSheet.swift
@@ -1,0 +1,185 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// A sheet for picking an SF Symbol and gradient background for an app icon.
+struct AppIconPickerSheet: View {
+    let appName: String
+    let currentSymbol: String
+    let currentColors: [String]
+    let onSave: (String, [String]) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var selectedSymbol: String
+    @State private var selectedColors: [String]
+
+    init(
+        appName: String,
+        currentSymbol: String,
+        currentColors: [String],
+        onSave: @escaping (String, [String]) -> Void
+    ) {
+        self.appName = appName
+        self.currentSymbol = currentSymbol
+        self.currentColors = currentColors
+        self.onSave = onSave
+        _selectedSymbol = State(initialValue: currentSymbol)
+        _selectedColors = State(initialValue: currentColors)
+    }
+
+    private let symbolColumns = Array(repeating: GridItem(.flexible(), spacing: VSpacing.sm), count: 6)
+
+    var body: some View {
+        VStack(spacing: VSpacing.xl) {
+            // Header
+            Text("Change Icon")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textPrimary)
+
+            // Live preview
+            VStack(spacing: VSpacing.sm) {
+                VAppIcon(
+                    sfSymbol: selectedSymbol,
+                    gradientColors: selectedColors,
+                    size: .large
+                )
+                Text(appName)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+            }
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            // Symbol picker
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Text("SYMBOL")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .tracking(1.2)
+
+                ScrollView {
+                    LazyVGrid(columns: symbolColumns, spacing: VSpacing.sm) {
+                        ForEach(VAppIconGenerator.symbols, id: \.self) { symbol in
+                            Button {
+                                selectedSymbol = symbol
+                            } label: {
+                                Image(systemName: symbol)
+                                    .font(.system(size: 16, weight: .medium))
+                                    .foregroundColor(
+                                        selectedSymbol == symbol
+                                            ? VColor.accent
+                                            : VColor.textSecondary
+                                    )
+                                    .frame(width: 36, height: 36)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: VRadius.md)
+                                            .fill(
+                                                selectedSymbol == symbol
+                                                    ? VColor.accent.opacity(0.15)
+                                                    : VColor.surface
+                                            )
+                                    )
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: VRadius.md)
+                                            .stroke(
+                                                selectedSymbol == symbol
+                                                    ? VColor.accent
+                                                    : Color.clear,
+                                                lineWidth: 2
+                                            )
+                                    )
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel(symbol)
+                        }
+                    }
+                }
+                .frame(maxHeight: 180)
+            }
+
+            // Color picker
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Text("COLOR")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .tracking(1.2)
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: VSpacing.sm) {
+                        ForEach(VAppIconGenerator.gradientPalettes, id: \.self) { palette in
+                            let isSelected = palette == selectedColors
+                            Button {
+                                selectedColors = palette
+                            } label: {
+                                Circle()
+                                    .fill(
+                                        LinearGradient(
+                                            colors: palette.map { Color(hexString: $0) },
+                                            startPoint: .topLeading,
+                                            endPoint: .bottomTrailing
+                                        )
+                                    )
+                                    .frame(width: 28, height: 28)
+                                    .overlay(
+                                        Circle()
+                                            .stroke(
+                                                isSelected ? VColor.accent : Color.clear,
+                                                lineWidth: 2.5
+                                            )
+                                            .padding(-3)
+                                    )
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Gradient swatch")
+                        }
+                    }
+                    .padding(.horizontal, VSpacing.xs)
+                    .padding(.vertical, VSpacing.xs)
+                }
+            }
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            // Buttons
+            HStack {
+                Button("Cancel") {
+                    dismiss()
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(VColor.textSecondary)
+                .font(VFont.body)
+
+                Spacer()
+
+                Button("Save") {
+                    onSave(selectedSymbol, selectedColors)
+                    dismiss()
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(VColor.accent)
+                .font(VFont.bodyBold)
+            }
+        }
+        .padding(VSpacing.xl)
+        .frame(width: 320)
+        .background(VColor.background)
+    }
+}
+
+// MARK: - Preview
+
+struct AppIconPickerSheet_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            VColor.background.ignoresSafeArea()
+            AppIconPickerSheet(
+                appName: "Safari",
+                currentSymbol: "globe",
+                currentColors: ["#059669", "#10B981"],
+                onSave: { _, _ in }
+            )
+        }
+        .frame(width: 360, height: 600)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -12,6 +12,7 @@ struct AppsGridView: View {
     @State private var searchText = ""
     @State private var hoveredAppId: String?
     @State private var recentVisibleCount = 10
+    @State private var editingApp: AppListManager.AppItem?
 
     private let columns = Array(repeating: GridItem(.flexible(), spacing: VSpacing.xl), count: 5)
 
@@ -51,6 +52,17 @@ struct AppsGridView: View {
             .padding(.bottom, VSpacing.xxl)
         }
         .background(VColor.backgroundSubtle)
+        .sheet(item: $editingApp) { app in
+            let iconInfo = resolvedIcon(for: app)
+            AppIconPickerSheet(
+                appName: app.name,
+                currentSymbol: iconInfo.sfSymbol,
+                currentColors: iconInfo.colors,
+                onSave: { symbol, colors in
+                    appListManager.updateAppIcon(id: app.id, sfSymbol: symbol, iconBackground: colors)
+                }
+            )
+        }
     }
 
     // MARK: - Search Bar
@@ -210,6 +222,9 @@ struct AppsGridView: View {
                 } else {
                     appListManager.pinApp(id: app.id)
                 }
+            }
+            Button("Change Icon") {
+                editingApp = app
             }
         }
         .accessibilityLabel(app.name)

--- a/clients/shared/DesignSystem/Components/Display/VAppIconGenerator.swift
+++ b/clients/shared/DesignSystem/Components/Display/VAppIconGenerator.swift
@@ -7,7 +7,7 @@ public enum VAppIconGenerator {
     // MARK: - Gradient Palettes
 
     /// Curated gradient color pairs covering a range of hues.
-    static let gradientPalettes: [[String]] = [
+    public static let gradientPalettes: [[String]] = [
         ["#7C3AED", "#4F46E5"],  // violet
         ["#059669", "#10B981"],  // emerald
         ["#D97706", "#F59E0B"],  // amber
@@ -25,7 +25,7 @@ public enum VAppIconGenerator {
     // MARK: - SF Symbols
 
     /// Curated SF Symbols suitable for generic app icons.
-    static let symbols: [String] = [
+    public static let symbols: [String] = [
         "chart.line.uptrend.xyaxis",
         "doc.text",
         "globe",


### PR DESCRIPTION
## Summary
- Auto-assign SF Symbol + gradient icons when new apps are created via recordAppOpen
- Migrate existing apps without icons on load
- Added updateAppIcon method to AppListManager
- Created AppIconPickerSheet with symbol grid and color palette
- Added 'Change Icon' to AppsGridView right-click context menu
- Exposed VAppIconGenerator symbol/gradient lists for picker access

Part of #8804
Closes #8808
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
