### PR TITLE
refactor: add proper setter for preactivatedSkillIds on Session

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -305,7 +305,7 @@ export async function handleSessionCreate(
   // Pre-activate skills before sending session_info so they're available
   // for the initial message processing.
   if (msg.preactivatedSkillIds?.length) {
-    session.preactivatedSkillIds = msg.preactivatedSkillIds;
+    session.setPreactivatedSkillIds(msg.preactivatedSkillIds);
   }
 
   ctx.send(socket, {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -843,7 +843,7 @@ export class DaemonServer {
     const resolvedContent = slashResult.content;
 
     if (slashResult.kind === 'rewritten') {
-      (session as unknown as { preactivatedSkillIds?: string[] }).preactivatedSkillIds = [slashResult.skillId];
+      session.setPreactivatedSkillIds([slashResult.skillId]);
     }
 
     const requestId = crypto.randomUUID();
@@ -851,7 +851,7 @@ export class DaemonServer {
     try {
       messageId = session.persistUserMessage(resolvedContent, attachments, requestId);
     } catch (err) {
-      (session as unknown as { preactivatedSkillIds?: string[] }).preactivatedSkillIds = undefined;
+      session.setPreactivatedSkillIds(undefined);
       throw err;
     }
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -358,6 +358,10 @@ export class Session {
     this.commandIntent = intent ?? undefined;
   }
 
+  setPreactivatedSkillIds(ids: string[] | undefined): void {
+    this.preactivatedSkillIds = ids;
+  }
+
   setTurnChannelContext(ctx: TurnChannelContext): void {
     this.currentTurnChannelContext = ctx;
   }


### PR DESCRIPTION
Replace unsafe (session as unknown as ...) casts with a proper setPreactivatedSkillIds() method on Session class.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8881" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
