### PR TITLE
fix: guard allowlist strategy lookup against prototype keys

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -757,8 +757,9 @@ const ALLOWLIST_STRATEGIES: Record<string, AllowlistStrategy> = {
 export async function generateAllowlistOptions(toolName: string, input: Record<string, unknown>, signal?: AbortSignal): Promise<AllowlistOption[]> {
   signal?.throwIfAborted();
 
-  const strategy = ALLOWLIST_STRATEGIES[toolName];
-  if (strategy) return strategy(toolName, input);
+  if (Object.hasOwn(ALLOWLIST_STRATEGIES, toolName)) {
+    return ALLOWLIST_STRATEGIES[toolName](toolName, input);
+  }
 
   return [{ label: '*', description: 'Everything', pattern: '*' }];
 }


### PR DESCRIPTION
Addresses review feedback on #8900. Adds Object.hasOwn check before accessing ALLOWLIST_STRATEGIES to prevent inherited Object.prototype members from being invoked as strategy functions for unknown tool names.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
