### PR TITLE
perf: add FTS5 virtual table for message content search

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -16,6 +16,8 @@ import {
   runLateMigrations,
   createNotificationTables,
   createSequenceTables,
+  createMessagesFts,
+  migrateMessagesFtsBackfill,
   validateMigrationState,
 } from './migrations/index.js';
 
@@ -69,6 +71,10 @@ export function initializeDb(): void {
 
   // 16. Sequences (multi-step outreach)
   createSequenceTables(database);
+
+  // 17. Messages FTS (full-text search over message content)
+  createMessagesFts(database);
+  migrateMessagesFtsBackfill(database);
 
   validateMigrationState(database);
 }

--- a/assistant/src/memory/migrations/025-messages-fts-backfill.ts
+++ b/assistant/src/memory/migrations/025-messages-fts-backfill.ts
@@ -1,0 +1,24 @@
+import { getSqliteFrom, type DrizzleDb } from '../db-connection.js';
+
+/**
+ * Backfill FTS rows for existing messages when upgrading from a version
+ * that did not have the messages_fts virtual table.
+ */
+export function migrateMessagesFtsBackfill(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  const ftsCountRow = raw.query(`SELECT COUNT(*) AS c FROM messages_fts`).get() as { c: number } | null;
+  const ftsCount = ftsCountRow?.c ?? 0;
+  if (ftsCount > 0) return;
+
+  try {
+    raw.exec('BEGIN');
+    raw.exec(/*sql*/ `
+      INSERT INTO messages_fts(message_id, content)
+      SELECT id, content FROM messages
+    `);
+    raw.exec('COMMIT');
+  } catch (e) {
+    try { raw.exec('ROLLBACK'); } catch { /* no active transaction */ }
+    throw e;
+  }
+}

--- a/assistant/src/memory/migrations/116-messages-fts.ts
+++ b/assistant/src/memory/migrations/116-messages-fts.ts
@@ -1,0 +1,44 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * FTS5 virtual table for full-text search over messages.content.
+ *
+ * Content is stored as raw JSON in the messages table — the FTS tokenizer
+ * handles it well enough for keyword search since the structural JSON tokens
+ * (type, text, tool_use) are short common words that rarely matter as search
+ * terms.  The existing buildExcerpt() in conversation-store handles extracting
+ * readable text from JSON for display after matching.
+ */
+export function createMessagesFts(database: DrizzleDb): void {
+  database.run(/*sql*/ `
+    CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+      message_id UNINDEXED,
+      content
+    )
+  `);
+
+  database.run(/*sql*/ `
+    CREATE TRIGGER IF NOT EXISTS messages_fts_ai
+    AFTER INSERT ON messages
+    BEGIN
+      INSERT INTO messages_fts(message_id, content) VALUES (new.id, new.content);
+    END
+  `);
+
+  database.run(/*sql*/ `
+    CREATE TRIGGER IF NOT EXISTS messages_fts_ad
+    AFTER DELETE ON messages
+    BEGIN
+      DELETE FROM messages_fts WHERE message_id = old.id;
+    END
+  `);
+
+  database.run(/*sql*/ `
+    CREATE TRIGGER IF NOT EXISTS messages_fts_au
+    AFTER UPDATE ON messages
+    BEGIN
+      DELETE FROM messages_fts WHERE message_id = old.id;
+      INSERT INTO messages_fts(message_id, content) VALUES (new.id, new.content);
+    END
+  `);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -28,6 +28,7 @@ export { migrateConversationStatusIndexes } from './021-conversation-status-inde
 export { migrateAddOriginInterface } from './022-add-origin-interface.js';
 export { migrateMemoryItemSourcesIndexes } from './023-memory-item-sources-indexes.js';
 export { migrateEmbeddingVectorBlob } from './024-embedding-vector-blob.js';
+export { migrateMessagesFtsBackfill } from './025-messages-fts-backfill.js';
 export { createCoreTables } from './100-core-tables.js';
 export { createWatchersAndLogsTables } from './101-watchers-and-logs.js';
 export { addCoreColumns } from './102-alter-table-columns.js';
@@ -44,3 +45,4 @@ export { createAssistantInboxTables } from './112-assistant-inbox.js';
 export { runLateMigrations } from './113-late-migrations.js';
 export { createNotificationTables } from './114-notifications.js';
 export { createSequenceTables } from './115-sequences.js';
+export { createMessagesFts } from './116-messages-fts.js';

--- a/assistant/src/memory/schema-migration.ts
+++ b/assistant/src/memory/schema-migration.ts
@@ -26,4 +26,5 @@ export {
   migrateAddOriginInterface,
   migrateMemoryItemSourcesIndexes,
   migrateEmbeddingVectorBlob,
+  migrateMessagesFtsBackfill,
 } from './migrations/index.js';


### PR DESCRIPTION
Add FTS5 virtual table indexed on messages.content for instant full-text search. Includes migration to create the virtual table, populate from existing data, and sync triggers for INSERT/UPDATE/DELETE.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
