### PR TITLE
fix: handle WhatsApp media messages instead of silently dropping them

### DIFF
--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -90,7 +90,7 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
 
     const normalizedMessages = normalizeWhatsAppWebhook(payload);
     if (normalizedMessages.length === 0) {
-      // Delivery receipts, status updates, non-text messages, etc. — acknowledge silently
+      // Delivery receipts, status updates, etc. — acknowledge silently
       return Response.json({ ok: true });
     }
 
@@ -100,7 +100,7 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
     let hasFailure = false;
 
     for (const normalized of normalizedMessages) {
-      const { event, whatsappMessageId } = normalized;
+      const { event, whatsappMessageId, mediaType } = normalized;
       const from = event.message.externalChatId;
 
       // Dedup by WhatsApp message ID — atomically reserve so concurrent retries
@@ -115,9 +115,26 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
           source: "whatsapp",
           messageId: whatsappMessageId,
           from,
+          ...(mediaType ? { mediaType } : {}),
         },
         "WhatsApp webhook received",
       );
+
+      if (mediaType) {
+        tlog.warn(
+          { whatsappMessageId, mediaType, hasCaption: event.message.content.length > 0 },
+          "WhatsApp media attachment not processed — media download not yet supported",
+        );
+
+        // No caption and no text — nothing to forward to the assistant
+        if (event.message.content.length === 0) {
+          markWhatsAppMessageRead(config, whatsappMessageId).catch((err) => {
+            tlog.debug({ err, messageId: whatsappMessageId }, "Failed to mark WhatsApp message as read");
+          });
+          dedupCache.mark(whatsappMessageId);
+          continue;
+        }
+      }
 
       // Mark message as read (best-effort, do not await)
       markWhatsAppMessageRead(config, whatsappMessageId).catch((err) => {

--- a/gateway/src/whatsapp/normalize.ts
+++ b/gateway/src/whatsapp/normalize.ts
@@ -30,14 +30,20 @@ interface WhatsAppInteractiveMessage {
   };
 }
 
-interface WhatsAppAudioMessage {
+interface WhatsAppMediaMessage {
   id: string;
   from: string;
   timestamp: string;
   type: "audio" | "video" | "image" | "document" | "sticker";
+  // image, video, and document messages can carry a caption
+  image?: { caption?: string; mime_type?: string; id?: string };
+  video?: { caption?: string; mime_type?: string; id?: string };
+  document?: { caption?: string; mime_type?: string; id?: string; filename?: string };
+  audio?: { mime_type?: string; id?: string };
+  sticker?: { mime_type?: string; id?: string };
 }
 
-type WhatsAppMessage = WhatsAppTextMessage | WhatsAppInteractiveMessage | WhatsAppAudioMessage;
+type WhatsAppMessage = WhatsAppTextMessage | WhatsAppInteractiveMessage | WhatsAppMediaMessage;
 
 interface WhatsAppValue {
   messaging_product: "whatsapp";
@@ -67,6 +73,8 @@ export interface NormalizedWhatsAppMessage {
   event: Omit<GatewayInboundEventV1, "routing">;
   /** Original WhatsApp message ID — used for marking as read. */
   whatsappMessageId: string;
+  /** The media type when the message contained an attachment (image, video, etc.). */
+  mediaType?: string;
 }
 
 /**
@@ -76,7 +84,10 @@ export interface NormalizedWhatsAppMessage {
  * - The payload is not a WhatsApp messages webhook
  * - Required fields are missing
  *
- * Non-text messages (audio/video/image/document) within the batch are skipped.
+ * Media messages (image/video/audio/document/sticker) are normalized with any
+ * accompanying caption as the message content. The `mediaType` field is set so
+ * the caller can log that media content itself was not processed.
+ *
  * Meta may batch multiple messages in a single webhook payload; we process all
  * of them rather than discarding messages beyond the first.
  */
@@ -100,6 +111,7 @@ export function normalizeWhatsAppWebhook(
     for (const msg of messages) {
       let body: string;
       let callbackData: string | undefined;
+      let mediaType: string | undefined;
 
       if (msg.type === "text") {
         const textMsg = msg as WhatsAppTextMessage;
@@ -112,8 +124,16 @@ export function normalizeWhatsAppWebhook(
         if (!buttonReply?.id) continue;
         callbackData = buttonReply.id;
         body = buttonReply.title ?? "";
+      } else if (msg.type === "image" || msg.type === "video" || msg.type === "audio" || msg.type === "document" || msg.type === "sticker") {
+        const mediaMsg = msg as WhatsAppMediaMessage;
+        // image, video, and document can carry a caption; audio and sticker cannot
+        const caption =
+          mediaMsg.image?.caption ??
+          mediaMsg.video?.caption ??
+          mediaMsg.document?.caption;
+        body = caption?.trim() ?? "";
+        mediaType = msg.type;
       } else {
-        // Other types (image, audio, etc.) are not supported
         continue;
       }
 
@@ -127,6 +147,7 @@ export function normalizeWhatsAppWebhook(
 
       results.push({
         whatsappMessageId: msg.id,
+        ...(mediaType ? { mediaType } : {}),
         event: {
           version: "v1",
           sourceChannel: "whatsapp",


### PR DESCRIPTION
Detect WhatsApp media messages, extract captions/text, forward text to assistant, and log warnings for dropped media content. Previously non-text WhatsApp messages were silently acknowledged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
