### PR TITLE
fix: reset scroll position when switching chat threads

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -61,6 +61,7 @@ struct ChatView: View {
     var isMemoryDegraded: Bool = false
     var memoryDegradedReason: String? = nil
     var connectionDiagnosticHint: String? = nil
+    var threadId: UUID?
 
     @State private var isNearBottom = true
     @State private var isDropTargeted = false
@@ -172,6 +173,7 @@ struct ChatView: View {
                             onAbortSubagent: onAbortSubagent,
                             onSubagentTap: onSubagentTap,
                             subagentDetailStore: subagentDetailStore,
+                            threadId: threadId,
                             isNearBottom: $isNearBottom
                         )
                         .safeAreaInset(edge: .bottom) {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -22,6 +22,7 @@ struct MessageListView: View {
     var onSubagentTap: ((String) -> Void)?
     var subagentDetailStore: SubagentDetailStore?
 
+    var threadId: UUID?
     @Binding var isNearBottom: Bool
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
     @AppStorage("completedConversationCount") private var completedConversationCount: Int = 0
@@ -310,5 +311,6 @@ struct MessageListView: View {
                 }
             }
         }
+        .id(threadId)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -472,7 +472,8 @@ extension MainWindowView {
                 ambientAgent: ambientAgent,
                 settingsStore: settingsStore,
                 onMicrophoneToggle: onMicrophoneToggle,
-                isTemporaryChat: activeThread?.kind == .private
+                isTemporaryChat: activeThread?.kind == .private,
+                threadId: threadManager.activeThreadId
             )
             .overlay(alignment: .bottomTrailing) {
                 DemoOverlayView()
@@ -650,6 +651,7 @@ struct ActiveChatViewWrapper: View {
     @ObservedObject var settingsStore: SettingsStore
     let onMicrophoneToggle: () -> Void
     var isTemporaryChat: Bool = false
+    var threadId: UUID?
 
     var body: some View {
         ChatView(
@@ -751,7 +753,8 @@ struct ActiveChatViewWrapper: View {
             onDismissDocumentWidget: { viewModel.dismissDocumentSurface(id: $0) },
             isMemoryDegraded: viewModel.isMemoryDegraded,
             memoryDegradedReason: viewModel.memoryDegradedReason,
-            connectionDiagnosticHint: viewModel.connectionDiagnosticHint
+            connectionDiagnosticHint: viewModel.connectionDiagnosticHint,
+            threadId: threadId
         )
     }
 }


### PR DESCRIPTION
## Summary
- When switching from a longer thread to a shorter one, scroll position persisted, leaving empty space below the content
- Threads `threadManager.activeThreadId` through `ActiveChatViewWrapper` → `ChatView` → `MessageListView`
- Uses `.id(threadId)` on the `ScrollViewReader` to reset scroll state on thread switch without destroying the full view tree

## Test plan
- [ ] Open two threads: one with many messages, one with few
- [ ] Switch from the long thread to the short thread
- [ ] Verify the short thread's content is visible (no empty space requiring scroll up)
- [ ] Verify app doesn't crash on thread switch
- [ ] Verify auto-scroll still works during streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8953" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
