### PR TITLE
fix: apply nested config defaults lost by Zod 4's .default({})

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -31,8 +31,24 @@ function ensureMigratedDataDir(): void {
 }
 
 
+/**
+ * Zod 4's .default({}) returns {} as output without running inner-schema
+ * parsing, so nested object defaults are never applied. Re-parse the config
+ * to cascade defaults through each nesting level.
+ * Max chain of .default({}) on object schemas is 4
+ * (e.g. memory → retrieval → freshness → maxAgeDays),
+ * so 5 parses are needed (N+1) to fully cascade.
+ */
+function applyNestedDefaults(config: unknown): AssistantConfig {
+  let current: unknown = config;
+  for (let i = 0; i < 5; i++) {
+    current = AssistantConfigSchema.parse(current);
+  }
+  return current as AssistantConfig;
+}
+
 function cloneDefaultConfig(): AssistantConfig {
-  return AssistantConfigSchema.parse({});
+  return applyNestedDefaults({});
 }
 
 /**
@@ -42,7 +58,7 @@ function cloneDefaultConfig(): AssistantConfig {
 function validateWithSchema(raw: Record<string, unknown>): AssistantConfig {
   const result = AssistantConfigSchema.safeParse(raw);
   if (result.success) {
-    return result.data;
+    return applyNestedDefaults(result.data);
   }
 
   // Log each validation issue as a warning
@@ -64,7 +80,7 @@ function validateWithSchema(raw: Record<string, unknown>): AssistantConfig {
 
   const retry = AssistantConfigSchema.safeParse(cleaned);
   if (retry.success) {
-    return retry.data;
+    return applyNestedDefaults(retry.data);
   }
 
   // If still failing, fall back to full defaults


### PR DESCRIPTION
## Summary

- Zod 4's `.default({})` returns `{}` as output without running inner-schema parsing, so nested object defaults are never applied. This caused `config.memory.qdrant`, `config.memory.segmentation`, and other nested config sections to be `undefined` at runtime, crashing the daemon on startup.
- Added `applyNestedDefaults()` to the config loader that re-parses the config 5 times (max nesting depth + 1) to cascade defaults through each level. User-provided partial configs are preserved.

## Original prompt
fix: daemon crash — `TypeError: undefined is not an object (evaluating 'config.memory.qdrant.url')` in lifecycle.ts due to Zod 4 `.default({})` not populating nested object defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
