### PR TITLE
fix: add cause support to error subclasses

### DIFF
--- a/assistant/src/util/errors.ts
+++ b/assistant/src/util/errors.ts
@@ -141,36 +141,36 @@ export class PermissionDeniedError extends AssistantError {
 }
 
 export class ConfigError extends AssistantError {
-  constructor(message: string) {
-    super(message, ErrorCode.CONFIG_ERROR);
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, ErrorCode.CONFIG_ERROR, options);
     this.name = 'ConfigError';
   }
 }
 
 export class DaemonError extends AssistantError {
-  constructor(message: string) {
-    super(message, ErrorCode.DAEMON_ERROR);
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, ErrorCode.DAEMON_ERROR, options);
     this.name = 'DaemonError';
   }
 }
 
 export class IpcError extends AssistantError {
-  constructor(message: string) {
-    super(message, ErrorCode.IPC_ERROR);
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, ErrorCode.IPC_ERROR, options);
     this.name = 'IpcError';
   }
 }
 
 export class PlatformError extends AssistantError {
-  constructor(message: string) {
-    super(message, ErrorCode.PLATFORM_ERROR);
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, ErrorCode.PLATFORM_ERROR, options);
     this.name = 'PlatformError';
   }
 }
 
 export class IntegrityError extends AssistantError {
-  constructor(message: string) {
-    super(message, ErrorCode.INTEGRITY_ERROR);
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, ErrorCode.INTEGRITY_ERROR, options);
     this.name = 'IntegrityError';
   }
 }


### PR DESCRIPTION
Add { cause } parameter support to ConfigError, DaemonError, IpcError, PlatformError, and IntegrityError for standard JavaScript error chaining.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
