### PR TITLE
feat(macos): inline refresh icons for connection checks on Connect page

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -115,28 +115,6 @@ struct SettingsConnectTab: View {
 
     // MARK: - Vellum Section
 
-    private var platformHealthIcon: String {
-        if store.isCheckingVellumPlatform {
-            return "arrow.trianglehead.2.counterclockwise"
-        }
-        switch store.vellumPlatformReachable {
-        case .some(true): return "checkmark.circle.fill"
-        case .some(false): return "xmark.circle.fill"
-        case .none: return "questionmark.circle"
-        }
-    }
-
-    private var platformHealthIconColor: Color {
-        if store.isCheckingVellumPlatform {
-            return VColor.textMuted
-        }
-        switch store.vellumPlatformReachable {
-        case .some(true): return VColor.success
-        case .some(false): return VColor.error
-        case .none: return VColor.textMuted
-        }
-    }
-
     private var vellumSection: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
             Text("Vellum")
@@ -182,50 +160,12 @@ struct SettingsConnectTab: View {
                     .foregroundColor(VColor.error)
             }
 
-            Divider().background(VColor.surfaceBorder)
-
-            // Platform URL connection status
-            connectionStatusRow(
-                label: "Platform",
-                status: platformUrlStatusInfo
-            )
-
-            HStack(spacing: VSpacing.sm) {
-                if store.isCheckingVellumPlatform {
-                    VLoadingIndicator(size: 14, color: VColor.accent)
-                    Text("Checking...")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textSecondary)
-                } else {
-                    VButton(
-                        label: "Test Connection",
-                        leftIcon: "antenna.radiowaves.left.and.right",
-                        style: .secondary,
-                        isDisabled: store.isCheckingVellumPlatform
-                    ) {
-                        Task { await store.checkVellumPlatform() }
-                    }
-                }
-            }
-
-            if let lastChecked = store.platformLastChecked {
-                Text("Last verified: \(relativeTimeString(from: lastChecked))")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
-            }
-
             if store.isDevMode {
                 Divider().background(VColor.surfaceBorder)
 
-                HStack(spacing: VSpacing.sm) {
-                    Image(systemName: platformHealthIcon)
-                        .foregroundColor(platformHealthIconColor)
-                        .font(.system(size: 12))
-                    Text("Platform URL")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                }
-                .help(store.vellumPlatformError ?? "")
+                Text("Platform URL")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
 
                 HStack(spacing: VSpacing.sm) {
                     TextField("https://platform.vellum.ai", text: $platformUrlText)
@@ -241,6 +181,17 @@ struct SettingsConnectTab: View {
                         Task { await store.checkVellumPlatform() }
                     }
                 }
+            }
+
+            Divider().background(VColor.surfaceBorder)
+
+            connectionStatusRow(
+                label: "Platform",
+                status: platformUrlStatusInfo,
+                isRefreshing: store.isCheckingVellumPlatform,
+                lastChecked: store.platformLastChecked
+            ) {
+                Task { await store.checkVellumPlatform() }
             }
         }
         .padding(VSpacing.lg)
@@ -306,8 +257,12 @@ struct SettingsConnectTab: View {
                 // Gateway connection status (checks local daemon)
                 connectionStatusRow(
                     label: "Gateway",
-                    status: gatewayStatusInfo
-                )
+                    status: gatewayStatusInfo,
+                    isRefreshing: store.isCheckingGateway,
+                    lastChecked: store.gatewayLastChecked
+                ) {
+                    Task { await store.testGatewayOnly() }
+                }
 
                 Divider()
                     .background(VColor.surfaceBorder)
@@ -334,8 +289,12 @@ struct SettingsConnectTab: View {
                 // Tunnel connection status (checks public URL)
                 connectionStatusRow(
                     label: "Tunnel",
-                    status: tunnelStatusInfo
-                )
+                    status: tunnelStatusInfo,
+                    isRefreshing: store.isCheckingTunnel,
+                    lastChecked: store.tunnelLastChecked
+                ) {
+                    Task { await store.testTunnelOnly() }
+                }
 
                 // Diagnostic message when gateway is up but tunnel is down
                 if store.gatewayReachable == true,
@@ -349,35 +308,6 @@ struct SettingsConnectTab: View {
                             .font(VFont.caption)
                             .foregroundColor(VColor.warning)
                     }
-                }
-
-                Divider()
-                    .background(VColor.surfaceBorder)
-
-                // Test Connection button
-                HStack(spacing: VSpacing.sm) {
-                    if store.isCheckingGateway {
-                        VLoadingIndicator(size: 14, color: VColor.accent)
-                        Text("Checking...")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textSecondary)
-                    } else {
-                        VButton(
-                            label: "Test Connection",
-                            leftIcon: "antenna.radiowaves.left.and.right",
-                            style: .secondary,
-                            isDisabled: store.isCheckingGateway
-                        ) {
-                            Task { await store.testGatewayConnection() }
-                        }
-                    }
-                }
-
-                // Last verified timestamp
-                if let lastChecked = store.gatewayLastChecked {
-                    Text("Last verified: \(relativeTimeString(from: lastChecked))")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
                 }
             }
         }
@@ -1461,9 +1391,6 @@ struct SettingsConnectTab: View {
     }
 
     private var platformUrlStatusInfo: ConnectionStatusInfo {
-        if store.isCheckingVellumPlatform {
-            return ConnectionStatusInfo(label: "Checking...", color: VColor.textMuted, icon: "arrow.trianglehead.2.counterclockwise")
-        }
         guard let reachable = store.vellumPlatformReachable else {
             return ConnectionStatusInfo(label: "Unknown", color: VColor.textMuted, icon: "questionmark.circle.fill")
         }
@@ -1502,7 +1429,13 @@ struct SettingsConnectTab: View {
         }
     }
 
-    private func connectionStatusRow(label: String, status: ConnectionStatusInfo) -> some View {
+    private func connectionStatusRow(
+        label: String,
+        status: ConnectionStatusInfo,
+        isRefreshing: Bool = false,
+        lastChecked: Date? = nil,
+        onRefresh: (() -> Void)? = nil
+    ) -> some View {
         HStack(spacing: VSpacing.sm) {
             Text(label)
                 .font(VFont.bodyMedium)
@@ -1516,6 +1449,31 @@ struct SettingsConnectTab: View {
             Text(status.label)
                 .font(VFont.body)
                 .foregroundColor(status.color)
+
+            Spacer()
+
+            if let onRefresh {
+                let tooltipText: String = {
+                    if isRefreshing { return "Checking..." }
+                    if let lastChecked { return "Last verified: \(relativeTimeString(from: lastChecked))" }
+                    return "Test connection"
+                }()
+
+                Button {
+                    if !isRefreshing { onRefresh() }
+                } label: {
+                    Image(systemName: "arrow.trianglehead.2.counterclockwise")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(isRefreshing ? VColor.accent : VColor.textMuted)
+                        .rotationEffect(.degrees(isRefreshing ? 360 : 0))
+                        .animation(isRefreshing ? .linear(duration: 1).repeatForever(autoreverses: false) : .default, value: isRefreshing)
+                        .frame(width: 24, height: 24)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Refresh \(label) status")
+                .help(tooltipText)
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -152,6 +152,8 @@ public final class SettingsStore: ObservableObject {
     @Published var ingressReachable: Bool?
     @Published var gatewayLastChecked: Date?
     @Published var isCheckingGateway: Bool = false
+    @Published var isCheckingTunnel: Bool = false
+    @Published var tunnelLastChecked: Date?
 
     @Published var vellumPlatformReachable: Bool?
     @Published var vellumPlatformError: String?
@@ -1276,22 +1278,26 @@ public final class SettingsStore: ObservableObject {
 
     // MARK: - Connection Health Check
 
-    /// Tests reachability of both the local gateway process and the public tunnel.
-    /// Updates `gatewayReachable`, `ingressReachable`, and `gatewayLastChecked` with results.
-    func testGatewayConnection() async {
+    /// Tests reachability of the local gateway process.
+    func testGatewayOnly() async {
         isCheckingGateway = true
         defer {
             isCheckingGateway = false
             gatewayLastChecked = Date()
         }
-
-        // Test local gateway
         gatewayReachable = await Self.checkHealthEndpoint(
             baseUrl: localGatewayTarget,
             timeoutSeconds: 3
         )
+    }
 
-        // Test public tunnel (only if URL is non-empty)
+    /// Tests reachability of the public tunnel URL.
+    func testTunnelOnly() async {
+        isCheckingTunnel = true
+        defer {
+            isCheckingTunnel = false
+            tunnelLastChecked = Date()
+        }
         let trimmedUrl = ingressPublicBaseUrl.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmedUrl.isEmpty {
             ingressReachable = nil


### PR DESCRIPTION
## Summary
- Replace bulky "Test Connection" buttons and "Last verified" timestamps with compact inline refresh icons (↻) on each connection status row
- Move Platform connection status below the Platform URL input (always visible; URL field remains dev-mode only)
- Split `testGatewayConnection()` into `testGatewayOnly()` and `testTunnelOnly()` so each row refreshes independently

## Original prompt
Refactor the Connect page (SettingsConnectTab.swift) to simplify the Test Connection UI for all three checks (Platform, Gateway, Tunnel):

1. **Replace the big "Test Connection" buttons and "Last verified" timestamp rows with inline refresh icons on the status rows.** Each `connectionStatusRow` should have a small clickable refresh/retry icon (arrow.trianglehead.2.counterclockwise) at the trailing edge of the row. When clicked, it triggers the health check. The icon spins/animates while checking. The "Last verified: X ago" text moves to a `.help()` tooltip on the refresh icon. Remove the standalone "Test Connection" button rows and standalone "Last verified" text rows entirely.

2. **Move the Platform connection status row to below the Platform URL text input** (currently in dev-mode only section). The Platform status row should appear right after the Platform URL field and Save button, but still be always visible even when not in dev mode. The dev-mode section just controls whether the URL text field is editable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
