### PR TITLE
M1: Create IntelligencePanel with tabbed layout and panel registration

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 // MARK: - Domain Types
 
 public enum NativePanelId: String, Codable, Equatable, Sendable {
-    case chat, threadList, settings, agent, debug, directory, generated, identity, avatarCustomization, voiceMode, assistantInbox, apps
+    case chat, threadList, settings, agent, debug, directory, generated, identity, intelligence, avatarCustomization, voiceMode, assistantInbox, apps
 }
 
 public enum SlotContent: Equatable, Sendable {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -91,6 +91,28 @@ extension MainWindowView {
             sidebarView
         case .identity:
             IdentityPanel(onClose: { windowState.selection = nil }, onCustomizeAvatar: { windowState.selection = .panel(.avatarCustomization) }, daemonClient: daemonClient)
+        case .intelligence:
+            IntelligencePanel(
+                onClose: { windowState.selection = nil },
+                onInvokeSkill: { skill in
+                    if threadManager.activeViewModel == nil {
+                        threadManager.createThread()
+                    }
+                    if let viewModel = threadManager.activeViewModel {
+                        viewModel.pendingSkillInvocation = SkillInvocationData(
+                            name: skill.name,
+                            emoji: skill.emoji,
+                            description: skill.description
+                        )
+                        viewModel.inputText = "Use the \(skill.name) skill"
+                        viewModel.sendMessage()
+                        viewModel.pendingSkillInvocation = nil
+                    }
+                    windowState.selection = nil
+                },
+                onCustomizeAvatar: { windowState.selection = .panel(.avatarCustomization) },
+                daemonClient: daemonClient
+            )
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.selection = .panel(.identity) })
         case .voiceMode:

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -1,6 +1,12 @@
 import SwiftUI
 import VellumAssistantShared
 
+// MARK: - Skills Tab Enum
+
+enum SkillsTab {
+    case installed, available
+}
+
 // MARK: - Agent Panel Content (embeddable)
 
 /// The skills management content, usable standalone (e.g. inside IdentityPanel)
@@ -9,24 +15,23 @@ struct AgentPanelContent: View {
     var onInvokeSkill: ((SkillInfo) -> Void)?
     var onSkillsChanged: (() -> Void)?
     let daemonClient: DaemonClient
+    let showTabBar: Bool
 
     @StateObject private var skillsManager: SkillsManager
-    @State private var selectedTab: SkillsTab = .installed
+    @Binding var selectedTab: SkillsTab
     @State private var expandedSkillId: String?
     @State private var selectedSkillSlug: String?
     @State private var selectedInstalledSkillId: String?
     @State private var skillToDelete: SkillInfo?
     @State private var showNewSkillSheet = false
 
-    private enum SkillsTab {
-        case installed, available
-    }
-
-    init(onInvokeSkill: ((SkillInfo) -> Void)? = nil, onSkillsChanged: (() -> Void)? = nil, daemonClient: DaemonClient) {
+    init(onInvokeSkill: ((SkillInfo) -> Void)? = nil, onSkillsChanged: (() -> Void)? = nil, daemonClient: DaemonClient, selectedTab: Binding<SkillsTab>? = nil, showTabBar: Bool = true) {
         self.onInvokeSkill = onInvokeSkill
         self.onSkillsChanged = onSkillsChanged
         self.daemonClient = daemonClient
+        self.showTabBar = showTabBar
         _skillsManager = StateObject(wrappedValue: SkillsManager(daemonClient: daemonClient))
+        _selectedTab = selectedTab ?? .constant(.installed)
     }
 
     var body: some View {
@@ -56,29 +61,31 @@ struct AgentPanelContent: View {
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .padding(.bottom, VSpacing.lg)
 
-            // Tab bar
-            VStack(spacing: 0) {
-                HStack(spacing: VSpacing.xl) {
-                    tabButton(installedTabTitle, tab: .installed)
-                    tabButton(availableTabTitle, tab: .available)
-                    Spacer()
-                    Button {
-                        showNewSkillSheet = true
-                    } label: {
-                        HStack(spacing: VSpacing.xs) {
-                            Image(systemName: "plus")
-                            Text("New Skill")
+            // Tab bar (hidden when controlled externally, e.g. from IntelligencePanel)
+            if showTabBar {
+                VStack(spacing: 0) {
+                    HStack(spacing: VSpacing.xl) {
+                        tabButton(installedTabTitle, tab: .installed)
+                        tabButton(availableTabTitle, tab: .available)
+                        Spacer()
+                        Button {
+                            showNewSkillSheet = true
+                        } label: {
+                            HStack(spacing: VSpacing.xs) {
+                                Image(systemName: "plus")
+                                Text("New Skill")
+                            }
+                            .font(VFont.body)
+                            .foregroundColor(VColor.accent)
                         }
-                        .font(VFont.body)
-                        .foregroundColor(VColor.accent)
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("New Skill")
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("New Skill")
-                }
 
-                Divider().background(VColor.surfaceBorder)
+                    Divider().background(VColor.surfaceBorder)
+                }
+                .padding(.bottom, VSpacing.lg)
             }
-            .padding(.bottom, VSpacing.lg)
 
             // Tab content
             switch selectedTab {
@@ -1001,6 +1008,8 @@ struct AgentPanel: View {
     var onInvokeSkill: ((SkillInfo) -> Void)?
     let daemonClient: DaemonClient
 
+    @State private var selectedTab: SkillsTab = .installed
+
     /// Maximum width of the centered content area.
     private let maxContentWidth: CGFloat = 1100
 
@@ -1020,7 +1029,7 @@ struct AgentPanel: View {
                 Divider().background(VColor.surfaceBorder)
                     .padding(.bottom, VSpacing.xl)
 
-                AgentPanelContent(onInvokeSkill: onInvokeSkill, daemonClient: daemonClient)
+                AgentPanelContent(onInvokeSkill: onInvokeSkill, daemonClient: daemonClient, selectedTab: $selectedTab)
             }
             .frame(maxWidth: maxContentWidth)
             .padding(.horizontal, VSpacing.xxl)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -1,10 +1,14 @@
 import SwiftUI
 import VellumAssistantShared
 
-struct IdentityPanel: View {
-    let onClose: () -> Void
+// MARK: - Identity Panel Content (embeddable)
+
+/// The identity content, usable standalone (e.g. inside IntelligencePanel)
+/// or wrapped by IdentityPanel.
+struct IdentityPanelContent: View {
     let onCustomizeAvatar: () -> Void
     let daemonClient: DaemonClient
+    var showTitle: Bool = false
     @State private var appearance = AvatarAppearanceManager.shared
 
     @State private var identity: IdentityInfo?
@@ -17,19 +21,19 @@ struct IdentityPanel: View {
     @State private var isFullscreen: Bool = false
 
     private let sidebarWidth: CGFloat = 260
-
     private let panelPadding: CGFloat = VSpacing.xl
 
     var body: some View {
         HStack(alignment: .top, spacing: 0) {
-            // Left sidebar: title, avatar, ID card — hidden in fullscreen
+            // Left sidebar: avatar, ID card — hidden in fullscreen
             if !isFullscreen {
                 VStack(alignment: .leading, spacing: 0) {
-                    // Header
-                    Text("Identity")
-                        .font(VFont.panelTitle)
-                        .foregroundColor(VColor.textPrimary)
-                        .padding(.bottom, VSpacing.lg)
+                    if showTitle {
+                        Text("Identity")
+                            .font(VFont.panelTitle)
+                            .foregroundColor(VColor.textPrimary)
+                            .padding(.bottom, VSpacing.lg)
+                    }
 
                     // Card wrapping avatar + ID fields
                     VStack(spacing: 0) {
@@ -204,6 +208,18 @@ struct IdentityPanel: View {
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
         return formatter.string(from: date)
+    }
+}
+
+// MARK: - Identity Panel (standalone wrapper)
+
+struct IdentityPanel: View {
+    let onClose: () -> Void
+    let onCustomizeAvatar: () -> Void
+    let daemonClient: DaemonClient
+
+    var body: some View {
+        IdentityPanelContent(onCustomizeAvatar: onCustomizeAvatar, daemonClient: daemonClient, showTitle: true)
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -1,0 +1,135 @@
+import SwiftUI
+import VellumAssistantShared
+
+// MARK: - Intelligence Panel
+
+/// Combined panel with three tabs: Identity, Installed Skills, and Community Skills.
+struct IntelligencePanel: View {
+    var onClose: () -> Void
+    var onInvokeSkill: ((SkillInfo) -> Void)?
+    var onCustomizeAvatar: () -> Void
+    let daemonClient: DaemonClient
+
+    /// Maximum width of the centered content area (matches AgentPanel).
+    private let maxContentWidth: CGFloat = 1100
+
+    private enum IntelligenceTab {
+        case identity, installed, community
+    }
+
+    @State private var selectedIntelligenceTab: IntelligenceTab = .identity
+
+    /// Maps the skills tabs to the AgentPanelContent binding.
+    @State private var selectedSkillsTab: SkillsTab = .installed
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Scrollable header + tabs + content for identity; skills tabs fill remaining space
+            if selectedIntelligenceTab == .identity {
+                // Identity tab: full-bleed layout (sidebar + constellation), not in ScrollView
+                VStack(alignment: .leading, spacing: 0) {
+                    headerSection
+                    tabBar
+                    IdentityPanelContent(onCustomizeAvatar: onCustomizeAvatar, daemonClient: daemonClient)
+                }
+            } else {
+                // Skills tabs: scrollable content with constrained width
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        headerSection
+                        tabBar
+
+                        AgentPanelContent(
+                            onInvokeSkill: onInvokeSkill,
+                            daemonClient: daemonClient,
+                            selectedTab: $selectedSkillsTab,
+                            showTabBar: false
+                        )
+                    }
+                    .frame(maxWidth: maxContentWidth)
+                    .padding(.horizontal, VSpacing.xxl)
+                    .padding(.bottom, VSpacing.xxl)
+                    .frame(maxWidth: .infinity)
+                }
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    @ViewBuilder
+    private var headerSection: some View {
+        HStack(alignment: .center) {
+            Text("Intelligence")
+                .font(VFont.panelTitle)
+                .foregroundColor(VColor.textPrimary)
+            Spacer()
+        }
+        .padding(.top, VSpacing.xxl)
+        .padding(.bottom, VSpacing.xl)
+        .padding(.horizontal, VSpacing.xxl)
+
+        Divider().background(VColor.surfaceBorder)
+            .padding(.bottom, VSpacing.xl)
+            .padding(.horizontal, VSpacing.xxl)
+    }
+
+    // MARK: - Tab Bar
+
+    @ViewBuilder
+    private var tabBar: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: VSpacing.xl) {
+                intelligenceTabButton("Identity", tab: .identity)
+                intelligenceTabButton("Installed", tab: .installed)
+                intelligenceTabButton("Community", tab: .community)
+                Spacer()
+            }
+
+            Divider().background(VColor.surfaceBorder)
+        }
+        .padding(.bottom, VSpacing.lg)
+        .padding(.horizontal, VSpacing.xxl)
+    }
+
+    @ViewBuilder
+    private func intelligenceTabButton(_ label: String, tab: IntelligenceTab) -> some View {
+        let isActive = selectedIntelligenceTab == tab
+        Button {
+            withAnimation(VAnimation.fast) {
+                selectedIntelligenceTab = tab
+                // Sync the skills tab binding when switching to a skills tab
+                switch tab {
+                case .installed:
+                    selectedSkillsTab = .installed
+                case .community:
+                    selectedSkillsTab = .available
+                case .identity:
+                    break
+                }
+            }
+        } label: {
+            VStack(spacing: VSpacing.sm) {
+                Text(label)
+                    .font(VFont.body)
+                    .foregroundColor(isActive ? VColor.textPrimary : VColor.textMuted)
+                    .padding(.bottom, VSpacing.xs)
+
+                Rectangle()
+                    .fill(isActive ? VColor.textPrimary : Color.clear)
+                    .frame(height: 2)
+            }
+            .fixedSize()
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    IntelligencePanel(
+        onClose: {},
+        onCustomizeAvatar: {},
+        daemonClient: DaemonClient()
+    )
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
@@ -5,6 +5,7 @@ enum SidePanelType: Hashable, CaseIterable {
     case directory
     case debug
     case identity
+    case intelligence
     case documentEditor
     case avatarCustomization
     case voiceMode
@@ -19,6 +20,7 @@ enum SidePanelType: Hashable, CaseIterable {
         case "directory": self = .directory
         case "debug": self = .debug
         case "identity": self = .identity
+        case "intelligence": self = .intelligence
         case "documentEditor": self = .documentEditor
         case "avatarCustomization": self = .avatarCustomization
         case "voiceMode": self = .voiceMode


### PR DESCRIPTION
Creates new IntelligencePanel combining Identity and Skills into a single tabbed view with Identity, Installed Skills, and Community Skills tabs. Adds .intelligence panel type to SidePanelType and NativePanelId. Wires up in PanelCoordinator. Part of #8932.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
