### PR TITLE
Improve chat message line spacing for readability

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -22,6 +22,7 @@ extension ChatBubble {
                 let attributed = Self.cachedInlineMarkdown(for: segmentText)
                 Text(attributed)
                     .font(.system(size: 13))
+                    .lineSpacing(3)
                     .foregroundColor(VColor.textPrimary)
                     .tint(VColor.accent)
                     .textSelection(.enabled)

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -24,6 +24,7 @@ struct MarkdownSegmentView: View {
                     let attributed = buildCombinedAttributedString(from: runSegments)
                     Text(attributed)
                         .font(.system(size: 13))
+                        .lineSpacing(4)
                         .foregroundColor(textColor)
                         .tint(tintColor)
                         .textSelection(.enabled)
@@ -212,6 +213,7 @@ struct MarkdownSegmentView: View {
                     let textColumn = leftMargin + prefixSize.width
 
                     nonisolated(unsafe) let paraStyle = NSMutableParagraphStyle()
+                    paraStyle.lineSpacing = 4
                     paraStyle.firstLineHeadIndent = leftMargin
                     paraStyle.headIndent = textColumn
                     paraStyle.tabStops = []

--- a/clients/shared/Features/Chat/MarkdownRenderer.swift
+++ b/clients/shared/Features/Chat/MarkdownRenderer.swift
@@ -263,7 +263,7 @@ public struct MarkdownRenderer: View {
             CodeBlockView(lang: lang, code: code)
 
         case .list(let ordered, let items):
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
                 ForEach(Array(items.enumerated()), id: \.offset) { index, item in
                     HStack(alignment: .top, spacing: VSpacing.xs) {
                         Text(ordered ? "\(index + 1)." : "•")


### PR DESCRIPTION
## Summary
- Add line spacing (4pt) to rich markdown content and list paragraph styles in MarkdownSegmentView for better readability
- Increase list item vertical spacing from 4pt to 8pt in MarkdownRenderer (shared)
- Add line spacing (3pt) to plain text chat bubbles in ChatBubbleTextContent

## Original prompt
Improve chat message line spacing for readability

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
