### PR TITLE
Remove notifications.enabled and shadowMode config keys

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4709,7 +4709,7 @@ Producer → NotificationSignal → Decision Engine (LLM) → Deterministic Chec
 
 **Audit trail (SQLite):** `notification_events` → `notification_decisions` → `notification_deliveries`
 
-**Configuration:** `notifications.enabled`, `notifications.shadowMode`, `notifications.decisionModel` in `config.json`.
+**Configuration:** `notifications.decisionModel` in `config.json`.
 
 ---
 

--- a/assistant/src/__tests__/send-notification-tool.test.ts
+++ b/assistant/src/__tests__/send-notification-tool.test.ts
@@ -1,16 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
 const emitNotificationSignalMock = mock(async (_params: unknown) => {});
-const getConfigMock = mock(() => ({
-  notifications: {
-    enabled: true,
-    shadowMode: false,
-  },
-}));
-
-mock.module('../config/loader.js', () => ({
-  getConfig: () => getConfigMock() as ReturnType<typeof getConfigMock>,
-}));
 
 mock.module('../notifications/emit-signal.js', () => ({
   emitNotificationSignal: (params: unknown) => emitNotificationSignalMock(params),
@@ -21,13 +11,6 @@ import { run } from '../config/bundled-skills/messaging/tools/send-notification.
 describe('send-notification tool', () => {
   beforeEach(() => {
     emitNotificationSignalMock.mockClear();
-    getConfigMock.mockClear();
-    getConfigMock.mockReturnValue({
-      notifications: {
-        enabled: true,
-        shadowMode: false,
-      },
-    });
   });
 
   test('emits a notification signal with normalized routing context', async () => {
@@ -76,52 +59,6 @@ describe('send-notification tool', () => {
       dedupeKey: 'voice-code-123456',
       throwOnError: true,
     });
-  });
-
-  test('returns an error when notifications are disabled', async () => {
-    getConfigMock.mockReturnValue({
-      notifications: {
-        enabled: false,
-        shadowMode: false,
-      },
-    });
-
-    const result = await run(
-      { message: 'test notification' },
-      {
-        workingDir: '/tmp',
-        sessionId: 'sess-1',
-        conversationId: 'conv-1',
-        assistantId: 'ast-alpha',
-      },
-    );
-
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain('disabled');
-    expect(emitNotificationSignalMock).not.toHaveBeenCalled();
-  });
-
-  test('returns an error when notifications are in shadow mode', async () => {
-    getConfigMock.mockReturnValue({
-      notifications: {
-        enabled: true,
-        shadowMode: true,
-      },
-    });
-
-    const result = await run(
-      { message: 'test notification' },
-      {
-        workingDir: '/tmp',
-        sessionId: 'sess-1',
-        conversationId: 'conv-1',
-        assistantId: 'ast-alpha',
-      },
-    );
-
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain('shadow mode');
-    expect(emitNotificationSignalMock).not.toHaveBeenCalled();
   });
 
   test('returns an error when the notification pipeline throws', async () => {

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -10,8 +10,6 @@
  */
 
 import { getLogger } from '../util/logger.js';
-import { getConfig } from '../config/loader.js';
-import { getGatewayInternalBaseUrl } from '../config/env.js';
 import { emitNotificationSignal } from '../notifications/emit-signal.js';
 import { getActiveBinding } from '../memory/channel-guardian-store.js';
 import {
@@ -19,21 +17,14 @@ import {
   createGuardianActionDelivery,
   updateDeliveryStatus,
 } from '../memory/guardian-action-store.js';
-import { deliverChannelReply } from '../runtime/gateway-client.js';
 import { getUserConsultationTimeoutMs } from './call-constants.js';
 import { getOrCreateConversation } from '../memory/conversation-key-store.js';
 import { addMessage, updateConversationTitle } from '../memory/conversation-store.js';
 import type { CallPendingQuestion } from './types.js';
-import { readHttpToken } from '../util/platform.js';
 import type { ServerMessage } from '../daemon/ipc-contract.js';
 import { generateGuardianCopy } from './guardian-question-copy.js';
 
 const log = getLogger('guardian-dispatch');
-
-/** Resolve the gateway base URL for internal delivery callbacks. */
-function getGatewayBaseUrl(): string {
-  return getGatewayInternalBaseUrl();
-}
 
 export interface GuardianDispatchParams {
   callSessionId: string;
@@ -103,12 +94,6 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
       },
       dedupeKey: `guardian:${request.id}`,
     });
-
-    // When the notification system is fully active (enabled + not shadow),
-    // it handles external channel delivery (Telegram, SMS) — skip the
-    // legacy dispatch for those channels to avoid duplicate alerts.
-    const notifConfig = getConfig().notifications;
-    const notificationsActive = notifConfig?.enabled === true && notifConfig.shadowMode !== true;
 
     // Determine delivery destinations
     const destinations: Array<{
@@ -197,13 +182,10 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
           destinationChatId: dest.chatId,
           destinationExternalUserId: dest.externalUserId,
         });
-        // External channel — POST to gateway (skip when notification pipeline handles delivery)
-        if (!notificationsActive) {
-          void deliverToExternalChannel(delivery.id, dest.channel, dest.chatId!, request.questionText, request.requestCode, assistantId, readHttpToken() ?? undefined);
-        } else {
-          updateDeliveryStatus(delivery.id, 'sent');
-          log.info({ deliveryId: delivery.id, channel: dest.channel }, 'Skipping legacy external delivery — notification pipeline active');
-        }
+        // External channel delivery is handled by the notification pipeline;
+        // mark the legacy delivery row as sent so auditing stays consistent.
+        updateDeliveryStatus(delivery.id, 'sent');
+        log.info({ deliveryId: delivery.id, channel: dest.channel }, 'Skipping legacy external delivery — notification pipeline active');
       }
     }
   } catch (err) {
@@ -211,37 +193,3 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
   }
 }
 
-async function deliverToExternalChannel(
-  deliveryId: string,
-  channel: string,
-  chatId: string,
-  questionText: string,
-  requestCode: string,
-  assistantId: string,
-  bearerToken?: string,
-): Promise<void> {
-  const gatewayBase = getGatewayBaseUrl();
-  const deliverUrl = `${gatewayBase}/deliver/${channel}`;
-
-  const messageText = [
-    `Your assistant needs your input during a phone call.`,
-    ``,
-    `Question: ${questionText}`,
-    ``,
-    `Reply to this message with your answer. (ref: ${requestCode})`,
-  ].join('\n');
-
-  try {
-    await deliverChannelReply(deliverUrl, {
-      chatId,
-      text: messageText,
-      assistantId,
-    }, bearerToken);
-    updateDeliveryStatus(deliveryId, 'sent');
-    log.info({ deliveryId, channel, chatId }, 'External guardian delivery sent');
-  } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : String(err);
-    updateDeliveryStatus(deliveryId, 'failed', errorMsg);
-    log.error({ err, deliveryId, channel, chatId }, 'External guardian delivery failed');
-  }
-}

--- a/assistant/src/config/bundled-skills/messaging/tools/send-notification.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/send-notification.ts
@@ -1,4 +1,3 @@
-import { getConfig } from '../../../../config/loader.js';
 import { emitNotificationSignal } from '../../../../notifications/emit-signal.js';
 import type { AttentionHints } from '../../../../notifications/signal.js';
 import type { NotificationChannel } from '../../../../notifications/types.js';
@@ -75,14 +74,6 @@ export async function run(input: Record<string, unknown>, context: ToolContext):
   const preferredChannels = parsePreferredChannels(input.preferred_channels);
   if (preferredChannels === INVALID) {
     return err('preferred_channels must be an array containing only "vellum" or "telegram".');
-  }
-
-  const config = getConfig();
-  if (!config.notifications?.enabled) {
-    return err('Notifications are disabled. Set notifications.enabled=true to deliver notifications.');
-  }
-  if (config.notifications.shadowMode) {
-    return err('Notifications are in shadow mode. Set notifications.shadowMode=false to deliver notifications.');
   }
 
   const sourceEventName = asNonEmptyString(input.source_event_name) ?? 'user.send_notification';

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -292,8 +292,6 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     titleGenerationMaxTokens: 30,
   },
   notifications: {
-    enabled: false,
-    shadowMode: true,
     decisionModel: 'claude-haiku-4-5-20251001',
   },
 };

--- a/assistant/src/config/notifications-schema.ts
+++ b/assistant/src/config/notifications-schema.ts
@@ -1,12 +1,6 @@
 import { z } from 'zod';
 
 export const NotificationsConfigSchema = z.object({
-  enabled: z
-    .boolean({ error: 'notifications.enabled must be a boolean' })
-    .default(false),
-  shadowMode: z
-    .boolean({ error: 'notifications.shadowMode must be a boolean' })
-    .default(true),
   decisionModel: z
     .string({ error: 'notifications.decisionModel must be a string' })
     .default('claude-haiku-4-5-20251001'),

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -457,8 +457,6 @@ export const AssistantConfigSchema = z.object({
     titleGenerationMaxTokens: 30,
   }),
   notifications: NotificationsConfigSchema.default({
-    enabled: false,
-    shadowMode: true,
     decisionModel: 'claude-haiku-4-5-20251001',
   }),
 }).superRefine((config, ctx) => {

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -277,7 +277,7 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
 
   // Fire-and-forget: detect notification preferences in the queued message
   // and persist any that are found, mirroring the logic in processMessage.
-  if (session.assistantId && getConfig().notifications.enabled) {
+  if (session.assistantId) {
     const aid = session.assistantId;
     extractPreferences(resolvedContent)
       .then((result) => {
@@ -461,7 +461,7 @@ export async function processMessage(
   // Fire-and-forget: detect notification preferences in the user message
   // and persist any that are found. Runs in the background so it doesn't
   // block the main conversation flow.
-  if (session.assistantId && getConfig().notifications.enabled) {
+  if (session.assistantId) {
     const aid = session.assistantId;
     extractPreferences(resolvedContent)
       .then((result) => {

--- a/assistant/src/notifications/README.md
+++ b/assistant/src/notifications/README.md
@@ -31,7 +31,7 @@ Hard invariants that the LLM cannot override (`deterministic-checks.ts`):
 
 ### 4. Dispatch
 
-`runtime-dispatch.ts` handles three early-exit cases (shouldNotify=false, shadow mode, no channels), then delegates to the broadcaster.
+`runtime-dispatch.ts` handles two early-exit cases (shouldNotify=false, no channels), then delegates to the broadcaster.
 
 ### 5. Broadcast and Delivery
 
@@ -46,7 +46,7 @@ The broadcaster (`broadcaster.ts`) iterates over selected channels, resolves des
 | `types.ts` | Channel adapter interfaces, delivery types, decision output contract |
 | `decision-engine.ts` | LLM-based routing with forced tool_choice; deterministic fallback |
 | `deterministic-checks.ts` | Pre-send gate checks (dedupe, source-active, channel availability) |
-| `runtime-dispatch.ts` | Dispatch gating (shadow mode, no-op decisions) |
+| `runtime-dispatch.ts` | Dispatch gating (no-op decisions, empty channels) |
 | `broadcaster.ts` | Fan-out to channel adapters with delivery audit trail |
 | `copy-composer.ts` | Template-based fallback copy when LLM copy is unavailable |
 | `destination-resolver.ts` | Resolves per-channel endpoints (macOS IPC, Telegram chat ID) |
@@ -127,8 +127,6 @@ All settings live under the `notifications` key in `config.json`:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `notifications.enabled` | boolean | `false` | Master switch for the notification pipeline |
-| `notifications.shadowMode` | boolean | `true` | When true, decisions are logged but not dispatched |
 | `notifications.decisionModel` | string | `"claude-haiku-4-5-20251001"` | Model used for both the decision engine and preference extraction |
 
-Shadow mode is useful for validating decision quality before enabling live delivery. The audit trail (events + decisions) is written regardless of shadow mode.
+The notification pipeline is always active — signals are processed and dispatched as soon as the daemon is running. The audit trail (events, decisions, deliveries) is written for every signal.

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -248,15 +248,10 @@ function validateDecisionOutput(
 
 // ── Core evaluation function ───────────────────────────────────────────
 
-export interface EvaluateSignalOptions {
-  shadowMode?: boolean;
-}
-
 export async function evaluateSignal(
   signal: NotificationSignal,
   availableChannels: NotificationChannel[],
   preferenceContext?: string,
-  options?: EvaluateSignalOptions,
 ): Promise<NotificationDecision> {
   const config = getConfig();
   const decisionModel = config.notifications.decisionModel;
@@ -293,19 +288,6 @@ export async function evaluateSignal(
   }
 
   decision.persistedDecisionId = persistDecision(signal, decision);
-
-  if (options?.shadowMode ?? config.notifications.shadowMode) {
-    log.info(
-      {
-        signalId: signal.signalId,
-        shouldNotify: decision.shouldNotify,
-        channels: decision.selectedChannels,
-        fallbackUsed: decision.fallbackUsed,
-        confidence: decision.confidence,
-      },
-      'Shadow mode: decision logged but not dispatched',
-    );
-  }
 
   return decision;
 }

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -10,7 +10,6 @@
  */
 
 import { v4 as uuid } from 'uuid';
-import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 import { getActiveBinding } from '../memory/channel-guardian-store.js';
 import { createEvent, updateEventDedupeKey } from './events-store.js';
@@ -104,12 +103,6 @@ export interface EmitSignalParams {
  * `throwOnError` is enabled by the caller.
  */
 export async function emitNotificationSignal(params: EmitSignalParams): Promise<void> {
-  const config = getConfig();
-  if (!config.notifications?.enabled) {
-    log.debug({ sourceEventName: params.sourceEventName }, 'Notification system disabled, skipping signal');
-    return;
-  }
-
   const signalId = uuid();
   const assistantId = params.assistantId ?? 'self';
 

--- a/assistant/src/notifications/runtime-dispatch.ts
+++ b/assistant/src/notifications/runtime-dispatch.ts
@@ -6,7 +6,6 @@
  * loop after the decision engine and deterministic checks have run.
  */
 
-import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 import type { NotificationBroadcaster } from './broadcaster.js';
 import type { NotificationSignal } from './signal.js';
@@ -23,10 +22,9 @@ export interface DispatchResult {
 /**
  * Dispatch a notification decision through the broadcaster.
  *
- * Handles three early-exit cases before delegating to the broadcaster:
+ * Handles two early-exit cases before delegating to the broadcaster:
  * 1. shouldNotify === false — the decision says not to notify
- * 2. Shadow mode — decisions are logged but not actually dispatched
- * 3. No selected channels — nothing to dispatch
+ * 2. No selected channels — nothing to dispatch
  */
 export async function dispatchDecision(
   signal: NotificationSignal,
@@ -42,25 +40,6 @@ export async function dispatchDecision(
     return {
       dispatched: false,
       reason: 'Decision: shouldNotify=false',
-      deliveryResults: [],
-    };
-  }
-
-  // Shadow mode: log the decision but skip actual delivery
-  const config = getConfig();
-  if (config.notifications.shadowMode) {
-    log.info(
-      {
-        signalId: signal.signalId,
-        channels: decision.selectedChannels,
-        confidence: decision.confidence,
-        fallbackUsed: decision.fallbackUsed,
-      },
-      'Shadow mode: skipping dispatch (decision logged only)',
-    );
-    return {
-      dispatched: false,
-      reason: 'Shadow mode enabled — dispatch skipped',
       deliveryResults: [],
     };
   }

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -46,7 +46,6 @@ import type {
 } from '../http-types.js';
 import { composeApprovalMessageGenerative } from '../approval-message-composer.js';
 import { refreshThreadEscalation } from '../../memory/inbox-escalation-projection.js';
-import { getConfig } from '../../config/loader.js';
 import { emitNotificationSignal } from '../../notifications/emit-signal.js';
 import {
   type GuardianContext,
@@ -434,46 +433,12 @@ export async function handleChannelInbound(
       dedupeKey: `escalation:${result.eventId}`,
     });
 
-    // Notify the guardian about the pending escalation via channel delivery.
-    // When the notification system is fully active it handles channel delivery,
-    // so skip the legacy path to avoid duplicate alerts.
-    const notifCfg = getConfig().notifications;
-    const notificationsActive = notifCfg.enabled && !notifCfg.shadowMode;
-    const senderIdentifier = body.senderName || body.senderUsername || body.senderExternalUserId || 'Unknown sender';
-    if (!notificationsActive && body.replyCallbackUrl) {
-      try {
-        const notificationText = await composeApprovalMessageGenerative(
-          {
-            scenario: 'guardian_prompt',
-            channel: sourceChannel,
-            toolName: 'ingress_message',
-            requesterIdentifier: senderIdentifier,
-          },
-          {
-            fallbackText: `New message from ${senderIdentifier} requires your review. Reply with "approve" or "deny".`,
-          },
-          approvalCopyGenerator,
-        );
-
-        await deliverChannelReply(
-          body.replyCallbackUrl,
-          { chatId: binding.guardianDeliveryChatId, text: notificationText, assistantId },
-          bearerToken,
-        );
-      } catch (err) {
-        // Fail-closed: approval request is already created in the DB and
-        // thread escalation state is updated — the desktop UI will show
-        // the pending escalation even if channel notification failed.
-        log.error({ err, conversationId: result.conversationId, guardianChatId: binding.guardianDeliveryChatId }, 'Failed to notify guardian of ingress escalation');
-      }
-    } else if (!notificationsActive) {
-      log.warn({ conversationId: result.conversationId }, 'Ingress escalation created but no replyCallbackUrl to notify guardian');
-    } else {
-      log.info(
-        { conversationId: result.conversationId },
-        'Skipping legacy guardian escalation callback delivery — notification pipeline active',
-      );
-    }
+    // Guardian escalation channel delivery is handled by the notification
+    // pipeline — no legacy callback dispatch needed.
+    log.info(
+      { conversationId: result.conversationId },
+      'Guardian escalation created — notification pipeline handles channel delivery',
+    );
 
     return Response.json({ accepted: true, escalated: true, reason: 'policy_escalate' });
   }


### PR DESCRIPTION
## Summary
- Remove `notifications.enabled` and `notifications.shadowMode` config keys from schema, defaults, and all runtime gates
- Notification pipeline is now always-on with live dispatch by default — no opt-in required
- Remove legacy external channel delivery in guardian-dispatch (notification pipeline handles it)
- Remove legacy guardian escalation callback in inbound-message-handler
- Clean up dead code: `deliverToExternalChannel`, `EvaluateSignalOptions.shadowMode`, unused imports

## Original prompt
Remove `notifications.enabled` and `notifications.shadowMode` entirely, and make the notification pipeline always-on/live by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
