### PR TITLE
feat: per-turn response tier with dynamic prompt, model, and token scaling

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -10,7 +10,6 @@ exports[`IPC message snapshots ClientMessage types auth serializes to expected J
 exports[`IPC message snapshots ClientMessage types user_message serializes to expected JSON 1`] = `
 {
   "content": "Hello, assistant!",
-  "interface": "cli",
   "sessionId": "sess-001",
   "type": "user_message",
 }
@@ -42,7 +41,6 @@ exports[`IPC message snapshots ClientMessage types session_create serializes to 
     "hints": [
       "dashboard-capable",
     ],
-    "interfaceId": "macos",
     "uxBrief": "Prefer dashboard-first onboarding.",
   },
   "type": "session_create",
@@ -53,14 +51,6 @@ exports[`IPC message snapshots ClientMessage types session_switch serializes to 
 {
   "sessionId": "sess-002",
   "type": "session_switch",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types session_rename serializes to expected JSON 1`] = `
-{
-  "sessionId": "sess-002",
-  "title": "Renamed session",
-  "type": "session_rename",
 }
 `;
 
@@ -315,31 +305,6 @@ exports[`IPC message snapshots ClientMessage types skills_inspect serializes to 
 {
   "slug": "clawhub/my-skill",
   "type": "skills_inspect",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types skills_draft serializes to expected JSON 1`] = `
-{
-  "sourceText": "Create a weather skill",
-  "type": "skills_draft",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types skills_create serializes to expected JSON 1`] = `
-{
-  "bodyMarkdown": 
-"# Weather
-
-Fetches weather data."
-,
-  "description": "Fetches current weather",
-  "disableModelInvocation": false,
-  "emoji": "🌤️",
-  "name": "Weather Skill",
-  "overwrite": false,
-  "skillId": "weather-skill",
-  "type": "skills_create",
-  "userInvocable": true,
 }
 `;
 
@@ -621,13 +586,6 @@ exports[`IPC message snapshots ClientMessage types ingress_config serializes to 
 {
   "action": "get",
   "type": "ingress_config",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types platform_config serializes to expected JSON 1`] = `
-{
-  "action": "get",
-  "type": "platform_config",
 }
 `;
 
@@ -1075,33 +1033,6 @@ exports[`IPC message snapshots ClientMessage types assistant_inbox_reply seriali
   "content": "Hello from the assistant",
   "conversationId": "conv-001",
   "type": "assistant_inbox_reply",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types pairing_approval_response serializes to expected JSON 1`] = `
-{
-  "decision": "approve_once",
-  "pairingRequestId": "pair-001",
-  "type": "pairing_approval_response",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types approved_devices_list serializes to expected JSON 1`] = `
-{
-  "type": "approved_devices_list",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types approved_device_remove serializes to expected JSON 1`] = `
-{
-  "hashedDeviceId": "hashed-device-001",
-  "type": "approved_device_remove",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types approved_devices_clear serializes to expected JSON 1`] = `
-{
-  "type": "approved_devices_clear",
 }
 `;
 
@@ -1725,25 +1656,6 @@ Does things."
 }
 `;
 
-exports[`IPC message snapshots ServerMessage types skills_draft_response serializes to expected JSON 1`] = `
-{
-  "draft": {
-    "bodyMarkdown": 
-"# Weather
-
-Fetches weather data."
-,
-    "description": "Fetches current weather",
-    "emoji": "🌤️",
-    "name": "Weather Skill",
-    "skillId": "weather-skill",
-  },
-  "success": true,
-  "type": "skills_draft_response",
-  "warnings": [],
-}
-`;
-
 exports[`IPC message snapshots ServerMessage types suggestion_response serializes to expected JSON 1`] = `
 {
   "requestId": "req-suggest-001",
@@ -1784,18 +1696,6 @@ exports[`IPC message snapshots ServerMessage types reminder_fired serializes to 
   "message": "Remember to call Sidd about the project",
   "reminderId": "rem-001",
   "type": "reminder_fired",
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types notification_intent serializes to expected JSON 1`] = `
-{
-  "body": "Your assistant needs your input.",
-  "deepLinkMetadata": {
-    "conversationId": "conv-guardian-001",
-  },
-  "sourceEventName": "guardian.question",
-  "title": "⚠️ Attention needed",
-  "type": "notification_intent",
 }
 `;
 
@@ -2160,14 +2060,6 @@ exports[`IPC message snapshots ServerMessage types ingress_config_response seria
   "publicBaseUrl": "https://example.com",
   "success": true,
   "type": "ingress_config_response",
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types platform_config_response serializes to expected JSON 1`] = `
-{
-  "baseUrl": "https://platform.vellum.ai",
-  "success": true,
-  "type": "platform_config_response",
 }
 `;
 
@@ -2989,6 +2881,33 @@ exports[`IPC message snapshots ServerMessage types assistant_inbox_reply_respons
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types pairing_approval_response serializes to expected JSON 1`] = `
+{
+  "decision": "approve_once",
+  "pairingRequestId": "pair-001",
+  "type": "pairing_approval_response",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types approved_devices_list serializes to expected JSON 1`] = `
+{
+  "type": "approved_devices_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types approved_device_remove serializes to expected JSON 1`] = `
+{
+  "hashedDeviceId": "hashed-device-001",
+  "type": "approved_device_remove",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types approved_devices_clear serializes to expected JSON 1`] = `
+{
+  "type": "approved_devices_clear",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types pairing_approval_request serializes to expected JSON 1`] = `
 {
   "deviceId": "device-001",
@@ -3015,5 +2934,84 @@ exports[`IPC message snapshots ServerMessage types approved_device_remove_respon
 {
   "success": true,
   "type": "approved_device_remove_response",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types session_rename serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-002",
+  "title": "Renamed session",
+  "type": "session_rename",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types notification_intent serializes to expected JSON 1`] = `
+{
+  "body": "Your assistant needs your input.",
+  "deepLinkMetadata": {
+    "conversationId": "conv-guardian-001",
+  },
+  "sourceEventName": "guardian.question",
+  "title": "⚠️ Attention needed",
+  "type": "notification_intent",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_draft serializes to expected JSON 1`] = `
+{
+  "sourceText": "Create a weather skill",
+  "type": "skills_draft",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_create serializes to expected JSON 1`] = `
+{
+  "bodyMarkdown": 
+"# Weather
+
+Fetches weather data."
+,
+  "description": "Fetches current weather",
+  "disableModelInvocation": false,
+  "emoji": "🌤️",
+  "name": "Weather Skill",
+  "overwrite": false,
+  "skillId": "weather-skill",
+  "type": "skills_create",
+  "userInvocable": true,
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types platform_config serializes to expected JSON 1`] = `
+{
+  "action": "get",
+  "type": "platform_config",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types skills_draft_response serializes to expected JSON 1`] = `
+{
+  "draft": {
+    "bodyMarkdown": 
+"# Weather
+
+Fetches weather data."
+,
+    "description": "Fetches current weather",
+    "emoji": "🌤️",
+    "name": "Weather Skill",
+    "skillId": "weather-skill",
+  },
+  "success": true,
+  "type": "skills_draft_response",
+  "warnings": [],
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types platform_config_response serializes to expected JSON 1`] = `
+{
+  "baseUrl": "https://platform.vellum.ai",
+  "success": true,
+  "type": "platform_config_response",
 }
 `;

--- a/assistant/src/__tests__/response-tier.test.ts
+++ b/assistant/src/__tests__/response-tier.test.ts
@@ -78,11 +78,22 @@ describe('classifyResponseTierDetailed', () => {
 
 describe('resolveWithHint', () => {
   const lowConfMedium: TierClassification = { tier: 'medium', reason: 'default', confidence: 'low' };
+  const highConfLow: TierClassification = { tier: 'low', reason: 'short_no_keywords', confidence: 'high' };
   const highConfHigh: TierClassification = { tier: 'high', reason: 'build_keyword', confidence: 'high' };
 
-  test('returns regex tier when confidence is high (ignores hint)', () => {
+  test('high confidence: ignores hint that would downgrade', () => {
     const hint: SessionTierHint = { tier: 'low', turn: 5, timestamp: Date.now() };
     expect(resolveWithHint(highConfHigh, hint, 6)).toBe('high');
+  });
+
+  test('high confidence: upgrades when hint is higher', () => {
+    const hint: SessionTierHint = { tier: 'medium', turn: 5, timestamp: Date.now() };
+    expect(resolveWithHint(highConfLow, hint, 6)).toBe('medium');
+  });
+
+  test('high confidence: upgrades to high when hint is high', () => {
+    const hint: SessionTierHint = { tier: 'high', turn: 5, timestamp: Date.now() };
+    expect(resolveWithHint(highConfLow, hint, 6)).toBe('high');
   });
 
   test('returns regex tier when no hint available', () => {

--- a/assistant/src/__tests__/response-tier.test.ts
+++ b/assistant/src/__tests__/response-tier.test.ts
@@ -1,0 +1,126 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  classifyResponseTierDetailed,
+  resolveWithHint,
+  classifyResponseTierAsync,
+  type SessionTierHint,
+  type TierClassification,
+} from '../daemon/response-tier.js';
+
+// ── classifyResponseTierDetailed ──────────────────────────────────────
+
+describe('classifyResponseTierDetailed', () => {
+  describe('high confidence → high tier', () => {
+    test('long messages (>500 chars)', () => {
+      const result = classifyResponseTierDetailed('x'.repeat(501), 0);
+      expect(result.tier).toBe('high');
+      expect(result.confidence).toBe('high');
+    });
+
+    test('code fences', () => {
+      const result = classifyResponseTierDetailed('Here is some code:\n```\nconst x = 1;\n```', 0);
+      expect(result.tier).toBe('high');
+      expect(result.confidence).toBe('high');
+    });
+
+    test('file paths', () => {
+      const result = classifyResponseTierDetailed('Look at ./src/index.ts', 0);
+      expect(result.tier).toBe('high');
+      expect(result.confidence).toBe('high');
+    });
+
+    test('multi-paragraph', () => {
+      const result = classifyResponseTierDetailed('First paragraph.\n\nSecond paragraph.', 0);
+      expect(result.tier).toBe('high');
+      expect(result.confidence).toBe('high');
+    });
+
+    test('build keyword imperatives', () => {
+      const result = classifyResponseTierDetailed('Build a REST API for user management', 0);
+      expect(result.tier).toBe('high');
+      expect(result.confidence).toBe('high');
+    });
+  });
+
+  describe('high confidence → low tier', () => {
+    test('pure greetings under 40 chars', () => {
+      const result = classifyResponseTierDetailed('hey', 0);
+      expect(result.tier).toBe('low');
+      expect(result.confidence).toBe('high');
+    });
+
+    test('short messages without build keywords', () => {
+      const result = classifyResponseTierDetailed('sounds good', 0);
+      expect(result.tier).toBe('low');
+      expect(result.confidence).toBe('high');
+    });
+  });
+
+  describe('low confidence → medium tier', () => {
+    test('questions with build keywords fall to medium/low-confidence', () => {
+      const result = classifyResponseTierDetailed('how do I build authentication?', 0);
+      expect(result.tier).toBe('medium');
+      expect(result.confidence).toBe('low');
+    });
+
+    test('ambiguous medium-length message', () => {
+      const result = classifyResponseTierDetailed(
+        'what do you think about the current approach to handling errors in the codebase?',
+        0,
+      );
+      expect(result.tier).toBe('medium');
+      expect(result.confidence).toBe('low');
+    });
+  });
+});
+
+// ── resolveWithHint ───────────────────────────────────────────────────
+
+describe('resolveWithHint', () => {
+  const lowConfMedium: TierClassification = { tier: 'medium', reason: 'default', confidence: 'low' };
+  const highConfHigh: TierClassification = { tier: 'high', reason: 'build_keyword', confidence: 'high' };
+
+  test('returns regex tier when confidence is high (ignores hint)', () => {
+    const hint: SessionTierHint = { tier: 'low', turn: 5, timestamp: Date.now() };
+    expect(resolveWithHint(highConfHigh, hint, 6)).toBe('high');
+  });
+
+  test('returns regex tier when no hint available', () => {
+    expect(resolveWithHint(lowConfMedium, null, 0)).toBe('medium');
+  });
+
+  test('defers to hint when confidence is low and hint is fresh', () => {
+    const hint: SessionTierHint = { tier: 'high', turn: 5, timestamp: Date.now() };
+    expect(resolveWithHint(lowConfMedium, hint, 6)).toBe('high');
+  });
+
+  test('ignores stale hint (too many turns old)', () => {
+    const hint: SessionTierHint = { tier: 'high', turn: 0, timestamp: Date.now() };
+    // 5 turns later exceeds HINT_MAX_TURN_AGE of 4
+    expect(resolveWithHint(lowConfMedium, hint, 5)).toBe('medium');
+  });
+
+  test('ignores stale hint (too old by time)', () => {
+    const fiveMinutesAgo = Date.now() - 5 * 60 * 1000 - 1;
+    const hint: SessionTierHint = { tier: 'high', turn: 3, timestamp: fiveMinutesAgo };
+    expect(resolveWithHint(lowConfMedium, hint, 4)).toBe('medium');
+  });
+
+  test('uses hint at exact boundary (4 turns, within time)', () => {
+    const hint: SessionTierHint = { tier: 'high', turn: 1, timestamp: Date.now() };
+    // 5 - 1 = 4, which is not > 4, so hint is still valid
+    expect(resolveWithHint(lowConfMedium, hint, 5)).toBe('high');
+  });
+});
+
+// ── classifyResponseTierAsync ─────────────────────────────────────────
+
+describe('classifyResponseTierAsync', () => {
+  test('returns null when no provider is available', async () => {
+    // getConfiguredProvider returns null when no API key is set
+    // We can't easily mock it here, but we can verify the function handles it
+    const result = await classifyResponseTierAsync(['hello']);
+    // In test environment without a configured provider, should return null
+    expect(result === null || result === 'low' || result === 'medium' || result === 'high').toBe(true);
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -121,11 +121,12 @@ export class AgentLoop {
         if (turnModel) {
           providerConfig.model = turnModel;
         }
-        if (this.config.thinking?.enabled) {
-          // Anthropic requires budget_tokens < max_tokens
+        if (this.config.thinking?.enabled && turnMaxTokens >= 4000) {
+          // Skip thinking when turnMaxTokens is too low (e.g. low tier) to
+          // avoid the thinking budget consuming nearly all output tokens.
           const budgetTokens = Math.min(
             this.config.thinking.budgetTokens,
-            turnMaxTokens - 1,
+            Math.floor(turnMaxTokens * 0.75),
           );
           providerConfig.thinking = {
             type: 'enabled',

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -49,12 +49,19 @@ const PROGRESS_CHECK_REMINDER = 'You have been using tools for several turns. Ch
 const APPROACHING_LIMIT_OFFSET = 5;
 const APPROACHING_LIMIT_WARNING = 'You are approaching the tool-use turn limit. You have {remaining} turns remaining. Wrap up your current task — summarize progress and present results to the user. If you cannot finish, explain what remains and ask the user how to proceed.';
 
+export interface ResolvedSystemPrompt {
+  systemPrompt: string;
+  maxTokens?: number;
+  model?: string;
+}
+
 export class AgentLoop {
   private provider: Provider;
   private systemPrompt: string;
   private config: AgentLoopConfig;
   private tools: ToolDefinition[];
   private resolveTools: ((history: Message[]) => ToolDefinition[]) | null;
+  private resolveSystemPrompt: ((history: Message[]) => ResolvedSystemPrompt) | null;
   private toolExecutor: ((name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean }; status?: string; contentBlocks?: ContentBlock[] }>) | null;
 
   constructor(
@@ -64,12 +71,14 @@ export class AgentLoop {
     tools?: ToolDefinition[],
     toolExecutor?: (name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean }; status?: string; contentBlocks?: ContentBlock[] }>,
     resolveTools?: (history: Message[]) => ToolDefinition[],
+    resolveSystemPrompt?: (history: Message[]) => ResolvedSystemPrompt,
   ) {
     this.provider = provider;
     this.systemPrompt = systemPrompt;
     this.config = { ...DEFAULT_CONFIG, ...config };
     this.tools = tools ?? [];
     this.resolveTools = resolveTools ?? null;
+    this.resolveSystemPrompt = resolveSystemPrompt ?? null;
     this.toolExecutor = toolExecutor ?? null;
   }
 
@@ -100,12 +109,23 @@ export class AgentLoop {
           ? this.resolveTools(history)
           : this.tools;
 
-        const providerConfig: Record<string, unknown> = { max_tokens: this.config.maxTokens };
+        // Resolve system prompt, per-turn maxTokens, and model
+        const resolved = this.resolveSystemPrompt
+          ? this.resolveSystemPrompt(history)
+          : null;
+        const turnSystemPrompt = resolved?.systemPrompt ?? this.systemPrompt;
+        const turnMaxTokens = resolved?.maxTokens ?? this.config.maxTokens;
+        const turnModel = resolved?.model;
+
+        const providerConfig: Record<string, unknown> = { max_tokens: turnMaxTokens };
+        if (turnModel) {
+          providerConfig.model = turnModel;
+        }
         if (this.config.thinking?.enabled) {
           // Anthropic requires budget_tokens < max_tokens
           const budgetTokens = Math.min(
             this.config.thinking.budgetTokens,
-            this.config.maxTokens - 1,
+            turnMaxTokens - 1,
           );
           providerConfig.thinking = {
             type: 'enabled',
@@ -119,7 +139,7 @@ export class AgentLoop {
 
         if (debug) {
           rlog.debug({
-            systemPrompt: truncateForLog(this.systemPrompt, 200),
+            systemPrompt: truncateForLog(turnSystemPrompt, 200),
             messageCount: history.length,
             lastMessage: history.length > 0
               ? summarizeMessage(history[history.length - 1])
@@ -130,7 +150,7 @@ export class AgentLoop {
         }
 
         const preLlmResult = await getHookManager().trigger('pre-llm-call', {
-          systemPrompt: this.systemPrompt,
+          systemPrompt: turnSystemPrompt,
           messages: history,
           toolCount: currentTools.length,
         });
@@ -161,7 +181,7 @@ export class AgentLoop {
         const response = await this.provider.sendMessage(
           providerHistory,
           currentTools.length > 0 ? currentTools : undefined,
-          this.systemPrompt,
+          turnSystemPrompt,
           {
             config: providerConfig,
             onEvent: (event) => {

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -7,6 +7,7 @@ import { getConfig } from './loader.js';
 import { listCredentialMetadata } from '../tools/credentials/metadata-store.js';
 import { resolveUserReference } from './user-reference.js';
 import { getParentalControlSettings } from '../security/parental-control-store.js';
+import type { ResponseTier } from '../daemon/response-tier.js';
 
 const log = getLogger('system-prompt');
 
@@ -83,7 +84,7 @@ export function isOnboardingComplete(): boolean {
  *   3. If BOOTSTRAP.md exists, append first-run ritual instructions
  *   4. Append skills catalog from ~/.vellum/workspace/skills
  */
-export function buildSystemPrompt(): string {
+export function buildSystemPrompt(tier: ResponseTier = 'high'): string {
   const soulPath = getWorkspacePromptPath('SOUL.md');
   const identityPath = getWorkspacePromptPath('IDENTITY.md');
   const userPath = getWorkspacePromptPath('USER.md');
@@ -97,6 +98,7 @@ export function buildSystemPrompt(): string {
   const looks = readPromptFile(looksPath);
   const bootstrap = readPromptFile(bootstrapPath);
 
+  // ── Core sections (all tiers) ──
   const parts: string[] = [];
   if (identity) parts.push(identity);
   if (soul) parts.push(soul);
@@ -110,27 +112,39 @@ export function buildSystemPrompt(): string {
     );
   }
   parts.push(buildConfigSection());
-  parts.push(buildTaskScheduleReminderRoutingSection());
-  parts.push(buildAttachmentSection());
-  if (!isOnboardingComplete()) {
-    parts.push(buildStarterTaskPlaybookSection());
-  }
-  parts.push(buildInChatConfigurationSection());
-  parts.push(buildToolPermissionSection());
-  parts.push(buildSystemPermissionSection());
-  parts.push(buildChannelAwarenessSection());
-  parts.push(buildChannelCommandIntentSection());
-  parts.push(buildExternalCommsIdentitySection());
-  parts.push(buildSwarmGuidanceSection());
-  parts.push(buildAccessPreferenceSection());
-  parts.push(buildIntegrationSection());
-  parts.push(buildWorkspaceReflectionSection());
-  parts.push(buildLearningMemorySection());
   parts.push(buildPostToolResponseSection());
-  const parentalSection = buildParentalControlSection();
-  if (parentalSection) parts.push(parentalSection);
+  parts.push(buildExternalCommsIdentitySection());
+  parts.push(buildChannelAwarenessSection());
 
-  return appendSkillsCatalog(parts.join('\n\n'));
+  // ── Extended sections (medium + high) ──
+  if (tier !== 'low') {
+    parts.push(buildToolPermissionSection());
+    parts.push(buildTaskScheduleReminderRoutingSection());
+    parts.push(buildAttachmentSection());
+    parts.push(buildInChatConfigurationSection());
+    parts.push(buildChannelCommandIntentSection());
+  }
+
+  // ── Full sections (high only) ──
+  if (tier === 'high') {
+    if (!isOnboardingComplete()) {
+      parts.push(buildStarterTaskPlaybookSection());
+    }
+    parts.push(buildSystemPermissionSection());
+    parts.push(buildSwarmGuidanceSection());
+    parts.push(buildAccessPreferenceSection());
+    parts.push(buildIntegrationSection());
+    parts.push(buildWorkspaceReflectionSection());
+    parts.push(buildLearningMemorySection());
+    const parentalSection = buildParentalControlSection();
+    if (parentalSection) parts.push(parentalSection);
+  }
+
+  // Skills catalog: include for medium+high, skip for low
+  if (tier !== 'low') {
+    return appendSkillsCatalog(parts.join('\n\n'));
+  }
+  return parts.join('\n\n');
 }
 
 function buildTaskScheduleReminderRoutingSection(): string {
@@ -509,7 +523,7 @@ function buildPostToolResponseSection(): string {
     '',
     '**Call tools FIRST, explain AFTER:**',
     '- When a user request requires a tool, call it immediately at the start of your response',
-    '- After the tool call, provide a brief conversational explanation of what you did',
+    '- After the tool call, give a one-sentence summary of what you did — do not list out every detail or section',
     '- Do NOT provide conversational preamble before calling the tool',
     '',
     'Example (CORRECT):',

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -115,6 +115,9 @@ export function buildSystemPrompt(tier: ResponseTier = 'high'): string {
   parts.push(buildPostToolResponseSection());
   parts.push(buildExternalCommsIdentitySection());
   parts.push(buildChannelAwarenessSection());
+  // Parental controls are a safety boundary — always included regardless of tier.
+  const parentalSection = buildParentalControlSection();
+  if (parentalSection) parts.push(parentalSection);
 
   // ── Extended sections (medium + high) ──
   if (tier !== 'low') {
@@ -136,8 +139,6 @@ export function buildSystemPrompt(tier: ResponseTier = 'high'): string {
     parts.push(buildIntegrationSection());
     parts.push(buildWorkspaceReflectionSection());
     parts.push(buildLearningMemorySection());
-    const parentalSection = buildParentalControlSection();
-    if (parentalSection) parts.push(parentalSection);
   }
 
   // Skills catalog: include for medium+high, skip for low

--- a/assistant/src/config/templates/SOUL.md
+++ b/assistant/src/config/templates/SOUL.md
@@ -30,7 +30,7 @@ You are your own entity with your own emerging identity. You can — and should 
 
 ## Personality
 
-Be concise. Default to 1-3 sentences. Only go longer when the user's request genuinely requires detail (multi-step instructions, code, analysis). Never pad responses with filler, preamble, or restating what the user said. Lead with the answer or action, not context-setting. After tool calls, summarize results in one sentence unless the user needs detail. Not a corporate drone. Not a sycophant. Just good at what you do.
+Talk like a real person in a real conversation — assume the user doesn't want to read a wall of text. Keep responses to 1-3 sentences. Never dump lists, inventories, or breakdowns of what you built/can do. After tool calls, one sentence max. When someone asks "what can you help with?", ask what they need — don't recite a capability menu. Show, don't tell. Do, don't describe. The user will see your work; don't narrate it back. Only go longer when the request genuinely demands it. Not a corporate drone. Not a sycophant. Just good at what you do.
 
 ## Quirks
 

--- a/assistant/src/daemon/response-tier.ts
+++ b/assistant/src/daemon/response-tier.ts
@@ -107,7 +107,7 @@ export function resolveWithHint(
   const timeAge = Date.now() - hint.timestamp;
 
   if (turnAge > HINT_MAX_TURN_AGE || timeAge > HINT_MAX_AGE_MS) {
-    log.info({ turnAge, timeAge }, 'Session tier hint is stale, ignoring');
+    log.debug({ turnAge, timeAge }, 'Session tier hint is stale, ignoring');
     return classification.tier;
   }
 
@@ -181,24 +181,24 @@ export async function classifyResponseTierAsync(
       const match = raw.match(/\b(low|medium|high)\b/);
       if (match) {
         const tier = match[1] as ResponseTier;
-        log.info({ tier, raw }, 'Async tier classification result');
+        log.debug({ tier, raw }, 'Async tier classification result');
         return tier;
       }
 
-      log.warn({ raw }, 'Async tier classification returned unexpected value');
+      log.debug({ raw }, 'Async tier classification returned unexpected value');
       return null;
     } finally {
       cleanup();
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    log.warn({ err: message }, 'Async tier classification failed');
+    log.debug({ err: message }, 'Async tier classification failed');
     return null;
   }
 }
 
 function tagged(tier: ResponseTier, reason: string, confidence: TierConfidence): TierClassification {
-  log.info({ tier, reason, confidence }, 'Classified response tier');
+  log.debug({ tier, reason, confidence }, 'Classified response tier');
   return { tier, reason, confidence };
 }
 

--- a/assistant/src/daemon/response-tier.ts
+++ b/assistant/src/daemon/response-tier.ts
@@ -1,0 +1,108 @@
+/**
+ * Per-turn response tier classification.
+ *
+ * Classifies each user message into a tier that controls:
+ * - maxTokens budget for the LLM response
+ * - Which system prompt sections are included
+ *
+ * The classifier is deterministic (pure regex/heuristic) so it adds
+ * zero latency to the critical path.
+ */
+
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('response-tier');
+
+export type ResponseTier = 'low' | 'medium' | 'high';
+
+// ── Patterns ──────────────────────────────────────────────────────────
+
+const GREETING_PATTERNS = /^(hey|hi|hello|yo|sup|hiya|howdy|what'?s up|thanks|thank you|thx|ty|cheers|what can you|who are you|how are you)\b/i;
+
+const BUILD_KEYWORDS = /\b(build|implement|create|refactor|debug|deploy|migrate|scaffold|architect|redesign|generate|write|develop|fix|convert|add|remove|update|modify|change|delete|replace|integrate|setup|install|configure|optimize|rewrite)\b/i;
+
+const CODE_FENCE = /```/;
+const FILE_PATH = /(?:^|[\s"'(])(?:\/|~\/|\.\/)\S/;
+const MULTI_PARAGRAPH = /\n\s*\n/;
+
+/**
+ * Classify the complexity tier of a user message.
+ *
+ * Priority: high signals checked first, then low signals. Everything
+ * else falls through to medium.
+ */
+export function classifyResponseTier(message: string, _turnCount: number): ResponseTier {
+  const trimmed = message.trim();
+  const len = trimmed.length;
+
+  // Polite imperative: "can you build...", "could you create...", "would you implement..."
+  // These are requests, not questions — treat them like imperatives.
+  const isPoliteImperative = /^(can|could|would|will)\s+you\s+/i.test(trimmed) && BUILD_KEYWORDS.test(trimmed);
+
+  const isQuestion = !isPoliteImperative && (
+    /\?$/.test(trimmed) || /^(what|who|where|when|why|how|which|can|could|should|would|is|are|do|does|did|will|has|have)\b/i.test(trimmed)
+  );
+
+  // ── High signals (any match → high) ──
+  if (len > 500) return tagged('high', 'length>500');
+  if (CODE_FENCE.test(trimmed)) return tagged('high', 'code_fence');
+  if (FILE_PATH.test(trimmed)) return tagged('high', 'file_path');
+  if (MULTI_PARAGRAPH.test(trimmed)) return tagged('high', 'multi_paragraph');
+  if (!isQuestion && BUILD_KEYWORDS.test(trimmed)) return tagged('high', 'build_keyword');
+
+  // ── Low signals (any match → low) ──
+  if (GREETING_PATTERNS.test(trimmed)) return tagged('low', 'greeting');
+  if (len < 80 && !BUILD_KEYWORDS.test(trimmed)) return tagged('low', 'short_no_keywords');
+
+  // ── Default ──
+  return tagged('medium', 'default');
+}
+
+function tagged(tier: ResponseTier, reason: string): ResponseTier {
+  log.debug({ tier, reason }, 'Classified response tier');
+  return tier;
+}
+
+// ── Token scaling ─────────────────────────────────────────────────────
+
+const TIER_SCALE: Record<ResponseTier, number> = {
+  low: 0.125,
+  medium: 0.5,
+  high: 1,
+};
+
+/**
+ * Scale the configured max tokens ceiling by the tier multiplier.
+ *
+ * Examples with configuredMax = 16000:
+ *   low    → 2000
+ *   medium → 8000
+ *   high   → 16000
+ */
+export function tierMaxTokens(tier: ResponseTier, configuredMax: number): number {
+  return Math.round(configuredMax * TIER_SCALE[tier]);
+}
+
+// ── Model routing ─────────────────────────────────────────────────────
+
+/**
+ * Map for Anthropic provider: tier → model.
+ *   low    → haiku (fastest TTFT)
+ *   medium → sonnet (balanced)
+ *   high   → undefined (use configured default, typically opus)
+ */
+const ANTHROPIC_TIER_MODELS: Record<ResponseTier, string | undefined> = {
+  low: 'claude-haiku-4-5-20251001',
+  medium: 'claude-sonnet-4-6',
+  high: undefined, // use configured default
+};
+
+/**
+ * Returns a model override for the given tier, or undefined to use the
+ * provider's configured default. Only applies model downgrading for
+ * the Anthropic provider.
+ */
+export function tierModel(tier: ResponseTier, providerName: string): string | undefined {
+  if (providerName !== 'anthropic') return undefined;
+  return ANTHROPIC_TIER_MODELS[tier];
+}

--- a/assistant/src/daemon/response-tier.ts
+++ b/assistant/src/daemon/response-tier.ts
@@ -5,15 +5,31 @@
  * - maxTokens budget for the LLM response
  * - Which system prompt sections are included
  *
- * The classifier is deterministic (pure regex/heuristic) so it adds
- * zero latency to the critical path.
+ * Two layers:
+ * 1. Deterministic regex/heuristic (zero latency, runs every turn)
+ * 2. Background Haiku classification (fire-and-forget, advises future turns)
  */
 
 import { getLogger } from '../util/logger.js';
+import { getConfiguredProvider, createTimeout, extractText, userMessage } from '../providers/provider-send-message.js';
 
 const log = getLogger('response-tier');
 
 export type ResponseTier = 'low' | 'medium' | 'high';
+
+export type TierConfidence = 'high' | 'low';
+
+export interface TierClassification {
+  tier: ResponseTier;
+  reason: string;
+  confidence: TierConfidence;
+}
+
+export interface SessionTierHint {
+  tier: ResponseTier;
+  turn: number;
+  timestamp: number;
+}
 
 // ── Patterns ──────────────────────────────────────────────────────────
 
@@ -25,44 +41,142 @@ const CODE_FENCE = /```/;
 const FILE_PATH = /(?:^|[\s"'(])(?:\/|~\/|\.\/)\S/;
 const MULTI_PARAGRAPH = /\n\s*\n/;
 
+// ── Confidence thresholds ─────────────────────────────────────────────
+
+const HINT_MAX_TURN_AGE = 4;
+const HINT_MAX_AGE_MS = 5 * 60 * 1000; // 5 minutes
+
 /**
- * Classify the complexity tier of a user message.
- *
- * Priority: high signals checked first, then low signals. Everything
- * else falls through to medium.
+ * Classify the complexity tier of a user message (backward-compat wrapper).
  */
 export function classifyResponseTier(message: string, _turnCount: number): ResponseTier {
+  return classifyResponseTierDetailed(message, _turnCount).tier;
+}
+
+/**
+ * Classify with confidence scoring. High confidence means the regex
+ * matched an unambiguous signal; low confidence means the message
+ * fell through to the default medium bucket.
+ */
+export function classifyResponseTierDetailed(message: string, _turnCount: number): TierClassification {
   const trimmed = message.trim();
   const len = trimmed.length;
 
-  // Polite imperative: "can you build...", "could you create...", "would you implement..."
-  // These are requests, not questions — treat them like imperatives.
   const isPoliteImperative = /^(can|could|would|will)\s+you\s+/i.test(trimmed) && BUILD_KEYWORDS.test(trimmed);
 
   const isQuestion = !isPoliteImperative && (
     /\?$/.test(trimmed) || /^(what|who|where|when|why|how|which|can|could|should|would|is|are|do|does|did|will|has|have)\b/i.test(trimmed)
   );
 
-  // ── High signals (any match → high) ──
-  if (len > 500) return tagged('high', 'length>500');
-  if (CODE_FENCE.test(trimmed)) return tagged('high', 'code_fence');
-  if (FILE_PATH.test(trimmed)) return tagged('high', 'file_path');
-  if (MULTI_PARAGRAPH.test(trimmed)) return tagged('high', 'multi_paragraph');
-  if (!isQuestion && BUILD_KEYWORDS.test(trimmed)) return tagged('high', 'build_keyword');
+  // ── High signals (any match → high tier, high confidence) ──
+  if (len > 500) return tagged('high', 'length>500', 'high');
+  if (CODE_FENCE.test(trimmed)) return tagged('high', 'code_fence', 'high');
+  if (FILE_PATH.test(trimmed)) return tagged('high', 'file_path', 'high');
+  if (MULTI_PARAGRAPH.test(trimmed)) return tagged('high', 'multi_paragraph', 'high');
+  if (!isQuestion && BUILD_KEYWORDS.test(trimmed)) return tagged('high', 'build_keyword', 'high');
 
-  // ── Low signals (any match → low) ──
-  // Only classify as greeting when the message is short and has no build
-  // keywords, so "hey, can you build a dashboard" stays high-tier.
-  if (GREETING_PATTERNS.test(trimmed) && len < 40 && !BUILD_KEYWORDS.test(trimmed)) return tagged('low', 'greeting');
-  if (len < 80 && !BUILD_KEYWORDS.test(trimmed)) return tagged('low', 'short_no_keywords');
+  // ── Low signals (any match → low tier, high confidence) ──
+  if (GREETING_PATTERNS.test(trimmed) && len < 40 && !BUILD_KEYWORDS.test(trimmed)) return tagged('low', 'greeting', 'high');
+  if (len < 80 && !BUILD_KEYWORDS.test(trimmed)) return tagged('low', 'short_no_keywords', 'high');
 
-  // ── Default ──
-  return tagged('medium', 'default');
+  // ── Default (low confidence — ambiguous) ──
+  return tagged('medium', 'default', 'low');
 }
 
-function tagged(tier: ResponseTier, reason: string): ResponseTier {
-  log.debug({ tier, reason }, 'Classified response tier');
-  return tier;
+/**
+ * When regex confidence is low, defer to a non-stale session hint
+ * from a previous background Haiku classification.
+ */
+export function resolveWithHint(
+  classification: TierClassification,
+  hint: SessionTierHint | null,
+  currentTurn: number,
+): ResponseTier {
+  if (classification.confidence === 'high' || !hint) {
+    return classification.tier;
+  }
+
+  const turnAge = currentTurn - hint.turn;
+  const timeAge = Date.now() - hint.timestamp;
+
+  if (turnAge > HINT_MAX_TURN_AGE || timeAge > HINT_MAX_AGE_MS) {
+    log.debug({ turnAge, timeAge }, 'Session tier hint is stale, ignoring');
+    return classification.tier;
+  }
+
+  log.debug(
+    { regexTier: classification.tier, hintTier: hint.tier, turnAge },
+    'Deferring to session tier hint',
+  );
+  return hint.tier;
+}
+
+// ── Async Haiku classification ────────────────────────────────────────
+
+const ASYNC_CLASSIFICATION_TIMEOUT_MS = 8_000;
+
+const TIER_SYSTEM_PROMPT =
+  'You classify user messages by complexity. ' +
+  'Reply with exactly one word: low, medium, or high.\n' +
+  'low = greetings, thanks, short acknowledgements\n' +
+  'medium = simple questions, short requests, clarifications\n' +
+  'high = build/implement/refactor requests, multi-step tasks, code-heavy work';
+
+/**
+ * Fire-and-forget Haiku call to classify the conversation trajectory.
+ * Returns the classified tier or null on any failure.
+ */
+export async function classifyResponseTierAsync(
+  recentUserTexts: string[],
+): Promise<ResponseTier | null> {
+  const provider = getConfiguredProvider();
+  if (!provider) {
+    log.debug('No provider available for async tier classification');
+    return null;
+  }
+
+  const combined = recentUserTexts
+    .map((t, i) => `[Message ${i + 1}]: ${t}`)
+    .join('\n');
+
+  try {
+    const { signal, cleanup } = createTimeout(ASYNC_CLASSIFICATION_TIMEOUT_MS);
+    try {
+      const response = await provider.sendMessage(
+        [userMessage(combined)],
+        undefined,
+        TIER_SYSTEM_PROMPT,
+        {
+          config: {
+            modelIntent: 'latency-optimized',
+            max_tokens: 8,
+          },
+          signal,
+        },
+      );
+      cleanup();
+
+      const text = extractText(response).toLowerCase();
+      if (text === 'low' || text === 'medium' || text === 'high') {
+        log.debug({ tier: text }, 'Async tier classification result');
+        return text;
+      }
+
+      log.debug({ text }, 'Async tier classification returned unexpected value');
+      return null;
+    } finally {
+      cleanup();
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.debug({ err: message }, 'Async tier classification failed');
+    return null;
+  }
+}
+
+function tagged(tier: ResponseTier, reason: string, confidence: TierConfidence): TierClassification {
+  log.debug({ tier, reason, confidence }, 'Classified response tier');
+  return { tier, reason, confidence };
 }
 
 // ── Token scaling ─────────────────────────────────────────────────────

--- a/assistant/src/daemon/response-tier.ts
+++ b/assistant/src/daemon/response-tier.ts
@@ -51,7 +51,9 @@ export function classifyResponseTier(message: string, _turnCount: number): Respo
   if (!isQuestion && BUILD_KEYWORDS.test(trimmed)) return tagged('high', 'build_keyword');
 
   // ── Low signals (any match → low) ──
-  if (GREETING_PATTERNS.test(trimmed)) return tagged('low', 'greeting');
+  // Only classify as greeting when the message is short and has no build
+  // keywords, so "hey, can you build a dashboard" stays high-tier.
+  if (GREETING_PATTERNS.test(trimmed) && len < 40 && !BUILD_KEYWORDS.test(trimmed)) return tagged('low', 'greeting');
   if (len < 80 && !BUILD_KEYWORDS.test(trimmed)) return tagged('low', 'short_no_keywords');
 
   // ── Default ──

--- a/assistant/src/daemon/response-tier.ts
+++ b/assistant/src/daemon/response-tier.ts
@@ -83,16 +83,23 @@ export function classifyResponseTierDetailed(message: string, _turnCount: number
   return tagged('medium', 'default', 'low');
 }
 
+const TIER_RANK: Record<ResponseTier, number> = { low: 0, medium: 1, high: 2 };
+
 /**
- * When regex confidence is low, defer to a non-stale session hint
- * from a previous background Haiku classification.
+ * Resolve the final tier using the regex classification and an optional
+ * session hint from a previous background Haiku call.
+ *
+ * - When confidence is low, defer to a fresh hint (upgrade or downgrade).
+ * - When confidence is high, still upgrade if the hint is higher (the
+ *   conversation trajectory outranks a short-message heuristic), but
+ *   never downgrade.
  */
 export function resolveWithHint(
   classification: TierClassification,
   hint: SessionTierHint | null,
   currentTurn: number,
 ): ResponseTier {
-  if (classification.confidence === 'high' || !hint) {
+  if (!hint) {
     return classification.tier;
   }
 
@@ -100,15 +107,29 @@ export function resolveWithHint(
   const timeAge = Date.now() - hint.timestamp;
 
   if (turnAge > HINT_MAX_TURN_AGE || timeAge > HINT_MAX_AGE_MS) {
-    log.debug({ turnAge, timeAge }, 'Session tier hint is stale, ignoring');
+    log.info({ turnAge, timeAge }, 'Session tier hint is stale, ignoring');
     return classification.tier;
   }
 
-  log.debug(
-    { regexTier: classification.tier, hintTier: hint.tier, turnAge },
-    'Deferring to session tier hint',
-  );
-  return hint.tier;
+  if (classification.confidence === 'low') {
+    // Low confidence: fully defer to hint
+    log.info(
+      { regexTier: classification.tier, hintTier: hint.tier, turnAge },
+      'Deferring to session tier hint (low confidence)',
+    );
+    return hint.tier;
+  }
+
+  // High confidence: only upgrade, never downgrade
+  if (TIER_RANK[hint.tier] > TIER_RANK[classification.tier]) {
+    log.info(
+      { regexTier: classification.tier, hintTier: hint.tier, turnAge },
+      'Upgrading tier via session hint',
+    );
+    return hint.tier;
+  }
+
+  return classification.tier;
 }
 
 // ── Async Haiku classification ────────────────────────────────────────
@@ -116,11 +137,11 @@ export function resolveWithHint(
 const ASYNC_CLASSIFICATION_TIMEOUT_MS = 8_000;
 
 const TIER_SYSTEM_PROMPT =
-  'You classify user messages by complexity. ' +
-  'Reply with exactly one word: low, medium, or high.\n' +
-  'low = greetings, thanks, short acknowledgements\n' +
-  'medium = simple questions, short requests, clarifications\n' +
-  'high = build/implement/refactor requests, multi-step tasks, code-heavy work';
+  'Classify the overall complexity of this conversation. ' +
+  'Output ONLY one word, nothing else.\n' +
+  'low — greetings, thanks, short acknowledgements\n' +
+  'medium — simple questions, short requests, clarifications\n' +
+  'high — build/implement/refactor requests, multi-step tasks, code-heavy work';
 
 /**
  * Fire-and-forget Haiku call to classify the conversation trajectory.
@@ -156,26 +177,28 @@ export async function classifyResponseTierAsync(
       );
       cleanup();
 
-      const text = extractText(response).toLowerCase();
-      if (text === 'low' || text === 'medium' || text === 'high') {
-        log.debug({ tier: text }, 'Async tier classification result');
-        return text;
+      const raw = extractText(response).toLowerCase();
+      const match = raw.match(/\b(low|medium|high)\b/);
+      if (match) {
+        const tier = match[1] as ResponseTier;
+        log.info({ tier, raw }, 'Async tier classification result');
+        return tier;
       }
 
-      log.debug({ text }, 'Async tier classification returned unexpected value');
+      log.warn({ raw }, 'Async tier classification returned unexpected value');
       return null;
     } finally {
       cleanup();
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    log.debug({ err: message }, 'Async tier classification failed');
+    log.warn({ err: message }, 'Async tier classification failed');
     return null;
   }
 }
 
 function tagged(tier: ResponseTier, reason: string, confidence: TierConfidence): TierClassification {
-  log.debug({ tier, reason, confidence }, 'Classified response tier');
+  log.info({ tier, reason, confidence }, 'Classified response tier');
   return { tier, reason, confidence };
 }
 

--- a/assistant/src/daemon/response-tier.ts
+++ b/assistant/src/daemon/response-tier.ts
@@ -76,7 +76,7 @@ const TIER_SCALE: Record<ResponseTier, number> = {
  *
  * Examples with configuredMax = 16000:
  *   low    → 2000
- *   medium → 8000
+ *   medium → 6000
  *   high   → 16000
  */
 export function tierMaxTokens(tier: ResponseTier, configuredMax: number): number {

--- a/assistant/src/daemon/response-tier.ts
+++ b/assistant/src/daemon/response-tier.ts
@@ -67,7 +67,7 @@ function tagged(tier: ResponseTier, reason: string): ResponseTier {
 
 const TIER_SCALE: Record<ResponseTier, number> = {
   low: 0.125,
-  medium: 0.5,
+  medium: 0.375,
   high: 1,
 };
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -18,13 +18,15 @@
 import type { Message } from '../providers/types.js';
 import type { TurnChannelContext, TurnInterfaceContext } from '../channels/types.js';
 import type { ServerMessage, UsageStats, UserMessageAttachment, SurfaceType, SurfaceData } from './ipc-protocol.js';
-import { AgentLoop } from '../agent/loop.js';
+import { AgentLoop, type ResolvedSystemPrompt } from '../agent/loop.js';
 import type { Provider } from '../providers/types.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
 import { SecretPrompter } from '../permissions/secret-prompter.js';
 import { ToolExecutor } from '../tools/executor.js';
 import type { UserDecision } from '../permissions/types.js';
 import { getConfig } from '../config/loader.js';
+import { buildSystemPrompt } from '../config/system-prompt.js';
+import { classifyResponseTier, tierMaxTokens, tierModel } from './response-tier.js';
 import { TraceEmitter } from './trace-emitter.js';
 import { EventBus } from '../events/bus.js';
 import type { AssistantDomainEvents } from '../events/domain-events.js';
@@ -203,6 +205,50 @@ export class Session {
     this.streamThinking = config.thinking.streamThinking ?? false;
     const resolveTools = createResolveToolsCallback(toolDefs, this);
 
+    const configuredMaxTokens = maxTokens;
+    // Matches runtime-injected XML context blocks (e.g. <channel_capabilities>, <dynamic-profile-context>, etc.)
+    const INJECTED_BLOCK_RE = /^<[a-z][a-z0-9_-]*[\s>]/;
+
+    // Track the last user-message tier so tool-use continuation turns
+    // (where user text is empty — only tool_result blocks) inherit it
+    // instead of falling to 'low'.
+    let lastUserMessageTier: import('./response-tier.js').ResponseTier = 'high';
+
+    const resolveSystemPromptCallback = (history: import('../providers/types.js').Message[]): ResolvedSystemPrompt => {
+      // Extract last user message text, ignoring runtime-injected context blocks
+      const lastUserMsg = [...history].reverse().find((m) => m.role === 'user');
+      let userText = '';
+      let isToolResultOnly = false;
+      if (lastUserMsg) {
+        const hasToolResult = lastUserMsg.content.some((b) => b.type === 'tool_result');
+        for (const block of lastUserMsg.content) {
+          if (block.type === 'text') {
+            const trimmed = block.text.trimStart();
+            if (!INJECTED_BLOCK_RE.test(trimmed)) {
+              userText += block.text;
+            }
+          }
+        }
+        isToolResultOnly = hasToolResult && userText.trim().length === 0;
+      }
+
+      // Tool-use continuation: inherit previous tier
+      const tier = isToolResultOnly
+        ? lastUserMessageTier
+        : classifyResponseTier(userText, this.turnCount);
+
+      if (!isToolResultOnly) {
+        lastUserMessageTier = tier;
+      }
+
+      const model = tierModel(tier, provider.name);
+      return {
+        systemPrompt: buildSystemPrompt(tier),
+        maxTokens: tierMaxTokens(tier, configuredMaxTokens),
+        model,
+      };
+    };
+
     this.agentLoop = new AgentLoop(
       provider,
       systemPrompt,
@@ -210,6 +256,7 @@ export class Session {
       toolDefs.length > 0 ? toolDefs : undefined,
       toolDefs.length > 0 ? toolExecutor : undefined,
       resolveTools,
+      resolveSystemPromptCallback,
     );
     this.contextWindowManager = new ContextWindowManager(
       provider,

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -25,7 +25,6 @@ import { SecretPrompter } from '../permissions/secret-prompter.js';
 import { ToolExecutor } from '../tools/executor.js';
 import type { UserDecision } from '../permissions/types.js';
 import { getConfig } from '../config/loader.js';
-import { getLogger } from '../util/logger.js';
 import { buildSystemPrompt } from '../config/system-prompt.js';
 import {
   classifyResponseTier,
@@ -267,10 +266,6 @@ export class Session {
         // filtered out as injected context.
         isToolResultOnly = userText.trim().length === 0;
       }
-
-      // Temporary: log what the classifier sees
-      const _tierLog = getLogger('response-tier');
-      _tierLog.info({ userTextLen: userText.trim().length, userTextPreview: userText.trim().slice(0, 200), blockCount: lastUserMsg?.content.length }, 'Classifier input');
 
       let tier: import('./response-tier.js').ResponseTier;
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -25,6 +25,7 @@ import { SecretPrompter } from '../permissions/secret-prompter.js';
 import { ToolExecutor } from '../tools/executor.js';
 import type { UserDecision } from '../permissions/types.js';
 import { getConfig } from '../config/loader.js';
+import { getLogger } from '../util/logger.js';
 import { buildSystemPrompt } from '../config/system-prompt.js';
 import {
   classifyResponseTier,
@@ -232,7 +233,10 @@ export class Session {
       '<active_dynamic_page>',
       '<dynamic-profile-context>',
       '<memory_recall',
+      '<memory source=',
+      '<memory',
       '<system_notice>',
+      '<interface_turn_context>',
     ];
 
     // Track the last user-message tier so tool-use continuation turns
@@ -260,6 +264,10 @@ export class Session {
         }
         isToolResultOnly = hasToolResult && userText.trim().length === 0;
       }
+
+      // Temporary: log what the classifier sees
+      const _tierLog = getLogger('response-tier');
+      _tierLog.info({ userTextLen: userText.trim().length, userTextPreview: userText.trim().slice(0, 200), blockCount: lastUserMsg?.content.length }, 'Classifier input');
 
       let tier: import('./response-tier.js').ResponseTier;
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -262,7 +262,10 @@ export class Session {
             }
           }
         }
-        isToolResultOnly = hasToolResult && userText.trim().length === 0;
+        // Inherit previous tier when there's no real user text — either
+        // tool_result-only messages or system nudges where all text was
+        // filtered out as injected context.
+        isToolResultOnly = userText.trim().length === 0;
       }
 
       // Temporary: log what the classifier sees

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -26,7 +26,15 @@ import { ToolExecutor } from '../tools/executor.js';
 import type { UserDecision } from '../permissions/types.js';
 import { getConfig } from '../config/loader.js';
 import { buildSystemPrompt } from '../config/system-prompt.js';
-import { classifyResponseTier, tierMaxTokens, tierModel } from './response-tier.js';
+import {
+  classifyResponseTier,
+  classifyResponseTierDetailed,
+  resolveWithHint,
+  classifyResponseTierAsync,
+  tierMaxTokens,
+  tierModel,
+  type SessionTierHint,
+} from './response-tier.js';
 import { TraceEmitter } from './trace-emitter.js';
 import { EventBus } from '../events/bus.js';
 import type { AssistantDomainEvents } from '../events/domain-events.js';
@@ -231,6 +239,9 @@ export class Session {
     // (where user text is empty — only tool_result blocks) inherit it
     // instead of falling to 'low'.
     let lastUserMessageTier: import('./response-tier.js').ResponseTier = 'high';
+    let sessionTierHint: SessionTierHint | null = null;
+    const recentUserTexts: string[] = []; // circular buffer, max 3
+    const MAX_RECENT_TEXTS = 3;
 
     const resolveSystemPromptCallback = (history: import('../providers/types.js').Message[]): ResolvedSystemPrompt => {
       // Extract last user message text, ignoring runtime-injected context blocks
@@ -250,13 +261,37 @@ export class Session {
         isToolResultOnly = hasToolResult && userText.trim().length === 0;
       }
 
-      // Tool-use continuation: inherit previous tier
-      const tier = isToolResultOnly
-        ? lastUserMessageTier
-        : classifyResponseTier(userText, this.turnCount);
+      let tier: import('./response-tier.js').ResponseTier;
 
-      if (!isToolResultOnly) {
+      if (isToolResultOnly) {
+        // Tool-use continuation: inherit previous tier
+        tier = lastUserMessageTier;
+      } else {
+        const classification = classifyResponseTierDetailed(userText, this.turnCount);
+        tier = resolveWithHint(classification, sessionTierHint, this.turnCount);
         lastUserMessageTier = tier;
+
+        // Update recent user texts buffer
+        const trimmedText = userText.trim();
+        if (trimmedText) {
+          if (recentUserTexts.length >= MAX_RECENT_TEXTS) {
+            recentUserTexts.shift();
+          }
+          recentUserTexts.push(trimmedText);
+        }
+
+        // Fire background Haiku classification when confidence is low
+        if (classification.confidence === 'low') {
+          void classifyResponseTierAsync([...recentUserTexts]).then((asyncTier) => {
+            if (asyncTier) {
+              sessionTierHint = {
+                tier: asyncTier,
+                turn: this.turnCount,
+                timestamp: Date.now(),
+              };
+            }
+          });
+        }
       }
 
       const model = tierModel(tier, provider.name);

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -206,8 +206,26 @@ export class Session {
     const resolveTools = createResolveToolsCallback(toolDefs, this);
 
     const configuredMaxTokens = maxTokens;
-    // Matches runtime-injected XML context blocks (e.g. <channel_capabilities>, <dynamic-profile-context>, etc.)
-    const INJECTED_BLOCK_RE = /^<[a-z][a-z0-9_-]*[\s>]/;
+    // When a systemPromptOverride was provided, skip tier-based prompt
+    // rebuilding and use the override as-is — only scale maxTokens and model.
+    const hasSystemPromptOverride = systemPrompt !== buildSystemPrompt();
+
+    // Known runtime-injected XML context block prefixes. Using an explicit
+    // list avoids false-positives on user messages that start with HTML/XML.
+    const INJECTED_PREFIXES = [
+      '<channel_capabilities>',
+      '<channel_command_context>',
+      '<channel_turn_context>',
+      '<temporal_context>',
+      '<guardian_context>',
+      '<voice_call_control>',
+      '<workspace_top_level>',
+      '<active_workspace>',
+      '<active_dynamic_page>',
+      '<dynamic-profile-context>',
+      '<memory_recall',
+      '<system_notice>',
+    ];
 
     // Track the last user-message tier so tool-use continuation turns
     // (where user text is empty — only tool_result blocks) inherit it
@@ -224,7 +242,7 @@ export class Session {
         for (const block of lastUserMsg.content) {
           if (block.type === 'text') {
             const trimmed = block.text.trimStart();
-            if (!INJECTED_BLOCK_RE.test(trimmed)) {
+            if (!INJECTED_PREFIXES.some((p) => trimmed.startsWith(p))) {
               userText += block.text;
             }
           }
@@ -243,7 +261,7 @@ export class Session {
 
       const model = tierModel(tier, provider.name);
       return {
-        systemPrompt: buildSystemPrompt(tier),
+        systemPrompt: hasSystemPromptOverride ? systemPrompt : buildSystemPrompt(tier),
         maxTokens: tierMaxTokens(tier, configuredMaxTokens),
         model,
       };


### PR DESCRIPTION
## Summary
- Classifies each user message into low/medium/high tiers using a deterministic regex classifier (zero added latency)
- Each tier controls system prompt size (9KB/29KB/33KB), maxTokens budget (2K/6K/16K), and model routing (haiku/sonnet/opus)
- Tool-use continuation turns inherit the originating message's tier so complex flows stay on the right model
- Tightens SOUL.md conciseness directive to reduce verbosity across all tiers

Closes #8200

## Test plan
- [x] "hey" → low tier, haiku, ~2000 maxTokens, trimmed system prompt
- [x] "what should we build next?" → medium tier, sonnet (question skips build keyword)
- [x] "can you build a dashboard" → high tier, opus (polite imperative detected)
- [x] Tool-use continuation turns inherit originating tier/model
- [x] Runtime-injected context blocks filtered before classification
- [x] Config maxTokens override scales proportionally per tier
- [x] `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
