### PR TITLE
fix: treat missing APP_VERSION as production in auth bypass guard

### DIFF
--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -352,7 +352,9 @@ export function loadConfig(): GatewayConfig {
   let smsDeliverAuthBypass = smsDeliverAuthBypassRaw === "true";
 
   // Production guard: auth bypass flags must never be active outside dev mode.
-  const appVersion = process.env.APP_VERSION ?? "0.0.0-dev";
+  // Fail closed: treat missing APP_VERSION as production, since the gateway
+  // release pipeline does not inject it (unlike the daemon build).
+  const appVersion = process.env.APP_VERSION;
   const isDevMode = appVersion === "0.0.0-dev";
   if (!isDevMode) {
     if (telegramDeliverAuthBypass) {


### PR DESCRIPTION
Addresses review feedback on #8876. When APP_VERSION is absent or unreadable, the bypass guard now fails closed (treats it as production) instead of defaulting to dev mode. This prevents bypass flags from being active in gateway production builds where APP_VERSION is not injected.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
