### PR TITLE
refactor: extract DoorDash step-tracking from generic tool executor

### DIFF
--- a/assistant/src/daemon/doordash-steps.ts
+++ b/assistant/src/daemon/doordash-steps.ts
@@ -1,0 +1,175 @@
+/**
+ * DoorDash-specific step-tracking logic for the task_progress surface.
+ *
+ * Extracted from session-tool-setup.ts so the generic tool executor
+ * remains clean and extensible.
+ */
+
+import type { CardSurfaceData } from './ipc-contract.js';
+import type { ToolSetupContext } from './session-tool-setup.js';
+import { isPlainObject } from '../util/object.js';
+
+interface DoordashStep { label: string; status: string; detail?: string }
+
+const SURFACE_ID = 'doordash-progress';
+
+/**
+ * Map a `doordash <subcommand>` (or `vellum doordash <subcommand>`) to the
+ * step label it corresponds to.
+ */
+function doordashCommandToStep(cmd: string): string | null {
+  // Match both standalone `doordash` and legacy `vellum doordash` prefixes
+  const dd = /(?:vellum )?doordash /;
+  if (new RegExp(dd.source + 'status\\b').test(cmd) || new RegExp(dd.source + 'refresh\\b').test(cmd) || new RegExp(dd.source + 'login\\b').test(cmd)) return 'Check session';
+  if (new RegExp(dd.source + 'search\\b').test(cmd) || new RegExp(dd.source + 'search-items\\b').test(cmd)) return 'Search restaurants';
+  if (new RegExp(dd.source + 'menu\\b').test(cmd) || new RegExp(dd.source + 'item\\b').test(cmd) || new RegExp(dd.source + 'store-search\\b').test(cmd)) return 'Browse menu';
+  if (new RegExp(dd.source + 'cart\\b').test(cmd)) return 'Add to cart';
+  if (new RegExp(dd.source + 'checkout\\b').test(cmd) || new RegExp(dd.source + 'payment-methods\\b').test(cmd)) return 'Add to cart';
+  if (new RegExp(dd.source + 'order\\b').test(cmd)) return 'Place order';
+  return null;
+}
+
+/**
+ * Given a completed DoorDash CLI command, return updated steps array or null if no change.
+ */
+function updateDoordashSteps(cmd: string, steps: DoordashStep[], isError: boolean): DoordashStep[] | null {
+  const stepLabel = doordashCommandToStep(cmd);
+  if (!stepLabel) return null;
+
+  const stepIndex = steps.findIndex(s => s.label === stepLabel);
+  if (stepIndex < 0) return null;
+
+  const updated = steps.map((s, i) => {
+    if (i < stepIndex) {
+      // Steps before current should be completed
+      return s.status === 'completed' ? s : { ...s, status: 'completed' };
+    }
+    if (i === stepIndex) {
+      if (isError) {
+        // If the command failed, mark as in_progress still (will retry)
+        return { ...s, status: 'in_progress' };
+      }
+      return { ...s, status: 'completed' };
+    }
+    if (i === stepIndex + 1 && !isError) {
+      // Next step becomes waiting (user may need to respond before it starts)
+      return { ...s, status: 'waiting' };
+    }
+    return s;
+  });
+
+  return updated;
+}
+
+// ── Helpers for reading/writing the task_progress surface ─────────────
+
+function getStoredSteps(ctx: ToolSetupContext): DoordashStep[] | null {
+  const stored = ctx.surfaceState.get(SURFACE_ID);
+  if (!stored || stored.surfaceType !== 'card') return null;
+  const card = stored.data as CardSurfaceData;
+  if (card.template !== 'task_progress' || !isPlainObject(card.templateData)) return null;
+  const steps = (card.templateData as Record<string, unknown>).steps;
+  return Array.isArray(steps) ? steps as DoordashStep[] : null;
+}
+
+function pushStepsUpdate(ctx: ToolSetupContext, updatedSteps: DoordashStep[]): void {
+  const stored = ctx.surfaceState.get(SURFACE_ID)!;
+  const card = stored.data as CardSurfaceData;
+  const updatedTemplateData = { ...card.templateData as Record<string, unknown>, steps: updatedSteps };
+  const updatedData = { ...card, templateData: updatedTemplateData };
+  stored.data = updatedData as CardSurfaceData;
+  ctx.sendToClient({
+    type: 'ui_surface_update',
+    sessionId: ctx.conversationId,
+    surfaceId: SURFACE_ID,
+    data: updatedData,
+  });
+}
+
+// ── Public API ────────────────────────────────────────────────────────
+
+/**
+ * Returns true if the given tool invocation is a DoorDash CLI command
+ * that should be tracked.
+ */
+export function isDoordashCommand(name: string, input: Record<string, unknown>): boolean {
+  if (name !== 'bash' && name !== 'host_bash') return false;
+  const cmd = input.command as string | undefined;
+  return !!cmd && doordashCommandToStep(cmd) !== null;
+}
+
+/**
+ * Pre-execution hook: mark the matching DoorDash step as in_progress
+ * before the command runs.
+ */
+export function markDoordashStepInProgress(ctx: ToolSetupContext, input: Record<string, unknown>): void {
+  const cmd = input.command as string | undefined;
+  const stepLabel = cmd ? doordashCommandToStep(cmd) : null;
+  if (!stepLabel) return;
+
+  const steps = getStoredSteps(ctx);
+  if (!steps) return;
+
+  const stepIndex = steps.findIndex(s => s.label === stepLabel);
+  if (stepIndex < 0 || steps[stepIndex].status === 'in_progress') return;
+
+  const updatedSteps = steps.map((s, i) =>
+    i === stepIndex ? { ...s, status: 'in_progress' } : s
+  );
+  pushStepsUpdate(ctx, updatedSteps);
+}
+
+/**
+ * Post-execution hook: auto-emit the task_progress card on first
+ * DoorDash CLI command, then update step statuses based on the result.
+ */
+export function updateDoordashProgress(ctx: ToolSetupContext, input: Record<string, unknown>, isError: boolean): void {
+  const cmd = input.command as string | undefined;
+  if (!cmd || !doordashCommandToStep(cmd)) return;
+
+  if (!ctx.surfaceState.has(SURFACE_ID)) {
+    // First DoorDash command — auto-emit the task_progress card
+    const data = {
+      title: 'Ordering from DoorDash',
+      body: '',
+      template: 'task_progress' as const,
+      templateData: {
+        title: 'Ordering from DoorDash',
+        status: 'in_progress',
+        steps: [
+          { label: 'Check session', status: 'in_progress' },
+          { label: 'Search restaurants', status: 'pending' },
+          { label: 'Browse menu', status: 'pending' },
+          { label: 'Add to cart', status: 'pending' },
+          { label: 'Place order', status: 'pending' },
+        ],
+      },
+    } satisfies CardSurfaceData;
+    ctx.surfaceState.set(SURFACE_ID, { surfaceType: 'card', data });
+    ctx.sendToClient({
+      type: 'ui_surface_show',
+      sessionId: ctx.conversationId,
+      surfaceId: SURFACE_ID,
+      surfaceType: 'card',
+      title: 'Ordering from DoorDash',
+      data,
+      display: 'inline',
+    });
+    ctx.currentTurnSurfaces.push({
+      surfaceId: SURFACE_ID,
+      surfaceType: 'card',
+      title: 'Ordering from DoorDash',
+      data,
+      display: 'inline',
+    });
+  }
+
+  // Auto-update step statuses based on the command that just ran
+  const steps = getStoredSteps(ctx);
+  if (!steps) return;
+
+  const updatedSteps = updateDoordashSteps(cmd, steps, isError);
+  if (updatedSteps) {
+    pushStepsUpdate(ctx, updatedSteps);
+  }
+}

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -15,7 +15,7 @@ import type { SecretPrompter } from '../permissions/secret-prompter.js';
 import { addRule, findHighestPriorityRule } from '../permissions/trust-store.js';
 import { generateAllowlistOptions, generateScopeOptions, normalizeWebFetchUrl } from '../permissions/checker.js';
 import { getLogger } from '../util/logger.js';
-import { isPlainObject } from '../util/object.js';
+import { isDoordashCommand, markDoordashStepInProgress, updateDoordashProgress } from './doordash-steps.js';
 
 const log = getLogger('session-tool-setup');
 import { getAllToolDefinitions } from '../tools/registry.js';
@@ -76,58 +76,6 @@ export function buildToolDefinitions(): ToolDefinition[] {
   ];
 }
 
-// ── DoorDash task_progress auto-update ────────────────────────────────
-
-interface DoordashStep { label: string; status: string; detail?: string }
-
-/**
- * Map a `doordash <subcommand>` (or `vellum doordash <subcommand>`) to the
- * step label it corresponds to.
- */
-function doordashCommandToStep(cmd: string): string | null {
-  // Match both standalone `doordash` and legacy `vellum doordash` prefixes
-  const dd = /(?:vellum )?doordash /;
-  if (new RegExp(dd.source + 'status\\b').test(cmd) || new RegExp(dd.source + 'refresh\\b').test(cmd) || new RegExp(dd.source + 'login\\b').test(cmd)) return 'Check session';
-  if (new RegExp(dd.source + 'search\\b').test(cmd) || new RegExp(dd.source + 'search-items\\b').test(cmd)) return 'Search restaurants';
-  if (new RegExp(dd.source + 'menu\\b').test(cmd) || new RegExp(dd.source + 'item\\b').test(cmd) || new RegExp(dd.source + 'store-search\\b').test(cmd)) return 'Browse menu';
-  if (new RegExp(dd.source + 'cart\\b').test(cmd)) return 'Add to cart';
-  if (new RegExp(dd.source + 'checkout\\b').test(cmd) || new RegExp(dd.source + 'payment-methods\\b').test(cmd)) return 'Add to cart';
-  if (new RegExp(dd.source + 'order\\b').test(cmd)) return 'Place order';
-  return null;
-}
-
-/**
- * Given a completed DoorDash CLI command, return updated steps array or null if no change.
- */
-function updateDoordashSteps(cmd: string, steps: DoordashStep[], isError: boolean): DoordashStep[] | null {
-  const stepLabel = doordashCommandToStep(cmd);
-  if (!stepLabel) return null;
-
-  const stepIndex = steps.findIndex(s => s.label === stepLabel);
-  if (stepIndex < 0) return null;
-
-  const updated = steps.map((s, i) => {
-    if (i < stepIndex) {
-      // Steps before current should be completed
-      return s.status === 'completed' ? s : { ...s, status: 'completed' };
-    }
-    if (i === stepIndex) {
-      if (isError) {
-        // If the command failed, mark as in_progress still (will retry)
-        return { ...s, status: 'in_progress' };
-      }
-      return { ...s, status: 'completed' };
-    }
-    if (i === stepIndex + 1 && !isError) {
-      // Next step becomes waiting (user may need to respond before it starts)
-      return { ...s, status: 'waiting' };
-    }
-    return s;
-  });
-
-  return updated;
-}
-
 // ── createToolExecutor ───────────────────────────────────────────────
 
 /**
@@ -148,37 +96,8 @@ export function createToolExecutor(
   registerSessionSender(ctx.conversationId, (msg) => ctx.sendToClient(msg));
 
   return async (name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => {
-    // Pre-execution: mark the current DoorDash step as in_progress when command starts
-    if (name === 'bash' || name === 'host_bash') {
-      const preCmd = input.command as string | undefined;
-      const preStepLabel = preCmd ? doordashCommandToStep(preCmd) : null;
-      if (preStepLabel) {
-        const surfaceId = 'doordash-progress';
-        const stored = ctx.surfaceState.get(surfaceId);
-        if (stored && stored.surfaceType === 'card') {
-          const card = stored.data as import('./ipc-contract.js').CardSurfaceData;
-          if (card.template === 'task_progress' && isPlainObject(card.templateData)) {
-            const steps = (card.templateData as Record<string, unknown>).steps;
-            if (Array.isArray(steps)) {
-              const stepIndex = (steps as DoordashStep[]).findIndex(s => s.label === preStepLabel);
-              if (stepIndex >= 0 && (steps as DoordashStep[])[stepIndex].status !== 'in_progress') {
-                const updatedSteps = (steps as DoordashStep[]).map((s, i) =>
-                  i === stepIndex ? { ...s, status: 'in_progress' } : s
-                );
-                const updatedTemplateData = { ...card.templateData as Record<string, unknown>, steps: updatedSteps };
-                const updatedData = { ...card, templateData: updatedTemplateData };
-                stored.data = updatedData as import('./ipc-contract.js').CardSurfaceData;
-                ctx.sendToClient({
-                  type: 'ui_surface_update',
-                  sessionId: ctx.conversationId,
-                  surfaceId,
-                  data: updatedData,
-                });
-              }
-            }
-          }
-        }
-      }
+    if (isDoordashCommand(name, input)) {
+      markDoordashStepInProgress(ctx, input);
     }
 
     const result = await executor.execute(name, input, {
@@ -307,72 +226,8 @@ export function createToolExecutor(
       }
     }
 
-    // Auto-emit task_progress card on first DoorDash CLI command
-    if (name === 'bash' || name === 'host_bash') {
-      const cmd = input.command as string | undefined;
-      if (cmd && doordashCommandToStep(cmd)) {
-        const surfaceId = 'doordash-progress';
-
-        if (!ctx.surfaceState.has(surfaceId)) {
-          // First DoorDash command — auto-emit the task_progress card
-          const data = {
-            title: 'Ordering from DoorDash',
-            body: '',
-            template: 'task_progress' as const,
-            templateData: {
-              title: 'Ordering from DoorDash',
-              status: 'in_progress',
-              steps: [
-                { label: 'Check session', status: 'in_progress' },
-                { label: 'Search restaurants', status: 'pending' },
-                { label: 'Browse menu', status: 'pending' },
-                { label: 'Add to cart', status: 'pending' },
-                { label: 'Place order', status: 'pending' },
-              ],
-            },
-          } satisfies import('./ipc-contract.js').CardSurfaceData;
-          ctx.surfaceState.set(surfaceId, { surfaceType: 'card', data });
-          ctx.sendToClient({
-            type: 'ui_surface_show',
-            sessionId: ctx.conversationId,
-            surfaceId,
-            surfaceType: 'card',
-            title: 'Ordering from DoorDash',
-            data,
-            display: 'inline',
-          });
-          ctx.currentTurnSurfaces.push({
-            surfaceId,
-            surfaceType: 'card',
-            title: 'Ordering from DoorDash',
-            data,
-            display: 'inline',
-          });
-        }
-
-        // Auto-update step statuses based on the command that just ran
-        const stored = ctx.surfaceState.get(surfaceId);
-        if (stored && stored.surfaceType === 'card') {
-          const card = stored.data as import('./ipc-contract.js').CardSurfaceData;
-          if (card.template === 'task_progress' && isPlainObject(card.templateData)) {
-            const steps = (card.templateData as Record<string, unknown>).steps;
-            if (Array.isArray(steps)) {
-              const updatedSteps = updateDoordashSteps(cmd, steps as Array<{ label: string; status: string; detail?: string }>, result.isError);
-              if (updatedSteps) {
-                const updatedTemplateData = { ...card.templateData as Record<string, unknown>, steps: updatedSteps };
-                const updatedData = { ...card, templateData: updatedTemplateData };
-                stored.data = updatedData as import('./ipc-contract.js').CardSurfaceData;
-                ctx.sendToClient({
-                  type: 'ui_surface_update',
-                  sessionId: ctx.conversationId,
-                  surfaceId,
-                  data: updatedData,
-                });
-              }
-            }
-          }
-        }
-      }
+    if (isDoordashCommand(name, input)) {
+      updateDoordashProgress(ctx, input, result.isError);
     }
 
     return result;


### PR DESCRIPTION
Move DoorDash-specific step-tracking logic out of session-tool-setup.ts into a dedicated module, keeping the generic tool executor clean and extensible per the Extensibility Principle.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
