### PR TITLE
fix: avoid duplicate unique index on memory_embeddings

### DIFF
--- a/assistant/src/memory/migrations/104-core-indexes.ts
+++ b/assistant/src/memory/migrations/104-core-indexes.ts
@@ -40,8 +40,8 @@ export function createCoreIndexes(database: DrizzleDb): void {
     ON memory_items(status, invalid_at, last_seen_at DESC, subject, statement, id, kind, confidence, importance, first_seen_at, scope_id)
     WHERE status = 'active' AND invalid_at IS NULL
   `);
-  // Deduplicate before creating unique index — existing DBs may have duplicate (target_type, target_id, provider, model) tuples.
-  // Keep the most recently updated row per group, delete the rest.
+  // Deduplicate — existing DBs may have duplicate (target_type, target_id, provider, model) tuples
+  // from before the table-level UNIQUE constraint was enforced. Keep the most recent row per group.
   {
     const rawEmb = getSqliteFrom(database);
     rawEmb.exec(/*sql*/ `
@@ -54,7 +54,10 @@ export function createCoreIndexes(database: DrizzleDb): void {
   }
   database.run(/*sql*/ `DROP INDEX IF EXISTS idx_memory_embeddings_target`);
   database.run(/*sql*/ `DROP INDEX IF EXISTS idx_memory_embeddings_provider_model`);
-  database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_embeddings_target_provider_model ON memory_embeddings(target_type, target_id, provider, model)`);
+  // The table-level UNIQUE(target_type, target_id, provider, model) in 100-core-tables.ts already
+  // creates an autoindex that SQLite uses for ON CONFLICT upserts. Drop the explicit index if a
+  // previous run of this migration created it, to avoid a duplicate B-tree.
+  database.run(/*sql*/ `DROP INDEX IF EXISTS idx_memory_embeddings_target_provider_model`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_content_hash ON memory_embeddings(content_hash, provider, model)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_jobs_status_run_after ON memory_jobs(status, run_after)`);
   database.run(/*sql*/ `


### PR DESCRIPTION
Addresses review feedback on #8972. The table-level UNIQUE(target_type, target_id, provider, model) constraint in 100-core-tables.ts already creates an autoindex that SQLite uses for ON CONFLICT upserts. The explicit CREATE UNIQUE INDEX added in #8972 was creating a duplicate B-tree on the same columns, increasing write cost and DB size. This PR drops the explicit index (if it was created by a previous migration run) and relies on the autoindex instead. The deduplication logic is retained for existing DBs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
