### PR TITLE
M4: ASK_GUARDIAN De-specialization

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -2631,17 +2631,6 @@ exports[`IPC message snapshots ServerMessage types task_run_thread_created seria
 }
 `;
 
-exports[`IPC message snapshots ServerMessage types guardian_request_thread_created serializes to expected JSON 1`] = `
-{
-  "callSessionId": "call-001",
-  "conversationId": "conv-guardian-001",
-  "questionText": "What is the gate code?",
-  "requestId": "req-guardian-001",
-  "title": "Guardian action request",
-  "type": "guardian_request_thread_created",
-}
-`;
-
 exports[`IPC message snapshots ServerMessage types subagent_spawned serializes to expected JSON 1`] = `
 {
   "label": "Research Agent",

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -30,6 +30,14 @@ mock.module('../config/env.js', () => ({
   getGatewayInternalBaseUrl: () => 'http://localhost:3000',
 }));
 
+// Mock the notification pipeline — guardian dispatch routes through it for
+// thread creation IPC (notification_thread_created). We stub it to a no-op
+// because the pipeline's own tests cover its behavior.
+mock.module('../notifications/emit-signal.js', () => ({
+  emitNotificationSignal: async () => {},
+  registerBroadcastFn: () => {},
+}));
+
 let mockTelegramBinding: unknown = null;
 let mockSmsBinding: unknown = null;
 
@@ -200,35 +208,6 @@ describe('guardian-dispatch', () => {
     expect(telegramMessage!.body.chatId).toBe('tg-chat-999');
   });
 
-  test('emits IPC event via broadcast for mac delivery', async () => {
-    const convId = 'conv-dispatch-3';
-    ensureConversation(convId);
-
-    const session = createCallSession({
-      conversationId: convId,
-      provider: 'twilio',
-      fromNumber: '+15550001111',
-      toNumber: '+15550002222',
-    });
-    const pq = createPendingQuestion(session.id, 'Approve action?');
-
-    const broadcastedMessages: unknown[] = [];
-    const broadcastFn = (msg: unknown) => { broadcastedMessages.push(msg); };
-
-    await dispatchGuardianQuestion({
-      callSessionId: session.id,
-      conversationId: convId,
-      assistantId: 'self',
-      pendingQuestion: pq,
-      broadcast: broadcastFn,
-    });
-
-    expect(broadcastedMessages).toHaveLength(1);
-    const msg = broadcastedMessages[0] as Record<string, unknown>;
-    expect(msg.type).toBe('guardian_request_thread_created');
-    expect(msg.callSessionId).toBe(session.id);
-  });
-
   test('adds initial guardian message to mac conversation', async () => {
     const convId = 'conv-dispatch-4';
     ensureConversation(convId);
@@ -241,20 +220,19 @@ describe('guardian-dispatch', () => {
     });
     const pq = createPendingQuestion(session.id, 'What is the password?');
 
-    const broadcastedMessages: unknown[] = [];
-    const broadcastFn = (msg: unknown) => { broadcastedMessages.push(msg); };
-
     await dispatchGuardianQuestion({
       callSessionId: session.id,
       conversationId: convId,
       assistantId: 'self',
       pendingQuestion: pq,
-      broadcast: broadcastFn,
     });
 
-    // Get the mac conversation ID from the broadcast
-    const msg = broadcastedMessages[0] as Record<string, unknown>;
-    const macConvId = msg.conversationId as string;
+    // Look up the mac conversation created by guardian dispatch via the DB
+    const db = getDb();
+    const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const requests = raw.query('SELECT * FROM guardian_action_requests WHERE call_session_id = ?').all(session.id) as Array<{ id: string }>;
+    const deliveries = raw.query('SELECT * FROM guardian_action_deliveries WHERE request_id = ? AND destination_channel = ?').all(requests[0].id, 'vellum') as Array<{ destination_conversation_id: string }>;
+    const macConvId = deliveries[0].destination_conversation_id;
 
     // The mac conversation should have a message with the question text
     const messages = getMessages(macConvId);
@@ -284,7 +262,7 @@ describe('guardian-dispatch', () => {
     })).resolves.toBeUndefined();
   });
 
-  test('broadcast title is emoji-prefixed and does not start with "Guardian question:"', async () => {
+  test('conversation title is emoji-prefixed and does not start with "Guardian question:"', async () => {
     const convId = 'conv-dispatch-6';
     ensureConversation(convId);
 
@@ -296,19 +274,21 @@ describe('guardian-dispatch', () => {
     });
     const pq = createPendingQuestion(session.id, 'What is the gate code?');
 
-    const broadcastedMessages: unknown[] = [];
-    const broadcastFn = (msg: unknown) => { broadcastedMessages.push(msg); };
-
     await dispatchGuardianQuestion({
       callSessionId: session.id,
       conversationId: convId,
       assistantId: 'self',
       pendingQuestion: pq,
-      broadcast: broadcastFn,
     });
 
-    const msg = broadcastedMessages[0] as Record<string, unknown>;
-    const title = msg.title as string;
+    // Look up the mac conversation title via the DB
+    const db = getDb();
+    const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const requests = raw.query('SELECT * FROM guardian_action_requests WHERE call_session_id = ?').all(session.id) as Array<{ id: string }>;
+    const deliveries = raw.query('SELECT * FROM guardian_action_deliveries WHERE request_id = ? AND destination_channel = ?').all(requests[0].id, 'vellum') as Array<{ destination_conversation_id: string }>;
+    const macConvId = deliveries[0].destination_conversation_id;
+    const conv = raw.query('SELECT * FROM conversations WHERE id = ?').get(macConvId) as { title: string };
+    const title = conv.title;
 
     // Title must NOT start with the old static "Guardian question:" prefix
     expect(title.startsWith('Guardian question:')).toBe(false);
@@ -316,36 +296,6 @@ describe('guardian-dispatch', () => {
     // Title must start with an emoji (code point > 127 or common emoji ranges)
     const firstCodePoint = title.codePointAt(0)!;
     expect(firstCodePoint).toBeGreaterThan(127);
-  });
-
-  test('broadcast includes questionText field matching the original question', async () => {
-    const convId = 'conv-dispatch-7';
-    ensureConversation(convId);
-
-    const questionText = 'What is the WiFi password?';
-    const session = createCallSession({
-      conversationId: convId,
-      provider: 'twilio',
-      fromNumber: '+15550001111',
-      toNumber: '+15550002222',
-    });
-    const pq = createPendingQuestion(session.id, questionText);
-
-    const broadcastedMessages: unknown[] = [];
-    const broadcastFn = (msg: unknown) => { broadcastedMessages.push(msg); };
-
-    await dispatchGuardianQuestion({
-      callSessionId: session.id,
-      conversationId: convId,
-      assistantId: 'self',
-      pendingQuestion: pq,
-      broadcast: broadcastFn,
-    });
-
-    expect(broadcastedMessages).toHaveLength(1);
-    const msg = broadcastedMessages[0] as Record<string, unknown>;
-    expect(msg.type).toBe('guardian_request_thread_created');
-    expect(msg.questionText).toBe(questionText);
   });
 
   test('initial message in mac conversation contains question text from generative copy', async () => {
@@ -366,19 +316,19 @@ describe('guardian-dispatch', () => {
     });
     const pq = createPendingQuestion(session.id, 'What is the gate code?');
 
-    const broadcastedMessages: unknown[] = [];
-    const broadcastFn = (msg: unknown) => { broadcastedMessages.push(msg); };
-
     await dispatchGuardianQuestion({
       callSessionId: session.id,
       conversationId: convId,
       assistantId: 'self',
       pendingQuestion: pq,
-      broadcast: broadcastFn,
     });
 
-    const msg = broadcastedMessages[0] as Record<string, unknown>;
-    const macConvId = msg.conversationId as string;
+    // Look up the mac conversation via the DB
+    const db = getDb();
+    const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const requests = raw.query('SELECT * FROM guardian_action_requests WHERE call_session_id = ?').all(session.id) as Array<{ id: string }>;
+    const deliveries = raw.query('SELECT * FROM guardian_action_deliveries WHERE request_id = ? AND destination_channel = ?').all(requests[0].id, 'vellum') as Array<{ destination_conversation_id: string }>;
+    const macConvId = deliveries[0].destination_conversation_id;
 
     const messages = getMessages(macConvId);
     expect(messages.length).toBeGreaterThanOrEqual(1);

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -36,6 +36,7 @@ mock.module('../config/env.js', () => ({
 mock.module('../notifications/emit-signal.js', () => ({
   emitNotificationSignal: async () => {},
   registerBroadcastFn: () => {},
+  getRegisteredBroadcastFn: () => null,
 }));
 
 let mockTelegramBinding: unknown = null;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -1753,14 +1753,6 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     workItemId: 'wi-001',
     title: 'Process report',
   },
-  guardian_request_thread_created: {
-    type: 'guardian_request_thread_created',
-    conversationId: 'conv-guardian-001',
-    requestId: 'req-guardian-001',
-    callSessionId: 'call-001',
-    title: 'Guardian action request',
-    questionText: 'What is the gate code?',
-  },
   subagent_spawned: {
     type: 'subagent_spawned',
     subagentId: 'sub-001',

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -531,7 +531,6 @@ export class CallController {
               conversationId: session.conversationId,
               assistantId: this.assistantId,
               pendingQuestion,
-              broadcast: this.broadcast,
             });
           }
 

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -3,13 +3,11 @@
  *
  * When a call controller detects ASK_GUARDIAN, this module:
  * 1. Creates a guardian_action_request
- * 2. Determines delivery destinations (telegram, sms, macos)
+ * 2. Routes through the generic notification pipeline (emitNotificationSignal)
  * 3. Creates guardian_action_delivery rows for each destination
- * 4. Sends HTTP POST to gateway for external channels
- * 5. Emits IPC events for the mac channel
+ * 4. Persists the vellum conversation + initial message for mac replies
  */
 
-import type { ServerMessage } from '../daemon/ipc-contract.js';
 import { getActiveBinding } from '../memory/channel-guardian-store.js';
 import { getOrCreateConversation } from '../memory/conversation-key-store.js';
 import { addMessage, updateConversationTitle } from '../memory/conversation-store.js';
@@ -31,8 +29,6 @@ export interface GuardianDispatchParams {
   conversationId: string;
   assistantId: string;
   pendingQuestion: CallPendingQuestion;
-  /** Broadcast function to emit IPC events to connected clients. */
-  broadcast?: (msg: ServerMessage) => void;
 }
 
 /**
@@ -45,7 +41,6 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
     conversationId,
     assistantId,
     pendingQuestion,
-    broadcast,
   } = params;
 
   try {
@@ -68,11 +63,9 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
       'Created guardian action request',
     );
 
-    // Emit notification signal through the unified pipeline (fire-and-forget).
-    // The existing guardian dispatch logic below handles the actual delivery
-    // to specific channels (telegram, sms, vellum), so this signal is
-    // supplementary — it lets the decision engine log and potentially route
-    // to additional channels in the future.
+    // Route through the generic notification pipeline — this handles
+    // conversation pairing, thread creation IPC (notification_thread_created),
+    // and multi-channel delivery automatically.
     void emitNotificationSignal({
       sourceEventName: 'guardian.question',
       sourceChannel: 'voice',
@@ -162,17 +155,8 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
           { userMessageChannel: 'voice', assistantMessageChannel: 'vellum', userMessageInterface: 'voice', assistantMessageInterface: 'vellum' },
         );
 
-        // Emit IPC event for the vellum client with the server-created conversation
-        if (broadcast) {
-          broadcast({
-            type: 'guardian_request_thread_created',
-            conversationId: macConversationId,
-            requestId: request.id,
-            callSessionId,
-            title: guardianCopy.threadTitle,
-            questionText: request.questionText,
-          } as ServerMessage);
-        }
+        // Thread creation IPC is now handled by the generic notification
+        // pipeline (notification_thread_created) via emitNotificationSignal above.
         updateDeliveryStatus(delivery.id, 'sent');
         log.info({ deliveryId: delivery.id, channel: 'vellum', macConversationId }, 'Vellum guardian delivery emitted');
       } else {

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -16,7 +16,7 @@ import {
   createGuardianActionRequest,
   updateDeliveryStatus,
 } from '../memory/guardian-action-store.js';
-import { emitNotificationSignal } from '../notifications/emit-signal.js';
+import { emitNotificationSignal, getRegisteredBroadcastFn } from '../notifications/emit-signal.js';
 import { getLogger } from '../util/logger.js';
 import { getUserConsultationTimeoutMs } from './call-constants.js';
 import { generateGuardianCopy } from './guardian-question-copy.js';
@@ -64,8 +64,10 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
     );
 
     // Route through the generic notification pipeline — this handles
-    // conversation pairing, thread creation IPC (notification_thread_created),
-    // and multi-channel delivery automatically.
+    // multi-channel delivery automatically. We suppress the pipeline's
+    // notification_thread_created IPC event because guardian-dispatch creates
+    // its own vellum conversation with proper LLM copy and delivery linkage;
+    // the pipeline's conversation would be a separate, unlinked thread.
     void emitNotificationSignal({
       sourceEventName: 'guardian.question',
       sourceChannel: 'voice',
@@ -86,6 +88,7 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
         pendingQuestionId: pendingQuestion.id,
       },
       dedupeKey: `guardian:${request.id}`,
+      skipVellumThread: true,
     });
 
     // Determine delivery destinations
@@ -155,8 +158,19 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
           { userMessageChannel: 'voice', assistantMessageChannel: 'vellum', userMessageInterface: 'voice', assistantMessageInterface: 'vellum' },
         );
 
-        // Thread creation IPC is now handled by the generic notification
-        // pipeline (notification_thread_created) via emitNotificationSignal above.
+        // Emit notification_thread_created directly for the guardian's own
+        // vellum conversation — the pipeline's event was suppressed via
+        // skipVellumThread so the macOS client surfaces this thread instead.
+        const broadcastFn = getRegisteredBroadcastFn();
+        if (broadcastFn) {
+          broadcastFn({
+            type: 'notification_thread_created',
+            conversationId: macConversationId,
+            title: guardianCopy.threadTitle,
+            sourceEventName: 'guardian.question',
+          });
+        }
+
         updateDeliveryStatus(delivery.id, 'sent');
         log.info({ deliveryId: delivery.id, channel: 'vellum', macConversationId }, 'Vellum guardian delivery emitted');
       } else {

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -229,7 +229,6 @@
     "generation_cancelled",
     "generation_handoff",
     "get_signing_identity",
-    "guardian_request_thread_created",
     "guardian_verification_response",
     "history_response",
     "home_base_get_response",

--- a/assistant/src/daemon/ipc-contract/work-items.ts
+++ b/assistant/src/daemon/ipc-contract/work-items.ts
@@ -214,16 +214,6 @@ export interface TaskRunThreadCreated {
   title: string;
 }
 
-/** Server push — broadcast when a guardian action request creates a thread for the mac channel. */
-export interface GuardianRequestThreadCreated {
-  type: 'guardian_request_thread_created';
-  conversationId: string;
-  requestId: string;
-  callSessionId: string;
-  title: string;
-  questionText: string;
-}
-
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
 export type _WorkItemsClientMessages =
@@ -250,6 +240,5 @@ export type _WorkItemsServerMessages =
   | WorkItemCancelResponse
   | WorkItemStatusChanged
   | TaskRunThreadCreated
-  | GuardianRequestThreadCreated
   | TasksChanged
   | OpenTasksWindow;

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -64,6 +64,7 @@ export class NotificationBroadcaster {
   async broadcastDecision(
     signal: NotificationSignal,
     decision: NotificationDecision,
+    options?: { skipThreadPush?: boolean },
   ): Promise<NotificationDeliveryResult[]> {
     const destinations = resolveDestinations(signal.assistantId, decision.selectedChannels);
 
@@ -128,7 +129,7 @@ export class NotificationBroadcaster {
         // conversation is paired, BEFORE waiting for adapter send or other
         // channel deliveries. This avoids a race where slow Telegram delivery
         // delays the IPC push past the macOS deep-link retry window.
-        if (pairing.strategy === 'start_new_conversation' && this.onThreadCreated) {
+        if (pairing.strategy === 'start_new_conversation' && this.onThreadCreated && !options?.skipThreadPush) {
           const threadTitle =
             copy.threadTitle ??
             copy.title ??

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -42,6 +42,12 @@ export function registerBroadcastFn(fn: BroadcastFn): void {
   broadcasterInstance = null;
 }
 
+/** Expose the registered broadcast function so external dispatchers
+ *  (e.g. guardian-dispatch) can emit IPC events directly. */
+export function getRegisteredBroadcastFn(): BroadcastFn | null {
+  return registeredBroadcastFn;
+}
+
 function getBroadcaster(): NotificationBroadcaster {
   if (!broadcasterInstance) {
     const adapters = [
@@ -123,6 +129,12 @@ export interface EmitSignalParams {
   contextPayload?: Record<string, unknown>;
   /** Optional deduplication key. */
   dedupeKey?: string;
+  /**
+   * When true, suppress the pipeline's notification_thread_created IPC event
+   * for the vellum channel. Used by callers (e.g. guardian-dispatch) that
+   * create their own vellum conversation and emit the event directly.
+   */
+  skipVellumThread?: boolean;
   /**
    * When true, rethrow pipeline errors to the caller instead of only logging.
    * Useful for direct user-invoked actions that must fail closed.
@@ -207,7 +219,12 @@ export async function emitNotificationSignal(params: EmitSignalParams): Promise<
     // than after all channel deliveries complete. This avoids a race where
     // slow Telegram delivery delays the push past the macOS deep-link retry.
     const broadcaster = getBroadcaster();
-    const dispatchResult = await dispatchDecision(signal, decision, broadcaster);
+    const dispatchResult = await dispatchDecision(
+      signal,
+      decision,
+      broadcaster,
+      params.skipVellumThread ? { skipThreadPush: true } : undefined,
+    );
 
     log.info(
       {

--- a/assistant/src/notifications/runtime-dispatch.ts
+++ b/assistant/src/notifications/runtime-dispatch.ts
@@ -30,6 +30,7 @@ export async function dispatchDecision(
   signal: NotificationSignal,
   decision: NotificationDecision,
   broadcaster: NotificationBroadcaster,
+  options?: { skipThreadPush?: boolean },
 ): Promise<DispatchResult> {
   // No-op when the decision engine says not to notify
   if (!decision.shouldNotify) {
@@ -58,7 +59,7 @@ export async function dispatchDecision(
   }
 
   // Dispatch through the broadcaster
-  const deliveryResults = await broadcaster.broadcastDecision(signal, decision);
+  const deliveryResults = await broadcaster.broadcastDecision(signal, decision, options);
 
   const sentCount = deliveryResults.filter((r) => r.status === 'sent').length;
   log.info(

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -240,26 +240,6 @@ extension AppDelegate {
         }
     }
 
-    func deliverGuardianRequestNotification(title: String, questionText: String, conversationId: String) {
-        let content = UNMutableNotificationContent()
-        content.title = title
-        content.body = String(questionText.prefix(200))
-        content.sound = .default
-        content.categoryIdentifier = "GUARDIAN_REQUEST"
-        content.userInfo = ["conversationId": conversationId]
-
-        let request = UNNotificationRequest(
-            identifier: "guardian-request-\(conversationId)",
-            content: content,
-            trigger: nil
-        )
-        UNUserNotificationCenter.current().add(request) { error in
-            if let error {
-                log.error("Failed to post guardian request notification: \(error.localizedDescription)")
-            }
-        }
-    }
-
     /// Opens the main window and navigates to the thread for the given conversation ID.
     /// Retries if the thread isn't populated yet (e.g., ThreadManager hasn't loaded it).
     /// Used by Quick Chat, Guardian Request, and other notification deep links.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -796,32 +796,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             )
         }
 
-        // Guardian request threads — created when a voice call's ASK_GUARDIAN dispatches
-        // a question to the mac channel so the user can see and respond in chat.
-        daemonClient.onGuardianRequestThreadCreated = { [weak self] msg in
-            guard let self, !self.isAwaitingFirstLaunchReady else { return }
-            self.mainWindow?.threadManager.createGuardianRequestThread(
-                conversationId: msg.conversationId,
-                requestId: msg.requestId,
-                callSessionId: msg.callSessionId,
-                title: msg.title
-            )
-            if NSApp.isActive {
-                // App is in foreground — select thread and show window immediately
-                if let thread = self.mainWindow?.threadManager.threads.first(where: { $0.sessionId == msg.conversationId }) {
-                    self.mainWindow?.threadManager.activeThreadId = thread.id
-                }
-                self.showMainWindow()
-            } else {
-                // App is backgrounded — post native notification
-                self.deliverGuardianRequestNotification(
-                    title: msg.title,
-                    questionText: msg.questionText,
-                    conversationId: msg.conversationId
-                )
-            }
-        }
-
         // Notification threads — created when the notification pipeline delivers
         // to the vellum channel with start_new_conversation strategy.
         daemonClient.onNotificationThreadCreated = { [weak self] msg in

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -170,27 +170,6 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         log.info("Created task run thread \(thread.id) for conversation \(conversationId) (work item \(workItemId))")
     }
 
-    /// Create a visible thread bound to an existing guardian action request conversation.
-    /// Called when the daemon broadcasts `guardian_request_thread_created` so the user
-    /// can see and respond to guardian questions from a voice call.
-    func createGuardianRequestThread(conversationId: String, requestId: String, callSessionId: String, title: String) {
-        // Avoid creating a duplicate thread if one already exists for this conversation
-        if threads.contains(where: { $0.sessionId == conversationId }) {
-            return
-        }
-
-        let thread = ThreadModel(title: title, sessionId: conversationId)
-        let viewModel = makeViewModel()
-        viewModel.sessionId = conversationId
-        // Start the message loop so the view model receives streamed messages
-        viewModel.startMessageLoop()
-
-        threads.insert(thread, at: 0)
-        chatViewModels[thread.id] = viewModel
-
-        log.info("Created guardian request thread \(thread.id) for conversation \(conversationId) (request \(requestId), call \(callSessionId))")
-    }
-
     /// Create a visible thread bound to a notification-created conversation.
     /// Called when the daemon broadcasts `notification_thread_created` so the user
     /// can see notification threads and deep-link into them.

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -429,9 +429,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when a task run creates a conversation so the client can show it as a visible chat thread.
     public var onTaskRunThreadCreated: ((IPCTaskRunThreadCreated) -> Void)?
 
-    /// Called when a guardian action request creates a thread for the mac channel.
-    public var onGuardianRequestThreadCreated: ((IPCGuardianRequestThreadCreated) -> Void)?
-
     /// Called when the daemon wants us to open/focus the tasks window.
     public var onOpenTasksWindow: (() -> Void)?
 

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -238,8 +238,6 @@ extension DaemonClient {
             onWorkItemCancelResponse?(msg)
         case .taskRunThreadCreated(let msg):
             onTaskRunThreadCreated?(msg)
-        case .guardianRequestThreadCreated(let msg):
-            onGuardianRequestThreadCreated?(msg)
         case .openTasksWindow:
             onOpenTasksWindow?()
         case .subagentSpawned(let msg):

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1906,25 +1906,6 @@ public struct IPCGetSigningIdentityResponse: Codable, Sendable {
     }
 }
 
-/// Server push — broadcast when a guardian action request creates a thread for the mac channel.
-public struct IPCGuardianRequestThreadCreated: Codable, Sendable {
-    public let type: String
-    public let conversationId: String
-    public let requestId: String
-    public let callSessionId: String
-    public let title: String
-    public let questionText: String
-
-    public init(type: String, conversationId: String, requestId: String, callSessionId: String, title: String, questionText: String) {
-        self.type = type
-        self.conversationId = conversationId
-        self.requestId = requestId
-        self.callSessionId = callSessionId
-        self.title = title
-        self.questionText = questionText
-    }
-}
-
 public struct IPCGuardianVerificationRequest: Codable, Sendable {
     public let type: String
     public let action: String

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2277,7 +2277,6 @@ public enum ServerMessage: Decodable, Sendable {
     case workItemApprovePermissionsResponse(IPCWorkItemApprovePermissionsResponse)
     case workItemCancelResponse(IPCWorkItemCancelResponse)
     case taskRunThreadCreated(IPCTaskRunThreadCreated)
-    case guardianRequestThreadCreated(IPCGuardianRequestThreadCreated)
     case openTasksWindow(OpenTasksWindowMessage)
     case subagentSpawned(IPCSubagentSpawned)
     case subagentStatusChanged(IPCSubagentStatusChanged)
@@ -2652,9 +2651,6 @@ public enum ServerMessage: Decodable, Sendable {
         case "task_run_thread_created":
             let message = try IPCTaskRunThreadCreated(from: decoder)
             self = .taskRunThreadCreated(message)
-        case "guardian_request_thread_created":
-            let message = try IPCGuardianRequestThreadCreated(from: decoder)
-            self = .guardianRequestThreadCreated(message)
         case "open_tasks_window":
             let message = try OpenTasksWindowMessage(from: decoder)
             self = .openTasksWindow(message)


### PR DESCRIPTION
## Summary
- Route ASK_GUARDIAN through generic notification path instead of custom guardian thread creation
- Remove guardian_request_thread_created IPC event (replaced by notification_thread_created)
- Remove guardian-specific thread handlers from Swift clients
- Keep guardian state machine and first-response-wins behavior unchanged

Closes #8856
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
