### PR TITLE
fix: use rawText for offline queue message matching in voice mode

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -224,6 +224,7 @@ public final class ChatViewModel: ObservableObject {
     var pendingUserAttachments: [IPCAttachment]?
     /// Stores the last user message that failed to send, enabling retry.
     private(set) var lastFailedMessageText: String?
+    private(set) var lastFailedMessageDisplayText: String?
     private(set) var lastFailedMessageAttachments: [IPCAttachment]?
     /// Set only when a send operation (bootstrapSession or sendUserMessage) fails.
     /// Used by `isRetryableError` to ensure the retry button only appears for
@@ -547,6 +548,7 @@ public final class ChatViewModel: ObservableObject {
                 errorText = nil
                 sessionError = nil
                 lastFailedMessageText = nil
+                lastFailedMessageDisplayText = nil
                 lastFailedMessageAttachments = nil
                 lastFailedSendError = nil
                 connectionDiagnosticHint = nil
@@ -594,6 +596,7 @@ public final class ChatViewModel: ObservableObject {
         errorText = nil
         sessionError = nil
         lastFailedMessageText = nil
+        lastFailedMessageDisplayText = nil
         lastFailedMessageAttachments = nil
         lastFailedSendError = nil
         connectionDiagnosticHint = nil
@@ -618,7 +621,7 @@ public final class ChatViewModel: ObservableObject {
             bootstrapSession(userMessage: text, attachments: ipcAttachments)
         } else {
             // Subsequent messages: send directly (daemon queues if busy)
-            sendUserMessage(text, attachments: ipcAttachments, queuedMessageId: queuedMessageId)
+            sendUserMessage(text, displayText: rawText, attachments: ipcAttachments, queuedMessageId: queuedMessageId)
         }
     }
 
@@ -683,7 +686,7 @@ public final class ChatViewModel: ObservableObject {
         }
     }
 
-    private func sendUserMessage(_ text: String, attachments: [IPCAttachment]? = nil, queuedMessageId: UUID? = nil) {
+    private func sendUserMessage(_ text: String, displayText: String? = nil, attachments: [IPCAttachment]? = nil, queuedMessageId: UUID? = nil) {
         guard let sessionId else { return }
 
         // Check connectivity before entering sending state so the UI
@@ -697,11 +700,12 @@ public final class ChatViewModel: ObservableObject {
             // "pending" indicator and is flushed automatically on reconnect.
             if queuedMessageId == nil {
                 log.info("Buffering message in offline queue (session: \(sessionId))")
-                OfflineMessageQueue.shared.enqueue(sessionId: sessionId, text: text, attachments: attachments)
+                OfflineMessageQueue.shared.enqueue(sessionId: sessionId, text: text, displayText: displayText, attachments: attachments)
                 // Mark the corresponding chat message as offline-pending so the UI
                 // can show a visual indicator. Find the last user message with this
                 // text — it is the one just appended by sendMessage().
-                if let idx = messages.indices.reversed().first(where: { messages[$0].role == .user && messages[$0].text == text }) {
+                let matchText = displayText ?? text
+                if let idx = messages.indices.reversed().first(where: { messages[$0].role == .user && messages[$0].text == matchText }) {
                     messages[idx].status = .pendingOffline
                 }
                 // Don't show the error banner — the pending indicator on the bubble
@@ -711,6 +715,7 @@ public final class ChatViewModel: ObservableObject {
 
             // Always track the failed message for retry support.
             lastFailedMessageText = text
+            lastFailedMessageDisplayText = displayText
             lastFailedMessageAttachments = attachments
             // Only update UI error state for the primary send (not a queued
             // retry). A queued retry failing must not clobber the active turn's
@@ -754,6 +759,7 @@ public final class ChatViewModel: ObservableObject {
             log.error("Failed to send user_message: \(error.localizedDescription)")
             // Always track the failed message for retry support.
             lastFailedMessageText = text
+            lastFailedMessageDisplayText = displayText
             lastFailedMessageAttachments = attachments
             // Only update UI error state for the primary send (not a queued
             // retry). A queued retry failing must not clobber the active turn's
@@ -805,9 +811,10 @@ public final class ChatViewModel: ObservableObject {
 
         // Update message bubbles: clear pendingOffline status so they show as sent.
         for queued in mine {
+            let matchText = queued.displayText ?? queued.text
             if let idx = messages.indices.reversed().first(where: {
                 messages[$0].role == .user
-                    && messages[$0].text == queued.text
+                    && messages[$0].text == matchText
                     && messages[$0].status == .pendingOffline
             }) {
                 messages[idx].status = .sent
@@ -819,7 +826,7 @@ public final class ChatViewModel: ObservableObject {
         // via the normal error retry path, rather than duplicating on the next flush.
         for queued in mine {
             queue.remove(id: queued.id)
-            sendUserMessage(queued.text, attachments: queued.ipcAttachments)
+            sendUserMessage(queued.text, displayText: queued.displayText, attachments: queued.ipcAttachments)
         }
     }
 
@@ -1257,6 +1264,7 @@ public final class ChatViewModel: ObservableObject {
         sessionError = nil
         errorText = nil
         lastFailedMessageText = nil
+        lastFailedMessageDisplayText = nil
         lastFailedMessageAttachments = nil
         lastFailedSendError = nil
         connectionDiagnosticHint = nil
@@ -1383,10 +1391,12 @@ public final class ChatViewModel: ObservableObject {
     /// Retry sending the last user message that failed (e.g. due to daemon disconnection).
     public func retryLastMessage() {
         guard let text = lastFailedMessageText else { return }
+        let displayText = lastFailedMessageDisplayText
         let attachments = lastFailedMessageAttachments
 
         // Clear failed message state and error
         lastFailedMessageText = nil
+        lastFailedMessageDisplayText = nil
         lastFailedMessageAttachments = nil
         lastFailedSendError = nil
         errorText = nil
@@ -1405,13 +1415,14 @@ public final class ChatViewModel: ObservableObject {
                 // (it was already appended to messages[] during the original
                 // sendMessage() call). Use the last user message with matching
                 // text as the queue entry.
-                if let idx = messages.lastIndex(where: { $0.role == .user && $0.text == text }) {
+                let matchText = displayText ?? text
+                if let idx = messages.lastIndex(where: { $0.role == .user && $0.text == matchText }) {
                     pendingMessageIds.append(messages[idx].id)
                     queuedMessageId = messages[idx].id
                     messages[idx].status = .queued(position: 0)
                 }
             }
-            sendUserMessage(text, attachments: attachments, queuedMessageId: queuedMessageId)
+            sendUserMessage(text, displayText: displayText, attachments: attachments, queuedMessageId: queuedMessageId)
         }
     }
 

--- a/clients/shared/Features/Chat/OfflineMessageQueue.swift
+++ b/clients/shared/Features/Chat/OfflineMessageQueue.swift
@@ -10,13 +10,18 @@ struct OfflineQueuedMessage: Codable, Identifiable {
     let id: UUID
     let sessionId: String?
     let text: String
+    /// The text stored in the ChatMessage for UI matching. In voice mode, `text`
+    /// carries the voice instruction prefix while the ChatMessage stores raw user
+    /// input — this field preserves that raw text so flush can find the right bubble.
+    let displayText: String?
     let attachments: [OfflineQueuedAttachment]
     let enqueuedAt: Date
 
-    init(sessionId: String?, text: String, attachments: [IPCAttachment]?) {
+    init(sessionId: String?, text: String, displayText: String? = nil, attachments: [IPCAttachment]?) {
         self.id = UUID()
         self.sessionId = sessionId
         self.text = text
+        self.displayText = displayText
         self.enqueuedAt = Date()
         self.attachments = (attachments ?? []).map {
             OfflineQueuedAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: $0.extractedText)
@@ -71,8 +76,8 @@ final class OfflineMessageQueue {
     // MARK: - Enqueue
 
     /// Append a message to the end of the offline queue and persist it.
-    func enqueue(sessionId: String?, text: String, attachments: [IPCAttachment]?) {
-        let message = OfflineQueuedMessage(sessionId: sessionId, text: text, attachments: attachments)
+    func enqueue(sessionId: String?, text: String, displayText: String? = nil, attachments: [IPCAttachment]?) {
+        let message = OfflineQueuedMessage(sessionId: sessionId, text: text, displayText: displayText, attachments: attachments)
         queue.append(message)
         save()
         log.info("OfflineMessageQueue: enqueued message (queue depth: \(self.queue.count))")


### PR DESCRIPTION
Addresses review feedback on #8917. Fixes voice-mode text mismatch in the offline message queue where the voice-prefixed text was used for message lookup instead of rawText, preventing pendingOffline status from being set or cleared correctly.

Changes:
- Add displayText parameter to sendUserMessage for UI message matching
- Add displayText field to OfflineQueuedMessage to preserve raw text through the queue
- Pass rawText as displayText from sendMessage() so voice-prefixed text is not used for matching
- Fix flushOfflineQueue to use displayText for clearing pendingOffline status
- Fix retryLastMessage to use displayText for message lookup
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
