### PR TITLE
Fix session overlay layout crash on state change

### DIFF
--- a/clients/macos/vellum-assistant/Features/Session/SessionOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/SessionOverlayWindow.swift
@@ -36,8 +36,12 @@ final class SessionOverlayWindow {
         sizeAndPosition(panel)
         stateCancellable = session.$state
             .sink { [weak self, weak panel] _ in
-                guard let self, let panel else { return }
-                self.sizeAndPosition(panel)
+                // Defer to next run loop iteration to avoid re-entrant constraint
+                // invalidation during an active SwiftUI layout pass (crashes AppKit).
+                DispatchQueue.main.async { [weak self, weak panel] in
+                    guard let self, let panel else { return }
+                    self.sizeAndPosition(panel)
+                }
             }
 
         panel.orderFront(nil)


### PR DESCRIPTION
## Summary
- Defer panel resize to next run loop iteration to avoid re-entrant constraint invalidation during SwiftUI layout pass
- Fixes crash when approving foreground computer use (EXC_BREAKPOINT in NSWindow _postWindowNeedsUpdateConstraints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
