### PR TITLE
fix(macos): restore ingressEnabled check in merged Gateway section

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -1485,9 +1485,15 @@ struct SettingsConnectTab: View {
 
         // URL is non-empty but not a valid absolute HTTP(S) URL
         if let parsed = URL(string: trimmedUrl), let scheme = parsed.scheme, ["http", "https"].contains(scheme.lowercased()) {
-            // valid — fall through to reachability check below
+            // valid — fall through to further checks below
         } else {
             return ConnectionStatusInfo(label: "Invalid URL format", color: VColor.error, icon: "exclamationmark.circle.fill")
+        }
+
+        // URL is set but ingress is disabled — the backend ignores the URL when
+        // ingress.enabled is false, so public callbacks are effectively off.
+        if !store.ingressEnabled {
+            return ConnectionStatusInfo(label: "URL set but gateway not active", color: VColor.warning, icon: "exclamationmark.triangle.fill")
         }
 
         // Haven't tested yet


### PR DESCRIPTION
Addresses Codex review feedback on PR #8838. Restores the ingressEnabled warning that was lost when the Diagnostics section was merged into Gateway. Now shows a warning when Gateway URL is set but ingress is disabled.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
