### PR TITLE
refactor: extract duplicate stripHopByHop into shared utility

### DIFF
--- a/gateway/src/http/routes/pairing-proxy.ts
+++ b/gateway/src/http/routes/pairing-proxy.ts
@@ -9,43 +9,12 @@
 import type { GatewayConfig } from "../../config.js";
 import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
+import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
 
 const log = getLogger("pairing-proxy");
 
 /** 64 KB — pairing payloads are tiny JSON; cap well below maxWebhookPayloadBytes. */
 const MAX_PAIRING_PAYLOAD_BYTES = 64 * 1024;
-
-const HOP_BY_HOP_HEADERS = [
-  "connection",
-  "keep-alive",
-  "proxy-authenticate",
-  "proxy-authorization",
-  "te",
-  "trailer",
-  "transfer-encoding",
-  "upgrade",
-];
-
-function stripHopByHop(headers: Headers): Headers {
-  const cleaned = new Headers(headers);
-  const connectionValue = cleaned.get("connection");
-  if (connectionValue) {
-    for (const name of connectionValue.split(",")) {
-      const trimmed = name.trim().toLowerCase();
-      if (trimmed) {
-        try {
-          cleaned.delete(trimmed);
-        } catch {
-          // Ignore invalid header names
-        }
-      }
-    }
-  }
-  for (const h of HOP_BY_HOP_HEADERS) {
-    cleaned.delete(h);
-  }
-  return cleaned;
-}
 
 export function createPairingProxyHandler(config: GatewayConfig) {
   const TIMEOUT_MS = 15_000;

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -1,45 +1,11 @@
 import type { GatewayConfig } from "../../config.js";
 import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
+import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
 import { validateBearerToken } from "../auth/bearer.js";
 import { GATEWAY_ORIGIN_HEADER } from "../../runtime/client.js";
 
 const log = getLogger("runtime-proxy");
-
-const HOP_BY_HOP_HEADERS = [
-  "connection",
-  "keep-alive",
-  "proxy-authenticate",
-  "proxy-authorization",
-  "te",
-  "trailer",
-  "transfer-encoding",
-  "upgrade",
-];
-
-function stripHopByHop(headers: Headers): Headers {
-  const cleaned = new Headers(headers);
-
-  // Also strip any headers listed in the Connection header value
-  const connectionValue = cleaned.get("connection");
-  if (connectionValue) {
-    for (const name of connectionValue.split(",")) {
-      const trimmed = name.trim().toLowerCase();
-      if (trimmed) {
-        try {
-          cleaned.delete(trimmed);
-        } catch {
-          // Ignore invalid header names (e.g., malformed Connection tokens like "@@@")
-        }
-      }
-    }
-  }
-
-  for (const h of HOP_BY_HOP_HEADERS) {
-    cleaned.delete(h);
-  }
-  return cleaned;
-}
 
 /**
  * Webhook paths are handled exclusively by the gateway's own route handlers

--- a/gateway/src/util/strip-hop-by-hop.ts
+++ b/gateway/src/util/strip-hop-by-hop.ts
@@ -1,0 +1,34 @@
+const HOP_BY_HOP_HEADERS = [
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+];
+
+export function stripHopByHop(headers: Headers): Headers {
+  const cleaned = new Headers(headers);
+
+  // Also strip any headers listed in the Connection header value
+  const connectionValue = cleaned.get("connection");
+  if (connectionValue) {
+    for (const name of connectionValue.split(",")) {
+      const trimmed = name.trim().toLowerCase();
+      if (trimmed) {
+        try {
+          cleaned.delete(trimmed);
+        } catch {
+          // Ignore invalid header names (e.g., malformed Connection tokens like "@@@")
+        }
+      }
+    }
+  }
+
+  for (const h of HOP_BY_HOP_HEADERS) {
+    cleaned.delete(h);
+  }
+  return cleaned;
+}


### PR DESCRIPTION
Extract the identical stripHopByHop function from runtime-proxy.ts and pairing-proxy.ts into a shared utility module.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8878" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
