### PR TITLE
fix: propagate isInteractive flag through message queue for non-interactive paths

### DIFF
--- a/assistant/src/daemon/session-messaging.ts
+++ b/assistant/src/daemon/session-messaging.ts
@@ -62,6 +62,7 @@ export function enqueueMessage(
   activeSurfaceId?: string,
   currentPage?: string,
   metadata?: Record<string, unknown>,
+  options?: { isInteractive?: boolean },
 ): { queued: boolean; rejected?: boolean; requestId: string } {
   if (!ctx.processing) {
     return { queued: false, requestId };
@@ -79,6 +80,7 @@ export function enqueueMessage(
     metadata,
     turnChannelContext,
     turnInterfaceContext,
+    isInteractive: options?.isInteractive,
     queuedAt: Date.now(),
   });
   if (!pushed) {

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -301,7 +301,9 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
   // Fire-and-forget: persistUserMessage set session.processing = true
   // so subsequent messages will still be enqueued.
   // runAgentLoop's finally block will call drainQueue when this run completes.
-  session.runAgentLoop(resolvedContent, userMessageId, next.onEvent).catch((err) => {
+  session.runAgentLoop(resolvedContent, userMessageId, next.onEvent,
+    next.isInteractive !== undefined ? { isInteractive: next.isInteractive } : undefined,
+  ).catch((err) => {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, conversationId: session.conversationId, requestId: next.requestId }, 'Error processing queued message');
     next.onEvent({ type: 'error', message: `Failed to process queued message: ${message}` });

--- a/assistant/src/daemon/session-queue-manager.ts
+++ b/assistant/src/daemon/session-queue-manager.ts
@@ -21,6 +21,8 @@ export interface QueuedMessage {
   metadata?: Record<string, unknown>;
   turnChannelContext?: TurnChannelContext;
   turnInterfaceContext?: TurnInterfaceContext;
+  /** When false, the turn has no interactive user and should skip clarification prompts. */
+  isInteractive?: boolean;
   /** Timestamp (ms) when the message was enqueued. */
   queuedAt: number;
 }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -390,8 +390,9 @@ export class Session {
     activeSurfaceId?: string,
     currentPage?: string,
     metadata?: Record<string, unknown>,
+    options?: { isInteractive?: boolean },
   ): { queued: boolean; rejected?: boolean; requestId: string } {
-    return enqueueMessageImpl(this, content, attachments, onEvent, requestId, activeSurfaceId, currentPage, metadata);
+    return enqueueMessageImpl(this, content, attachments, onEvent, requestId, activeSurfaceId, currentPage, metadata, options);
   }
 
   getQueueDepth(): number {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -314,6 +314,7 @@ export async function handleSendMessage(
           userMessageInterface: sourceInterface,
           assistantMessageInterface: sourceInterface,
         },
+        { isInteractive: false },
       );
       if (result.rejected) {
         return Response.json(


### PR DESCRIPTION
Addresses review feedback on #8931.

When handleSendMessage enqueues a turn (busy-path), the isInteractive: false flag was lost because drainQueue called runAgentLoop without passing the flag. This meant queued HTTP/Telegram turns could trigger conflict clarification prompts even though no user was present to answer them.

Threads the isInteractive flag through QueuedMessage so the non-interactive signal survives the enqueue/drain cycle.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
