### PR TITLE
fix: silence main actor isolation warning in QuickInputWindow dismiss

### DIFF
--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
@@ -247,12 +247,14 @@ final class QuickInputWindow {
             context.timingFunction = CAMediaTimingFunction(name: .easeIn)
             panel.animator().alphaValue = 0
         }, completionHandler: { [weak self] in
-            panel.close()
-            self?.panel = nil
-            self?.isDismissing = false
-            self?.attachedImageData = nil
-            self?.attachedImage = nil
-            appToRestore?.activate()
+            MainActor.assumeIsolated {
+                panel.close()
+                self?.panel = nil
+                self?.isDismissing = false
+                self?.attachedImageData = nil
+                self?.attachedImage = nil
+                appToRestore?.activate()
+            }
         })
     }
 


### PR DESCRIPTION
## Summary

- Wrapped the `NSAnimationContext.runAnimationGroup` completion handler body in `MainActor.assumeIsolated` to fix the "main actor-isolated property cannot be mutated from a Sendable closure" warning — the handler already runs on the main thread

## Original prompt
Fix Sendable closure warning in QuickInputWindow.swift where @MainActor-isolated properties are mutated from the animation completion handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
