### PR TITLE
M3: Generic notification_thread_created IPC + macOS Thread Surfacing

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1799,6 +1799,15 @@ exports[`IPC message snapshots ServerMessage types notification_intent serialize
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types notification_thread_created serializes to expected JSON 1`] = `
+{
+  "conversationId": "conv-notif-001",
+  "sourceEventName": "watcher.escalation",
+  "title": "Weather alert for your area",
+  "type": "notification_thread_created",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types schedule_complete serializes to expected JSON 1`] = `
 {
   "name": "Daily backup",

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -1111,6 +1111,12 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
       conversationId: 'conv-guardian-001',
     },
   },
+  notification_thread_created: {
+    type: 'notification_thread_created',
+    conversationId: 'conv-notif-001',
+    title: 'Weather alert for your area',
+    sourceEventName: 'watcher.escalation',
+  },
   schedule_complete: {
     type: 'schedule_complete',
     scheduleId: 'sched-001',

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -248,6 +248,7 @@
     "message_queued_deleted",
     "model_info",
     "notification_intent",
+    "notification_thread_created",
     "open_bundle_response",
     "open_tasks_window",
     "open_url",

--- a/assistant/src/daemon/ipc-contract/notifications.ts
+++ b/assistant/src/daemon/ipc-contract/notifications.ts
@@ -8,7 +8,15 @@ export interface NotificationIntent {
   deepLinkMetadata?: Record<string, unknown>;
 }
 
+/** Server push — broadcast when a notification creates a new vellum conversation thread. */
+export interface NotificationThreadCreated {
+  type: 'notification_thread_created';
+  conversationId: string;
+  title: string;
+  sourceEventName: string;
+}
+
 // --- Domain-level union aliases (consumed by the barrel file) ---
 // Notifications has no client messages.
 
-export type _NotificationsServerMessages = NotificationIntent;
+export type _NotificationsServerMessages = NotificationIntent | NotificationThreadCreated;

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -66,12 +66,21 @@ export class NotificationBroadcaster {
   ): Promise<NotificationDeliveryResult[]> {
     const destinations = resolveDestinations(signal.assistantId, decision.selectedChannels);
 
+    // Ensure vellum is processed first so the notification_thread_created IPC
+    // push fires immediately, before slower channel sends (e.g. Telegram 30s
+    // timeout) can delay it past the macOS deep-link retry window.
+    const orderedChannels = [...decision.selectedChannels].sort((a, b) => {
+      if (a === 'vellum') return -1;
+      if (b === 'vellum') return 1;
+      return 0;
+    });
+
     // Pre-compute fallback copy in case any channel is missing rendered copy
     let fallbackCopy: Partial<Record<NotificationChannel, RenderedChannelCopy>> | null = null;
 
     const results: NotificationDeliveryResult[] = [];
 
-    for (const channel of decision.selectedChannels) {
+    for (const channel of orderedChannels) {
       const adapter = this.adapters.get(channel);
       if (!adapter) {
         log.warn({ channel, signalId: signal.signalId }, 'No adapter registered for channel -- skipping');

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -27,14 +27,28 @@ import type {
 
 const log = getLogger('notif-broadcaster');
 
+/** Callback invoked immediately when a vellum notification thread is created. */
+export interface ThreadCreatedInfo {
+  conversationId: string;
+  title: string;
+  sourceEventName: string;
+}
+export type OnThreadCreatedFn = (info: ThreadCreatedInfo) => void;
+
 export class NotificationBroadcaster {
   private adapters: Map<NotificationChannel, ChannelAdapter>;
+  private onThreadCreated: OnThreadCreatedFn | null = null;
 
   constructor(adapters: ChannelAdapter[]) {
     this.adapters = new Map();
     for (const adapter of adapters) {
       this.adapters.set(adapter.channel, adapter);
     }
+  }
+
+  /** Register a callback that fires immediately when a vellum conversation is paired. */
+  setOnThreadCreated(fn: OnThreadCreatedFn): void {
+    this.onThreadCreated = fn;
   }
 
   /**
@@ -99,6 +113,22 @@ export class NotificationBroadcaster {
       let deepLinkTarget = decision.deepLinkTarget;
       if (channel === 'vellum' && pairing.conversationId) {
         deepLinkTarget = { ...deepLinkTarget, conversationId: pairing.conversationId };
+
+        // Emit notification_thread_created immediately when the vellum
+        // conversation is paired, BEFORE waiting for adapter send or other
+        // channel deliveries. This avoids a race where slow Telegram delivery
+        // delays the IPC push past the macOS deep-link retry window.
+        if (pairing.strategy === 'start_new_conversation' && this.onThreadCreated) {
+          const threadTitle =
+            copy.threadTitle ??
+            copy.title ??
+            signal.sourceEventName;
+          this.onThreadCreated({
+            conversationId: pairing.conversationId,
+            title: threadTitle,
+            sourceEventName: signal.sourceEventName,
+          });
+        }
       }
 
       const payload: ChannelDeliveryPayload = {

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -123,11 +123,15 @@ export class NotificationBroadcaster {
             copy.threadTitle ??
             copy.title ??
             signal.sourceEventName;
-          this.onThreadCreated({
-            conversationId: pairing.conversationId,
-            title: threadTitle,
-            sourceEventName: signal.sourceEventName,
-          });
+          try {
+            this.onThreadCreated({
+              conversationId: pairing.conversationId,
+              title: threadTitle,
+              sourceEventName: signal.sourceEventName,
+            });
+          } catch (err) {
+            log.error({ err, signalId: signal.signalId }, 'onThreadCreated callback failed — continuing broadcast');
+          }
         }
       }
 

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -50,6 +50,25 @@ function getBroadcaster(): NotificationBroadcaster {
       adapters.unshift(new VellumAdapter(registeredBroadcastFn));
     }
     broadcasterInstance = new NotificationBroadcaster(adapters);
+
+    // Wire the thread-created callback so the macOS client is notified
+    // immediately when a vellum notification thread is paired — before
+    // slower channel deliveries (e.g. Telegram) delay the IPC push.
+    if (registeredBroadcastFn) {
+      const broadcastFn = registeredBroadcastFn;
+      broadcasterInstance.setOnThreadCreated((info) => {
+        broadcastFn({
+          type: 'notification_thread_created',
+          conversationId: info.conversationId,
+          title: info.title,
+          sourceEventName: info.sourceEventName,
+        });
+        log.info(
+          { conversationId: info.conversationId },
+          'Emitted notification_thread_created push event',
+        );
+      });
+    }
   }
   return broadcasterInstance;
 }
@@ -182,38 +201,12 @@ export async function emitNotificationSignal(params: EmitSignalParams): Promise<
     }
 
     // Step 4: Dispatch through the broadcaster
+    // Note: notification_thread_created IPC events are emitted eagerly inside
+    // the broadcaster as soon as vellum conversation pairing succeeds, rather
+    // than after all channel deliveries complete. This avoids a race where
+    // slow Telegram delivery delays the push past the macOS deep-link retry.
     const broadcaster = getBroadcaster();
     const dispatchResult = await dispatchDecision(signal, decision, broadcaster);
-
-    // Step 5: Emit notification_thread_created for vellum deliveries that
-    // created a new conversation (start_new_conversation strategy), so the
-    // macOS client can immediately surface the thread in the sidebar.
-    if (registeredBroadcastFn && dispatchResult.dispatched) {
-      for (const delivery of dispatchResult.deliveryResults) {
-        if (
-          delivery.channel === 'vellum' &&
-          delivery.status === 'sent' &&
-          delivery.conversationId &&
-          delivery.conversationStrategy === 'start_new_conversation'
-        ) {
-          const vellumCopy = decision.renderedCopy[delivery.channel];
-          const threadTitle =
-            vellumCopy?.threadTitle ??
-            vellumCopy?.title ??
-            params.sourceEventName;
-          registeredBroadcastFn({
-            type: 'notification_thread_created',
-            conversationId: delivery.conversationId,
-            title: threadTitle,
-            sourceEventName: params.sourceEventName,
-          });
-          log.info(
-            { signalId, conversationId: delivery.conversationId },
-            'Emitted notification_thread_created push event',
-          );
-        }
-      }
-    }
 
     log.info(
       {

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -185,6 +185,36 @@ export async function emitNotificationSignal(params: EmitSignalParams): Promise<
     const broadcaster = getBroadcaster();
     const dispatchResult = await dispatchDecision(signal, decision, broadcaster);
 
+    // Step 5: Emit notification_thread_created for vellum deliveries that
+    // created a new conversation (start_new_conversation strategy), so the
+    // macOS client can immediately surface the thread in the sidebar.
+    if (registeredBroadcastFn && dispatchResult.dispatched) {
+      for (const delivery of dispatchResult.deliveryResults) {
+        if (
+          delivery.channel === 'vellum' &&
+          delivery.status === 'sent' &&
+          delivery.conversationId &&
+          delivery.conversationStrategy === 'start_new_conversation'
+        ) {
+          const vellumCopy = decision.renderedCopy[delivery.channel];
+          const threadTitle =
+            vellumCopy?.threadTitle ??
+            vellumCopy?.title ??
+            params.sourceEventName;
+          registeredBroadcastFn({
+            type: 'notification_thread_created',
+            conversationId: delivery.conversationId,
+            title: threadTitle,
+            sourceEventName: params.sourceEventName,
+          });
+          log.info(
+            { signalId, conversationId: delivery.conversationId },
+            'Emitted notification_thread_created push event',
+          );
+        }
+      }
+    }
+
     log.info(
       {
         signalId,

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -822,6 +822,17 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        // Notification threads — created when the notification pipeline delivers
+        // to the vellum channel with start_new_conversation strategy.
+        daemonClient.onNotificationThreadCreated = { [weak self] msg in
+            guard let self, !self.isAwaitingFirstLaunchReady else { return }
+            self.mainWindow?.threadManager.createNotificationThread(
+                conversationId: msg.conversationId,
+                title: msg.title,
+                sourceEventName: msg.sourceEventName
+            )
+        }
+
         // Handle escalation: text_qa -> computer_use via computer_use_request_control
         daemonClient.onTaskRouted = { [weak self] routed in
             guard let self else { return }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -191,6 +191,27 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         log.info("Created guardian request thread \(thread.id) for conversation \(conversationId) (request \(requestId), call \(callSessionId))")
     }
 
+    /// Create a visible thread bound to a notification-created conversation.
+    /// Called when the daemon broadcasts `notification_thread_created` so the user
+    /// can see notification threads and deep-link into them.
+    func createNotificationThread(conversationId: String, title: String, sourceEventName: String) {
+        // Avoid creating a duplicate thread if one already exists for this conversation
+        if threads.contains(where: { $0.sessionId == conversationId }) {
+            return
+        }
+
+        let thread = ThreadModel(title: title, sessionId: conversationId)
+        let viewModel = makeViewModel()
+        viewModel.sessionId = conversationId
+        // Start the message loop so the view model receives streamed messages
+        viewModel.startMessageLoop()
+
+        threads.insert(thread, at: 0)
+        chatViewModels[thread.id] = viewModel
+
+        log.info("Created notification thread \(thread.id) for conversation \(conversationId) (source: \(sourceEventName))")
+    }
+
     func closeThread(id: UUID) {
         // No-op if only 1 thread remains
         guard threads.count > 1 else { return }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -225,6 +225,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon emits a generic `notification_intent` payload.
     public var onNotificationIntent: ((NotificationIntentMessage) -> Void)?
 
+    /// Called when a notification delivery creates a new vellum conversation thread.
+    public var onNotificationThreadCreated: ((IPCNotificationThreadCreated) -> Void)?
+
     /// Called when a scheduled task completes.
     public var onScheduleComplete: ((ScheduleCompleteMessage) -> Void)?
 

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -81,6 +81,8 @@ extension DaemonClient {
             onReminderFired?(msg)
         case .notificationIntent(let msg):
             onNotificationIntent?(msg)
+        case .notificationThreadCreated(let msg):
+            onNotificationThreadCreated?(msg)
         case .scheduleComplete(let msg):
             onScheduleComplete?(msg)
         case .trustRulesListResponse(let msg):

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -2765,6 +2765,21 @@ public struct IPCNotificationIntent: Codable, Sendable {
     }
 }
 
+/// Server push — broadcast when a notification creates a new vellum conversation thread.
+public struct IPCNotificationThreadCreated: Codable, Sendable {
+    public let type: String
+    public let conversationId: String
+    public let title: String
+    public let sourceEventName: String
+
+    public init(type: String, conversationId: String, title: String, sourceEventName: String) {
+        self.type = type
+        self.conversationId = conversationId
+        self.title = title
+        self.sourceEventName = sourceEventName
+    }
+}
+
 public struct IPCOpenBundleRequest: Codable, Sendable {
     public let type: String
     public let filePath: String

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2209,6 +2209,7 @@ public enum ServerMessage: Decodable, Sendable {
     case toolResult(ToolResultMessage)
     case reminderFired(ReminderFiredMessage)
     case notificationIntent(NotificationIntentMessage)
+    case notificationThreadCreated(IPCNotificationThreadCreated)
     case scheduleComplete(ScheduleCompleteMessage)
     case watchStarted(WatchStartedMessage)
     case watchCompleteRequest(WatchCompleteRequestMessage)
@@ -2462,6 +2463,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "notification_intent":
             let message = try NotificationIntentMessage(from: decoder)
             self = .notificationIntent(message)
+        case "notification_thread_created":
+            let message = try IPCNotificationThreadCreated(from: decoder)
+            self = .notificationThreadCreated(message)
         case "schedule_complete":
             let message = try ScheduleCompleteMessage(from: decoder)
             self = .scheduleComplete(message)


### PR DESCRIPTION
Add notification_thread_created server push message to IPC contract. Emit it from the notification pipeline when a vellum channel delivery creates a new conversation (start_new_conversation strategy). Wire up macOS client to create visible threads from these events, enabling deep-link navigation from notification intents. Part of #8852.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
