### PR TITLE
perf: add index on memoryItemSources.memoryItemId

### DIFF
--- a/assistant/src/memory/migrations/023-memory-item-sources-indexes.ts
+++ b/assistant/src/memory/migrations/023-memory-item-sources-indexes.ts
@@ -1,0 +1,10 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Idempotent migration to add an index on memory_item_sources.memory_item_id.
+ * This column is used in inArray() queries in the memory retriever and as a
+ * foreign key with ON DELETE CASCADE — both benefit from an index.
+ */
+export function migrateMemoryItemSourcesIndexes(database: DrizzleDb): void {
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_item_sources_memory_item_id ON memory_item_sources(memory_item_id)`);
+}

--- a/assistant/src/memory/migrations/113-late-migrations.ts
+++ b/assistant/src/memory/migrations/113-late-migrations.ts
@@ -7,6 +7,7 @@ import { migrateRemainingTableIndexes } from './018-remaining-table-indexes.js';
 import { migrateRenameChannelToVellum } from './020-rename-macos-ios-channel-to-vellum.js';
 import { migrateConversationStatusIndexes } from './021-conversation-status-indexes.js';
 import { migrateAddOriginInterface } from './022-add-origin-interface.js';
+import { migrateMemoryItemSourcesIndexes } from './023-memory-item-sources-indexes.js';
 
 /**
  * Late-stage migrations that must run after all tables and indexes exist:
@@ -21,4 +22,5 @@ export function runLateMigrations(database: DrizzleDb): void {
   migrateRenameChannelToVellum(database);
   migrateConversationStatusIndexes(database);
   migrateAddOriginInterface(database);
+  migrateMemoryItemSourcesIndexes(database);
 }

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -26,6 +26,7 @@ export { migrateNotificationTablesSchema } from './019-notification-tables-schem
 export { migrateRenameChannelToVellum } from './020-rename-macos-ios-channel-to-vellum.js';
 export { migrateConversationStatusIndexes } from './021-conversation-status-indexes.js';
 export { migrateAddOriginInterface } from './022-add-origin-interface.js';
+export { migrateMemoryItemSourcesIndexes } from './023-memory-item-sources-indexes.js';
 export { createCoreTables } from './100-core-tables.js';
 export { createWatchersAndLogsTables } from './101-watchers-and-logs.js';
 export { addCoreColumns } from './102-alter-table-columns.js';

--- a/assistant/src/memory/schema-migration.ts
+++ b/assistant/src/memory/schema-migration.ts
@@ -24,4 +24,5 @@ export {
   migrateMemoryItemsIndexes,
   migrateRemainingTableIndexes,
   migrateAddOriginInterface,
+  migrateMemoryItemSourcesIndexes,
 } from './migrations/index.js';

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -99,7 +99,9 @@ export const memoryItemSources = sqliteTable('memory_item_sources', {
     .references(() => messages.id, { onDelete: 'cascade' }),
   evidence: text('evidence'),
   createdAt: integer('created_at').notNull(),
-});
+}, (table) => [
+  index('idx_memory_item_sources_memory_item_id').on(table.memoryItemId),
+]);
 
 export const memoryItemConflicts = sqliteTable('memory_item_conflicts', {
   id: text('id').primaryKey(),


### PR DESCRIPTION
Add database index on memoryItemSources.memoryItemId join table column. This table is frequently queried via inArray() in the memory retriever but had no index, causing full table scans.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
