### PR TITLE
M6: Handle stale or invalid display selection

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Recording.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Recording.swift
@@ -59,7 +59,8 @@ extension AppDelegate {
                 self?.startRecording(
                     recordingId: recordingId,
                     options: selectedOptions,
-                    attachToConversationId: attachToConversationId
+                    attachToConversationId: attachToConversationId,
+                    promptForSource: true
                 )
             },
             onCancel: { [weak self] in
@@ -79,7 +80,8 @@ extension AppDelegate {
     private func startRecording(
         recordingId: String,
         options: IPCRecordingOptions?,
-        attachToConversationId: String?
+        attachToConversationId: String?,
+        promptForSource: Bool = false
     ) {
         // Wire up re-prompt callback so RecordingManager can re-show the
         // source picker when the selected source is no longer available.
@@ -105,7 +107,7 @@ extension AppDelegate {
                 sessionId: recordingId,
                 options: options,
                 attachToConversationId: attachToConversationId,
-                promptForSource: options?.promptForSource ?? false
+                promptForSource: promptForSource
             )
 
             guard started else { return }

--- a/clients/macos/vellum-assistant/App/AppDelegate+Recording.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Recording.swift
@@ -81,6 +81,12 @@ extension AppDelegate {
         options: IPCRecordingOptions?,
         attachToConversationId: String?
     ) {
+        // Wire up re-prompt callback so RecordingManager can re-show the
+        // source picker when the selected source is no longer available.
+        recordingManager.onSourceValidationFailed = { [weak self] sessionId, conversationId in
+            self?.showRecordingSourcePicker(recordingId: sessionId, attachToConversationId: conversationId)
+        }
+
         Task {
             // Check microphone permission if microphone is requested
             if options?.includeMicrophone == true {
@@ -98,7 +104,8 @@ extension AppDelegate {
             let started = await recordingManager.start(
                 sessionId: recordingId,
                 options: options,
-                attachToConversationId: attachToConversationId
+                attachToConversationId: attachToConversationId,
+                promptForSource: options?.promptForSource ?? false
             )
 
             guard started else { return }

--- a/clients/macos/vellum-assistant/Recording/RecordingManager.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingManager.swift
@@ -143,8 +143,8 @@ final class RecordingManager: ObservableObject {
                     log.warning("Source validation failed with promptForSource — re-showing source picker for session \(sessionId, privacy: .public)")
                     state = .idle
                     ownerSessionId = nil
-                    self.attachToConversationId = nil
                     onSourceValidationFailed?(sessionId, attachToConversationId)
+                    self.attachToConversationId = nil
                     return false
                 }
 

--- a/clients/macos/vellum-assistant/Recording/RecordingManager.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingManager.swift
@@ -44,6 +44,11 @@ final class RecordingManager: ObservableObject {
     private let recorder = ScreenRecorder()
     private weak var daemonClient: DaemonClient?
 
+    /// Callback invoked when source validation fails with `.noMatchingDisplay`
+    /// or `.noMatchingWindow` and `promptForSource` was set. The caller
+    /// (AppDelegate) can use this to re-show the source picker.
+    var onSourceValidationFailed: ((_ sessionId: String, _ attachToConversationId: String?) -> Void)?
+
     init(daemonClient: DaemonClient? = nil) {
         self.daemonClient = daemonClient
     }
@@ -62,7 +67,7 @@ final class RecordingManager: ObservableObject {
     ///   - attachToConversationId: Optional conversation ID to attach the recording to.
     /// - Returns: `true` if the recording started successfully, `false` otherwise.
     @discardableResult
-    func start(sessionId: String, options: IPCRecordingOptions? = nil, attachToConversationId: String? = nil) async -> Bool {
+    func start(sessionId: String, options: IPCRecordingOptions? = nil, attachToConversationId: String? = nil, promptForSource: Bool = false) async -> Bool {
         guard !state.isActive else {
             log.warning("Cannot start recording — already active (state=\(String(describing: self.state)), owner=\(self.ownerSessionId ?? "nil"))")
             sendStatus(sessionId: sessionId, status: "failed", error: "Another recording is already active")
@@ -120,6 +125,29 @@ final class RecordingManager: ObservableObject {
         } catch {
             // Only update state if we're still the active start attempt
             if state == .starting, ownerSessionId == sessionId {
+                // If source validation failed and promptForSource was set,
+                // re-show the source picker instead of failing permanently.
+                let isSourceValidationError: Bool
+                if let recorderError = error as? RecorderError {
+                    switch recorderError {
+                    case .noMatchingDisplay, .noMatchingWindow:
+                        isSourceValidationError = true
+                    default:
+                        isSourceValidationError = false
+                    }
+                } else {
+                    isSourceValidationError = false
+                }
+
+                if isSourceValidationError && promptForSource {
+                    log.warning("Source validation failed with promptForSource — re-showing source picker for session \(sessionId, privacy: .public)")
+                    state = .idle
+                    ownerSessionId = nil
+                    self.attachToConversationId = nil
+                    onSourceValidationFailed?(sessionId, attachToConversationId)
+                    return false
+                }
+
                 let message = error.localizedDescription
                 state = .failed(message)
                 sendStatus(sessionId: sessionId, status: "failed", error: message)

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
@@ -42,6 +42,9 @@ final class RecordingSourcePickerViewModel: ObservableObject {
     @Published private(set) var displays: [DisplaySource] = []
     @Published private(set) var windows: [WindowSource] = []
     @Published private(set) var isLoading = true
+    /// Brief notice shown when the selected source is no longer available
+    /// after a refresh. Cleared automatically after a short delay.
+    @Published var sourceUnavailableNotice: String?
 
     /// Computed recording options for the current selection.
     var selectedRecordingOptions: IPCRecordingOptions {
@@ -110,6 +113,61 @@ final class RecordingSourcePickerViewModel: ObservableObject {
             log.info("Found \(self.displays.count) displays, \(self.windows.count) windows")
         } catch {
             log.error("Failed to enumerate shareable content: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Refresh Sources
+
+    /// Re-enumerate available sources while preserving the current selection.
+    ///
+    /// If the previously selected display or window still exists, it remains
+    /// selected. If not, the selection is cleared and a brief notice is shown
+    /// to inform the user.
+    func refreshSources() async {
+        let previousDisplayId = selectedDisplayId
+        let previousWindowId = selectedWindowId
+        let previousScope = captureScope
+
+        await loadSources()
+
+        // Check whether the previous selection still exists
+        switch previousScope {
+        case .display:
+            if let prevId = previousDisplayId {
+                if displays.contains(where: { $0.id == prevId }) {
+                    // Previous display still available — keep selection
+                    selectedDisplayId = prevId
+                } else {
+                    // Previous display is gone — clear and notify
+                    selectedDisplayId = displays.first?.id
+                    showSourceUnavailableNotice("The previously selected display is no longer available.")
+                    log.info("Refresh: display \(prevId) no longer available — cleared selection")
+                }
+            }
+        case .window:
+            if let prevId = previousWindowId {
+                if windows.contains(where: { $0.id == prevId }) {
+                    // Previous window still available — keep selection
+                    selectedWindowId = prevId
+                } else {
+                    // Previous window is gone — clear and notify
+                    selectedWindowId = nil
+                    showSourceUnavailableNotice("The previously selected window is no longer available.")
+                    log.info("Refresh: window \(prevId) no longer available — cleared selection")
+                }
+            }
+        }
+    }
+
+    /// Show a brief unavailability notice, auto-clearing after 4 seconds.
+    private func showSourceUnavailableNotice(_ message: String) {
+        sourceUnavailableNotice = message
+        Task {
+            try? await Task.sleep(nanoseconds: 4_000_000_000)
+            // Only clear if the message hasn't been replaced by a newer one
+            if sourceUnavailableNotice == message {
+                sourceUnavailableNotice = nil
+            }
         }
     }
 }

--- a/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
+++ b/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
@@ -645,6 +645,9 @@ final class ScreenRecorder: NSObject {
     func cancelRecording() {
         guard isRecordingActive else { return }
 
+        // Unregister display monitoring since the recording session is ending.
+        unregisterDisplayReconfiguration()
+
         // Stop the stream synchronously (best-effort — stopCapture is async but
         // we nil it out so no more buffers arrive).
         stream = nil
@@ -699,6 +702,9 @@ final class ScreenRecorder: NSObject {
 
             log.error("Stream error during active recording — cleaning up (error=\(recorderError.localizedDescription, privacy: .public))")
 
+            // Unregister display monitoring since the recording session is ending.
+            unregisterDisplayReconfiguration()
+
             // Cancel the writer and remove the partial file
             assetWriter?.cancelWriting()
             if let outputURL = assetWriter?.outputURL {
@@ -724,7 +730,6 @@ final class ScreenRecorder: NSObject {
         recordingStartDate = nil
         outputDelegate = nil
         activeConfigLabel = nil
-        unregisterDisplayReconfiguration()
     }
 
     // MARK: - Display Reconfiguration Monitoring
@@ -763,6 +768,8 @@ final class ScreenRecorder: NSObject {
             // Stop the stream and notify via the error callback
             Task { @MainActor in
                 guard self.isRecordingActive else { return }
+                // Unregister display monitoring since the recording session is ending.
+                self.unregisterDisplayReconfiguration()
                 self.assetWriter?.cancelWriting()
                 if let outputURL = self.assetWriter?.outputURL {
                     try? FileManager.default.removeItem(at: outputURL)

--- a/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
+++ b/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
@@ -754,7 +754,7 @@ final class ScreenRecorder: NSObject {
     ///
     /// Called on the main actor. Checks whether the recorded display was
     /// removed or changed resolution.
-    private func handleDisplayReconfiguration(displayID: CGDirectDisplayID, flags: CGDisplayChangeSummaryFlags) {
+    fileprivate func handleDisplayReconfiguration(displayID: CGDirectDisplayID, flags: CGDisplayChangeSummaryFlags) {
         guard isRecordingActive, let recordedID = recordedDisplayID else { return }
         guard displayID == recordedID else { return }
 

--- a/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
+++ b/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
@@ -36,8 +36,8 @@ enum RecorderError: Error, LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .noMatchingDisplay: return "No matching display found for recording"
-        case .noMatchingWindow: return "No matching window found for recording"
+        case .noMatchingDisplay: return "The selected display is no longer available. It may have been unplugged or reconfigured."
+        case .noMatchingWindow: return "The selected window is no longer available. It may have been closed or moved to a different space."
         case .streamStartFailed(let reason): return "Failed to start screen capture stream: \(reason)"
         case .writerSetupFailed(let reason): return "Failed to set up video writer: \(reason)"
         case .notRecording: return "No active recording to stop"
@@ -77,6 +77,10 @@ final class ScreenRecorder: NSObject {
     private var recordingStartDate: Date?
     private var isRecordingActive = false
     private var hasReceivedVideoFrame = false
+
+    /// The display being recorded (nil for window captures). Used by the
+    /// display reconfiguration callback to detect removal or resolution changes.
+    private var recordedDisplayID: CGDirectDisplayID?
 
     /// Label of the encode config that was successfully used, for telemetry (M9).
     private(set) var activeConfigLabel: String?
@@ -287,6 +291,9 @@ final class ScreenRecorder: NSObject {
             captureWidth = Int(CGFloat(targetDisplay.width) * displayScale)
             captureHeight = Int(CGFloat(targetDisplay.height) * displayScale)
             log.info("Display capture: displayID=\(targetDisplay.displayID), scaleFactor=\(displayScale), sourceSize=\(targetDisplay.width)x\(targetDisplay.height), streamSize=\(captureWidth)x\(captureHeight)")
+
+            // Monitor this display for reconfiguration (unplug, resolution change)
+            registerDisplayReconfiguration(for: targetDisplay.displayID)
         }
 
         let fallbackConfigs = Self.buildFallbackConfigs(primaryWidth: captureWidth, primaryHeight: captureHeight)
@@ -529,6 +536,10 @@ final class ScreenRecorder: NSObject {
             throw RecorderError.notRecording
         }
 
+        // Unregister display monitoring early to avoid the reconfiguration
+        // callback racing with teardown.
+        unregisterDisplayReconfiguration()
+
         // Stop the capture stream
         if let stream {
             try? await stream.stopCapture()
@@ -713,6 +724,82 @@ final class ScreenRecorder: NSObject {
         recordingStartDate = nil
         outputDelegate = nil
         activeConfigLabel = nil
+        unregisterDisplayReconfiguration()
+    }
+
+    // MARK: - Display Reconfiguration Monitoring
+
+    /// Register for CoreGraphics display reconfiguration notifications.
+    ///
+    /// Called when a display recording starts. Detects display removal and
+    /// resolution changes while recording is active.
+    private func registerDisplayReconfiguration(for displayID: CGDirectDisplayID) {
+        recordedDisplayID = displayID
+        // `Unmanaged.passUnretained(self).toOpaque()` passes `self` as the
+        // user-info pointer without retaining, since the callback lifetime
+        // is bounded by the recording session.
+        CGDisplayRegisterReconfigurationCallback(displayReconfigurationCallback, Unmanaged.passUnretained(self).toOpaque())
+        log.info("Registered display reconfiguration callback for displayID=\(displayID)")
+    }
+
+    /// Unregister the CoreGraphics display reconfiguration callback.
+    private func unregisterDisplayReconfiguration() {
+        guard recordedDisplayID != nil else { return }
+        CGDisplayRemoveReconfigurationCallback(displayReconfigurationCallback, Unmanaged.passUnretained(self).toOpaque())
+        log.info("Unregistered display reconfiguration callback for displayID=\(self.recordedDisplayID!)")
+        recordedDisplayID = nil
+    }
+
+    /// Handle a display reconfiguration event dispatched from the C callback.
+    ///
+    /// Called on the main actor. Checks whether the recorded display was
+    /// removed or changed resolution.
+    private func handleDisplayReconfiguration(displayID: CGDirectDisplayID, flags: CGDisplayChangeSummaryFlags) {
+        guard isRecordingActive, let recordedID = recordedDisplayID else { return }
+        guard displayID == recordedID else { return }
+
+        if flags.contains(.removeFlag) {
+            log.error("Recorded display \(displayID) was removed during active recording — stopping gracefully")
+            // Stop the stream and notify via the error callback
+            Task { @MainActor in
+                guard self.isRecordingActive else { return }
+                self.assetWriter?.cancelWriting()
+                if let outputURL = self.assetWriter?.outputURL {
+                    try? FileManager.default.removeItem(at: outputURL)
+                    log.info("Removed partial recording file: \(outputURL.path, privacy: .public)")
+                }
+                self.stream = nil
+                self.cleanUpWriter()
+                self.onStreamError?(.sourceUnavailable("The recorded display was disconnected or removed."))
+            }
+        } else if flags.contains(.movedFlag) || flags.contains(.setMainFlag) || flags.contains(.setModeFlag) {
+            // Resolution or arrangement changed — ScreenCaptureKit handles
+            // this internally, so just log for diagnostics.
+            log.info("Recorded display \(displayID) reconfigured (flags=\(flags.rawValue)) — continuing recording (ScreenCaptureKit handles resolution changes)")
+        }
+    }
+}
+
+// MARK: - Display Reconfiguration C Callback
+
+/// C-function callback for `CGDisplayRegisterReconfigurationCallback`.
+///
+/// CoreGraphics invokes this on an arbitrary thread whenever a display is
+/// added, removed, or reconfigured. The `userInfo` pointer carries the
+/// `ScreenRecorder` instance (passed without retain). We dispatch to the
+/// main actor to safely access recorder state.
+private func displayReconfigurationCallback(
+    displayID: CGDirectDisplayID,
+    flags: CGDisplayChangeSummaryFlags,
+    userInfo: UnsafeMutableRawPointer?
+) {
+    // Only process the "after reconfiguration" phase
+    guard !flags.contains(.beginConfigurationFlag) else { return }
+    guard let userInfo else { return }
+
+    let recorder = Unmanaged<ScreenRecorder>.fromOpaque(userInfo).takeUnretainedValue()
+    Task { @MainActor in
+        recorder.handleDisplayReconfiguration(displayID: displayID, flags: flags)
     }
 }
 

--- a/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
+++ b/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
@@ -296,47 +296,54 @@ final class ScreenRecorder: NSObject {
             registerDisplayReconfiguration(for: targetDisplay.displayID)
         }
 
-        let fallbackConfigs = Self.buildFallbackConfigs(primaryWidth: captureWidth, primaryHeight: captureHeight)
-        log.info("Encoder fallback chain: \(fallbackConfigs.map { "\($0.label)(\($0.width)x\($0.height))" }.joined(separator: " → "), privacy: .public)")
+        do {
+            let fallbackConfigs = Self.buildFallbackConfigs(primaryWidth: captureWidth, primaryHeight: captureHeight)
+            log.info("Encoder fallback chain: \(fallbackConfigs.map { "\($0.label)(\($0.width)x\($0.height))" }.joined(separator: " → "), privacy: .public)")
 
-        try Self.ensureRecordingsDirectory()
+            try Self.ensureRecordingsDirectory()
 
-        for (index, encodeConfig) in fallbackConfigs.enumerated() {
-            let isLastConfig = index == fallbackConfigs.count - 1
-            log.info("Trying encoder config [\(index + 1)/\(fallbackConfigs.count)]: \(encodeConfig.label, privacy: .public) — codec=\(encodeConfig.codec.rawValue, privacy: .public), \(encodeConfig.width)x\(encodeConfig.height)")
+            for (index, encodeConfig) in fallbackConfigs.enumerated() {
+                let isLastConfig = index == fallbackConfigs.count - 1
+                log.info("Trying encoder config [\(index + 1)/\(fallbackConfigs.count)]: \(encodeConfig.label, privacy: .public) — codec=\(encodeConfig.codec.rawValue, privacy: .public), \(encodeConfig.width)x\(encodeConfig.height)")
 
-            let attemptResult = await attemptStartWithConfig(
-                encodeConfig: encodeConfig,
-                filter: filter,
-                includeAudio: includeAudio,
-                includeMicrophone: includeMicrophone
-            )
+                let attemptResult = await attemptStartWithConfig(
+                    encodeConfig: encodeConfig,
+                    filter: filter,
+                    includeAudio: includeAudio,
+                    includeMicrophone: includeMicrophone
+                )
 
-            switch attemptResult {
-            case .success:
-                activeConfigLabel = encodeConfig.label
-                log.info("Encoder config '\(encodeConfig.label, privacy: .public)' succeeded")
-                return
-            case .writerSetupFailed(let reason):
-                log.warning("Encoder config '\(encodeConfig.label, privacy: .public)' failed: writer setup error — \(reason, privacy: .public)")
-                if isLastConfig {
-                    throw RecorderError.allFallbacksExhausted
-                }
-            case .noFramesReceived:
-                log.warning("Encoder config '\(encodeConfig.label, privacy: .public)' failed: no frames received within timeout")
-                if isLastConfig {
-                    throw RecorderError.allFallbacksExhausted
-                }
-            case .streamStartFailed(let reason):
-                log.warning("Encoder config '\(encodeConfig.label, privacy: .public)' failed: stream start error — \(reason, privacy: .public)")
-                if isLastConfig {
-                    throw RecorderError.allFallbacksExhausted
+                switch attemptResult {
+                case .success:
+                    activeConfigLabel = encodeConfig.label
+                    log.info("Encoder config '\(encodeConfig.label, privacy: .public)' succeeded")
+                    return
+                case .writerSetupFailed(let reason):
+                    log.warning("Encoder config '\(encodeConfig.label, privacy: .public)' failed: writer setup error — \(reason, privacy: .public)")
+                    if isLastConfig {
+                        throw RecorderError.allFallbacksExhausted
+                    }
+                case .noFramesReceived:
+                    log.warning("Encoder config '\(encodeConfig.label, privacy: .public)' failed: no frames received within timeout")
+                    if isLastConfig {
+                        throw RecorderError.allFallbacksExhausted
+                    }
+                case .streamStartFailed(let reason):
+                    log.warning("Encoder config '\(encodeConfig.label, privacy: .public)' failed: stream start error — \(reason, privacy: .public)")
+                    if isLastConfig {
+                        throw RecorderError.allFallbacksExhausted
+                    }
                 }
             }
-        }
 
-        // Should not reach here — the loop either returns on success or throws on last failure
-        throw RecorderError.allFallbacksExhausted
+            // Should not reach here — the loop either returns on success or throws on last failure
+            throw RecorderError.allFallbacksExhausted
+        } catch {
+            // If start() fails after registering the display reconfiguration callback,
+            // unregister it to avoid a dangling callback referencing this instance.
+            unregisterDisplayReconfiguration()
+            throw error
+        }
     }
 
     // MARK: - Fallback Attempt

--- a/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
+++ b/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
@@ -663,7 +663,7 @@ final class ScreenRecorder: NSObject {
     // MARK: - Stream Error Handling
 
     /// Map an NSError from SCStream to a specific RecorderError case.
-    static func mapStreamError(_ nsError: NSError) -> RecorderError {
+    nonisolated static func mapStreamError(_ nsError: NSError) -> RecorderError {
         let domain = nsError.domain
         let code = nsError.code
 
@@ -697,7 +697,7 @@ final class ScreenRecorder: NSObject {
         Task { @MainActor in
             guard isRecordingActive else { return }
 
-            log.error("Stream error during active recording — cleaning up (error=\(recorderError.localizedDescription ?? "unknown", privacy: .public))")
+            log.error("Stream error during active recording — cleaning up (error=\(recorderError.localizedDescription, privacy: .public))")
 
             // Cancel the writer and remove the partial file
             assetWriter?.cancelWriting()


### PR DESCRIPTION
Re-validate sources at recording start time and handle display reconfiguration during active recording. Add CGDisplayReconfigurationCallback monitoring to detect display removal/changes. Add refreshSources() to picker ViewModel for re-enumeration. Re-prompt source picker when selected source becomes unavailable.

Part of #8885.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
