### PR TITLE
fix: register missing config CLI command

### DIFF
--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -16,6 +16,7 @@ import {
   registerCompletionsCommand,
 } from './cli/core-commands.js';
 import {
+  registerConfigCommand,
   registerKeysCommand,
   registerTrustCommand,
   registerMemoryCommand,
@@ -40,6 +41,7 @@ registerDefaultAction(program);
 registerDaemonCommand(program);
 registerDevCommand(program);
 registerSessionsCommand(program);
+registerConfigCommand(program);
 registerKeysCommand(program);
 registerTrustCommand(program);
 registerMemoryCommand(program);


### PR DESCRIPTION
## Summary

- `registerConfigCommand` was imported in `index.ts` but never called, so the `config` subcommand (set/get/list/validate-allowlist) was never registered on the CLI program
- Running `vellum config set provider anthropic` failed with "too many arguments. Expected 0 arguments but got 4"
- Added the missing `registerConfigCommand(program)` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
