### PR TITLE
fix: preserve previousApp across quick input panel recreations

### DIFF
--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
@@ -149,8 +149,13 @@ final class QuickInputWindow {
     // MARK: - Panel Creation & Presentation
 
     private func makePanel() -> NSPanel {
-        // Remember the frontmost app so we can restore focus on dismiss
-        previousApp = NSWorkspace.shared.frontmostApplication
+        // Remember the frontmost app so we can restore focus on dismiss.
+        // Only capture on first invocation — panel recreation (e.g. after
+        // screenshot capture) happens while Vellum is frontmost, so
+        // overwriting would lose the original app reference.
+        if previousApp == nil {
+            previousApp = NSWorkspace.shared.frontmostApplication
+        }
 
         if let existing = panel {
             existing.makeKeyAndOrderFront(nil)


### PR DESCRIPTION
## Summary
- Only capture `previousApp` on first `makePanel()` call, not on subsequent recreations
- Screenshot/attachment flows recreate the panel while Vellum is frontmost, which was overwriting `previousApp` with Vellum itself
- After submit, focus now correctly restores to the user's original app

## Original prompt
Addresses review feedback from #8986.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
