### PR TITLE
Fix recording ownership and sessionId issues

### DIFF
--- a/assistant/src/__tests__/recording-handler.test.ts
+++ b/assistant/src/__tests__/recording-handler.test.ts
@@ -165,17 +165,22 @@ describe('handleRecordingStart', () => {
     expect(sent[0].options).toEqual(options);
   });
 
-  test('overwrites previous recording for the same conversation', () => {
+  test('returns early with existing recordingId when recording already active', () => {
     const { ctx, sent, fakeSocket } = createCtx();
 
     const id1 = handleRecordingStart('conv-3', undefined, fakeSocket, ctx);
     const id2 = handleRecordingStart('conv-3', undefined, fakeSocket, ctx);
 
-    expect(id1).not.toBe(id2);
-    // Both start messages were sent
-    expect(sent).toHaveLength(2);
+    // Should return the same recording ID (no overwrite)
+    expect(id2).toBe(id1);
+    // First call: recording_start; second call: assistant_text_delta + message_complete
+    expect(sent).toHaveLength(3);
+    expect(sent[0].type).toBe('recording_start');
     expect(sent[0].recordingId).toBe(id1);
-    expect(sent[1].recordingId).toBe(id2);
+    expect(sent[1].type).toBe('assistant_text_delta');
+    expect(sent[1].text).toBe('A recording is already active.');
+    expect(sent[2].type).toBe('message_complete');
+    expect(sent[2].sessionId).toBe('conv-3');
   });
 });
 

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -75,15 +75,22 @@ export async function handleTaskSubmit(
       if (isStopRecordingOnly(msg.task)) {
         // Find the active session for this socket so we can resolve the
         // conversation that owns the recording.
-        const activeSessionId = ctx.socketToSession.get(socket);
+        let activeSessionId = ctx.socketToSession.get(socket);
         let stopped = false;
         if (activeSessionId) {
           stopped = handleRecordingStop(activeSessionId, ctx) !== undefined;
+        }
+        // Ensure we have a sessionId for message_complete even if no prior session exists
+        if (!activeSessionId) {
+          const conversation = conversationStore.createConversation(msg.task);
+          activeSessionId = conversation.id;
+          ctx.socketToSession.set(socket, activeSessionId);
         }
         rlog.info('Recording stop intent intercepted');
         ctx.send(socket, {
           type: 'assistant_text_delta',
           text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',
+          sessionId: activeSessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
         return;
@@ -102,7 +109,7 @@ export async function handleTaskSubmit(
           interactionType: 'text_qa',
         });
         rlog.info({ sessionId: conversation.id }, 'Recording-only intent intercepted — routed to standalone recording');
-        ctx.send(socket, { type: 'assistant_text_delta', text: 'Starting screen recording.' });
+        ctx.send(socket, { type: 'assistant_text_delta', text: 'Starting screen recording.', sessionId: conversation.id });
         ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
         return;
       }

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -31,13 +31,19 @@ export function handleRecordingStart(
   socket: net.Socket,
   ctx: HandlerContext,
 ): string {
-  const recordingId = uuid();
-
   const existingRecordingId = recordingOwnerByConversation.get(conversationId);
   if (existingRecordingId) {
-    log.warn({ conversationId, existingRecordingId }, 'Overwriting active recording for conversation');
-    standaloneRecordingConversationId.delete(existingRecordingId);
+    log.warn({ conversationId, existingRecordingId }, 'Recording already active for conversation');
+    ctx.send(socket, {
+      type: 'assistant_text_delta',
+      text: 'A recording is already active.',
+      sessionId: conversationId,
+    });
+    ctx.send(socket, { type: 'message_complete', sessionId: conversationId });
+    return existingRecordingId;
   }
+
+  const recordingId = uuid();
 
   standaloneRecordingConversationId.set(recordingId, conversationId);
   recordingOwnerByConversation.set(conversationId, recordingId);


### PR DESCRIPTION
Fixes two review issues: (1) Don't overwrite recording maps on duplicate start - return early with error instead. (2) Create conversation when sessionId is undefined in task_submit stop path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
