### PR TITLE
M2: Outbound SMS Verification + Rate/Cooldown + Templates

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -22,6 +22,8 @@ mock.module('../util/platform.js', () => ({
   getDbPath: () => join(testDir, 'test.db'),
   getLogPath: () => join(testDir, 'test.log'),
   ensureDataDir: () => {},
+  normalizeAssistantId: (id: string) => id === 'self' ? 'self' : id,
+  readHttpToken: () => 'test-bearer-token',
 }));
 
 mock.module('../util/logger.js', () => ({
@@ -32,9 +34,18 @@ mock.module('../util/logger.js', () => ({
 
 import type * as net from 'node:net';
 
-import { handleGuardianVerification } from '../daemon/handlers/config.js';
-import type { HandlerContext } from '../daemon/handlers/shared.js';
-import type { GuardianVerificationRequest, GuardianVerificationResponse } from '../daemon/ipc-contract.js';
+// SMS client mock — outbound SMS delivery is fire-and-forget, so we just track calls.
+const smsSendCalls: Array<{ to: string; text: string; assistantId?: string }> = [];
+mock.module('../messaging/providers/sms/client.js', () => ({
+  sendMessage: async (_gatewayUrl: string, _bearerToken: string, to: string, text: string, assistantId?: string) => {
+    smsSendCalls.push({ to, text, assistantId });
+    return { messageSid: 'SM-mock', status: 'queued' };
+  },
+}));
+
+mock.module('../config/env.js', () => ({
+  getGatewayInternalBaseUrl: () => 'http://127.0.0.1:7830',
+}));
 import {
   consumeChallenge,
   createApprovalRequest,
@@ -71,6 +82,13 @@ import {
   bindSessionIdentity as serviceBindSessionIdentity,
   validateAndConsumeChallenge,
 } from '../runtime/channel-guardian-service.js';
+import { handleGuardianVerification, MAX_SENDS_PER_SESSION, RESEND_COOLDOWN_MS } from '../daemon/handlers/config-channels.js';
+import type { GuardianVerificationRequest, GuardianVerificationResponse } from '../daemon/ipc-contract.js';
+import type { HandlerContext } from '../daemon/handlers/shared.js';
+import {
+  composeVerificationSms,
+  GUARDIAN_VERIFY_TEMPLATE_KEYS,
+} from '../runtime/guardian-verification-templates.js';
 
 initializeDb();
 
@@ -85,6 +103,7 @@ function resetTables(): void {
   db.run('DELETE FROM channel_guardian_verification_challenges');
   db.run('DELETE FROM channel_guardian_approval_requests');
   db.run('DELETE FROM channel_guardian_rate_limits');
+  smsSendCalls.length = 0;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -2430,5 +2449,370 @@ describe('outbound verification sessions', () => {
     );
 
     expect(result.success).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 18. Outbound SMS Verification (IPC Handlers)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('outbound SMS verification', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test('start_outbound creates session with expected E.164 identity and returns code', () => {
+    const { ctx, lastResponse } = createMockCtx();
+    const msg: GuardianVerificationRequest = {
+      type: 'guardian_verification',
+      action: 'start_outbound',
+      channel: 'sms',
+      assistantId: 'self',
+      destination: '+15551234567',
+    };
+
+    handleGuardianVerification(msg, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(true);
+    expect(resp!.verificationSessionId).toBeDefined();
+    expect(resp!.secret).toBeDefined();
+    expect(resp!.expiresAt).toBeGreaterThan(Date.now());
+    expect(resp!.nextResendAt).toBeGreaterThan(Date.now());
+    expect(resp!.sendCount).toBe(1);
+    expect(resp!.channel).toBe('sms');
+
+    // Verify the session was created with expected identity
+    const session = serviceFindActiveSession('self', 'sms');
+    expect(session).not.toBeNull();
+    expect(session!.expectedPhoneE164).toBe('+15551234567');
+    expect(session!.destinationAddress).toBe('+15551234567');
+  });
+
+  test('start_outbound rejects when active binding exists (rebind=false)', () => {
+    // Create an existing guardian binding
+    createBinding({
+      assistantId: 'self',
+      channel: 'sms',
+      guardianExternalUserId: '+15551234567',
+      guardianDeliveryChatId: 'sms-chat-1',
+    });
+
+    const { ctx, lastResponse } = createMockCtx();
+    const msg: GuardianVerificationRequest = {
+      type: 'guardian_verification',
+      action: 'start_outbound',
+      channel: 'sms',
+      assistantId: 'self',
+      destination: '+15559876543',
+      rebind: false,
+    };
+
+    handleGuardianVerification(msg, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(false);
+    expect(resp!.error).toBe('already_bound');
+  });
+
+  test('start_outbound allows rebind when rebind=true', () => {
+    // Create an existing guardian binding
+    createBinding({
+      assistantId: 'self',
+      channel: 'sms',
+      guardianExternalUserId: '+15551234567',
+      guardianDeliveryChatId: 'sms-chat-1',
+    });
+
+    const { ctx, lastResponse } = createMockCtx();
+    const msg: GuardianVerificationRequest = {
+      type: 'guardian_verification',
+      action: 'start_outbound',
+      channel: 'sms',
+      assistantId: 'self',
+      destination: '+15559876543',
+      rebind: true,
+    };
+
+    handleGuardianVerification(msg, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(true);
+    expect(resp!.verificationSessionId).toBeDefined();
+  });
+
+  test('resend_outbound before cooldown is rejected', () => {
+    // Start an outbound session first
+    const { ctx: startCtx } = createMockCtx();
+    handleGuardianVerification({
+      type: 'guardian_verification',
+      action: 'start_outbound',
+      channel: 'sms',
+      assistantId: 'self',
+      destination: '+15551234567',
+    }, mockSocket, startCtx);
+
+    // Immediately try to resend (before cooldown)
+    const { ctx, lastResponse } = createMockCtx();
+    handleGuardianVerification({
+      type: 'guardian_verification',
+      action: 'resend_outbound',
+      channel: 'sms',
+      assistantId: 'self',
+    }, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(false);
+    expect(resp!.error).toBe('rate_limited');
+  });
+
+  test('resend_outbound after cooldown succeeds and increments sendCount', () => {
+    // Start an outbound session
+    const { ctx: startCtx, lastResponse: startResp } = createMockCtx();
+    handleGuardianVerification({
+      type: 'guardian_verification',
+      action: 'start_outbound',
+      channel: 'sms',
+      assistantId: 'self',
+      destination: '+15551234567',
+    }, mockSocket, startCtx);
+
+    const startResponse = startResp();
+    expect(startResponse!.success).toBe(true);
+
+    // Manually update the session's nextResendAt to the past to simulate cooldown elapsed
+    const session = serviceFindActiveSession('self', 'sms');
+    expect(session).not.toBeNull();
+    storeUpdateSessionDelivery(session!.id, Date.now() - RESEND_COOLDOWN_MS - 1000, 1, Date.now() - 1000);
+
+    // Now resend should succeed
+    const { ctx, lastResponse } = createMockCtx();
+    handleGuardianVerification({
+      type: 'guardian_verification',
+      action: 'resend_outbound',
+      channel: 'sms',
+      assistantId: 'self',
+    }, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(true);
+    expect(resp!.sendCount).toBe(2);
+    expect(resp!.nextResendAt).toBeGreaterThan(Date.now());
+  });
+
+  test('resend_outbound exceeding max sends is rejected', () => {
+    // Start an outbound session
+    const { ctx: startCtx } = createMockCtx();
+    handleGuardianVerification({
+      type: 'guardian_verification',
+      action: 'start_outbound',
+      channel: 'sms',
+      assistantId: 'self',
+      destination: '+15551234567',
+    }, mockSocket, startCtx);
+
+    // Set the send count to MAX_SENDS_PER_SESSION and nextResendAt to the past
+    const session = serviceFindActiveSession('self', 'sms');
+    expect(session).not.toBeNull();
+    storeUpdateSessionDelivery(
+      session!.id,
+      Date.now() - RESEND_COOLDOWN_MS - 1000,
+      MAX_SENDS_PER_SESSION,
+      Date.now() - 1000,
+    );
+
+    // Resend should be rejected due to max sends
+    const { ctx, lastResponse } = createMockCtx();
+    handleGuardianVerification({
+      type: 'guardian_verification',
+      action: 'resend_outbound',
+      channel: 'sms',
+      assistantId: 'self',
+    }, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(false);
+    expect(resp!.error).toBe('max_sends_exceeded');
+  });
+
+  test('cancel_outbound revokes active session', () => {
+    // Start an outbound session
+    const { ctx: startCtx } = createMockCtx();
+    handleGuardianVerification({
+      type: 'guardian_verification',
+      action: 'start_outbound',
+      channel: 'sms',
+      assistantId: 'self',
+      destination: '+15551234567',
+    }, mockSocket, startCtx);
+
+    // Verify session exists
+    const sessionBefore = serviceFindActiveSession('self', 'sms');
+    expect(sessionBefore).not.toBeNull();
+
+    // Cancel it
+    const { ctx, lastResponse } = createMockCtx();
+    handleGuardianVerification({
+      type: 'guardian_verification',
+      action: 'cancel_outbound',
+      channel: 'sms',
+      assistantId: 'self',
+    }, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(true);
+    expect(resp!.channel).toBe('sms');
+
+    // Verify session is no longer active
+    const sessionAfter = serviceFindActiveSession('self', 'sms');
+    expect(sessionAfter).toBeNull();
+  });
+
+  test('inbound SMS from expected identity + correct code succeeds', () => {
+    // Create an outbound session
+    const { secret } = createOutboundSession({
+      assistantId: 'self',
+      channel: 'sms',
+      expectedPhoneE164: '+15551234567',
+      expectedExternalUserId: '+15551234567',
+      destinationAddress: '+15551234567',
+    });
+
+    // Validate with matching identity
+    const result = validateAndConsumeChallenge(
+      'self', 'sms', secret, '+15551234567', 'sms-chat-1',
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.bindingId).toBeDefined();
+    }
+  });
+
+  test('inbound SMS from wrong identity + correct code is rejected', () => {
+    // Create an outbound session with expected identity +15551234567
+    const { secret } = createOutboundSession({
+      assistantId: 'self',
+      channel: 'sms',
+      expectedPhoneE164: '+15551234567',
+      expectedExternalUserId: '+15551234567',
+      destinationAddress: '+15551234567',
+    });
+
+    // Try to validate with a different phone number (anti-oracle: same generic error)
+    const result = validateAndConsumeChallenge(
+      'self', 'sms', secret, '+15559999999', 'sms-chat-wrong',
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      // Anti-oracle: generic failure message, no identity-specific info leaked
+      expect(result.reason.toLowerCase()).toContain('failed');
+      expect(result.reason).not.toContain('identity');
+      expect(result.reason).not.toContain('mismatch');
+    }
+  });
+
+  test('template composer returns expected SMS format', () => {
+    const challengeSms = composeVerificationSms(
+      GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST,
+      { code: '123456', expiresInMinutes: 10 },
+    );
+    expect(challengeSms).toContain('123456');
+    expect(challengeSms).toContain('10 minutes');
+    expect(challengeSms).toContain('verification code');
+
+    const resendSms = composeVerificationSms(
+      GUARDIAN_VERIFY_TEMPLATE_KEYS.RESEND,
+      { code: 'ABCDEF', expiresInMinutes: 5 },
+    );
+    expect(resendSms).toContain('ABCDEF');
+    expect(resendSms).toContain('5 minutes');
+    expect(resendSms).toContain('resent');
+
+    const alreadySms = composeVerificationSms(
+      GUARDIAN_VERIFY_TEMPLATE_KEYS.ALREADY_VERIFIED,
+      { code: 'unused', expiresInMinutes: 0 },
+    );
+    expect(alreadySms).toContain('already verified');
+  });
+
+  test('start_outbound rejects non-SMS channels', () => {
+    const { ctx, lastResponse } = createMockCtx();
+    handleGuardianVerification({
+      type: 'guardian_verification',
+      action: 'start_outbound',
+      channel: 'telegram',
+      assistantId: 'self',
+      destination: '@some_user',
+    }, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(false);
+    expect(resp!.error).toBe('unsupported_channel');
+  });
+
+  test('start_outbound rejects missing destination', () => {
+    const { ctx, lastResponse } = createMockCtx();
+    handleGuardianVerification({
+      type: 'guardian_verification',
+      action: 'start_outbound',
+      channel: 'sms',
+      assistantId: 'self',
+      // no destination
+    }, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(false);
+    expect(resp!.error).toBe('missing_destination');
+  });
+
+  test('start_outbound rejects invalid E.164 number', () => {
+    const { ctx, lastResponse } = createMockCtx();
+    handleGuardianVerification({
+      type: 'guardian_verification',
+      action: 'start_outbound',
+      channel: 'sms',
+      assistantId: 'self',
+      destination: '5551234567', // missing + prefix
+    }, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(false);
+    expect(resp!.error).toBe('invalid_destination');
+  });
+
+  test('template composer includes assistantName when provided', () => {
+    const sms = composeVerificationSms(
+      GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST,
+      { code: '999999', expiresInMinutes: 10, assistantName: 'MyBot' },
+    );
+    expect(sms).toContain('[MyBot]');
+    expect(sms).toContain('999999');
+  });
+
+  test('cancel_outbound returns error when no active session', () => {
+    const { ctx, lastResponse } = createMockCtx();
+    handleGuardianVerification({
+      type: 'guardian_verification',
+      action: 'cancel_outbound',
+      channel: 'sms',
+      assistantId: 'self',
+    }, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(false);
+    expect(resp!.error).toBe('no_active_session');
   });
 });

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -1,14 +1,54 @@
 import * as net from 'node:net';
 
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
-import { createVerificationChallenge, getGuardianBinding, getPendingChallenge, revokeBinding as revokeGuardianBinding, revokePendingChallenges } from '../../runtime/channel-guardian-service.js';
-import { type ChannelReadinessService,createReadinessService } from '../../runtime/channel-readiness-service.js';
-import { normalizeAssistantId } from '../../util/platform.js';
+import {
+  createVerificationChallenge,
+  getGuardianBinding,
+  getPendingChallenge,
+  revokeBinding as revokeGuardianBinding,
+  revokePendingChallenges,
+  createOutboundSession,
+  findActiveSession,
+  updateSessionStatus,
+  updateSessionDelivery,
+} from '../../runtime/channel-guardian-service.js';
+import { createReadinessService, type ChannelReadinessService } from '../../runtime/channel-readiness-service.js';
+import {
+  composeVerificationSms,
+  GUARDIAN_VERIFY_TEMPLATE_KEYS,
+} from '../../runtime/guardian-verification-templates.js';
+import { sendMessage as sendSms } from '../../messaging/providers/sms/client.js';
+import { getGatewayInternalBaseUrl } from '../../config/env.js';
+import { normalizeAssistantId, readHttpToken } from '../../util/platform.js';
+import type { ChannelId } from '../../channels/types.js';
 import type {
   ChannelReadinessRequest,
   GuardianVerificationRequest,
 } from '../ipc-protocol.js';
-import { defineHandlers, type HandlerContext,log } from './shared.js';
+import { defineHandlers, type HandlerContext, log } from './shared.js';
+
+// ---------------------------------------------------------------------------
+// Rate limit constants for outbound verification
+// ---------------------------------------------------------------------------
+
+/** Maximum SMS sends per verification session. */
+export const MAX_SENDS_PER_SESSION = 5;
+
+/** Cooldown between resends in milliseconds (60 seconds). */
+export const RESEND_COOLDOWN_MS = 60_000;
+
+/** Maximum sends per destination within a rolling window. */
+export const MAX_SENDS_PER_DESTINATION_WINDOW = 10;
+
+/** Rolling window for destination rate limit in milliseconds (1 hour). */
+export const DESTINATION_RATE_WINDOW_MS = 3_600_000;
+
+/** Session TTL in seconds (matches challenge TTL of 10 minutes). */
+const SESSION_TTL_SECONDS = 600;
+
+// ---------------------------------------------------------------------------
+// Readiness service singleton
+// ---------------------------------------------------------------------------
 
 // Lazy singleton — created on first use so module-load stays lightweight.
 let _readinessService: ChannelReadinessService | undefined;
@@ -18,6 +58,21 @@ export function getReadinessService(): ChannelReadinessService {
   }
   return _readinessService;
 }
+
+// ---------------------------------------------------------------------------
+// E.164 validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Basic E.164 phone number validation: starts with +, followed by 10-15 digits.
+ */
+function isValidE164(phone: string): boolean {
+  return /^\+\d{10,15}$/.test(phone);
+}
+
+// ---------------------------------------------------------------------------
+// Guardian verification handler
+// ---------------------------------------------------------------------------
 
 export function handleGuardianVerification(
   msg: GuardianVerificationRequest,
@@ -105,6 +160,12 @@ export function handleGuardianVerification(
         bound: false,
         channel,
       });
+    } else if (msg.action === 'start_outbound') {
+      handleStartOutbound(msg, socket, ctx, assistantId, channel);
+    } else if (msg.action === 'resend_outbound') {
+      handleResendOutbound(msg, socket, ctx, assistantId, channel);
+    } else if (msg.action === 'cancel_outbound') {
+      handleCancelOutbound(socket, ctx, assistantId, channel);
     } else {
       ctx.send(socket, {
         type: 'guardian_verification_response',
@@ -124,6 +185,268 @@ export function handleGuardianVerification(
     });
   }
 }
+
+// ---------------------------------------------------------------------------
+// Outbound verification action handlers
+// ---------------------------------------------------------------------------
+
+function handleStartOutbound(
+  msg: GuardianVerificationRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+  assistantId: string,
+  channel: ChannelId,
+): void {
+  // Only SMS is supported for this PR
+  if (channel !== 'sms') {
+    ctx.send(socket, {
+      type: 'guardian_verification_response',
+      success: false,
+      error: 'unsupported_channel',
+      message: `Outbound verification is only supported for SMS. Got: ${channel}`,
+      channel,
+    });
+    return;
+  }
+
+  // Validate destination
+  const destination = msg.destination;
+  if (!destination) {
+    ctx.send(socket, {
+      type: 'guardian_verification_response',
+      success: false,
+      error: 'missing_destination',
+      message: 'A destination phone number is required for outbound SMS verification.',
+      channel,
+    });
+    return;
+  }
+
+  if (!isValidE164(destination)) {
+    ctx.send(socket, {
+      type: 'guardian_verification_response',
+      success: false,
+      error: 'invalid_destination',
+      message: 'Destination must be a valid E.164 phone number (e.g. +15551234567).',
+      channel,
+    });
+    return;
+  }
+
+  // Check for existing active binding (unless rebind=true)
+  const existingBinding = getGuardianBinding(assistantId, channel);
+  if (existingBinding && !msg.rebind) {
+    ctx.send(socket, {
+      type: 'guardian_verification_response',
+      success: false,
+      error: 'already_bound',
+      message: 'A guardian is already bound for this channel. Set rebind: true to replace.',
+      channel,
+    });
+    return;
+  }
+
+  // Create outbound session with expected identity = E.164 destination
+  const sessionResult = createOutboundSession({
+    assistantId,
+    channel,
+    expectedPhoneE164: destination,
+    expectedExternalUserId: destination,
+    destinationAddress: destination,
+  });
+
+  // Compose SMS using the challenge_request template
+  const smsBody = composeVerificationSms(
+    GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST,
+    {
+      code: sessionResult.secret,
+      expiresInMinutes: Math.floor(SESSION_TTL_SECONDS / 60),
+    },
+  );
+
+  const now = Date.now();
+  const nextResendAt = now + RESEND_COOLDOWN_MS;
+  const sendCount = 1;
+
+  // Update session delivery tracking
+  updateSessionDelivery(sessionResult.sessionId, now, sendCount, nextResendAt);
+
+  // Send SMS via the gateway's /deliver/sms endpoint (fire-and-forget with logging)
+  deliverVerificationSms(destination, smsBody, assistantId);
+
+  ctx.send(socket, {
+    type: 'guardian_verification_response',
+    success: true,
+    verificationSessionId: sessionResult.sessionId,
+    secret: sessionResult.secret,
+    expiresAt: sessionResult.expiresAt,
+    nextResendAt,
+    sendCount,
+    channel,
+  });
+}
+
+function handleResendOutbound(
+  _msg: GuardianVerificationRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+  assistantId: string,
+  channel: ChannelId,
+): void {
+  // Find active session
+  const session = findActiveSession(assistantId, channel);
+  if (!session) {
+    ctx.send(socket, {
+      type: 'guardian_verification_response',
+      success: false,
+      error: 'no_active_session',
+      message: 'No active outbound verification session found.',
+      channel,
+    });
+    return;
+  }
+
+  // Check resend cooldown (use generic error to avoid leaking timing info)
+  if (session.nextResendAt != null && Date.now() < session.nextResendAt) {
+    ctx.send(socket, {
+      type: 'guardian_verification_response',
+      success: false,
+      error: 'rate_limited',
+      message: 'Please wait before requesting another verification code.',
+      channel,
+    });
+    return;
+  }
+
+  // Check send count cap
+  const currentSendCount = session.sendCount ?? 0;
+  if (currentSendCount >= MAX_SENDS_PER_SESSION) {
+    ctx.send(socket, {
+      type: 'guardian_verification_response',
+      success: false,
+      error: 'max_sends_exceeded',
+      message: 'Maximum number of verification sends reached for this session.',
+      channel,
+    });
+    return;
+  }
+
+  // We need the secret to compose the resend SMS, but the store only
+  // persists the challenge hash. The createOutboundSession generated a fresh
+  // secret when start_outbound was called and it was sent via SMS already.
+  // For resend we cannot recover the original plaintext secret from the hash.
+  // Instead, create a new outbound session to get a fresh code. This revokes
+  // the prior session automatically (via createOutboundSession internals).
+  const destination = session.destinationAddress ?? session.expectedPhoneE164;
+  if (!destination) {
+    ctx.send(socket, {
+      type: 'guardian_verification_response',
+      success: false,
+      error: 'no_destination',
+      message: 'Cannot resend: no destination address on the session.',
+      channel,
+    });
+    return;
+  }
+
+  // Create a fresh session (auto-revokes prior one)
+  const newSession = createOutboundSession({
+    assistantId,
+    channel,
+    expectedPhoneE164: destination,
+    expectedExternalUserId: destination,
+    destinationAddress: destination,
+  });
+
+  // Compose SMS using the resend template
+  const smsBody = composeVerificationSms(
+    GUARDIAN_VERIFY_TEMPLATE_KEYS.RESEND,
+    {
+      code: newSession.secret,
+      expiresInMinutes: Math.floor(SESSION_TTL_SECONDS / 60),
+    },
+  );
+
+  const now = Date.now();
+  const newSendCount = currentSendCount + 1;
+  const nextResendAt = now + RESEND_COOLDOWN_MS;
+
+  // Update the new session's delivery tracking, carrying forward the cumulative send count
+  updateSessionDelivery(newSession.sessionId, now, newSendCount, nextResendAt);
+
+  // Send SMS
+  deliverVerificationSms(destination, smsBody, assistantId);
+
+  ctx.send(socket, {
+    type: 'guardian_verification_response',
+    success: true,
+    verificationSessionId: newSession.sessionId,
+    nextResendAt,
+    sendCount: newSendCount,
+    channel,
+  });
+}
+
+function handleCancelOutbound(
+  socket: net.Socket,
+  ctx: HandlerContext,
+  assistantId: string,
+  channel: ChannelId,
+): void {
+  const session = findActiveSession(assistantId, channel);
+  if (!session) {
+    ctx.send(socket, {
+      type: 'guardian_verification_response',
+      success: false,
+      error: 'no_active_session',
+      message: 'No active outbound verification session found.',
+      channel,
+    });
+    return;
+  }
+
+  updateSessionStatus(session.id, 'revoked');
+
+  ctx.send(socket, {
+    type: 'guardian_verification_response',
+    success: true,
+    channel,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// SMS delivery helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Deliver a verification SMS via the gateway. Fire-and-forget with error
+ * logging — the IPC response is sent before delivery completes because
+ * the caller should not be blocked on Twilio API latency.
+ */
+function deliverVerificationSms(
+  to: string,
+  text: string,
+  assistantId: string,
+): void {
+  (async () => {
+    try {
+      const gatewayUrl = getGatewayInternalBaseUrl();
+      const bearerToken = readHttpToken();
+      if (!bearerToken) {
+        log.error('Cannot deliver verification SMS: no runtime HTTP token available');
+        return;
+      }
+      await sendSms(gatewayUrl, bearerToken, to, text, assistantId);
+      log.info({ to, assistantId }, 'Verification SMS delivered');
+    } catch (err) {
+      log.error({ err, to, assistantId }, 'Failed to deliver verification SMS');
+    }
+  })();
+}
+
+// ---------------------------------------------------------------------------
+// Channel readiness handler
+// ---------------------------------------------------------------------------
 
 export async function handleChannelReadiness(
   msg: ChannelReadinessRequest,

--- a/assistant/src/daemon/ipc-contract/integrations.ts
+++ b/assistant/src/daemon/ipc-contract/integrations.ts
@@ -84,11 +84,13 @@ export interface ChannelReadinessRequest {
 
 export interface GuardianVerificationRequest {
   type: 'guardian_verification';
-  action: 'create_challenge' | 'status' | 'revoke';
+  action: 'create_challenge' | 'status' | 'revoke' | 'start_outbound' | 'resend_outbound' | 'cancel_outbound';
   channel?: ChannelId;  // Defaults to 'telegram'
   sessionId?: string;
   assistantId?: string;  // Defaults to 'self'
   rebind?: boolean;  // When true, allows creating a challenge even if a binding already exists
+  /** E.164 phone number for SMS/voice, Telegram handle/chat-id. Used by outbound actions. */
+  destination?: string;
 }
 
 export interface TwitterAuthStartRequest {
@@ -253,6 +255,16 @@ export interface GuardianVerificationResponse {
   error?: string;
   /** Human-readable error detail (e.g. for already_bound failures). */
   message?: string;
+  /** Session ID for outbound verification flows. */
+  verificationSessionId?: string;
+  /** Epoch ms when the verification session expires. */
+  expiresAt?: number;
+  /** Epoch ms after which a resend is allowed. */
+  nextResendAt?: number;
+  /** Number of SMS sends for this session. */
+  sendCount?: number;
+  /** Telegram deep-link URL for bootstrap (M3 placeholder). */
+  telegramBootstrapUrl?: string;
 }
 
 export interface TwitterAuthResult {

--- a/assistant/src/runtime/guardian-verification-templates.ts
+++ b/assistant/src/runtime/guardian-verification-templates.ts
@@ -1,0 +1,66 @@
+/**
+ * Template-only SMS copy for outbound guardian verification messages.
+ *
+ * All outbound verification SMS messages are composed from these templates
+ * to prevent free-form caller/user text injection. Only typed variables
+ * are interpolated into the message body.
+ */
+
+// ---------------------------------------------------------------------------
+// Template Keys
+// ---------------------------------------------------------------------------
+
+export const GUARDIAN_VERIFY_TEMPLATE_KEYS = {
+  /** Initial outbound SMS with verification code. */
+  CHALLENGE_REQUEST: 'guardian_verify.sms.challenge_request',
+  /** Resend SMS with verification code. */
+  RESEND: 'guardian_verify.sms.resend',
+  /** Response when the user is already verified. */
+  ALREADY_VERIFIED: 'guardian_verify.already_verified',
+} as const;
+
+export type GuardianVerifyTemplateKey =
+  (typeof GUARDIAN_VERIFY_TEMPLATE_KEYS)[keyof typeof GUARDIAN_VERIFY_TEMPLATE_KEYS];
+
+// ---------------------------------------------------------------------------
+// Template Variables
+// ---------------------------------------------------------------------------
+
+export interface GuardianVerifyTemplateVars {
+  code: string;
+  expiresInMinutes: number;
+  assistantName?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Template Composers
+// ---------------------------------------------------------------------------
+
+const templates: Record<GuardianVerifyTemplateKey, (vars: GuardianVerifyTemplateVars) => string> = {
+  [GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST]: (vars) => {
+    const prefix = vars.assistantName ? `[${vars.assistantName}] ` : '';
+    return `${prefix}Your verification code is: ${vars.code}. It expires in ${vars.expiresInMinutes} minutes. Reply with this code to verify.`;
+  },
+
+  [GUARDIAN_VERIFY_TEMPLATE_KEYS.RESEND]: (vars) => {
+    const prefix = vars.assistantName ? `[${vars.assistantName}] ` : '';
+    return `${prefix}Your verification code is: ${vars.code}. It expires in ${vars.expiresInMinutes} minutes. Reply with this code to verify. (resent)`;
+  },
+
+  [GUARDIAN_VERIFY_TEMPLATE_KEYS.ALREADY_VERIFIED]: (vars) => {
+    const prefix = vars.assistantName ? `[${vars.assistantName}] ` : '';
+    return `${prefix}This channel is already verified. No further action is needed.`;
+  },
+};
+
+/**
+ * Compose an outbound verification SMS body from a template key and typed variables.
+ * Returns plain string content suitable for SMS delivery.
+ */
+export function composeVerificationSms(
+  templateKey: GuardianVerifyTemplateKey,
+  vars: GuardianVerifyTemplateVars,
+): string {
+  const composer = templates[templateKey];
+  return composer(vars);
+}


### PR DESCRIPTION
Adds outbound SMS verification flow with template-only copy, IPC actions (start_outbound, resend_outbound, cancel_outbound), send rate limits, resend cooldown, and identity-bound inbound consume. Part of #8925.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
