### PR TITLE
Add global recording guard and fix missing sessionId

### DIFF
--- a/assistant/src/__tests__/recording-handler.test.ts
+++ b/assistant/src/__tests__/recording-handler.test.ts
@@ -94,7 +94,7 @@ mock.module('node:fs', () => {
 
 // ─── Imports (after mocks) ──────────────────────────────────────────────────
 
-import { handleRecordingStart, handleRecordingStop, recordingHandlers } from '../daemon/handlers/recording.js';
+import { handleRecordingStart, handleRecordingStop, recordingHandlers, __resetRecordingState } from '../daemon/handlers/recording.js';
 import type { HandlerContext } from '../daemon/handlers/shared.js';
 import type { RecordingStatus } from '../daemon/ipc-contract/computer-use.js';
 import { DebouncerMap } from '../util/debounce.js';
@@ -132,6 +132,7 @@ function createCtx(): { ctx: HandlerContext; sent: Array<{ type: string; [k: str
 
 describe('handleRecordingStart', () => {
   beforeEach(() => {
+    __resetRecordingState();
     mockMessages.length = 0;
     mockAttachments.length = 0;
     mockMessageIdCounter = 0;
@@ -180,10 +181,27 @@ describe('handleRecordingStart', () => {
     expect(sent[0].type).toBe('recording_start');
     expect(sent[0].recordingId).toBe(id1);
   });
+
+  test('returns null when a different conversation already has an active recording (global guard)', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+
+    const id1 = handleRecordingStart('conv-global-a', undefined, fakeSocket, ctx);
+    expect(id1).toBeTruthy();
+
+    // A second start from a different conversation should be rejected
+    const id2 = handleRecordingStart('conv-global-b', undefined, fakeSocket, ctx);
+    expect(id2).toBeNull();
+
+    // Only the first call sends recording_start
+    expect(sent).toHaveLength(1);
+    expect(sent[0].type).toBe('recording_start');
+    expect(sent[0].recordingId).toBe(id1);
+  });
 });
 
 describe('handleRecordingStop', () => {
   beforeEach(() => {
+    __resetRecordingState();
     mockMessages.length = 0;
     mockAttachments.length = 0;
     mockMessageIdCounter = 0;
@@ -237,6 +255,7 @@ describe('handleRecordingStop', () => {
 
 describe('recordingHandlers.recording_status', () => {
   beforeEach(() => {
+    __resetRecordingState();
     mockMessages.length = 0;
     mockAttachments.length = 0;
     mockMessageIdCounter = 0;

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -37,6 +37,13 @@ export function handleRecordingStart(
     return null;
   }
 
+  // Global single-active guard: only one recording at a time
+  if (recordingOwnerByConversation.size > 0) {
+    const [activeConv, activeRec] = [...recordingOwnerByConversation.entries()][0];
+    log.warn({ conversationId, activeConversationId: activeConv, activeRecordingId: activeRec }, 'Recording already active globally');
+    return null;
+  }
+
   const recordingId = uuid();
 
   standaloneRecordingConversationId.set(recordingId, conversationId);
@@ -236,6 +243,14 @@ function handleRecordingStatus(
       break;
     }
   }
+}
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+/** Reset module-level state. Only for use in tests. */
+export function __resetRecordingState(): void {
+  standaloneRecordingConversationId.clear();
+  recordingOwnerByConversation.clear();
 }
 
 // ─── Export handler group ────────────────────────────────────────────────────

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -97,6 +97,7 @@ export async function handleUserMessage(
         ctx.send(socket, {
           type: 'assistant_text_delta',
           text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',
+          sessionId: msg.sessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
         return;


### PR DESCRIPTION
Adds global single-active guard to handleRecordingStart (not just per-conversation). Adds sessionId to stop-recording assistant_text_delta in sessions.ts. Updates tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
