### PR TITLE
fix: use production platform URL as default instead of dev URL

### DIFF
--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -371,7 +371,11 @@ final class AssistantCli {
         env["VELLUM_DESKTOP_APP"] = "1"
 
         if env["VELLUM_ASSISTANT_PLATFORM_URL"] == nil {
+            #if DEBUG
             env["VELLUM_ASSISTANT_PLATFORM_URL"] = "https://dev-assistant.vellum.ai"
+            #else
+            env["VELLUM_ASSISTANT_PLATFORM_URL"] = "https://assistant.vellum.ai"
+            #endif
         }
 
         if !config.anthropicApiKey.isEmpty {


### PR DESCRIPTION
Replace the hardcoded dev-assistant.vellum.ai URL with a build-configuration-aware default in runRemoteHatch. Debug builds use dev-assistant.vellum.ai, Release builds use assistant.vellum.ai. Previously, all builds defaulted to the dev URL.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
