### PR TITLE
M2: Integrate Identity and Skills content into Intelligence tabs

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -3,12 +3,24 @@ import VellumAssistantShared
 
 // MARK: - Agent Panel Content (embeddable)
 
+/// Which skills tab to display.
+enum SkillsTab {
+    case installed, available
+}
+
 /// The skills management content, usable standalone (e.g. inside IdentityPanel)
 /// or wrapped in a VSidePanel via AgentPanel.
+///
+/// When `visibleTab` is set, the internal tab bar is hidden and only
+/// the specified tab's content is shown. When nil (default), the full
+/// tab bar is displayed — preserving backward compatibility.
 struct AgentPanelContent: View {
     var onInvokeSkill: ((SkillInfo) -> Void)?
     var onSkillsChanged: (() -> Void)?
     let daemonClient: DaemonClient
+
+    /// When non-nil, locks the view to a single tab and hides the tab bar.
+    var visibleTab: SkillsTab?
 
     @StateObject private var skillsManager: SkillsManager
     @State private var selectedTab: SkillsTab = .installed
@@ -18,15 +30,15 @@ struct AgentPanelContent: View {
     @State private var skillToDelete: SkillInfo?
     @State private var showNewSkillSheet = false
 
-    private enum SkillsTab {
-        case installed, available
-    }
-
-    init(onInvokeSkill: ((SkillInfo) -> Void)? = nil, onSkillsChanged: (() -> Void)? = nil, daemonClient: DaemonClient) {
+    init(onInvokeSkill: ((SkillInfo) -> Void)? = nil, onSkillsChanged: (() -> Void)? = nil, daemonClient: DaemonClient, visibleTab: SkillsTab? = nil) {
         self.onInvokeSkill = onInvokeSkill
         self.onSkillsChanged = onSkillsChanged
         self.daemonClient = daemonClient
+        self.visibleTab = visibleTab
         _skillsManager = StateObject(wrappedValue: SkillsManager(daemonClient: daemonClient))
+        if let visibleTab {
+            _selectedTab = State(initialValue: visibleTab)
+        }
     }
 
     var body: some View {
@@ -56,32 +68,34 @@ struct AgentPanelContent: View {
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .padding(.bottom, VSpacing.lg)
 
-            // Tab bar
-            VStack(spacing: 0) {
-                HStack(spacing: VSpacing.xl) {
-                    tabButton(installedTabTitle, tab: .installed)
-                    tabButton(availableTabTitle, tab: .available)
-                    Spacer()
-                    Button {
-                        showNewSkillSheet = true
-                    } label: {
-                        HStack(spacing: VSpacing.xs) {
-                            Image(systemName: "plus")
-                            Text("New Skill")
+            // Tab bar — hidden when locked to a single tab via visibleTab
+            if visibleTab == nil {
+                VStack(spacing: 0) {
+                    HStack(spacing: VSpacing.xl) {
+                        tabButton(installedTabTitle, tab: .installed)
+                        tabButton(availableTabTitle, tab: .available)
+                        Spacer()
+                        Button {
+                            showNewSkillSheet = true
+                        } label: {
+                            HStack(spacing: VSpacing.xs) {
+                                Image(systemName: "plus")
+                                Text("New Skill")
+                            }
+                            .font(VFont.body)
+                            .foregroundColor(VColor.accent)
                         }
-                        .font(VFont.body)
-                        .foregroundColor(VColor.accent)
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("New Skill")
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("New Skill")
+
+                    Divider().background(VColor.surfaceBorder)
                 }
-
-                Divider().background(VColor.surfaceBorder)
+                .padding(.bottom, VSpacing.lg)
             }
-            .padding(.bottom, VSpacing.lg)
 
-            // Tab content
-            switch selectedTab {
+            // Tab content — use visibleTab when locked, otherwise selectedTab
+            switch visibleTab ?? selectedTab {
             case .installed:
                 skillsContent
             case .available:
@@ -226,7 +240,7 @@ struct AgentPanelContent: View {
                         icon: "magnifyingglass"
                     )
 
-                    if !filteredUserSkills.isEmpty {
+                    if visibleTab == nil, !filteredUserSkills.isEmpty {
                         Button {
                             withAnimation(VAnimation.fast) { selectedTab = .installed }
                         } label: {
@@ -737,7 +751,7 @@ struct AgentPanelContent: View {
                         icon: "magnifyingglass"
                     )
 
-                    if !availableClawhubSkills.isEmpty {
+                    if visibleTab == nil, !availableClawhubSkills.isEmpty {
                         Button {
                             withAnimation(VAnimation.fast) { selectedTab = .available }
                         } label: {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -20,7 +20,8 @@ struct IntelligencePanel: View {
     private let maxContentWidth: CGFloat = 1100
 
     var body: some View {
-        ScrollView {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header + tab bar (fixed at top)
             VStack(alignment: .leading, spacing: 0) {
                 // Header
                 HStack(alignment: .center) {
@@ -47,14 +48,13 @@ struct IntelligencePanel: View {
                     Divider().background(VColor.surfaceBorder)
                 }
                 .padding(.bottom, VSpacing.lg)
-
-                // Tab content
-                tabContent
             }
             .frame(maxWidth: maxContentWidth)
             .padding(.horizontal, VSpacing.xxl)
-            .padding(.bottom, VSpacing.xxl)
-            .frame(maxWidth: .infinity)
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            // Tab content — each tab manages its own scrolling
+            tabContent
         }
     }
 
@@ -88,23 +88,37 @@ struct IntelligencePanel: View {
     private var tabContent: some View {
         switch selectedTab {
         case .identity:
-            placeholderContent("Identity")
-        case .installedSkills:
-            placeholderContent("Installed Skills")
-        case .communitySkills:
-            placeholderContent("Community Skills")
-        }
-    }
+            IdentityPanel(
+                onClose: onClose,
+                onCustomizeAvatar: onCustomizeAvatar,
+                daemonClient: daemonClient
+            )
 
-    @ViewBuilder
-    private func placeholderContent(_ title: String) -> some View {
-        VStack {
-            Spacer().frame(height: 100)
-            Text(title)
-                .font(VFont.body)
-                .foregroundColor(VColor.textMuted)
-                .frame(maxWidth: .infinity, alignment: .center)
-            Spacer().frame(height: 100)
+        case .installedSkills:
+            ScrollView {
+                AgentPanelContent(
+                    onInvokeSkill: onInvokeSkill,
+                    daemonClient: daemonClient,
+                    visibleTab: .installed
+                )
+                .frame(maxWidth: maxContentWidth)
+                .padding(.horizontal, VSpacing.xxl)
+                .padding(.bottom, VSpacing.xxl)
+                .frame(maxWidth: .infinity)
+            }
+
+        case .communitySkills:
+            ScrollView {
+                AgentPanelContent(
+                    onInvokeSkill: onInvokeSkill,
+                    daemonClient: daemonClient,
+                    visibleTab: .available
+                )
+                .frame(maxWidth: maxContentWidth)
+                .padding(.horizontal, VSpacing.xxl)
+                .padding(.bottom, VSpacing.xxl)
+                .frame(maxWidth: .infinity)
+            }
         }
     }
 }


### PR DESCRIPTION
Replace placeholder tab content in IntelligencePanel with actual Identity and Skills content. Identity tab embeds IdentityPanel content. Installed Skills and Community Skills tabs embed AgentPanelContent with a new visibleTab parameter to show only the relevant section. Part of #8968.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
