### PR TITLE
fix: skip memory conflict clarification for scheduled tasks

### DIFF
--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -253,6 +253,7 @@ export async function runAgentLoopImpl(
         scopeId: ctx.memoryPolicy.scopeId,
         includeDefaultFallback: ctx.memoryPolicy.includeDefaultFallback,
         guardianActorRole: ctx.guardianContext?.actorRole,
+        isInteractive: !ctx.hasNoClient,
       },
       content,
       userMessageId,

--- a/assistant/src/daemon/session-memory.ts
+++ b/assistant/src/daemon/session-memory.ts
@@ -35,6 +35,8 @@ export interface MemoryPrepareContext {
   scopeId: string;
   includeDefaultFallback: boolean;
   guardianActorRole?: 'guardian' | 'non-guardian' | 'unverified_channel';
+  /** When false (e.g. scheduled tasks), skip conflict clarification prompts. */
+  isInteractive?: boolean;
 }
 
 /**
@@ -87,8 +89,10 @@ export async function prepareMemoryContext(
   const runtimeConfig = getConfig();
   const memoryEnabled = runtimeConfig.memory?.enabled !== false;
 
-  // Conflict gate
-  const conflictConfig = memoryEnabled ? runtimeConfig.memory?.conflicts : undefined;
+  // Conflict gate — skip entirely for non-interactive sessions (scheduled tasks,
+  // work items) since there is no human to answer the clarification question.
+  const isInteractive = ctx.isInteractive !== false;
+  const conflictConfig = memoryEnabled && isInteractive ? runtimeConfig.memory?.conflicts : undefined;
   const conflictGateResult = conflictConfig
     ? await ctx.conflictGate.evaluate(content, conflictConfig, ctx.scopeId)
     : null;


### PR DESCRIPTION
## Summary
- Add `isInteractive` flag to `MemoryPrepareContext` interface
- Skip conflict gate evaluation when `isInteractive` is false (non-interactive sessions like scheduled tasks)
- Pass `!ctx.hasNoClient` as `isInteractive` from the agent loop

## Original prompt
Scheduled tasks should never ask for clarification on memory items

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
