### PR TITLE
fix: process MMS text body instead of dropping it with media

### DIFF
--- a/gateway/src/http/routes/twilio-sms-webhook.test.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.test.ts
@@ -436,7 +436,7 @@ describe("twilio-sms-webhook", () => {
     expect(handleInboundMock).toHaveBeenCalledTimes(0);
   });
 
-  it("MMS payload (NumMedia > 0) returns unsupported notice and does not forward", async () => {
+  it("MMS payload (NumMedia > 0) sends unsupported notice and forwards text body", async () => {
     const handler = createTwilioSmsWebhookHandler(baseConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
@@ -463,11 +463,14 @@ describe("twilio-sms-webhook", () => {
     expect((text as string).toLowerCase()).toContain("not supported");
     expect(assistantId).toBe("ast-default");
 
-    // handleInbound should NOT have been called
-    expect(handleInboundMock).toHaveBeenCalledTimes(0);
+    // Text body should have been forwarded as a regular message
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+    const [, event] = handleInboundMock.mock.calls[0] as unknown[];
+    const typedEvent = event as { message: { content: string } };
+    expect(typedEvent.message.content).toBe("Check out this photo");
   });
 
-  it("MMS detected via MediaUrl0 when NumMedia is absent", async () => {
+  it("MMS detected via MediaUrl0 when NumMedia is absent forwards text body", async () => {
     const handler = createTwilioSmsWebhookHandler(baseConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
@@ -492,8 +495,11 @@ describe("twilio-sms-webhook", () => {
     expect((text as string).toLowerCase()).toContain("not supported");
     expect(assistantId).toBe("ast-default");
 
-    // handleInbound should NOT have been called
-    expect(handleInboundMock).toHaveBeenCalledTimes(0);
+    // Text body should have been forwarded
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+    const [, event] = handleInboundMock.mock.calls[0] as unknown[];
+    const typedEvent = event as { message: { content: string } };
+    expect(typedEvent.message.content).toBe("Check out this photo");
   });
 
   it("routes by To phone number when assistantPhoneNumbers is configured", async () => {
@@ -575,7 +581,11 @@ describe("twilio-sms-webhook", () => {
     expect(sendSmsReplyMock).toHaveBeenCalledTimes(1);
     const [, , , assistantId] = sendSmsReplyMock.mock.calls[0] as unknown[];
     expect(assistantId).toBe("ast-beta");
-    expect(handleInboundMock).toHaveBeenCalledTimes(0);
+    // Text body should have been forwarded
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+    const [, event] = handleInboundMock.mock.calls[0] as unknown[];
+    const typedEvent = event as { message: { content: string } };
+    expect(typedEvent.message.content).toBe("MMS inbound");
   });
 
   it("falls through to standard routing when To number is not in assistantPhoneNumbers", async () => {
@@ -718,7 +728,7 @@ describe("twilio-sms-webhook", () => {
     expect((text as string).toLowerCase()).toContain("could not be routed");
   });
 
-  it("MMS detected via MediaContentType0 when NumMedia is absent", async () => {
+  it("MMS detected via MediaContentType0 when NumMedia is absent forwards text body", async () => {
     const handler = createTwilioSmsWebhookHandler(baseConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
@@ -743,7 +753,36 @@ describe("twilio-sms-webhook", () => {
     expect((text as string).toLowerCase()).toContain("not supported");
     expect(assistantId).toBe("ast-default");
 
-    // handleInbound should NOT have been called
+    // Text body should have been forwarded
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+    const [, event] = handleInboundMock.mock.calls[0] as unknown[];
+    const typedEvent = event as { message: { content: string } };
+    expect(typedEvent.message.content).toBe("Here is a file");
+  });
+
+  it("MMS with empty body sends unsupported notice but does not forward", async () => {
+    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const url = "http://localhost:7830/webhooks/twilio/sms";
+    const params = {
+      Body: "",
+      From: "+15551234567",
+      To: "+15559876543",
+      MessageSid: "SM-mms-nobody",
+      NumMedia: "1",
+      MediaUrl0: "https://api.twilio.com/media/789",
+      MediaContentType0: "image/jpeg",
+    };
+    const req = buildSignedSmsRequest(url, params, AUTH_TOKEN);
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    // Unsupported notice should have been sent
+    expect(sendSmsReplyMock).toHaveBeenCalledTimes(1);
+
+    // handleInbound should NOT have been called — no text to forward
     expect(handleInboundMock).toHaveBeenCalledTimes(0);
   });
 });

--- a/gateway/src/http/routes/twilio-sms-webhook.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.ts
@@ -92,6 +92,7 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
     // --- MMS intercept: detect media attachments and reply with unsupported notice ---
     // Treat as MMS when NumMedia > 0, or when any MediaUrl/MediaContentType
     // fields are present (some Twilio configurations omit NumMedia).
+    // The text body is still forwarded as a regular SMS so it isn't silently dropped.
     const numMedia = parseInt(params.NumMedia || "0", 10);
     const hasMediaFields = Object.keys(params).some(
       (key) =>
@@ -108,8 +109,16 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
       ).catch((err) => {
         tlog.error({ err, to: params.From }, "Failed to send MMS unsupported notice");
       });
-      dedupCache.mark(messageSid);
-      return Response.json({ ok: true });
+
+      // If the MMS has no text body, we're done — nothing to forward.
+      const mmsTextBody = (params.Body || "").trim();
+      if (!mmsTextBody) {
+        dedupCache.mark(messageSid);
+        return Response.json({ ok: true });
+      }
+
+      // Fall through to process the text body as a regular message.
+      tlog.info({ messageSid }, "MMS has text body, forwarding as SMS");
     }
 
     const normalized = normalizeSmsPayload(params);


### PR DESCRIPTION
Ensure the text portion of MMS messages is always processed as regular SMS content, even when media attachments are present. Previously the entire message was dropped when media was detected.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
