### PR TITLE
fix: address PR #8558 feedback — replace static titles without blocking session-agent-loop

### DIFF
--- a/assistant/src/daemon/handlers/config-scheduling.ts
+++ b/assistant/src/daemon/handlers/config-scheduling.ts
@@ -1,6 +1,7 @@
 import * as net from 'node:net';
 import { listSchedules, updateSchedule, deleteSchedule, describeCronExpression, getSchedule, createScheduleRun, completeScheduleRun } from '../../schedule/schedule-store.js';
 import { createConversation } from '../../memory/conversation-store.js';
+import { GENERATING_TITLE, queueGenerateConversationTitle } from '../../memory/conversation-title-service.js';
 import { listReminders, cancelReminder } from '../../tools/reminder/reminder-store.js';
 import type {
   ScheduleToggle,
@@ -101,7 +102,11 @@ export async function handleScheduleRunNow(
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.warn({ err, jobId: schedule.id, name: schedule.name, taskId }, 'Manual scheduled task execution failed');
-      const fallbackConversation = createConversation({ title: `Schedule (manual): ${schedule.name}`, source: 'schedule' });
+      const fallbackConversation = createConversation({ title: GENERATING_TITLE, source: 'schedule' });
+      queueGenerateConversationTitle({
+        conversationId: fallbackConversation.id,
+        context: { origin: 'schedule', systemHint: `Schedule (manual): ${schedule.name}` },
+      });
       const runId = createScheduleRun(schedule.id, fallbackConversation.id);
       completeScheduleRun(runId, { status: 'error', error: message });
     }
@@ -109,7 +114,7 @@ export async function handleScheduleRunNow(
     return;
   }
 
-  const conversation = createConversation({ title: `Schedule (manual): ${schedule.name}`, source: 'schedule' });
+  const conversation = createConversation({ title: GENERATING_TITLE, source: 'schedule' });
   const runId = createScheduleRun(schedule.id, conversation.id);
 
   try {

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -10,6 +10,7 @@ import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { parseSlashCandidate } from '../../skills/slash-commands.js';
 import { classifySessionError, buildSessionErrorMessage } from '../session-error.js';
 import { resolveBlobPath, deleteBlob, isValidBlobId } from '../ipc-blob-store.js';
+import { GENERATING_TITLE } from '../../memory/conversation-title-service.js';
 import type {
   TaskSubmit,
   SuggestionRequest,
@@ -91,7 +92,7 @@ export async function handleTaskSubmit(
       });
     } else {
       // Create text QA session and immediately start processing
-      const conversation = conversationStore.createConversation(msg.task);
+      const conversation = conversationStore.createConversation(GENERATING_TITLE);
       ctx.socketToSession.set(socket, conversation.id);
       const session = await ctx.getOrCreateSession(conversation.id, socket, true);
 


### PR DESCRIPTION
## Summary
- Replace static titles in `config-scheduling.ts` (schedule run-now) and `misc.ts` (task_submit text QA) with `GENERATING_TITLE` placeholder so session-agent-loop generates better titles from actual conversation content
- Only the schedule error fallback (which bypasses session-agent-loop) gets an explicit `queueGenerateConversationTitle` call
- Intentionally omits the broader `getOrCreateConversation` auto-queue changes from PR #8558, addressing all three review comments: P1 (early title gen blocks session-agent-loop), P2 (wasteful SSE subscribe title gen), and Devin's guardian dispatch duplicate LLM call

Closes #8558

## Original prompt
Help me address feedback comments on this PR and fix merge conflicts https://github.com/vellum-ai/vellum-assistant/pull/8558

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
