### PR TITLE
feat(macos): add Platform URL connection check to Connect page

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -59,7 +59,7 @@ struct SettingsConnectTab: View {
         .onAppear {
             Task { await authManager.checkSession() }
             store.refreshPlatformConfig()
-            if store.isDevMode { Task { await store.checkVellumPlatform() } }
+            Task { await store.checkVellumPlatform() }
             store.refreshIngressConfig()
             store.refreshAssistantEmail()
             store.refreshApprovedDevices()
@@ -180,6 +180,38 @@ struct SettingsConnectTab: View {
                 Text(error)
                     .font(VFont.caption)
                     .foregroundColor(VColor.error)
+            }
+
+            Divider().background(VColor.surfaceBorder)
+
+            // Platform URL connection status
+            connectionStatusRow(
+                label: "Platform",
+                status: platformUrlStatusInfo
+            )
+
+            HStack(spacing: VSpacing.sm) {
+                if store.isCheckingVellumPlatform {
+                    VLoadingIndicator(size: 14, color: VColor.accent)
+                    Text("Checking...")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                } else {
+                    VButton(
+                        label: "Test Connection",
+                        leftIcon: "antenna.radiowaves.left.and.right",
+                        style: .secondary,
+                        isDisabled: store.isCheckingVellumPlatform
+                    ) {
+                        Task { await store.checkVellumPlatform() }
+                    }
+                }
+            }
+
+            if let lastChecked = store.platformLastChecked {
+                Text("Last verified: \(relativeTimeString(from: lastChecked))")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
             }
 
             if store.isDevMode {
@@ -1425,6 +1457,21 @@ struct SettingsConnectTab: View {
             return ConnectionStatusInfo(label: "Running", color: VColor.success, icon: "checkmark.circle.fill")
         } else {
             return ConnectionStatusInfo(label: "Stopped", color: VColor.error, icon: "xmark.circle.fill")
+        }
+    }
+
+    private var platformUrlStatusInfo: ConnectionStatusInfo {
+        if store.isCheckingVellumPlatform {
+            return ConnectionStatusInfo(label: "Checking...", color: VColor.textMuted, icon: "arrow.trianglehead.2.counterclockwise")
+        }
+        guard let reachable = store.vellumPlatformReachable else {
+            return ConnectionStatusInfo(label: "Unknown", color: VColor.textMuted, icon: "questionmark.circle.fill")
+        }
+        if reachable {
+            return ConnectionStatusInfo(label: "Reachable", color: VColor.success, icon: "checkmark.circle.fill")
+        } else {
+            let detail = store.vellumPlatformError ?? "Unreachable"
+            return ConnectionStatusInfo(label: detail, color: VColor.error, icon: "xmark.circle.fill")
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -156,6 +156,7 @@ public final class SettingsStore: ObservableObject {
     @Published var vellumPlatformReachable: Bool?
     @Published var vellumPlatformError: String?
     @Published var isCheckingVellumPlatform: Bool = false
+    @Published var platformLastChecked: Date?
 
     // MARK: - Dev Mode
 
@@ -1323,7 +1324,10 @@ public final class SettingsStore: ObservableObject {
 
     func checkVellumPlatform() async {
         isCheckingVellumPlatform = true
-        defer { isCheckingVellumPlatform = false }
+        defer {
+            isCheckingVellumPlatform = false
+            platformLastChecked = Date()
+        }
 
         let baseUrl = platformBaseUrl.isEmpty ? AuthService.shared.baseURL : platformBaseUrl
         let normalized = baseUrl.hasSuffix("/") ? String(baseUrl.dropLast()) : baseUrl


### PR DESCRIPTION
## Summary
- Add a Platform URL health check row to the Vellum section on the Connect page, using the same `connectionStatusRow` pattern as Gateway and Tunnel checks
- Health check runs automatically on appear (not just in dev mode) and hits `<platformBaseUrl>/healthz`
- Includes Test Connection button, loading state, and last verified timestamp

## Original prompt
On the Connect page, we have connection checks for the gateway and tunnel. Lets add something analogous for "Platform URL" We have health check apis for this:

Checked just now (February 25, 2026).

Yes, there is a platform health endpoint you can use: GET /healthz.

Live check: https://platform.vellum.ai/healthz returns 200 with body "OK".
In the macOS app, the Platform URL health probe is hardcoded as <baseUrl>/healthz (SettingsStore.swift, SettingsStore.swift).
Equivalent URLs:

Prod/default: https://platform.vellum.ai/healthz
Debug localhost (from app defaults): http://localhost:8000/healthz (AuthService.swift, AuthService.swift)
Also in vellum-assistant-platform, there is a Django chat health route at GET /v1/chat/health/ (config/urls.py, chat/urls.py, chat/health.py), but on the public domain it currently returns 403 unauthenticated. So for the Connect page, /healthz is the right one.

Locally right now, nothing is listening on localhost (line 8000) on this machine (connection refused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
