### PR TITLE
M2: Generic Notification Conversation Pairing + Audit Columns

### DIFF
--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -230,7 +230,7 @@ export function getLatestConversation(): ConversationRow | null {
   return row ? parseConversation(row) : null;
 }
 
-export function addMessage(conversationId: string, role: string, content: string, metadata?: Record<string, unknown>) {
+export function addMessage(conversationId: string, role: string, content: string, metadata?: Record<string, unknown>, opts?: { skipIndexing?: boolean }) {
   const db = getDb();
   const messageId = uuid();
 
@@ -287,22 +287,24 @@ export function addMessage(conversationId: string, role: string, content: string
   }
   const message = { id: messageId, conversationId, role, content, createdAt: now, ...(metadataStr ? { metadata: metadataStr } : {}) };
 
-  try {
-    const config = getConfig();
-    const scopeId = getConversationMemoryScopeId(conversationId);
-    const parsed = metadata ? messageMetadataSchema.safeParse(metadata) : null;
-    const provenanceActorRole = parsed?.success ? parsed.data.provenanceActorRole : undefined;
-    indexMessageNow({
-      messageId: message.id,
-      conversationId: message.conversationId,
-      role: message.role,
-      content: message.content,
-      createdAt: message.createdAt,
-      scopeId,
-      provenanceActorRole,
-    }, config.memory);
-  } catch (err) {
-    log.warn({ err, conversationId, messageId: message.id }, 'Failed to index message for memory');
+  if (!opts?.skipIndexing) {
+    try {
+      const config = getConfig();
+      const scopeId = getConversationMemoryScopeId(conversationId);
+      const parsed = metadata ? messageMetadataSchema.safeParse(metadata) : null;
+      const provenanceActorRole = parsed?.success ? parsed.data.provenanceActorRole : undefined;
+      indexMessageNow({
+        messageId: message.id,
+        conversationId: message.conversationId,
+        role: message.role,
+        content: message.content,
+        createdAt: message.createdAt,
+        scopeId,
+        provenanceActorRole,
+      }, config.memory);
+    } catch (err) {
+      log.warn({ err, conversationId, messageId: message.id }, 'Failed to index message for memory');
+    }
   }
 
   return message;

--- a/assistant/src/memory/migrations/023-notification-delivery-pairing-columns.ts
+++ b/assistant/src/memory/migrations/023-notification-delivery-pairing-columns.ts
@@ -1,0 +1,19 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Add conversation pairing audit columns to notification_deliveries.
+ *
+ * These columns track which conversation and message were materialized
+ * for each notification delivery, plus the strategy that was used.
+ */
+export function migrateNotificationDeliveryPairingColumns(database: DrizzleDb): void {
+  try {
+    database.run(/*sql*/ `ALTER TABLE notification_deliveries ADD COLUMN conversation_id TEXT`);
+  } catch { /* Column already exists */ }
+  try {
+    database.run(/*sql*/ `ALTER TABLE notification_deliveries ADD COLUMN message_id TEXT`);
+  } catch { /* Column already exists */ }
+  try {
+    database.run(/*sql*/ `ALTER TABLE notification_deliveries ADD COLUMN conversation_strategy TEXT`);
+  } catch { /* Column already exists */ }
+}

--- a/assistant/src/memory/migrations/114-notifications.ts
+++ b/assistant/src/memory/migrations/114-notifications.ts
@@ -1,5 +1,6 @@
 import type { DrizzleDb } from '../db-connection.js';
 import { migrateNotificationTablesSchema } from './019-notification-tables-schema-migration.js';
+import { migrateNotificationDeliveryPairingColumns } from './023-notification-delivery-pairing-columns.js';
 
 /**
  * Notification system tables: preferences, events, decisions, and deliveries.
@@ -82,4 +83,7 @@ export function createNotificationTables(database: DrizzleDb): void {
   database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_deliveries_unique ON notification_deliveries(notification_decision_id, channel, destination, attempt)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_notification_deliveries_decision_id ON notification_deliveries(notification_decision_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_notification_deliveries_assistant_status ON notification_deliveries(assistant_id, status)`);
+
+  // Add conversation pairing audit columns (idempotent ALTER TABLE)
+  migrateNotificationDeliveryPairingColumns(database);
 }

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -26,6 +26,7 @@ export { migrateNotificationTablesSchema } from './019-notification-tables-schem
 export { migrateRenameChannelToVellum } from './020-rename-macos-ios-channel-to-vellum.js';
 export { migrateConversationStatusIndexes } from './021-conversation-status-indexes.js';
 export { migrateAddOriginInterface } from './022-add-origin-interface.js';
+export { migrateNotificationDeliveryPairingColumns } from './023-notification-delivery-pairing-columns.js';
 export { createCoreTables } from './100-core-tables.js';
 export { createWatchersAndLogsTables } from './101-watchers-and-logs.js';
 export { addCoreColumns } from './102-alter-table-columns.js';

--- a/assistant/src/memory/schema-migration.ts
+++ b/assistant/src/memory/schema-migration.ts
@@ -24,4 +24,5 @@ export {
   migrateMemoryItemsIndexes,
   migrateRemainingTableIndexes,
   migrateAddOriginInterface,
+  migrateNotificationDeliveryPairingColumns,
 } from './migrations/index.js';

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -992,6 +992,9 @@ export const notificationDeliveries = sqliteTable('notification_deliveries', {
   errorCode: text('error_code'),
   errorMessage: text('error_message'),
   sentAt: integer('sent_at'),
+  conversationId: text('conversation_id'),
+  messageId: text('message_id'),
+  conversationStrategy: text('conversation_strategy'),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 });

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -12,6 +12,7 @@
 import { v4 as uuid } from 'uuid';
 import { getLogger } from '../util/logger.js';
 import { composeFallbackCopy } from './copy-composer.js';
+import { pairDeliveryWithConversation } from './conversation-pairing.js';
 import { resolveDestinations } from './destination-resolver.js';
 import { createDelivery, updateDeliveryStatus } from './deliveries-store.js';
 import type { NotificationSignal } from './signal.js';
@@ -90,10 +91,20 @@ export class NotificationBroadcaster {
         copy = fallbackCopy[channel] ?? { title: 'Notification', body: signal.sourceEventName };
       }
 
+      // Pair the delivery with a conversation before sending
+      const pairing = pairDeliveryWithConversation(signal, channel, copy);
+
+      // For the vellum channel, merge the conversationId into deep-link metadata
+      // so the macOS/iOS client can navigate directly to the notification thread.
+      let deepLinkTarget = decision.deepLinkTarget;
+      if (channel === 'vellum' && pairing.conversationId) {
+        deepLinkTarget = { ...deepLinkTarget, conversationId: pairing.conversationId };
+      }
+
       const payload: ChannelDeliveryPayload = {
         sourceEventName: signal.sourceEventName,
         copy,
-        deepLinkTarget: decision.deepLinkTarget,
+        deepLinkTarget,
       };
 
       const deliveryId = uuid();
@@ -118,6 +129,9 @@ export class NotificationBroadcaster {
             attempt: 1,
             renderedTitle: copy.title,
             renderedBody: copy.body,
+            conversationId: pairing.conversationId ?? undefined,
+            messageId: pairing.messageId ?? undefined,
+            conversationStrategy: pairing.strategy,
           });
         } else {
           log.warn(
@@ -137,6 +151,9 @@ export class NotificationBroadcaster {
             destination: destinationLabel,
             status: 'sent',
             sentAt: Date.now(),
+            conversationId: pairing.conversationId ?? undefined,
+            messageId: pairing.messageId ?? undefined,
+            conversationStrategy: pairing.strategy,
           });
         } else {
           if (hasPersistedDecision) {
@@ -147,6 +164,9 @@ export class NotificationBroadcaster {
             destination: destinationLabel,
             status: 'failed',
             errorMessage: adapterResult.error,
+            conversationId: pairing.conversationId ?? undefined,
+            messageId: pairing.messageId ?? undefined,
+            conversationStrategy: pairing.strategy,
           });
         }
       } catch (err) {
@@ -166,6 +186,9 @@ export class NotificationBroadcaster {
           destination: destinationLabel,
           status: 'failed',
           errorMessage,
+          conversationId: pairing.conversationId ?? undefined,
+          messageId: pairing.messageId ?? undefined,
+          conversationStrategy: pairing.strategy,
         });
       }
     }

--- a/assistant/src/notifications/conversation-pairing.ts
+++ b/assistant/src/notifications/conversation-pairing.ts
@@ -55,9 +55,13 @@ export function pairDeliveryWithConversation(
     // record the intended strategy so the audit trail is complete.
     const title = copy.threadTitle ?? copy.title ?? signal.sourceEventName;
 
+    // Use 'standard' threadType so notification threads remain visible in
+    // conversation listings and deep-linkable from notification intents.
+    // Memory indexing is skipped on the seed message below to prevent
+    // notification copy from polluting conversational recall.
     const conversation = createConversation({
       title,
-      threadType: 'background',
+      threadType: 'standard',
       source: 'notification',
     });
 

--- a/assistant/src/notifications/conversation-pairing.ts
+++ b/assistant/src/notifications/conversation-pairing.ts
@@ -57,12 +57,14 @@ export function pairDeliveryWithConversation(
 
     const conversation = createConversation({
       title,
-      threadType: 'standard',
+      threadType: 'background',
       source: 'notification',
     });
 
     const messageContent = copy.threadSeedMessage ?? `${copy.title}\n\n${copy.body}`;
-    const message = addMessage(conversation.id, 'assistant', messageContent);
+    // Skip memory indexing — notification audit messages are not conversational
+    // memory and should not pollute recall or incur embedding/extraction overhead.
+    const message = addMessage(conversation.id, 'assistant', messageContent, undefined, { skipIndexing: true });
 
     log.info(
       {

--- a/assistant/src/notifications/conversation-pairing.ts
+++ b/assistant/src/notifications/conversation-pairing.ts
@@ -1,0 +1,97 @@
+/**
+ * Generic notification conversation pairing.
+ *
+ * Materializes a conversation + message for each notification delivery
+ * before the adapter sends it. This ensures every delivery has an
+ * auditable conversation trail and enables the macOS/iOS client to
+ * deep-link directly into the notification thread.
+ */
+
+import { getLogger } from '../util/logger.js';
+import { getConversationStrategy } from '../channels/config.js';
+import { createConversation, addMessage } from '../memory/conversation-store.js';
+import type { NotificationChannel } from './types.js';
+import type { NotificationSignal } from './signal.js';
+import type { RenderedChannelCopy } from './types.js';
+import type { ConversationStrategy } from '../channels/config.js';
+import type { ChannelId } from '../channels/types.js';
+
+const log = getLogger('notification-conversation-pairing');
+
+export interface PairingResult {
+  conversationId: string | null;
+  messageId: string | null;
+  strategy: ConversationStrategy;
+}
+
+/**
+ * Pair a notification delivery with a conversation and seed message.
+ *
+ * Looks up the channel's conversation strategy from the policy registry
+ * and materializes a conversation + assistant message accordingly.
+ *
+ * Errors are caught and logged — this function never throws so the
+ * notification pipeline is not disrupted by pairing failures.
+ */
+export function pairDeliveryWithConversation(
+  signal: NotificationSignal,
+  channel: NotificationChannel,
+  copy: RenderedChannelCopy,
+): PairingResult {
+  try {
+    const strategy = getConversationStrategy(channel as ChannelId);
+
+    if (strategy === 'not_deliverable') {
+      return { conversationId: null, messageId: null, strategy: 'not_deliverable' };
+    }
+
+    // For both start_new_conversation and continue_existing_conversation,
+    // we create a new conversation per notification delivery for now.
+    //
+    // True conversation continuation (reusing an existing conversation scoped
+    // to channel + assistant via a key like `notif:{assistantId}:{channel}:ongoing`)
+    // requires external chat binding lookup which is complex. A future PR will
+    // add that capability. For this milestone we materialize conversations and
+    // record the intended strategy so the audit trail is complete.
+    const title = copy.threadTitle ?? copy.title ?? signal.sourceEventName;
+
+    const conversation = createConversation({
+      title,
+      threadType: 'standard',
+      source: 'notification',
+    });
+
+    const messageContent = copy.threadSeedMessage ?? `${copy.title}\n\n${copy.body}`;
+    const message = addMessage(conversation.id, 'assistant', messageContent);
+
+    log.info(
+      {
+        signalId: signal.signalId,
+        channel,
+        strategy,
+        conversationId: conversation.id,
+        messageId: message.id,
+      },
+      'Paired notification delivery with conversation',
+    );
+
+    return {
+      conversationId: conversation.id,
+      messageId: message.id,
+      strategy,
+    };
+  } catch (err) {
+    log.error(
+      { err, signalId: signal.signalId, channel },
+      'Failed to pair notification delivery with conversation — continuing without pairing',
+    );
+    const fallbackStrategy = (() => {
+      try {
+        return getConversationStrategy(channel as ChannelId);
+      } catch {
+        return 'not_deliverable' as const;
+      }
+    })();
+    return { conversationId: null, messageId: null, strategy: fallbackStrategy };
+  }
+}

--- a/assistant/src/notifications/deliveries-store.ts
+++ b/assistant/src/notifications/deliveries-store.ts
@@ -24,6 +24,9 @@ export interface NotificationDeliveryRow {
   errorCode: string | null;
   errorMessage: string | null;
   sentAt: number | null;
+  conversationId: string | null;
+  messageId: string | null;
+  conversationStrategy: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -42,6 +45,9 @@ function rowToDelivery(row: typeof notificationDeliveries.$inferSelect): Notific
     errorCode: row.errorCode,
     errorMessage: row.errorMessage,
     sentAt: row.sentAt,
+    conversationId: row.conversationId,
+    messageId: row.messageId,
+    conversationStrategy: row.conversationStrategy,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -60,6 +66,9 @@ export interface CreateDeliveryParams {
   errorCode?: string;
   errorMessage?: string;
   sentAt?: number;
+  conversationId?: string;
+  messageId?: string;
+  conversationStrategy?: string;
 }
 
 /** Create a new delivery audit record. */
@@ -80,6 +89,9 @@ export function createDelivery(params: CreateDeliveryParams): NotificationDelive
     errorCode: params.errorCode ?? null,
     errorMessage: params.errorMessage ?? null,
     sentAt: params.sentAt ?? null,
+    conversationId: params.conversationId ?? null,
+    messageId: params.messageId ?? null,
+    conversationStrategy: params.conversationStrategy ?? null,
     createdAt: now,
     updatedAt: now,
   };

--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -26,6 +26,9 @@ export interface NotificationDeliveryResult {
   errorCode?: string;
   errorMessage?: string;
   sentAt?: number;
+  conversationId?: string;
+  messageId?: string;
+  conversationStrategy?: string;
 }
 
 // -- Channel adapter interfaces -----------------------------------------------


### PR DESCRIPTION
Add conversation pairing step to notification broadcaster that materializes a conversation and message for each delivery before adapter send. Attach conversationId to vellum deep-link metadata. Add conversation_id, message_id, conversation_strategy audit columns to notification_deliveries with schema migration. Part of #8852.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
