### PR TITLE
fix: ensure embedding migration handles NOT NULL constraint correctly

### DIFF
--- a/assistant/src/memory/migrations/026-embeddings-nullable-vector-json.ts
+++ b/assistant/src/memory/migrations/026-embeddings-nullable-vector-json.ts
@@ -1,4 +1,4 @@
-import { getSqliteFrom, type DrizzleDb } from '../db-connection.js';
+import { type DrizzleDb, getSqliteFrom } from '../db-connection.js';
 
 /**
  * Rebuild memory_embeddings to make vector_json nullable.
@@ -54,11 +54,12 @@ export function migrateEmbeddingsNullableVectorJson(database: DrizzleDb): void {
         vector_blob BLOB,
         content_hash TEXT,
         created_at INTEGER NOT NULL,
-        updated_at INTEGER NOT NULL
+        updated_at INTEGER NOT NULL,
+        UNIQUE (target_type, target_id, provider, model)
       )
     `);
     raw.exec(/*sql*/ `
-      INSERT INTO memory_embeddings_new (
+      INSERT OR IGNORE INTO memory_embeddings_new (
         id, target_type, target_id, provider, model, dimensions,
         vector_json, vector_blob, content_hash, created_at, updated_at
       )
@@ -69,6 +70,10 @@ export function migrateEmbeddingsNullableVectorJson(database: DrizzleDb): void {
     `);
     raw.exec(/*sql*/ `DROP TABLE memory_embeddings`);
     raw.exec(/*sql*/ `ALTER TABLE memory_embeddings_new RENAME TO memory_embeddings`);
+
+    // Recreate indexes destroyed by the DROP TABLE (createCoreIndexes ran earlier)
+    raw.exec(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_embeddings_target_provider_model ON memory_embeddings(target_type, target_id, provider, model)`);
+    raw.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_content_hash ON memory_embeddings(content_hash, provider, model)`);
 
     raw.query(
       `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,


### PR DESCRIPTION
Addresses review feedback on #8909. Ensures the embedding vector blob migration properly handles the NOT NULL → nullable transition for vector_json, preventing crashes on existing databases.

Changes to migration 026 (embeddings-nullable-vector-json):
- Added UNIQUE constraint on (target_type, target_id, provider, model) to the rebuilt table schema, matching 100-core-tables.ts
- Used INSERT OR IGNORE to handle potential duplicates during data copy
- Recreated indexes (idx_memory_embeddings_target_provider_model, idx_memory_embeddings_content_hash) that get destroyed when DROP TABLE removes the old table, since createCoreIndexes runs earlier in the startup sequence
- Fixed import sort order
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
