### PR TITLE
fix: use ModelIntent type instead of string in swarm/notification code

### DIFF
--- a/assistant/src/__tests__/swarm-router-planner.test.ts
+++ b/assistant/src/__tests__/swarm-router-planner.test.ts
@@ -104,7 +104,7 @@ describe('generatePlan', () => {
     const plan = await generatePlan({
       objective: 'Build feature X',
       provider: makeProvider(responseText),
-      model: 'test-model',
+      modelIntent: 'latency-optimized',
       limits: DEFAULT_LIMITS,
     });
     expect(plan.tasks).toHaveLength(2);
@@ -116,7 +116,7 @@ describe('generatePlan', () => {
     const plan = await generatePlan({
       objective: 'Build feature X',
       provider: makeProvider('Sorry, I cannot help with that.'),
-      model: 'test-model',
+      modelIntent: 'latency-optimized',
       limits: DEFAULT_LIMITS,
     });
     expect(plan.tasks).toHaveLength(1);
@@ -127,7 +127,7 @@ describe('generatePlan', () => {
     const plan = await generatePlan({
       objective: 'Build feature X',
       provider: makeFailingProvider(),
-      model: 'test-model',
+      modelIntent: 'latency-optimized',
       limits: DEFAULT_LIMITS,
     });
     expect(plan.tasks).toHaveLength(1);
@@ -143,7 +143,7 @@ describe('generatePlan', () => {
     const plan = await generatePlan({
       objective: 'Build feature X',
       provider: makeProvider(responseText),
-      model: 'test-model',
+      modelIntent: 'latency-optimized',
       limits: DEFAULT_LIMITS,
     });
     // Plan validator rejects invalid roles, so generatePlan catches and falls back
@@ -161,7 +161,7 @@ describe('generatePlan', () => {
     const plan = await generatePlan({
       objective: 'Build feature X',
       provider: makeProvider(responseText),
-      model: 'test-model',
+      modelIntent: 'latency-optimized',
       limits: DEFAULT_LIMITS,
     });
     expect(plan.tasks).toHaveLength(1);
@@ -178,7 +178,7 @@ describe('generatePlan', () => {
     const plan = await generatePlan({
       objective: 'Big feature',
       provider: makeProvider(JSON.stringify({ tasks })),
-      model: 'test-model',
+      modelIntent: 'latency-optimized',
       limits: DEFAULT_LIMITS,
     });
     expect(plan.tasks.length).toBeLessThanOrEqual(DEFAULT_LIMITS.maxTasks);
@@ -199,7 +199,7 @@ describe('generatePlan', () => {
     const plan = await generatePlan({
       objective: 'Build feature',
       provider,
-      model: 'test-model',
+      modelIntent: 'latency-optimized',
       limits: DEFAULT_LIMITS,
     });
     expect(plan.tasks).toHaveLength(1);

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -12,6 +12,7 @@
 import { v4 as uuid } from 'uuid';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
+import type { ModelIntent } from '../providers/types.js';
 import { getConfiguredProvider, createTimeout, extractToolUse, userMessage } from '../providers/provider-send-message.js';
 import { createDecision } from './decisions-store.js';
 import { getPreferenceSummary } from './preference-summary.js';
@@ -298,7 +299,7 @@ async function classifyWithLLM(
   signal: NotificationSignal,
   availableChannels: NotificationChannel[],
   preferenceContext: string | undefined,
-  modelIntent: string,
+  modelIntent: ModelIntent,
 ): Promise<NotificationDecision> {
   const provider = getConfiguredProvider()!;
   const { signal: abortSignal, cleanup } = createTimeout(DECISION_TIMEOUT_MS);

--- a/assistant/src/swarm/orchestrator.ts
+++ b/assistant/src/swarm/orchestrator.ts
@@ -3,7 +3,7 @@ import type { SwarmLimits } from './limits.js';
 import { getTimeoutForRole } from './limits.js';
 import type { SwarmWorkerBackend } from './worker-backend.js';
 import { runWorkerTask } from './worker-runner.js';
-import type { Provider } from '../providers/types.js';
+import type { Provider, ModelIntent } from '../providers/types.js';
 import { synthesizeResults } from './synthesizer.js';
 import { detectCycles } from './graph-utils.js';
 import { getLogger } from '../util/logger.js';
@@ -36,7 +36,7 @@ export interface ExecuteSwarmOptions {
   modelIntent?: string;
   /** Provider + model intent for final synthesis. */
   synthesisProvider?: Provider;
-  synthesisModelIntent?: string;
+  synthesisModelIntent?: ModelIntent;
   onStatus?: OrchestratorStatusCallback;
   signal?: AbortSignal;
   /** Stable identifier for this swarm run, used for checkpoint persistence. */

--- a/assistant/src/swarm/router-planner.ts
+++ b/assistant/src/swarm/router-planner.ts
@@ -1,4 +1,4 @@
-import type { Provider, Message } from '../providers/types.js';
+import type { Provider, Message, ModelIntent } from '../providers/types.js';
 import { parseJsonSafe } from '../util/json.js';
 import type { SwarmPlan, SwarmTaskNode } from './types.js';
 import { VALID_SWARM_ROLES } from './types.js';
@@ -13,7 +13,7 @@ import { ROUTER_SYSTEM_PROMPT, buildPlannerUserMessage } from './router-prompts.
 export async function generatePlan(opts: {
   objective: string;
   provider: Provider;
-  modelIntent: string;
+  modelIntent: ModelIntent;
   limits: SwarmLimits;
 }): Promise<SwarmPlan> {
   const { objective, provider, modelIntent, limits } = opts;


### PR DESCRIPTION
## Summary
- Replace `string` with `ModelIntent` type in `router-planner.ts`, `orchestrator.ts`, and `decision-engine.ts` parameters
- Fix test file `swarm-router-planner.test.ts` to use `modelIntent` instead of removed `model` property in `generatePlan()` calls

## Original prompt
fix: https://github.com/vellum-ai/vellum-assistant/actions/runs/22407807061/job/64872558473

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
