### PR TITLE
fix: add queueGenerateConversationTitle fallback for task_submit and schedule_run_now paths

### DIFF
--- a/assistant/src/daemon/handlers/config-scheduling.ts
+++ b/assistant/src/daemon/handlers/config-scheduling.ts
@@ -115,6 +115,10 @@ export async function handleScheduleRunNow(
   }
 
   const conversation = createConversation({ title: GENERATING_TITLE, source: 'schedule' });
+  queueGenerateConversationTitle({
+    conversationId: conversation.id,
+    context: { origin: 'schedule', systemHint: `Schedule (manual): ${schedule.name}` },
+  });
   const runId = createScheduleRun(schedule.id, conversation.id);
 
   try {

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -10,7 +10,7 @@ import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { parseSlashCandidate } from '../../skills/slash-commands.js';
 import { classifySessionError, buildSessionErrorMessage } from '../session-error.js';
 import { resolveBlobPath, deleteBlob, isValidBlobId } from '../ipc-blob-store.js';
-import { GENERATING_TITLE } from '../../memory/conversation-title-service.js';
+import { GENERATING_TITLE, queueGenerateConversationTitle } from '../../memory/conversation-title-service.js';
 import type {
   TaskSubmit,
   SuggestionRequest,
@@ -93,6 +93,10 @@ export async function handleTaskSubmit(
     } else {
       // Create text QA session and immediately start processing
       const conversation = conversationStore.createConversation(GENERATING_TITLE);
+      queueGenerateConversationTitle({
+        conversationId: conversation.id,
+        context: { origin: 'task_submit', triggerTextSnippet: msg.task },
+      });
       ctx.socketToSession.set(socket, conversation.id);
       const session = await ctx.getOrCreateSession(conversation.id, socket, true);
 


### PR DESCRIPTION
Addresses review feedback on PR #8839. Adds queueGenerateConversationTitle calls in the task_submit and schedule_run_now happy paths so titles don't stay stuck as 'Generating title...' when the agent loop errors or takes a non-loop path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8846" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
