### PR TITLE
fix(macos): keep quick input visible during screenshot + open main window on submit

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -146,6 +146,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private weak var recordingViewModel: ChatViewModel?
     var statusIconCancellable: AnyCancellable?
     var connectionStatusCancellable: AnyCancellable?
+    private var quickInputAttachmentCancellable: AnyCancellable?
     var pulseTimer: Timer?
     var pulsePhase: CGFloat = 1.0
     var pulseDirection: CGFloat = -1.0
@@ -1367,30 +1368,30 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func handleQuickInputSubmit(_ message: String, imageData: Data?) {
-        // Ensure MainWindow exists without bringing it to the foreground.
-        // showMainWindow() would activate the app — instead, create the
-        // window lazily if needed, but don't call show().
-        if mainWindow == nil {
-            let main = MainWindow(services: services)
-            main.onMicrophoneToggle = { [weak self] in
-                self?.voiceInput?.toggleRecording()
-            }
-            main.threadManager.onInlineConfirmationResponse = { [weak self] requestId, decision in
-                guard let self else { return }
-                self.toolConfirmationNotificationService.handleInlineResponse(requestId: requestId)
-                UNUserNotificationCenter.current().removeDeliveredNotifications(
-                    withIdentifiers: ["tool-confirm-\(requestId)"]
-                )
-            }
-            mainWindow = main
-            observeAssistantStatus()
-        }
+        showMainWindow()
         guard let mainWindow else { return }
         mainWindow.threadManager.createThread()
-        if let viewModel = mainWindow.activeViewModel {
-            if let imageData {
-                viewModel.addAttachment(imageData: imageData, filename: "Screenshot.jpg")
-            }
+        // Navigate the sidebar to the new thread's chat view so the user
+        // sees the conversation immediately (not Home Base or another panel).
+        if let threadId = mainWindow.threadManager.activeThreadId {
+            mainWindow.windowState.selection = .thread(threadId)
+        }
+        guard let viewModel = mainWindow.activeViewModel else { return }
+
+        if let imageData {
+            // addAttachment is async — it spawns a Task internally for image
+            // processing. Wait for it to finish before sending the message so
+            // the attachment is included in the API call.
+            viewModel.addAttachment(imageData: imageData, filename: "Screenshot.jpg")
+            viewModel.inputText = message
+            quickInputAttachmentCancellable = viewModel.attachmentManager.$isLoadingAttachment
+                .filter { !$0 }
+                .first()
+                .sink { [weak self] _ in
+                    viewModel.sendMessage()
+                    self?.quickInputAttachmentCancellable = nil
+                }
+        } else {
             viewModel.inputText = message
             viewModel.sendMessage()
         }

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
@@ -85,12 +85,18 @@ final class QuickInputWindow {
 
         isCapturingScreen = true
 
-        // Hide the panel temporarily
+        // Remove the resign-key observer so the panel doesn't dismiss when the
+        // selection overlay takes key status. The panel stays visible — the
+        // screenshot excludes app windows via SCContentFilter, and the selection
+        // overlay renders above the panel (.screenSaver > .floating).
         if let resignObserver {
             NotificationCenter.default.removeObserver(resignObserver)
         }
         resignObserver = nil
-        panel?.orderOut(nil)
+
+        // Save the panel's current frame so we can restore it after recreating
+        // the panel (needed because attachedImage is a `let` init param).
+        let savedFrame = self.panel?.frame
 
         let selectionWindow = ScreenSelectionWindow()
         selectionWindow.onComplete = { [weak self] imageData, selectionRect in
@@ -100,11 +106,16 @@ final class QuickInputWindow {
             self.screenSelectionWindow = nil
             self.isCapturingScreen = false
 
-            // Recreate the panel with the image attached and reposition near selection
+            // Recreate the panel with the image attached
             self.panel?.close()
             self.panel = nil
             let newPanel = self.makePanel()
-            self.repositionNearRect(newPanel, rect: selectionRect)
+            // Restore to the saved position instead of repositioning near the selection rect
+            if let savedFrame {
+                newPanel.setFrame(savedFrame, display: true)
+            } else {
+                self.repositionNearRect(newPanel, rect: selectionRect)
+            }
             self.presentPanel(newPanel)
         }
         selectionWindow.onCancel = { [weak self] in
@@ -112,11 +123,16 @@ final class QuickInputWindow {
             self.screenSelectionWindow = nil
             self.isCapturingScreen = false
 
-            // Re-show the panel in its original position
-            if let panel = self.panel {
-                self.presentPanel(panel)
-            } else {
-                self.show()
+            // Panel was never hidden — just restore the resign-key observer
+            self.resignObserver = NotificationCenter.default.addObserver(
+                forName: NSWindow.didResignKeyNotification,
+                object: self.panel,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    guard self?.isCapturingScreen != true else { return }
+                    self?.dismiss(restorePreviousApp: false)
+                }
             }
         }
         selectionWindow.show()
@@ -148,7 +164,7 @@ final class QuickInputWindow {
                 } else {
                     self?.onSubmit?(message, self?.attachedImageData)
                 }
-                self?.dismiss(restorePreviousApp: true)
+                self?.dismiss(restorePreviousApp: false)
             },
             onDismiss: { [weak self] in
                 self?.dismiss()


### PR DESCRIPTION
## Summary
- Keep the quick input floating widget visible during screenshot capture (it was hiding, breaking visual continuity). The screenshot already excludes app windows via `SCContentFilter`.
- Fix image attachment not being sent with the message by waiting for the async `addAttachment` processing to complete before calling `sendMessage()`.
- Show the main window and navigate to the new thread's chat view on submit, so the user immediately sees their conversation instead of having to manually click on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
