### PR TITLE
test: add unit tests for web_fetch SSRF protection

### DIFF
--- a/assistant/src/__tests__/url-safety.test.ts
+++ b/assistant/src/__tests__/url-safety.test.ts
@@ -164,6 +164,31 @@ describe('url-safety helpers', () => {
       expect(isPrivateIPv4('100.64.0.1')).toBe(true);
       expect(isPrivateIPv4('100.127.255.255')).toBe(true);
     });
+
+    test('boundary: 172.15 is public but 172.16 is private', () => {
+      expect(isPrivateIPv4('172.15.255.255')).toBe(false);
+      expect(isPrivateIPv4('172.16.0.0')).toBe(true);
+      expect(isPrivateIPv4('172.31.255.255')).toBe(true);
+      expect(isPrivateIPv4('172.32.0.0')).toBe(false);
+    });
+
+    test('boundary: CGNAT edges (100.63 public, 100.64 private, 100.127 private, 100.128 public)', () => {
+      expect(isPrivateIPv4('100.63.255.255')).toBe(false);
+      expect(isPrivateIPv4('100.64.0.0')).toBe(true);
+      expect(isPrivateIPv4('100.127.0.0')).toBe(true);
+      expect(isPrivateIPv4('100.128.0.0')).toBe(false);
+    });
+
+    test('boundary: benchmarking range edges (198.17 public, 198.18 private, 198.19 private, 198.20 public)', () => {
+      expect(isPrivateIPv4('198.17.255.255')).toBe(false);
+      expect(isPrivateIPv4('198.18.0.0')).toBe(true);
+      expect(isPrivateIPv4('198.19.0.0')).toBe(true);
+      expect(isPrivateIPv4('198.20.0.0')).toBe(false);
+    });
+
+    test('AWS metadata IP 169.254.169.254 is classified as private', () => {
+      expect(isPrivateIPv4('169.254.169.254')).toBe(true);
+    });
   });
 
   // ── unwrapBracketedHostname ──────────────────────────────────
@@ -295,9 +320,46 @@ describe('url-safety helpers', () => {
       expect(isPrivateOrLocalHost('::1')).toBe(true);
     });
 
+    test('detects .local mDNS suffix', () => {
+      expect(isPrivateOrLocalHost('my-nas.local')).toBe(true);
+      expect(isPrivateOrLocalHost('printer.local')).toBe(true);
+    });
+
+    test('detects link-local 169.254.x.x (cloud metadata)', () => {
+      expect(isPrivateOrLocalHost('169.254.169.254')).toBe(true);
+    });
+
+    test('detects CGNAT range', () => {
+      expect(isPrivateOrLocalHost('100.100.100.100')).toBe(true);
+    });
+
+    test('detects IPv6 unique local addresses', () => {
+      expect(isPrivateOrLocalHost('fc00::1')).toBe(true);
+      expect(isPrivateOrLocalHost('fd12:3456::1')).toBe(true);
+    });
+
+    test('detects IPv6 link-local addresses', () => {
+      expect(isPrivateOrLocalHost('fe80::1')).toBe(true);
+    });
+
+    test('detects IPv4-mapped IPv6 private addresses', () => {
+      expect(isPrivateOrLocalHost('[::ffff:127.0.0.1]')).toBe(true);
+      expect(isPrivateOrLocalHost('[::ffff:10.0.0.1]')).toBe(true);
+      expect(isPrivateOrLocalHost('[::ffff:192.168.1.1]')).toBe(true);
+    });
+
     test('does not flag public hosts', () => {
       expect(isPrivateOrLocalHost('example.com')).toBe(false);
       expect(isPrivateOrLocalHost('93.184.216.34')).toBe(false);
+    });
+
+    test('does not flag public IPv6 addresses', () => {
+      expect(isPrivateOrLocalHost('2001:db8::1')).toBe(false);
+    });
+
+    test('handles case-insensitive hostnames', () => {
+      expect(isPrivateOrLocalHost('Metadata.Google.Internal')).toBe(true);
+      expect(isPrivateOrLocalHost('My-NAS.Local')).toBe(true);
     });
   });
 
@@ -352,6 +414,52 @@ describe('url-safety helpers', () => {
         false,
       );
       expect(result.addresses).toEqual(['93.184.216.34']);
+    });
+
+    test('blocks IPv6 loopback literal when not allowed', async () => {
+      const result = await resolveRequestAddress('[::1]', async () => [], false);
+      expect(result.blockedAddress).toBe('::1');
+      expect(result.addresses).toEqual([]);
+    });
+
+    test('allows IPv6 loopback literal when allowed', async () => {
+      const result = await resolveRequestAddress('[::1]', async () => [], true);
+      expect(result.blockedAddress).toBeUndefined();
+      expect(result.addresses).toEqual(['::1']);
+    });
+
+    test('blocks hostname resolving to IPv6 loopback', async () => {
+      const result = await resolveRequestAddress(
+        'example.com',
+        async () => ['::1'],
+        false,
+      );
+      expect(result.blockedAddress).toBe('::1');
+    });
+
+    test('blocks hostname resolving to link-local address', async () => {
+      const result = await resolveRequestAddress(
+        'example.com',
+        async () => ['169.254.169.254'],
+        false,
+      );
+      expect(result.blockedAddress).toBe('169.254.169.254');
+    });
+
+    test('blocks any private address in a list of mixed addresses', async () => {
+      const result = await resolveRequestAddress(
+        'example.com',
+        async () => ['93.184.216.34', '10.0.0.1', '203.0.113.1'],
+        false,
+      );
+      expect(result.blockedAddress).toBe('10.0.0.1');
+      expect(result.addresses).toEqual([]);
+    });
+
+    test('allows public IPv4 literal when not allowed', async () => {
+      const result = await resolveRequestAddress('8.8.8.8', async () => [], false);
+      expect(result.blockedAddress).toBeUndefined();
+      expect(result.addresses).toEqual(['8.8.8.8']);
     });
   });
 

--- a/assistant/src/__tests__/web-fetch.test.ts
+++ b/assistant/src/__tests__/web-fetch.test.ts
@@ -107,6 +107,8 @@ describe('web_fetch tool', () => {
     expect(requestedUrl).toBe('https://example.com:8443/docs');
   });
 
+  // ── SSRF protection: direct IP/hostname blocking ──────────────
+
   test('blocks localhost targets unless explicitly enabled', async () => {
     let called = false;
     globalThis.fetch = (async () => {
@@ -118,6 +120,150 @@ describe('web_fetch tool', () => {
     }) as any;
 
     const result = await executeWithMockFetch({ url: 'http://localhost:3000/health' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Refusing to fetch local/private network target');
+    expect(called).toBe(false);
+  });
+
+  test('blocks 127.0.0.1 loopback targets', async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response('ok', {
+        status: 200,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }) as any;
+
+    const result = await executeWithMockFetch({ url: 'http://127.0.0.1:8080/admin' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Refusing to fetch local/private network target');
+    expect(called).toBe(false);
+  });
+
+  test('blocks 10.x.x.x private network targets', async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response('ok', {
+        status: 200,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }) as any;
+
+    const result = await executeWithMockFetch({ url: 'http://10.0.0.1/internal' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Refusing to fetch local/private network target');
+    expect(called).toBe(false);
+  });
+
+  test('blocks 192.168.x.x private network targets', async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response('ok', {
+        status: 200,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }) as any;
+
+    const result = await executeWithMockFetch({ url: 'http://192.168.1.1/' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Refusing to fetch local/private network target');
+    expect(called).toBe(false);
+  });
+
+  test('blocks 172.16-31.x.x private network targets', async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response('ok', {
+        status: 200,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }) as any;
+
+    const result = await executeWithMockFetch({ url: 'http://172.16.0.1/' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Refusing to fetch local/private network target');
+    expect(called).toBe(false);
+  });
+
+  test('blocks 169.254.x.x link-local targets', async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response('ok', {
+        status: 200,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }) as any;
+
+    const result = await executeWithMockFetch({ url: 'http://169.254.169.254/latest/meta-data/' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Refusing to fetch local/private network target');
+    expect(called).toBe(false);
+  });
+
+  test('blocks 0.0.0.0 targets', async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response('ok', {
+        status: 200,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }) as any;
+
+    const result = await executeWithMockFetch({ url: 'http://0.0.0.0/' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Refusing to fetch local/private network target');
+    expect(called).toBe(false);
+  });
+
+  test('blocks cloud metadata endpoint (metadata.google.internal)', async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response('ok', {
+        status: 200,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }) as any;
+
+    const result = await executeWithMockFetch({ url: 'http://metadata.google.internal/computeMetadata/v1/' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Refusing to fetch local/private network target');
+    expect(called).toBe(false);
+  });
+
+  test('blocks .local mDNS suffix targets', async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response('ok', {
+        status: 200,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }) as any;
+
+    const result = await executeWithMockFetch({ url: 'http://my-nas.local/admin' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Refusing to fetch local/private network target');
+    expect(called).toBe(false);
+  });
+
+  test('blocks CGNAT range 100.64-127.x.x targets', async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response('ok', {
+        status: 200,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }) as any;
+
+    const result = await executeWithMockFetch({ url: 'http://100.100.100.100/' });
     expect(result.isError).toBe(true);
     expect(result.content).toContain('Refusing to fetch local/private network target');
     expect(called).toBe(false);
@@ -169,6 +315,282 @@ describe('web_fetch tool', () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain('Refusing to fetch local/private network target');
     expect(called).toBe(false);
+  });
+
+  test('allows public IP addresses', async () => {
+    const result = await executeWithMockFetch(
+      { url: 'http://93.184.216.34/page' },
+      {
+        resolveHostAddresses: async () => ['93.184.216.34'],
+        requestExecutor: async () =>
+          new Response('public content', {
+            status: 200,
+            headers: { 'content-type': 'text/plain; charset=utf-8' },
+          }),
+      },
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('public content');
+  });
+
+  test('allows public hostnames that resolve to public IPs', async () => {
+    const result = await executeWithMockFetch(
+      { url: 'https://example.com/page' },
+      {
+        resolveHostAddresses: async () => ['93.184.216.34'],
+        requestExecutor: async () =>
+          new Response('public content', {
+            status: 200,
+            headers: { 'content-type': 'text/plain; charset=utf-8' },
+          }),
+      },
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('public content');
+  });
+
+  // ── SSRF protection: DNS rebinding ────────────────────────────
+
+  test('blocks hostnames that resolve to private addresses unless explicitly enabled', async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response('ok', {
+        status: 200,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }) as any;
+
+    const result = await executeWithMockFetch(
+      { url: 'https://evil.example.com/health' },
+      {
+        resolveHostAddresses: async () => ['10.0.0.5'],
+      },
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('resolves to local/private network address 10.0.0.5');
+    expect(called).toBe(false);
+  });
+
+  test('blocks hostnames that resolve to loopback via DNS rebinding', async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response('ok', {
+        status: 200,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }) as any;
+
+    const result = await executeWithMockFetch(
+      { url: 'https://rebind.example.com/steal' },
+      {
+        resolveHostAddresses: async () => ['127.0.0.1'],
+      },
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('resolves to local/private network address 127.0.0.1');
+    expect(called).toBe(false);
+  });
+
+  test('blocks hostnames that resolve to IPv6 loopback via DNS', async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response('ok', {
+        status: 200,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }) as any;
+
+    const result = await executeWithMockFetch(
+      { url: 'https://evil.example.com/steal' },
+      {
+        resolveHostAddresses: async () => ['::1'],
+      },
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('resolves to local/private network address ::1');
+    expect(called).toBe(false);
+  });
+
+  test('blocks hostnames resolving to link-local 169.254.x.x (AWS metadata)', async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response('ok', {
+        status: 200,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }) as any;
+
+    const result = await executeWithMockFetch(
+      { url: 'https://evil.example.com/metadata' },
+      {
+        resolveHostAddresses: async () => ['169.254.169.254'],
+      },
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('resolves to local/private network address 169.254.169.254');
+    expect(called).toBe(false);
+  });
+
+  test('blocks when any resolved address is private (mixed public/private DNS)', async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response('ok', {
+        status: 200,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }) as any;
+
+    const result = await executeWithMockFetch(
+      { url: 'https://dual.example.com/' },
+      {
+        resolveHostAddresses: async () => ['93.184.216.34', '192.168.1.1'],
+      },
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('resolves to local/private network address 192.168.1.1');
+    expect(called).toBe(false);
+  });
+
+  // ── SSRF protection: redirect-to-internal-IP ──────────────────
+
+  test('blocks redirects to 10.x.x.x private targets', async () => {
+    let callCount = 0;
+    globalThis.fetch = (async (_url: string) => {
+      callCount++;
+      if (callCount === 1) {
+        return new Response('', {
+          status: 302,
+          headers: { location: 'http://10.0.0.1/internal' },
+        });
+      }
+      return new Response('should-not-be-fetched', {
+        status: 200,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }) as any;
+
+    const result = await executeWithMockFetch({ url: 'https://example.com/start' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Refusing redirect to local/private network target');
+    expect(callCount).toBe(1);
+  });
+
+  test('blocks redirects to 192.168.x.x private targets', async () => {
+    let callCount = 0;
+    globalThis.fetch = (async (_url: string) => {
+      callCount++;
+      if (callCount === 1) {
+        return new Response('', {
+          status: 302,
+          headers: { location: 'http://192.168.0.1/admin' },
+        });
+      }
+      return new Response('should-not-be-fetched', {
+        status: 200,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }) as any;
+
+    const result = await executeWithMockFetch({ url: 'https://example.com/start' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Refusing redirect to local/private network target');
+    expect(callCount).toBe(1);
+  });
+
+  test('blocks redirects to 169.254.169.254 (cloud metadata via redirect)', async () => {
+    let callCount = 0;
+    globalThis.fetch = (async (_url: string) => {
+      callCount++;
+      if (callCount === 1) {
+        return new Response('', {
+          status: 302,
+          headers: { location: 'http://169.254.169.254/latest/meta-data/' },
+        });
+      }
+      return new Response('should-not-be-fetched', {
+        status: 200,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }) as any;
+
+    const result = await executeWithMockFetch({ url: 'https://example.com/start' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Refusing redirect to local/private network target');
+    expect(callCount).toBe(1);
+  });
+
+  test('blocks redirect chain where intermediate hop resolves to private IP', async () => {
+    let callCount = 0;
+
+    const result = await executeWithMockFetch(
+      { url: 'https://example.com/start' },
+      {
+        resolveHostAddresses: async (hostname) => {
+          if (hostname === 'example.com') return ['93.184.216.34'];
+          if (hostname === 'evil-redirect.example') return ['192.168.1.100'];
+          return ['93.184.216.34'];
+        },
+        requestExecutor: async (_url, requestOptions) => {
+          callCount++;
+          if (callCount === 1) {
+            return new Response('', {
+              status: 302,
+              headers: { location: 'https://evil-redirect.example/steal' },
+            });
+          }
+          return new Response('should-not-be-fetched', {
+            status: 200,
+            headers: { 'content-type': 'text/plain; charset=utf-8' },
+          });
+        },
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('resolves to local/private network address 192.168.1.100');
+    expect(callCount).toBe(1);
+  });
+
+  test('blocks redirect to non-http protocol', async () => {
+    let callCount = 0;
+    globalThis.fetch = (async (_url: string) => {
+      callCount++;
+      if (callCount === 1) {
+        return new Response('', {
+          status: 302,
+          headers: { location: 'file:///etc/passwd' },
+        });
+      }
+      return new Response('should-not-be-fetched', {
+        status: 200,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }) as any;
+
+    const result = await executeWithMockFetch({ url: 'https://example.com/start' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Refusing redirect to unsupported protocol');
+    expect(callCount).toBe(1);
+  });
+
+  test('blocks excessive redirects', async () => {
+    let callCount = 0;
+    globalThis.fetch = (async (_url: string) => {
+      callCount++;
+      return new Response('', {
+        status: 302,
+        headers: { location: `https://example.com/hop${callCount}` },
+      });
+    }) as any;
+
+    const result = await executeWithMockFetch({ url: 'https://example.com/start' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Too many redirects');
   });
 
   test('blocks hostnames that resolve to private addresses unless explicitly enabled', async () => {


### PR DESCRIPTION
Add dedicated unit tests for the web_fetch tool's SSRF protection logic, covering private IP blocking (127.0.0.1, 10.x, 192.168.x, 172.16-31.x, 169.254.x, CGNAT 100.64-127.x), localhost and .local blocking, cloud metadata endpoint blocking (metadata.google.internal), IPv6 private address blocking (::1, fc/fd, fe80, fec0, ff), IPv4-mapped IPv6 blocking, DNS rebinding protection (hostname resolving to private IP), redirect-to-internal-IP protection, redirect to non-http protocol blocking, redirect chain DNS rebinding, mixed public/private DNS blocking, boundary value tests for IP range edges, and public address allowlisting.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
