### PR TITLE
fix: make vector_json nullable in memory_embeddings for pre-100 databases

### DIFF
--- a/assistant/src/memory/migrations/026-embeddings-nullable-vector-json.ts
+++ b/assistant/src/memory/migrations/026-embeddings-nullable-vector-json.ts
@@ -1,0 +1,90 @@
+import { getSqliteFrom, type DrizzleDb } from '../db-connection.js';
+
+/**
+ * Rebuild memory_embeddings to make vector_json nullable.
+ *
+ * Pre-migration-100 databases created the table with `vector_json TEXT NOT NULL`.
+ * Migration 024 switched new writes to vector_blob only (setting vector_json = null),
+ * but never relaxed the NOT NULL constraint — causing SQLITE_CONSTRAINT_NOTNULL on
+ * every new embedding insert.
+ *
+ * This migration rebuilds the table only when the constraint is still present.
+ */
+export function migrateEmbeddingsNullableVectorJson(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  const checkpointKey = 'migration_embeddings_nullable_vector_json_v1';
+  const checkpoint = raw.query(
+    `SELECT 1 FROM memory_checkpoints WHERE key = ?`,
+  ).get(checkpointKey);
+  if (checkpoint) return;
+
+  // Check if vector_json has a NOT NULL constraint
+  const ddl = raw.query(
+    `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'memory_embeddings'`,
+  ).get() as { sql: string } | null;
+  if (!ddl) {
+    // Table doesn't exist yet — nothing to fix; core-tables will create it correctly.
+    raw.query(
+      `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,
+    ).run(checkpointKey, Date.now());
+    return;
+  }
+
+  // Only rebuild if vector_json is declared NOT NULL in the actual DDL
+  if (!isColumnNotNull(ddl.sql, 'vector_json')) {
+    raw.query(
+      `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,
+    ).run(checkpointKey, Date.now());
+    return;
+  }
+
+  raw.exec('PRAGMA foreign_keys = OFF');
+  try {
+    raw.exec('BEGIN');
+
+    raw.exec(/*sql*/ `
+      CREATE TABLE memory_embeddings_new (
+        id TEXT PRIMARY KEY,
+        target_type TEXT NOT NULL,
+        target_id TEXT NOT NULL,
+        provider TEXT NOT NULL,
+        model TEXT NOT NULL,
+        dimensions INTEGER NOT NULL,
+        vector_json TEXT,
+        vector_blob BLOB,
+        content_hash TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_embeddings_new (
+        id, target_type, target_id, provider, model, dimensions,
+        vector_json, vector_blob, content_hash, created_at, updated_at
+      )
+      SELECT
+        id, target_type, target_id, provider, model, dimensions,
+        vector_json, vector_blob, content_hash, created_at, updated_at
+      FROM memory_embeddings
+    `);
+    raw.exec(/*sql*/ `DROP TABLE memory_embeddings`);
+    raw.exec(/*sql*/ `ALTER TABLE memory_embeddings_new RENAME TO memory_embeddings`);
+
+    raw.query(
+      `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,
+    ).run(checkpointKey, Date.now());
+
+    raw.exec('COMMIT');
+  } catch (e) {
+    try { raw.exec('ROLLBACK'); } catch { /* no active transaction */ }
+    throw e;
+  } finally {
+    raw.exec('PRAGMA foreign_keys = ON');
+  }
+}
+
+/** Check whether a column is declared NOT NULL in a CREATE TABLE DDL string. */
+function isColumnNotNull(ddl: string, column: string): boolean {
+  const pattern = new RegExp(`${column}\\s+\\w+.*?NOT\\s+NULL`, 'i');
+  return pattern.test(ddl);
+}

--- a/assistant/src/memory/migrations/113-late-migrations.ts
+++ b/assistant/src/memory/migrations/113-late-migrations.ts
@@ -9,6 +9,7 @@ import { migrateConversationStatusIndexes } from './021-conversation-status-inde
 import { migrateAddOriginInterface } from './022-add-origin-interface.js';
 import { migrateMemoryItemSourcesIndexes } from './023-memory-item-sources-indexes.js';
 import { migrateEmbeddingVectorBlob } from './024-embedding-vector-blob.js';
+import { migrateEmbeddingsNullableVectorJson } from './026-embeddings-nullable-vector-json.js';
 
 /**
  * Late-stage migrations that must run after all tables and indexes exist:
@@ -25,4 +26,5 @@ export function runLateMigrations(database: DrizzleDb): void {
   migrateAddOriginInterface(database);
   migrateMemoryItemSourcesIndexes(database);
   migrateEmbeddingVectorBlob(database);
+  migrateEmbeddingsNullableVectorJson(database);
 }

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -23,6 +23,7 @@ export { migrateAddOriginInterface } from './022-add-origin-interface.js';
 export { migrateMemoryItemSourcesIndexes } from './023-memory-item-sources-indexes.js';
 export { migrateEmbeddingVectorBlob } from './024-embedding-vector-blob.js';
 export { migrateMessagesFtsBackfill } from './025-messages-fts-backfill.js';
+export { migrateEmbeddingsNullableVectorJson } from './026-embeddings-nullable-vector-json.js';
 export { createCoreTables } from './100-core-tables.js';
 export { createWatchersAndLogsTables } from './101-watchers-and-logs.js';
 export { addCoreColumns } from './102-alter-table-columns.js';

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -84,6 +84,12 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     version: 12,
     description: 'Add vector_blob BLOB column to memory_embeddings and backfill from vector_json for compact binary storage',
   },
+  {
+    key: 'migration_embeddings_nullable_vector_json_v1',
+    version: 13,
+    dependsOn: ['migration_embedding_vector_blob_v1'],
+    description: 'Rebuild memory_embeddings to make vector_json nullable (pre-100 DBs had NOT NULL)',
+  },
 ];
 
 export interface MigrationValidationResult {


### PR DESCRIPTION
## Summary

- Pre-migration-100 databases created `memory_embeddings` with `vector_json TEXT NOT NULL`, but migration 024 switched new writes to `vector_blob` only (setting `vector_json = null`), causing `SQLITE_CONSTRAINT_NOTNULL` on every embedding insert.
- Adds migration 026 that rebuilds the table to drop the NOT NULL constraint, using the standard create-copy-drop-rename pattern.
- No-ops on fresh databases where migration 100 already creates the column as nullable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
