### PR TITLE
Fix: record app open from AppsGridView

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -188,6 +188,10 @@ struct AppsGridView: View {
         let iconInfo = resolvedIcon(for: app)
 
         return Button {
+            appListManager.recordAppOpen(
+                id: app.id, name: app.name, icon: app.icon,
+                previewBase64: app.previewBase64, appType: app.appType
+            )
             onOpenApp(app.id)
         } label: {
             VStack(spacing: VSpacing.sm) {


### PR DESCRIPTION
## Summary
- Call appListManager.recordAppOpen inside AppsGridView's appGridItem button action
- Ensures lastOpenedAt is updated when apps are opened from the grid, matching the sidebar behavior
- Fixes Recent section ordering for grid-launched apps

Addresses review feedback on #8814
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
