### PR TITLE
fix: address rate limiting feedback from PR #8916

### DIFF
--- a/gateway/src/auth-rate-limiter.ts
+++ b/gateway/src/auth-rate-limiter.ts
@@ -24,9 +24,13 @@ export class AuthRateLimiter {
     let timestamps = this.failures.get(ip);
 
     if (!timestamps) {
-      // Evict stale entries if the map grows too large
       if (this.failures.size >= MAX_TRACKED_IPS) {
         this.evictStale(now);
+        // Hard-cap: if still at capacity after eviction, drop the oldest entry
+        if (this.failures.size >= MAX_TRACKED_IPS) {
+          const oldest = this.failures.keys().next().value;
+          if (oldest !== undefined) this.failures.delete(oldest);
+        }
       }
       timestamps = [];
       this.failures.set(ip, timestamps);

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -78,6 +78,8 @@ export type GatewayConfig = {
   whatsappTimeoutMs: number;
   whatsappMaxRetries: number;
   whatsappInitialBackoffMs: number;
+  /** When true, trust X-Forwarded-For for client IP resolution (set when behind a reverse proxy). */
+  trustProxy: boolean;
 };
 
 function parseRoutingJson(raw: string): RoutingEntry[] {
@@ -371,6 +373,14 @@ export function loadConfig(): GatewayConfig {
     }
   }
 
+  const trustProxyRaw = process.env.GATEWAY_TRUST_PROXY;
+  if (trustProxyRaw !== undefined && trustProxyRaw !== "true" && trustProxyRaw !== "false") {
+    throw new Error(
+      `GATEWAY_TRUST_PROXY must be "true" or "false", got "${trustProxyRaw}"`,
+    );
+  }
+  const trustProxy = trustProxyRaw === "true";
+
   const ingressPublicBaseUrl = process.env.INGRESS_PUBLIC_BASE_URL || undefined;
 
   // Assistant email from workspace config file
@@ -421,6 +431,7 @@ export function loadConfig(): GatewayConfig {
       hasWhatsAppAppSecret: !!whatsappAppSecret,
       hasWhatsAppWebhookVerifyToken: !!whatsappWebhookVerifyToken,
       whatsappDeliverAuthBypass,
+      trustProxy,
     },
     "Configuration loaded",
   );
@@ -467,5 +478,6 @@ export function loadConfig(): GatewayConfig {
     whatsappTimeoutMs,
     whatsappMaxRetries,
     whatsappInitialBackoffMs,
+    trustProxy,
   };
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -38,12 +38,13 @@ let draining = false;
 // Shared rate limiter for auth failures and unauthenticated endpoints
 const authRateLimiter = new AuthRateLimiter();
 
-function getClientIp(req: Request, server: ReturnType<typeof Bun.serve>): string {
-  // Prefer X-Forwarded-For when behind a reverse proxy
-  const forwarded = req.headers.get("x-forwarded-for");
-  if (forwarded) {
-    const first = forwarded.split(",")[0].trim();
-    if (first) return first;
+function getClientIp(req: Request, server: ReturnType<typeof Bun.serve>, trustProxy: boolean): string {
+  if (trustProxy) {
+    const forwarded = req.headers.get("x-forwarded-for");
+    if (forwarded) {
+      const first = forwarded.split(",")[0].trim();
+      if (first) return first;
+    }
   }
   const addr = server.requestIP(req);
   return addr?.address ?? "unknown";
@@ -166,14 +167,16 @@ function main() {
 
       // Rate-limit check for auth-protected and pairing endpoints.
       // Checked early so blocked IPs are rejected before any work.
-      const isAuthRoute = url.pathname.startsWith("/v1/") ||
-        url.pathname === "/integrations/status" ||
+      const isAuthRoute = url.pathname === "/integrations/status" ||
         url.pathname === "/deliver/telegram" ||
         url.pathname === "/deliver/sms" ||
         url.pathname === "/deliver/whatsapp" ||
-        url.pathname.startsWith("/pairing/");
+        url.pathname.startsWith("/pairing/") ||
+        (url.pathname.startsWith("/v1/") &&
+          !url.pathname.startsWith("/v1/calls/twilio/") &&
+          url.pathname !== "/v1/calls/relay");
       if (isAuthRoute) {
-        const clientIp = getClientIp(req, svr);
+        const clientIp = getClientIp(req, svr, config.trustProxy);
         if (authRateLimiter.isBlocked(clientIp)) {
           log.warn({ ip: clientIp, path: url.pathname }, "Auth rate limit exceeded");
           return Response.json(
@@ -213,7 +216,7 @@ function main() {
         }
         const res = await handleTelegramDeliver(tracedReq);
         if (res.status === 401) {
-          authRateLimiter.recordFailure(getClientIp(req, svr));
+          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
         }
         return res;
       }
@@ -246,7 +249,7 @@ function main() {
       if (url.pathname === "/deliver/sms") {
         const res = await handleSmsDeliver(tracedReq);
         if (res.status === 401) {
-          authRateLimiter.recordFailure(getClientIp(req, svr));
+          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
         }
         return res;
       }
@@ -270,7 +273,7 @@ function main() {
         }
         const res = await handleWhatsAppDeliver(tracedReq);
         if (res.status === 401) {
-          authRateLimiter.recordFailure(getClientIp(req, svr));
+          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
         }
         return res;
       }
@@ -298,7 +301,7 @@ function main() {
           config.runtimeBearerToken,
         );
         if (!authResult.authorized) {
-          authRateLimiter.recordFailure(getClientIp(req, svr));
+          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
           return Response.json({ error: "Unauthorized" }, { status: 401 });
         }
         return Response.json({
@@ -313,14 +316,14 @@ function main() {
       if (url.pathname === "/pairing/request" && tracedReq.method === "POST") {
         const res = await pairingProxy.handlePairingRequest(tracedReq);
         if (res.status === 401 || res.status === 403) {
-          authRateLimiter.recordFailure(getClientIp(req, svr));
+          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
         }
         return res;
       }
       if (url.pathname === "/pairing/status" && tracedReq.method === "GET") {
         const res = await pairingProxy.handlePairingStatus(tracedReq);
         if (res.status === 401 || res.status === 403) {
-          authRateLimiter.recordFailure(getClientIp(req, svr));
+          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
         }
         return res;
       }
@@ -328,7 +331,7 @@ function main() {
       if (handleRuntimeProxy) {
         const res = await handleRuntimeProxy(tracedReq);
         if (res.status === 401) {
-          authRateLimiter.recordFailure(getClientIp(req, svr));
+          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
         }
         return res;
       }


### PR DESCRIPTION
Addresses review feedback on #8916.

Three changes:

1. **X-Forwarded-For trust gate**: Added `GATEWAY_TRUST_PROXY` config flag. `getClientIp` only reads `X-Forwarded-For` when `trustProxy` is enabled, otherwise uses `server.requestIP()`. Prevents attackers from spoofing IPs to bypass or abuse rate limiting.

2. **Enforce MAX_TRACKED_IPS hard cap**: After `evictStale()`, if the map is still at capacity, the oldest insertion-order entry is evicted before admitting a new IP. Prevents unbounded memory growth under distributed attack traffic.

3. **Exclude webhook routes from auth rate limiting**: `/v1/calls/twilio/*` and `/v1/calls/relay` are unauthenticated webhook endpoints and should not be gated by the auth failure rate limiter.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
