### PR TITLE
fix: use emptyDefault() for Zod 4 object schema defaults

### DIFF
--- a/assistant/src/config/agent-schema.ts
+++ b/assistant/src/config/agent-schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { emptyDefault } from './schema-utils.js';
 
 export const AgentHeartbeatConfigSchema = z.object({
   enabled: z
@@ -128,7 +129,7 @@ export const WorkspaceGitConfigSchema = z.object({
     .int('workspaceGit.enrichmentMaxRetries must be an integer')
     .nonnegative('workspaceGit.enrichmentMaxRetries must be non-negative')
     .default(2),
-  commitMessageLLM: z.object({
+  commitMessageLLM: emptyDefault(z.object({
     enabled: z.boolean({ error: 'workspaceGit.commitMessageLLM.enabled must be a boolean' }).default(false),
     useConfiguredProvider: z.boolean({ error: 'workspaceGit.commitMessageLLM.useConfiguredProvider must be a boolean' }).default(true),
     providerFastModelOverrides: z.record(z.string(), z.string()).default({}),
@@ -156,15 +157,15 @@ export const WorkspaceGitConfigSchema = z.object({
       .int('workspaceGit.commitMessageLLM.minRemainingTurnBudgetMs must be an integer')
       .nonnegative('workspaceGit.commitMessageLLM.minRemainingTurnBudgetMs must be non-negative')
       .default(1000),
-    breaker: z.object({
+    breaker: emptyDefault(z.object({
       openAfterFailures: z.number({ error: 'workspaceGit.commitMessageLLM.breaker.openAfterFailures must be a number' })
         .int().positive().default(3),
       backoffBaseMs: z.number({ error: 'workspaceGit.commitMessageLLM.breaker.backoffBaseMs must be a number' })
         .int().positive().default(2000),
       backoffMaxMs: z.number({ error: 'workspaceGit.commitMessageLLM.breaker.backoffMaxMs must be a number' })
         .int().positive().default(60000),
-    }).default({}),
-  }).default({}),
+    })),
+  })),
 });
 
 export type AgentHeartbeatConfig = z.infer<typeof AgentHeartbeatConfigSchema>;

--- a/assistant/src/config/calls-schema.ts
+++ b/assistant/src/config/calls-schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { emptyDefault } from './schema-utils.js';
 
 const VALID_CALL_PROVIDERS = ['twilio'] as const;
 const VALID_CALL_VOICE_MODES = ['twilio_standard', 'twilio_elevenlabs_tts', 'elevenlabs_agent'] as const;
@@ -76,7 +77,7 @@ export const CallsVoiceConfigSchema = z.object({
   fallbackToStandardOnError: z
     .boolean({ error: 'calls.voice.fallbackToStandardOnError must be a boolean' })
     .default(true),
-  elevenlabs: CallsElevenLabsConfigSchema.default({}),
+  elevenlabs: emptyDefault(CallsElevenLabsConfigSchema),
 });
 
 export const CallerIdentityConfigSchema = z.object({
@@ -125,14 +126,14 @@ export const CallsConfigSchema = z.object({
     .positive('calls.userConsultTimeoutSeconds must be a positive integer')
     .max(2_147_483, 'calls.userConsultTimeoutSeconds must be at most 2147483 (setTimeout-safe limit)')
     .default(120),
-  disclosure: CallsDisclosureConfigSchema.default({}),
-  safety: CallsSafetyConfigSchema.default({}),
-  voice: CallsVoiceConfigSchema.default({}),
+  disclosure: emptyDefault(CallsDisclosureConfigSchema),
+  safety: emptyDefault(CallsSafetyConfigSchema),
+  voice: emptyDefault(CallsVoiceConfigSchema),
   model: z
     .string({ error: 'calls.model must be a string' })
     .optional(),
-  callerIdentity: CallerIdentityConfigSchema.default({}),
-  verification: CallsVerificationConfigSchema.default({}),
+  callerIdentity: emptyDefault(CallerIdentityConfigSchema),
+  verification: emptyDefault(CallsVerificationConfigSchema),
 });
 
 export type CallsConfig = z.infer<typeof CallsConfigSchema>;

--- a/assistant/src/config/core-schema.ts
+++ b/assistant/src/config/core-schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { emptyDefault } from './schema-utils.js';
 
 const VALID_SECRET_ACTIONS = ['redact', 'warn', 'block', 'prompt'] as const;
 const VALID_PERMISSIONS_MODES = ['legacy', 'strict', 'workspace'] as const;
@@ -223,8 +224,8 @@ const IngressBaseSchema = z.object({
       'ingress.publicBaseUrl must be an absolute URL starting with http:// or https://',
     )
     .default(''),
-  webhook: IngressWebhookConfigSchema.default({}),
-  rateLimit: IngressRateLimitConfigSchema.default({}),
+  webhook: emptyDefault(IngressWebhookConfigSchema),
+  rateLimit: emptyDefault(IngressRateLimitConfigSchema),
   shutdownDrainMs: z
     .number({ error: 'ingress.shutdownDrainMs must be a number' })
     .int('ingress.shutdownDrainMs must be an integer')
@@ -232,8 +233,7 @@ const IngressBaseSchema = z.object({
     .default(5_000),
 });
 
-export const IngressConfigSchema = IngressBaseSchema
-  .default({})
+export const IngressConfigSchema = emptyDefault(IngressBaseSchema)
   .transform((val) => ({
     ...val,
     // Backward compatibility: if `enabled` was never explicitly set (undefined),

--- a/assistant/src/config/memory-schema.ts
+++ b/assistant/src/config/memory-schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { emptyDefault } from './schema-utils.js';
 
 const VALID_MEMORY_EMBEDDING_PROVIDERS = ['auto', 'local', 'openai', 'gemini', 'ollama'] as const;
 const VALID_MEMORY_ITEM_KINDS = [
@@ -124,7 +125,7 @@ const MemoryFreshnessConfigSchema = z.object({
   enabled: z
     .boolean({ error: 'memory.retrieval.freshness.enabled must be a boolean' })
     .default(true),
-  maxAgeDays: z.object({
+  maxAgeDays: emptyDefault(z.object({
     fact: z
       .number({ error: 'memory.retrieval.freshness.maxAgeDays.fact must be a number' })
       .nonnegative('memory.retrieval.freshness.maxAgeDays.fact must be non-negative')
@@ -145,7 +146,7 @@ const MemoryFreshnessConfigSchema = z.object({
       .number({ error: 'memory.retrieval.freshness.maxAgeDays.opinion must be a number' })
       .nonnegative('memory.retrieval.freshness.maxAgeDays.opinion must be non-negative')
       .default(60),
-  }).default({}),
+  })),
   staleDecay: z
     .number({ error: 'memory.retrieval.freshness.staleDecay must be a number' })
     .min(0, 'memory.retrieval.freshness.staleDecay must be >= 0')
@@ -181,15 +182,15 @@ export const MemoryRetrievalConfigSchema = z.object({
       error: 'memory.retrieval.injectionStrategy must be "prepend_user_block" or "separate_context_message"',
     })
     .default('prepend_user_block'),
-  reranking: MemoryRerankingConfigSchema.default({}),
-  freshness: MemoryFreshnessConfigSchema.default({}),
+  reranking: emptyDefault(MemoryRerankingConfigSchema),
+  freshness: emptyDefault(MemoryFreshnessConfigSchema),
   scopePolicy: z
     .enum(['allow_global_fallback', 'strict'], {
       error: 'memory.retrieval.scopePolicy must be "allow_global_fallback" or "strict"',
     })
     .default('allow_global_fallback'),
-  dynamicBudget: MemoryDynamicBudgetConfigSchema.default({}),
-  earlyTermination: MemoryEarlyTerminationConfigSchema.default({}),
+  dynamicBudget: emptyDefault(MemoryDynamicBudgetConfigSchema),
+  earlyTermination: emptyDefault(MemoryEarlyTerminationConfigSchema),
 });
 
 export const MemorySegmentationConfigSchema = z.object({
@@ -273,7 +274,7 @@ export const MemoryEntityConfigSchema = z.object({
       error: 'memory.entity.modelIntent must be a valid model intent',
     })
     .default('latency-optimized'),
-  extractRelations: z.object({
+  extractRelations: emptyDefault(z.object({
     enabled: z
       .boolean({ error: 'memory.entity.extractRelations.enabled must be a boolean' })
       .default(true),
@@ -282,8 +283,8 @@ export const MemoryEntityConfigSchema = z.object({
       .int('memory.entity.extractRelations.backfillBatchSize must be an integer')
       .positive('memory.entity.extractRelations.backfillBatchSize must be a positive integer')
       .default(200),
-  }).default({}),
-  relationRetrieval: z.object({
+  })),
+  relationRetrieval: emptyDefault(z.object({
     enabled: z
       .boolean({ error: 'memory.entity.relationRetrieval.enabled must be a boolean' })
       .default(true),
@@ -315,7 +316,7 @@ export const MemoryEntityConfigSchema = z.object({
     depthDecay: z
       .boolean({ error: 'memory.entity.relationRetrieval.depthDecay must be a boolean' })
       .default(true),
-  }).default({}),
+  })),
 });
 
 export const MemoryConflictsConfigSchema = z.object({
@@ -379,18 +380,18 @@ export const MemoryConfigSchema = z.object({
   enabled: z
     .boolean({ error: 'memory.enabled must be a boolean' })
     .default(true),
-  embeddings: MemoryEmbeddingsConfigSchema.default({}),
-  qdrant: QdrantConfigSchema.default({}),
-  retrieval: MemoryRetrievalConfigSchema.default({}),
-  segmentation: MemorySegmentationConfigSchema.default({}),
-  jobs: MemoryJobsConfigSchema.default({}),
-  retention: MemoryRetentionConfigSchema.default({}),
-  cleanup: MemoryCleanupConfigSchema.default({}),
-  extraction: MemoryExtractionConfigSchema.default({}),
-  summarization: MemorySummarizationConfigSchema.default({}),
-  entity: MemoryEntityConfigSchema.default({}),
-  conflicts: MemoryConflictsConfigSchema.default({}),
-  profile: MemoryProfileConfigSchema.default({}),
+  embeddings: emptyDefault(MemoryEmbeddingsConfigSchema),
+  qdrant: emptyDefault(QdrantConfigSchema),
+  retrieval: emptyDefault(MemoryRetrievalConfigSchema),
+  segmentation: emptyDefault(MemorySegmentationConfigSchema),
+  jobs: emptyDefault(MemoryJobsConfigSchema),
+  retention: emptyDefault(MemoryRetentionConfigSchema),
+  cleanup: emptyDefault(MemoryCleanupConfigSchema),
+  extraction: emptyDefault(MemoryExtractionConfigSchema),
+  summarization: emptyDefault(MemorySummarizationConfigSchema),
+  entity: emptyDefault(MemoryEntityConfigSchema),
+  conflicts: emptyDefault(MemoryConflictsConfigSchema),
+  profile: emptyDefault(MemoryProfileConfigSchema),
 });
 
 export type MemoryEmbeddingsConfig = z.infer<typeof MemoryEmbeddingsConfigSchema>;

--- a/assistant/src/config/sandbox-schema.ts
+++ b/assistant/src/config/sandbox-schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { emptyDefault } from './schema-utils.js';
 
 const VALID_SANDBOX_BACKENDS = ['native', 'docker'] as const;
 const VALID_DOCKER_NETWORKS = ['none', 'bridge'] as const;
@@ -41,7 +42,7 @@ export const SandboxConfigSchema = z.object({
       error: `sandbox.backend must be one of: ${VALID_SANDBOX_BACKENDS.join(', ')}`,
     })
     .default('docker'),
-  docker: DockerConfigSchema.default({}),
+  docker: emptyDefault(DockerConfigSchema),
 });
 
 export type SandboxConfig = z.infer<typeof SandboxConfigSchema>;

--- a/assistant/src/config/schema-utils.ts
+++ b/assistant/src/config/schema-utils.ts
@@ -1,0 +1,13 @@
+import type { z } from 'zod';
+
+/**
+ * Apply `.default({})` to a Zod object schema whose fields all carry their own
+ * defaults.  Zod fills in inner defaults at parse time, but its `.default()`
+ * overload expects the **output** type, so TypeScript rejects the literal `{}`.
+ * This wraps the cast in a single location.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function emptyDefault<T extends z.ZodType>(schema: T): z.ZodDefault<T> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (schema as any).default({});
+}

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { emptyDefault } from './schema-utils.js';
 import { getDataDir } from '../util/platform.js';
 
 // Re-export all domain schemas
@@ -193,32 +194,32 @@ export const AssistantConfigSchema = z.object({
     .int('maxToolUseTurns must be an integer')
     .positive('maxToolUseTurns must be a positive integer')
     .default(60),
-  thinking: ThinkingConfigSchema.default({}),
-  contextWindow: ContextWindowConfigSchema.default({}),
-  memory: MemoryConfigSchema.default({}),
+  thinking: emptyDefault(ThinkingConfigSchema),
+  contextWindow: emptyDefault(ContextWindowConfigSchema),
+  memory: emptyDefault(MemoryConfigSchema),
   dataDir: z
     .string({ error: 'dataDir must be a string' })
     .default(getDataDir()),
-  timeouts: TimeoutConfigSchema.default({}),
-  sandbox: SandboxConfigSchema.default({}),
-  rateLimit: RateLimitConfigSchema.default({}),
-  secretDetection: SecretDetectionConfigSchema.default({}),
-  permissions: PermissionsConfigSchema.default({}),
-  auditLog: AuditLogConfigSchema.default({}),
-  logFile: LogFileConfigSchema.default({}),
+  timeouts: emptyDefault(TimeoutConfigSchema),
+  sandbox: emptyDefault(SandboxConfigSchema),
+  rateLimit: emptyDefault(RateLimitConfigSchema),
+  secretDetection: emptyDefault(SecretDetectionConfigSchema),
+  permissions: emptyDefault(PermissionsConfigSchema),
+  auditLog: emptyDefault(AuditLogConfigSchema),
+  logFile: emptyDefault(LogFileConfigSchema),
   pricingOverrides: z
     .array(ModelPricingOverrideSchema)
     .default([]),
-  agentHeartbeat: AgentHeartbeatConfigSchema.default({}),
-  swarm: SwarmConfigSchema.default({}),
-  skills: SkillsConfigSchema.default({}),
-  workspaceGit: WorkspaceGitConfigSchema.default({}),
-  calls: CallsConfigSchema.default({}),
-  sms: SmsConfigSchema.default({}),
+  agentHeartbeat: emptyDefault(AgentHeartbeatConfigSchema),
+  swarm: emptyDefault(SwarmConfigSchema),
+  skills: emptyDefault(SkillsConfigSchema),
+  workspaceGit: emptyDefault(WorkspaceGitConfigSchema),
+  calls: emptyDefault(CallsConfigSchema),
+  sms: emptyDefault(SmsConfigSchema),
   ingress: IngressConfigSchema,
-  platform: PlatformConfigSchema.default({}),
-  daemon: DaemonConfigSchema.default({}),
-  notifications: NotificationsConfigSchema.default({}),
+  platform: emptyDefault(PlatformConfigSchema),
+  daemon: emptyDefault(DaemonConfigSchema),
+  notifications: emptyDefault(NotificationsConfigSchema),
 }).superRefine((config, ctx) => {
   if (config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {
     ctx.addIssue({

--- a/assistant/src/config/skills-schema.ts
+++ b/assistant/src/config/skills-schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { emptyDefault } from './schema-utils.js';
 
 export const SkillEntryConfigSchema = z.object({
   enabled: z.boolean({ error: 'skills.entries[].enabled must be a boolean' }).default(true),
@@ -21,8 +22,8 @@ export const SkillsInstallConfigSchema = z.object({
 
 export const SkillsConfigSchema = z.object({
   entries: z.record(z.string(), SkillEntryConfigSchema).default({}),
-  load: SkillsLoadConfigSchema.default({}),
-  install: SkillsInstallConfigSchema.default({}),
+  load: emptyDefault(SkillsLoadConfigSchema),
+  install: emptyDefault(SkillsInstallConfigSchema),
   allowBundled: z.array(z.string()).nullable().default(null),
 });
 


### PR DESCRIPTION
## Summary
- Replace `.default({})` with `emptyDefault()` wrapper on all Zod object schemas across config files
- In Zod 4, `.default({})` on object schemas is type-incompatible because `{}` doesn't satisfy the fully-resolved output type; `emptyDefault()` (from `schema-utils.ts`) handles the cast in one place
- Fixes ~50 type errors in `agent-schema.ts`, `calls-schema.ts`, `core-schema.ts`, `memory-schema.ts`, `sandbox-schema.ts`, `schema.ts`, and `skills-schema.ts`

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22408105291

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8951" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
