### PR TITLE
fix: remove redundant memoryItemSources index covered by composite PK

### DIFF
--- a/assistant/src/memory/migrations/023-memory-item-sources-indexes.ts
+++ b/assistant/src/memory/migrations/023-memory-item-sources-indexes.ts
@@ -1,10 +1,12 @@
 import type { DrizzleDb } from '../db-connection.js';
 
 /**
- * Idempotent migration to add an index on memory_item_sources.memory_item_id.
- * This column is used in inArray() queries in the memory retriever and as a
- * foreign key with ON DELETE CASCADE — both benefit from an index.
+ * Originally added an index on memory_item_sources(memory_item_id), but that
+ * column is the leftmost key in PRIMARY KEY (memory_item_id, message_id) which
+ * SQLite already covers with an autoindex. The explicit index was redundant and
+ * added unnecessary write overhead, so it has been removed.
  */
 export function migrateMemoryItemSourcesIndexes(database: DrizzleDb): void {
-  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_item_sources_memory_item_id ON memory_item_sources(memory_item_id)`);
+  // Drop the redundant index if it was already created on existing databases.
+  database.run(/*sql*/ `DROP INDEX IF EXISTS idx_memory_item_sources_memory_item_id`);
 }


### PR DESCRIPTION
Addresses review feedback on #8882. The memory_item_sources table already has PRIMARY KEY (memory_item_id, message_id), which in SQLite creates an autoindex with memory_item_id as the leftmost key. The additional single-column index was redundant and added unnecessary write overhead. The migration now drops the redundant index (cleaning up existing databases) instead of creating it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
