### PR TITLE
lint: enable no-explicit-any ESLint rule with targeted suppressions

### DIFF
--- a/assistant/eslint.config.mjs
+++ b/assistant/eslint.config.mjs
@@ -10,6 +10,7 @@ const eslintConfig = defineConfig([
         "error",
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
+      "@typescript-eslint/no-explicit-any": "error",
 
       // Standardize on `undefined` only — avoid `null` in new code.
       // Prefer `=== undefined`, `?? fallback`, or `?.` optional chaining
@@ -41,6 +42,12 @@ const eslintConfig = defineConfig([
             "Avoid `null !==`. Prefer `!== undefined`, nullish coalescing `??`, or optional chaining `?.` instead.",
         },
       ],
+    },
+  },
+  {
+    files: ["**/__tests__/**/*.ts", "**/*.test.ts"],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
     },
   },
 ]);

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -101,7 +101,7 @@ function createMockVoiceTurn(tokens: string[]) {
   };
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 let mockStartVoiceTurn: Mock<any>;
 
 mock.module('../calls/voice-session-bridge.js', () => {

--- a/assistant/src/__tests__/delete-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/delete-managed-skill-tool.test.ts
@@ -20,7 +20,7 @@ mock.module('../util/logger.js', () => ({
 import { DeleteManagedSkillTool } from '../tools/skills/delete-managed.js';
 import type { ToolContext } from '../tools/types.js';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- bypass private constructor for testing
+ 
 const tool = new (DeleteManagedSkillTool as any)() as InstanceType<typeof DeleteManagedSkillTool>;
 
 function makeContext(): ToolContext {

--- a/assistant/src/__tests__/ephemeral-permissions.test.ts
+++ b/assistant/src/__tests__/ephemeral-permissions.test.ts
@@ -26,7 +26,7 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 const testConfig: Record<string, any> = {
   permissions: { mode: 'legacy' as 'legacy' | 'strict' | 'workspace' },
   skills: { load: { extraDirs: [] as string[] } },

--- a/assistant/src/__tests__/handlers-add-trust-rule-metadata.test.ts
+++ b/assistant/src/__tests__/handlers-add-trust-rule-metadata.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+ 
 import { describe, test, expect, beforeEach } from 'bun:test';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -74,9 +74,9 @@ import { loadSkillCatalog } from '../config/skills.js';
 import { buildSystemPrompt } from '../config/system-prompt.js';
 import type { ToolContext } from '../tools/types.js';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- bypass private constructor for testing
+ 
 const scaffoldTool = new (ScaffoldManagedSkillTool as any)() as InstanceType<typeof ScaffoldManagedSkillTool>;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 const deleteTool = new (DeleteManagedSkillTool as any)() as InstanceType<typeof DeleteManagedSkillTool>;
 
 function makeContext(): ToolContext {
@@ -203,9 +203,9 @@ describe('managed skill lifecycle: scaffold → catalog → prompt → delete', 
 
   test('evaluate → scaffold → skill_load chain: literal tool execution', async () => {
     const ctx = makeContext();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- bypass private constructor for testing
+     
     const evalTool = new (EvaluateTypescriptTool as any)() as InstanceType<typeof EvaluateTypescriptTool>;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     const skillLoadTool = new (SkillLoadTool as any)() as InstanceType<typeof SkillLoadTool>;
 
     // Step 1: Run evaluate_typescript_code with code that returns skill metadata

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -92,7 +92,7 @@ function createMockProviderResponse(tokens: string[]) {
 
 // ── Provider registry mock ──────────────────────────────────────────
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 let mockSendMessage: Mock<any>;
 
 mock.module('../providers/registry.js', () => {

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -21,7 +21,7 @@ import { ScaffoldManagedSkillTool } from '../tools/skills/scaffold-managed.js';
 import type { ToolContext } from '../tools/types.js';
 
 // Use internal class directly to avoid registry side effects
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- bypass private constructor for testing
+ 
 const tool = new (ScaffoldManagedSkillTool as any)() as InstanceType<typeof ScaffoldManagedSkillTool>;
 
 function makeContext(): ToolContext {

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -1152,7 +1152,7 @@ describe('Surface-action queue-full trace', () => {
     expect(session.getQueueDepth()).toBe(MAX_QUEUE_DEPTH);
 
     // Register a pending surface action so handleSurfaceAction doesn't bail early
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- access private property for testing
+     
     (session as any).pendingSurfaceActions.set('surf-1', { surfaceType: 'confirmation' });
 
     // Trigger the surface action — queue is full, should be rejected
@@ -1169,7 +1169,7 @@ describe('Surface-action queue-full trace', () => {
     );
     expect(errorTrace).toBeDefined();
     expect(errorTrace).toHaveProperty('attributes');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- access trace attributes
+     
     const attrs = (errorTrace as any).attributes;
     expect(attrs.reason).toBe('queue_full');
     expect(attrs.source).toBe('surface_action');
@@ -1310,7 +1310,7 @@ describe('Session attachment event payloads', () => {
       content: 'ok',
       isError: false,
       contentBlocks: [
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock content block
+         
         { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'iVBORw0K' } } as any,
       ],
     });
@@ -1354,7 +1354,7 @@ describe('Session attachment event payloads', () => {
       content: 'ok',
       isError: false,
       contentBlocks: [
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock content block
+         
         { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'iVBORw0K' } } as any,
       ],
     });
@@ -1430,7 +1430,7 @@ describe('Regression: cancel semantics and error channel split', () => {
       content: 'ok',
       isError: false,
       contentBlocks: [
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock content block
+         
         { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'iVBORw0K' } } as any,
       ],
     });

--- a/assistant/src/__tests__/swarm-plan-validator.test.ts
+++ b/assistant/src/__tests__/swarm-plan-validator.test.ts
@@ -82,7 +82,7 @@ describe('validateAndNormalizePlan', () => {
   test('rejects invalid role', () => {
     const plan = makePlan({
       tasks: [
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- testing invalid role
+         
         { id: 'bad', role: 'hacker' as any, objective: 'Hack', dependencies: [] },
       ],
     });
@@ -229,7 +229,7 @@ describe('validateAndNormalizePlan', () => {
     const plan: SwarmPlan = {
       objective: 'Test',
       tasks: [
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- testing missing dependencies
+         
         { id: 'a', role: 'coder', objective: 'A', dependencies: undefined as any },
       ],
     };
@@ -241,7 +241,7 @@ describe('validateAndNormalizePlan', () => {
     const plan = makePlan({
       objective: '',
       tasks: [
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- testing invalid role
+         
         { id: 'a', role: 'invalid' as any, objective: 'A', dependencies: ['nonexistent'] },
         { id: 'a', role: 'coder', objective: 'B', dependencies: [] },
       ],

--- a/assistant/src/__tests__/tool-permission-simulate-handler.test.ts
+++ b/assistant/src/__tests__/tool-permission-simulate-handler.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+ 
 import { describe, test, expect, beforeEach, mock } from 'bun:test';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -1113,9 +1113,9 @@ describe('Trust Store', () => {
       expect(rule!.tool).toBe('bash');
       expect(rule!.pattern).toBe('git *');
       // Extra fields pass through because the migration does not strip them
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- asserting extra fields pass through migration
+       
       expect((rule as any).customField).toBe('should-survive');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- asserting extra fields pass through migration
+       
       expect((rule as any).nested).toEqual({ deep: true });
     });
 

--- a/assistant/src/__tests__/view-image-tool.test.ts
+++ b/assistant/src/__tests__/view-image-tool.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+ 
 import { describe, test, expect, afterAll, mock } from 'bun:test';
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync, realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/assistant/src/__tests__/web-fetch.test.ts
+++ b/assistant/src/__tests__/web-fetch.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+ 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { PassThrough } from 'node:stream';
 import type { IncomingHttpHeaders } from 'node:http';

--- a/assistant/src/tools/network/__tests__/web-search.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+ 
 import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
 
 // Mutable mock state — set per test


### PR DESCRIPTION
Enable @typescript-eslint/no-explicit-any rule as an error. Production code already had inline suppression comments for the 4 legitimate WebSocket type casts in http-server.ts. Test files are excluded from the rule since they use as any extensively for mocking. Removed now-redundant eslint-disable directives from test files.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
