### PR TITLE
fix: restore UNIQUE constraint in vector_json nullable migration (#8955)

### DIFF
--- a/assistant/src/memory/migrations/026-embeddings-nullable-vector-json.ts
+++ b/assistant/src/memory/migrations/026-embeddings-nullable-vector-json.ts
@@ -54,7 +54,8 @@ export function migrateEmbeddingsNullableVectorJson(database: DrizzleDb): void {
         vector_blob BLOB,
         content_hash TEXT,
         created_at INTEGER NOT NULL,
-        updated_at INTEGER NOT NULL
+        updated_at INTEGER NOT NULL,
+        UNIQUE (target_type, target_id, provider, model)
       )
     `);
     raw.exec(/*sql*/ `


### PR DESCRIPTION
Addresses review feedback on #8955.

Both Codex and Devin identified that the table rebuild in migration 026 drops the UNIQUE constraint on (target_type, target_id, provider, model). This constraint is required by the onConflictDoUpdate upserts in job-utils.ts. Without it, SQLite raises 'ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint' on every embedding insert for upgraded pre-100 databases.

Fix: add the missing UNIQUE constraint to the CREATE TABLE statement for the rebuilt table.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
