### PR TITLE
security: use timing-safe comparison for WhatsApp webhook verify token

### DIFF
--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "crypto";
 import { buildWhatsAppTransportMetadata } from "../../channels/transport-hints.js";
 import type { GatewayConfig } from "../../config.js";
 import { StringDedupCache } from "../../dedup-cache.js";
@@ -31,7 +32,10 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
       const challenge = url.searchParams.get("hub.challenge");
 
       if (mode === "subscribe" && token && config.whatsappWebhookVerifyToken) {
-        if (token === config.whatsappWebhookVerifyToken) {
+        const a = Buffer.from(token);
+        const b = Buffer.from(config.whatsappWebhookVerifyToken);
+        const match = a.length === b.length && timingSafeEqual(a, b);
+        if (match) {
           tlog.info("WhatsApp webhook verify token validated");
           // Return the challenge as plain text to complete the handshake
           return new Response(challenge ?? "", { status: 200 });


### PR DESCRIPTION
Replace plain === with timingSafeEqual for WhatsApp webhook verify token comparison, consistent with Telegram and Twilio verification paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
