### PR TITLE
refactor: extract per-tool post-execution side effects into registry pattern

### DIFF
--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -15,7 +15,8 @@ import type { SecretPrompter } from '../permissions/secret-prompter.js';
 import { addRule, findHighestPriorityRule } from '../permissions/trust-store.js';
 import { generateAllowlistOptions, generateScopeOptions, normalizeWebFetchUrl } from '../permissions/checker.js';
 import { getLogger } from '../util/logger.js';
-import { isDoordashCommand, markDoordashStepInProgress, updateDoordashProgress } from './doordash-steps.js';
+import { isDoordashCommand, markDoordashStepInProgress } from './doordash-steps.js';
+import { runPostExecutionSideEffects } from './tool-side-effects.js';
 
 const log = getLogger('session-tool-setup');
 import { getAllToolDefinitions } from '../tools/registry.js';
@@ -23,12 +24,9 @@ import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
 import { coreAppProxyTools } from '../tools/apps/definitions.js';
 import { requestComputerControlTool } from '../tools/computer-use/request-computer-control.js';
 import {
-  refreshSurfacesForApp,
   surfaceProxyResolver,
 } from './session-surfaces.js';
 import type { SurfaceSessionContext } from './session-surfaces.js';
-import { updatePublishedAppDeployment } from '../services/published-app-updater.js';
-import { openAppViaSurface } from '../tools/apps/open-proxy.js';
 import { registerSessionSender } from '../tools/browser/browser-screencast.js';
 import type { ProxyApprovalCallback, ProxyApprovalRequest } from '../tools/network/script-proxy/index.js';
 import { projectSkillTools, type SkillProjectionCache } from './session-skill-tools.js';
@@ -184,51 +182,7 @@ export function createToolExecutor(
       },
     });
 
-    // Auto-refresh workspace surfaces when a persisted app is updated.
-    // If no surface is currently showing the app, auto-open it.
-    if (name === 'app_update' && !result.isError) {
-      const appId = input.app_id as string | undefined;
-      if (appId) {
-        const refreshed = refreshSurfacesForApp(ctx, appId);
-        broadcastToAllClients?.({ type: 'app_files_changed', appId });
-        void updatePublishedAppDeployment(appId);
-        if (!refreshed && !ctx.hasNoClient && !ctx.headlessLock) {
-          const resolver = (tn: string, pi: Record<string, unknown>) => surfaceProxyResolver(ctx, tn, pi);
-          void openAppViaSurface(appId, resolver);
-        }
-      }
-    }
-
-    // Tell the client to open/focus the tasks window when the model lists tasks
-    if (name === 'task_list_show' && !result.isError) {
-      ctx.sendToClient({ type: 'open_tasks_window' });
-    }
-
-    // Broadcast tasks_changed so connected clients (e.g. macOS Tasks window)
-    // auto-refresh when the LLM mutates the task queue via tools
-    if ((name === 'task_list_add' || name === 'task_list_update' || name === 'task_list_remove' || name === 'task_queue_run') && !result.isError) {
-      broadcastToAllClients?.({ type: 'tasks_changed' });
-    }
-
-    // Auto-refresh workspace surfaces when app files are edited.
-    // If no surface is currently showing the app, auto-open it.
-    if ((name === 'app_file_edit' || name === 'app_file_write') && !result.isError) {
-      const appId = input.app_id as string | undefined;
-      const status = input.status as string | undefined;
-      if (appId) {
-        const refreshed = refreshSurfacesForApp(ctx, appId, { fileChange: true, status });
-        broadcastToAllClients?.({ type: 'app_files_changed', appId });
-        void updatePublishedAppDeployment(appId);
-        if (!refreshed && !ctx.hasNoClient && !ctx.headlessLock) {
-          const resolver = (tn: string, pi: Record<string, unknown>) => surfaceProxyResolver(ctx, tn, pi);
-          void openAppViaSurface(appId, resolver);
-        }
-      }
-    }
-
-    if (isDoordashCommand(name, input)) {
-      updateDoordashProgress(ctx, input, result.isError);
-    }
+    runPostExecutionSideEffects(name, input, result, { ctx, broadcastToAllClients });
 
     return result;
   };

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -1,0 +1,129 @@
+/**
+ * Registry of per-tool post-execution side effects.
+ *
+ * Each entry maps one or more tool names to a handler that runs after
+ * successful execution. This keeps the main tool executor callback
+ * focused on orchestration — adding a new side effect is a single
+ * registry entry instead of another if/else branch.
+ */
+
+import type { ToolExecutionResult } from '../tools/types.js';
+import type { ServerMessage } from './ipc-protocol.js';
+import type { ToolSetupContext } from './session-tool-setup.js';
+import { isDoordashCommand, updateDoordashProgress } from './doordash-steps.js';
+import {
+  refreshSurfacesForApp,
+  surfaceProxyResolver,
+} from './session-surfaces.js';
+import { updatePublishedAppDeployment } from '../services/published-app-updater.js';
+import { openAppViaSurface } from '../tools/apps/open-proxy.js';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface SideEffectContext {
+  ctx: ToolSetupContext;
+  broadcastToAllClients?: (msg: ServerMessage) => void;
+}
+
+export type PostExecutionHook = (
+  name: string,
+  input: Record<string, unknown>,
+  result: ToolExecutionResult,
+  sideEffectCtx: SideEffectContext,
+) => void;
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/** Shared logic for refreshing app surfaces, broadcasting changes, and auto-opening. */
+function handleAppChange(
+  ctx: ToolSetupContext,
+  appId: string,
+  broadcastToAllClients: ((msg: ServerMessage) => void) | undefined,
+  opts?: { fileChange?: boolean; status?: string },
+): void {
+  const refreshed = refreshSurfacesForApp(ctx, appId, opts);
+  broadcastToAllClients?.({ type: 'app_files_changed', appId });
+  void updatePublishedAppDeployment(appId);
+  if (!refreshed && !ctx.hasNoClient && !ctx.headlessLock) {
+    const resolver = (tn: string, pi: Record<string, unknown>) => surfaceProxyResolver(ctx, tn, pi);
+    void openAppViaSurface(appId, resolver);
+  }
+}
+
+// ── Registry ─────────────────────────────────────────────────────────
+
+/**
+ * Map of tool names to their post-execution side effect hooks.
+ * Hooks only run when `result.isError` is false (checked by the runner).
+ */
+const postExecutionHooks = new Map<string, PostExecutionHook>();
+
+function registerHook(toolNames: string | string[], hook: PostExecutionHook): void {
+  const names = Array.isArray(toolNames) ? toolNames : [toolNames];
+  for (const name of names) {
+    postExecutionHooks.set(name, hook);
+  }
+}
+
+// Auto-refresh workspace surfaces when a persisted app is updated.
+// If no surface is currently showing the app, auto-open it.
+registerHook('app_update', (_name, input, _result, { ctx, broadcastToAllClients }) => {
+  const appId = input.app_id as string | undefined;
+  if (appId) {
+    handleAppChange(ctx, appId, broadcastToAllClients);
+  }
+});
+
+// Tell the client to open/focus the tasks window when the model lists tasks
+registerHook('task_list_show', (_name, _input, _result, { ctx }) => {
+  ctx.sendToClient({ type: 'open_tasks_window' });
+});
+
+// Broadcast tasks_changed so connected clients (e.g. macOS Tasks window)
+// auto-refresh when the LLM mutates the task queue via tools
+registerHook(
+  ['task_list_add', 'task_list_update', 'task_list_remove', 'task_queue_run'],
+  (_name, _input, _result, { broadcastToAllClients }) => {
+    broadcastToAllClients?.({ type: 'tasks_changed' });
+  },
+);
+
+// Auto-refresh workspace surfaces when app files are edited.
+// If no surface is currently showing the app, auto-open it.
+registerHook(
+  ['app_file_edit', 'app_file_write'],
+  (_name, input, _result, { ctx, broadcastToAllClients }) => {
+    const appId = input.app_id as string | undefined;
+    const status = input.status as string | undefined;
+    if (appId) {
+      handleAppChange(ctx, appId, broadcastToAllClients, { fileChange: true, status });
+    }
+  },
+);
+
+// ── Runner ───────────────────────────────────────────────────────────
+
+/**
+ * Run all applicable post-execution side effects for a completed tool call.
+ * Handles both registry-based hooks and the DoorDash step tracker (which
+ * uses its own name-matching logic).
+ */
+export function runPostExecutionSideEffects(
+  name: string,
+  input: Record<string, unknown>,
+  result: ToolExecutionResult,
+  sideEffectCtx: SideEffectContext,
+): void {
+  // Registry-based hooks only fire on success
+  if (!result.isError) {
+    const hook = postExecutionHooks.get(name);
+    if (hook) {
+      hook(name, input, result, sideEffectCtx);
+    }
+  }
+
+  // DoorDash progress tracking fires on both success and failure
+  if (isDoordashCommand(name, input)) {
+    updateDoordashProgress(sideEffectCtx.ctx, input, result.isError);
+  }
+}


### PR DESCRIPTION
Replace growing if/else chain of per-tool post-execution side effects in session-tool-setup.ts with a registry/map pattern. Makes adding new tool side effects declarative instead of modifying a monolithic block.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
