### PR TITLE
feat: route guardian verify responses through assistant pipeline

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -1610,7 +1610,7 @@ describe('SMS channel approval decisions', () => {
 describe('SMS guardian verify intercept', () => {
   test('/guardian_verify command works with sourceChannel sms', async () => {
     // Set up a guardian verification challenge for SMS
-    const { createVerificationChallenge } = await import('../runtime/channel-guardian-service.js');
+    const { createVerificationChallenge, getGuardianBinding } = await import('../runtime/channel-guardian-service.js');
     const { secret } = createVerificationChallenge('self', 'sms');
 
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
@@ -1637,19 +1637,24 @@ describe('SMS guardian verify intercept', () => {
     expect(body.accepted).toBe(true);
     expect(body.guardianVerification).toBe('verified');
 
-    // Verify the reply was delivered
-    expect(deliverSpy).toHaveBeenCalled();
-    const replyArgs = deliverSpy.mock.calls[0];
-    const replyPayload = replyArgs[1] as { chatId: string; text: string };
-    expect(replyPayload.chatId).toBe('sms-chat-verify');
-    expect(typeof replyPayload.text).toBe('string');
-    expect(replyPayload.text.toLowerCase()).toContain('guardian');
-    expect(replyPayload.text.toLowerCase()).toContain('verif');
+    // Verification side effects: guardian binding should be created
+    const binding = getGuardianBinding('self', 'sms');
+    expect(binding).not.toBeNull();
+    expect(binding!.guardianExternalUserId).toBe('sms-user-42');
+
+    // The message now flows through processMessage (the assistant generates
+    // the response dynamically) instead of composing a canned reply.
+    expect(noopProcessMessage).toHaveBeenCalled();
 
     deliverSpy.mockRestore();
   });
 
   test('/guardian_verify with invalid token returns failed via SMS', async () => {
+    // Create a pending challenge so the ACL bypass is granted for the
+    // non-member user, allowing the verify intercept to evaluate the code.
+    const { createVerificationChallenge } = await import('../runtime/channel-guardian-service.js');
+    createVerificationChallenge('self', 'sms');
+
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
 
     const req = new Request('http://localhost/channels/inbound', {
@@ -1674,12 +1679,9 @@ describe('SMS guardian verify intercept', () => {
     expect(body.accepted).toBe(true);
     expect(body.guardianVerification).toBe('failed');
 
-    expect(deliverSpy).toHaveBeenCalled();
-    const replyArgs = deliverSpy.mock.calls[0];
-    const replyPayload = replyArgs[1] as { chatId: string; text: string };
-    expect(typeof replyPayload.text).toBe('string');
-    expect(replyPayload.text.toLowerCase()).toContain('verif');
-    expect(replyPayload.text.toLowerCase()).toContain('failed');
+    // The message flows through processMessage with a guardian_verify
+    // commandIntent so the assistant generates a failure response.
+    expect(noopProcessMessage).toHaveBeenCalled();
 
     deliverSpy.mockRestore();
   });
@@ -2919,6 +2921,9 @@ describe('assistant-scoped guardian verification via handleChannelInbound', () =
     expect(body.accepted).toBe(true);
     expect(body.guardianVerification).toBe('verified');
 
+    // The message is processed by the assistant instead of composing a canned reply
+    expect(noopProcessMessage).toHaveBeenCalled();
+
     deliverSpy.mockRestore();
   });
 
@@ -2954,8 +2959,13 @@ describe('assistant-scoped guardian verification via handleChannelInbound', () =
   test('cross-assistant challenge verification fails', async () => {
     const { createVerificationChallenge } = await import('../runtime/channel-guardian-service.js');
 
-    // Create challenge for asst-A
+    // Create challenge for asst-A — also creates a pending challenge so
+    // the ACL bypass is available for this channel.
     const { secret } = createVerificationChallenge('asst-A-cross', 'telegram');
+    // Create a pending challenge for asst-B-cross so the ACL guardian_verify
+    // bypass lets the non-member through (bypass requires a pending challenge
+    // for the target assistant).
+    createVerificationChallenge('asst-B-cross', 'telegram');
 
     const deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
 

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -475,7 +475,7 @@ export async function handleChannelInbound(
 
   // Extract channel command intent (e.g. /start from Telegram)
   const rawCommandIntent = sourceMetadata?.commandIntent;
-  const commandIntent = rawCommandIntent && typeof rawCommandIntent === 'object' && !Array.isArray(rawCommandIntent)
+  let commandIntent = rawCommandIntent && typeof rawCommandIntent === 'object' && !Array.isArray(rawCommandIntent)
     ? rawCommandIntent as Record<string, unknown>
     : undefined;
 
@@ -487,11 +487,15 @@ export async function handleChannelInbound(
   const replyCallbackUrl = body.replyCallbackUrl;
 
   // ── Guardian verification command intercept ──
-  // Handled before normal message processing so it never enters the agent loop.
+  // Validate/consume the challenge synchronously so side effects (member
+  // upsert, binding creation) happen before the message enters the agent
+  // loop. Instead of composing a canned reply and short-circuiting, inject
+  // the verification result as a commandIntent so the full assistant
+  // generates a dynamic, context-aware response.
+  let guardianVerifyOutcome: 'verified' | 'failed' | undefined;
   if (
     !result.duplicate &&
     guardianVerifyCode !== undefined &&
-    replyCallbackUrl &&
     body.senderExternalUserId
   ) {
     const verifyResult = validateAndConsumeChallenge(
@@ -516,35 +520,19 @@ export async function handleChannelInbound(
         username: body.senderUsername,
       });
       log.info({ sourceChannel, externalUserId: body.senderExternalUserId }, 'Guardian verified: auto-upserted ingress member');
+      guardianVerifyOutcome = 'verified';
+    } else {
+      guardianVerifyOutcome = 'failed';
     }
 
-    const replyText = verifyResult.success
-      ? await composeApprovalMessageGenerative({
-        scenario: 'guardian_verify_success',
-        channel: sourceChannel,
-      }, {}, approvalCopyGenerator)
-      : await composeApprovalMessageGenerative({
-        scenario: 'guardian_verify_failed',
-        channel: sourceChannel,
-        failureReason: stripVerificationFailurePrefix(verifyResult.reason),
-      }, {}, approvalCopyGenerator);
-
-    try {
-      await deliverChannelReply(replyCallbackUrl, {
-        chatId: externalChatId,
-        text: replyText,
-        assistantId,
-      }, bearerToken);
-    } catch (err) {
-      log.error({ err, externalChatId }, 'Failed to deliver guardian verification reply');
-    }
-
-    return Response.json({
-      accepted: true,
-      duplicate: false,
-      eventId: result.eventId,
-      guardianVerification: verifyResult.success ? 'verified' : 'failed',
-    });
+    // Override commandIntent so the assistant sees the verification result
+    // and can generate a natural, personalized response.
+    commandIntent = {
+      type: 'guardian_verify',
+      payload: verifyResult.success
+        ? 'success: The user has been verified and is now set as the guardian for this channel.'
+        : `failed: ${stripVerificationFailurePrefix(verifyResult.reason)}`,
+    };
   }
 
   // ── Guardian action answer interception ──
@@ -814,6 +802,7 @@ export async function handleChannelInbound(
     accepted: result.accepted,
     duplicate: result.duplicate,
     eventId: result.eventId,
+    ...(guardianVerifyOutcome ? { guardianVerification: guardianVerifyOutcome } : {}),
   });
 }
 


### PR DESCRIPTION
## Summary
- Guardian `/guardian_verify` command responses now flow through the full assistant pipeline instead of short-circuiting with a canned reply
- Verification result is injected as a `commandIntent` with type `guardian_verify`, letting the assistant generate dynamic, personalized responses
- Side effects (member upsert, binding creation) still happen synchronously before the message enters the agent loop
- Updated tests to verify `processMessage` is called and guardian bindings are created

## Original prompt
when I submitted the /guardian_verify command in Telegram, it responded with the hard-coded message "Guardian verification successful! You are now set as the guardian for this channel." Instead, the message should have been produced by my assistant through the daemon and have been generated dynamically based on this context. We should do the same for all guardian verification responses, regardless of the channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
