### PR TITLE
fix: add offline message queue to macOS Unix socket DaemonClient

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -190,22 +190,18 @@ public final class ChatViewModel: ObservableObject {
     let daemonClient: any DaemonClientProtocol
     public var sessionId: String? {
         didSet {
-            #if os(iOS)
             // If the daemon reconnected before this VM had a session ID, a deferred
             // flush was requested. Now that we have a session, run it.
             if sessionId != nil && needsOfflineFlush {
                 needsOfflineFlush = false
                 flushOfflineQueue()
             }
-            #endif
         }
     }
     private var reconnectObserver: NSObjectProtocol?
-    #if os(iOS)
     /// Set to true when daemonDidReconnect fires before sessionId is populated.
     /// Cleared and actioned in the sessionId didSet observer.
     private var needsOfflineFlush: Bool = false
-    #endif
     /// Set to true when reconnecting after an SSE gap while a run was in progress.
     /// Causes `populateFromHistory` to do a full message replace instead of
     /// prepending, so the missed assistant response is displayed.
@@ -474,7 +470,6 @@ public final class ChatViewModel: ObservableObject {
                         self?.onReconnectHistoryNeeded?(sessionId)
                     }
                 }
-                #if os(iOS)
                 // If we already have a session ID, flush immediately. Otherwise
                 // defer: sessionId's didSet will trigger flushOfflineQueue() once
                 // the session is restored from history (cold-start reconnect case).
@@ -483,7 +478,6 @@ public final class ChatViewModel: ObservableObject {
                 } else {
                     self?.needsOfflineFlush = true
                 }
-                #endif
             }
         }
     }
@@ -698,8 +692,7 @@ public final class ChatViewModel: ObservableObject {
         guard daemonClient.isConnected else {
             log.error("Cannot send user_message: daemon not connected")
 
-            #if os(iOS)
-            // On iOS, buffer the primary (non-queued-retry) send in the offline queue
+            // Buffer the primary (non-queued-retry) send in the offline queue
             // instead of surfacing an error. The message stays visible with a
             // "pending" indicator and is flushed automatically on reconnect.
             if queuedMessageId == nil {
@@ -715,7 +708,6 @@ public final class ChatViewModel: ObservableObject {
                 // communicates the offline state without interrupting the conversation.
                 return
             }
-            #endif
 
             // Always track the failed message for retry support.
             lastFailedMessageText = text
@@ -783,9 +775,8 @@ public final class ChatViewModel: ObservableObject {
         }
     }
 
-    // MARK: - Offline Queue Flush (iOS only)
+    // MARK: - Offline Queue Flush
 
-    #if os(iOS)
     /// Drain the persistent offline queue and send all buffered messages in order.
     ///
     /// Called automatically when the daemon reconnects. Only flushes messages whose
@@ -831,7 +822,6 @@ public final class ChatViewModel: ObservableObject {
             sendUserMessage(queued.text, attachments: queued.ipcAttachments)
         }
     }
-    #endif
 
     public func startMessageLoop() {
         messageLoopTask?.cancel()

--- a/clients/shared/Features/Chat/OfflineMessageQueue.swift
+++ b/clients/shared/Features/Chat/OfflineMessageQueue.swift
@@ -1,4 +1,3 @@
-#if os(iOS)
 import Foundation
 import os
 
@@ -117,4 +116,3 @@ final class OfflineMessageQueue {
         UserDefaults.standard.removeObject(forKey: Self.userDefaultsKey)
     }
 }
-#endif


### PR DESCRIPTION
Queue messages when the daemon connection is down and replay them on reconnect, preventing message loss during connection interruptions. Uses a pattern consistent with the existing OfflineMessageQueue.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
