### PR TITLE
fix: shell tools no longer capped at 120s by executor timeout

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -438,8 +438,22 @@ export class ToolExecutor {
 
       // Execute the tool — proxy tools delegate to an external resolver
       let execResult: ToolExecutionResult;
-      const rawTimeoutSec = getConfig().timeouts.toolExecutionTimeoutSec;
-      const toolTimeoutMs = safeTimeoutMs(rawTimeoutSec);
+      let toolTimeoutMs: number;
+      if (name === 'bash' || name === 'host_bash') {
+        // Shell tools manage their own timeouts (SIGKILL on expiry).
+        // Compute the same effective timeout so the executor wrapper
+        // doesn't prematurely kill them with the generic toolExecutionTimeoutSec.
+        const { shellDefaultTimeoutSec, shellMaxTimeoutSec } = getConfig().timeouts;
+        const requestedSec = typeof input.timeout_seconds === 'number'
+          ? input.timeout_seconds
+          : shellDefaultTimeoutSec;
+        const shellTimeoutSec = Math.max(1, Math.min(requestedSec, shellMaxTimeoutSec));
+        // Buffer so the shell's own timeout fires first and handles cleanup
+        toolTimeoutMs = (shellTimeoutSec + 5) * 1000;
+      } else {
+        const rawTimeoutSec = getConfig().timeouts.toolExecutionTimeoutSec;
+        toolTimeoutMs = safeTimeoutMs(rawTimeoutSec);
+      }
 
       const execContext = context;
 


### PR DESCRIPTION
## Summary
- Shell tools (`bash`, `host_bash`) manage their own timeouts internally via `setTimeout` + `SIGKILL`
- The executor's generic `toolExecutionTimeoutSec` (default 120s) was wrapping shell executions as an outer timeout, firing before the shell's own timeout even when `timeout_seconds` was set higher
- Now the executor uses the shell's computed timeout + 5s buffer for these tools, so the shell's own timeout fires first

## Original prompt
look into what's going on here and fix it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8947" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
