### PR TITLE
security: guard auth bypass flags against production use

### DIFF
--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -228,7 +228,7 @@ export function loadConfig(): GatewayConfig {
       `GATEWAY_TELEGRAM_DELIVER_AUTH_BYPASS must be "true" or "false", got "${telegramDeliverAuthBypassRaw}"`,
     );
   }
-  const telegramDeliverAuthBypass = telegramDeliverAuthBypassRaw === "true";
+  let telegramDeliverAuthBypass = telegramDeliverAuthBypassRaw === "true";
 
   const telegramTimeoutMs = Number(process.env.GATEWAY_TELEGRAM_TIMEOUT_MS || "15000");
   if (!Number.isFinite(telegramTimeoutMs) || telegramTimeoutMs <= 0) {
@@ -322,7 +322,7 @@ export function loadConfig(): GatewayConfig {
       `GATEWAY_WHATSAPP_DELIVER_AUTH_BYPASS must be "true" or "false", got "${whatsappDeliverAuthBypassRaw}"`,
     );
   }
-  const whatsappDeliverAuthBypass = whatsappDeliverAuthBypassRaw === "true";
+  let whatsappDeliverAuthBypass = whatsappDeliverAuthBypassRaw === "true";
 
   const whatsappTimeoutMs = Number(process.env.GATEWAY_WHATSAPP_TIMEOUT_MS || "15000");
   if (!Number.isFinite(whatsappTimeoutMs) || whatsappTimeoutMs <= 0) {
@@ -349,7 +349,25 @@ export function loadConfig(): GatewayConfig {
       `GATEWAY_SMS_DELIVER_AUTH_BYPASS must be "true" or "false", got "${smsDeliverAuthBypassRaw}"`,
     );
   }
-  const smsDeliverAuthBypass = smsDeliverAuthBypassRaw === "true";
+  let smsDeliverAuthBypass = smsDeliverAuthBypassRaw === "true";
+
+  // Production guard: auth bypass flags must never be active outside dev mode.
+  const appVersion = process.env.APP_VERSION ?? "0.0.0-dev";
+  const isDevMode = appVersion === "0.0.0-dev";
+  if (!isDevMode) {
+    if (telegramDeliverAuthBypass) {
+      log.warn("GATEWAY_TELEGRAM_DELIVER_AUTH_BYPASS is set but ignored in production (APP_VERSION=%s)", appVersion);
+      telegramDeliverAuthBypass = false;
+    }
+    if (smsDeliverAuthBypass) {
+      log.warn("GATEWAY_SMS_DELIVER_AUTH_BYPASS is set but ignored in production (APP_VERSION=%s)", appVersion);
+      smsDeliverAuthBypass = false;
+    }
+    if (whatsappDeliverAuthBypass) {
+      log.warn("GATEWAY_WHATSAPP_DELIVER_AUTH_BYPASS is set but ignored in production (APP_VERSION=%s)", appVersion);
+      whatsappDeliverAuthBypass = false;
+    }
+  }
 
   const ingressPublicBaseUrl = process.env.INGRESS_PUBLIC_BASE_URL || undefined;
 


### PR DESCRIPTION
Add production guard for *DeliverAuthBypass env vars in gateway config. Bypass flags are now forced to false in production mode (APP_VERSION != 0.0.0-dev), with a warning logged if they were set.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
