### PR TITLE
security: fail instead of starting gateway unauthenticated on token timeout

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -318,12 +318,13 @@ export async function startGateway(): Promise<string> {
 
   // If no token is available (first startup — daemon hasn't written it yet),
   // poll for the file to appear. The daemon writes the token shortly after
-  // startup, so a short wait avoids starting the gateway without auth
-  // (which would leave it permanently unauthenticated since the gateway
-  // config is loaded once at startup and never reloads).
+  // startup, so we wait generously — the daemon socket wait is 15s, and
+  // the token may be written after the socket. Starting the gateway without
+  // auth is a security risk since the config is loaded once at startup and
+  // never reloads, so we fail rather than silently disabling auth.
   if (!runtimeProxyBearerToken) {
     console.log("   Waiting for bearer token file...");
-    const maxWait = 10000;
+    const maxWait = 30000;
     const pollInterval = 500;
     const start = Date.now();
     while (Date.now() - start < maxWait) {
@@ -340,24 +341,21 @@ export async function startGateway(): Promise<string> {
     }
   }
 
-  // If the token still isn't available after polling, fall back to starting
-  // the gateway without auth so it doesn't block forever. This is a degraded
-  // mode — the proxy will be broken because the runtime expects a token.
-  const proxyRequireAuth = runtimeProxyBearerToken ? "true" : "false";
   if (!runtimeProxyBearerToken) {
-    console.log("   ⚠️  Bearer token not found after 10s — gateway proxy auth disabled");
+    throw new Error(
+      `Bearer token file not found at ${httpTokenPath} after 30s.\n` +
+        "  The gateway cannot start without authentication — this would leave the proxy permanently unauthenticated.\n" +
+        "  Ensure the daemon is running and has written the token file, or set VELLUM_HTTP_TOKEN_PATH to the correct path.",
+    );
   }
 
   const gatewayEnv: Record<string, string> = {
     ...process.env as Record<string, string>,
     GATEWAY_RUNTIME_PROXY_ENABLED: "true",
-    GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH: proxyRequireAuth,
+    GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH: "true",
+    RUNTIME_PROXY_BEARER_TOKEN: runtimeProxyBearerToken,
     RUNTIME_HTTP_PORT: process.env.RUNTIME_HTTP_PORT || "7821",
   };
-
-  if (runtimeProxyBearerToken) {
-    gatewayEnv.RUNTIME_PROXY_BEARER_TOKEN = runtimeProxyBearerToken;
-  }
 
   if (process.env.GATEWAY_UNMAPPED_POLICY) {
     gatewayEnv.GATEWAY_UNMAPPED_POLICY = process.env.GATEWAY_UNMAPPED_POLICY;


### PR DESCRIPTION
Instead of silently disabling auth when the token file doesn't appear within 10s, increase retry timeout to 30s and fail with an error rather than starting the gateway unauthenticated. The gateway config is loaded once at startup and never reloads, so starting without auth would leave the proxy permanently unauthenticated for that session.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
