### PR TITLE
fix: use upsert for memory_summaries to avoid UNIQUE constraint race condition

### DIFF
--- a/assistant/src/memory/job-handlers/summarization.ts
+++ b/assistant/src/memory/job-handlers/summarization.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, isNull, lt } from 'drizzle-orm';
+import { and, desc, eq, gte, isNull, lt, sql } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
 import type { AssistantConfig } from '../../config/types.js';
@@ -84,34 +84,30 @@ export async function buildConversationSummaryJob(job: MemoryJob, config: Assist
   const now = Date.now();
   const summaryId = existing?.id ?? uuid();
   const nextVersion = (existing?.version ?? 0) + 1;
-  if (existing) {
-    db.update(memorySummaries)
-      .set({
-        summary: summaryText,
-        tokenEstimate: estimateTextTokens(summaryText),
-        version: nextVersion,
-        scopeId,
-        startAt: rows[rows.length - 1].createdAt,
-        endAt: rows[0].createdAt,
-        updatedAt: now,
-      })
-      .where(eq(memorySummaries.id, existing.id))
-      .run();
-  } else {
-    db.insert(memorySummaries).values({
-      id: summaryId,
-      scope: 'conversation',
-      scopeKey: conversationId,
-      scopeId,
+  db.insert(memorySummaries).values({
+    id: summaryId,
+    scope: 'conversation',
+    scopeKey: conversationId,
+    scopeId,
+    summary: summaryText,
+    tokenEstimate: estimateTextTokens(summaryText),
+    version: nextVersion,
+    startAt: rows[rows.length - 1].createdAt,
+    endAt: rows[0].createdAt,
+    createdAt: now,
+    updatedAt: now,
+  }).onConflictDoUpdate({
+    target: [memorySummaries.scope, memorySummaries.scopeKey],
+    set: {
       summary: summaryText,
       tokenEstimate: estimateTextTokens(summaryText),
-      version: nextVersion,
+      version: sql`${memorySummaries.version} + 1`,
+      scopeId,
       startAt: rows[rows.length - 1].createdAt,
       endAt: rows[0].createdAt,
-      createdAt: now,
       updatedAt: now,
-    }).run();
-  }
+    },
+  }).run();
   enqueueMemoryJob('embed_summary', { summaryId });
 }
 
@@ -188,33 +184,28 @@ export async function buildGlobalSummaryJob(scope: 'weekly_global' | 'monthly_gl
 
   const ts = Date.now();
   const summaryId = existing?.id ?? uuid();
-  const nextVersion = (existing?.version ?? 0) + 1;
-  if (existing) {
-    db.update(memorySummaries)
-      .set({
-        summary: summaryText,
-        tokenEstimate: estimateTextTokens(summaryText),
-        version: nextVersion,
-        startAt: startMs,
-        endAt: endMs,
-        updatedAt: ts,
-      })
-      .where(eq(memorySummaries.id, existing.id))
-      .run();
-  } else {
-    db.insert(memorySummaries).values({
-      id: summaryId,
-      scope,
-      scopeKey,
+  db.insert(memorySummaries).values({
+    id: summaryId,
+    scope,
+    scopeKey,
+    summary: summaryText,
+    tokenEstimate: estimateTextTokens(summaryText),
+    version: (existing?.version ?? 0) + 1,
+    startAt: startMs,
+    endAt: endMs,
+    createdAt: ts,
+    updatedAt: ts,
+  }).onConflictDoUpdate({
+    target: [memorySummaries.scope, memorySummaries.scopeKey],
+    set: {
       summary: summaryText,
       tokenEstimate: estimateTextTokens(summaryText),
-      version: nextVersion,
+      version: sql`${memorySummaries.version} + 1`,
       startAt: startMs,
       endAt: endMs,
-      createdAt: ts,
       updatedAt: ts,
-    }).run();
-  }
+    },
+  }).run();
   enqueueMemoryJob('embed_summary', { summaryId });
 }
 

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -138,6 +138,7 @@ export const memorySummaries = sqliteTable('memory_summaries', {
   updatedAt: integer('updated_at').notNull(),
 }, (table) => [
   index('idx_memory_summaries_scope_id').on(table.scopeId),
+  uniqueIndex('idx_memory_summaries_scope_scope_key').on(table.scope, table.scopeKey),
 ]);
 
 export const memoryEmbeddings = sqliteTable('memory_embeddings', {


### PR DESCRIPTION
## Summary
- Replace read-then-write pattern in `buildConversationSummaryJob` and `buildGlobalSummaryJob` with `INSERT ... ON CONFLICT DO UPDATE` (upsert) to eliminate race condition when concurrent jobs try to insert summaries with the same `(scope, scope_key)`
- Add `uniqueIndex` on `(scope, scopeKey)` to the Drizzle schema to match the existing migration constraint

## Original prompt
fix this error: {"level":40,"time":1772044208183,"pid":3401,"hostname":"MacBook-Pro-4.local","module":"memory-jobs-worker","err":{"name":"SQLiteError","message":"UNIQUE constraint failed: memory_summaries.scope, memory_summaries.scope_key","code":"SQLITE_CONSTRAINT_UNIQUE","stack":"SQLiteError: UNIQUE constraint failed: memory_summaries.scope, memory_summaries.scope_key\n    at run (unknown)\n    at #run (bun:sqlite:185:20)\n    at buildConversationSummaryJob (/Users/sidd/vocify/vellum-assistant/assistant/src/memory/job-handlers/summarization.ts:113:8)\n    at async processJob (/Users/sidd/vocify/vellum-assistant/assistant/src/memory/jobs-worker.ts:233:13)\n    at async <anonymous> (/Users/sidd/vocify/vellum-assistant/assistant/src/memory/jobs-worker.ts:121:15)\n    at processTicksAndRejections (native:7:39)","errno":2067,"byteOffset":-1},"jobId":"bbe5506a-41dc-40d8-af1e-2be670646040","type":"build_conversation_summary","category":"fatal","msg":"Memory job failed (fatal)"}

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/8999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
