### PR TITLE
fix: make entire steps progress bar clickable to expand/collapse

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/LiveToolProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/LiveToolProgressView.swift
@@ -67,6 +67,7 @@ struct LiveToolProgressView: View {
                         .foregroundColor(VColor.textMuted)
                         .rotationEffect(.degrees(isExpanded ? 90 : 0))
                 }
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .padding(.horizontal, VSpacing.sm)


### PR DESCRIPTION
## Summary
- Add `.contentShape(Rectangle())` to the header HStack in `LiveToolProgressView` so the entire bar area (including the spacer between the label and chevron) responds to clicks, not just the visible text and arrow icon.

## Original prompt
clicking anywhere on this bar should expand the list of items not just the arrow on the right

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
