### PR TITLE
perf: fix memory recall cache invalidation on every message

### DIFF
--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -7,7 +7,6 @@ import { getDb } from './db.js';
 import { enqueueMemoryJob, enqueueResolvePendingConflictsForMessageJob } from './jobs-store.js';
 import { extractTextFromStoredMessageContent } from './message-content.js';
 import { segmentText } from './segmenter.js';
-import { bumpMemoryVersion } from './recall-cache.js';
 import { memorySegments } from './schema.js';
 
 const log = getLogger('memory-indexer');
@@ -119,7 +118,6 @@ export function indexMessageNow(
     log.info(`Skipping extraction/conflict jobs for untrusted actor (role=${input.provenanceActorRole})`);
   }
 
-  bumpMemoryVersion();
   enqueueSummaryRollupJobsIfDue();
 
   const extractionGated = !isTrustedActor;


### PR DESCRIPTION
Fix memory recall cache being defeated by continuous message indexing. bumpMemoryVersion() was invalidating cache on every new message, making it useless across turns. Now only bumps when memory items actually change (via jobs-worker after job completion and task-memory-cleanup after invalidation).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
