### PR TITLE
fix: restore assistant Dockerfile deleted in PR #8724

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -1,0 +1,101 @@
+# Use debian as base image
+FROM us-central1-docker.pkg.dev/code-executor-service/base-images/debian:bookworm@sha256:940221f8c2564efc4e7909caba7014dc8bcba7f05b7881eb2b557b4058c41269 AS builder
+
+WORKDIR /app
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    unzip \
+    python3 \
+    make \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install bun
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
+# Copy package files
+COPY package.json bun.lock ./
+
+# Install dependencies
+RUN bun install --frozen-lockfile
+
+# Copy source
+COPY . .
+
+# Final stage
+FROM debian:bookworm AS runner
+
+WORKDIR /app
+
+# Install runtime dependencies for Playwright and tree-sitter
+RUN apt-get update && apt-get install -y \
+    curl \
+    unzip \
+    ca-certificates \
+    python3 \
+    libnss3 \
+    libfreetype6 \
+    libharfbuzz0b \
+    fonts-freefont-ttf \
+    make \
+    g++ \
+    git \
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy bun binary from builder instead of re-installing
+COPY --from=builder /root/.bun/bin/bun /usr/local/bin/bun
+RUN ln -sf /usr/local/bin/bun /usr/local/bin/bunx
+
+# Create non-root user that also has sudo access so it can like install stuff
+RUN groupadd --system --gid 1001 assistant && \
+    useradd --system --uid 1001 --gid assistant --create-home --shell /bin/bash assistant && \
+    echo "assistant ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Copy from builder
+COPY --from=builder /app /app
+
+# Set up data directory
+RUN mkdir -p /home/assistant/.vellum /data && \
+    chown -R assistant:assistant /home/assistant/.vellum /data && \
+    chmod a+rwx /data
+
+# Update PATH for assistant user
+ENV PATH="/home/assistant/.bun/bin:/data/bin:${PATH}"
+
+# Configure package managers to use /data
+ENV BUN_INSTALL="/data/.bun"
+ENV PATH="${BUN_INSTALL}/bin:${PATH}"
+ENV PYTHONUSERBASE="/data/.python"
+ENV PATH="${PYTHONUSERBASE}/bin:${PATH}"
+
+# Configure apt/dpkg to install future packages to /data
+RUN mkdir -p /data/dpkg/info /data/dpkg/updates /data/dpkg/triggers && \
+    mkdir -p /data/usr/bin /data/usr/lib /data/usr/share && \
+    chown -R assistant:assistant /data/dpkg /data/usr
+
+# Create dpkg configuration for using /data as install prefix
+RUN echo 'Dir::State "/data/dpkg";' > /etc/apt/apt.conf.d/99data-dir && \
+    echo 'Dir::State::status "/data/dpkg/status";' >> /etc/apt/apt.conf.d/99data-dir && \
+    echo 'Dir::Cache "/data/apt/cache";' >> /etc/apt/apt.conf.d/99data-dir && \
+    echo 'DPkg::Options {"--instdir=/data/usr";"--admindir=/data/dpkg";"--force-not-root";"--force-bad-path";};' >> /etc/apt/apt.conf.d/99data-dir && \
+    mkdir -p /data/apt/cache && \
+    touch /data/dpkg/status && \
+    chown -R assistant:assistant /data/apt /data/dpkg
+
+ENV PATH="/data/usr/bin:/data/usr/sbin:${PATH}"
+ENV LD_LIBRARY_PATH="/data/usr/lib:/data/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH}"
+
+USER assistant
+
+EXPOSE 3001
+
+ENV RUNTIME_HTTP_PORT=3001
+ENV VELLUM_DAEMON_SOCKET=/home/assistant/.vellum/vellum.sock
+ENV BASE_DATA_DIR=/data
+
+# Run the daemon + http server
+CMD ["bun", "run", "src/daemon/main.ts"]


### PR DESCRIPTION
Restores assistant/Dockerfile that was accidentally deleted in #8724. The release workflow (push-assistant-image job) depends on this file.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
