### PR TITLE
M3: Remove old Identity and Agent nav items and clean up

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
@@ -3,8 +3,28 @@ import VellumAssistantShared
 
 // MARK: - Domain Types
 
-public enum NativePanelId: String, Codable, Equatable, Sendable {
+public enum NativePanelId: String, Equatable, Sendable {
     case chat, threadList, settings, debug, directory, generated, avatarCustomization, voiceMode, assistantInbox, apps, intelligence
+}
+
+extension NativePanelId: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        // Legacy values from older builds — map to the unified Intelligence panel
+        switch rawValue {
+        case "identity", "agent":
+            self = .intelligence
+        default:
+            guard let value = NativePanelId(rawValue: rawValue) else {
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Unknown NativePanelId: \(rawValue)"
+                )
+            }
+            self = value
+        }
+    }
 }
 
 public enum SlotContent: Equatable, Sendable {
@@ -103,7 +123,16 @@ extension SlotContent {
     static func from(wire: SlotContentWire) -> SlotContent? {
         switch wire.type {
         case "native":
-            guard let panel = wire.panel, let id = NativePanelId(rawValue: panel) else { return nil }
+            guard let panel = wire.panel else { return nil }
+            // Handle legacy panel IDs that were renamed to intelligence
+            let id: NativePanelId
+            switch panel {
+            case "identity", "agent":
+                id = .intelligence
+            default:
+                guard let parsed = NativePanelId(rawValue: panel) else { return nil }
+                id = parsed
+            }
             return .native(id)
         case "surface":
             guard let surfaceId = wire.surfaceId else { return nil }

--- a/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 // MARK: - Domain Types
 
 public enum NativePanelId: String, Codable, Equatable, Sendable {
-    case chat, threadList, settings, agent, debug, directory, generated, identity, avatarCustomization, voiceMode, assistantInbox, apps, intelligence
+    case chat, threadList, settings, debug, directory, generated, avatarCustomization, voiceMode, assistantInbox, apps, intelligence
 }
 
 public enum SlotContent: Equatable, Sendable {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -32,7 +32,7 @@ final class MainWindowState: ObservableObject {
     @Published var persistentThreadId: UUID?
 
     /// Tracks which panel originated the avatar customization flow so we can return to it.
-    @Published var avatarCustomizationReturnPanel: SidePanelType = .identity
+    @Published var avatarCustomizationReturnPanel: SidePanelType = .intelligence
 
     @Published var selectedSubagentId: String?
     @Published var activeDynamicSurface: UiSurfaceShowMessage?

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -728,7 +728,7 @@ struct MainWindowView: View {
                     break
                 }
             }
-            if case .panel(.identity) = windowState.selection {
+            if case .panel(.intelligence) = windowState.selection {
                 windowState.selection = nil
             }
             // Clear subagent detail panel on thread switch
@@ -1069,12 +1069,7 @@ struct MainWindowView: View {
             SidebarNavRow(icon: "brain.head.profile", label: "Intelligence", isActive: windowState.activePanel == .intelligence) {
                 windowState.togglePanel(.intelligence)
             }
-            SidebarNavRow(icon: "person.crop.circle", label: "Identity", isActive: windowState.activePanel == .identity) {
-                windowState.togglePanel(.identity)
-            }
-            SidebarNavRow(icon: "sparkles", label: "Skills", isActive: windowState.activePanel == .agent) {
-                windowState.togglePanel(.agent)
-            }
+
             SidebarNavRow(icon: "tray.fill", label: "Inbox", isActive: windowState.activePanel == .assistantInbox) {
                 windowState.togglePanel(.assistantInbox)
             }
@@ -1187,12 +1182,7 @@ struct MainWindowView: View {
             SidebarNavRow(icon: "brain.head.profile", label: "Intelligence", isActive: windowState.activePanel == .intelligence, isExpanded: false) {
                 windowState.togglePanel(.intelligence)
             }
-            SidebarNavRow(icon: "person.crop.circle", label: "Identity", isActive: windowState.activePanel == .identity, isExpanded: false) {
-                windowState.togglePanel(.identity)
-            }
-            SidebarNavRow(icon: "sparkles", label: "Skills", isActive: windowState.activePanel == .agent, isExpanded: false) {
-                windowState.togglePanel(.agent)
-            }
+
             SidebarNavRow(icon: "tray.fill", label: "Inbox", isActive: windowState.activePanel == .assistantInbox, isExpanded: false) {
                 windowState.togglePanel(.assistantInbox)
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -24,23 +24,6 @@ extension MainWindowView {
             chatView
         case .settings:
             SettingsPanel(onClose: { windowState.selection = nil }, store: settingsStore, daemonClient: daemonClient, threadManager: threadManager, authManager: authManager)
-        case .agent:
-            AgentPanel(onClose: { windowState.selection = nil }, onInvokeSkill: { skill in
-                if threadManager.activeViewModel == nil {
-                    threadManager.createThread()
-                }
-                if let viewModel = threadManager.activeViewModel {
-                    viewModel.pendingSkillInvocation = SkillInvocationData(
-                        name: skill.name,
-                        emoji: skill.emoji,
-                        description: skill.description
-                    )
-                    viewModel.inputText = "Use the \(skill.name) skill"
-                    viewModel.sendMessage()
-                    viewModel.pendingSkillInvocation = nil
-                }
-                windowState.selection = nil
-            }, daemonClient: daemonClient)
         case .debug:
             DebugPanel(
                 traceStore: traceStore,
@@ -89,11 +72,6 @@ extension MainWindowView {
             )
         case .threadList:
             sidebarView
-        case .identity:
-            IdentityPanel(onClose: { windowState.selection = nil }, onCustomizeAvatar: {
-                windowState.avatarCustomizationReturnPanel = .identity
-                windowState.selection = .panel(.avatarCustomization)
-            }, daemonClient: daemonClient)
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.selection = .panel(windowState.avatarCustomizationReturnPanel) })
         case .voiceMode:
@@ -515,25 +493,6 @@ extension MainWindowView {
         case .settings:
             SettingsPanel(onClose: { windowState.dismissOverlay() }, store: settingsStore, daemonClient: daemonClient, threadManager: threadManager, authManager: authManager)
                 .background(adaptiveColor(light: Moss._50, dark: Moss._950))
-        case .agent:
-            AgentPanel(onClose: { windowState.dismissOverlay() }, onInvokeSkill: { skill in
-                if threadManager.activeViewModel == nil {
-                    threadManager.createThread()
-                }
-                if let viewModel = threadManager.activeViewModel {
-                    viewModel.pendingSkillInvocation = SkillInvocationData(
-                        name: skill.name,
-                        emoji: skill.emoji,
-                        description: skill.description
-                    )
-                    viewModel.inputText = "Use the \(skill.name) skill"
-                    viewModel.sendMessage()
-                    viewModel.pendingSkillInvocation = nil
-                }
-                windowState.dismissOverlay()
-            }, daemonClient: daemonClient)
-                .overlay(alignment: .topTrailing) { panelDismissButton }
-                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
         case .debug:
             DebugPanel(
                 traceStore: traceStore,
@@ -542,12 +501,6 @@ extension MainWindowView {
                 onClose: { windowState.dismissOverlay() }
             )
             .overlay(alignment: .topTrailing) { panelDismissButton }
-        case .identity:
-            IdentityPanel(onClose: { windowState.dismissOverlay() }, onCustomizeAvatar: {
-                windowState.avatarCustomizationReturnPanel = .identity
-                windowState.selection = .panel(.avatarCustomization)
-            }, daemonClient: daemonClient)
-                .background(adaptiveColor(light: Color(hex: 0xF5F3EB), dark: Moss._900))
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.selection = .panel(windowState.avatarCustomizationReturnPanel) })
         case .generated:

--- a/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
@@ -1,10 +1,8 @@
 enum SidePanelType: Hashable, CaseIterable {
     case generated
-    case agent
     case settings
     case directory
     case debug
-    case identity
     case documentEditor
     case avatarCustomization
     case voiceMode
@@ -15,11 +13,9 @@ enum SidePanelType: Hashable, CaseIterable {
     init?(rawValue: String) {
         switch rawValue {
         case "generated": self = .generated
-        case "agent": self = .agent
         case "settings": self = .settings
         case "directory": self = .directory
         case "debug": self = .debug
-        case "identity": self = .identity
         case "documentEditor": self = .documentEditor
         case "avatarCustomization": self = .avatarCustomization
         case "voiceMode": self = .voiceMode

--- a/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
@@ -22,6 +22,8 @@ enum SidePanelType: Hashable, CaseIterable {
         case "assistantInbox": self = .assistantInbox
         case "apps": self = .apps
         case "intelligence": self = .intelligence
+        // Legacy values from older builds — map to the unified Intelligence panel
+        case "identity", "agent": self = .intelligence
         default: return nil
         }
     }

--- a/clients/macos/vellum-assistantTests/MainWindowAvatarRoutingTests.swift
+++ b/clients/macos/vellum-assistantTests/MainWindowAvatarRoutingTests.swift
@@ -7,11 +7,11 @@ final class MainWindowAvatarRoutingTests: XCTestCase {
 
     // MARK: - Callback Wiring Tests
 
-    /// Constructs an IdentityPanel with the same closure pattern used in MainWindowView,
+    /// Constructs an IdentityPanel with the same closure pattern used in IntelligencePanel,
     /// then invokes the panel's onCustomizeAvatar callback and verifies it transitions state.
     func testIdentityPanelOnCustomizeAvatarTransitionsState() {
         let state = MainWindowState(hasAPIKey: false)
-        state.selection = .panel(.identity)
+        state.selection = .panel(.intelligence)
         let daemonClient = DaemonClient()
 
         let panel = IdentityPanel(
@@ -31,7 +31,7 @@ final class MainWindowAvatarRoutingTests: XCTestCase {
     /// Constructs an IdentityPanel and verifies the onClose callback clears selection.
     func testIdentityPanelOnCloseCallback() {
         let state = MainWindowState(hasAPIKey: false)
-        state.selection = .panel(.identity)
+        state.selection = .panel(.intelligence)
         let daemonClient = DaemonClient()
 
         let panel = IdentityPanel(
@@ -72,10 +72,10 @@ final class MainWindowAvatarRoutingTests: XCTestCase {
 
     // MARK: - State Transition Tests
 
-    func testAvatarCustomizationIsDistinctFromIdentity() {
-        let identity: ViewSelection = .panel(.identity)
+    func testAvatarCustomizationIsDistinctFromIntelligence() {
+        let intelligence: ViewSelection = .panel(.intelligence)
         let avatar: ViewSelection = .panel(.avatarCustomization)
-        XCTAssertNotEqual(identity, avatar)
+        XCTAssertNotEqual(intelligence, avatar)
     }
 
     func testAvatarCustomizationPanelTypeExists() {


### PR DESCRIPTION
Remove standalone Identity and Skills (Agent) sidebar nav items, SidePanelType cases, and PanelCoordinator cases. All content now lives under the Intelligence panel. Update avatar customization return path to default to .intelligence. Part of #8968.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
