### PR TITLE
feat: add notification toggle to quick input bar

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1293,11 +1293,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let window = QuickInputWindow()
-        window.onSubmit = { [weak self] message, imageData in
-            self?.handleQuickInputSubmit(message, imageData: imageData)
+        window.onSubmit = { [weak self, weak window] message, imageData in
+            let notify = window?.notifyOnComplete ?? false
+            self?.handleQuickInputSubmit(message, imageData: imageData, notifyOnComplete: notify)
         }
-        window.onSubmitToThread = { [weak self] message, imageData in
-            self?.handleQuickInputSubmitToThread(message, imageData: imageData)
+        window.onSubmitToThread = { [weak self, weak window] message, imageData in
+            let notify = window?.notifyOnComplete ?? false
+            self?.handleQuickInputSubmitToThread(message, imageData: imageData, notifyOnComplete: notify)
         }
         window.onSelectThread = { [weak self] threadId in
             self?.handleQuickInputSelectThread(threadId)
@@ -1340,11 +1342,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let self else { return }
 
             let window = QuickInputWindow()
-            window.onSubmit = { [weak self] message, imgData in
-                self?.handleQuickInputSubmit(message, imageData: imgData)
+            window.onSubmit = { [weak self, weak window] message, imgData in
+                let notify = window?.notifyOnComplete ?? false
+                self?.handleQuickInputSubmit(message, imageData: imgData, notifyOnComplete: notify)
             }
-            window.onSubmitToThread = { [weak self] message, imgData in
-                self?.handleQuickInputSubmitToThread(message, imageData: imgData)
+            window.onSubmitToThread = { [weak self, weak window] message, imgData in
+                let notify = window?.notifyOnComplete ?? false
+                self?.handleQuickInputSubmitToThread(message, imageData: imgData, notifyOnComplete: notify)
             }
             window.onSelectThread = { [weak self] threadId in
                 self?.handleQuickInputSelectThread(threadId)
@@ -1367,21 +1371,22 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         selectionWindow.show()
     }
 
-    private func handleQuickInputSubmit(_ message: String, imageData: Data?) {
-        showMainWindow()
+    private func handleQuickInputSubmit(_ message: String, imageData: Data?, notifyOnComplete: Bool) {
+        // Ensure mainWindow exists so we can get a ChatViewModel.
+        // Never show it — quick input is fire-and-forget.
+        ensureMainWindowExists()
         guard let mainWindow else { return }
         mainWindow.threadManager.createThread()
-        // Navigate the sidebar to the new thread's chat view so the user
-        // sees the conversation immediately (not Home Base or another panel).
         if let threadId = mainWindow.threadManager.activeThreadId {
             mainWindow.windowState.selection = .thread(threadId)
         }
         guard let viewModel = mainWindow.activeViewModel else { return }
 
+        if notifyOnComplete {
+            setupQuickInputNotification(on: viewModel)
+        }
+
         if let imageData {
-            // addAttachment is async — it spawns a Task internally for image
-            // processing. Wait for it to finish before sending the message so
-            // the attachment is included in the API call.
             viewModel.addAttachment(imageData: imageData, filename: "Screenshot.jpg")
             viewModel.inputText = message
             quickInputAttachmentCancellable = viewModel.attachmentManager.$isLoadingAttachment
@@ -1397,14 +1402,29 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    private func handleQuickInputSubmitToThread(_ message: String, imageData: Data?) {
+    private func handleQuickInputSubmitToThread(_ message: String, imageData: Data?, notifyOnComplete: Bool) {
         guard let mainWindow else { return }
         if let viewModel = mainWindow.activeViewModel {
+            if notifyOnComplete {
+                setupQuickInputNotification(on: viewModel)
+            }
             if let imageData {
                 viewModel.addAttachment(imageData: imageData, filename: "Screenshot.jpg")
             }
             viewModel.inputText = message
             viewModel.sendMessage()
+        }
+    }
+
+    /// Sets a one-shot `onResponseComplete` callback on the view model to send a macOS notification.
+    private func setupQuickInputNotification(on viewModel: ChatViewModel) {
+        let notificationService = services.activityNotificationService
+        viewModel.onResponseComplete = { [weak viewModel] summary in
+            // One-shot — clear the callback after firing
+            viewModel?.onResponseComplete = nil
+            Task {
+                await notificationService.notifyQuickInputComplete(summary: summary)
+            }
         }
     }
 
@@ -1703,27 +1723,33 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Main Window
 
+    /// Creates the MainWindow and wires callbacks, without showing it.
+    /// Safe to call multiple times — no-ops if mainWindow already exists.
+    @discardableResult
+    private func ensureMainWindowExists(isFirstLaunch: Bool = false) -> MainWindow {
+        if let existing = mainWindow { return existing }
+        let main = MainWindow(services: services, isFirstLaunch: isFirstLaunch)
+        main.onMicrophoneToggle = { [weak self] in
+            self?.voiceInput?.toggleRecording()
+        }
+        main.threadManager.onInlineConfirmationResponse = { [weak self] requestId, decision in
+            guard let self else { return }
+            self.toolConfirmationNotificationService.handleInlineResponse(requestId: requestId)
+            UNUserNotificationCenter.current().removeDeliveredNotifications(
+                withIdentifiers: ["tool-confirm-\(requestId)"]
+            )
+        }
+        mainWindow = main
+        observeAssistantStatus()
+        return main
+    }
+
     func showMainWindow(initialMessage: String? = nil, isFirstLaunch: Bool = false) {
         if let existing = mainWindow {
             existing.show()
             return
         }
-        let main = MainWindow(services: services, isFirstLaunch: isFirstLaunch)
-        main.onMicrophoneToggle = { [weak self] in
-            self?.voiceInput?.toggleRecording()
-        }
-        // Voice mode uses OpenAI Whisper + TTS directly (no VoiceInputManager needed)
-        main.threadManager.onInlineConfirmationResponse = { [weak self] requestId, decision in
-            guard let self else { return }
-            // Resume the notification service continuation with a sentinel so
-            // setupToolConfirmationNotifications skips the duplicate IPC send
-            // (the inline chat path already forwarded the response).
-            self.toolConfirmationNotificationService.handleInlineResponse(requestId: requestId)
-            // Remove the delivered notification from Notification Center
-            UNUserNotificationCenter.current().removeDeliveredNotifications(
-                withIdentifiers: ["tool-confirm-\(requestId)"]
-            )
-        }
+        let main = ensureMainWindowExists(isFirstLaunch: isFirstLaunch)
         // On first launch, defer the wake-up message until after the
         // "coming alive" transition so the animation plays uninterrupted.
         // For non-first-launch cases, send the message immediately so
@@ -1737,8 +1763,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
         main.show()
-        mainWindow = main
-        observeAssistantStatus()
     }
 
     private func observeAssistantStatus() {

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputView.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputView.swift
@@ -16,6 +16,7 @@ struct QuickInputView: View {
     let onRemoveAttachment: (() -> Void)?
     let onAllowScreenRecording: (() -> Void)?
     let onMicrophoneToggle: (() -> Void)?
+    let onNotificationToggle: (() -> Void)?
     let recentThreads: [QuickInputThread]
     let attachedImage: NSImage?
     let showScreenPermissionPrompt: Bool
@@ -34,6 +35,7 @@ struct QuickInputView: View {
         onRemoveAttachment: (() -> Void)? = nil,
         onAllowScreenRecording: (() -> Void)? = nil,
         onMicrophoneToggle: (() -> Void)? = nil,
+        onNotificationToggle: (() -> Void)? = nil,
         recentThreads: [QuickInputThread] = [],
         attachedImage: NSImage? = nil,
         showScreenPermissionPrompt: Bool = false
@@ -46,6 +48,7 @@ struct QuickInputView: View {
         self.onRemoveAttachment = onRemoveAttachment
         self.onAllowScreenRecording = onAllowScreenRecording
         self.onMicrophoneToggle = onMicrophoneToggle
+        self.onNotificationToggle = onNotificationToggle
         self.recentThreads = recentThreads
         self.attachedImage = attachedImage
         self.showScreenPermissionPrompt = showScreenPermissionPrompt
@@ -144,6 +147,16 @@ struct QuickInputView: View {
                 .menuStyle(.borderlessButton)
                 .menuIndicator(.hidden)
                 .fixedSize()
+
+                // Notification toggle
+                Button(action: { onNotificationToggle?() }) {
+                    Image(systemName: textModel.notifyOnComplete ? "bell.fill" : "bell.slash")
+                        .font(.system(size: 14, weight: .regular))
+                        .foregroundColor(textModel.notifyOnComplete ? VColor.textSecondary : VColor.textMuted)
+                        .frame(width: 32, height: 32)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(textModel.notifyOnComplete ? "Notifications on" : "Notifications off")
 
                 // Screenshot button
                 if attachedImage == nil {

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
@@ -18,6 +18,8 @@ final class QuickInputTextModel: ObservableObject {
     /// When set, the user has selected an existing thread to continue.
     @Published var selectedThreadId: UUID?
     @Published var selectedThreadTitle: String?
+    /// Whether to send a notification when the assistant response completes.
+    @Published var notifyOnComplete: Bool = UserDefaults.standard.object(forKey: "quickInputNotifyOnComplete") as? Bool ?? true
 }
 
 /// A borderless, floating NSPanel that hosts the Quick Input text field.
@@ -43,12 +45,17 @@ final class QuickInputWindow {
     var onSubmitToThread: ((String, Data?) -> Void)?
     /// Callback invoked when the user taps the microphone button.
     var onMicrophoneToggle: (() -> Void)?
+    /// Callback invoked when the user toggles the notification bell.
+    var onNotificationToggle: (() -> Void)?
     /// Callback invoked when the user selects an existing thread (navigates to it).
     var onSelectThread: ((UUID) -> Void)?
     /// Recent threads to show in the dropdown.
     var recentThreads: [QuickInputThread] = []
     /// When true, show a screen recording permission prompt below the bar.
     var showScreenPermissionPrompt = false
+
+    /// Whether to send a notification when the assistant response completes.
+    var notifyOnComplete: Bool { textModel.notifyOnComplete }
 
     /// Shared text model for voice input injection.
     private let textModel = QuickInputTextModel()
@@ -164,7 +171,7 @@ final class QuickInputWindow {
                 } else {
                     self?.onSubmit?(message, self?.attachedImageData)
                 }
-                self?.dismiss(restorePreviousApp: false)
+                self?.dismiss(restorePreviousApp: true)
             },
             onDismiss: { [weak self] in
                 self?.dismiss()
@@ -184,6 +191,11 @@ final class QuickInputWindow {
                 self?.dismiss()
             },
             onMicrophoneToggle: onMicrophoneToggle,
+            onNotificationToggle: { [weak self] in
+                guard let self else { return }
+                self.textModel.notifyOnComplete.toggle()
+                UserDefaults.standard.set(self.textModel.notifyOnComplete, forKey: "quickInputNotifyOnComplete")
+            },
             recentThreads: recentThreads,
             attachedImage: attachedImage,
             showScreenPermissionPrompt: showScreenPermissionPrompt

--- a/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
@@ -85,6 +85,34 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
         }
     }
 
+    /// Sends a notification when a quick input response completes.
+    /// Only sends if the app is not active and notification permissions are granted.
+    public func notifyQuickInputComplete(summary: String) async {
+        // Check if app is in background
+        guard !NSApp.isActive else { return }
+
+        // Check notification permissions
+        let center = UNUserNotificationCenter.current()
+        let settings = await center.notificationSettings()
+        guard settings.authorizationStatus == .authorized else { return }
+
+        let content = UNMutableNotificationContent()
+        // Use first line of summary, truncated
+        let firstLine = summary.components(separatedBy: .newlines).first ?? summary
+        let truncated = firstLine.count > 100 ? String(firstLine.prefix(100)) + "…" : firstLine
+        content.title = "Vellum"
+        content.body = truncated.isEmpty ? "Response complete" : truncated
+        content.sound = .default
+        content.userInfo = ["type": "quick_input_complete"]
+
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: nil
+        )
+        try? await center.add(request)
+    }
+
     // MARK: - Private Helpers
 
     private func formatTitle(summary: String, steps: Int) -> String {

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -638,6 +638,17 @@ extension ChatViewModel {
             if let toolCalls = completedToolCalls, let callback = onToolCallsComplete {
                 callback(toolCalls)
             }
+            // Notify that the assistant response is complete
+            if let callback = onResponseComplete, !wasRefinement {
+                // Extract a summary from the last assistant message
+                if let existingId = messages.last(where: { $0.role == .assistant })?.id,
+                   let index = messages.firstIndex(where: { $0.id == existingId }) {
+                    let summary = messages[index].textSegments.joined()
+                    callback(summary)
+                } else {
+                    callback("Response complete")
+                }
+            }
 
         case .undoComplete(let undoMsg):
             guard belongsToSession(undoMsg.sessionId) else { return }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -217,6 +217,8 @@ public final class ChatViewModel: ObservableObject {
     public var pendingVoiceMessage: Bool = false
     /// Called when a voice-triggered assistant response completes, with the response text.
     public var onVoiceResponseComplete: ((String) -> Void)?
+    /// Called when any assistant response completes, with a summary of the response text.
+    public var onResponseComplete: ((String) -> Void)?
     /// Called with each streaming text delta during a voice-triggered response, for real-time TTS.
     public var onVoiceTextDelta: ((String) -> Void)?
     /// When true, messages are prefixed with a concise-response instruction for voice conversations.


### PR DESCRIPTION
## Summary
- Add a bell icon to the quick input bar that toggles macOS notifications when the assistant finishes responding
- Quick input is now fully fire-and-forget — submitting never opens or activates the main window
- Notification preference persists across sessions via UserDefaults

## Test plan
- [ ] Open quick input (Cmd+/) — bell icon appears between thread selector and camera button, default filled (on)
- [ ] Tap bell — icon changes to `bell.slash` (off), persists across invocations
- [ ] Submit with bell on → stay in current app → get macOS notification when response completes
- [ ] Submit with bell off → stay in current app → no notification
- [ ] Submit when main window was never opened — window created silently, no flash or focus steal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
