### PR TITLE
fix(macos): fix tunnel timestamp bugs in connection health checks

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1247,9 +1247,9 @@ public final class SettingsStore: ObservableObject {
         pendingIngressUrl = previous
         // Reset stale health status so the UI doesn't show results from the old URL
         let previousReachable = ingressReachable
-        let previousLastChecked = gatewayLastChecked
+        let previousLastChecked = tunnelLastChecked
         ingressReachable = nil
-        gatewayLastChecked = nil
+        tunnelLastChecked = nil
         // Auto-enable ingress when a non-empty URL is saved, auto-disable when cleared.
         // The dedicated Public Ingress toggle was removed, so this is the only path
         // that controls the enabled flag.
@@ -1262,7 +1262,7 @@ public final class SettingsStore: ObservableObject {
             ingressPublicBaseUrl = previous
             pendingIngressUrl = nil
             ingressReachable = previousReachable
-            gatewayLastChecked = previousLastChecked
+            tunnelLastChecked = previousLastChecked
         }
     }
 
@@ -1294,10 +1294,7 @@ public final class SettingsStore: ObservableObject {
     /// Tests reachability of the public tunnel URL.
     func testTunnelOnly() async {
         isCheckingTunnel = true
-        defer {
-            isCheckingTunnel = false
-            tunnelLastChecked = Date()
-        }
+        defer { isCheckingTunnel = false }
         let trimmedUrl = ingressPublicBaseUrl.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmedUrl.isEmpty {
             ingressReachable = nil
@@ -1306,6 +1303,7 @@ public final class SettingsStore: ObservableObject {
                 baseUrl: trimmedUrl,
                 timeoutSeconds: 5
             )
+            tunnelLastChecked = Date()
         }
     }
 


### PR DESCRIPTION
Addresses review feedback on PR #8844. Fixes two bugs: (1) testTunnelOnly() no longer sets tunnelLastChecked when URL is empty and no check runs, (2) saveIngressPublicBaseUrl now correctly resets tunnelLastChecked instead of gatewayLastChecked when the tunnel URL changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
