### PR TITLE
M1: Canonical Channel Policy Registry + Typing Cleanup

### DIFF
--- a/assistant/src/channels/config.ts
+++ b/assistant/src/channels/config.ts
@@ -35,7 +35,7 @@ const CHANNEL_POLICIES = {
   },
   sms: {
     notification: {
-      deliveryEnabled: true,
+      deliveryEnabled: false,
       conversationStrategy: 'continue_existing_conversation',
     },
   },

--- a/assistant/src/channels/config.ts
+++ b/assistant/src/channels/config.ts
@@ -1,0 +1,95 @@
+/**
+ * Canonical per-channel notification policy registry.
+ *
+ * Every ChannelId must have an entry here. The `satisfies` constraint
+ * ensures that adding a new ChannelId to channels/types.ts will fail
+ * to compile until a policy is added below.
+ */
+
+import type { ChannelId } from './types.js';
+
+export type ConversationStrategy =
+  | 'start_new_conversation'
+  | 'continue_existing_conversation'
+  | 'not_deliverable';
+
+export interface ChannelNotificationPolicy {
+  notification: {
+    deliveryEnabled: boolean;
+    conversationStrategy: ConversationStrategy;
+  };
+}
+
+const CHANNEL_POLICIES = {
+  vellum: {
+    notification: {
+      deliveryEnabled: true,
+      conversationStrategy: 'start_new_conversation',
+    },
+  },
+  telegram: {
+    notification: {
+      deliveryEnabled: true,
+      conversationStrategy: 'continue_existing_conversation',
+    },
+  },
+  sms: {
+    notification: {
+      deliveryEnabled: true,
+      conversationStrategy: 'continue_existing_conversation',
+    },
+  },
+  whatsapp: {
+    notification: {
+      deliveryEnabled: false,
+      conversationStrategy: 'continue_existing_conversation',
+    },
+  },
+  slack: {
+    notification: {
+      deliveryEnabled: false,
+      conversationStrategy: 'continue_existing_conversation',
+    },
+  },
+  email: {
+    notification: {
+      deliveryEnabled: false,
+      conversationStrategy: 'continue_existing_conversation',
+    },
+  },
+  voice: {
+    notification: {
+      deliveryEnabled: false,
+      conversationStrategy: 'not_deliverable',
+    },
+  },
+} as const satisfies Record<ChannelId, ChannelNotificationPolicy>;
+
+export type ChannelPolicies = typeof CHANNEL_POLICIES;
+
+/** Returns the full notification policy for a channel. */
+export function getChannelPolicy(channelId: ChannelId): ChannelNotificationPolicy {
+  return CHANNEL_POLICIES[channelId];
+}
+
+/**
+ * Returns the list of channels where notification delivery is enabled.
+ *
+ * The return type is derived from the registry so downstream consumers
+ * get a narrow union rather than the full ChannelId set.
+ */
+export function getDeliverableChannels(): ChannelId[] {
+  return (Object.keys(CHANNEL_POLICIES) as ChannelId[]).filter(
+    (id) => CHANNEL_POLICIES[id].notification.deliveryEnabled,
+  );
+}
+
+/** Whether notification delivery is enabled for the given channel. */
+export function isNotificationDeliverable(channelId: ChannelId): boolean {
+  return CHANNEL_POLICIES[channelId].notification.deliveryEnabled;
+}
+
+/** Returns the conversation strategy for the given channel. */
+export function getConversationStrategy(channelId: ChannelId): ConversationStrategy {
+  return CHANNEL_POLICIES[channelId].notification.conversationStrategy;
+}

--- a/assistant/src/config/bundled-skills/messaging/tools/send-notification.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/send-notification.ts
@@ -1,3 +1,4 @@
+import { getDeliverableChannels } from '../../../../channels/config.js';
 import { emitNotificationSignal } from '../../../../notifications/emit-signal.js';
 import type { AttentionHints } from '../../../../notifications/signal.js';
 import type { NotificationChannel } from '../../../../notifications/types.js';
@@ -7,7 +8,7 @@ import { err, ok } from './shared.js';
 const INVALID = Symbol('invalid');
 
 const VALID_URGENCY = new Set<AttentionHints['urgency']>(['low', 'medium', 'high']);
-const VALID_CHANNEL_HINTS = new Set<NotificationChannel>(['vellum', 'telegram']);
+const VALID_CHANNEL_HINTS = new Set<NotificationChannel>(getDeliverableChannels() as NotificationChannel[]);
 
 function asNonEmptyString(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
@@ -73,7 +74,7 @@ export async function run(input: Record<string, unknown>, context: ToolContext):
 
   const preferredChannels = parsePreferredChannels(input.preferred_channels);
   if (preferredChannels === INVALID) {
-    return err('preferred_channels must be an array containing only "vellum" or "telegram".');
+    return err(`preferred_channels must be an array containing only: ${[...VALID_CHANNEL_HINTS].join(', ')}.`);
   }
 
   const sourceEventName = asNonEmptyString(input.source_event_name) ?? 'user.send_notification';

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -16,6 +16,7 @@ import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } fro
 import { createDecision } from './decisions-store.js';
 import { getPreferenceSummary } from './preference-summary.js';
 import type { NotificationSignal } from './signal.js';
+import { getDeliverableChannels } from '../channels/config.js';
 import type { NotificationChannel, NotificationDecision, RenderedChannelCopy } from './types.js';
 
 const log = getLogger('notification-decision-engine');
@@ -189,7 +190,7 @@ function buildFallbackDecision(
 
 // ── Validation ─────────────────────────────────────────────────────────
 
-const VALID_CHANNELS = new Set<string>(['vellum', 'telegram']);
+const VALID_CHANNELS = new Set<string>(getDeliverableChannels());
 
 function validateDecisionOutput(
   input: Record<string, unknown>,

--- a/assistant/src/notifications/destination-resolver.ts
+++ b/assistant/src/notifications/destination-resolver.ts
@@ -3,11 +3,12 @@
  *
  * - Vellum: no external endpoint needed — delivery goes through the IPC
  *   broadcast mechanism to connected desktop/mobile clients.
- * - Telegram: requires a chat ID sourced from the guardian binding for the
- *   assistant.
+ * - Binding-based channels (telegram, sms): require a chat/delivery ID
+ *   sourced from the guardian binding for the assistant.
  */
 
 import { getActiveBinding } from '../memory/channel-guardian-store.js';
+import { isNotificationDeliverable } from '../channels/config.js';
 import type { NotificationChannel, ChannelDestination } from './types.js';
 
 /**
@@ -15,6 +16,7 @@ import type { NotificationChannel, ChannelDestination } from './types.js';
  *
  * Returns a map keyed by channel name. Channels that cannot be resolved
  * (e.g. no Telegram binding configured) are omitted from the result.
+ * Channels that are not deliverable per the policy registry are skipped.
  */
 export function resolveDestinations(
   assistantId: string,
@@ -23,17 +25,20 @@ export function resolveDestinations(
   const result = new Map<NotificationChannel, ChannelDestination>();
 
   for (const channel of channels) {
+    if (!isNotificationDeliverable(channel)) continue;
+
     switch (channel) {
       case 'vellum': {
         // Vellum delivery is local IPC — no external endpoint required.
         result.set('vellum', { channel: 'vellum' });
         break;
       }
-      case 'telegram': {
-        const binding = getActiveBinding(assistantId, 'telegram');
+      case 'telegram':
+      case 'sms': {
+        const binding = getActiveBinding(assistantId, channel);
         if (binding) {
-          result.set('telegram', {
-            channel: 'telegram',
+          result.set(channel, {
+            channel,
             endpoint: binding.guardianDeliveryChatId,
             metadata: {
               externalUserId: binding.guardianExternalUserId,
@@ -44,7 +49,7 @@ export function resolveDestinations(
         break;
       }
       default: {
-        // Unknown channel — skip silently.
+        // Channel with no resolver — skip silently.
         break;
       }
     }

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -20,6 +20,7 @@ import { NotificationBroadcaster } from './broadcaster.js';
 import { VellumAdapter, type BroadcastFn } from './adapters/macos.js';
 import { TelegramAdapter } from './adapters/telegram.js';
 import type { NotificationSignal, AttentionHints } from './signal.js';
+import { getDeliverableChannels } from '../channels/config.js';
 import type { NotificationChannel } from './types.js';
 
 const log = getLogger('emit-signal');
@@ -56,18 +57,32 @@ function getBroadcaster(): NotificationBroadcaster {
 // ── Connected channels resolution ──────────────────────────────────────
 
 function getConnectedChannels(assistantId: string): NotificationChannel[] {
-  // Vellum is always considered connected (IPC socket is always available
-  // when the daemon is running).
-  const channels: NotificationChannel[] = ['vellum'];
-  // Only report Telegram as connected when there is an active guardian
-  // binding for this assistant. Without a binding, the destination
-  // resolver will fail to resolve a chat ID and dispatch will silently
-  // drop the message — which is worse than the decision engine knowing
-  // up front that the channel is unavailable.
-  const telegramBinding = getActiveBinding(assistantId, 'telegram');
-  if (telegramBinding) {
-    channels.push('telegram');
+  const channels: NotificationChannel[] = [];
+
+  for (const channel of getDeliverableChannels()) {
+    switch (channel) {
+      case 'vellum':
+        // Vellum is always considered connected (IPC socket is always
+        // available when the daemon is running).
+        channels.push(channel);
+        break;
+      case 'telegram':
+      case 'sms':
+        // Only report binding-based channels as connected when there is
+        // an active guardian binding for this assistant. Without a
+        // binding, the destination resolver will fail to resolve a
+        // delivery endpoint and dispatch will silently drop the
+        // message — which is worse than the decision engine knowing up
+        // front that the channel is unavailable.
+        if (getActiveBinding(assistantId, channel)) {
+          channels.push(channel);
+        }
+        break;
+      default:
+        break;
+    }
   }
+
   return channels;
 }
 

--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -5,7 +5,16 @@
  * depend on, plus the decision engine output contract.
  */
 
-export type NotificationChannel = 'vellum' | 'telegram';
+import type { ChannelId } from '../channels/types.js';
+import type { ChannelPolicies } from '../channels/config.js';
+
+/**
+ * Derived from the channel policy registry: only channels whose
+ * deliveryEnabled flag is true are valid notification channels.
+ */
+export type NotificationChannel = {
+  [K in keyof ChannelPolicies]: ChannelPolicies[K]['notification']['deliveryEnabled'] extends true ? K : never;
+}[keyof ChannelPolicies] & ChannelId;
 
 export type NotificationDeliveryStatus = 'pending' | 'sent' | 'failed' | 'skipped';
 


### PR DESCRIPTION
Create exhaustive per-channel notification policy registry keyed by ChannelId. Replace hardcoded channel sets in notification types, decision engine, emit-signal, destination-resolver, and send-notification tool with policy-driven helpers. Runtime behavior unchanged — only centralizes where deliverable channels are defined. Part of #8852.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
