### PR TITLE
security: add size cap to OAuth consumedStates map

### DIFF
--- a/gateway/src/http/routes/oauth-callback.ts
+++ b/gateway/src/http/routes/oauth-callback.ts
@@ -11,9 +11,19 @@ const MIN_STATE_LENGTH = 32;
 // Track consumed state tokens to prevent replay attacks. Each entry has a TTL
 // so the set doesn't grow unboundedly.
 const CONSUMED_STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const MAX_CONSUMED_STATES = 1000;
 const consumedStates = new Map<string, ReturnType<typeof setTimeout>>();
 
 function markStateConsumed(state: string): void {
+  // Evict oldest entry if at capacity to prevent unbounded memory growth
+  if (consumedStates.size >= MAX_CONSUMED_STATES) {
+    const oldest = consumedStates.keys().next().value;
+    if (oldest !== undefined) {
+      clearTimeout(consumedStates.get(oldest)!);
+      consumedStates.delete(oldest);
+    }
+  }
+
   const timer = setTimeout(() => {
     consumedStates.delete(state);
   }, CONSUMED_STATE_TTL_MS);


### PR DESCRIPTION
Add maxSize eviction to the consumedStates Map in oauth-callback.ts to prevent unbounded memory growth from state flooding attacks.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
