### PR TITLE
M9: Add operational telemetry for screen recording

### DIFF
--- a/clients/macos/vellum-assistant/Recording/RecordingManager.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingManager.swift
@@ -152,6 +152,16 @@ final class RecordingManager: ObservableObject {
                 state = .failed(message)
                 sendStatus(sessionId: sessionId, status: "failed", error: message)
                 log.error("Recording failed to start: \(message, privacy: .public)")
+
+                if let recorderError = error as? RecorderError {
+                    RecordingTelemetry.logError(
+                        category: RecordingTelemetry.categorize(recorderError),
+                        sourceWidth: nil,
+                        sourceHeight: nil,
+                        configLabel: nil,
+                        message: message
+                    )
+                }
             }
             return false
         }

--- a/clients/macos/vellum-assistant/Recording/RecordingManager.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingManager.swift
@@ -152,16 +152,9 @@ final class RecordingManager: ObservableObject {
                 state = .failed(message)
                 sendStatus(sessionId: sessionId, status: "failed", error: message)
                 log.error("Recording failed to start: \(message, privacy: .public)")
-
-                if let recorderError = error as? RecorderError {
-                    RecordingTelemetry.logError(
-                        category: RecordingTelemetry.categorize(recorderError),
-                        sourceWidth: nil,
-                        sourceHeight: nil,
-                        configLabel: nil,
-                        message: message
-                    )
-                }
+                // Note: telemetry logging is handled inside ScreenRecorder.start()
+                // with richer context (source dimensions, config labels). Logging
+                // here again would double-report with lower-fidelity data.
             }
             return false
         }

--- a/clients/macos/vellum-assistant/Recording/RecordingTelemetry.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingTelemetry.swift
@@ -1,0 +1,164 @@
+import Foundation
+import os
+
+/// Structured telemetry for the screen recording subsystem.
+///
+/// Emits key metrics at recording start, stop, and on errors via os.Logger
+/// so that monitor-specific regressions can be caught quickly after rollout.
+/// All data stays local — no external analytics SDKs.
+enum RecordingTelemetry {
+
+    private static let log = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant",
+        category: "RecordingTelemetry"
+    )
+
+    // MARK: - Error Categories
+
+    /// Coarse error category for telemetry grouping.
+    enum ErrorCategory: String {
+        case dimension
+        case codec
+        case permission
+        case stream
+        case writer
+        case source
+        case unknown
+    }
+
+    /// Classify a RecorderError into a telemetry-friendly category.
+    static func categorize(_ error: RecorderError) -> ErrorCategory {
+        switch error {
+        case .unsupportedDimensions:
+            return .dimension
+        case .allFallbacksExhausted:
+            return .codec
+        case .permissionDenied:
+            return .permission
+        case .streamStartFailed, .sessionInterrupted:
+            return .stream
+        case .writerSetupFailed:
+            return .writer
+        case .noMatchingDisplay, .noMatchingWindow, .sourceUnavailable:
+            return .source
+        case .notRecording, .noFramesCaptured:
+            return .unknown
+        }
+    }
+
+    // MARK: - Start Telemetry
+
+    /// Log structured telemetry when a recording starts successfully.
+    ///
+    /// - Parameters:
+    ///   - displayID: The CGDirectDisplayID of the target display (nil for window captures).
+    ///   - sourceWidth: Raw width from ScreenCaptureKit before normalization.
+    ///   - sourceHeight: Raw height from ScreenCaptureKit before normalization.
+    ///   - scaleFactor: The backing scale factor used for dimension calculation.
+    ///   - encodeWidth: Final encode width after normalization.
+    ///   - encodeHeight: Final encode height after normalization.
+    ///   - configLabel: The encoder config label that succeeded (e.g. "primary", "fallback-half").
+    ///   - usedFallback: Whether a non-primary config was used.
+    static func logStart(
+        displayID: UInt32?,
+        sourceWidth: Int,
+        sourceHeight: Int,
+        scaleFactor: Double,
+        encodeWidth: Int,
+        encodeHeight: Int,
+        configLabel: String,
+        usedFallback: Bool
+    ) {
+        log.info("""
+            recording.start: \
+            displayID=\(displayID.map { String($0) } ?? "window", privacy: .public), \
+            sourceSize=\(sourceWidth)x\(sourceHeight), \
+            scaleFactor=\(String(format: "%.1f", scaleFactor)), \
+            encodeSize=\(encodeWidth)x\(encodeHeight), \
+            config=\(configLabel, privacy: .public), \
+            usedFallback=\(usedFallback)
+            """)
+    }
+
+    // MARK: - Stop Telemetry
+
+    /// Terminal status of a completed recording.
+    enum TerminalStatus: String {
+        case success
+        case error
+        case cancel
+    }
+
+    /// Log structured telemetry when a recording stops.
+    ///
+    /// - Parameters:
+    ///   - durationMs: Total recording duration in milliseconds.
+    ///   - fileSize: Final file size in bytes.
+    ///   - status: Terminal status (success, error, or cancel).
+    static func logStop(
+        durationMs: Int,
+        fileSize: Int,
+        status: TerminalStatus
+    ) {
+        log.info("""
+            recording.stop: \
+            durationMs=\(durationMs), \
+            fileSize=\(fileSize), \
+            status=\(status.rawValue, privacy: .public)
+            """)
+    }
+
+    // MARK: - Error Telemetry
+
+    /// Log structured telemetry when a recording error occurs.
+    ///
+    /// - Parameters:
+    ///   - category: Coarse error classification for grouping.
+    ///   - sourceWidth: Source dimensions at the time of failure (if available).
+    ///   - sourceHeight: Source dimensions at the time of failure (if available).
+    ///   - configLabel: The fallback config that was active when the error occurred (if any).
+    ///   - message: Human-readable error description.
+    static func logError(
+        category: ErrorCategory,
+        sourceWidth: Int?,
+        sourceHeight: Int?,
+        configLabel: String?,
+        message: String
+    ) {
+        let dims: String
+        if let w = sourceWidth, let h = sourceHeight {
+            dims = "\(w)x\(h)"
+        } else {
+            dims = "unknown"
+        }
+
+        log.error("""
+            recording.error: \
+            category=\(category.rawValue, privacy: .public), \
+            sourceDimensions=\(dims, privacy: .public), \
+            config=\(configLabel ?? "none", privacy: .public), \
+            message=\(message, privacy: .public)
+            """)
+    }
+
+    // MARK: - Fallback Attempt Telemetry
+
+    /// Log when a fallback config is being attempted after a previous config failed.
+    ///
+    /// - Parameters:
+    ///   - fromConfig: The config label that failed.
+    ///   - toConfig: The config label being tried next.
+    ///   - reason: Why the previous config failed.
+    static func logFallbackAttempt(
+        fromConfig: String,
+        toConfig: String,
+        reason: String
+    ) {
+        log.info("""
+            recording.fallback: \
+            from=\(fromConfig, privacy: .public), \
+            to=\(toConfig, privacy: .public), \
+            reason=\(reason, privacy: .public)
+            """)
+    }
+}

--- a/clients/macos/vellum-assistant/Recording/RecordingTelemetry.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingTelemetry.swift
@@ -73,7 +73,7 @@ enum RecordingTelemetry {
             recording.start: \
             displayID=\(displayID.map { String($0) } ?? "window", privacy: .public), \
             sourceSize=\(sourceWidth)x\(sourceHeight), \
-            scaleFactor=\(String(format: "%.1f", scaleFactor)), \
+            scaleFactor=\(String(format: "%.1f", scaleFactor), privacy: .public), \
             encodeSize=\(encodeWidth)x\(encodeHeight), \
             config=\(configLabel, privacy: .public), \
             usedFallback=\(usedFallback)

--- a/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
+++ b/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
@@ -85,6 +85,16 @@ final class ScreenRecorder: NSObject {
     /// Label of the encode config that was successfully used, for telemetry (M9).
     private(set) var activeConfigLabel: String?
 
+    // MARK: - Telemetry State
+
+    /// Source dimensions before normalization, captured at start for telemetry.
+    private var telemetrySourceWidth: Int?
+    private var telemetrySourceHeight: Int?
+    /// Scale factor used to derive capture dimensions, for telemetry.
+    private var telemetryScaleFactor: Double?
+    /// Display ID being recorded, for telemetry (nil for window captures).
+    private var telemetryDisplayID: UInt32?
+
     /// Callback invoked when the SCStream stops with an error mid-recording.
     /// RecordingManager sets this to react to stream failures (update state, send IPC, clean up).
     var onStreamError: ((RecorderError) -> Void)?
@@ -271,6 +281,10 @@ final class ScreenRecorder: NSObject {
             let windowScale = Self.scaleFactor(for: windowDisplayID)
             captureWidth = Int(CGFloat(window.frame.width) * windowScale)
             captureHeight = Int(CGFloat(window.frame.height) * windowScale)
+            telemetrySourceWidth = captureWidth
+            telemetrySourceHeight = captureHeight
+            telemetryScaleFactor = Double(windowScale)
+            telemetryDisplayID = nil
             log.info("Window capture: windowID=\(windowId), displayID=\(windowDisplayID), scaleFactor=\(windowScale), sourceSize=\(Int(window.frame.width))x\(Int(window.frame.height)), streamSize=\(captureWidth)x\(captureHeight)")
         } else {
             // Display capture (default)
@@ -290,6 +304,10 @@ final class ScreenRecorder: NSObject {
             let displayScale = Self.scaleFactor(for: targetDisplay.displayID)
             captureWidth = Int(CGFloat(targetDisplay.width) * displayScale)
             captureHeight = Int(CGFloat(targetDisplay.height) * displayScale)
+            telemetrySourceWidth = captureWidth
+            telemetrySourceHeight = captureHeight
+            telemetryScaleFactor = Double(displayScale)
+            telemetryDisplayID = targetDisplay.displayID
             log.info("Display capture: displayID=\(targetDisplay.displayID), scaleFactor=\(displayScale), sourceSize=\(targetDisplay.width)x\(targetDisplay.height), streamSize=\(captureWidth)x\(captureHeight)")
 
             // Monitor this display for reconfiguration (unplug, resolution change)
@@ -316,23 +334,61 @@ final class ScreenRecorder: NSObject {
                 switch attemptResult {
                 case .success:
                     activeConfigLabel = encodeConfig.label
+                    let usedFallback = index > 0
+                    RecordingTelemetry.logStart(
+                        displayID: telemetryDisplayID,
+                        sourceWidth: telemetrySourceWidth ?? captureWidth,
+                        sourceHeight: telemetrySourceHeight ?? captureHeight,
+                        scaleFactor: telemetryScaleFactor ?? 1.0,
+                        encodeWidth: encodeConfig.width,
+                        encodeHeight: encodeConfig.height,
+                        configLabel: encodeConfig.label,
+                        usedFallback: usedFallback
+                    )
                     log.info("Encoder config '\(encodeConfig.label, privacy: .public)' succeeded")
                     return
                 case .writerSetupFailed(let reason):
                     log.warning("Encoder config '\(encodeConfig.label, privacy: .public)' failed: writer setup error — \(reason, privacy: .public)")
                     if isLastConfig {
+                        RecordingTelemetry.logError(
+                            category: .writer,
+                            sourceWidth: telemetrySourceWidth,
+                            sourceHeight: telemetrySourceHeight,
+                            configLabel: encodeConfig.label,
+                            message: "All fallbacks exhausted (last: writer setup — \(reason))"
+                        )
                         throw RecorderError.allFallbacksExhausted
                     }
+                    let nextLabel = fallbackConfigs[index + 1].label
+                    RecordingTelemetry.logFallbackAttempt(fromConfig: encodeConfig.label, toConfig: nextLabel, reason: "writer setup — \(reason)")
                 case .noFramesReceived:
                     log.warning("Encoder config '\(encodeConfig.label, privacy: .public)' failed: no frames received within timeout")
                     if isLastConfig {
+                        RecordingTelemetry.logError(
+                            category: .codec,
+                            sourceWidth: telemetrySourceWidth,
+                            sourceHeight: telemetrySourceHeight,
+                            configLabel: encodeConfig.label,
+                            message: "All fallbacks exhausted (last: no frames received)"
+                        )
                         throw RecorderError.allFallbacksExhausted
                     }
+                    let nextLabel = fallbackConfigs[index + 1].label
+                    RecordingTelemetry.logFallbackAttempt(fromConfig: encodeConfig.label, toConfig: nextLabel, reason: "no frames received")
                 case .streamStartFailed(let reason):
                     log.warning("Encoder config '\(encodeConfig.label, privacy: .public)' failed: stream start error — \(reason, privacy: .public)")
                     if isLastConfig {
+                        RecordingTelemetry.logError(
+                            category: .stream,
+                            sourceWidth: telemetrySourceWidth,
+                            sourceHeight: telemetrySourceHeight,
+                            configLabel: encodeConfig.label,
+                            message: "All fallbacks exhausted (last: stream start — \(reason))"
+                        )
                         throw RecorderError.allFallbacksExhausted
                     }
+                    let nextLabel = fallbackConfigs[index + 1].label
+                    RecordingTelemetry.logFallbackAttempt(fromConfig: encodeConfig.label, toConfig: nextLabel, reason: "stream start — \(reason)")
                 }
             }
 
@@ -342,6 +398,7 @@ final class ScreenRecorder: NSObject {
             // If start() fails after registering the display reconfiguration callback,
             // unregister it to avoid a dangling callback referencing this instance.
             unregisterDisplayReconfiguration()
+            clearTelemetryState()
             throw error
         }
     }
@@ -555,7 +612,15 @@ final class ScreenRecorder: NSObject {
 
         guard hasReceivedVideoFrame else {
             log.error("Stop: no video frames captured — discarding recording")
+            RecordingTelemetry.logError(
+                category: .codec,
+                sourceWidth: telemetrySourceWidth,
+                sourceHeight: telemetrySourceHeight,
+                configLabel: activeConfigLabel,
+                message: "No video frames captured during recording"
+            )
             cleanUpWriter()
+            clearTelemetryState()
             throw RecorderError.noFramesCaptured
         }
 
@@ -593,7 +658,11 @@ final class ScreenRecorder: NSObject {
 
         let fileSize = (try? FileManager.default.attributesOfItem(atPath: outputURL.path)[.size] as? Int) ?? 0
 
+        let stopStatus: RecordingTelemetry.TerminalStatus = writerStatus == .completed ? .success : .error
+        RecordingTelemetry.logStop(durationMs: durationMs, fileSize: fileSize, status: stopStatus)
+
         cleanUpWriter()
+        clearTelemetryState()
         log.info("Recording complete — duration=\(durationMs)ms, fileSize=\(fileSize) bytes, file=\(outputURL.path, privacy: .public)")
 
         return RecordingResult(filePath: outputURL.path, durationMs: durationMs)
@@ -652,6 +721,15 @@ final class ScreenRecorder: NSObject {
     func cancelRecording() {
         guard isRecordingActive else { return }
 
+        // Emit cancel telemetry before tearing down state
+        let durationMs: Int
+        if let startDate = recordingStartDate {
+            durationMs = Int(Date().timeIntervalSince(startDate) * 1000)
+        } else {
+            durationMs = 0
+        }
+        RecordingTelemetry.logStop(durationMs: durationMs, fileSize: 0, status: .cancel)
+
         // Unregister display monitoring since the recording session is ending.
         unregisterDisplayReconfiguration()
 
@@ -668,6 +746,7 @@ final class ScreenRecorder: NSObject {
         }
 
         cleanUpWriter()
+        clearTelemetryState()
     }
 
     // MARK: - Stream Error Handling
@@ -709,6 +788,14 @@ final class ScreenRecorder: NSObject {
 
             log.error("Stream error during active recording — cleaning up (error=\(recorderError.localizedDescription, privacy: .public))")
 
+            RecordingTelemetry.logError(
+                category: RecordingTelemetry.categorize(recorderError),
+                sourceWidth: telemetrySourceWidth,
+                sourceHeight: telemetrySourceHeight,
+                configLabel: activeConfigLabel,
+                message: recorderError.localizedDescription ?? "Unknown stream error"
+            )
+
             // Unregister display monitoring since the recording session is ending.
             unregisterDisplayReconfiguration()
 
@@ -721,6 +808,7 @@ final class ScreenRecorder: NSObject {
 
             stream = nil
             cleanUpWriter()
+            clearTelemetryState()
 
             onStreamError?(recorderError)
         }
@@ -737,6 +825,16 @@ final class ScreenRecorder: NSObject {
         recordingStartDate = nil
         outputDelegate = nil
         activeConfigLabel = nil
+    }
+
+    /// Reset telemetry state. Called separately from cleanUpWriter because
+    /// telemetry state must persist across fallback attempts within a single
+    /// start() call, but should be cleared when the recording fully ends.
+    private func clearTelemetryState() {
+        telemetrySourceWidth = nil
+        telemetrySourceHeight = nil
+        telemetryScaleFactor = nil
+        telemetryDisplayID = nil
     }
 
     // MARK: - Display Reconfiguration Monitoring
@@ -784,6 +882,7 @@ final class ScreenRecorder: NSObject {
                 }
                 self.stream = nil
                 self.cleanUpWriter()
+                self.clearTelemetryState()
                 self.onStreamError?(.sourceUnavailable("The recorded display was disconnected or removed."))
             }
         } else if flags.contains(.movedFlag) || flags.contains(.setMainFlag) || flags.contains(.setModeFlag) {

--- a/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
+++ b/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
@@ -625,6 +625,7 @@ final class ScreenRecorder: NSObject {
         }
 
         guard let writer = assetWriter else {
+            clearTelemetryState()
             throw RecorderError.notRecording
         }
 
@@ -873,6 +874,17 @@ final class ScreenRecorder: NSObject {
             // Stop the stream and notify via the error callback
             Task { @MainActor in
                 guard self.isRecordingActive else { return }
+
+                // Log telemetry before tearing down state so source dimensions
+                // and config label are still available.
+                RecordingTelemetry.logError(
+                    category: .source,
+                    sourceWidth: self.telemetrySourceWidth,
+                    sourceHeight: self.telemetrySourceHeight,
+                    configLabel: self.activeConfigLabel,
+                    message: "Recorded display \(displayID) was disconnected or removed during active recording"
+                )
+
                 // Unregister display monitoring since the recording session is ending.
                 self.unregisterDisplayReconfiguration()
                 self.assetWriter?.cancelWriting()


### PR DESCRIPTION
Adds structured telemetry logging to the screen recording subsystem. Emits key metrics (display ID, source size, encode size, fallback path, error category) at recording start, stop, and on errors via os.Logger for diagnosing monitor-specific regressions. Closes #8894
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
