### PR TITLE
fix: enable Logfire LLM observability in production

### DIFF
--- a/assistant/src/logfire.ts
+++ b/assistant/src/logfire.ts
@@ -8,7 +8,6 @@ const log = getLogger('logfire');
 type LogfireModule = typeof import('@pydantic/logfire-node');
 
 const LOGFIRE_ENABLED: boolean =
-  APP_VERSION === '0.0.0-dev' &&
   !!getLogfireToken() &&
   isMonitoringEnabled();
 


### PR DESCRIPTION
Remove the dev-only APP_VERSION gate on Logfire initialization. Logfire is now enabled in all environments when VELLUM_ENABLE_MONITORING=1 and LOGFIRE_TOKEN are set.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
