### PR TITLE
security: add bearer auth to /integrations/status endpoint

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1296,7 +1296,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             bearerToken = httpTransport.bearerToken
         } else if let gatewayBaseURL {
             baseURL = gatewayBaseURL
-            bearerToken = nil
+            bearerToken = readHttpToken()
         } else {
             return nil
         }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -19,6 +19,7 @@ import { createWhatsAppWebhookHandler } from "./http/routes/whatsapp-webhook.js"
 import { createWhatsAppDeliverHandler } from "./http/routes/whatsapp-deliver.js";
 import { createOAuthCallbackHandler } from "./http/routes/oauth-callback.js";
 import { createPairingProxyHandler } from "./http/routes/pairing-proxy.js";
+import { validateBearerToken } from "./http/auth/bearer.js";
 import { getLogger, initLogger } from "./logger.js";
 import { CircuitBreakerOpenError } from "./runtime/client.js";
 import { buildSchema } from "./schema.js";
@@ -240,6 +241,19 @@ function main() {
       }
 
       if (url.pathname === "/integrations/status" && req.method === "GET") {
+        if (!config.runtimeProxyBearerToken) {
+          return Response.json(
+            { error: "Service not configured: bearer token required" },
+            { status: 503 },
+          );
+        }
+        const authResult = validateBearerToken(
+          tracedReq.headers.get("authorization"),
+          config.runtimeProxyBearerToken,
+        );
+        if (!authResult.authorized) {
+          return Response.json({ error: "Unauthorized" }, { status: 401 });
+        }
         return Response.json({
           email: {
             address: config.assistantEmail ?? null,

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -730,14 +730,31 @@ export function buildSchema(): Record<string, unknown> {
         get: {
           summary: "Integration status",
           description:
-            "Returns the current status of configured integrations, including the assistant's email address. The desktop app uses this endpoint to display integration info in its settings UI.",
+            "Returns the current status of configured integrations, including the assistant's email address. Requires a valid bearer token.",
           operationId: "integrationsStatus",
+          security: [{ BearerAuth: [] }],
           responses: {
             "200": {
               description: "Integration status",
               content: {
                 "application/json": {
                   schema: { $ref: "#/components/schemas/IntegrationsStatusResponse" },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "503": {
+              description: "Bearer token not configured",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
                 },
               },
             },


### PR DESCRIPTION
Add bearer token authentication to the /integrations/status endpoint which previously exposed the assistant email address without authentication.

Changes:
- gateway/src/index.ts: Added bearer token validation using validateBearerToken before returning integration status
- clients/shared/IPC/DaemonClient.swift: Updated local connection path to read bearer token from disk via readHttpToken()
- gateway/src/schema.ts: Added BearerAuth security requirement and 401/503 error responses to the endpoint schema
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
