### PR TITLE
fix: validate /integrations/status against daemon HTTP token

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -287,7 +287,7 @@ function main() {
       }
 
       if (url.pathname === "/integrations/status" && req.method === "GET") {
-        if (!config.runtimeProxyBearerToken) {
+        if (!config.runtimeBearerToken) {
           return Response.json(
             { error: "Service not configured: bearer token required" },
             { status: 503 },
@@ -295,7 +295,7 @@ function main() {
         }
         const authResult = validateBearerToken(
           tracedReq.headers.get("authorization"),
-          config.runtimeProxyBearerToken,
+          config.runtimeBearerToken,
         );
         if (!authResult.authorized) {
           authRateLimiter.recordFailure(getClientIp(req, svr));


### PR DESCRIPTION
Addresses review feedback on #8904. Changes the /integrations/status endpoint to validate against the daemon HTTP token (runtimeBearerToken) instead of runtimeProxyBearerToken. Clients (macOS, iOS) send the daemon HTTP token from the http-token file, not the runtime proxy token. When RUNTIME_PROXY_BEARER_TOKEN is explicitly overridden, these diverge, causing legitimate clients to consistently receive 401.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
