### PR TITLE
fix: add missing YAML frontmatter to knowledge-graph skill

### DIFF
--- a/assistant/src/config/bundled-skills/knowledge-graph/SKILL.md
+++ b/assistant/src/config/bundled-skills/knowledge-graph/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: "Knowledge Graph"
+description: "Query the entity knowledge graph to explore relationships between people, projects, tools, and other entities tracked in memory"
+---
+
 # Knowledge Graph
 
 Query the entity knowledge graph to explore relationships between people, projects, tools, and other entities tracked in memory.


### PR DESCRIPTION
## Summary

- Added YAML frontmatter (`name` and `description`) to the knowledge-graph `SKILL.md` file so it is no longer skipped by the skill loader

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
