### PR TITLE
Wake word settings education + voice mode mic sensitivity fix

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/WakeWordSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WakeWordSettingsView.swift
@@ -29,7 +29,7 @@ struct WakeWordSettingsView: View {
     private var statusSection: some View {
         HStack(spacing: VSpacing.sm) {
             Circle()
-                .fill(VColor.success)
+                .fill(wakeWordEnabled ? VColor.success : VColor.textMuted)
                 .frame(width: 8, height: 8)
 
             Text(wakeWordEnabled ? "Listening for \"\(wakeWordKeyword)\"" : "Wake word disabled")
@@ -41,10 +41,10 @@ struct WakeWordSettingsView: View {
         .padding(VSpacing.lg)
         .background(
             RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(VColor.success.opacity(0.08))
+                .fill(wakeWordEnabled ? VColor.success.opacity(0.08) : VColor.surfaceSubtle)
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.lg)
-                        .strokeBorder(VColor.success.opacity(0.2), lineWidth: 1)
+                        .strokeBorder(wakeWordEnabled ? VColor.success.opacity(0.2) : VColor.surfaceBorder, lineWidth: 1)
                 )
         )
     }

--- a/clients/macos/vellum-assistant/Features/Settings/WakeWordSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WakeWordSettingsView.swift
@@ -13,9 +13,14 @@ struct WakeWordSettingsView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
             statusSection
+            educationHero
+            howItWorksSteps
+            tryItPrompt
+            settingsDivider
             enableSection
             keywordSection
             timeoutSection
+            privacyNote
         }
     }
 
@@ -23,43 +28,165 @@ struct WakeWordSettingsView: View {
 
     private var statusSection: some View {
         HStack(spacing: VSpacing.sm) {
-            Image(systemName: wakeWordEnabled ? "waveform" : "waveform.slash")
-                .font(.system(size: 14))
-                .foregroundColor(wakeWordEnabled ? VColor.success : VColor.textMuted)
+            Circle()
+                .fill(VColor.success)
+                .frame(width: 8, height: 8)
 
             Text(wakeWordEnabled ? "Listening for \"\(wakeWordKeyword)\"" : "Wake word disabled")
                 .font(VFont.body)
-                .foregroundColor(wakeWordEnabled ? VColor.textPrimary : VColor.textSecondary)
+                .foregroundColor(wakeWordEnabled ? VColor.success : VColor.textSecondary)
 
             Spacer()
         }
         .padding(VSpacing.lg)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(VColor.success.opacity(0.08))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.lg)
+                        .strokeBorder(VColor.success.opacity(0.2), lineWidth: 1)
+                )
+        )
+    }
+
+    // MARK: - Education Hero
+
+    private var educationHero: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Talk to Vellum, hands-free")
+                .font(VFont.cardTitle)
+                .foregroundColor(VColor.textPrimary)
+
+            Text("Wake word lets you start a conversation by speaking a keyword aloud \u{2014} no need to click or press anything. It uses on-device speech recognition, so nothing you say ever leaves your Mac.")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+                .lineSpacing(2)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(VSpacing.xl)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.xl)
+                .fill(VColor.surfaceSubtle)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.xl)
+                .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
+        )
+    }
+
+    // MARK: - How It Works
+
+    private var howItWorksSteps: some View {
+        HStack(alignment: .top, spacing: VSpacing.md) {
+            stepCard(number: "1", title: "Say the keyword", description: "Speak your wake word when you're ready to talk.", showConnector: true)
+            stepCard(number: "2", title: "Vellum starts listening", description: "A chime plays and your microphone activates.", showConnector: true)
+            stepCard(number: "3", title: "Ask anything", description: "Speak naturally. Vellum responds when you pause.", showConnector: false)
+        }
+    }
+
+    private func stepCard(number: String, title: String, description: String, showConnector: Bool) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text(number)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(VColor.success)
+                .frame(width: 24, height: 24)
+                .background(
+                    Circle()
+                        .fill(VColor.success.opacity(0.15))
+                )
+
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text(title)
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.textPrimary)
+
+                Text(description)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .lineSpacing(1)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)
+    }
+
+    // MARK: - Try It
+
+    private var tryItPrompt: some View {
+        HStack(spacing: VSpacing.md) {
+            Image(systemName: "mic.fill")
+                .font(.system(size: 14))
+                .foregroundColor(VColor.textSecondary)
+
+            HStack(spacing: VSpacing.xs) {
+                Text("Try it now")
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.textPrimary)
+
+                Text("\u{2014} say")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+
+                Text(wakeWordKeyword)
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(.white)
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.vertical, VSpacing.xxs)
+                    .background(
+                        Capsule()
+                            .fill(Forest._700)
+                    )
+
+                Text("followed by a question")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+            }
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(VColor.success.opacity(0.08))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.lg)
+                        .strokeBorder(VColor.success.opacity(0.2), style: StrokeStyle(lineWidth: 1, dash: [6, 4]))
+                )
+        )
+    }
+
+    // MARK: - Section Divider
+
+    private var settingsDivider: some View {
+        HStack(spacing: VSpacing.md) {
+            Text("SETTINGS")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(VColor.textMuted)
+                .tracking(1)
+
+            Rectangle()
+                .fill(VColor.surfaceBorder)
+                .frame(height: 1)
+        }
     }
 
     // MARK: - Enable/Disable
 
     private var enableSection: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Wake Word")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.textPrimary)
-
-            HStack {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Enable wake word listening")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textSecondary)
-                    Text("Activate the assistant by saying the wake word instead of using a keyboard shortcut.")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
-                }
-                Spacer()
-                Toggle("", isOn: $wakeWordEnabled)
-                    .toggleStyle(.switch)
-                    .labelsHidden()
-                    .accessibilityLabel("Enable wake word listening")
+        HStack {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Enable wake word listening")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                Text("Activate the assistant by speaking instead of using a keyboard shortcut.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
             }
+            Spacer()
+            Toggle("", isOn: $wakeWordEnabled)
+                .toggleStyle(.switch)
+                .labelsHidden()
+                .accessibilityLabel("Enable wake word listening")
         }
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)
@@ -70,7 +197,7 @@ struct WakeWordSettingsView: View {
     private var keywordSection: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
             Text("Keyword")
-                .font(VFont.sectionTitle)
+                .font(VFont.bodyMedium)
                 .foregroundColor(VColor.textPrimary)
 
             TextField("Enter wake word or phrase", text: $wakeWordKeyword)
@@ -84,19 +211,28 @@ struct WakeWordSettingsView: View {
                     }
                     .buttonStyle(.plain)
                     .font(VFont.caption)
-                    .foregroundColor(wakeWordKeyword == suggestion ? VColor.accent : VColor.textMuted)
+                    .foregroundColor(wakeWordKeyword == suggestion ? .white : VColor.textMuted)
                     .padding(.horizontal, VSpacing.sm)
                     .padding(.vertical, VSpacing.xs)
                     .background(
-                        RoundedRectangle(cornerRadius: VRadius.sm)
-                            .fill(wakeWordKeyword == suggestion ? VColor.accentSubtle : VColor.surface)
+                        Capsule()
+                            .fill(wakeWordKeyword == suggestion ? Forest._700 : VColor.surface)
+                    )
+                    .overlay(
+                        Capsule()
+                            .strokeBorder(wakeWordKeyword == suggestion ? Color.clear : VColor.surfaceBorder, lineWidth: 1)
                     )
                 }
             }
 
-            Text("Type any word or phrase. Uses on-device speech recognition — no data leaves your Mac.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 10))
+                    .foregroundColor(VColor.textMuted)
+                Text("Type any word or phrase. Uses on-device speech recognition \u{2014} no data leaves your Mac.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            }
         }
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)
@@ -105,32 +241,52 @@ struct WakeWordSettingsView: View {
     // MARK: - Timeout
 
     private var timeoutSection: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Conversation Timeout")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.textPrimary)
-
-            HStack {
-                Text("Auto-end conversation after")
+        HStack {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Conversation timeout")
                     .font(VFont.body)
-                    .foregroundColor(VColor.textSecondary)
-                Spacer()
-                Picker("", selection: $wakeWordTimeoutSeconds) {
-                    Text("15 seconds").tag(15)
-                    Text("30 seconds").tag(30)
-                    Text("60 seconds").tag(60)
-                    Text("120 seconds").tag(120)
-                }
-                .pickerStyle(.menu)
-                .frame(width: 160)
-                .accessibilityLabel("Conversation timeout duration")
+                    .foregroundColor(VColor.textPrimary)
+                Text("How long to wait for follow-up speech before ending the conversation.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
             }
-
-            Text("How long to wait for follow-up speech before ending the conversation.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
+            Spacer()
+            Picker("", selection: $wakeWordTimeoutSeconds) {
+                Text("5 seconds").tag(5)
+                Text("10 seconds").tag(10)
+                Text("15 seconds").tag(15)
+                Text("30 seconds").tag(30)
+                Text("60 seconds").tag(60)
+            }
+            .pickerStyle(.menu)
+            .frame(width: 140)
+            .accessibilityLabel("Conversation timeout duration")
         }
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)
+    }
+
+    // MARK: - Privacy Note
+
+    private var privacyNote: some View {
+        HStack(alignment: .top, spacing: VSpacing.sm) {
+            Image(systemName: "shield.fill")
+                .font(.system(size: 12))
+                .foregroundColor(VColor.textMuted)
+
+            Text("Wake word detection runs entirely on your device using Apple's Speech framework. Audio is only processed when the wake word is detected, and no recordings are stored or sent anywhere.")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .lineSpacing(2)
+        }
+        .padding(VSpacing.lg)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(Color.white.opacity(0.02))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
+                )
+        )
     }
 }

--- a/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
@@ -51,9 +51,10 @@ final class OpenAIVoiceService: ObservableObject {
     private var silenceHandled = false
     private var hasSpeechOccurred = false
     private var enginePrewarmed = false
+    private var rmsLogCounter = 0
 
-    private static let silenceThreshold: Float = 0.002
-    private static let speechThreshold: Float = 0.004
+    private static let silenceThreshold: Float = 0.003
+    private static let speechThreshold: Float = 0.003
     private static let silenceTimeout: TimeInterval = 1.0
     private static let minRecordingDuration: TimeInterval = 0.5
 
@@ -126,6 +127,7 @@ final class OpenAIVoiceService: ObservableObject {
 
         silenceHandled = false
         hasSpeechOccurred = false
+        rmsLogCounter = 0
         latestTranscription = ""
 
         let inputNode = audioEngine.inputNode
@@ -221,6 +223,12 @@ final class OpenAIVoiceService: ObservableObject {
             Task { @MainActor [weak self] in
                 guard let self, self.isRecording else { return }
                 self.amplitude = min(rms * 5, 1.0)
+
+                // Log RMS every ~50 buffers (~1s) for diagnostics
+                self.rmsLogCounter += 1
+                if self.rmsLogCounter % 50 == 0 {
+                    log.info("Voice RMS: \(rms, privacy: .public) (speech threshold: \(Self.speechThreshold, privacy: .public), hasSpeech: \(self.hasSpeechOccurred, privacy: .public))")
+                }
 
                 if rms > Self.speechThreshold {
                     self.hasSpeechOccurred = true

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1565,6 +1565,17 @@ public final class ChatViewModel: ObservableObject {
         self.suggestion = nil
     }
 
+    /// Strip the voice mode instruction prefix from user messages so it
+    /// doesn't clutter the chat when conversations are reloaded from history.
+    private static let voicePrefixPattern = /^\[Voice conversation\s—[^\]]*\]\n\n/
+
+    private func stripVoicePrefix(_ text: String) -> String {
+        if let match = text.prefixMatch(of: Self.voicePrefixPattern) {
+            return String(text[match.range.upperBound...])
+        }
+        return text
+    }
+
     /// Populate messages from history data returned by the daemon.
     /// If the user hasn't sent any messages yet, replaces messages entirely.
     /// If the user already sent messages (late history_response), prepends
@@ -1640,13 +1651,16 @@ public final class ChatViewModel: ObservableObject {
             if item.text.isEmpty && toolCalls.isEmpty && attachments.isEmpty && inlineSurfaces.isEmpty { continue }
             let timestamp = Date(timeIntervalSince1970: TimeInterval(item.timestamp) / 1000.0)
 
+            // Strip voice mode instruction prefix from user messages
+            let displayText = role == .user ? stripVoicePrefix(item.text) : item.text
+
             // Use the database message ID if available (for matching surfaces)
             var chatMsg: ChatMessage
             if let dbId = item.id, let uuid = UUID(uuidString: dbId) {
                 chatMsg = ChatMessage(
                     id: uuid,
                     role: role,
-                    text: item.text,
+                    text: displayText,
                     timestamp: timestamp,
                     attachments: attachments,
                     toolCalls: toolCalls
@@ -1654,7 +1668,7 @@ public final class ChatViewModel: ObservableObject {
             } else {
                 chatMsg = ChatMessage(
                     role: role,
-                    text: item.text,
+                    text: displayText,
                     timestamp: timestamp,
                     attachments: attachments,
                     toolCalls: toolCalls


### PR DESCRIPTION
## Summary
- Add educational content to wake word settings page: hero section explaining the feature, 3-step "how it works" flow, interactive try-it prompt, and privacy note
- Fix voice mode mic sensitivity: tune RMS thresholds from 0.002/0.004 to 0.003/0.003 so silence detection works reliably above ambient noise (~0.002 RMS) while still catching normal speech (0.009+ RMS)
- Strip voice mode instruction prefix from chat history: the `[Voice conversation — ...]` block was being stored by the daemon and shown in the UI when conversations were reloaded

## Test plan
- [ ] Open Settings → Wake Word and verify the new educational sections render correctly
- [ ] Trigger wake word and verify voice mode activates and listens for speech
- [ ] Speak at normal volume and verify transcription is captured and submitted
- [ ] Verify silence detection fires ~1s after you stop speaking
- [ ] Verify no "Hey Val" loop (voice mode shouldn't repeatedly submit wake word residue)
- [ ] Reload a conversation that had voice messages and verify no `[Voice conversation ...]` blocks appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)