### PR TITLE
fix: invalidate recall cache after synchronous segment upserts in indexMessageNow

### DIFF
--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -7,6 +7,7 @@ import { getMemoryCheckpoint, setMemoryCheckpoint } from './checkpoints.js';
 import { getDb } from './db.js';
 import { enqueueMemoryJob, enqueueResolvePendingConflictsForMessageJob } from './jobs-store.js';
 import { extractTextFromStoredMessageContent } from './message-content.js';
+import { bumpMemoryVersion } from './recall-cache.js';
 import { memorySegments } from './schema.js';
 import { segmentText } from './segmenter.js';
 
@@ -113,6 +114,12 @@ export function indexMessageNow(
 
   if (skippedEmbedJobs > 0) {
     log.debug(`Skipped ${skippedEmbedJobs}/${segments.length} embed_segment jobs (content unchanged)`);
+  }
+
+  // Invalidate recall cache when synchronous segment writes changed content,
+  // so lexical/recency retrieval doesn't serve stale results during worker lag.
+  if (segments.length - skippedEmbedJobs > 0) {
+    bumpMemoryVersion();
   }
 
   if (!isTrustedActor && (shouldExtract || shouldResolveConflicts)) {


### PR DESCRIPTION
Addresses review feedback on #8940. Restores cache invalidation in indexMessageNow when synchronous segment writes change memory content, preventing stale recall results during worker lag.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
