### PR TITLE
fix: skip memory conflict clarification for all non-interactive paths

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -755,7 +755,7 @@ export class DaemonServer {
     const requestId = crypto.randomUUID();
     const messageId = session.persistUserMessage(content, attachments, requestId);
 
-    session.runAgentLoop(content, messageId, () => {}).catch((err) => {
+    session.runAgentLoop(content, messageId, () => {}, { isInteractive: false }).catch((err) => {
       log.error({ err, conversationId }, 'Background agent loop failed');
     });
 
@@ -839,7 +839,7 @@ export class DaemonServer {
       throw err;
     }
 
-    await session.runAgentLoop(resolvedContent, messageId, () => {});
+    await session.runAgentLoop(resolvedContent, messageId, () => {}, { isInteractive: false });
 
     return { messageId };
   }

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -118,6 +118,7 @@ export interface AgentLoopSessionContext {
   lastAttachmentWarnings: string[];
 
   hasNoClient: boolean;
+  headlessLock?: boolean;
   readonly streamThinking: boolean;
   readonly prompter: PermissionPrompter;
   readonly queue: MessageQueue;
@@ -142,7 +143,7 @@ export async function runAgentLoopImpl(
   content: string,
   userMessageId: string,
   onEvent: (msg: ServerMessage) => void,
-  options?: { skipPreMessageRollback?: boolean },
+  options?: { skipPreMessageRollback?: boolean; isInteractive?: boolean },
 ): Promise<void> {
   if (!ctx.abortController) {
     throw new Error('runAgentLoop called without prior persistUserMessage');
@@ -253,7 +254,7 @@ export async function runAgentLoopImpl(
         scopeId: ctx.memoryPolicy.scopeId,
         includeDefaultFallback: ctx.memoryPolicy.includeDefaultFallback,
         guardianActorRole: ctx.guardianContext?.actorRole,
-        isInteractive: !ctx.hasNoClient,
+        isInteractive: options?.isInteractive ?? (!ctx.hasNoClient && !ctx.headlessLock),
       },
       content,
       userMessageId,

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -393,7 +393,7 @@ export class Session {
     content: string,
     userMessageId: string,
     onEvent: (msg: ServerMessage) => void,
-    options?: { skipPreMessageRollback?: boolean },
+    options?: { skipPreMessageRollback?: boolean; isInteractive?: boolean },
   ): Promise<void> {
     return runAgentLoopImpl(this, content, userMessageId, onEvent, options);
   }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -335,8 +335,9 @@ export async function handleSendMessage(
     const requestId = crypto.randomUUID();
     const messageId = session.persistUserMessage(content ?? '', attachments, requestId);
 
-    // Fire-and-forget the agent loop; events flow to the hub via onEvent
-    session.runAgentLoop(content ?? '', messageId, onEvent).catch((err) => {
+    // Fire-and-forget the agent loop; events flow to the hub via onEvent.
+    // Mark non-interactive so conflict clarification doesn't block the turn.
+    session.runAgentLoop(content ?? '', messageId, onEvent, { isInteractive: false }).catch((err) => {
       log.error({ err, conversationId: mapping.conversationId }, 'Agent loop failed (POST /messages)');
     });
 


### PR DESCRIPTION
## Summary
- Thread `isInteractive` option through `runAgentLoop` so callers can explicitly signal non-interactivity per-turn
- Pass `isInteractive: false` from `processMessage`, `persistAndProcessMessage`, and `POST /v1/messages` (scheduler, Telegram, HTTP API paths) — these have no user present to answer clarification
- Also check `headlessLock` in the conflict gate fallback, aligning with `session-tool-setup.ts` so work-item execution also skips clarification

## Original prompt
this memory clarification should never kick in on cronjob tasks because the user might not be there to clarify

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
