### PR TITLE
Fix double message_complete on duplicate recording start

### DIFF
--- a/assistant/src/__tests__/recording-handler.test.ts
+++ b/assistant/src/__tests__/recording-handler.test.ts
@@ -165,22 +165,20 @@ describe('handleRecordingStart', () => {
     expect(sent[0].options).toEqual(options);
   });
 
-  test('returns early with existing recordingId when recording already active', () => {
+  test('returns null when recording already active and sends no messages', () => {
     const { ctx, sent, fakeSocket } = createCtx();
 
     const id1 = handleRecordingStart('conv-3', undefined, fakeSocket, ctx);
+    expect(id1).toBeTruthy();
+
     const id2 = handleRecordingStart('conv-3', undefined, fakeSocket, ctx);
 
-    // Should return the same recording ID (no overwrite)
-    expect(id2).toBe(id1);
-    // First call: recording_start; second call: assistant_text_delta + message_complete
-    expect(sent).toHaveLength(3);
+    // Should return null (callers handle messaging)
+    expect(id2).toBeNull();
+    // Only the first call sends recording_start — the duplicate sends nothing
+    expect(sent).toHaveLength(1);
     expect(sent[0].type).toBe('recording_start');
     expect(sent[0].recordingId).toBe(id1);
-    expect(sent[1].type).toBe('assistant_text_delta');
-    expect(sent[1].text).toBe('A recording is already active.');
-    expect(sent[2].type).toBe('message_complete');
-    expect(sent[2].sessionId).toBe('conv-3');
   });
 });
 

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -101,16 +101,16 @@ export async function handleTaskSubmit(
         const conversation = conversationStore.createConversation(msg.task);
         ctx.socketToSession.set(socket, conversation.id);
 
-        handleRecordingStart(conversation.id, { promptForSource: true }, socket, ctx);
+        const recordingId = handleRecordingStart(conversation.id, { promptForSource: true }, socket, ctx);
 
-        ctx.send(socket, {
-          type: 'task_routed',
-          sessionId: conversation.id,
-          interactionType: 'text_qa',
-        });
-        rlog.info({ sessionId: conversation.id }, 'Recording-only intent intercepted — routed to standalone recording');
-        ctx.send(socket, { type: 'assistant_text_delta', text: 'Starting screen recording.', sessionId: conversation.id });
+        if (recordingId) {
+          ctx.send(socket, { type: 'task_routed', sessionId: conversation.id, interactionType: 'text_qa' });
+          ctx.send(socket, { type: 'assistant_text_delta', text: 'Starting screen recording.', sessionId: conversation.id });
+        } else {
+          ctx.send(socket, { type: 'assistant_text_delta', text: 'A recording is already active.', sessionId: conversation.id });
+        }
         ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
+        rlog.info({ sessionId: conversation.id }, 'Recording-only intent intercepted — routed to standalone recording');
         return;
       }
     }

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -30,17 +30,11 @@ export function handleRecordingStart(
   options: RecordingOptions | undefined,
   socket: net.Socket,
   ctx: HandlerContext,
-): string {
+): string | null {
   const existingRecordingId = recordingOwnerByConversation.get(conversationId);
   if (existingRecordingId) {
     log.warn({ conversationId, existingRecordingId }, 'Recording already active for conversation');
-    ctx.send(socket, {
-      type: 'assistant_text_delta',
-      text: 'A recording is already active.',
-      sessionId: conversationId,
-    });
-    ctx.send(socket, { type: 'message_complete', sessionId: conversationId });
-    return existingRecordingId;
+    return null;
   }
 
   const recordingId = uuid();

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -103,9 +103,14 @@ export async function handleUserMessage(
       }
 
       if (isRecordingOnly(messageText)) {
-        handleRecordingStart(msg.sessionId, { promptForSource: true }, socket, ctx);
+        const recordingId = handleRecordingStart(msg.sessionId, { promptForSource: true }, socket, ctx);
         rlog.info('Recording-only intent intercepted in user_message');
-        ctx.send(socket, { type: 'assistant_text_delta', text: 'Starting screen recording.' });
+
+        if (recordingId) {
+          ctx.send(socket, { type: 'assistant_text_delta', text: 'Starting screen recording.', sessionId: msg.sessionId });
+        } else {
+          ctx.send(socket, { type: 'assistant_text_delta', text: 'A recording is already active.', sessionId: msg.sessionId });
+        }
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
         return;
       }


### PR DESCRIPTION
Removes message sending from handleRecordingStart duplicate path. Returns null when already active, callers check return value and send appropriate message. Prevents double message_complete.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
