### PR TITLE
fix: preserve concrete IPC member drift detection with alias-based composition

### DIFF
--- a/assistant/scripts/ipc/check-contract-inventory.ts
+++ b/assistant/scripts/ipc/check-contract-inventory.ts
@@ -89,6 +89,8 @@ if (!snapshot) {
 const diffs: string[] = [
   ...diffArrays('ClientMessage', snapshot.clientMessageTypes, inventory.clientMessageTypes),
   ...diffArrays('ServerMessage', snapshot.serverMessageTypes, inventory.serverMessageTypes),
+  ...diffArrays('ClientWireType', snapshot.clientWireTypes, inventory.clientWireTypes),
+  ...diffArrays('ServerWireType', snapshot.serverWireTypes, inventory.serverWireTypes),
 ];
 
 if (diffs.length > 0) {

--- a/assistant/src/__tests__/ipc-contract-inventory.test.ts
+++ b/assistant/src/__tests__/ipc-contract-inventory.test.ts
@@ -20,6 +20,8 @@ describe('IPC contract inventory', () => {
 
     expect(current.clientMessageTypes).toEqual(snapshot.clientMessageTypes);
     expect(current.serverMessageTypes).toEqual(snapshot.serverMessageTypes);
+    expect(current.clientWireTypes).toEqual(snapshot.clientWireTypes);
+    expect(current.serverWireTypes).toEqual(snapshot.serverWireTypes);
   });
 
   test('extracted types are sorted alphabetically', () => {


### PR DESCRIPTION
Addresses review feedback on #8944. Updates the IPC contract inventory checker to detect concrete message-level changes even with alias-based composition, preventing contract drift from slipping through CI.

The checker and test previously only compared `clientMessageTypes` and `serverMessageTypes` (which now contain alias names like `_SessionsClientMessages`). Adding/removing a concrete message inside a domain alias would not change these lists, so drift would go undetected.

Now both the CI checker and the test also compare `clientWireTypes` and `serverWireTypes`, which resolve aliases down to concrete wire type string literals (e.g. `user_message`, `session_create`). Any addition or removal of a concrete IPC message will be caught.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
