### PR TITLE
feat: hexagonal skill tree layout for identity panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -444,7 +444,6 @@ extension MainWindowView {
             .overlay(alignment: .topTrailing) { panelDismissButton }
         case .identity:
             IdentityPanel(onClose: { windowState.dismissOverlay() }, onCustomizeAvatar: { windowState.selection = .panel(.avatarCustomization) }, daemonClient: daemonClient)
-                .overlay(alignment: .topTrailing) { panelDismissButton }
                 .background(adaptiveColor(light: Color(hex: 0xF5F3EB), dark: Moss._900))
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.selection = .panel(.identity) })

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -404,6 +404,33 @@ private struct SkillPopoverView: View {
     }
 }
 
+// MARK: - Viewport Toolbar Button
+
+private struct ViewportToolbarButton: View {
+    let icon: String
+    let accessibilityLabel: String
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(isHovered ? VColor.textPrimary : VColor.textSecondary)
+                .frame(width: 28, height: 28)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            withAnimation(.easeInOut(duration: 0.1)) {
+                isHovered = hovering
+            }
+        }
+        .accessibilityLabel(accessibilityLabel)
+    }
+}
+
 // MARK: - Constellation View
 
 struct ConstellationView: View {
@@ -411,6 +438,7 @@ struct ConstellationView: View {
     let skills: [SkillInfo]
     let workspaceFiles: [WorkspaceFileNode]
     var onFileSelected: ((String) -> Void)?
+    @Binding var isFullscreen: Bool
     @State private var appearance = AvatarAppearanceManager.shared
 
     @State private var phase: AnimationPhase = .hidden
@@ -556,6 +584,72 @@ struct ConstellationView: View {
         return result
     }
 
+    /// Computes zoom and pan to fit all hexes in the viewport with padding.
+    private func fitAll(viewSize: CGSize) {
+        let hexes = positionedHexes
+
+        // When no skills/files are loaded the center avatar is still rendered.
+        // Reset to default viewport so the user can recover after drag/zoom.
+        guard !hexes.isEmpty else {
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.8)) {
+                zoomScale = 1.0
+                baseZoomScale = 1.0
+                panOffset = .zero
+                dragOffset = .zero
+            }
+            return
+        }
+
+        // Compute bounding box of all hex pixel positions
+        var minX = CGFloat.infinity
+        var maxX = -CGFloat.infinity
+        var minY = CGFloat.infinity
+        var maxY = -CGFloat.infinity
+
+        for hex in hexes {
+            let pos = hex.coord.toPixel(size: hexSize, gap: hexGap)
+            minX = min(minX, pos.x)
+            maxX = max(maxX, pos.x)
+            minY = min(minY, pos.y)
+            maxY = max(maxY, pos.y)
+        }
+        // Also include center hex at (0,0)
+        minX = min(minX, 0)
+        maxX = max(maxX, 0)
+        minY = min(minY, 0)
+        maxY = max(maxY, 0)
+
+        // Add padding around the bounding box
+        let padding = hexSize * 2
+        let contentWidth = (maxX - minX) + padding * 2
+        let contentHeight = (maxY - minY) + padding * 2
+
+        guard contentWidth > 0, contentHeight > 0 else { return }
+
+        let fitZoom = min(viewSize.width / contentWidth, viewSize.height / contentHeight)
+        let clampedZoom = max(0.4, min(3.0, fitZoom))
+
+        // Center of the bounding box in canvas-local coords (relative to
+        // the canvas center, which is at viewSize/2). The hex pixel positions
+        // are already relative to the canvas center, so the content centroid
+        // offset is just the midpoint of the bounding box.
+        let contentCenterX = (minX + maxX) / 2
+        let contentCenterY = (minY + maxY) / 2
+
+        // Pan offset to re-center the content centroid in the viewport.
+        // After scaling, the centroid is at (contentCenter * zoom) from the
+        // view center, so we pan by the negative of that.
+        let targetPanX = -contentCenterX * clampedZoom
+        let targetPanY = -contentCenterY * clampedZoom
+
+        withAnimation(.spring(response: 0.5, dampingFraction: 0.8)) {
+            zoomScale = clampedZoom
+            baseZoomScale = clampedZoom
+            panOffset = CGSize(width: targetPanX, height: targetPanY)
+            dragOffset = .zero
+        }
+    }
+
     var body: some View {
         GeometryReader { proxy in
             let totalOffset = CGSize(
@@ -601,6 +695,10 @@ struct ConstellationView: View {
                 .frame(width: proxy.size.width, height: proxy.size.height)
                 .clipped()
                 .contentShape(Rectangle())
+                .overlay(alignment: .bottomTrailing) {
+                    viewportToolbar(viewSize: proxy.size)
+                        .padding(VSpacing.lg)
+                }
                 .gesture(
                     DragGesture()
                         .onChanged { value in
@@ -642,6 +740,51 @@ struct ConstellationView: View {
                 }
                 #endif
         }
+    }
+
+    // MARK: - Viewport Toolbar
+
+    @ViewBuilder
+    private func viewportToolbar(viewSize: CGSize) -> some View {
+        HStack(spacing: VSpacing.xxs) {
+            ViewportToolbarButton(icon: "plus.magnifyingglass", accessibilityLabel: "Zoom in") {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    zoomScale = min(3.0, zoomScale + 0.25)
+                    baseZoomScale = zoomScale
+                }
+            }
+
+            ViewportToolbarButton(icon: "minus.magnifyingglass", accessibilityLabel: "Zoom out") {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    zoomScale = max(0.4, zoomScale - 0.25)
+                    baseZoomScale = zoomScale
+                }
+            }
+
+            ViewportToolbarButton(icon: "arrow.up.left.and.arrow.down.right", accessibilityLabel: "Fit all") {
+                fitAll(viewSize: viewSize)
+            }
+
+            ViewportToolbarButton(
+                icon: isFullscreen
+                    ? "arrow.down.right.and.arrow.up.left"
+                    : "arrow.up.left.and.arrow.down.right.square",
+                accessibilityLabel: isFullscreen ? "Exit fullscreen" : "Enter fullscreen"
+            ) {
+                withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+                    isFullscreen.toggle()
+                }
+            }
+        }
+        .padding(VSpacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(VColor.surface.opacity(0.85))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
     }
 
     // MARK: - Canvas

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -201,18 +201,18 @@ private struct HexTileView: View {
         let hexWidth = sqrt(3) * size
         let hexHeight = 2 * size
 
-        VStack(spacing: 2) {
+        VStack(spacing: 3) {
             if let emoji, !emoji.isEmpty {
                 Text(emoji)
-                    .font(.system(size: 20))
+                    .font(.system(size: 24))
             } else {
                 Image(systemName: icon)
-                    .font(.system(size: 18, weight: .medium))
+                    .font(.system(size: 22, weight: .medium))
                     .foregroundColor(color)
             }
 
             Text(label)
-                .font(VFont.small)
+                .font(VFont.caption)
                 .foregroundColor(VColor.textPrimary)
                 .lineLimit(1)
                 .truncationMode(.tail)
@@ -266,11 +266,11 @@ private struct HubHexTileView: View {
 
         VStack(spacing: 3) {
             Image(systemName: category.icon)
-                .font(.system(size: 22, weight: .bold))
+                .font(.system(size: 26, weight: .bold))
                 .foregroundColor(category.color)
 
             Text(category.displayName)
-                .font(VFont.captionMedium)
+                .font(VFont.bodyMedium)
                 .foregroundColor(VColor.textPrimary)
                 .lineLimit(1)
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -22,15 +22,15 @@ private enum SkillCategory: String, CaseIterable {
         }
     }
 
-    /// Distinct accent colors per category so each group is visually separate.
+    /// High-contrast accent colors per category for visual separation.
     var color: Color {
         switch self {
-        case .core: return Amber._500          // gold
-        case .devTools: return Danger._600      // red-orange
-        case .communication: return Color(hex: 0xAD88BC) // purple
-        case .daily: return Emerald._500        // bright green
-        case .utilities: return Forest._400     // sage green
-        case .skills: return Color(hex: 0x0E9B8B) // teal
+        case .core: return Color(hex: 0xD4A017)          // deep gold
+        case .devTools: return Color(hex: 0xC1421B)      // red
+        case .communication: return Color(hex: 0x8B5DAA) // vivid purple
+        case .daily: return Color(hex: 0xD4D1C1)         // warm neutral
+        case .utilities: return Color(hex: 0x4682B4)     // steel blue
+        case .skills: return Color(hex: 0x0E8A7B)        // dark teal
         }
     }
 
@@ -204,10 +204,10 @@ private struct HexTileView: View {
         VStack(spacing: 2) {
             if let emoji, !emoji.isEmpty {
                 Text(emoji)
-                    .font(.system(size: 16))
+                    .font(.system(size: 20))
             } else {
                 Image(systemName: icon)
-                    .font(.system(size: 13, weight: .medium))
+                    .font(.system(size: 18, weight: .medium))
                     .foregroundColor(color)
             }
 
@@ -221,11 +221,11 @@ private struct HexTileView: View {
         .frame(width: hexWidth, height: hexHeight)
         .background(
             HexagonShape()
-                .fill(color.opacity(isHovered ? 0.18 : 0.08))
+                .fill(color.opacity(isHovered ? 0.22 : 0.12))
         )
         .overlay(
             HexagonShape()
-                .stroke(color.opacity(isHovered ? 0.7 : 0.35), lineWidth: isHovered ? 2 : 1.5)
+                .stroke(color.opacity(isHovered ? 0.75 : 0.45), lineWidth: isHovered ? 2 : 1.5)
         )
         .contentShape(HexagonShape())
         .onHover { hovering in
@@ -266,7 +266,7 @@ private struct HubHexTileView: View {
 
         VStack(spacing: 3) {
             Image(systemName: category.icon)
-                .font(.system(size: 17, weight: .bold))
+                .font(.system(size: 22, weight: .bold))
                 .foregroundColor(category.color)
 
             Text(category.displayName)
@@ -278,11 +278,11 @@ private struct HubHexTileView: View {
         .frame(width: hexWidth, height: hexHeight)
         .background(
             HexagonShape()
-                .fill(category.color.opacity(isHovered ? 0.26 : 0.16))
+                .fill(category.color.opacity(isHovered ? 0.30 : 0.20))
         )
         .overlay(
             HexagonShape()
-                .stroke(category.color.opacity(isHovered ? 0.85 : 0.55), lineWidth: isHovered ? 3 : 2.5)
+                .stroke(category.color.opacity(isHovered ? 0.90 : 0.65), lineWidth: isHovered ? 3 : 2.5)
         )
         .contentShape(HexagonShape())
         .onHover { hovering in
@@ -377,32 +377,7 @@ private struct SkillPopoverView: View {
     }
 }
 
-// MARK: - Viewport Toolbar Button
-
-private struct ViewportToolbarButton: View {
-    let icon: String
-    let accessibilityLabel: String
-    let action: () -> Void
-
-    @State private var isHovered = false
-
-    var body: some View {
-        Button(action: action) {
-            Image(systemName: icon)
-                .font(.system(size: 12, weight: .medium))
-                .foregroundColor(isHovered ? VColor.textPrimary : VColor.textSecondary)
-                .frame(width: 28, height: 28)
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .onHover { hovering in
-            withAnimation(.easeInOut(duration: 0.1)) {
-                isHovered = hovering
-            }
-        }
-        .accessibilityLabel(accessibilityLabel)
-    }
-}
+// ViewportToolbarButton removed — using VIconButton from design system instead.
 
 // MARK: - Constellation View
 
@@ -724,25 +699,18 @@ struct ConstellationView: View {
     // MARK: - Fullscreen Toggle (top-left)
 
     private var fullscreenToggle: some View {
-        ViewportToolbarButton(
+        VIconButton(
+            label: isFullscreen ? "Collapse" : "Expand",
             icon: isFullscreen
                 ? "arrow.down.right.and.arrow.up.left"
-                : "arrow.up.left.and.arrow.down.right.square",
-            accessibilityLabel: isFullscreen ? "Exit fullscreen" : "Enter fullscreen"
+                : "arrow.up.left.and.arrow.down.right",
+            iconOnly: true,
+            tooltip: isFullscreen ? "Exit fullscreen" : "Enter fullscreen"
         ) {
             withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
                 isFullscreen.toggle()
             }
         }
-        .padding(VSpacing.sm)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(VColor.surface.opacity(0.85))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .stroke(VColor.surfaceBorder, lineWidth: 1)
-        )
     }
 
     // MARK: - Viewport Controls (bottom-right)
@@ -750,25 +718,25 @@ struct ConstellationView: View {
     @ViewBuilder
     private func viewportControls(viewSize: CGSize) -> some View {
         HStack(spacing: VSpacing.xxs) {
-            ViewportToolbarButton(icon: "plus.magnifyingglass", accessibilityLabel: "Zoom in") {
+            VIconButton(label: "Zoom in", icon: "plus.magnifyingglass", iconOnly: true, tooltip: "Zoom in") {
                 withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
                     zoomScale = min(3.0, zoomScale + 0.25)
                     baseZoomScale = zoomScale
                 }
             }
 
-            ViewportToolbarButton(icon: "minus.magnifyingglass", accessibilityLabel: "Zoom out") {
+            VIconButton(label: "Zoom out", icon: "minus.magnifyingglass", iconOnly: true, tooltip: "Zoom out") {
                 withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
                     zoomScale = max(0.4, zoomScale - 0.25)
                     baseZoomScale = zoomScale
                 }
             }
 
-            ViewportToolbarButton(icon: "arrow.up.left.and.arrow.down.right", accessibilityLabel: "Fit all") {
+            VIconButton(label: "Fit all", icon: "viewfinder", iconOnly: true, tooltip: "Fit all skills") {
                 fitAll(viewSize: viewSize)
             }
         }
-        .padding(VSpacing.sm)
+        .padding(VSpacing.xs)
         .background(
             RoundedRectangle(cornerRadius: VRadius.lg)
                 .fill(VColor.surface.opacity(0.85))

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -22,16 +22,15 @@ private enum SkillCategory: String, CaseIterable {
         }
     }
 
-    /// Category accent colors inspired by game skill trees.
-    /// Core = gold, Dev Tools = red, Comms = purple, fallback = teal.
+    /// Distinct accent colors per category so each group is visually separate.
     var color: Color {
         switch self {
-        case .core: return Color(hex: 0xE9C91A)
-        case .devTools: return Color(hex: 0xC1421B)
-        case .communication: return Color(hex: 0xAD88BC)
-        case .daily: return Color(hex: 0x0E9B8B)
-        case .utilities: return Color(hex: 0x0E9B8B)
-        case .skills: return Color(hex: 0x0E9B8B)
+        case .core: return Amber._500          // gold
+        case .devTools: return Danger._600      // red-orange
+        case .communication: return Color(hex: 0xAD88BC) // purple
+        case .daily: return Emerald._500        // bright green
+        case .utilities: return Forest._400     // sage green
+        case .skills: return Color(hex: 0x0E9B8B) // teal
         }
     }
 
@@ -88,32 +87,6 @@ private func inferCategory(_ skill: SkillInfo) -> SkillCategory {
         return .utilities
     }
     return .skills
-}
-
-// MARK: - Dot Grid Background
-
-private struct DotGridBackground: View {
-    let spacing: CGFloat = 20
-    let dotRadius: CGFloat = 1
-
-    var body: some View {
-        Canvas { context, size in
-            let cols = Int(size.width / spacing) + 1
-            let rows = Int(size.height / spacing) + 1
-            for row in 0..<rows {
-                for col in 0..<cols {
-                    let point = CGPoint(x: CGFloat(col) * spacing, y: CGFloat(row) * spacing)
-                    let rect = CGRect(
-                        x: point.x - dotRadius,
-                        y: point.y - dotRadius,
-                        width: dotRadius * 2,
-                        height: dotRadius * 2
-                    )
-                    context.fill(Circle().path(in: rect), with: .color(Moss._500.opacity(0.4)))
-                }
-            }
-        }
-    }
 }
 
 // MARK: - Hexagon Shape
@@ -400,7 +373,7 @@ private struct SkillPopoverView: View {
             RoundedRectangle(cornerRadius: VRadius.lg)
                 .stroke(VColor.surfaceBorder, lineWidth: 1)
         )
-        .vShadow(.md)
+        .vShadow(VShadow.md)
     }
 }
 
@@ -657,8 +630,6 @@ struct ConstellationView: View {
                 height: panOffset.height + dragOffset.height
             )
             ZStack {
-                DotGridBackground()
-
                 canvas(size: proxy.size)
                     .scaleEffect(zoomScale)
                     .offset(totalOffset)
@@ -695,8 +666,12 @@ struct ConstellationView: View {
                 .frame(width: proxy.size.width, height: proxy.size.height)
                 .clipped()
                 .contentShape(Rectangle())
+                .overlay(alignment: .topLeading) {
+                    fullscreenToggle
+                        .padding(VSpacing.lg)
+                }
                 .overlay(alignment: .bottomTrailing) {
-                    viewportToolbar(viewSize: proxy.size)
+                    viewportControls(viewSize: proxy.size)
                         .padding(VSpacing.lg)
                 }
                 .gesture(
@@ -726,6 +701,10 @@ struct ConstellationView: View {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                         phase = .complete
                     }
+                    // Auto-fit all hexes into the viewport on initial load
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        fitAll(viewSize: proxy.size)
+                    }
                 }
                 #if os(macOS)
                 .onKeyPress(.escape) {
@@ -742,10 +721,34 @@ struct ConstellationView: View {
         }
     }
 
-    // MARK: - Viewport Toolbar
+    // MARK: - Fullscreen Toggle (top-left)
+
+    private var fullscreenToggle: some View {
+        ViewportToolbarButton(
+            icon: isFullscreen
+                ? "arrow.down.right.and.arrow.up.left"
+                : "arrow.up.left.and.arrow.down.right.square",
+            accessibilityLabel: isFullscreen ? "Exit fullscreen" : "Enter fullscreen"
+        ) {
+            withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+                isFullscreen.toggle()
+            }
+        }
+        .padding(VSpacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(VColor.surface.opacity(0.85))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+    }
+
+    // MARK: - Viewport Controls (bottom-right)
 
     @ViewBuilder
-    private func viewportToolbar(viewSize: CGSize) -> some View {
+    private func viewportControls(viewSize: CGSize) -> some View {
         HStack(spacing: VSpacing.xxs) {
             ViewportToolbarButton(icon: "plus.magnifyingglass", accessibilityLabel: "Zoom in") {
                 withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
@@ -763,17 +766,6 @@ struct ConstellationView: View {
 
             ViewportToolbarButton(icon: "arrow.up.left.and.arrow.down.right", accessibilityLabel: "Fit all") {
                 fitAll(viewSize: viewSize)
-            }
-
-            ViewportToolbarButton(
-                icon: isFullscreen
-                    ? "arrow.down.right.and.arrow.up.left"
-                    : "arrow.up.left.and.arrow.down.right.square",
-                accessibilityLabel: isFullscreen ? "Exit fullscreen" : "Enter fullscreen"
-            ) {
-                withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
-                    isFullscreen.toggle()
-                }
             }
         }
         .padding(VSpacing.sm)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -22,14 +22,16 @@ private enum SkillCategory: String, CaseIterable {
         }
     }
 
+    /// Category accent colors inspired by game skill trees.
+    /// Core = gold, Dev Tools = red, Comms = purple, fallback = teal.
     var color: Color {
         switch self {
-        case .core: return Amber._400
-        case .devTools: return Forest._400
-        case .communication: return Forest._400
-        case .daily: return Emerald._400
-        case .utilities: return Stone._400
-        case .skills: return Danger._400
+        case .core: return Color(hex: 0xE9C91A)
+        case .devTools: return Color(hex: 0xC1421B)
+        case .communication: return Color(hex: 0xAD88BC)
+        case .daily: return Color(hex: 0x0E9B8B)
+        case .utilities: return Color(hex: 0x0E9B8B)
+        case .skills: return Color(hex: 0x0E9B8B)
         }
     }
 
@@ -48,12 +50,12 @@ private enum SkillCategory: String, CaseIterable {
 // MARK: - Data Models
 
 private struct OrbitItem: Identifiable {
-    let id: String // stable key for offset tracking
+    let id: String
     let label: String
     let icon: String
     let emoji: String?
     let color: Color
-    let filePath: String? // non-nil for workspace .md files
+    let filePath: String?
 }
 
 private struct CategoryGroup: Identifiable {
@@ -112,58 +114,202 @@ private struct DotGridBackground: View {
     }
 }
 
-// MARK: - Branch Shape
+// MARK: - Hexagon Shape
 
-private struct BranchShape: Shape {
-    let from: CGPoint
-    let to: CGPoint
-
+/// Pointy-top hexagon shape for the skill tree tiles.
+private struct HexagonShape: Shape {
     func path(in rect: CGRect) -> Path {
+        let w = rect.width
+        let h = rect.height
+        let cx = rect.midX
+        let cy = rect.midY
+        // Pointy-top: vertices at 30-degree intervals starting from top
+        // For a pointy-top hex inscribed in the rect:
+        //   width = sqrt(3) * size, height = 2 * size
+        let size = min(w / sqrt(3), h / 2)
         var path = Path()
-        path.move(to: from)
-
-        let dx = to.x - from.x
-        let dy = to.y - from.y
-        let mid = CGPoint(x: (from.x + to.x) / 2, y: (from.y + to.y) / 2)
-        let offset: CGFloat = 12
-        let length = sqrt(dx * dx + dy * dy)
-        guard length > 0 else { return path }
-        let nx = -dy / length * offset
-        let ny = dx / length * offset
-        let control = CGPoint(x: mid.x + nx, y: mid.y + ny)
-
-        path.addQuadCurve(to: to, control: control)
+        for i in 0..<6 {
+            let angleDeg = 60.0 * Double(i) - 90.0
+            let angleRad = angleDeg * .pi / 180.0
+            let px = cx + size * CGFloat(cos(angleRad))
+            let py = cy + size * CGFloat(sin(angleRad))
+            if i == 0 {
+                path.move(to: CGPoint(x: px, y: py))
+            } else {
+                path.addLine(to: CGPoint(x: px, y: py))
+            }
+        }
+        path.closeSubpath()
         return path
     }
 }
 
-// MARK: - Category Hub Label
+// MARK: - Hex Coordinate
 
-private struct CategoryHubLabel: View {
+/// Axial hex coordinate (q, r) for pointy-top hexagonal grid layout.
+private struct HexCoord: Hashable {
+    let q: Int
+    let r: Int
+
+    /// Convert axial coordinate to pixel position (pointy-top orientation).
+    func toPixel(size: CGFloat, gap: CGFloat) -> CGPoint {
+        let effectiveSize = size + gap / 2
+        let x = effectiveSize * (sqrt(3) * CGFloat(q) + sqrt(3) / 2 * CGFloat(r))
+        let y = effectiveSize * (3.0 / 2.0 * CGFloat(r))
+        return CGPoint(x: x, y: y)
+    }
+}
+
+/// Ring 1 positions (6 hexes immediately around center) for pointy-top hex grid.
+private let ring1Coords: [HexCoord] = [
+    HexCoord(q: 1, r: 0),
+    HexCoord(q: 0, r: 1),
+    HexCoord(q: -1, r: 1),
+    HexCoord(q: -1, r: 0),
+    HexCoord(q: 0, r: -1),
+    HexCoord(q: 1, r: -1),
+]
+
+/// Returns the axial hex neighbors adjacent to a given hex, filtered to exclude
+/// positions already in use and the center hex.
+private func neighborsOf(_ coord: HexCoord, excluding used: Set<HexCoord>) -> [HexCoord] {
+    let directions = [
+        HexCoord(q: 1, r: 0), HexCoord(q: 0, r: 1), HexCoord(q: -1, r: 1),
+        HexCoord(q: -1, r: 0), HexCoord(q: 0, r: -1), HexCoord(q: 1, r: -1),
+    ]
+    return directions.compactMap { dir in
+        let neighbor = HexCoord(q: coord.q + dir.q, r: coord.r + dir.r)
+        if used.contains(neighbor) || (neighbor.q == 0 && neighbor.r == 0) {
+            return nil
+        }
+        return neighbor
+    }
+}
+
+/// Computes the hex ring at a given distance from center.
+private func hexRing(radius: Int) -> [HexCoord] {
+    guard radius > 0 else { return [HexCoord(q: 0, r: 0)] }
+    let directions = [
+        HexCoord(q: 1, r: 0), HexCoord(q: 0, r: 1), HexCoord(q: -1, r: 1),
+        HexCoord(q: -1, r: 0), HexCoord(q: 0, r: -1), HexCoord(q: 1, r: -1),
+    ]
+    var results: [HexCoord] = []
+    // Start at the hex that is `radius` steps in direction 4 (q: 0, r: -1)
+    var current = HexCoord(q: 0, r: -radius)
+    for side in 0..<6 {
+        for _ in 0..<radius {
+            results.append(current)
+            current = HexCoord(
+                q: current.q + directions[side].q,
+                r: current.r + directions[side].r
+            )
+        }
+    }
+    return results
+}
+
+// MARK: - Hex Tile View (Leaf)
+
+private struct HexTileView: View {
+    let label: String
+    let icon: String
+    let emoji: String?
+    let color: Color
+    let size: CGFloat
+    var onTap: (() -> Void)?
+
+    @State private var isHovered = false
+
+    private var isTappable: Bool { onTap != nil }
+
+    var body: some View {
+        let hexWidth = sqrt(3) * size
+        let hexHeight = 2 * size
+
+        VStack(spacing: 2) {
+            if let emoji, !emoji.isEmpty {
+                Text(emoji)
+                    .font(.system(size: 16))
+            } else {
+                Image(systemName: icon)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(color)
+            }
+
+            Text(label)
+                .font(VFont.small)
+                .foregroundColor(VColor.textPrimary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: hexWidth * 0.75)
+        }
+        .frame(width: hexWidth, height: hexHeight)
+        .background(
+            HexagonShape()
+                .fill(color.opacity(isHovered ? 0.18 : 0.08))
+        )
+        .overlay(
+            HexagonShape()
+                .stroke(color.opacity(isHovered ? 0.7 : 0.35), lineWidth: isHovered ? 2 : 1.5)
+        )
+        .contentShape(HexagonShape())
+        .onHover { hovering in
+            withAnimation(.easeInOut(duration: 0.15)) {
+                isHovered = hovering
+            }
+            #if os(macOS)
+            if isTappable {
+                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            }
+            #endif
+        }
+        #if os(macOS)
+        .onDisappear {
+            if isHovered && isTappable {
+                NSCursor.pop()
+                isHovered = false
+            }
+        }
+        #endif
+        .onTapGesture {
+            onTap?()
+        }
+    }
+}
+
+// MARK: - Hub Hex Tile View
+
+private struct HubHexTileView: View {
     let category: SkillCategory
-    let itemCount: Int
+    let size: CGFloat
+
     @State private var isHovered = false
 
     var body: some View {
-        HStack(spacing: VSpacing.xs) {
+        let hexWidth = sqrt(3) * size
+        let hexHeight = 2 * size
+
+        VStack(spacing: 3) {
             Image(systemName: category.icon)
-                .font(.system(size: 9, weight: .semibold))
+                .font(.system(size: 17, weight: .bold))
                 .foregroundColor(category.color)
 
             Text(category.displayName)
                 .font(VFont.captionMedium)
                 .foregroundColor(VColor.textPrimary)
+                .lineLimit(1)
         }
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.xs)
+        .padding(4)
+        .frame(width: hexWidth, height: hexHeight)
         .background(
-            Capsule()
-                .fill(category.color.opacity(isHovered ? 0.14 : 0.08))
-                .overlay(
-                    Capsule()
-                        .stroke(category.color.opacity(isHovered ? 0.35 : 0.2), lineWidth: 0.5)
-                )
+            HexagonShape()
+                .fill(category.color.opacity(isHovered ? 0.26 : 0.16))
         )
+        .overlay(
+            HexagonShape()
+                .stroke(category.color.opacity(isHovered ? 0.85 : 0.55), lineWidth: isHovered ? 3 : 2.5)
+        )
+        .contentShape(HexagonShape())
         .onHover { hovering in
             withAnimation(.easeInOut(duration: 0.15)) {
                 isHovered = hovering
@@ -172,49 +318,29 @@ private struct CategoryHubLabel: View {
     }
 }
 
-// MARK: - Draggable Node Wrapper
+// MARK: - Animation Phase
 
-private struct DraggableNode<Content: View>: View {
-    let nodeKey: String
-    /// Additional node keys that move together with this node (e.g. child leaves of a hub).
-    var childKeys: [String] = []
-    @Binding var offsets: [String: CGSize]
-    @ViewBuilder let content: () -> Content
+private enum AnimationPhase: Equatable {
+    case hidden
+    case complete
 
-    @State private var dragStartOffset: CGSize?
-    @State private var childStartOffsets: [String: CGSize] = [:]
+    var centerVisible: Bool { self == .complete }
+    var hubsVisible: Bool { self == .complete }
+    var leavesVisible: Bool { self == .complete }
+}
 
-    var body: some View {
-        content()
-            .offset(offsets[nodeKey] ?? .zero)
-            .highPriorityGesture(
-                DragGesture()
-                    .onChanged { value in
-                        if dragStartOffset == nil {
-                            dragStartOffset = offsets[nodeKey] ?? .zero
-                            for key in childKeys {
-                                childStartOffsets[key] = offsets[key] ?? .zero
-                            }
-                        }
-                        let start = dragStartOffset ?? .zero
-                        offsets[nodeKey] = CGSize(
-                            width: start.width + value.translation.width,
-                            height: start.height + value.translation.height
-                        )
-                        for key in childKeys {
-                            let childStart = childStartOffsets[key] ?? .zero
-                            offsets[key] = CGSize(
-                                width: childStart.width + value.translation.width,
-                                height: childStart.height + value.translation.height
-                            )
-                        }
-                    }
-                    .onEnded { _ in
-                        dragStartOffset = nil
-                        childStartOffsets.removeAll()
-                    }
-            )
-    }
+// MARK: - Positioned Hex Item
+
+/// Pairs a hex coordinate with its content metadata for rendering.
+private struct PositionedHex: Identifiable {
+    let id: String
+    let coord: HexCoord
+    let kind: HexKind
+}
+
+private enum HexKind {
+    case hub(SkillCategory)
+    case leaf(OrbitItem)
 }
 
 // MARK: - Constellation View
@@ -229,9 +355,14 @@ struct ConstellationView: View {
     @State private var phase: AnimationPhase = .hidden
     @State private var panOffset: CGSize = .zero
     @State private var dragOffset: CGSize = .zero
-    @State private var nodeOffsets: [String: CGSize] = [:]
     @State private var zoomScale: CGFloat = 1.0
     @State private var baseZoomScale: CGFloat = 1.0
+
+    // Uniform hex size for both positioning and rendering — hubs are
+    // visually distinguished via styling (heavier border, higher fill
+    // opacity, larger font) rather than a physically bigger hexagon.
+    private let hexSize: CGFloat = 62
+    private let hexGap: CGFloat = 4
 
     private var existingFiles: [WorkspaceFileNode] {
         workspaceFiles.filter { $0.exists }
@@ -240,7 +371,10 @@ struct ConstellationView: View {
     private var groups: [CategoryGroup] {
         let fileItems = existingFiles.enumerated().map { idx, node in
             let path: String? = node.label.hasSuffix(".md") ? node.path : nil
-            return OrbitItem(id: "core-\(idx)", label: node.label, icon: "doc.text.fill", emoji: nil, color: Amber._400, filePath: path)
+            return OrbitItem(
+                id: "core-\(idx)", label: node.label, icon: "doc.text.fill",
+                emoji: nil, color: SkillCategory.core.color, filePath: path
+            )
         }
 
         var categoryMap: [SkillCategory: [OrbitItem]] = [:]
@@ -267,6 +401,89 @@ struct ConstellationView: View {
         for cat in SkillCategory.allCases where cat != .core {
             if let items = categoryMap[cat], !items.isEmpty {
                 result.append(CategoryGroup(category: cat, items: items))
+            }
+        }
+
+        return result
+    }
+
+    /// Computes hex positions for all hubs and their leaves, fanning outward from center.
+    private var positionedHexes: [PositionedHex] {
+        let layoutGroups = groups
+        var result: [PositionedHex] = []
+        var usedCoords: Set<HexCoord> = [HexCoord(q: 0, r: 0)]
+
+        // Place category hubs in ring 1
+        let hubCount = min(layoutGroups.count, ring1Coords.count)
+        var hubCoords: [HexCoord] = []
+
+        for i in 0..<hubCount {
+            let coord = ring1Coords[i]
+            hubCoords.append(coord)
+            usedCoords.insert(coord)
+            result.append(PositionedHex(
+                id: "hub-\(layoutGroups[i].category.rawValue)",
+                coord: coord,
+                kind: .hub(layoutGroups[i].category)
+            ))
+        }
+
+        // Place leaf items in round-robin across categories so that no
+        // single category starves later ones of free neighbor positions.
+        // Each category maintains its own expansion frontier rooted at its hub.
+        struct CategoryState {
+            var leafQueue: [OrbitItem]
+            let hubCoord: HexCoord
+            var frontier: [HexCoord]
+        }
+
+        var states: [CategoryState] = (0..<hubCount).map { i in
+            CategoryState(
+                leafQueue: layoutGroups[i].items,
+                hubCoord: hubCoords[i],
+                frontier: [hubCoords[i]]
+            )
+        }
+
+        var anyPlaced = true
+        while anyPlaced {
+            anyPlaced = false
+            for idx in 0..<states.count {
+                if states[idx].leafQueue.isEmpty { continue }
+
+                // Expand frontier: find all unused neighbors of current frontier
+                var candidateCoords: [HexCoord] = []
+                for f in states[idx].frontier {
+                    let neighbors = neighborsOf(f, excluding: usedCoords)
+                    for n in neighbors where !candidateCoords.contains(where: { $0 == n }) {
+                        candidateCoords.append(n)
+                    }
+                }
+
+                // Sort candidates by distance from center to prefer outward expansion,
+                // then by distance from hub to keep the group clustered
+                let hub = states[idx].hubCoord
+                candidateCoords.sort { a, b in
+                    let distA = abs(a.q) + abs(a.r) + abs(a.q + a.r)
+                    let distB = abs(b.q) + abs(b.r) + abs(b.q + b.r)
+                    if distA != distB { return distA < distB }
+                    let hubDistA = abs(a.q - hub.q) + abs(a.r - hub.r)
+                    let hubDistB = abs(b.q - hub.q) + abs(b.r - hub.r)
+                    return hubDistA < hubDistB
+                }
+
+                // Place one leaf per category per round
+                if let coord = candidateCoords.first {
+                    let item = states[idx].leafQueue.removeFirst()
+                    usedCoords.insert(coord)
+                    states[idx].frontier.append(coord)
+                    result.append(PositionedHex(
+                        id: item.id,
+                        coord: coord,
+                        kind: .leaf(item)
+                    ))
+                    anyPlaced = true
+                }
             }
         }
 
@@ -320,28 +537,15 @@ struct ConstellationView: View {
         }
     }
 
-    // MARK: - Effective position (base + user offset)
-
-    private func effectivePos(_ base: CGPoint, key: String) -> CGPoint {
-        let off = nodeOffsets[key] ?? .zero
-        return CGPoint(x: base.x + off.width, y: base.y + off.height)
-    }
-
     // MARK: - Canvas
 
     @ViewBuilder
     private func canvas(size: CGSize) -> some View {
-        // Shift center down so upper nodes aren't clipped by the panel header
-        let center = CGPoint(x: size.width / 2, y: size.height * 0.55)
-        let hubRadius: CGFloat = 160
-        let leafRadius: CGFloat = 110
-        let layoutGroups = groups
-        let hubBasePositions = computeHubPositions(
-            center: center, radius: hubRadius, count: layoutGroups.count
-        )
+        let center = CGPoint(x: size.width / 2, y: size.height * 0.5)
+        let hexes = positionedHexes
 
         ZStack {
-            // Background glow
+            // Background radial glow
             RadialGradient(
                 colors: [Forest._600.opacity(0.06), Color.clear],
                 center: .center,
@@ -349,13 +553,58 @@ struct ConstellationView: View {
                 endRadius: min(size.width, size.height) * 0.5
             )
 
-            canvasBranches(center: center, hubBasePositions: hubBasePositions, leafRadius: leafRadius, layoutGroups: layoutGroups)
-            canvasHubs(hubBasePositions: hubBasePositions, layoutGroups: layoutGroups)
-            canvasLeaves(center: center, hubBasePositions: hubBasePositions, leafRadius: leafRadius, layoutGroups: layoutGroups)
+            // Hex tiles
+            ForEach(Array(hexes.enumerated()), id: \.element.id) { idx, hex in
+                let pixelPos = hex.coord.toPixel(size: hexSize, gap: hexGap)
+                let position = CGPoint(x: center.x + pixelPos.x, y: center.y + pixelPos.y)
 
-            // Center dino face — non-interactive so drags pass to canvas pan
+                switch hex.kind {
+                case .hub(let category):
+                    HubHexTileView(category: category, size: hexSize)
+                        .position(position)
+                        .scaleEffect(phase.hubsVisible ? 1 : 0.3)
+                        .opacity(phase.hubsVisible ? 1 : 0)
+                        .animation(
+                            .spring(response: 0.45, dampingFraction: 0.7)
+                                .delay(0.12 + Double(idx) * 0.04),
+                            value: phase
+                        )
+
+                case .leaf(let item):
+                    HexTileView(
+                        label: item.label,
+                        icon: item.icon,
+                        emoji: item.emoji,
+                        color: item.color,
+                        size: hexSize,
+                        onTap: item.filePath.map { path in
+                            { onFileSelected?(path) }
+                        }
+                    )
+                    .position(position)
+                    .scaleEffect(phase.leavesVisible ? 1 : 0.4)
+                    .opacity(phase.leavesVisible ? 1 : 0)
+                    .animation(
+                        .spring(response: 0.5, dampingFraction: 0.7)
+                            .delay(0.20 + Double(idx) * 0.03),
+                        value: phase
+                    )
+                }
+            }
+
+            // Center avatar on top of everything
             DinoFaceView(seed: identity?.name ?? "default", palette: appearance.palette, outfit: appearance.outfit)
                 .frame(width: 80, height: 80)
+                .background(
+                    HexagonShape()
+                        .fill(VColor.background.opacity(0.9))
+                        .frame(width: sqrt(3) * hexSize, height: 2 * hexSize)
+                )
+                .overlay(
+                    HexagonShape()
+                        .stroke(Forest._500.opacity(0.4), lineWidth: 2)
+                        .frame(width: sqrt(3) * hexSize, height: 2 * hexSize)
+                )
                 .allowsHitTesting(false)
                 .position(center)
                 .scaleEffect(phase.centerVisible ? 1 : 0.6)
@@ -364,237 +613,6 @@ struct ConstellationView: View {
                     .spring(response: 0.5, dampingFraction: 0.7).delay(0.05),
                     value: phase
                 )
-        }
-    }
-
-    @ViewBuilder
-    private func canvasBranches(center: CGPoint, hubBasePositions: [CGPoint], leafRadius: CGFloat, layoutGroups: [CategoryGroup]) -> some View {
-        // Center → hub branches
-        ForEach(Array(layoutGroups.enumerated()), id: \.element.id) { groupIdx, group in
-            let hubKey = "hub-\(group.category.rawValue)"
-            let hubPos = effectivePos(hubBasePositions[groupIdx], key: hubKey)
-            BranchShape(from: center, to: hubPos)
-                .stroke(group.category.color.opacity(0.25), lineWidth: 1.5)
-                .opacity(phase.hubBranchesVisible ? 1 : 0)
-                .animation(
-                    .easeIn(duration: 0.3).delay(0.20 + Double(groupIdx) * 0.04),
-                    value: phase
-                )
-        }
-
-        // Hub → leaf branches
-        ForEach(Array(layoutGroups.enumerated()), id: \.element.id) { groupIdx, group in
-            let hubKey = "hub-\(group.category.rawValue)"
-            let hubPos = effectivePos(hubBasePositions[groupIdx], key: hubKey)
-            let leafBasePositions = computeLeafPositions(
-                hub: hubBasePositions[groupIdx], center: center, radius: leafRadius,
-                count: group.items.count
-            )
-
-            ForEach(Array(group.items.enumerated()), id: \.element.id) { leafIdx, item in
-                let leafPos = effectivePos(leafBasePositions[leafIdx], key: item.id)
-                BranchShape(from: hubPos, to: leafPos)
-                    .stroke(group.category.color.opacity(0.18), lineWidth: 1)
-                    .opacity(phase.leafBranchesVisible ? 1 : 0)
-                    .animation(
-                        .easeIn(duration: 0.25).delay(0.35 + Double(groupIdx) * 0.04 + Double(leafIdx) * 0.03),
-                        value: phase
-                    )
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func canvasHubs(hubBasePositions: [CGPoint], layoutGroups: [CategoryGroup]) -> some View {
-        ForEach(Array(layoutGroups.enumerated()), id: \.element.id) { groupIdx, group in
-            let hubKey = "hub-\(group.category.rawValue)"
-            let leafKeys = group.items.map(\.id)
-            DraggableNode(nodeKey: hubKey, childKeys: leafKeys, offsets: $nodeOffsets) {
-                CategoryHubLabel(category: group.category, itemCount: group.items.count)
-            }
-            .position(hubBasePositions[groupIdx])
-            .scaleEffect(phase.hubsVisible ? 1 : 0.3)
-            .opacity(phase.hubsVisible ? 1 : 0)
-            .animation(
-                .spring(response: 0.45, dampingFraction: 0.7)
-                    .delay(0.12 + Double(groupIdx) * 0.05),
-                value: phase
-            )
-        }
-    }
-
-    @ViewBuilder
-    private func canvasLeaves(center: CGPoint, hubBasePositions: [CGPoint], leafRadius: CGFloat, layoutGroups: [CategoryGroup]) -> some View {
-        ForEach(Array(layoutGroups.enumerated()), id: \.element.id) { groupIdx, group in
-            canvasLeafGroup(
-                groupIdx: groupIdx, group: group, center: center,
-                hubPosition: hubBasePositions[groupIdx], leafRadius: leafRadius
-            )
-        }
-    }
-
-    @ViewBuilder
-    private func canvasLeafGroup(groupIdx: Int, group: CategoryGroup, center: CGPoint, hubPosition: CGPoint, leafRadius: CGFloat) -> some View {
-        let leafBasePositions = computeLeafPositions(
-            hub: hubPosition, center: center, radius: leafRadius,
-            count: group.items.count
-        )
-
-        ForEach(Array(group.items.enumerated()), id: \.element.id) { leafIdx, item in
-            DraggableNode(nodeKey: item.id, offsets: $nodeOffsets) {
-                ConstellationPill(
-                    label: item.label, icon: item.icon,
-                    emoji: item.emoji, color: item.color,
-                    onTap: item.filePath.map { path in
-                        { onFileSelected?(path) }
-                    }
-                )
-            }
-            .position(leafBasePositions[leafIdx])
-            .scaleEffect(phase.leavesVisible ? 1 : 0.4)
-            .opacity(phase.leavesVisible ? 1 : 0)
-            .animation(
-                .spring(response: 0.5, dampingFraction: 0.7)
-                    .delay(0.25 + Double(groupIdx) * 0.06 + Double(leafIdx) * 0.04),
-                value: phase
-            )
-        }
-    }
-
-    // MARK: - Layout
-
-    private func computeHubPositions(center: CGPoint, radius: CGFloat, count: Int) -> [CGPoint] {
-        guard count > 0 else { return [] }
-        if count == 1 {
-            return [CGPoint(x: center.x, y: center.y - radius)]
-        }
-        return (0..<count).map { i in
-            let angle = (2 * .pi * Double(i) / Double(count)) - .pi / 2
-            return CGPoint(
-                x: center.x + radius * CGFloat(Darwin.cos(angle)),
-                y: center.y + radius * CGFloat(Darwin.sin(angle))
-            )
-        }
-    }
-
-    private func computeLeafPositions(
-        hub: CGPoint, center: CGPoint, radius: CGFloat, count: Int
-    ) -> [CGPoint] {
-        guard count > 0 else { return [] }
-
-        let dx = hub.x - center.x
-        let dy = hub.y - center.y
-        let baseAngle = atan2(dy, dx)
-
-        if count == 1 {
-            return [CGPoint(
-                x: hub.x + radius * CGFloat(Darwin.cos(baseAngle)),
-                y: hub.y + radius * CGFloat(Darwin.sin(baseAngle))
-            )]
-        }
-
-        let maxArc: Double = 2 * .pi / 3
-        let arc = min(maxArc, Double(count - 1) * (.pi / 5))
-        let startAngle = baseAngle - arc / 2
-
-        return (0..<count).map { i in
-            let fraction = Double(i) / Double(count - 1)
-            let angle = startAngle + arc * fraction
-            return CGPoint(
-                x: hub.x + radius * CGFloat(Darwin.cos(angle)),
-                y: hub.y + radius * CGFloat(Darwin.sin(angle))
-            )
-        }
-    }
-}
-
-// MARK: - Animation Phase
-
-private enum AnimationPhase: Equatable {
-    case hidden
-    case complete
-
-    var centerVisible: Bool { self == .complete }
-    var hubsVisible: Bool { self == .complete }
-    var hubBranchesVisible: Bool { self == .complete }
-    var leavesVisible: Bool { self == .complete }
-    var leafBranchesVisible: Bool { self == .complete }
-}
-
-// MARK: - Polished Pill
-
-private struct ConstellationPill: View {
-    let label: String
-    let icon: String
-    let emoji: String?
-    let color: Color
-    var onTap: (() -> Void)?
-
-    @State private var isHovered = false
-
-    private var isTappable: Bool { onTap != nil }
-
-    var body: some View {
-        HStack(spacing: VSpacing.sm) {
-            if let emoji, !emoji.isEmpty {
-                Text(emoji)
-                    .font(.system(size: 13))
-                    .frame(width: 24, height: 24)
-                    .background(
-                        RoundedRectangle(cornerRadius: VRadius.sm)
-                            .fill(color.opacity(0.12))
-                    )
-            } else {
-                Image(systemName: icon)
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundColor(color)
-                    .frame(width: 24, height: 24)
-                    .background(
-                        RoundedRectangle(cornerRadius: VRadius.sm)
-                            .fill(color.opacity(0.12))
-                    )
-            }
-
-            Text(label)
-                .font(VFont.captionMedium)
-                .foregroundColor(VColor.textPrimary)
-                .lineLimit(1)
-        }
-        .padding(.leading, VSpacing.xs)
-        .padding(.trailing, VSpacing.md)
-        .padding(.vertical, VSpacing.xs)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(VColor.surface.opacity(isHovered ? 1 : 0.9))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
-                        .stroke(
-                            isHovered ? color.opacity(0.4) : VColor.surfaceBorder.opacity(0.6),
-                            lineWidth: 1
-                        )
-                )
-                .shadow(color: Color.black.opacity(isHovered ? 0.3 : 0.15), radius: isHovered ? 8 : 4, y: 2)
-        )
-        .onHover { hovering in
-            withAnimation(.easeInOut(duration: 0.15)) {
-                isHovered = hovering
-            }
-            #if os(macOS)
-            if isTappable {
-                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-            }
-            #endif
-        }
-        #if os(macOS)
-        .onDisappear {
-            if isHovered && isTappable {
-                NSCursor.pop()
-                isHovered = false
-            }
-        }
-        #endif
-        .onTapGesture {
-            onTap?()
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -56,6 +56,8 @@ private struct OrbitItem: Identifiable {
     let emoji: String?
     let color: Color
     let filePath: String?
+    let description: String?
+    let category: SkillCategory?
 }
 
 private struct CategoryGroup: Identifiable {
@@ -343,6 +345,65 @@ private enum HexKind {
     case leaf(OrbitItem)
 }
 
+// MARK: - Skill Popover View
+
+private struct SkillPopoverView: View {
+    let item: OrbitItem
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            // Emoji/icon + name row
+            HStack(spacing: VSpacing.sm) {
+                if let emoji = item.emoji, !emoji.isEmpty {
+                    Text(emoji)
+                        .font(.system(size: 20))
+                } else {
+                    Image(systemName: item.icon)
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(item.color)
+                }
+
+                Text(item.label)
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(2)
+            }
+
+            // Description
+            if let description = item.description, !description.isEmpty {
+                Text(description)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+                    .lineLimit(4)
+            }
+
+            // Category badge
+            if let category = item.category {
+                Text(category.displayName)
+                    .font(VFont.small)
+                    .foregroundColor(category.color)
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.vertical, VSpacing.xxs)
+                    .background(
+                        Capsule()
+                            .fill(category.color.opacity(0.15))
+                    )
+            }
+        }
+        .padding(VSpacing.md)
+        .frame(maxWidth: 250, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(VColor.surface)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+        .vShadow(.md)
+    }
+}
+
 // MARK: - Constellation View
 
 struct ConstellationView: View {
@@ -357,6 +418,8 @@ struct ConstellationView: View {
     @State private var dragOffset: CGSize = .zero
     @State private var zoomScale: CGFloat = 1.0
     @State private var baseZoomScale: CGFloat = 1.0
+    @State private var selectedSkillItem: OrbitItem?
+    @State private var selectedHexCoord: HexCoord?
 
     // Uniform hex size for both positioning and rendering — hubs are
     // visually distinguished via styling (heavier border, higher fill
@@ -373,7 +436,8 @@ struct ConstellationView: View {
             let path: String? = node.label.hasSuffix(".md") ? node.path : nil
             return OrbitItem(
                 id: "core-\(idx)", label: node.label, icon: "doc.text.fill",
-                emoji: nil, color: SkillCategory.core.color, filePath: path
+                emoji: nil, color: SkillCategory.core.color, filePath: path,
+                description: nil, category: nil
             )
         }
 
@@ -387,7 +451,9 @@ struct ConstellationView: View {
                 icon: cat.icon,
                 emoji: skill.emoji,
                 color: cat.color,
-                filePath: nil
+                filePath: nil,
+                description: skill.description,
+                category: cat
             )
             categoryMap[cat, default: []].append(item)
         }
@@ -502,6 +568,35 @@ struct ConstellationView: View {
                 canvas(size: proxy.size)
                     .scaleEffect(zoomScale)
                     .offset(totalOffset)
+
+                // Dismiss layer: clear tap target behind the popover
+                if selectedSkillItem != nil {
+                    Color.clear
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            withAnimation(VAnimation.fast) {
+                                selectedSkillItem = nil
+                                selectedHexCoord = nil
+                            }
+                        }
+                }
+
+                // Skill popover overlay — recompute pixel position from the
+                // stored hex coord each render cycle so the popover tracks the
+                // correct hex even after window resize or geometry changes.
+                if let selected = selectedSkillItem, let coord = selectedHexCoord {
+                    let canvasCenter = CGPoint(x: proxy.size.width / 2, y: proxy.size.height * 0.5)
+                    let pixelPos = coord.toPixel(size: hexSize, gap: hexGap)
+                    let anchorInCanvas = CGPoint(x: canvasCenter.x + pixelPos.x, y: canvasCenter.y + pixelPos.y)
+
+                    let viewCenter = CGPoint(x: proxy.size.width / 2, y: proxy.size.height / 2)
+                    let scaledX = viewCenter.x + (anchorInCanvas.x - viewCenter.x) * zoomScale + totalOffset.width
+                    let scaledY = viewCenter.y + (anchorInCanvas.y - viewCenter.y) * zoomScale + totalOffset.height - 80
+
+                    SkillPopoverView(item: selected)
+                        .position(x: scaledX, y: scaledY)
+                        .transition(.opacity.combined(with: .scale(scale: 0.9)))
+                }
             }
                 .frame(width: proxy.size.width, height: proxy.size.height)
                 .clipped()
@@ -534,6 +629,18 @@ struct ConstellationView: View {
                         phase = .complete
                     }
                 }
+                #if os(macOS)
+                .onKeyPress(.escape) {
+                    if selectedSkillItem != nil {
+                        withAnimation(VAnimation.fast) {
+                            selectedSkillItem = nil
+                            selectedHexCoord = nil
+                        }
+                        return .handled
+                    }
+                    return .ignored
+                }
+                #endif
         }
     }
 
@@ -577,9 +684,21 @@ struct ConstellationView: View {
                         emoji: item.emoji,
                         color: item.color,
                         size: hexSize,
-                        onTap: item.filePath.map { path in
-                            { onFileSelected?(path) }
-                        }
+                        onTap: item.filePath != nil
+                            ? { onFileSelected?(item.filePath!) }
+                            : item.description != nil
+                                ? {
+                                    withAnimation(VAnimation.fast) {
+                                        if selectedSkillItem?.id == item.id {
+                                            selectedSkillItem = nil
+                                            selectedHexCoord = nil
+                                        } else {
+                                            selectedSkillItem = item
+                                            selectedHexCoord = hex.coord
+                                        }
+                                    }
+                                }
+                                : nil
                     )
                     .position(position)
                     .scaleEffect(phase.leavesVisible ? 1 : 0.4)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -18,67 +18,52 @@ struct IdentityPanel: View {
 
     private let sidebarWidth: CGFloat = 260
 
+    private let panelPadding: CGFloat = VSpacing.xl
+
     var body: some View {
         HStack(alignment: .top, spacing: 0) {
             // Left sidebar: title, avatar, ID card — hidden in fullscreen
             if !isFullscreen {
                 VStack(alignment: .leading, spacing: 0) {
-                    // Header — reduced top padding to align with close icon
+                    // Header
                     Text("Identity")
                         .font(VFont.panelTitle)
                         .foregroundColor(VColor.textPrimary)
-                        .padding(.top, VSpacing.lg)
                         .padding(.bottom, VSpacing.lg)
 
-                    // Card wrapping avatar + ID fields + CTA
-                    VStack(alignment: .leading, spacing: 0) {
+                    // Card wrapping avatar + ID fields
+                    VStack(spacing: 0) {
                         // Compact avatar
                         DinoSceneView(seed: identity?.name ?? remoteIdentity?.name ?? lockfileAssistant?.assistantId ?? "default", palette: appearance.palette, outfit: appearance.outfit)
                             .frame(width: 120, height: 140)
                             .frame(maxWidth: .infinity, alignment: .center)
                             .padding(.top, VSpacing.lg)
 
+                        // Customize Avatar CTA — directly under avatar
+                        VButton(label: "Customize Avatar", style: .secondary, isFullWidth: true, action: onCustomizeAvatar)
+                            .padding(.top, VSpacing.sm)
+                            .padding(.horizontal, VSpacing.lg)
+                            .padding(.bottom, VSpacing.lg)
+
                         // ID card fields
                         idCardSection(identity: identity, remoteIdentity: remoteIdentity)
-                            .padding(.top, VSpacing.lg)
                             .padding(.horizontal, VSpacing.lg)
-
-                        // Customize Avatar CTA
-                        Button(action: onCustomizeAvatar) {
-                            HStack(spacing: VSpacing.xs) {
-                                Image(systemName: "paintpalette")
-                                    .font(.system(size: 12, weight: .medium))
-                                Text("Customize Avatar")
-                                    .font(VFont.bodyMedium)
-                            }
-                            .foregroundColor(VColor.accent)
-                            .padding(.horizontal, VSpacing.lg)
-                            .padding(.vertical, VSpacing.sm)
-                            .background(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .stroke(VColor.accent.opacity(0.3), lineWidth: 1)
-                            )
-                        }
-                        .buttonStyle(.plain)
-                        .padding(.top, VSpacing.lg)
-                        .padding(.horizontal, VSpacing.lg)
-                        .padding(.bottom, VSpacing.lg)
+                            .padding(.bottom, VSpacing.lg)
                     }
-                    .background(VColor.surface)
+                    .background(VColor.backgroundSubtle)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.lg)
-                            .stroke(VColor.surfaceBorder, lineWidth: 1)
-                    )
 
                     Spacer()
                 }
                 .frame(width: sidebarWidth)
-                .padding(.horizontal, VSpacing.xl)
+                .padding(.leading, panelPadding)
+                .padding(.trailing, VSpacing.lg)
+                .padding(.top, panelPadding)
+                .padding(.bottom, panelPadding)
                 .transition(.move(edge: .leading).combined(with: .opacity))
             }
 
-            // Hex grid fills the rest of the space — full height, wrapped in a card
+            // Hex grid fills the rest of the space — card when not fullscreen
             ConstellationView(
                 identity: identity,
                 skills: skills,
@@ -89,15 +74,15 @@ struct IdentityPanel: View {
                 isFullscreen: $isFullscreen
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(VColor.backgroundSubtle)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+            .background(isFullscreen ? Color.clear : VColor.backgroundSubtle)
+            .clipShape(RoundedRectangle(cornerRadius: isFullscreen ? 0 : VRadius.lg))
             .overlay(
-                RoundedRectangle(cornerRadius: VRadius.lg)
-                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+                RoundedRectangle(cornerRadius: isFullscreen ? 0 : VRadius.lg)
+                    .stroke(isFullscreen ? Color.clear : VColor.surfaceBorder, lineWidth: 1)
             )
-            .padding(.top, VSpacing.lg)
-            .padding(.trailing, VSpacing.xl)
-            .padding(.bottom, VSpacing.xl)
+            .padding(.top, isFullscreen ? 0 : panelPadding)
+            .padding(.trailing, isFullscreen ? 0 : panelPadding)
+            .padding(.bottom, isFullscreen ? 0 : panelPadding)
         }
         .animation(.spring(response: 0.4, dampingFraction: 0.8), value: isFullscreen)
         .overlay {
@@ -193,11 +178,10 @@ struct IdentityPanel: View {
     }
 
     private func idRow(label: String, value: String, mono: Bool = false, truncate: Bool = false) -> some View {
-        HStack(alignment: .top) {
+        VStack(alignment: .leading, spacing: VSpacing.xxs) {
             Text(label)
                 .font(VFont.caption)
                 .foregroundColor(VColor.textMuted)
-                .frame(width: 100, alignment: .leading)
 
             if truncate {
                 Text(value)
@@ -212,8 +196,6 @@ struct IdentityPanel: View {
                     .foregroundColor(VColor.textPrimary)
                     .textSelection(.enabled)
             }
-
-            Spacer()
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -14,57 +14,62 @@ struct IdentityPanel: View {
     @State private var workspaceFiles: [WorkspaceFileNode] = []
     @State private var skills: [SkillInfo] = []
     @State private var viewingFilePath: String?
+    @State private var isFullscreen: Bool = false
 
     private let maxContentWidth: CGFloat = 1100
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Header + ID card area (max width matches other panels)
-            VStack(alignment: .leading, spacing: 0) {
-                // Header
-                HStack(alignment: .center) {
-                    Text("Assistant ID")
-                        .font(VFont.panelTitle)
-                        .foregroundColor(VColor.textPrimary)
-                    Spacer()
-                }
-                .padding(.top, VSpacing.xxl)
-                .padding(.bottom, VSpacing.xl)
-
-                Divider().background(VColor.surfaceBorder)
-
-                // Avatar + ID card + CTA
-                HStack(alignment: .center, spacing: VSpacing.lg) {
-                    DinoSceneView(seed: identity?.name ?? remoteIdentity?.name ?? lockfileAssistant?.assistantId ?? "default", palette: appearance.palette, outfit: appearance.outfit)
-                        .frame(width: 180, height: 200)
-
-                    VStack(alignment: .leading, spacing: VSpacing.lg) {
-                        idCardSection(identity: identity, remoteIdentity: remoteIdentity)
-
-                        // Customize Avatar CTA
-                        Button(action: onCustomizeAvatar) {
-                            HStack(spacing: VSpacing.xs) {
-                                Image(systemName: "paintpalette")
-                                    .font(.system(size: 12, weight: .medium))
-                                Text("Customize Avatar")
-                                    .font(VFont.bodyMedium)
-                            }
-                            .foregroundColor(VColor.accent)
-                            .padding(.horizontal, VSpacing.lg)
-                            .padding(.vertical, VSpacing.sm)
-                            .background(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .stroke(VColor.accent.opacity(0.3), lineWidth: 1)
-                            )
-                        }
-                        .buttonStyle(.plain)
+            // Header + ID card area — hidden in fullscreen so the
+            // constellation grid fills the entire panel height.
+            if !isFullscreen {
+                VStack(alignment: .leading, spacing: 0) {
+                    // Header
+                    HStack(alignment: .center) {
+                        Text("Assistant ID")
+                            .font(VFont.panelTitle)
+                            .foregroundColor(VColor.textPrimary)
+                        Spacer()
                     }
+                    .padding(.top, VSpacing.xxl)
+                    .padding(.bottom, VSpacing.xl)
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    // Avatar + ID card + CTA
+                    HStack(alignment: .center, spacing: VSpacing.lg) {
+                        DinoSceneView(seed: identity?.name ?? remoteIdentity?.name ?? lockfileAssistant?.assistantId ?? "default", palette: appearance.palette, outfit: appearance.outfit)
+                            .frame(width: 180, height: 200)
+
+                        VStack(alignment: .leading, spacing: VSpacing.lg) {
+                            idCardSection(identity: identity, remoteIdentity: remoteIdentity)
+
+                            // Customize Avatar CTA
+                            Button(action: onCustomizeAvatar) {
+                                HStack(spacing: VSpacing.xs) {
+                                    Image(systemName: "paintpalette")
+                                        .font(.system(size: 12, weight: .medium))
+                                    Text("Customize Avatar")
+                                        .font(VFont.bodyMedium)
+                                }
+                                .foregroundColor(VColor.accent)
+                                .padding(.horizontal, VSpacing.lg)
+                                .padding(.vertical, VSpacing.sm)
+                                .background(
+                                    RoundedRectangle(cornerRadius: VRadius.md)
+                                        .stroke(VColor.accent.opacity(0.3), lineWidth: 1)
+                                )
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .padding(.vertical, VSpacing.xl)
                 }
-                .padding(.vertical, VSpacing.xl)
+                .frame(maxWidth: maxContentWidth)
+                .padding(.horizontal, VSpacing.xxl)
+                .frame(maxWidth: .infinity)
+                .transition(.move(edge: .top).combined(with: .opacity))
             }
-            .frame(maxWidth: maxContentWidth)
-            .padding(.horizontal, VSpacing.xxl)
-            .frame(maxWidth: .infinity)
 
             // Constellation fills remaining space (pan + zoom to navigate)
             ConstellationView(
@@ -73,11 +78,13 @@ struct IdentityPanel: View {
                 workspaceFiles: workspaceFiles,
                 onFileSelected: { path in
                     viewingFilePath = path
-                }
+                },
+                isFullscreen: $isFullscreen
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(adaptiveColor(light: Color(hex: 0xF5F3EB), dark: Moss._900))
         }
+        .animation(.spring(response: 0.4, dampingFraction: 0.8), value: isFullscreen)
         .overlay {
             if let path = viewingFilePath {
                 // Dismiss backdrop

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -16,62 +16,69 @@ struct IdentityPanel: View {
     @State private var viewingFilePath: String?
     @State private var isFullscreen: Bool = false
 
-    private let maxContentWidth: CGFloat = 1100
+    private let sidebarWidth: CGFloat = 260
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Header + ID card area — hidden in fullscreen so the
-            // constellation grid fills the entire panel height.
+        HStack(alignment: .top, spacing: 0) {
+            // Left sidebar: title, avatar, ID card — hidden in fullscreen
             if !isFullscreen {
                 VStack(alignment: .leading, spacing: 0) {
-                    // Header
-                    HStack(alignment: .center) {
-                        Text("Assistant ID")
-                            .font(VFont.panelTitle)
-                            .foregroundColor(VColor.textPrimary)
-                        Spacer()
-                    }
-                    .padding(.top, VSpacing.xxl)
-                    .padding(.bottom, VSpacing.xl)
+                    // Header — reduced top padding to align with close icon
+                    Text("Identity")
+                        .font(VFont.panelTitle)
+                        .foregroundColor(VColor.textPrimary)
+                        .padding(.top, VSpacing.lg)
+                        .padding(.bottom, VSpacing.lg)
 
-                    Divider().background(VColor.surfaceBorder)
-
-                    // Avatar + ID card + CTA
-                    HStack(alignment: .center, spacing: VSpacing.lg) {
+                    // Card wrapping avatar + ID fields + CTA
+                    VStack(alignment: .leading, spacing: 0) {
+                        // Compact avatar
                         DinoSceneView(seed: identity?.name ?? remoteIdentity?.name ?? lockfileAssistant?.assistantId ?? "default", palette: appearance.palette, outfit: appearance.outfit)
-                            .frame(width: 180, height: 200)
+                            .frame(width: 120, height: 140)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .padding(.top, VSpacing.lg)
 
-                        VStack(alignment: .leading, spacing: VSpacing.lg) {
-                            idCardSection(identity: identity, remoteIdentity: remoteIdentity)
+                        // ID card fields
+                        idCardSection(identity: identity, remoteIdentity: remoteIdentity)
+                            .padding(.top, VSpacing.lg)
+                            .padding(.horizontal, VSpacing.lg)
 
-                            // Customize Avatar CTA
-                            Button(action: onCustomizeAvatar) {
-                                HStack(spacing: VSpacing.xs) {
-                                    Image(systemName: "paintpalette")
-                                        .font(.system(size: 12, weight: .medium))
-                                    Text("Customize Avatar")
-                                        .font(VFont.bodyMedium)
-                                }
-                                .foregroundColor(VColor.accent)
-                                .padding(.horizontal, VSpacing.lg)
-                                .padding(.vertical, VSpacing.sm)
-                                .background(
-                                    RoundedRectangle(cornerRadius: VRadius.md)
-                                        .stroke(VColor.accent.opacity(0.3), lineWidth: 1)
-                                )
+                        // Customize Avatar CTA
+                        Button(action: onCustomizeAvatar) {
+                            HStack(spacing: VSpacing.xs) {
+                                Image(systemName: "paintpalette")
+                                    .font(.system(size: 12, weight: .medium))
+                                Text("Customize Avatar")
+                                    .font(VFont.bodyMedium)
                             }
-                            .buttonStyle(.plain)
+                            .foregroundColor(VColor.accent)
+                            .padding(.horizontal, VSpacing.lg)
+                            .padding(.vertical, VSpacing.sm)
+                            .background(
+                                RoundedRectangle(cornerRadius: VRadius.md)
+                                    .stroke(VColor.accent.opacity(0.3), lineWidth: 1)
+                            )
                         }
+                        .buttonStyle(.plain)
+                        .padding(.top, VSpacing.lg)
+                        .padding(.horizontal, VSpacing.lg)
+                        .padding(.bottom, VSpacing.lg)
                     }
-                    .padding(.vertical, VSpacing.xl)
+                    .background(VColor.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.lg)
+                            .stroke(VColor.surfaceBorder, lineWidth: 1)
+                    )
+
+                    Spacer()
                 }
-                .frame(maxWidth: maxContentWidth)
-                .padding(.horizontal, VSpacing.xxl)
-                .frame(maxWidth: .infinity)
-                .transition(.move(edge: .top).combined(with: .opacity))
+                .frame(width: sidebarWidth)
+                .padding(.horizontal, VSpacing.xl)
+                .transition(.move(edge: .leading).combined(with: .opacity))
             }
 
-            // Constellation fills remaining space (pan + zoom to navigate)
+            // Hex grid fills the rest of the space — full height, wrapped in a card
             ConstellationView(
                 identity: identity,
                 skills: skills,
@@ -82,7 +89,15 @@ struct IdentityPanel: View {
                 isFullscreen: $isFullscreen
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(adaptiveColor(light: Color(hex: 0xF5F3EB), dark: Moss._900))
+            .background(VColor.backgroundSubtle)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+            )
+            .padding(.top, VSpacing.lg)
+            .padding(.trailing, VSpacing.xl)
+            .padding(.bottom, VSpacing.xl)
         }
         .animation(.spring(response: 0.4, dampingFraction: 0.8), value: isFullscreen)
         .overlay {
@@ -153,10 +168,10 @@ struct IdentityPanel: View {
                 idRow(label: "Given name", value: name)
             }
 
-            // Role: remote > local
+            // Role: remote > local (truncated with tooltip for long values)
             let role = remoteIdentity?.role.nilIfEmpty ?? identity?.role
             if let role, !role.isEmpty {
-                idRow(label: "Role", value: role)
+                idRow(label: "Role", value: role, truncate: true)
             }
 
             // Personality: remote > local
@@ -177,17 +192,26 @@ struct IdentityPanel: View {
         }
     }
 
-    private func idRow(label: String, value: String, mono: Bool = false) -> some View {
+    private func idRow(label: String, value: String, mono: Bool = false, truncate: Bool = false) -> some View {
         HStack(alignment: .top) {
             Text(label)
                 .font(VFont.caption)
                 .foregroundColor(VColor.textMuted)
                 .frame(width: 100, alignment: .leading)
 
-            Text(value)
-                .font(mono ? VFont.mono : VFont.body)
-                .foregroundColor(VColor.textPrimary)
-                .textSelection(.enabled)
+            if truncate {
+                Text(value)
+                    .font(mono ? VFont.mono : VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .help(value)
+            } else {
+                Text(value)
+                    .font(mono ? VFont.mono : VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .textSelection(.enabled)
+            }
 
             Spacer()
         }


### PR DESCRIPTION
## Summary
- Replaces the circular constellation layout with a hexagonal honeycomb grid inspired by game skill trees
- Avatar sits at center, skill categories fan outward as colored hex clusters with round-robin allocation
- Clicking a skill hex opens a popover with its description
- Viewport controls: zoom in/out, fit-all, fullscreen toggle
- Side-by-side layout with ID card sidebar and full-height skill grid
- Uses VButton/VIconButton design system components throughout

## Milestone PRs (merged into feature branch)
- #8821: M1 — Hexagonal Honeycomb Grid Layout
- #8823: M2 — Skill Popover on Click
- #8825: M3 — Full-Screen Toggle & Viewport Controls
- Plus iterative visual polish commits

## Test plan
- [ ] Open Identity panel and verify hex grid renders with all skills
- [ ] Click a skill hex to verify popover appears with description
- [ ] Test zoom in/out, fit-all, and fullscreen toggle
- [ ] Verify auto-fit on initial load
- [ ] Check category colors are distinct and readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
