### PR TITLE
fix: tighten pre-commit safe-line regex to exclude literal secrets in function calls

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -75,8 +75,10 @@ declare -a SAFE_LINE_PATTERNS=(
     # `clientSecret: config.clientSecret || "real_secret"`.
     "[.?]+[a-zA-Z0-9_]*[Cc]lient[Ss]ecret([^\"'/]*$|[^\"'/]*//.*)$"
     # TS/JS: secret/key variable assigned from a function call (no string literal).
-    # E.g. `const clientSecret = getSecureKey(...)`.
-    "(client[_-]?[Ss]ecret|[Pp]rivate[_-]?[Kk]ey)[[:space:]]*=[[:space:]]*(get[A-Za-z]*|create[A-Za-z]*|load[A-Za-z]*|read[A-Za-z]*|delete[A-Za-z]*|set[A-Za-z]*)\("
+    # E.g. `const clientSecret = getSecureKey(keyVault)`.
+    # The [^"']* after `(` ensures the call args contain no quoted strings,
+    # preventing `getSecureKey("sk_live_...")` from being whitelisted.
+    "(client[_-]?[Ss]ecret|[Pp]rivate[_-]?[Kk]ey)[[:space:]]*=[[:space:]]*(get[A-Za-z]*|create[A-Za-z]*|load[A-Za-z]*|read[A-Za-z]*|delete[A-Za-z]*|set[A-Za-z]*)\([^\"']*$"
     # TS/JS: property key followed by type annotation or opening brace.
     # E.g. `requiresClientSecret: boolean;` or `client_secret: {`.
     "[Cc]lient[_-]?[Ss]ecret['\"]?:[[:space:]]*(boolean|number)[[:space:]]*[;,]?"
@@ -182,6 +184,9 @@ if [ "${1:-}" = "--self-test" ]; then
     # Function-call assignments (false positives to whitelist)
     SAFE_FUNC_CALL_SECRET='const clientSecret = getSecureKey(keyVault)'
     SAFE_CREATE_PRIVATE_KEY='const key = createPrivateKey(keyPem)'
+    # Function-call with literal secret in args — must NOT be whitelisted
+    UNSAFE_FUNC_CALL_LITERAL='const clientSecret = getSecureKey("sk_live_12345678901234567890")'
+    UNSAFE_FUNC_CALL_SINGLE_QUOTE="const privateKey = loadPrivateKey('real_secret_key_value_12345')"
     # Type-annotated property (false positive to whitelist)
     SAFE_TYPED_PROP_SECRET='  requiresClientSecret: boolean;'
     # Variable-to-variable assignment (false positive to whitelist)
@@ -376,6 +381,14 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$SAFE_CREATE_PRIVATE_KEY" && ! matches_safe_line_pattern "$SAFE_CREATE_PRIVATE_KEY"; then
         echo -e "${RED}Self-test failed:${NC} createPrivateKey function-call false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$UNSAFE_FUNC_CALL_LITERAL" && matches_safe_line_pattern "$UNSAFE_FUNC_CALL_LITERAL"; then
+        echo -e "${RED}Self-test failed:${NC} function-call with literal secret was incorrectly whitelisted"
+        exit 1
+    fi
+    if matches_secret_pattern "$UNSAFE_FUNC_CALL_SINGLE_QUOTE" && matches_safe_line_pattern "$UNSAFE_FUNC_CALL_SINGLE_QUOTE"; then
+        echo -e "${RED}Self-test failed:${NC} function-call with single-quoted literal secret was incorrectly whitelisted"
         exit 1
     fi
     if matches_secret_pattern "$SAFE_TYPED_PROP_SECRET" && ! matches_safe_line_pattern "$SAFE_TYPED_PROP_SECRET"; then


### PR DESCRIPTION
Addresses review feedback on #8954. Tightens the safe-line pattern in the pre-commit hook to not whitelist function calls that contain string literals with secret-like patterns, preventing false negatives in secret detection.

Changes:
- Added `[^"']*$` after the opening paren in the function-call safe-line pattern, ensuring lines with quoted strings in the call args are not whitelisted
- Added self-test cases for function calls with double-quoted and single-quoted literal secrets
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
