### PR TITLE
security: add rate limiting for gateway auth failures

### DIFF
--- a/gateway/src/auth-rate-limiter.ts
+++ b/gateway/src/auth-rate-limiter.ts
@@ -1,0 +1,76 @@
+// Sliding-window rate limiter for authentication failures.
+// Tracks failed attempts per IP and blocks IPs that exceed the threshold.
+
+const DEFAULT_MAX_FAILURES = 10;
+const DEFAULT_WINDOW_MS = 60_000; // 60 seconds
+const MAX_TRACKED_IPS = 50_000;
+
+export class AuthRateLimiter {
+  private failures = new Map<string, number[]>();
+  private readonly maxFailures: number;
+  private readonly windowMs: number;
+
+  constructor(
+    maxFailures = DEFAULT_MAX_FAILURES,
+    windowMs = DEFAULT_WINDOW_MS,
+  ) {
+    this.maxFailures = maxFailures;
+    this.windowMs = windowMs;
+  }
+
+  /** Record a failed auth attempt for the given IP. */
+  recordFailure(ip: string): void {
+    const now = Date.now();
+    let timestamps = this.failures.get(ip);
+
+    if (!timestamps) {
+      // Evict stale entries if the map grows too large
+      if (this.failures.size >= MAX_TRACKED_IPS) {
+        this.evictStale(now);
+      }
+      timestamps = [];
+      this.failures.set(ip, timestamps);
+    }
+
+    timestamps.push(now);
+  }
+
+  /** Returns true if the IP has exceeded the failure threshold. */
+  isBlocked(ip: string): boolean {
+    const timestamps = this.failures.get(ip);
+    if (!timestamps) return false;
+
+    const now = Date.now();
+    const cutoff = now - this.windowMs;
+
+    // Remove expired timestamps from the front
+    while (timestamps.length > 0 && timestamps[0] <= cutoff) {
+      timestamps.shift();
+    }
+
+    if (timestamps.length === 0) {
+      this.failures.delete(ip);
+      return false;
+    }
+
+    return timestamps.length >= this.maxFailures;
+  }
+
+  /** Clear all state on a successful auth (optional — reduces false positives after rotation). */
+  clearIp(ip: string): void {
+    this.failures.delete(ip);
+  }
+
+  private evictStale(now: number): void {
+    const cutoff = now - this.windowMs;
+    for (const [ip, timestamps] of this.failures) {
+      // Remove expired entries from front
+      while (timestamps.length > 0 && timestamps[0] <= cutoff) {
+        timestamps.shift();
+      }
+      if (timestamps.length === 0) {
+        this.failures.delete(ip);
+      }
+    }
+  }
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import { readFileSync, watch, existsSync, mkdirSync, type FSWatcher } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
+import { AuthRateLimiter } from "./auth-rate-limiter.js";
 import { ConfigFileWatcher } from "./config-file-watcher.js";
 import { loadConfig, type GatewayConfig } from "./config.js";
 import { CredentialWatcher } from "./credential-watcher.js";
@@ -33,6 +34,20 @@ function generateTraceId(): string {
 }
 
 let draining = false;
+
+// Shared rate limiter for auth failures and unauthenticated endpoints
+const authRateLimiter = new AuthRateLimiter();
+
+function getClientIp(req: Request, server: ReturnType<typeof Bun.serve>): string {
+  // Prefer X-Forwarded-For when behind a reverse proxy
+  const forwarded = req.headers.get("x-forwarded-for");
+  if (forwarded) {
+    const first = forwarded.split(",")[0].trim();
+    if (first) return first;
+  }
+  const addr = server.requestIP(req);
+  return addr?.address ?? "unknown";
+}
 
 /**
  * Watch `~/.vellum/http-token` and update the config when the daemon
@@ -131,7 +146,7 @@ function main() {
       log.error({ err }, "Unhandled gateway error");
       return Response.json({ error: "Internal server error" }, { status: 500 });
     },
-    async fetch(req) {
+    async fetch(req, svr) {
       const url = new URL(req.url);
 
       if (url.pathname === "/healthz") {
@@ -147,6 +162,25 @@ function main() {
           return Response.json({ status: "draining" }, { status: 503 });
         }
         return Response.json({ status: "ok" });
+      }
+
+      // Rate-limit check for auth-protected and pairing endpoints.
+      // Checked early so blocked IPs are rejected before any work.
+      const isAuthRoute = url.pathname.startsWith("/v1/") ||
+        url.pathname === "/integrations/status" ||
+        url.pathname === "/deliver/telegram" ||
+        url.pathname === "/deliver/sms" ||
+        url.pathname === "/deliver/whatsapp" ||
+        url.pathname.startsWith("/pairing/");
+      if (isAuthRoute) {
+        const clientIp = getClientIp(req, svr);
+        if (authRateLimiter.isBlocked(clientIp)) {
+          log.warn({ ip: clientIp, path: url.pathname }, "Auth rate limit exceeded");
+          return Response.json(
+            { error: "Too many failed attempts. Try again later." },
+            { status: 429, headers: { "Retry-After": "60" } },
+          );
+        }
       }
 
       // Attach a trace ID to every non-healthcheck request for
@@ -177,7 +211,11 @@ function main() {
             { status: 503 },
           );
         }
-        return handleTelegramDeliver(tracedReq);
+        const res = await handleTelegramDeliver(tracedReq);
+        if (res.status === 401) {
+          authRateLimiter.recordFailure(getClientIp(req, svr));
+        }
+        return res;
       }
 
       if (
@@ -206,7 +244,11 @@ function main() {
       }
 
       if (url.pathname === "/deliver/sms") {
-        return handleSmsDeliver(tracedReq);
+        const res = await handleSmsDeliver(tracedReq);
+        if (res.status === 401) {
+          authRateLimiter.recordFailure(getClientIp(req, svr));
+        }
+        return res;
       }
 
       if (url.pathname === "/webhooks/whatsapp") {
@@ -226,7 +268,11 @@ function main() {
             { status: 503 },
           );
         }
-        return handleWhatsAppDeliver(tracedReq);
+        const res = await handleWhatsAppDeliver(tracedReq);
+        if (res.status === 401) {
+          authRateLimiter.recordFailure(getClientIp(req, svr));
+        }
+        return res;
       }
 
       if (url.pathname === "/webhooks/twilio/relay" || url.pathname === "/v1/calls/relay") {
@@ -252,6 +298,7 @@ function main() {
           config.runtimeProxyBearerToken,
         );
         if (!authResult.authorized) {
+          authRateLimiter.recordFailure(getClientIp(req, svr));
           return Response.json({ error: "Unauthorized" }, { status: 401 });
         }
         return Response.json({
@@ -262,15 +309,28 @@ function main() {
       }
 
       // ── Pairing proxy (unauthenticated at gateway, secret-gated) ──
+      // Record auth failures when the daemon rejects the pairing secret
       if (url.pathname === "/pairing/request" && tracedReq.method === "POST") {
-        return pairingProxy.handlePairingRequest(tracedReq);
+        const res = await pairingProxy.handlePairingRequest(tracedReq);
+        if (res.status === 401 || res.status === 403) {
+          authRateLimiter.recordFailure(getClientIp(req, svr));
+        }
+        return res;
       }
       if (url.pathname === "/pairing/status" && tracedReq.method === "GET") {
-        return pairingProxy.handlePairingStatus(tracedReq);
+        const res = await pairingProxy.handlePairingStatus(tracedReq);
+        if (res.status === 401 || res.status === 403) {
+          authRateLimiter.recordFailure(getClientIp(req, svr));
+        }
+        return res;
       }
 
       if (handleRuntimeProxy) {
-        return handleRuntimeProxy(tracedReq);
+        const res = await handleRuntimeProxy(tracedReq);
+        if (res.status === 401) {
+          authRateLimiter.recordFailure(getClientIp(req, svr));
+        }
+        return res;
       }
 
       return Response.json({ error: "Not found", source: "gateway" }, { status: 404 });


### PR DESCRIPTION
Add in-memory IP-based rate limiter for authentication failures in the gateway. Tracks failed auth attempts per IP and blocks IPs exceeding threshold (10 failures in 60s). Applies to bearer token auth and pairing endpoints.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
