### PR TITLE
fix: classify Bun-style connection errors as retryable in memory jobs

### DIFF
--- a/assistant/src/memory/job-utils.ts
+++ b/assistant/src/memory/job-utils.ts
@@ -74,9 +74,17 @@ export function classifyError(err: unknown): ErrorCategory {
     }
   }
 
-  // Connection/network errors without a status code
-  if (err instanceof Error && /ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENETUNREACH|fetch failed/i.test(err.message)) {
-    return 'retryable';
+  // Connection/network errors without a status code.
+  // Check both the message (Node.js style) and the `code` property (Bun style,
+  // e.g. code: "ConnectionRefused" from Bun's HTTP client).
+  if (err instanceof Error) {
+    if (/ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENETUNREACH|fetch failed/i.test(err.message)) {
+      return 'retryable';
+    }
+    const code = (err as Error & { code?: string }).code;
+    if (typeof code === 'string' && /^Connection(Refused|Reset|Timeout)|NetworkUnreachable|Unable.?to.?connect/i.test(code)) {
+      return 'retryable';
+    }
   }
 
   // Unknown errors default to fatal to avoid infinite retry loops


### PR DESCRIPTION
## Summary
- Bun's HTTP client sets `code: "ConnectionRefused"` on connection errors instead of embedding `ECONNREFUSED` in the message like Node.js does.
- `classifyError` only checked `err.message`, so Qdrant connection failures (when Qdrant isn't running) were classified as `fatal` — permanently failing the job instead of retrying.
- Added a check for the error's `code` property matching Bun-style connection error codes (`ConnectionRefused`, `ConnectionReset`, `ConnectionTimeout`, `NetworkUnreachable`).

## Original prompt
Fix Qdrant connection refused errors being classified as fatal instead of retryable in memory-jobs-worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8975" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
