### PR TITLE
Add task_routed to stop-recording intent in task_submit

### DIFF
--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -87,6 +87,7 @@ export async function handleTaskSubmit(
           ctx.socketToSession.set(socket, activeSessionId);
         }
         rlog.info('Recording stop intent intercepted');
+        ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, {
           type: 'assistant_text_delta',
           text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',


### PR DESCRIPTION
Adds task_routed message before assistant_text_delta in the isStopRecordingOnly branch of handleTaskSubmit. Without this, the macOS client hangs waiting for task_routed after sending task_submit.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
