### PR TITLE
feat: add vellum memory dismiss-conflicts CLI command

### DIFF
--- a/assistant/src/cli/config-commands.ts
+++ b/assistant/src/cli/config-commands.ts
@@ -8,12 +8,14 @@ import {
   setNestedValue,
 } from '../config/loader.js';
 import {
+  dismissPendingConflicts,
   getMemorySystemStatus,
   queryMemory,
   requestMemoryBackfill,
   requestMemoryCleanup,
   requestMemoryRebuildIndex,
 } from '../memory/admin.js';
+import { listPendingConflictDetails } from '../memory/conflict-store.js';
 import { listConversations } from '../memory/conversation-store.js';
 import { initializeDb } from '../memory/db.js';
 import {
@@ -330,5 +332,49 @@ export function registerMemoryCommand(program: Command): void {
       initializeDb();
       const jobId = requestMemoryRebuildIndex();
       log.info(`Queued rebuild-index job: ${jobId}`);
+    });
+
+  memory
+    .command('dismiss-conflicts')
+    .description('Dismiss pending memory conflicts (all or matching a pattern)')
+    .option('-a, --all', 'Dismiss all pending conflicts')
+    .option('-p, --pattern <regex>', 'Dismiss conflicts where either statement matches this regex')
+    .option('-s, --scope <id>', 'Memory scope (default: "default")')
+    .option('--dry-run', 'Show what would be dismissed without making changes')
+    .action((opts: { all?: boolean; pattern?: string; scope?: string; dryRun?: boolean }) => {
+      if (!opts.all && !opts.pattern) {
+        log.info('Usage: vellum memory dismiss-conflicts --all  OR  --pattern <regex>');
+        log.info('Use --dry-run to preview without making changes.');
+        return;
+      }
+
+      initializeDb();
+
+      const pattern = opts.pattern ? new RegExp(opts.pattern, 'i') : undefined;
+
+      if (opts.dryRun) {
+        const scopeId = opts.scope ?? 'default';
+        const pending = listPendingConflictDetails(scopeId, 1000);
+        let matchCount = 0;
+        for (const conflict of pending) {
+          const matches = opts.all
+            || (pattern && (pattern.test(conflict.existingStatement) || pattern.test(conflict.candidateStatement)));
+          if (!matches) continue;
+          matchCount++;
+          log.info(`  [${conflict.id.slice(0, SHORT_HASH_LENGTH)}] "${conflict.existingStatement}" vs "${conflict.candidateStatement}"`);
+        }
+        log.info(`\nDry run: ${matchCount} of ${pending.length} pending conflicts would be dismissed.`);
+        return;
+      }
+
+      const result = dismissPendingConflicts({
+        all: opts.all,
+        pattern,
+        scopeId: opts.scope,
+      });
+      for (const detail of result.details) {
+        log.info(`  Dismissed [${detail.id.slice(0, SHORT_HASH_LENGTH)}]: "${detail.existingStatement}" vs "${detail.candidateStatement}"`);
+      }
+      log.info(`\nDismissed ${result.dismissed} conflicts. ${result.remaining} pending conflicts remain.`);
     });
 }

--- a/assistant/src/memory/admin.ts
+++ b/assistant/src/memory/admin.ts
@@ -1,5 +1,6 @@
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
+import { listPendingConflictDetails, resolveConflict } from './conflict-store.js';
 import { rawGet } from './db.js';
 import { getMemoryBackendStatus } from './embedding-backend.js';
 import { enqueueBackfillJob, enqueueRebuildIndexJob } from './indexer.js';
@@ -198,4 +199,51 @@ export async function queryMemory(
   conversationId: string,
 ) {
   return queryMemoryForCli(query, conversationId, getConfig());
+}
+
+export interface DismissConflictsResult {
+  dismissed: number;
+  remaining: number;
+  details: Array<{ id: string; existingStatement: string; candidateStatement: string }>;
+}
+
+/**
+ * Dismiss pending memory conflicts. With `all: true`, dismisses every
+ * pending conflict. Otherwise, dismisses only conflicts matching the
+ * given `pattern` regex against either statement.
+ */
+export function dismissPendingConflicts(
+  options: { all?: boolean; pattern?: RegExp; scopeId?: string },
+): DismissConflictsResult {
+  const scopeId = options.scopeId ?? 'default';
+  const pending = listPendingConflictDetails(scopeId, 1000);
+  const dismissed: DismissConflictsResult['details'] = [];
+
+  for (const conflict of pending) {
+    const matches = options.all
+      || (options.pattern && (
+        options.pattern.test(conflict.existingStatement)
+        || options.pattern.test(conflict.candidateStatement)
+      ));
+    if (!matches) continue;
+
+    resolveConflict(conflict.id, {
+      status: 'dismissed',
+      resolutionNote: options.all
+        ? 'Bulk dismissed via CLI (dismiss-conflicts --all).'
+        : `Dismissed via CLI (pattern: ${options.pattern?.source}).`,
+    });
+    dismissed.push({
+      id: conflict.id,
+      existingStatement: conflict.existingStatement,
+      candidateStatement: conflict.candidateStatement,
+    });
+  }
+
+  log.info({ dismissed: dismissed.length, remaining: pending.length - dismissed.length, scopeId }, 'Dismissed pending conflicts');
+  return {
+    dismissed: dismissed.length,
+    remaining: pending.length - dismissed.length,
+    details: dismissed,
+  };
 }


### PR DESCRIPTION
## Summary
- Adds `vellum memory dismiss-conflicts` CLI command with `--all`, `--pattern <regex>`, `--scope`, and `--dry-run` options
- Adds `dismissPendingConflicts()` function to `memory/admin.ts` that bulk-dismisses pending conflicts matching criteria
- Companion to PR #8981 — that PR prevents new poisoned conflicts from forming, this command lets users clean up existing ones

## Original prompt
#2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
