### PR TITLE
fix: guard superRefine cross-field checks against undefined nested config

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -215,21 +215,24 @@ export const AssistantConfigSchema = z.object({
   daemon: DaemonConfigSchema.default({} as any),
   notifications: NotificationsConfigSchema.default({} as any),
 }).superRefine((config, ctx) => {
-  if (config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {
+  if (config.contextWindow?.targetInputTokens != null && config.contextWindow?.maxInputTokens != null &&
+      config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ['contextWindow', 'targetInputTokens'],
       message: 'contextWindow.targetInputTokens must be less than contextWindow.maxInputTokens',
     });
   }
-  if (config.memory.segmentation.overlapTokens >= config.memory.segmentation.targetTokens) {
+  const segmentation = config.memory?.segmentation;
+  if (segmentation && segmentation.overlapTokens >= segmentation.targetTokens) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ['memory', 'segmentation', 'overlapTokens'],
       message: 'memory.segmentation.overlapTokens must be less than memory.segmentation.targetTokens',
     });
   }
-  if (config.memory.retrieval.dynamicBudget.minInjectTokens > config.memory.retrieval.dynamicBudget.maxInjectTokens) {
+  const dynamicBudget = config.memory?.retrieval?.dynamicBudget;
+  if (dynamicBudget && dynamicBudget.minInjectTokens > dynamicBudget.maxInjectTokens) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ['memory', 'retrieval', 'dynamicBudget'],


### PR DESCRIPTION
## Summary

- Add optional chaining guards in the config schema's `superRefine` callback so cross-field validations (segmentation overlap vs target, dynamic budget min vs max, context window target vs max) don't crash when nested properties are undefined due to Zod 4's `.default({} as any)` not fully populating nested defaults before `superRefine` runs.

## Original prompt
fix: daemon crash on startup — `TypeError: undefined is not an object (evaluating 'config.memory.segmentation.overlapTokens')` in config schema superRefine validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
