### PR TITLE
fix: resolve swarm worker model intent against anthropic provider

### DIFF
--- a/assistant/src/swarm/backend-claude-code.ts
+++ b/assistant/src/swarm/backend-claude-code.ts
@@ -76,7 +76,7 @@ export function createClaudeCodeBackend(): SwarmWorkerBackend {
           options: {
             cwd: input.workingDir,
             model: input.modelIntent
-              ? resolveModelIntent(getConfig().provider, input.modelIntent as ModelIntent)
+              ? resolveModelIntent('anthropic', input.modelIntent as ModelIntent)
               : 'claude-sonnet-4-6',
             canUseTool,
             permissionMode: 'default',


### PR DESCRIPTION
Addresses review feedback on #8923. The Claude Code backend always communicates with Anthropic's API, so model intents must be resolved against the 'anthropic' provider rather than the user's configured top-level provider. This prevents non-Anthropic model names from being passed to Claude Code.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
