### PR TITLE
fix: silence deprecated onChange(of:perform:) warning in InboxThreadDetailView

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/InboxThreadDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/InboxThreadDetailView.swift
@@ -84,7 +84,7 @@ struct InboxThreadDetailView: View {
                             proxy.scrollTo(lastMessage.id, anchor: .bottom)
                         }
                     }
-                    .onChange(of: viewModel.messages.count) { _ in
+                    .onChange(of: viewModel.messages.count) {
                         if let lastMessage = viewModel.messages.last {
                             withAnimation(VAnimation.fast) {
                                 proxy.scrollTo(lastMessage.id, anchor: .bottom)


### PR DESCRIPTION
## Summary

- Updated `InboxThreadDetailView.swift` to use the zero-parameter `onChange` closure instead of the deprecated single-parameter variant (`onChange(of:perform:)` deprecated in macOS 14.0)

## Original prompt
fix: silence deprecated onChange(of:perform:) warning in InboxThreadDetailView.swift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
