### PR TITLE
fix: prevent conflict gate from blocking scheduled jobs

### DIFF
--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -420,7 +420,7 @@ async function executeApprove(
   // Process the message through the agent loop (no IPC event callback
   // since this is a background execution without a connected client)
   const noop = () => {};
-  await session.processMessage(messageContent, [], noop);
+  await session.processMessage(messageContent, [], noop, undefined, undefined, undefined, { isInteractive: false });
 
   // Deliver the assistant's reply to the external user via the gateway
   const replyCallbackUrl = typeof payload?.replyCallbackUrl === 'string'

--- a/assistant/src/daemon/handlers/config-scheduling.ts
+++ b/assistant/src/daemon/handlers/config-scheduling.ts
@@ -90,7 +90,7 @@ export async function handleScheduleRunNow(
           (session as unknown as { taskRunId?: string }).taskRunId = taskRunId;
           await session.processMessage(message, [], (event) => {
             ctx.send(socket, event);
-          });
+          }, undefined, undefined, undefined, { isInteractive: false });
         },
       );
 
@@ -127,7 +127,7 @@ export async function handleScheduleRunNow(
     const session = await ctx.getOrCreateSession(conversation.id, socket, true);
     await session.processMessage(schedule.message, [], (event) => {
       ctx.send(socket, event);
-    });
+    }, undefined, undefined, undefined, { isInteractive: false });
     completeScheduleRun(runId, { status: 'ok' });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -460,7 +460,7 @@ export async function handleWorkItemRunTask(
         }
         await session.processMessage(message, [], (event) => {
           ctx.broadcast(event);
-        });
+        }, undefined, undefined, undefined, { isInteractive: false });
       },
     );
 

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -342,6 +342,7 @@ export async function runAgentLoopImpl(
       conversationOriginInterface: getConversationOriginInterface(ctx.conversationId),
     };
 
+    const isInteractiveResolved = options?.isInteractive ?? (!ctx.hasNoClient && !ctx.headlessLock);
     runMessages = applyRuntimeInjections(runMessages, {
       softConflictInstruction,
       activeSurface,
@@ -353,6 +354,7 @@ export async function runAgentLoopImpl(
       guardianContext: ctx.guardianContext ?? null,
       temporalContext,
       voiceCallControlPrompt: ctx.voiceCallControlPrompt ?? null,
+      isNonInteractive: !isInteractiveResolved,
     });
 
     // Pre-run repair
@@ -471,6 +473,7 @@ export async function runAgentLoopImpl(
           guardianContext: ctx.guardianContext ?? null,
           temporalContext,
           voiceCallControlPrompt: ctx.voiceCallControlPrompt ?? null,
+          isNonInteractive: !isInteractiveResolved,
         });
         preRepairMessages = runMessages;
         preRunHistoryLength = runMessages.length;
@@ -508,6 +511,7 @@ export async function runAgentLoopImpl(
             guardianContext: ctx.guardianContext ?? null,
             temporalContext,
             voiceCallControlPrompt: ctx.voiceCallControlPrompt ?? null,
+            isNonInteractive: !isInteractiveResolved,
           });
           preRepairMessages = runMessages;
           preRunHistoryLength = runMessages.length;

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -80,7 +80,7 @@ export interface ProcessSessionContext {
     content: string,
     userMessageId: string,
     onEvent: (msg: ServerMessage) => void,
-    options?: { skipPreMessageRollback?: boolean },
+    options?: { skipPreMessageRollback?: boolean; isInteractive?: boolean },
   ): Promise<void>;
   getTurnChannelContext(): TurnChannelContext | null;
   setTurnChannelContext(ctx: TurnChannelContext): void;
@@ -322,6 +322,7 @@ export async function processMessage(
   requestId?: string,
   activeSurfaceId?: string,
   currentPage?: string,
+  options?: { isInteractive?: boolean },
 ): Promise<string> {
   session.currentActiveSurfaceId = activeSurfaceId;
   session.currentPage = currentPage;
@@ -482,6 +483,8 @@ export async function processMessage(
       });
   }
 
-  await session.runAgentLoop(resolvedContent, userMessageId, onEvent);
+  await session.runAgentLoop(resolvedContent, userMessageId, onEvent,
+    options?.isInteractive !== undefined ? { isInteractive: options.isInteractive } : undefined,
+  );
   return userMessageId;
 }

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -655,9 +655,28 @@ export function applyRuntimeInjections(
     guardianContext?: GuardianRuntimeContext | null;
     temporalContext?: string | null;
     voiceCallControlPrompt?: string | null;
+    isNonInteractive?: boolean;
   },
 ): Message[] {
   let result = runMessages;
+
+  // For non-interactive sessions (scheduled jobs, work items), instruct the
+  // model to never ask for clarification — there is no human present to answer.
+  if (options.isNonInteractive) {
+    const userTail = result[result.length - 1];
+    if (userTail && userTail.role === 'user') {
+      result = [
+        ...result.slice(0, -1),
+        {
+          ...userTail,
+          content: [
+            ...userTail.content,
+            { type: 'text' as const, text: '\n\n[Non-interactive scheduled task — do not ask for clarification or confirmation. Follow the instructions exactly using your best judgment. If recalled memory contains conflicting notes, prefer the explicit instruction in this message.]' },
+          ],
+        },
+      ];
+    }
+  }
 
   if (options.voiceCallControlPrompt) {
     const userTail = result[result.length - 1];

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -514,8 +514,9 @@ export class Session {
     requestId?: string,
     activeSurfaceId?: string,
     currentPage?: string,
+    options?: { isInteractive?: boolean },
   ): Promise<string> {
-    return processMessageImpl(this as ProcessSessionContext, content, attachments, onEvent, requestId, activeSurfaceId, currentPage);
+    return processMessageImpl(this as ProcessSessionContext, content, attachments, onEvent, requestId, activeSurfaceId, currentPage, options);
   }
 
   // ── History ──────────────────────────────────────────────────────

--- a/assistant/src/memory/conflict-policy.ts
+++ b/assistant/src/memory/conflict-policy.ts
@@ -33,6 +33,11 @@ const PR_URL_PATTERN = /github\.com\/[^/]+\/[^/]+\/pull\/\d+/i;
 const ISSUE_TICKET_PATTERN = /\b(?:issue|pr|ticket|pull request)\s*#?\d+/i;
 const TRACKING_LANGUAGE_PATTERN = /\b(?:this pr|that issue|while we wait|currently tracking)\b/i;
 
+// Statements about needing clarification are transient conversational artifacts
+// extracted from previous conflict-gate interactions — not durable facts.
+// Allowing them into the conflict pipeline creates self-reinforcing loops.
+const META_CLARIFICATION_PATTERN = /\b(?:needs? clarification|unclear which|user should (?:specify|clarify|choose)|which (?:one|option) (?:to|should)|conflicting (?:notes|instructions))\b/i;
+
 /**
  * Returns true when a statement looks like a transient tracking note
  * (PR URLs, issue references, short-lived progress notes) rather than
@@ -42,6 +47,7 @@ export function isTransientTrackingStatement(statement: string): boolean {
   if (PR_URL_PATTERN.test(statement)) return true;
   if (ISSUE_TICKET_PATTERN.test(statement)) return true;
   if (TRACKING_LANGUAGE_PATTERN.test(statement)) return true;
+  if (META_CLARIFICATION_PATTERN.test(statement)) return true;
   return false;
 }
 


### PR DESCRIPTION
## Summary
- **Bug 1 fixed**: `handleScheduleRunNow`, work item, and inbox handlers now pass `{ isInteractive: false }` through `Session.processMessage` → `runAgentLoop`, ensuring the conflict gate is skipped for all non-interactive code paths (not just the cron scheduler path which already worked correctly)
- **Bug 2 fixed**: Meta-clarification statements like "User needs clarification on..." are now classified as transient in `conflict-policy.ts`, breaking the self-reinforcing loop where the conflict gate's own output gets extracted as a memory item that triggers future conflicts
- **Bug 3 fixed**: Non-interactive sessions now receive a user-message injection instructing the model to never ask for clarification and to prefer explicit instructions over conflicting recalled memory

## Original prompt
Fix the scheduled job conflict gate bypass bug and self-reinforcing memory loop. Execute as a series of PRs:

**PR 1: Pass `isInteractive: false` in `handleScheduleRunNow`**
In `assistant/src/daemon/handlers/config-scheduling.ts`, the "Run Now" handler calls `session.processMessage()` which calls `runAgentLoop()` WITHOUT passing `isInteractive: false`. This means when a scheduled job is manually triggered from the UI, the conflict gate fires and blocks execution.

**PR 2: Prevent memory extraction of meta-clarification notes**
The memory extractor extracts notes like "User needs clarification on which CI workflow to monitor" from conversations where the conflict gate fired. These meta-observations about needing clarification are then stored as `instruction`-kind memory items, creating a self-reinforcing loop where the conflict keeps re-appearing.

**PR 3: Add system prompt guidance for non-interactive sessions to never ask for clarification**
Even with the conflict gate properly gated, the LLM can independently decide to ask for clarification based on contradictory recalled memory items. For non-interactive sessions (scheduled jobs, work items), the system prompt should instruct the model to never ask for clarification and instead use its best judgment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
