### PR TITLE
security: add authentication to Twilio WebSocket relay endpoint

### DIFF
--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -29,6 +29,7 @@ import { fireCallCompletionNotifier } from './call-state.js';
 import { persistCallCompletionMessage } from './call-conversation-messages.js';
 import { resolveVoiceQualityProfile, isVoiceProfileValid } from './voice-quality.js';
 import { createInboundVoiceSession } from './call-domain.js';
+import { readHttpToken } from '../util/platform.js';
 
 const log = getLogger('twilio-routes');
 
@@ -48,15 +49,17 @@ export function generateTwiML(
   relayUrl: string,
   welcomeGreeting: string | null,
   profile: { language: string; transcriptionProvider: string; ttsProvider: string; voice: string },
+  relayToken?: string,
 ): string {
   const greetingAttr = welcomeGreeting && welcomeGreeting.trim().length > 0
     ? `\n      welcomeGreeting="${escapeXml(welcomeGreeting.trim())}"`
     : '';
+  const tokenParam = relayToken ? `&amp;token=${escapeXml(encodeURIComponent(relayToken))}` : '';
   return `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <Connect>
     <ConversationRelay
-      url="${escapeXml(relayUrl)}?callSessionId=${escapeXml(callSessionId)}"
+      url="${escapeXml(relayUrl)}?callSessionId=${escapeXml(callSessionId)}${tokenParam}"
 ${greetingAttr}
       voice="${escapeXml(profile.voice)}"
       language="${escapeXml(profile.language)}"
@@ -237,7 +240,12 @@ function buildVoiceWebhookTwiml(
   }
   const welcomeGreeting = buildWelcomeGreeting(task, getCallWelcomeGreeting());
 
-  const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, profile);
+  // Include the gateway bearer token so the WebSocket relay endpoint can
+  // authenticate the connection. Without this, any client that guesses a
+  // callSessionId could inject frames into a live call.
+  const relayToken = readHttpToken() ?? undefined;
+
+  const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, profile, relayToken);
 
   log.info({ callSessionId }, 'Returning ConversationRelay TwiML');
 

--- a/gateway/src/__tests__/twilio-relay-websocket.test.ts
+++ b/gateway/src/__tests__/twilio-relay-websocket.test.ts
@@ -122,6 +122,8 @@ function createFakeUpstreamWs() {
 // ---------------------------------------------------------------------------
 
 describe("createTwilioRelayWebsocketHandler", () => {
+  const TEST_TOKEN = "test-relay-token-abc123";
+
   test("returns 400 when callSessionId is missing", () => {
     const handler = createTwilioRelayWebsocketHandler(makeConfig());
     const req = new Request("http://localhost:7830/ws/twilio/relay");
@@ -133,11 +135,11 @@ describe("createTwilioRelayWebsocketHandler", () => {
     expect(fakeServer.upgrade).not.toHaveBeenCalled();
   });
 
-  test("calls server.upgrade with callSessionId and config on valid request", () => {
-    const config = makeConfig();
+  test("calls server.upgrade with callSessionId and config on valid request with query token", () => {
+    const config = makeConfig({ runtimeProxyBearerToken: TEST_TOKEN });
     const handler = createTwilioRelayWebsocketHandler(config);
     const req = new Request(
-      "http://localhost:7830/ws/twilio/relay?callSessionId=sess-42",
+      `http://localhost:7830/ws/twilio/relay?callSessionId=sess-42&token=${TEST_TOKEN}`,
     );
     const fakeServer = { upgrade: mock(() => true) } as unknown as import("bun").Server<any>;
     const res = handler(req, fakeServer);
@@ -153,16 +155,87 @@ describe("createTwilioRelayWebsocketHandler", () => {
     expect(upgradeData.config).toBe(config);
   });
 
-  test("returns 500 when server.upgrade fails", () => {
-    const handler = createTwilioRelayWebsocketHandler(makeConfig());
+  test("calls server.upgrade when Authorization header provides valid token", () => {
+    const config = makeConfig({ runtimeProxyBearerToken: TEST_TOKEN });
+    const handler = createTwilioRelayWebsocketHandler(config);
     const req = new Request(
-      "http://localhost:7830/ws/twilio/relay?callSessionId=sess-1",
+      "http://localhost:7830/ws/twilio/relay?callSessionId=sess-42",
+      { headers: { authorization: `Bearer ${TEST_TOKEN}` } },
+    );
+    const fakeServer = { upgrade: mock(() => true) } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeUndefined();
+    expect(fakeServer.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns 500 when server.upgrade fails", () => {
+    const config = makeConfig({ runtimeProxyBearerToken: TEST_TOKEN });
+    const handler = createTwilioRelayWebsocketHandler(config);
+    const req = new Request(
+      `http://localhost:7830/ws/twilio/relay?callSessionId=sess-1&token=${TEST_TOKEN}`,
     );
     const fakeServer = { upgrade: mock(() => false) } as unknown as import("bun").Server<any>;
     const res = handler(req, fakeServer);
 
     expect(res).toBeInstanceOf(Response);
     expect(res!.status).toBe(500);
+  });
+
+  // --- Auth tests ---
+
+  test("returns 503 when no bearer token is configured and bypass is off", () => {
+    const handler = createTwilioRelayWebsocketHandler(makeConfig());
+    const req = new Request(
+      "http://localhost:7830/ws/twilio/relay?callSessionId=sess-1",
+    );
+    const fakeServer = { upgrade: mock(() => true) } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(503);
+    expect(fakeServer.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("allows upgrade when no token configured but smsDeliverAuthBypass is true", () => {
+    const config = makeConfig({ smsDeliverAuthBypass: true });
+    const handler = createTwilioRelayWebsocketHandler(config);
+    const req = new Request(
+      "http://localhost:7830/ws/twilio/relay?callSessionId=sess-1",
+    );
+    const fakeServer = { upgrade: mock(() => true) } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeUndefined();
+    expect(fakeServer.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns 401 when token is missing from request", () => {
+    const config = makeConfig({ runtimeProxyBearerToken: TEST_TOKEN });
+    const handler = createTwilioRelayWebsocketHandler(config);
+    const req = new Request(
+      "http://localhost:7830/ws/twilio/relay?callSessionId=sess-1",
+    );
+    const fakeServer = { upgrade: mock(() => true) } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(401);
+    expect(fakeServer.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("returns 401 when token is wrong", () => {
+    const config = makeConfig({ runtimeProxyBearerToken: TEST_TOKEN });
+    const handler = createTwilioRelayWebsocketHandler(config);
+    const req = new Request(
+      "http://localhost:7830/ws/twilio/relay?callSessionId=sess-1&token=wrong-token",
+    );
+    const fakeServer = { upgrade: mock(() => true) } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(401);
+    expect(fakeServer.upgrade).not.toHaveBeenCalled();
   });
 });
 

--- a/gateway/src/http/routes/twilio-relay-websocket.ts
+++ b/gateway/src/http/routes/twilio-relay-websocket.ts
@@ -1,5 +1,6 @@
 import type { GatewayConfig } from "../../config.js";
 import { getLogger } from "../../logger.js";
+import { validateBearerToken } from "../auth/bearer.js";
 
 const log = getLogger("twilio-relay-ws");
 
@@ -27,6 +28,12 @@ export function createTwilioRelayWebsocketHandler(config: GatewayConfig) {
       return new Response("Missing callSessionId", { status: 400 });
     }
 
+    // Authenticate before upgrading. Twilio ConversationRelay passes the
+    // token as a query parameter since WebSocket upgrades don't support
+    // arbitrary headers.
+    const authResponse = checkRelayAuth(req, url, config);
+    if (authResponse) return authResponse;
+
     const upgraded = server.upgrade(req, {
       data: { callSessionId, config },
     });
@@ -38,6 +45,44 @@ export function createTwilioRelayWebsocketHandler(config: GatewayConfig) {
     // Return undefined to indicate upgrade was handled
     return undefined;
   };
+}
+
+/**
+ * Validate the relay WebSocket upgrade request.
+ *
+ * Accepts a bearer token via:
+ *   1. `Authorization: Bearer <token>` header (standard clients)
+ *   2. `token` query parameter (Twilio ConversationRelay — no custom headers)
+ *
+ * Fail-closed: rejects when no token is configured unless the SMS deliver
+ * auth bypass flag is set (reusing the same local-dev escape hatch).
+ */
+function checkRelayAuth(
+  req: Request,
+  url: URL,
+  config: GatewayConfig,
+): Response | null {
+  if (!config.runtimeProxyBearerToken) {
+    if (config.smsDeliverAuthBypass) {
+      return null;
+    }
+    log.error("Relay WS: no bearer token configured — rejecting (fail-closed)");
+    return new Response("Service not configured: bearer token required", { status: 503 });
+  }
+
+  // Try Authorization header first, then fall back to query param
+  const authHeader = req.headers.get("authorization");
+  const queryToken = url.searchParams.get("token");
+
+  const tokenSource = authHeader ?? (queryToken ? `Bearer ${queryToken}` : null);
+
+  const result = validateBearerToken(tokenSource, config.runtimeProxyBearerToken);
+  if (!result.authorized) {
+    log.warn({ reason: result.reason }, "Relay WS: authentication failed");
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  return null;
 }
 
 /**


### PR DESCRIPTION
Add bearer token validation to the WebSocket relay endpoint before allowing upgrades. Previously, any client that guessed a callSessionId could inject frames into live voice calls.

Changes:
- Gateway: Added checkRelayAuth() to validate bearer token (via Authorization header or query param) before WebSocket upgrade. Fail-closed when no token is configured.
- Assistant: Updated generateTwiML() to include the gateway bearer token in the ConversationRelay WebSocket URL so Twilio passes it on connection.
- Tests: Updated existing tests to supply valid tokens, added new tests for auth rejection scenarios (missing token, wrong token, no config, bypass).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
