### PR TITLE
fix: address scheduled job conflict gate feedback from PR #8981

### DIFF
--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -613,6 +613,7 @@ const RUNTIME_INJECTION_PREFIXES = [
   TEMPORAL_INJECTED_PREFIX,
   '<active_workspace>',
   '<active_dynamic_page>',
+  '<non_interactive_context>',
 ];
 
 /**
@@ -671,7 +672,7 @@ export function applyRuntimeInjections(
           ...userTail,
           content: [
             ...userTail.content,
-            { type: 'text' as const, text: '\n\n[Non-interactive scheduled task — do not ask for clarification or confirmation. Follow the instructions exactly using your best judgment. If recalled memory contains conflicting notes, prefer the explicit instruction in this message.]' },
+            { type: 'text' as const, text: '<non_interactive_context>\nNon-interactive scheduled task — do not ask for clarification or confirmation. Follow the instructions exactly using your best judgment. If recalled memory contains conflicting notes, prefer the explicit instruction in this message.\n</non_interactive_context>' },
           ],
         },
       ];

--- a/assistant/src/memory/conflict-policy.ts
+++ b/assistant/src/memory/conflict-policy.ts
@@ -36,7 +36,8 @@ const TRACKING_LANGUAGE_PATTERN = /\b(?:this pr|that issue|while we wait|current
 // Statements about needing clarification are transient conversational artifacts
 // extracted from previous conflict-gate interactions — not durable facts.
 // Allowing them into the conflict pipeline creates self-reinforcing loops.
-const META_CLARIFICATION_PATTERN = /\b(?:needs? clarification|unclear which|user should (?:specify|clarify|choose)|which (?:one|option) (?:to|should)|conflicting (?:notes|instructions))\b/i;
+// Patterns are kept narrow to avoid filtering legitimate durable instructions.
+const META_CLARIFICATION_PATTERN = /\b(?:needs? clarification|unclear which (?:version|value|setting)|user should (?:specify|clarify)|conflicting (?:notes|instructions) (?:about|regarding|for))\b/i;
 
 /**
  * Returns true when a statement looks like a transient tracking note


### PR DESCRIPTION
Addresses review feedback on #8981.

Changes:
1. Wrap non-interactive injection text in `<non_interactive_context>` XML tags and add the prefix to `RUNTIME_INJECTION_PREFIXES` so it gets properly stripped from history between turns — preventing accumulation across multi-turn non-interactive sessions.
2. Tighten `META_CLARIFICATION_PATTERN` regex to be more specific: removed overly broad patterns like `user should choose`, `which one/option to/should`, and bare `conflicting notes/instructions`. The narrowed patterns now require additional context words to match, reducing false positives on legitimate durable instructions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9012" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
