### PR TITLE
fix: pass userMessage instead of triggerTextSnippet in task_submit title generation

### DIFF
--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -95,7 +95,8 @@ export async function handleTaskSubmit(
       const conversation = conversationStore.createConversation(GENERATING_TITLE);
       queueGenerateConversationTitle({
         conversationId: conversation.id,
-        context: { origin: 'task_submit', triggerTextSnippet: msg.task },
+        context: { origin: 'task_submit' },
+        userMessage: msg.task,
       });
       ctx.socketToSession.set(socket, conversation.id);
       const session = await ctx.getOrCreateSession(conversation.id, socket, true);


### PR DESCRIPTION
Addresses review feedback on PR #8846. The queueGenerateConversationTitle call was passing triggerTextSnippet which is not read by buildTitlePrompt. Changed to pass userMessage: msg.task so the title generator has actual content to work with, matching the pattern used in sessions.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
