### PR TITLE
Always create new message for recording + notify on missing file

### DIFF
--- a/assistant/src/__tests__/recording-handler.test.ts
+++ b/assistant/src/__tests__/recording-handler.test.ts
@@ -316,7 +316,7 @@ describe('recordingHandlers.recording_status', () => {
     expect(recordingId).not.toBeNull();
     sent.length = 0;
 
-    // Add a mock assistant message for the attachment to link to
+    // Even with an existing assistant message, a NEW one should be created
     mockMessages.push({ id: 'existing-msg', role: 'assistant', content: 'Hello' });
 
     const statusMsg: RecordingStatus = {
@@ -343,6 +343,10 @@ describe('recordingHandlers.recording_status', () => {
     expect(mockAttachments.length).toBe(1);
     expect(mockAttachments[0].mimeType).toBe('video/quicktime');
     expect(mockAttachments[0].sizeBytes).toBe(mockFileSize);
+
+    // A new assistant message should have been created (not reuse existing-msg)
+    const createdMsg = mockMessages.find((m) => m.id !== 'existing-msg' && m.role === 'assistant');
+    expect(createdMsg).toBeTruthy();
   });
 
   test('handles stopped status and creates assistant message when none exists', () => {
@@ -373,7 +377,7 @@ describe('recordingHandlers.recording_status', () => {
     expect(createdMsg).toBeTruthy();
   });
 
-  test('handles stopped status when file does not exist', () => {
+  test('handles stopped status when file does not exist — notifies client', () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = 'conv-status-no-file';
 
@@ -392,13 +396,22 @@ describe('recordingHandlers.recording_status', () => {
       durationMs: 1000,
     };
 
-    // Should not throw — the handler logs the error and skips attachment
+    // Should not throw — the handler logs the error and notifies the client
     expect(() => {
       recordingHandlers.recording_status(statusMsg, fakeSocket, ctx);
     }).not.toThrow();
 
     // No attachment should have been created
     expect(mockAttachments.length).toBe(0);
+
+    // Client should be notified that the file is unavailable
+    const textDeltas = sent.filter((m) => m.type === 'assistant_text_delta');
+    expect(textDeltas.length).toBeGreaterThanOrEqual(1);
+    expect(textDeltas[0].text).toContain('unavailable');
+
+    const completes = sent.filter((m) => m.type === 'message_complete');
+    expect(completes.length).toBeGreaterThanOrEqual(1);
+    expect(completes[0].sessionId).toBe(conversationId);
   });
 
   test('handles failed status and notifies client', () => {

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -140,6 +140,17 @@ function handleRecordingStatus(
         try {
           if (!existsSync(msg.filePath)) {
             log.error({ recordingId, filePath: msg.filePath }, 'Recording file does not exist');
+            if (conversationId) {
+              const errSocket = findSocketForSession(conversationId, ctx);
+              if (errSocket) {
+                ctx.send(errSocket, {
+                  type: 'assistant_text_delta',
+                  text: 'Recording file is unavailable or expired.',
+                  sessionId: conversationId,
+                });
+                ctx.send(errSocket, { type: 'message_complete', sessionId: conversationId });
+              }
+            }
           } else if (!conversationId) {
             log.warn({ recordingId }, 'No conversationId found for recording — cannot link attachment');
           } else {
@@ -155,22 +166,16 @@ function handleRecordingStatus(
             const attachment = uploadFileBackedAttachment(filename, mimeType, msg.filePath, sizeBytes);
             log.info({ recordingId, attachmentId: attachment.id, sizeBytes, filePath: msg.filePath }, 'Created attachment for standalone recording');
 
-            // Find or create an assistant message to attach the recording to
-            const existingMessages = conversationStore.getMessages(conversationId);
-            const lastAssistantMsg = [...existingMessages].reverse().find((m) => m.role === 'assistant');
-
-            let messageId: string;
-            if (lastAssistantMsg) {
-              messageId = lastAssistantMsg.id;
-            } else {
-              const newMsg = conversationStore.addMessage(
-                conversationId,
-                'assistant',
-                JSON.stringify([{ type: 'text', text: 'Screen recording attached.' }]),
-              );
-              messageId = newMsg.id;
-              log.info({ recordingId, conversationId, messageId }, 'Created assistant message for recording attachment');
-            }
+            // Always create a new assistant message for the recording attachment.
+            // Reusing the last assistant message would attach the recording to an
+            // unrelated older message after reload.
+            const newMsg = conversationStore.addMessage(
+              conversationId,
+              'assistant',
+              JSON.stringify([{ type: 'text', text: 'Screen recording attached.' }]),
+            );
+            const messageId = newMsg.id;
+            log.info({ recordingId, conversationId, messageId }, 'Created assistant message for recording attachment');
 
             linkAttachmentToMessage(messageId, attachment.id, 0);
             log.info({ recordingId, messageId, attachmentId: attachment.id }, 'Linked recording attachment to assistant message');


### PR DESCRIPTION
Always creates a new assistant message for recording attachments instead of reusing existing ones. Notifies the client when the recording file is unavailable.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
