### PR TITLE
M1: Create IntelligencePanel with tabbed layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 // MARK: - Domain Types
 
 public enum NativePanelId: String, Codable, Equatable, Sendable {
-    case chat, threadList, settings, agent, debug, directory, generated, identity, avatarCustomization, voiceMode, assistantInbox, apps
+    case chat, threadList, settings, agent, debug, directory, generated, identity, avatarCustomization, voiceMode, assistantInbox, apps, intelligence
 }
 
 public enum SlotContent: Equatable, Sendable {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -31,6 +31,9 @@ final class MainWindowState: ObservableObject {
     /// Tracks the "background" thread that persists even when viewing an app or panel overlay.
     @Published var persistentThreadId: UUID?
 
+    /// Tracks which panel originated the avatar customization flow so we can return to it.
+    @Published var avatarCustomizationReturnPanel: SidePanelType = .identity
+
     @Published var selectedSubagentId: String?
     @Published var activeDynamicSurface: UiSurfaceShowMessage?
     @Published var activeDynamicParsedSurface: Surface?

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1066,6 +1066,9 @@ struct MainWindowView: View {
             SidebarNavRow(icon: "house.fill", label: "Home Base", isActive: homeBaseIsActive) {
                 openHomeBaseApp()
             }
+            SidebarNavRow(icon: "brain.head.profile", label: "Intelligence", isActive: windowState.activePanel == .intelligence) {
+                windowState.togglePanel(.intelligence)
+            }
             SidebarNavRow(icon: "person.crop.circle", label: "Identity", isActive: windowState.activePanel == .identity) {
                 windowState.togglePanel(.identity)
             }
@@ -1180,6 +1183,9 @@ struct MainWindowView: View {
 
             SidebarNavRow(icon: "house.fill", label: "Home Base", isActive: homeBaseIsActive, isExpanded: false) {
                 openHomeBaseApp()
+            }
+            SidebarNavRow(icon: "brain.head.profile", label: "Intelligence", isActive: windowState.activePanel == .intelligence, isExpanded: false) {
+                windowState.togglePanel(.intelligence)
             }
             SidebarNavRow(icon: "person.crop.circle", label: "Identity", isActive: windowState.activePanel == .identity, isExpanded: false) {
                 windowState.togglePanel(.identity)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -121,6 +121,28 @@ extension MainWindowView {
                     }
                 }
             )
+        case .intelligence:
+            IntelligencePanel(
+                onClose: { windowState.selection = nil },
+                onCustomizeAvatar: { windowState.selection = .panel(.avatarCustomization) },
+                onInvokeSkill: { skill in
+                    if threadManager.activeViewModel == nil {
+                        threadManager.createThread()
+                    }
+                    if let viewModel = threadManager.activeViewModel {
+                        viewModel.pendingSkillInvocation = SkillInvocationData(
+                            name: skill.name,
+                            emoji: skill.emoji,
+                            description: skill.description
+                        )
+                        viewModel.inputText = "Use the \(skill.name) skill"
+                        viewModel.sendMessage()
+                        viewModel.pendingSkillInvocation = nil
+                    }
+                    windowState.selection = nil
+                },
+                daemonClient: daemonClient
+            )
         }
     }
 
@@ -549,6 +571,30 @@ extension MainWindowView {
                         windowState.selection = .panel(.directory)
                     }
                 }
+            )
+            .overlay(alignment: .topTrailing) { panelDismissButton }
+            .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+        case .intelligence:
+            IntelligencePanel(
+                onClose: { windowState.dismissOverlay() },
+                onCustomizeAvatar: { windowState.selection = .panel(.avatarCustomization) },
+                onInvokeSkill: { skill in
+                    if threadManager.activeViewModel == nil {
+                        threadManager.createThread()
+                    }
+                    if let viewModel = threadManager.activeViewModel {
+                        viewModel.pendingSkillInvocation = SkillInvocationData(
+                            name: skill.name,
+                            emoji: skill.emoji,
+                            description: skill.description
+                        )
+                        viewModel.inputText = "Use the \(skill.name) skill"
+                        viewModel.sendMessage()
+                        viewModel.pendingSkillInvocation = nil
+                    }
+                    windowState.dismissOverlay()
+                },
+                daemonClient: daemonClient
             )
             .overlay(alignment: .topTrailing) { panelDismissButton }
             .background(adaptiveColor(light: Moss._50, dark: Moss._950))

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -90,9 +90,12 @@ extension MainWindowView {
         case .threadList:
             sidebarView
         case .identity:
-            IdentityPanel(onClose: { windowState.selection = nil }, onCustomizeAvatar: { windowState.selection = .panel(.avatarCustomization) }, daemonClient: daemonClient)
+            IdentityPanel(onClose: { windowState.selection = nil }, onCustomizeAvatar: {
+                windowState.avatarCustomizationReturnPanel = .identity
+                windowState.selection = .panel(.avatarCustomization)
+            }, daemonClient: daemonClient)
         case .avatarCustomization:
-            AvatarCustomizationPanel(onClose: { windowState.selection = .panel(.identity) })
+            AvatarCustomizationPanel(onClose: { windowState.selection = .panel(windowState.avatarCustomizationReturnPanel) })
         case .voiceMode:
             VoiceModePanel(
                 manager: voiceModeManager,
@@ -124,7 +127,10 @@ extension MainWindowView {
         case .intelligence:
             IntelligencePanel(
                 onClose: { windowState.selection = nil },
-                onCustomizeAvatar: { windowState.selection = .panel(.avatarCustomization) },
+                onCustomizeAvatar: {
+                    windowState.avatarCustomizationReturnPanel = .intelligence
+                    windowState.selection = .panel(.avatarCustomization)
+                },
                 onInvokeSkill: { skill in
                     if threadManager.activeViewModel == nil {
                         threadManager.createThread()
@@ -537,10 +543,13 @@ extension MainWindowView {
             )
             .overlay(alignment: .topTrailing) { panelDismissButton }
         case .identity:
-            IdentityPanel(onClose: { windowState.dismissOverlay() }, onCustomizeAvatar: { windowState.selection = .panel(.avatarCustomization) }, daemonClient: daemonClient)
+            IdentityPanel(onClose: { windowState.dismissOverlay() }, onCustomizeAvatar: {
+                windowState.avatarCustomizationReturnPanel = .identity
+                windowState.selection = .panel(.avatarCustomization)
+            }, daemonClient: daemonClient)
                 .background(adaptiveColor(light: Color(hex: 0xF5F3EB), dark: Moss._900))
         case .avatarCustomization:
-            AvatarCustomizationPanel(onClose: { windowState.selection = .panel(.identity) })
+            AvatarCustomizationPanel(onClose: { windowState.selection = .panel(windowState.avatarCustomizationReturnPanel) })
         case .generated:
             // Generated panel is handled inline in chatContentView when expanded;
             // if we reach here, isDynamicExpanded is false — clear selection so
@@ -577,7 +586,10 @@ extension MainWindowView {
         case .intelligence:
             IntelligencePanel(
                 onClose: { windowState.dismissOverlay() },
-                onCustomizeAvatar: { windowState.selection = .panel(.avatarCustomization) },
+                onCustomizeAvatar: {
+                    windowState.avatarCustomizationReturnPanel = .intelligence
+                    windowState.selection = .panel(.avatarCustomization)
+                },
                 onInvokeSkill: { skill in
                     if threadManager.activeViewModel == nil {
                         threadManager.createThread()
@@ -605,9 +617,9 @@ extension MainWindowView {
 
     /// Consistent X close button for panel overlays.
     func panelDismissAction() {
-        // Avatar customization → back to Identity; everything else → dismiss overlay
+        // Avatar customization → back to originating panel; everything else → dismiss overlay
         if case .panel(.avatarCustomization) = windowState.selection {
-            windowState.selection = .panel(.identity)
+            windowState.selection = .panel(windowState.avatarCustomizationReturnPanel)
         } else {
             windowState.dismissOverlay()
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+import VellumAssistantShared
+
+// MARK: - Intelligence Panel
+
+struct IntelligencePanel: View {
+    var onClose: () -> Void
+    var onCustomizeAvatar: () -> Void
+    var onInvokeSkill: ((SkillInfo) -> Void)?
+    let daemonClient: DaemonClient
+
+    @State private var selectedTab: IntelligenceTab = .identity
+
+    private enum IntelligenceTab: String, CaseIterable {
+        case identity = "Identity"
+        case installedSkills = "Installed Skills"
+        case communitySkills = "Community Skills"
+    }
+
+    private let maxContentWidth: CGFloat = 1100
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                // Header
+                HStack(alignment: .center) {
+                    Text("Intelligence")
+                        .font(VFont.panelTitle)
+                        .foregroundColor(VColor.textPrimary)
+                    Spacer()
+                }
+                .padding(.top, VSpacing.xxl)
+                .padding(.bottom, VSpacing.xl)
+
+                Divider().background(VColor.surfaceBorder)
+                    .padding(.bottom, VSpacing.xl)
+
+                // Tab bar
+                VStack(spacing: 0) {
+                    HStack(spacing: VSpacing.xl) {
+                        ForEach(IntelligenceTab.allCases, id: \.self) { tab in
+                            tabButton(tab.rawValue, tab: tab)
+                        }
+                        Spacer()
+                    }
+
+                    Divider().background(VColor.surfaceBorder)
+                }
+                .padding(.bottom, VSpacing.lg)
+
+                // Tab content
+                tabContent
+            }
+            .frame(maxWidth: maxContentWidth)
+            .padding(.horizontal, VSpacing.xxl)
+            .padding(.bottom, VSpacing.xxl)
+            .frame(maxWidth: .infinity)
+        }
+    }
+
+    // MARK: - Tab Button
+
+    @ViewBuilder
+    private func tabButton(_ label: String, tab: IntelligenceTab) -> some View {
+        let isActive = selectedTab == tab
+        Button {
+            withAnimation(VAnimation.fast) { selectedTab = tab }
+        } label: {
+            VStack(spacing: VSpacing.sm) {
+                Text(label)
+                    .font(VFont.body)
+                    .foregroundColor(isActive ? VColor.textPrimary : VColor.textMuted)
+                    .padding(.bottom, VSpacing.xs)
+
+                Rectangle()
+                    .fill(isActive ? VColor.textPrimary : Color.clear)
+                    .frame(height: 2)
+            }
+            .fixedSize()
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Tab Content
+
+    @ViewBuilder
+    private var tabContent: some View {
+        switch selectedTab {
+        case .identity:
+            placeholderContent("Identity")
+        case .installedSkills:
+            placeholderContent("Installed Skills")
+        case .communitySkills:
+            placeholderContent("Community Skills")
+        }
+    }
+
+    @ViewBuilder
+    private func placeholderContent(_ title: String) -> some View {
+        VStack {
+            Spacer().frame(height: 100)
+            Text(title)
+                .font(VFont.body)
+                .foregroundColor(VColor.textMuted)
+                .frame(maxWidth: .infinity, alignment: .center)
+            Spacer().frame(height: 100)
+        }
+    }
+}
+
+#Preview {
+    IntelligencePanel(onClose: {}, onCustomizeAvatar: {}, daemonClient: DaemonClient())
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
@@ -10,6 +10,7 @@ enum SidePanelType: Hashable, CaseIterable {
     case voiceMode
     case assistantInbox
     case apps
+    case intelligence
 
     init?(rawValue: String) {
         switch rawValue {
@@ -24,6 +25,7 @@ enum SidePanelType: Hashable, CaseIterable {
         case "voiceMode": self = .voiceMode
         case "assistantInbox": self = .assistantInbox
         case "apps": self = .apps
+        case "intelligence": self = .intelligence
         default: return nil
         }
     }


### PR DESCRIPTION
Create IntelligencePanel.swift with 3-tab layout (Identity, Installed Skills, Community Skills), add .intelligence to SidePanelType and NativePanelId, wire into PanelCoordinator, add Intelligence nav item to sidebar. Part of #8968.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
