### PR TITLE
fix: apply applyNestedDefaults to DEFAULT_CONFIG in defaults.ts

### DIFF
--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -1,7 +1,7 @@
-import { AssistantConfigSchema } from './schema.js';
+import { applyNestedDefaults } from './loader.js';
 import type { AssistantConfig } from './types.js';
 
 // Single source of truth: Zod schema field-level .default() values.
-// Parsing an empty object applies every default, so this object always
-// matches the schema and cannot drift.
-export const DEFAULT_CONFIG: AssistantConfig = AssistantConfigSchema.parse({});
+// Uses applyNestedDefaults to cascade through nested .default({}) calls,
+// which Zod 4 doesn't resolve in a single parse pass.
+export const DEFAULT_CONFIG: AssistantConfig = applyNestedDefaults({});

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -39,7 +39,7 @@ function ensureMigratedDataDir(): void {
  * (e.g. memory → retrieval → freshness → maxAgeDays),
  * so 5 parses are needed (N+1) to fully cascade.
  */
-function applyNestedDefaults(config: unknown): AssistantConfig {
+export function applyNestedDefaults(config: unknown): AssistantConfig {
   let current: unknown = config;
   for (let i = 0; i < 5; i++) {
     current = AssistantConfigSchema.parse(current);


### PR DESCRIPTION
Addresses review feedback on #8966. Updates DEFAULT_CONFIG to use applyNestedDefaults like the rest of the config loading pipeline, ensuring nested defaults are correctly applied when using Zod 4 which doesn't cascade nested .default({}) in a single parse pass.

Exports applyNestedDefaults from loader.ts and imports it in defaults.ts, replacing the single AssistantConfigSchema.parse({}) call.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
