### PR TITLE
M7: Improve source picker UX for multi-monitor

### DIFF
--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -61,10 +61,8 @@ struct RecordingSourcePickerView: View {
                 switch viewModel.captureScope {
                 case .display:
                     ForEach(viewModel.displays) { display in
-                        sourceRow(
-                            title: display.name,
-                            subtitle: "\(display.width) x \(display.height)",
-                            icon: "display",
+                        displayRow(
+                            display: display,
                             isSelected: viewModel.selectedDisplayId == display.id
                         ) {
                             viewModel.selectedDisplayId = display.id
@@ -115,6 +113,65 @@ struct RecordingSourcePickerView: View {
                         .foregroundColor(VColor.textPrimary)
                         .lineLimit(1)
                     Text(subtitle)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                if isSelected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(VColor.accent)
+                }
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(isSelected ? VColor.accent.opacity(0.1) : Color.clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(isSelected ? VColor.accent.opacity(0.3) : VColor.surfaceBorder, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    /// Row for a display source showing name, resolution + scale, and a badge
+    /// when this is the display the picker window is on.
+    private func displayRow(
+        display: DisplaySource,
+        isSelected: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: VSpacing.md) {
+                Image(systemName: "display")
+                    .font(.system(size: 16))
+                    .foregroundColor(isSelected ? VColor.accent : VColor.textSecondary)
+                    .frame(width: 24)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: VSpacing.sm) {
+                        Text(display.name)
+                            .font(VFont.bodyMedium)
+                            .foregroundColor(VColor.textPrimary)
+                            .lineLimit(1)
+                        if display.isCurrentDisplay {
+                            Text("This display")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.accent)
+                                .padding(.horizontal, VSpacing.xs)
+                                .padding(.vertical, 1)
+                                .background(
+                                    Capsule()
+                                        .fill(VColor.accent.opacity(0.15))
+                                )
+                        }
+                    }
+                    Text(display.subtitle)
                         .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
                         .lineLimit(1)

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
@@ -216,6 +216,24 @@ final class RecordingSourcePickerViewModel: ObservableObject {
         }
     }
 
+    // MARK: - Update Current Display
+
+    /// Recalculates `isCurrentDisplay` for every display source based on
+    /// the screen the picker window currently occupies.  Because `displays`
+    /// is `@Published`, the UI updates reactively.
+    func updateCurrentDisplay() {
+        guard let pickerScreen = pickerWindow?.screen else { return }
+        let pickerDisplayId = pickerScreen.deviceDescription[
+            NSDeviceDescriptionKey("NSScreenNumber")
+        ] as? UInt32
+
+        displays = displays.map { source in
+            var updated = source
+            updated.isCurrentDisplay = (source.id == pickerDisplayId)
+            return updated
+        }
+    }
+
     /// Show a brief unavailability notice, auto-clearing after 4 seconds.
     private func showSourceUnavailableNotice(_ message: String) {
         sourceUnavailableNotice = message

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
@@ -1,3 +1,4 @@
+import AppKit
 import ScreenCaptureKit
 import VellumAssistantShared
 import os
@@ -10,6 +11,15 @@ struct DisplaySource: Identifiable, Hashable {
     let name: String
     let width: Int
     let height: Int
+    let scaleFactor: CGFloat
+    /// Whether the picker window is currently on this display.
+    var isCurrentDisplay: Bool
+
+    /// Human-readable resolution and scale, e.g. "2560 × 1440 @ 2x".
+    var subtitle: String {
+        let scaleLabel = scaleFactor >= 2 ? "@ \(Int(scaleFactor))x" : "@ 1x"
+        return "\(width) × \(height) \(scaleLabel)"
+    }
 }
 
 /// Represents an available window for recording.
@@ -46,6 +56,9 @@ final class RecordingSourcePickerViewModel: ObservableObject {
     /// after a refresh. Cleared automatically after a short delay.
     @Published var sourceUnavailableNotice: String?
 
+    /// The picker window, used to determine which display it's on.
+    weak var pickerWindow: NSWindow?
+
     /// Computed recording options for the current selection.
     var selectedRecordingOptions: IPCRecordingOptions {
         IPCRecordingOptions(
@@ -77,14 +90,58 @@ final class RecordingSourcePickerViewModel: ObservableObject {
             let shareable = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
             let selfBundleId = Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant"
 
-            displays = shareable.displays.map { display in
-                DisplaySource(
+            // Build a lookup from CGDirectDisplayID -> NSScreen for metadata
+            let screens = NSScreen.screens
+            let screensByDisplayId: [UInt32: NSScreen] = {
+                var map: [UInt32: NSScreen] = [:]
+                for screen in screens {
+                    if let screenNumber = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? UInt32 {
+                        map[screenNumber] = screen
+                    }
+                }
+                return map
+            }()
+
+            // Determine which display the picker window is on
+            let pickerDisplayId: UInt32? = {
+                guard let pickerScreen = pickerWindow?.screen ?? NSScreen.main else { return nil }
+                return pickerScreen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? UInt32
+            }()
+
+            var displaySources = shareable.displays.enumerated().map { (index, display) -> DisplaySource in
+                let screen = screensByDisplayId[display.displayID]
+                let scale = screen?.backingScaleFactor ?? 1.0
+                let name: String = {
+                    if let screen = screen {
+                        return screen.localizedName
+                    }
+                    // Fall back to 1-based index if NSScreen lookup fails
+                    return "Display \(index + 1)"
+                }()
+
+                return DisplaySource(
                     id: display.displayID,
-                    name: "Display \(display.displayID)",
+                    name: name,
                     width: display.width,
-                    height: display.height
+                    height: display.height,
+                    scaleFactor: scale,
+                    isCurrentDisplay: display.displayID == pickerDisplayId
                 )
             }
+
+            // Sort: built-in display first, then by horizontal position (leftmost first)
+            displaySources.sort { a, b in
+                let screenA = screensByDisplayId[a.id]
+                let screenB = screensByDisplayId[b.id]
+                let isBuiltInA = CGDisplayIsBuiltin(a.id) != 0
+                let isBuiltInB = CGDisplayIsBuiltin(b.id) != 0
+                if isBuiltInA != isBuiltInB { return isBuiltInA }
+                let xA = screenA?.frame.origin.x ?? CGFloat.greatestFiniteMagnitude
+                let xB = screenB?.frame.origin.x ?? CGFloat.greatestFiniteMagnitude
+                return xA < xB
+            }
+
+            displays = displaySources
 
             windows = shareable.windows
                 .filter { window in

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerWindow.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerWindow.swift
@@ -101,6 +101,10 @@ final class RecordingSourcePickerWindow: NSObject, NSWindowDelegate {
     nonisolated func windowWillClose(_ notification: Notification) {
         Task { @MainActor in
             fireCancel()
+            if let observer = moveObserver {
+                NotificationCenter.default.removeObserver(observer)
+                moveObserver = nil
+            }
             window = nil
             viewModel = nil
         }

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerWindow.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerWindow.swift
@@ -67,6 +67,8 @@ final class RecordingSourcePickerWindow: NSObject, NSWindowDelegate {
         NSApp.activate(ignoringOtherApps: true)
 
         self.window = newWindow
+        // Let the view model know which window it's in so it can detect the current display
+        vm.pickerWindow = newWindow
     }
 
     /// Dismiss the picker window.

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerWindow.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerWindow.swift
@@ -14,6 +14,9 @@ final class RecordingSourcePickerWindow: NSObject, NSWindowDelegate {
     /// Guards against double-invocation of the cancel callback (e.g., if
     /// the Cancel button is pressed and then the window also closes).
     private var cancelFired = false
+    /// Observation token for window-move notifications so we can update
+    /// the "This display" badge when the picker is dragged to another monitor.
+    private var moveObserver: NSObjectProtocol?
 
     /// Show the source picker window.
     ///
@@ -69,10 +72,23 @@ final class RecordingSourcePickerWindow: NSObject, NSWindowDelegate {
         self.window = newWindow
         // Let the view model know which window it's in so it can detect the current display
         vm.pickerWindow = newWindow
+
+        // Update the "This display" badge whenever the window moves to a different monitor
+        moveObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didMoveNotification,
+            object: newWindow,
+            queue: .main
+        ) { [weak self] _ in
+            self?.viewModel?.updateCurrentDisplay()
+        }
     }
 
     /// Dismiss the picker window.
     func dismiss() {
+        if let observer = moveObserver {
+            NotificationCenter.default.removeObserver(observer)
+            moveObserver = nil
+        }
         window?.delegate = nil
         window?.close()
         window = nil


### PR DESCRIPTION
Replace raw display IDs with human-friendly monitor labels (e.g., 'Built-in Retina Display', 'LG UltraFine'). Show resolution and scale factor metadata. Highlight which display the picker window is on. Sort displays by position with built-in first.

Part of #8885.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
