### PR TITLE
refactor: replace hardcoded model names with modelIntent in config defaults

### DIFF
--- a/assistant/src/__tests__/swarm-recursion.test.ts
+++ b/assistant/src/__tests__/swarm-recursion.test.ts
@@ -40,8 +40,8 @@ mock.module('../config/loader.js', () => ({
       maxRetriesPerTask: 1,
       workerTimeoutSec: 900,
       roleTimeoutsSec: {},
-      plannerModel: 'claude-haiku-4-5-20251001',
-      synthesizerModel: 'claude-sonnet-4-6',
+      plannerModelIntent: 'latency-optimized',
+      synthesizerModelIntent: 'quality-optimized',
     },
   }),
 }));

--- a/assistant/src/__tests__/swarm-session-integration.test.ts
+++ b/assistant/src/__tests__/swarm-session-integration.test.ts
@@ -31,8 +31,8 @@ mock.module('../config/loader.js', () => ({
       maxRetriesPerTask: 1,
       workerTimeoutSec: 900,
       roleTimeoutsSec: {},
-      plannerModel: 'claude-haiku-4-5-20251001',
-      synthesizerModel: 'claude-sonnet-4-6',
+      plannerModelIntent: 'latency-optimized',
+      synthesizerModelIntent: 'quality-optimized',
     },
   }),
 }));

--- a/assistant/src/__tests__/swarm-tool.test.ts
+++ b/assistant/src/__tests__/swarm-tool.test.ts
@@ -22,15 +22,15 @@ mock.module('../config/loader.js', () => ({
       maxRetriesPerTask: 1,
       workerTimeoutSec: 900,
       roleTimeoutsSec: {},
-      plannerModel: 'claude-haiku-4-5-20251001',
-      synthesizerModel: 'claude-sonnet-4-6',
+      plannerModelIntent: 'latency-optimized',
+      synthesizerModelIntent: 'quality-optimized',
     },
   }),
   getSwarmDisabledConfig: () => ({
     provider: 'anthropic',
     providerOrder: ['anthropic'],
     apiKeys: { anthropic: 'test-key' },
-    swarm: { enabled: false, maxWorkers: 3, maxTasks: 8, maxRetriesPerTask: 1, workerTimeoutSec: 900, roleTimeoutsSec: {}, plannerModel: 'h', synthesizerModel: 's' },
+    swarm: { enabled: false, maxWorkers: 3, maxTasks: 8, maxRetriesPerTask: 1, workerTimeoutSec: 900, roleTimeoutsSec: {}, plannerModelIntent: 'latency-optimized', synthesizerModelIntent: 'quality-optimized' },
   }),
 }));
 

--- a/assistant/src/config/agent-schema.ts
+++ b/assistant/src/config/agent-schema.ts
@@ -75,12 +75,16 @@ export const SwarmConfigSchema = z.object({
       reviewer: z.number().int().positive().optional(),
     })
     .default({}),
-  plannerModel: z
-    .string({ error: 'swarm.plannerModel must be a string' })
-    .default('claude-haiku-4-5-20251001'),
-  synthesizerModel: z
-    .string({ error: 'swarm.synthesizerModel must be a string' })
-    .default('claude-sonnet-4-6'),
+  plannerModelIntent: z
+    .enum(['latency-optimized', 'quality-optimized', 'vision-optimized'], {
+      error: 'swarm.plannerModelIntent must be a valid model intent',
+    })
+    .default('latency-optimized'),
+  synthesizerModelIntent: z
+    .enum(['latency-optimized', 'quality-optimized', 'vision-optimized'], {
+      error: 'swarm.synthesizerModelIntent must be a valid model intent',
+    })
+    .default('quality-optimized'),
 });
 
 export const WorkspaceGitConfigSchema = z.object({

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -49,7 +49,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
       injectionStrategy: 'prepend_user_block' as const,
       reranking: {
         enabled: false,
-        model: 'claude-haiku-4-5-20251001',
+        modelIntent: 'latency-optimized',
         topK: 20,
       },
       freshness: {
@@ -92,16 +92,16 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     },
     extraction: {
       useLLM: true,
-      model: 'claude-haiku-4-5-20251001',
+      modelIntent: 'latency-optimized',
       extractFromAssistant: true,
     },
     summarization: {
       useLLM: true,
-      model: 'claude-haiku-4-5-20251001',
+      modelIntent: 'latency-optimized',
     },
     entity: {
       enabled: true,
-      model: 'claude-haiku-4-5-20251001',
+      modelIntent: 'latency-optimized',
       extractRelations: {
         enabled: true,
         backfillBatchSize: 200,
@@ -187,8 +187,8 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     maxRetriesPerTask: 1,
     workerTimeoutSec: 900,
     roleTimeoutsSec: {},
-    plannerModel: 'claude-haiku-4-5-20251001',
-    synthesizerModel: 'claude-sonnet-4-6',
+    plannerModelIntent: 'latency-optimized',
+    synthesizerModelIntent: 'quality-optimized',
   },
   skills: {
     entries: {},
@@ -292,6 +292,6 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     titleGenerationMaxTokens: 30,
   },
   notifications: {
-    decisionModel: 'claude-haiku-4-5-20251001',
+    decisionModelIntent: 'latency-optimized',
   },
 };

--- a/assistant/src/config/memory-schema.ts
+++ b/assistant/src/config/memory-schema.ts
@@ -61,9 +61,11 @@ export const MemoryRerankingConfigSchema = z.object({
   enabled: z
     .boolean({ error: 'memory.retrieval.reranking.enabled must be a boolean' })
     .default(false),
-  model: z
-    .string({ error: 'memory.retrieval.reranking.model must be a string' })
-    .default('claude-haiku-4-5-20251001'),
+  modelIntent: z
+    .enum(['latency-optimized', 'quality-optimized', 'vision-optimized'], {
+      error: 'memory.retrieval.reranking.modelIntent must be a valid model intent',
+    })
+    .default('latency-optimized'),
   topK: z
     .number({ error: 'memory.retrieval.reranking.topK must be a number' })
     .int('memory.retrieval.reranking.topK must be an integer')
@@ -187,7 +189,7 @@ export const MemoryRetrievalConfigSchema = z.object({
     .default('prepend_user_block'),
   reranking: MemoryRerankingConfigSchema.default({
     enabled: false,
-    model: 'claude-haiku-4-5-20251001',
+    modelIntent: 'latency-optimized',
     topK: 20,
   }),
   freshness: MemoryFreshnessConfigSchema.default({
@@ -283,9 +285,11 @@ export const MemoryExtractionConfigSchema = z.object({
   useLLM: z
     .boolean({ error: 'memory.extraction.useLLM must be a boolean' })
     .default(true),
-  model: z
-    .string({ error: 'memory.extraction.model must be a string' })
-    .default('claude-haiku-4-5-20251001'),
+  modelIntent: z
+    .enum(['latency-optimized', 'quality-optimized', 'vision-optimized'], {
+      error: 'memory.extraction.modelIntent must be a valid model intent',
+    })
+    .default('latency-optimized'),
   extractFromAssistant: z
     .boolean({ error: 'memory.extraction.extractFromAssistant must be a boolean' })
     .default(true),
@@ -295,9 +299,11 @@ export const MemoryEntityConfigSchema = z.object({
   enabled: z
     .boolean({ error: 'memory.entity.enabled must be a boolean' })
     .default(true),
-  model: z
-    .string({ error: 'memory.entity.model must be a string' })
-    .default('claude-haiku-4-5-20251001'),
+  modelIntent: z
+    .enum(['latency-optimized', 'quality-optimized', 'vision-optimized'], {
+      error: 'memory.entity.modelIntent must be a valid model intent',
+    })
+    .default('latency-optimized'),
   extractRelations: z.object({
     enabled: z
       .boolean({ error: 'memory.entity.extractRelations.enabled must be a boolean' })
@@ -404,9 +410,11 @@ export const MemorySummarizationConfigSchema = z.object({
   useLLM: z
     .boolean({ error: 'memory.summarization.useLLM must be a boolean' })
     .default(true),
-  model: z
-    .string({ error: 'memory.summarization.model must be a string' })
-    .default('claude-haiku-4-5-20251001'),
+  modelIntent: z
+    .enum(['latency-optimized', 'quality-optimized', 'vision-optimized'], {
+      error: 'memory.summarization.modelIntent must be a valid model intent',
+    })
+    .default('latency-optimized'),
 });
 
 export const MemoryConfigSchema = z.object({
@@ -436,7 +444,7 @@ export const MemoryConfigSchema = z.object({
     injectionStrategy: 'prepend_user_block',
     reranking: {
       enabled: false,
-      model: 'claude-haiku-4-5-20251001',
+      modelIntent: 'latency-optimized',
       topK: 20,
     },
     freshness: {
@@ -479,16 +487,16 @@ export const MemoryConfigSchema = z.object({
   }),
   extraction: MemoryExtractionConfigSchema.default({
     useLLM: true,
-    model: 'claude-haiku-4-5-20251001',
+    modelIntent: 'latency-optimized',
     extractFromAssistant: true,
   }),
   summarization: MemorySummarizationConfigSchema.default({
     useLLM: true,
-    model: 'claude-haiku-4-5-20251001',
+    modelIntent: 'latency-optimized',
   }),
   entity: MemoryEntityConfigSchema.default({
     enabled: true,
-    model: 'claude-haiku-4-5-20251001',
+    modelIntent: 'latency-optimized',
     extractRelations: {
       enabled: true,
       backfillBatchSize: 200,

--- a/assistant/src/config/notifications-schema.ts
+++ b/assistant/src/config/notifications-schema.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod';
 
 export const NotificationsConfigSchema = z.object({
-  decisionModel: z
-    .string({ error: 'notifications.decisionModel must be a string' })
-    .default('claude-haiku-4-5-20251001'),
+  decisionModelIntent: z
+    .enum(['latency-optimized', 'quality-optimized', 'vision-optimized'], {
+      error: 'notifications.decisionModelIntent must be a valid model intent',
+    })
+    .default('latency-optimized'),
 });
 
 export type NotificationsConfig = z.infer<typeof NotificationsConfigSchema>;

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -232,7 +232,7 @@ export const AssistantConfigSchema = z.object({
       injectionStrategy: 'prepend_user_block',
       reranking: {
         enabled: false,
-        model: 'claude-haiku-4-5-20251001',
+        modelIntent: 'latency-optimized',
         topK: 20,
       },
       freshness: {
@@ -275,16 +275,16 @@ export const AssistantConfigSchema = z.object({
     },
     extraction: {
       useLLM: true,
-      model: 'claude-haiku-4-5-20251001',
+      modelIntent: 'latency-optimized',
       extractFromAssistant: true,
     },
     summarization: {
       useLLM: true,
-      model: 'claude-haiku-4-5-20251001',
+      modelIntent: 'latency-optimized',
     },
     entity: {
       enabled: true,
-      model: 'claude-haiku-4-5-20251001',
+      modelIntent: 'latency-optimized',
       extractRelations: {
         enabled: true,
         backfillBatchSize: 200,
@@ -370,8 +370,8 @@ export const AssistantConfigSchema = z.object({
     maxRetriesPerTask: 1,
     workerTimeoutSec: 900,
     roleTimeoutsSec: {},
-    plannerModel: 'claude-haiku-4-5-20251001',
-    synthesizerModel: 'claude-sonnet-4-6',
+    plannerModelIntent: 'latency-optimized',
+    synthesizerModelIntent: 'quality-optimized',
   }),
   skills: SkillsConfigSchema.default({
     entries: {},
@@ -457,7 +457,7 @@ export const AssistantConfigSchema = z.object({
     titleGenerationMaxTokens: 30,
   }),
   notifications: NotificationsConfigSchema.default({
-    decisionModel: 'claude-haiku-4-5-20251001',
+    decisionModelIntent: 'latency-optimized',
   }),
 }).superRefine((config, ctx) => {
   if (config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {

--- a/assistant/src/memory/entity-extractor.ts
+++ b/assistant/src/memory/entity-extractor.ts
@@ -143,7 +143,7 @@ export async function extractEntitiesWithLLM(
         ENTITY_EXTRACTION_SYSTEM_PROMPT,
         {
           config: {
-            model: entityConfig.model,
+            modelIntent: entityConfig.modelIntent,
             max_tokens: 1024,
             tool_choice: { type: 'tool' as const, name: 'store_entities' },
           },

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -172,7 +172,7 @@ async function extractItemsWithLLM(
         EXTRACTION_SYSTEM_PROMPT,
         {
           config: {
-            model: extractionConfig.model,
+            modelIntent: extractionConfig.modelIntent,
             max_tokens: 1024,
             tool_choice: { type: 'tool' as const, name: 'store_memory_items' },
           },

--- a/assistant/src/memory/job-handlers/summarization.ts
+++ b/assistant/src/memory/job-handlers/summarization.ts
@@ -255,7 +255,7 @@ async function summarizeWithLLM(
         systemPrompt,
         {
           config: {
-            model: summarizationConfig.model,
+            modelIntent: summarizationConfig.modelIntent,
             max_tokens: SUMMARY_MAX_TOKENS,
           },
           signal,

--- a/assistant/src/memory/search/ranking.ts
+++ b/assistant/src/memory/search/ranking.ts
@@ -313,7 +313,7 @@ export async function rerankWithLLM(
     'You are a relevance scoring assistant. Given a query and a list of memory candidates, rate each candidate\'s relevance to the query on a scale of 0-10. Return ONLY a JSON array of objects with "index" (the candidate index) and "score" (0-10 integer). No explanation.',
     {
       config: {
-        model: rerankingConfig.model,
+        modelIntent: rerankingConfig.modelIntent,
         max_tokens: 1024,
       },
     },

--- a/assistant/src/notifications/README.md
+++ b/assistant/src/notifications/README.md
@@ -16,7 +16,7 @@ A producer calls `emitNotificationSignal()` with a free-form event name, attenti
 
 ### 2. Decision
 
-The decision engine (`decision-engine.ts`) sends the signal to an LLM (configured via `notifications.decisionModel`) along with available channels and the user's preference summary. The LLM responds with a structured decision: whether to notify, which channels, rendered copy per channel, and a deduplication key.
+The decision engine (`decision-engine.ts`) sends the signal to an LLM (configured via `notifications.decisionModelIntent`) along with available channels and the user's preference summary. The LLM responds with a structured decision: whether to notify, which channels, rendered copy per channel, and a deduplication key.
 
 When the LLM is unavailable or returns invalid output, a deterministic fallback fires: high-urgency + requires-action signals notify on all channels; everything else is suppressed.
 
@@ -127,6 +127,6 @@ All settings live under the `notifications` key in `config.json`:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `notifications.decisionModel` | string | `"claude-haiku-4-5-20251001"` | Model used for both the decision engine and preference extraction |
+| `notifications.decisionModelIntent` | string | `"latency-optimized"` | Model intent used for both the decision engine and preference extraction |
 
 The notification pipeline is always active — signals are processed and dispatched as soon as the daemon is running. The audit trail (events, decisions, deliveries) is written for every signal.

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -254,7 +254,7 @@ export async function evaluateSignal(
   preferenceContext?: string,
 ): Promise<NotificationDecision> {
   const config = getConfig();
-  const decisionModel = config.notifications.decisionModel;
+  const decisionModelIntent = config.notifications.decisionModelIntent;
 
   // When no explicit preference context is provided, load the user's
   // stored notification preferences from the memory-backed store.
@@ -280,7 +280,7 @@ export async function evaluateSignal(
 
   let decision: NotificationDecision;
   try {
-    decision = await classifyWithLLM(signal, availableChannels, resolvedPreferenceContext, decisionModel);
+    decision = await classifyWithLLM(signal, availableChannels, resolvedPreferenceContext, decisionModelIntent);
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
     log.warn({ err: errMsg }, 'Notification decision LLM call failed, using fallback');
@@ -298,7 +298,7 @@ async function classifyWithLLM(
   signal: NotificationSignal,
   availableChannels: NotificationChannel[],
   preferenceContext: string | undefined,
-  model: string,
+  modelIntent: string,
 ): Promise<NotificationDecision> {
   const provider = getConfiguredProvider()!;
   const { signal: abortSignal, cleanup } = createTimeout(DECISION_TIMEOUT_MS);
@@ -314,7 +314,7 @@ async function classifyWithLLM(
       systemPrompt,
       {
         config: {
-          model,
+          modelIntent,
           max_tokens: 2048,
           tool_choice: { type: 'tool' as const, name: 'record_notification_decision' },
         },

--- a/assistant/src/notifications/preference-extractor.ts
+++ b/assistant/src/notifications/preference-extractor.ts
@@ -128,7 +128,7 @@ export async function extractPreferences(message: string): Promise<ExtractionRes
   }
 
   const config = getConfig();
-  const model = config.notifications.decisionModel;
+  const modelIntent = config.notifications.decisionModelIntent;
 
   const { signal, cleanup } = createTimeout(EXTRACTION_TIMEOUT_MS);
 
@@ -139,7 +139,7 @@ export async function extractPreferences(message: string): Promise<ExtractionRes
       SYSTEM_PROMPT,
       {
         config: {
-          model,
+          modelIntent,
           max_tokens: 1024,
           tool_choice: { type: 'tool' as const, name: 'extract_notification_preferences' },
         },

--- a/assistant/src/swarm/backend-claude-code.ts
+++ b/assistant/src/swarm/backend-claude-code.ts
@@ -7,6 +7,8 @@
 
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
+import { resolveModelIntent } from '../providers/model-intents.js';
+import type { ModelIntent } from '../providers/types.js';
 import type { SwarmWorkerBackend, SwarmWorkerBackendInput } from './worker-backend.js';
 import { getProfilePolicy } from './worker-backend.js';
 
@@ -73,7 +75,9 @@ export function createClaudeCodeBackend(): SwarmWorkerBackend {
           prompt: input.prompt,
           options: {
             cwd: input.workingDir,
-            model: input.model ?? 'claude-sonnet-4-6',
+            model: input.modelIntent
+              ? resolveModelIntent(getConfig().provider, input.modelIntent as ModelIntent)
+              : 'claude-sonnet-4-6',
             canUseTool,
             permissionMode: 'default',
             maxTurns: 30,

--- a/assistant/src/swarm/orchestrator.ts
+++ b/assistant/src/swarm/orchestrator.ts
@@ -33,10 +33,10 @@ export interface ExecuteSwarmOptions {
   limits: SwarmLimits;
   backend: SwarmWorkerBackend;
   workingDir: string;
-  model?: string;
-  /** Provider + model for final synthesis. */
+  modelIntent?: string;
+  /** Provider + model intent for final synthesis. */
   synthesisProvider?: Provider;
-  synthesisModel?: string;
+  synthesisModelIntent?: string;
   onStatus?: OrchestratorStatusCallback;
   signal?: AbortSignal;
   /** Stable identifier for this swarm run, used for checkpoint persistence. */
@@ -50,7 +50,7 @@ export interface ExecuteSwarmOptions {
  * bounded concurrency, and per-task retries.
  */
 export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExecutionSummary> {
-  const { plan, limits, backend, workingDir, model, onStatus, signal, runId, resume } = opts;
+  const { plan, limits, backend, workingDir, modelIntent, onStatus, signal, runId, resume } = opts;
   const startTime = Date.now();
 
   // Safety net: reject cyclic plans even if the caller skipped validation
@@ -183,7 +183,7 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
         dependencyOutputs: depOutputs,
         backend,
         workingDir,
-        model,
+        modelIntent,
         timeoutMs: taskTimeoutMs,
         signal,
       });
@@ -202,7 +202,7 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
           dependencyOutputs: depOutputs,
           backend,
           workingDir,
-          model,
+          modelIntent,
           timeoutMs: taskTimeoutMs,
           signal,
         });
@@ -287,9 +287,7 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
       objective: plan.objective,
       results: allResults,
       provider: opts.synthesisProvider,
-      ...(opts.synthesisModel
-        ? { model: opts.synthesisModel }
-        : { modelIntent: 'quality-optimized' as const }),
+      modelIntent: opts.synthesisModelIntent ?? 'quality-optimized',
     });
   } else {
     if (!signal?.aborted) onStatus?.({ kind: 'synthesis_started' });

--- a/assistant/src/swarm/router-planner.ts
+++ b/assistant/src/swarm/router-planner.ts
@@ -13,10 +13,10 @@ import { ROUTER_SYSTEM_PROMPT, buildPlannerUserMessage } from './router-prompts.
 export async function generatePlan(opts: {
   objective: string;
   provider: Provider;
-  model: string;
+  modelIntent: string;
   limits: SwarmLimits;
 }): Promise<SwarmPlan> {
-  const { objective, provider, model, limits } = opts;
+  const { objective, provider, modelIntent, limits } = opts;
 
   try {
     const messages: Message[] = [
@@ -30,7 +30,7 @@ export async function generatePlan(opts: {
       messages,
       undefined,
       ROUTER_SYSTEM_PROMPT,
-      { config: { max_tokens: 2048, model } },
+      { config: { max_tokens: 2048, modelIntent } },
     );
 
     // Extract text from response

--- a/assistant/src/swarm/synthesizer.ts
+++ b/assistant/src/swarm/synthesizer.ts
@@ -9,10 +9,9 @@ export async function synthesizeResults(opts: {
   objective: string;
   results: SwarmTaskResult[];
   provider: Provider;
-  model?: string;
   modelIntent?: ModelIntent;
 }): Promise<string> {
-  const { objective, results, provider, model, modelIntent } = opts;
+  const { objective, results, provider, modelIntent } = opts;
 
   // Cap individual summaries and total input to avoid blowing up context on large plans
   const MAX_SUMMARY_CHARS = 500;
@@ -48,7 +47,7 @@ Synthesize these results into a clear, complete answer for the user.`;
       messages,
       undefined,
       systemPrompt,
-      { config: { max_tokens: 4096, ...(model ? { model } : { modelIntent }) } },
+      { config: { max_tokens: 4096, modelIntent } },
     );
 
     const textBlock = response.content.find((b) => b.type === 'text');

--- a/assistant/src/swarm/worker-backend.ts
+++ b/assistant/src/swarm/worker-backend.ts
@@ -104,7 +104,7 @@ export interface SwarmWorkerBackendInput {
   prompt: string;
   profile: WorkerProfile;
   workingDir: string;
-  model?: string;
+  modelIntent?: string;
   timeoutMs?: number;
   signal?: AbortSignal;
 }

--- a/assistant/src/swarm/worker-runner.ts
+++ b/assistant/src/swarm/worker-runner.ts
@@ -15,7 +15,7 @@ export interface RunWorkerTaskOptions {
   dependencyOutputs?: Array<{ taskId: string; summary: string }>;
   backend: SwarmWorkerBackend;
   workingDir: string;
-  model?: string;
+  modelIntent?: string;
   timeoutMs: number;
   onStatus?: WorkerStatusCallback;
   signal?: AbortSignal;
@@ -89,7 +89,7 @@ export async function runWorkerTask(opts: RunWorkerTaskOptions): Promise<SwarmTa
       prompt,
       profile,
       workingDir,
-      model: opts.model,
+      modelIntent: opts.modelIntent,
       timeoutMs,
       signal,
     });

--- a/assistant/src/tools/swarm/delegate.ts
+++ b/assistant/src/tools/swarm/delegate.ts
@@ -90,7 +90,7 @@ export const swarmDelegateTool: Tool = {
       const plan = await generatePlan({
         objective: extraContext ? `${objective}\n\nContext: ${extraContext}` : objective,
         provider: planProvider,
-        model: config.swarm.plannerModel,
+        modelIntent: config.swarm.plannerModelIntent,
         limits,
       });
 
@@ -118,9 +118,9 @@ export const swarmDelegateTool: Tool = {
         limits,
         backend,
         workingDir: context.workingDir,
-        model: config.swarm.synthesizerModel,
+        modelIntent: config.swarm.synthesizerModelIntent,
         synthesisProvider,
-        synthesisModel: config.swarm.synthesizerModel,
+        synthesisModelIntent: config.swarm.synthesizerModelIntent,
         signal: context.signal,
         onStatus: (event) => {
           switch (event.kind) {


### PR DESCRIPTION
Replace ~10 hardcoded 'claude-haiku-4-5-20251001' model name strings in defaults.ts and Zod schema with modelIntent references ('latency-optimized', 'quality-optimized', 'vision-optimized'). The RetryProvider already resolves intents to models.

Changed config fields:
- memory.retrieval.reranking.model -> modelIntent: 'latency-optimized'
- memory.extraction.model -> modelIntent: 'latency-optimized'
- memory.entity.model -> modelIntent: 'latency-optimized'
- memory.summarization.model -> modelIntent: 'latency-optimized'
- swarm.plannerModel -> plannerModelIntent: 'latency-optimized'
- swarm.synthesizerModel -> synthesizerModelIntent: 'quality-optimized'
- notifications.decisionModel -> decisionModelIntent: 'latency-optimized'

Updated consumers in memory/, notifications/, swarm/ to pass modelIntent instead of model in SendMessageConfig.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
