### PR TITLE
fix: add unique index on memory_embeddings for ON CONFLICT upsert

### DIFF
--- a/assistant/src/memory/migrations/104-core-indexes.ts
+++ b/assistant/src/memory/migrations/104-core-indexes.ts
@@ -40,8 +40,21 @@ export function createCoreIndexes(database: DrizzleDb): void {
     ON memory_items(status, invalid_at, last_seen_at DESC, subject, statement, id, kind, confidence, importance, first_seen_at, scope_id)
     WHERE status = 'active' AND invalid_at IS NULL
   `);
-  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_target ON memory_embeddings(target_type, target_id)`);
-  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_provider_model ON memory_embeddings(provider, model)`);
+  // Deduplicate before creating unique index — existing DBs may have duplicate (target_type, target_id, provider, model) tuples.
+  // Keep the most recently updated row per group, delete the rest.
+  {
+    const rawEmb = getSqliteFrom(database);
+    rawEmb.exec(/*sql*/ `
+      DELETE FROM memory_embeddings
+      WHERE rowid NOT IN (
+        SELECT MAX(rowid) FROM memory_embeddings
+        GROUP BY target_type, target_id, provider, model
+      )
+    `);
+  }
+  database.run(/*sql*/ `DROP INDEX IF EXISTS idx_memory_embeddings_target`);
+  database.run(/*sql*/ `DROP INDEX IF EXISTS idx_memory_embeddings_provider_model`);
+  database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_embeddings_target_provider_model ON memory_embeddings(target_type, target_id, provider, model)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_content_hash ON memory_embeddings(content_hash, provider, model)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_jobs_status_run_after ON memory_jobs(status, run_after)`);
   database.run(/*sql*/ `

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -1,4 +1,4 @@
-import { blob, index,integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { blob, index,integer, real, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core';
 
 export const conversations = sqliteTable('conversations', {
   id: text('id').primaryKey(),
@@ -152,7 +152,9 @@ export const memoryEmbeddings = sqliteTable('memory_embeddings', {
   contentHash: text('content_hash'),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
-});
+}, (table) => [
+  uniqueIndex('idx_memory_embeddings_target_provider_model').on(table.targetType, table.targetId, table.provider, table.model),
+]);
 
 export const memoryJobs = sqliteTable('memory_jobs', {
   id: text('id').primaryKey(),


### PR DESCRIPTION
## Summary
- The `embedAndUpsert` function uses `onConflictDoUpdate` targeting `(target_type, target_id, provider, model)`, but those columns had no unique constraint — only regular indexes. SQLite requires a unique index/constraint for `ON CONFLICT` to match.
- Added deduplication of existing rows + a `CREATE UNIQUE INDEX` on `(target_type, target_id, provider, model)` in the core-indexes migration, replacing the two separate non-unique indexes.
- Declared the unique index in the Drizzle schema for consistency.

## Original prompt
Fix SQLiteError: ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint in `embedAndUpsert` (memory-jobs-worker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)