### PR TITLE
M2: Shared OAuth Connect Orchestrator + Scope Policy Engine

### DIFF
--- a/assistant/src/__tests__/oauth-scope-policy.test.ts
+++ b/assistant/src/__tests__/oauth-scope-policy.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { OAuthProviderProfile } from '../oauth/connect-types.js';
+import { resolveScopes } from '../oauth/scope-policy.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal profile for testing scope resolution. */
+function makeProfile(overrides: Partial<OAuthProviderProfile> = {}): OAuthProviderProfile {
+  return {
+    service: 'integration:test-service',
+    authUrl: 'https://auth.example.com/authorize',
+    tokenUrl: 'https://auth.example.com/token',
+    defaultScopes: ['read', 'write'],
+    scopePolicy: {
+      allowAdditionalScopes: false,
+      allowedOptionalScopes: [],
+      forbiddenScopes: [],
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('resolveScopes', () => {
+  it('returns default scopes when no requestedScopes are provided', () => {
+    const profile = makeProfile({ defaultScopes: ['read', 'write'] });
+    const result = resolveScopes(profile);
+    expect(result).toEqual({ ok: true, scopes: ['read', 'write'] });
+  });
+
+  it('returns default scopes when requestedScopes is undefined', () => {
+    const profile = makeProfile({ defaultScopes: ['read', 'write'] });
+    const result = resolveScopes(profile, undefined);
+    expect(result).toEqual({ ok: true, scopes: ['read', 'write'] });
+  });
+
+  it('returns default scopes when requestedScopes is an empty array', () => {
+    const profile = makeProfile({ defaultScopes: ['read', 'write'] });
+    const result = resolveScopes(profile, []);
+    expect(result).toEqual({ ok: true, scopes: ['read', 'write'] });
+  });
+
+  it('rejects a forbidden scope with a clear error message', () => {
+    const profile = makeProfile({
+      scopePolicy: {
+        allowAdditionalScopes: true,
+        allowedOptionalScopes: ['admin'],
+        forbiddenScopes: ['delete'],
+      },
+    });
+    const result = resolveScopes(profile, ['delete']);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("Scope 'delete' is forbidden for integration:test-service");
+    }
+  });
+
+  it('rejects additional scopes when allowAdditionalScopes is false', () => {
+    const profile = makeProfile({
+      defaultScopes: ['read', 'write'],
+      scopePolicy: {
+        allowAdditionalScopes: false,
+        allowedOptionalScopes: [],
+        forbiddenScopes: [],
+      },
+    });
+    const result = resolveScopes(profile, ['admin']);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('Additional scopes are not allowed for integration:test-service');
+      expect(result.allowedScopes).toEqual(['read', 'write']);
+    }
+  });
+
+  it('rejects a scope not in allowedOptionalScopes even when allowAdditionalScopes is true', () => {
+    const profile = makeProfile({
+      defaultScopes: ['read'],
+      scopePolicy: {
+        allowAdditionalScopes: true,
+        allowedOptionalScopes: ['write'],
+        forbiddenScopes: [],
+      },
+    });
+    const result = resolveScopes(profile, ['admin']);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("Scope 'admin' is not in the allowed optional scopes for integration:test-service");
+      expect(result.allowedScopes).toEqual(['read', 'write']);
+    }
+  });
+
+  it('accepts an additional scope when it is in allowedOptionalScopes and allowAdditionalScopes is true', () => {
+    const profile = makeProfile({
+      defaultScopes: ['read'],
+      scopePolicy: {
+        allowAdditionalScopes: true,
+        allowedOptionalScopes: ['write', 'admin'],
+        forbiddenScopes: [],
+      },
+    });
+    const result = resolveScopes(profile, ['write']);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.scopes).toEqual(['read', 'write']);
+    }
+  });
+
+  it('deduplicates scopes in the result', () => {
+    const profile = makeProfile({
+      defaultScopes: ['read', 'write'],
+      scopePolicy: {
+        allowAdditionalScopes: true,
+        allowedOptionalScopes: ['admin'],
+        forbiddenScopes: [],
+      },
+    });
+    // Request duplicates of existing defaults and a new scope twice
+    const result = resolveScopes(profile, ['read', 'write', 'admin', 'admin']);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.scopes).toEqual(['read', 'write', 'admin']);
+    }
+  });
+
+  it('keeps requested scopes that are already in defaults without error', () => {
+    const profile = makeProfile({
+      defaultScopes: ['read', 'write'],
+      scopePolicy: {
+        allowAdditionalScopes: false,
+        allowedOptionalScopes: [],
+        forbiddenScopes: [],
+      },
+    });
+    // Requesting only default scopes should succeed even when
+    // allowAdditionalScopes is false
+    const result = resolveScopes(profile, ['read', 'write']);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.scopes).toEqual(['read', 'write']);
+    }
+  });
+
+  it('checks forbidden scopes before allowAdditionalScopes policy', () => {
+    const profile = makeProfile({
+      defaultScopes: ['read'],
+      scopePolicy: {
+        allowAdditionalScopes: true,
+        allowedOptionalScopes: [],
+        forbiddenScopes: ['destroy'],
+      },
+    });
+    const result = resolveScopes(profile, ['destroy']);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // Should be the forbidden error, not the "not in optional scopes" error
+      expect(result.error).toContain('forbidden');
+    }
+  });
+
+  it('returns a defensive copy of defaultScopes (not the same array reference)', () => {
+    const defaults = ['read', 'write'];
+    const profile = makeProfile({ defaultScopes: defaults });
+    const result = resolveScopes(profile);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.scopes).toEqual(defaults);
+      expect(result.scopes).not.toBe(defaults);
+    }
+  });
+});

--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -1,0 +1,255 @@
+/**
+ * Shared OAuth connect orchestrator.
+ *
+ * Encapsulates the full OAuth2 authorization code flow (interactive and
+ * deferred paths) so that both the credential vault tool and future
+ * callers can connect OAuth services without duplicating orchestration
+ * logic.
+ *
+ * The caller is responsible for:
+ * - Resolving client_id / client_secret (from user input or the vault)
+ * - Early validation (missing service, missing client_id, requiresSecret)
+ * - Ensuring metadata is writable (assertMetadataWritable)
+ *
+ * The orchestrator handles:
+ * - Provider profile resolution
+ * - Scope policy enforcement
+ * - Building the OAuth2Config
+ * - Running the interactive or deferred flow
+ * - Storing tokens on completion
+ * - Running identity verifiers
+ */
+
+import type { TokenEndpointAuthMethod } from '../security/oauth2.js';
+import { prepareOAuth2Flow, startOAuth2Flow } from '../security/oauth2.js';
+import { getLogger } from '../util/logger.js';
+import type { OAuthConnectResult, OAuthProviderProfile } from './connect-types.js';
+import { getProviderProfile, resolveService } from './provider-profiles.js';
+import { resolveScopes } from './scope-policy.js';
+import { storeOAuth2Tokens } from './token-persistence.js';
+
+const log = getLogger('oauth-connect-orchestrator');
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface OAuthConnectOptions {
+  /** Raw service name (may be an alias like "gmail"). */
+  service: string;
+  /** Scopes to request beyond the provider's defaults. */
+  requestedScopes?: string[];
+  /** OAuth2 client ID (required). */
+  clientId: string;
+  /** OAuth2 client secret (optional — PKCE-only when absent). */
+  clientSecret?: string;
+  /** Whether the session can open a browser and block for completion. */
+  isInteractive: boolean;
+  /** Open a URL in the user's browser (interactive path). */
+  openUrl?: (url: string) => void;
+  /** Send a message to the client (e.g. open_url IPC). */
+  sendToClient?: (msg: { type: string; [key: string]: unknown }) => void;
+  /** Tools allowed to use the resulting credential. */
+  allowedTools?: string[];
+
+  // Optional overrides — when provided, these take precedence over the
+  // provider profile. This lets callers connect custom / unknown providers.
+  authUrl?: string;
+  tokenUrl?: string;
+  scopes?: string[];
+  extraParams?: Record<string, string>;
+  userinfoUrl?: string;
+  tokenEndpointAuthMethod?: TokenEndpointAuthMethod;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Orchestrate an OAuth2 connect flow end to end.
+ *
+ * Returns a discriminated result:
+ * - Interactive success: `{ success: true, deferred: false, grantedScopes, accountInfo }`
+ * - Deferred success:    `{ success: true, deferred: true, authUrl, state, service }`
+ * - Error:               `{ success: false, error }`
+ */
+export async function orchestrateOAuthConnect(options: OAuthConnectOptions): Promise<OAuthConnectResult> {
+  const resolvedService = resolveService(options.service);
+  const profile = getProviderProfile(resolvedService);
+
+  // Merge explicit overrides with profile defaults
+  const authUrl = options.authUrl ?? profile?.authUrl;
+  const tokenUrl = options.tokenUrl ?? profile?.tokenUrl;
+  const extraParams = options.extraParams ?? profile?.extraParams;
+  const userinfoUrl = options.userinfoUrl ?? profile?.userinfoUrl;
+  const tokenEndpointAuthMethod = options.tokenEndpointAuthMethod ?? profile?.tokenEndpointAuthMethod;
+
+  // Scopes: use explicit override, then try scope policy resolution, then profile defaults
+  let finalScopes: string[];
+  if (options.scopes) {
+    // Explicit scopes override — bypass policy (caller takes responsibility)
+    finalScopes = options.scopes;
+  } else if (profile) {
+    const scopeResult = resolveScopes(profile, options.requestedScopes);
+    if (!scopeResult.ok) {
+      const guidance = scopeResult.allowedScopes
+        ? ` Allowed scopes: ${scopeResult.allowedScopes.join(', ')}`
+        : '';
+      return { success: false, error: `${scopeResult.error}${guidance}` };
+    }
+    finalScopes = scopeResult.scopes;
+  } else {
+    // No profile and no explicit scopes — cannot proceed
+    return { success: false, error: `No well-known OAuth config found for "${options.service}" and no scopes were provided` };
+  }
+
+  if (!authUrl) {
+    return { success: false, error: 'auth_url is required (no well-known config for this service)' };
+  }
+  if (!tokenUrl) {
+    return { success: false, error: 'token_url is required (no well-known config for this service)' };
+  }
+
+  const oauthConfig = {
+    authUrl,
+    tokenUrl,
+    scopes: finalScopes,
+    clientId: options.clientId,
+    clientSecret: options.clientSecret,
+    extraParams,
+    userinfoUrl,
+    tokenEndpointAuthMethod,
+  };
+
+  const storageParams = {
+    service: resolvedService,
+    clientId: options.clientId,
+    clientSecret: options.clientSecret,
+    tokenUrl,
+    tokenEndpointAuthMethod,
+    userinfoUrl,
+    allowedTools: options.allowedTools,
+    wellKnownInjectionTemplates: profile?.injectionTemplates,
+  };
+
+  // -----------------------------------------------------------------------
+  // Deferred (non-interactive) path
+  // -----------------------------------------------------------------------
+  if (!options.isInteractive) {
+    try {
+      const callbackTransport = profile?.callbackTransport ?? 'gateway';
+
+      // Gateway transport needs a public ingress URL
+      if (callbackTransport !== 'loopback') {
+        const { loadConfig } = await import('../config/loader.js');
+        const { getPublicBaseUrl } = await import('../inbound/public-ingress-urls.js');
+        try {
+          getPublicBaseUrl(loadConfig());
+        } catch {
+          return {
+            success: false,
+            error: 'oauth2_connect from a non-interactive session requires a public ingress URL. Configure ingress.publicBaseUrl first.',
+          };
+        }
+      }
+
+      const prepared = await prepareOAuth2Flow(
+        oauthConfig,
+        callbackTransport === 'loopback'
+          ? { callbackTransport, loopbackPort: profile?.loopbackPort }
+          : undefined,
+      );
+
+      // Fire-and-forget: store tokens when the callback arrives
+      prepared.completion.then(async (result) => {
+        try {
+          let accountInfo: string | undefined;
+
+          // Run identity verifier if available
+          if (profile?.identityVerifier) {
+            try {
+              accountInfo = await profile.identityVerifier(result.tokens.accessToken);
+            } catch {
+              // Non-fatal
+            }
+          }
+
+          const stored = await storeOAuth2Tokens({
+            ...storageParams,
+            tokens: result.tokens,
+            grantedScopes: result.grantedScopes,
+            rawTokenResponse: result.rawTokenResponse,
+          });
+          log.info(
+            { service: resolvedService, accountInfo: stored.accountInfo ?? accountInfo },
+            'Deferred OAuth2 flow completed — tokens stored',
+          );
+        } catch (err) {
+          log.error({ err, service: resolvedService }, 'Failed to store tokens from deferred OAuth2 flow');
+        }
+      }).catch((err) => {
+        log.error({ err, service: resolvedService }, 'Deferred OAuth2 flow failed');
+      });
+
+      return {
+        success: true,
+        deferred: true,
+        authUrl: prepared.authUrl,
+        state: prepared.state,
+        service: resolvedService,
+      };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Unknown error preparing OAuth flow';
+      return { success: false, error: `Error connecting "${resolvedService}": ${message}` };
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Interactive path — open browser, block until completion
+  // -----------------------------------------------------------------------
+  try {
+    const { tokens, grantedScopes, rawTokenResponse } = await startOAuth2Flow(
+      oauthConfig,
+      {
+        openUrl: (url) => {
+          if (options.openUrl) {
+            options.openUrl(url);
+          } else if (options.sendToClient) {
+            options.sendToClient({ type: 'open_url', url, title: `Connect ${resolvedService}` });
+          }
+        },
+      },
+      profile?.callbackTransport
+        ? { callbackTransport: profile.callbackTransport, loopbackPort: profile.loopbackPort }
+        : undefined,
+    );
+
+    // Run identity verifier if available
+    let verifiedIdentity: string | undefined;
+    if (profile?.identityVerifier) {
+      try {
+        verifiedIdentity = await profile.identityVerifier(tokens.accessToken);
+      } catch {
+        // Non-fatal
+      }
+    }
+
+    const { accountInfo } = await storeOAuth2Tokens({
+      ...storageParams,
+      tokens,
+      grantedScopes,
+      rawTokenResponse,
+    });
+
+    return {
+      success: true,
+      deferred: false,
+      grantedScopes,
+      accountInfo: accountInfo ?? verifiedIdentity,
+    };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error during OAuth flow';
+    return { success: false, error: `Error connecting "${resolvedService}": ${message}` };
+  }
+}

--- a/assistant/src/oauth/connect-types.ts
+++ b/assistant/src/oauth/connect-types.ts
@@ -88,5 +88,29 @@ export interface OAuthProviderProfile {
 
 /** Outcome of an OAuth connect attempt. */
 export type OAuthConnectResult =
-  | { success: true; grantedScopes: string[]; accountInfo?: string }
-  | { success: false; error: string };
+  | OAuthConnectInteractiveResult
+  | OAuthConnectDeferredResult
+  | OAuthConnectErrorResult;
+
+/** Successful interactive flow — tokens stored, ready to use. */
+export interface OAuthConnectInteractiveResult {
+  success: true;
+  deferred: false;
+  grantedScopes: string[];
+  accountInfo?: string;
+}
+
+/** Successful deferred flow — auth URL returned for the user to open. */
+export interface OAuthConnectDeferredResult {
+  success: true;
+  deferred: true;
+  authUrl: string;
+  state: string;
+  service: string;
+}
+
+/** Failed connect attempt. */
+export interface OAuthConnectErrorResult {
+  success: false;
+  error: string;
+}

--- a/assistant/src/oauth/scope-policy.ts
+++ b/assistant/src/oauth/scope-policy.ts
@@ -1,0 +1,79 @@
+/**
+ * Scope resolution and policy enforcement for OAuth providers.
+ *
+ * Pure module (no side effects, no I/O) that resolves the final set of
+ * scopes for an OAuth flow based on the provider profile's scope policy.
+ */
+
+import type { OAuthProviderProfile } from './connect-types.js';
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+export type ScopeResolutionResult =
+  | { ok: true; scopes: string[] }
+  | { ok: false; error: string; allowedScopes?: string[] };
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the final set of scopes for an OAuth flow.
+ *
+ * - If `requestedScopes` is undefined or empty, returns the provider's
+ *   `defaultScopes`.
+ * - Otherwise, starts with `defaultScopes` and validates each additional
+ *   requested scope against the provider's `scopePolicy`.
+ * - Returns a deduplicated union of default + approved requested scopes.
+ */
+export function resolveScopes(
+  profile: OAuthProviderProfile,
+  requestedScopes?: string[],
+): ScopeResolutionResult {
+  const { defaultScopes, scopePolicy, service } = profile;
+
+  // No requested scopes — use defaults
+  if (!requestedScopes || requestedScopes.length === 0) {
+    return { ok: true, scopes: [...defaultScopes] };
+  }
+
+  const defaultSet = new Set(defaultScopes);
+  const finalScopes = new Set(defaultScopes);
+
+  for (const scope of requestedScopes) {
+    // Already in defaults — no policy check needed
+    if (defaultSet.has(scope)) {
+      continue;
+    }
+
+    // Check forbidden list first
+    if (scopePolicy.forbiddenScopes.includes(scope)) {
+      return { ok: false, error: `Scope '${scope}' is forbidden for ${service}` };
+    }
+
+    // Additional scopes not allowed at all
+    if (!scopePolicy.allowAdditionalScopes) {
+      return {
+        ok: false,
+        error: `Additional scopes are not allowed for ${service}. Only the default scopes may be used.`,
+        allowedScopes: [...defaultScopes],
+      };
+    }
+
+    // Additional scopes allowed, but this one isn't in the optional list
+    if (!scopePolicy.allowedOptionalScopes.includes(scope)) {
+      return {
+        ok: false,
+        error: `Scope '${scope}' is not in the allowed optional scopes for ${service}`,
+        allowedScopes: [...defaultScopes, ...scopePolicy.allowedOptionalScopes],
+      };
+    }
+
+    // Passed all checks — include it
+    finalScopes.add(scope);
+  }
+
+  return { ok: true, scopes: [...finalScopes] };
+}

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -486,15 +486,22 @@ class CredentialStoreTool implements Tool {
           ?? findStoredOAuthField(service, ['client_secret', 'oauth_client_secret']);
 
         // Early guardrails that stay in vault.ts (credential resolution is vault-specific)
-        const scopes = (input.scopes as string[] | undefined) ?? profile?.defaultScopes;
+        const inputScopes = input.scopes as string[] | undefined;
+
+        if (profile) {
+          // Profile-based provider (well-known like gmail, slack, twitter):
+          // Don't pass authUrl/tokenUrl — the orchestrator resolves those from the profile.
+          // Pass user-provided scopes as requestedScopes so the scope policy engine is invoked.
+          // If no scopes provided, pass neither — let the orchestrator use profile defaults via scope policy.
+        } else {
+          // Custom/unknown provider: require authUrl, tokenUrl, scopes from input
+          if (!input.auth_url) return { content: 'Error: auth_url is required for oauth2_connect action (no well-known config for this service)', isError: true };
+          if (!input.token_url) return { content: 'Error: token_url is required for oauth2_connect action (no well-known config for this service)', isError: true };
+          if (!inputScopes) return { content: 'Error: scopes is required for oauth2_connect action (no well-known config for this service)', isError: true };
+        }
+
         const authUrl = (input.auth_url as string | undefined) ?? profile?.authUrl;
         const tokenUrl = (input.token_url as string | undefined) ?? profile?.tokenUrl;
-        if (!authUrl) return { content: 'Error: auth_url is required for oauth2_connect action (no well-known config for this service)', isError: true };
-        if (!tokenUrl) return { content: 'Error: token_url is required for oauth2_connect action (no well-known config for this service)', isError: true };
-        // Scopes are optional — some providers (e.g. Notion) configure authorization at the integration
-        // level and don't use traditional scope strings. Reject only when scopes is entirely absent (not
-        // provided and no well-known config), not when it is an empty array.
-        if (!scopes) return { content: 'Error: scopes is required for oauth2_connect action (no well-known config for this service)', isError: true };
         if (!clientId) return { content: 'Error: client_id is required for oauth2_connect action. Provide it directly or store it first with credential_store.', isError: true };
 
         // Fail early when client_secret is required but missing — guide the
@@ -522,7 +529,10 @@ class CredentialStoreTool implements Tool {
         const tokenEndpointAuthMethod = (input.token_endpoint_auth_method as TokenEndpointAuthMethod | undefined)
           ?? profile?.tokenEndpointAuthMethod;
 
-        // Delegate to the shared orchestrator
+        // Delegate to the shared orchestrator.
+        // For profile-based providers, pass user scopes as requestedScopes so the
+        // scope policy engine (resolveScopes) is invoked. For custom providers,
+        // pass scopes directly as an explicit override.
         const result = await orchestrateOAuthConnect({
           service: rawService,
           clientId,
@@ -532,7 +542,16 @@ class CredentialStoreTool implements Tool {
           allowedTools: input.allowed_tools as string[] | undefined,
           authUrl,
           tokenUrl,
-          scopes,
+          ...(profile
+            ? {
+                // Profile-based: let orchestrator resolve scopes via policy engine.
+                // Only pass requestedScopes if the user explicitly provided scopes.
+                ...(inputScopes ? { requestedScopes: inputScopes } : {}),
+              }
+            : {
+                // Custom provider: explicit scopes override (bypasses policy engine)
+                scopes: inputScopes,
+              }),
           extraParams: (input.extra_params as Record<string, string> | undefined) ?? profile?.extraParams,
           userinfoUrl: (input.userinfo_url as string | undefined) ?? profile?.userinfoUrl,
           tokenEndpointAuthMethod,

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -1,9 +1,9 @@
 import { getConfig } from '../../config/loader.js';
+import { orchestrateOAuthConnect } from '../../oauth/connect-orchestrator.js';
 import { getProviderProfile, resolveService, SERVICE_ALIASES } from '../../oauth/provider-profiles.js';
-import { storeOAuth2Tokens } from '../../oauth/token-persistence.js';
 import { RiskLevel } from '../../permissions/types.js';
 import type { ToolDefinition } from '../../providers/types.js';
-import { prepareOAuth2Flow, startOAuth2Flow, type TokenEndpointAuthMethod } from '../../security/oauth2.js';
+import type { TokenEndpointAuthMethod } from '../../security/oauth2.js';
 import {
   deleteSecureKey,
   getBackendType,
@@ -478,20 +478,17 @@ class CredentialStoreTool implements Tool {
 
         // Fill missing params from provider profile
         const profile = getProviderProfile(service);
-        const authUrl = (input.auth_url as string | undefined) ?? profile?.authUrl;
-        const tokenUrl = (input.token_url as string | undefined) ?? profile?.tokenUrl;
-        const scopes = (input.scopes as string[] | undefined) ?? profile?.defaultScopes;
-        const extraParams = (input.extra_params as Record<string, string> | undefined) ?? profile?.extraParams;
-        const userinfoUrl = (input.userinfo_url as string | undefined) ?? profile?.userinfoUrl;
 
         // Look up client_id/client_secret from stored credentials if not provided
         const clientId = (input.client_id as string | undefined)
           ?? findStoredOAuthField(service, ['client_id', 'oauth_client_id']);
         const clientSecret = (input.client_secret as string | undefined)
           ?? findStoredOAuthField(service, ['client_secret', 'oauth_client_secret']);
-        const tokenEndpointAuthMethod = (input.token_endpoint_auth_method as TokenEndpointAuthMethod | undefined)
-          ?? profile?.tokenEndpointAuthMethod;
 
+        // Early guardrails that stay in vault.ts (credential resolution is vault-specific)
+        const scopes = (input.scopes as string[] | undefined) ?? profile?.defaultScopes;
+        const authUrl = (input.auth_url as string | undefined) ?? profile?.authUrl;
+        const tokenUrl = (input.token_url as string | undefined) ?? profile?.tokenUrl;
         if (!authUrl) return { content: 'Error: auth_url is required for oauth2_connect action (no well-known config for this service)', isError: true };
         if (!tokenUrl) return { content: 'Error: token_url is required for oauth2_connect action (no well-known config for this service)', isError: true };
         // Scopes are optional — some providers (e.g. Notion) configure authorization at the integration
@@ -522,96 +519,40 @@ class CredentialStoreTool implements Tool {
           return { content: 'Error: credential metadata file has an unrecognized version; cannot store credentials', isError: true };
         }
 
-        const allowedTools = input.allowed_tools as string[] | undefined;
-        const wellKnownInjectionTemplates = profile?.injectionTemplates;
-        const oauthConfig = { authUrl, tokenUrl, scopes, clientId, clientSecret, extraParams, userinfoUrl, tokenEndpointAuthMethod };
-        const storageParams = {
-          service, clientId, clientSecret, tokenUrl, tokenEndpointAuthMethod,
-          userinfoUrl, allowedTools, wellKnownInjectionTemplates,
-        };
+        const tokenEndpointAuthMethod = (input.token_endpoint_auth_method as TokenEndpointAuthMethod | undefined)
+          ?? profile?.tokenEndpointAuthMethod;
 
-        if (!context.isInteractive) {
-          // Channel path: return the auth URL as text for the user to open manually.
-          // Token storage happens asynchronously when the callback arrives.
-          try {
-            const callbackTransport = profile?.callbackTransport ?? 'gateway';
+        // Delegate to the shared orchestrator
+        const result = await orchestrateOAuthConnect({
+          service: rawService,
+          clientId,
+          clientSecret,
+          isInteractive: !!context.isInteractive,
+          sendToClient: context.sendToClient,
+          allowedTools: input.allowed_tools as string[] | undefined,
+          authUrl,
+          tokenUrl,
+          scopes,
+          extraParams: (input.extra_params as Record<string, string> | undefined) ?? profile?.extraParams,
+          userinfoUrl: (input.userinfo_url as string | undefined) ?? profile?.userinfoUrl,
+          tokenEndpointAuthMethod,
+        });
 
-            // Gateway transport needs a public ingress URL; loopback runs locally
-            // on the daemon so it works regardless of ingress configuration.
-            if (callbackTransport !== 'loopback') {
-              const { loadConfig } = await import('../../config/loader.js');
-              const { getPublicBaseUrl } = await import('../../inbound/public-ingress-urls.js');
-              try {
-                getPublicBaseUrl(loadConfig());
-              } catch {
-                return {
-                  content: 'Error: oauth2_connect from a non-interactive session requires a public ingress URL. Configure ingress.publicBaseUrl first.',
-                  isError: true,
-                };
-              }
-            }
-
-            const prepared = await prepareOAuth2Flow(
-              oauthConfig,
-              callbackTransport === 'loopback'
-                ? { callbackTransport, loopbackPort: profile?.loopbackPort }
-                : undefined,
-            );
-
-            // Fire-and-forget: when the callback arrives, store tokens in the background
-            prepared.completion.then(async (result) => {
-              try {
-                const { accountInfo } = await storeOAuth2Tokens({
-                  ...storageParams,
-                  tokens: result.tokens,
-                  grantedScopes: result.grantedScopes,
-                  rawTokenResponse: result.rawTokenResponse,
-                });
-                log.info({ service, accountInfo }, 'Deferred OAuth2 flow completed — tokens stored');
-              } catch (err) {
-                log.error({ err, service }, 'Failed to store tokens from deferred OAuth2 flow');
-              }
-            }).catch((err) => {
-              log.error({ err, service }, 'Deferred OAuth2 flow failed');
-            });
-
-            return {
-              content: `To connect ${rawService}, open this link and authorize access:\n\n${prepared.authUrl}\n\nOnce you authorize, the connection will be set up automatically. You can verify by asking me to check your inbox.`,
-              isError: false,
-            };
-          } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : 'Unknown error preparing OAuth flow';
-            return { content: `Error connecting "${service}": ${message}`, isError: true };
-          }
+        if (!result.success) {
+          return { content: `Error: ${result.error}`, isError: true };
         }
 
-        // Interactive path (desktop): open browser and wait for completion
-        try {
-          const { tokens, grantedScopes, rawTokenResponse } = await startOAuth2Flow(
-            oauthConfig,
-            {
-              openUrl: (url) => {
-                context.sendToClient?.({ type: 'open_url', url, title: `Connect ${service}` });
-              },
-            },
-            profile?.callbackTransport ? { callbackTransport: profile.callbackTransport, loopbackPort: profile.loopbackPort } : undefined,
-          );
-
-          const { accountInfo } = await storeOAuth2Tokens({
-            ...storageParams,
-            tokens,
-            grantedScopes,
-            rawTokenResponse,
-          });
-
+        if (result.deferred) {
           return {
-            content: `Successfully connected "${service}"${accountInfo ? ` as ${accountInfo}` : ''}. The service is now ready to use.`,
+            content: `To connect ${rawService}, open this link and authorize access:\n\n${result.authUrl}\n\nOnce you authorize, the connection will be set up automatically. You can verify by asking me to check your inbox.`,
             isError: false,
           };
-        } catch (err: unknown) {
-          const message = err instanceof Error ? err.message : 'Unknown error during OAuth flow';
-          return { content: `Error connecting "${service}": ${message}`, isError: true };
         }
+
+        return {
+          content: `Successfully connected "${service}"${result.accountInfo ? ` as ${result.accountInfo}` : ''}. The service is now ready to use.`,
+          isError: false,
+        };
       }
 
       case 'describe': {


### PR DESCRIPTION
Part of #8959. Adds scope-policy.ts for deterministic scope resolution and policy enforcement, connect-orchestrator.ts for shared OAuth flow orchestration, and routes vault.ts oauth2_connect through the orchestrator. Includes unit tests for scope policy. Closes #8961.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
