### PR TITLE
fix: handle NOT NULL constraint on vector_json in embedding migration

### DIFF
--- a/assistant/src/memory/migrations/024-embedding-vector-blob.ts
+++ b/assistant/src/memory/migrations/024-embedding-vector-blob.ts
@@ -7,7 +7,7 @@ import { getSqliteFrom, type DrizzleDb } from '../db-connection.js';
  * This migration adds a vector_blob column (Float32Array BLOB) and converts
  * all existing vector_json values into the compact binary format.
  *
- * After migration, new writes go to vector_blob only (vector_json is set to NULL).
+ * After migration, new writes go to vector_blob only.
  * Reads prefer vector_blob and fall back to vector_json for safety.
  */
 export function migrateEmbeddingVectorBlob(database: DrizzleDb): void {
@@ -28,7 +28,7 @@ export function migrateEmbeddingVectorBlob(database: DrizzleDb): void {
 
   if (rows.length > 0) {
     const update = raw.prepare(
-      `UPDATE memory_embeddings SET vector_blob = ?, vector_json = NULL WHERE id = ?`,
+      `UPDATE memory_embeddings SET vector_blob = ? WHERE id = ?`,
     );
     raw.exec('BEGIN');
     try {


### PR DESCRIPTION
## Summary

- The embedding blob migration (`024-embedding-vector-blob.ts`) tried to set `vector_json = NULL` after converting to `vector_blob`, but older databases have a NOT NULL constraint on `vector_json`, crashing the daemon on startup.
- Fixed by only setting `vector_blob` during backfill — the JSON data stays in place, and reads already prefer `vector_blob`.

## Original prompt
```
SQLiteError: NOT NULL constraint failed: memory_embeddings.vector_json
  at migrateEmbeddingVectorBlob (024-embedding-vector-blob.ts:39:16)
```
Daemon fails to start because the blob migration tries to NULL out vector_json on databases with a NOT NULL constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
