### PR TITLE
fix: filter Anthropic-specific thinking config for non-Anthropic providers

### DIFF
--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -29,12 +29,19 @@ function normalizeSendMessageOptions(providerName: string, options?: SendMessage
   const intent = isModelIntent(config.modelIntent) ? config.modelIntent : undefined;
   const hasIntent = config.modelIntent !== undefined;
 
-  if (!hasIntent && explicitModel === config.model) {
+  const needsThinkingStrip = providerName !== 'anthropic' && config.thinking !== undefined;
+
+  if (!hasIntent && explicitModel === config.model && !needsThinkingStrip) {
     return options;
   }
 
   const nextConfig: Record<string, unknown> = { ...config };
   delete nextConfig.modelIntent;
+
+  // thinking/budget_tokens is Anthropic-specific; strip it for other providers
+  if (providerName !== 'anthropic' && nextConfig.thinking !== undefined) {
+    delete nextConfig.thinking;
+  }
 
   if (explicitModel) {
     nextConfig.model = explicitModel;


### PR DESCRIPTION
Strip the thinking/budget_tokens config from providerConfig when the active provider is not Anthropic. Previously this Anthropic-specific config was passed to all providers unfiltered.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
