### PR TITLE
docs: add call transcript retrieval guide to phone-calls skill

### DIFF
--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -442,6 +442,63 @@ Use `call_end` with the call session ID to terminate an active call:
 call_end call_session_id="<session_id>" reason="User requested to end the call"
 ```
 
+## Retrieving Past Call Transcripts
+
+After a call ends, the full bidirectional transcript (caller speech, assistant responses, tool calls, and tool results) is stored in the SQLite database. The daemon logs (`vellum.log`) only contain caller-side transcripts and lifecycle events at the default log level, so they are **not sufficient** for full transcript reconstruction.
+
+### Finding the conversation
+
+1. **Get the call session ID and voice conversation ID** from `vellum.log` by searching for recent session creation entries:
+
+```bash
+grep "voiceConversationId" ~/.vellum/workspace/data/logs/vellum.log | tail -5
+```
+
+The `voiceConversationId` field in the `Created new inbound voice session` (or outbound equivalent) log line is the key you need.
+
+2. **Query the messages table** in the SQLite database using the voice conversation ID:
+
+```bash
+sqlite3 ~/.vellum/workspace/data/db/assistant.db \
+  "SELECT role, content FROM messages WHERE conversation_id = '<voiceConversationId>' ORDER BY created_at ASC;"
+```
+
+This returns all messages in chronological order with:
+- `role: "user"` — caller speech (prefixed with `[SPEAKER]` tags) and system events
+- `role: "assistant"` — assistant responses, including `text` content and any `tool_use`/`tool_result` blocks
+
+### Quick one-liner for the most recent call
+
+```bash
+CONV_ID=$(grep "voiceConversationId" ~/.vellum/workspace/data/logs/vellum.log | tail -1 | python3 -c "import sys,json; print(json.loads(sys.stdin.readline().strip())['voiceConversationId'])")
+
+sqlite3 ~/.vellum/workspace/data/db/assistant.db \
+  "SELECT role, content FROM messages WHERE conversation_id = '$CONV_ID' ORDER BY created_at ASC;"
+```
+
+### Additional tables for call metadata
+
+| Table | What it contains |
+|---|---|
+| `call_sessions` | Session metadata (start time, duration, phone numbers, status) |
+| `call_events` | Granular event log for the call lifecycle |
+| `notification_decisions` | Whether notifications were evaluated during the call |
+| `notification_deliveries` | Notification delivery attempts |
+
+### Key paths
+
+| Resource | Path |
+|---|---|
+| Daemon logs (caller-side transcripts only) | `~/.vellum/workspace/data/logs/vellum.log` |
+| Full conversation database | `~/.vellum/workspace/data/db/assistant.db` |
+| Messages table | `messages` (keyed by `conversation_id`) |
+| Call sessions table | `call_sessions` |
+| Call events table | `call_events` |
+
+### Important
+
+`vellum.log` at the default log level does **not** contain assistant responses, TTS text, or LLM completions for voice calls. Always use the `messages` table in `assistant.db` as the source of truth for complete call transcripts.
+
 ## Call Quality Tips
 
 When crafting tasks for the AI voice agent, follow these guidelines for the best call experience:


### PR DESCRIPTION
## Summary
- Add "Retrieving Past Call Transcripts" section to phone-calls SKILL.md documenting how to find full bidirectional transcripts in the SQLite database
- Clarifies that `vellum.log` only contains caller-side transcripts at default log level, and `assistant.db` messages table is the source of truth

## Original prompt
The phone-calls skill had no documentation on retrieving past call transcripts. The assistant was wasting rounds grepping through `vellum.log` before discovering the database was the actual source of truth. Added a new section with step-by-step instructions, quick one-liners, and reference tables for call metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
