### PR TITLE
fix: use gateway-configured token for Twilio relay TwiML

### DIFF
--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -6,7 +6,7 @@
  * - handleConnectAction: called when the ConversationRelay connection ends
  */
 
-import { getCallWelcomeGreeting } from '../config/env.js';
+import { getCallWelcomeGreeting, getRuntimeProxyBearerToken } from '../config/env.js';
 import { loadConfig } from '../config/loader.js';
 import { getTwilioRelayUrl } from '../inbound/public-ingress-urls.js';
 import { getLogger } from '../util/logger.js';
@@ -240,10 +240,9 @@ function buildVoiceWebhookTwiml(
   }
   const welcomeGreeting = buildWelcomeGreeting(task, getCallWelcomeGreeting());
 
-  // Include the gateway bearer token so the WebSocket relay endpoint can
-  // authenticate the connection. Without this, any client that guesses a
-  // callSessionId could inject frames into a live call.
-  const relayToken = readHttpToken() ?? undefined;
+  // Use the same token resolution the gateway uses for runtimeProxyBearerToken:
+  // env var override first, then the on-disk http-token file.
+  const relayToken = getRuntimeProxyBearerToken() ?? readHttpToken() ?? undefined;
 
   const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, profile, relayToken);
 


### PR DESCRIPTION
Addresses review feedback on #8884. Sources the relay token for TwiML from the same configured secret path the gateway uses (RUNTIME_PROXY_BEARER_TOKEN env var first, then http-token file), ensuring consistency when the env var is overridden.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
