### PR TITLE
M3: Generic Daemon OAuth Connect IPC

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -10,6 +10,7 @@ exports[`IPC message snapshots ClientMessage types auth serializes to expected J
 exports[`IPC message snapshots ClientMessage types user_message serializes to expected JSON 1`] = `
 {
   "content": "Hello, assistant!",
+  "interface": "cli",
   "sessionId": "sess-001",
   "type": "user_message",
 }
@@ -41,6 +42,7 @@ exports[`IPC message snapshots ClientMessage types session_create serializes to 
     "hints": [
       "dashboard-capable",
     ],
+    "interfaceId": "macos",
     "uxBrief": "Prefer dashboard-first onboarding.",
   },
   "type": "session_create",
@@ -51,6 +53,14 @@ exports[`IPC message snapshots ClientMessage types session_switch serializes to 
 {
   "sessionId": "sess-002",
   "type": "session_switch",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types session_rename serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-002",
+  "title": "Renamed session",
+  "type": "session_rename",
 }
 `;
 
@@ -305,6 +315,31 @@ exports[`IPC message snapshots ClientMessage types skills_inspect serializes to 
 {
   "slug": "clawhub/my-skill",
   "type": "skills_inspect",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_draft serializes to expected JSON 1`] = `
+{
+  "sourceText": "Create a weather skill",
+  "type": "skills_draft",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_create serializes to expected JSON 1`] = `
+{
+  "bodyMarkdown": 
+"# Weather
+
+Fetches weather data."
+,
+  "description": "Fetches current weather",
+  "disableModelInvocation": false,
+  "emoji": "🌤️",
+  "name": "Weather Skill",
+  "overwrite": false,
+  "skillId": "weather-skill",
+  "type": "skills_create",
+  "userInvocable": true,
 }
 `;
 
@@ -589,6 +624,13 @@ exports[`IPC message snapshots ClientMessage types ingress_config serializes to 
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types platform_config serializes to expected JSON 1`] = `
+{
+  "action": "get",
+  "type": "platform_config",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types vercel_api_config serializes to expected JSON 1`] = `
 {
   "action": "get",
@@ -713,6 +755,16 @@ exports[`IPC message snapshots ClientMessage types integration_disconnect serial
 {
   "integrationId": "gmail",
   "type": "integration_disconnect",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types oauth_connect_start serializes to expected JSON 1`] = `
+{
+  "requestedScopes": [
+    "https://www.googleapis.com/auth/gmail.readonly",
+  ],
+  "service": "gmail",
+  "type": "oauth_connect_start",
 }
 `;
 
@@ -1033,6 +1085,33 @@ exports[`IPC message snapshots ClientMessage types assistant_inbox_reply seriali
   "content": "Hello from the assistant",
   "conversationId": "conv-001",
   "type": "assistant_inbox_reply",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types pairing_approval_response serializes to expected JSON 1`] = `
+{
+  "decision": "approve_once",
+  "pairingRequestId": "pair-001",
+  "type": "pairing_approval_response",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types approved_devices_list serializes to expected JSON 1`] = `
+{
+  "type": "approved_devices_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types approved_device_remove serializes to expected JSON 1`] = `
+{
+  "hashedDeviceId": "hashed-device-001",
+  "type": "approved_device_remove",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types approved_devices_clear serializes to expected JSON 1`] = `
+{
+  "type": "approved_devices_clear",
 }
 `;
 
@@ -1656,6 +1735,25 @@ Does things."
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types skills_draft_response serializes to expected JSON 1`] = `
+{
+  "draft": {
+    "bodyMarkdown": 
+"# Weather
+
+Fetches weather data."
+,
+    "description": "Fetches current weather",
+    "emoji": "🌤️",
+    "name": "Weather Skill",
+    "skillId": "weather-skill",
+  },
+  "success": true,
+  "type": "skills_draft_response",
+  "warnings": [],
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types suggestion_response serializes to expected JSON 1`] = `
 {
   "requestId": "req-suggest-001",
@@ -1696,6 +1794,18 @@ exports[`IPC message snapshots ServerMessage types reminder_fired serializes to 
   "message": "Remember to call Sidd about the project",
   "reminderId": "rem-001",
   "type": "reminder_fired",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types notification_intent serializes to expected JSON 1`] = `
+{
+  "body": "Your assistant needs your input.",
+  "deepLinkMetadata": {
+    "conversationId": "conv-guardian-001",
+  },
+  "sourceEventName": "guardian.question",
+  "title": "⚠️ Attention needed",
+  "type": "notification_intent",
 }
 `;
 
@@ -2063,6 +2173,14 @@ exports[`IPC message snapshots ServerMessage types ingress_config_response seria
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types platform_config_response serializes to expected JSON 1`] = `
+{
+  "baseUrl": "https://platform.vellum.ai",
+  "success": true,
+  "type": "platform_config_response",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types vercel_api_config_response serializes to expected JSON 1`] = `
 {
   "hasToken": true,
@@ -2349,6 +2467,17 @@ exports[`IPC message snapshots ServerMessage types integration_connect_result se
   "integrationId": "gmail",
   "success": true,
   "type": "integration_connect_result",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types oauth_connect_result serializes to expected JSON 1`] = `
+{
+  "accountInfo": "user@example.com",
+  "grantedScopes": [
+    "https://www.googleapis.com/auth/gmail.readonly",
+  ],
+  "success": true,
+  "type": "oauth_connect_result",
 }
 `;
 
@@ -2881,33 +3010,6 @@ exports[`IPC message snapshots ServerMessage types assistant_inbox_reply_respons
 }
 `;
 
-exports[`IPC message snapshots ClientMessage types pairing_approval_response serializes to expected JSON 1`] = `
-{
-  "decision": "approve_once",
-  "pairingRequestId": "pair-001",
-  "type": "pairing_approval_response",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types approved_devices_list serializes to expected JSON 1`] = `
-{
-  "type": "approved_devices_list",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types approved_device_remove serializes to expected JSON 1`] = `
-{
-  "hashedDeviceId": "hashed-device-001",
-  "type": "approved_device_remove",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types approved_devices_clear serializes to expected JSON 1`] = `
-{
-  "type": "approved_devices_clear",
-}
-`;
-
 exports[`IPC message snapshots ServerMessage types pairing_approval_request serializes to expected JSON 1`] = `
 {
   "deviceId": "device-001",
@@ -2934,84 +3036,5 @@ exports[`IPC message snapshots ServerMessage types approved_device_remove_respon
 {
   "success": true,
   "type": "approved_device_remove_response",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types session_rename serializes to expected JSON 1`] = `
-{
-  "sessionId": "sess-002",
-  "title": "Renamed session",
-  "type": "session_rename",
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types notification_intent serializes to expected JSON 1`] = `
-{
-  "body": "Your assistant needs your input.",
-  "deepLinkMetadata": {
-    "conversationId": "conv-guardian-001",
-  },
-  "sourceEventName": "guardian.question",
-  "title": "⚠️ Attention needed",
-  "type": "notification_intent",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types skills_draft serializes to expected JSON 1`] = `
-{
-  "sourceText": "Create a weather skill",
-  "type": "skills_draft",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types skills_create serializes to expected JSON 1`] = `
-{
-  "bodyMarkdown": 
-"# Weather
-
-Fetches weather data."
-,
-  "description": "Fetches current weather",
-  "disableModelInvocation": false,
-  "emoji": "🌤️",
-  "name": "Weather Skill",
-  "overwrite": false,
-  "skillId": "weather-skill",
-  "type": "skills_create",
-  "userInvocable": true,
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types platform_config serializes to expected JSON 1`] = `
-{
-  "action": "get",
-  "type": "platform_config",
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types skills_draft_response serializes to expected JSON 1`] = `
-{
-  "draft": {
-    "bodyMarkdown": 
-"# Weather
-
-Fetches weather data."
-,
-    "description": "Fetches current weather",
-    "emoji": "🌤️",
-    "name": "Weather Skill",
-    "skillId": "weather-skill",
-  },
-  "success": true,
-  "type": "skills_draft_response",
-  "warnings": [],
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types platform_config_response serializes to expected JSON 1`] = `
-{
-  "baseUrl": "https://platform.vellum.ai",
-  "success": true,
-  "type": "platform_config_response",
 }
 `;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -476,6 +476,11 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'integration_disconnect',
     integrationId: 'gmail',
   },
+  oauth_connect_start: {
+    type: 'oauth_connect_start',
+    service: 'gmail',
+    requestedScopes: ['https://www.googleapis.com/auth/gmail.readonly'],
+  },
   browser_cdp_response: {
     type: 'browser_cdp_response',
     sessionId: 'test-session',
@@ -1559,6 +1564,12 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     type: 'integration_connect_result',
     integrationId: 'gmail',
     success: true,
+  },
+  oauth_connect_result: {
+    type: 'oauth_connect_result',
+    success: true,
+    grantedScopes: ['https://www.googleapis.com/auth/gmail.readonly'],
+    accountInfo: 'user@example.com',
   },
   browser_cdp_request: {
     type: 'browser_cdp_request',

--- a/assistant/src/__tests__/oauth-connect-handler.test.ts
+++ b/assistant/src/__tests__/oauth-connect-handler.test.ts
@@ -1,0 +1,346 @@
+import { mkdtempSync } from 'node:fs';
+import * as net from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'handlers-oauth-connect-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  getIpcBlobDir: () => join(testDir, 'ipc-blobs'),
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({}),
+  loadConfig: () => ({ ingress: { publicBaseUrl: 'https://test.example.com' } }),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  saveConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module('../inbound/public-ingress-urls.js', () => ({
+  getPublicBaseUrl: () => 'https://test.example.com',
+  getOAuthCallbackUrl: () => 'https://test.example.com/webhooks/oauth/callback',
+}));
+
+// Mock secure key storage
+let secureKeyStore: Record<string, string> = {};
+
+mock.module('../security/secure-keys.js', () => ({
+  getSecureKey: (account: string) => secureKeyStore[account] ?? undefined,
+  setSecureKey: (account: string, value: string) => {
+    secureKeyStore[account] = value;
+    return true;
+  },
+  deleteSecureKey: (account: string) => {
+    if (account in secureKeyStore) {
+      delete secureKeyStore[account];
+      return true;
+    }
+    return false;
+  },
+  listSecureKeys: () => Object.keys(secureKeyStore),
+  getBackendType: () => 'encrypted',
+  isDowngradedFromKeychain: () => false,
+  _resetBackend: () => {},
+  _setBackend: () => {},
+}));
+
+// Mock orchestrateOAuthConnect
+import type { OAuthConnectResult } from '../oauth/connect-types.js';
+
+let orchestratorResult: OAuthConnectResult | null = null;
+let orchestratorError: Error | null = null;
+let lastOrchestratorOptions: Record<string, unknown> | undefined;
+
+mock.module('../oauth/connect-orchestrator.js', () => ({
+  orchestrateOAuthConnect: async (options: Record<string, unknown>) => {
+    lastOrchestratorOptions = options;
+    if (orchestratorError) throw orchestratorError;
+    return orchestratorResult;
+  },
+}));
+
+// Mock credential metadata store
+mock.module('../tools/credentials/metadata-store.js', () => ({
+  getCredentialMetadata: () => undefined,
+  upsertCredentialMetadata: () => ({}),
+  deleteCredentialMetadata: () => false,
+  listCredentialMetadata: () => [],
+  assertMetadataWritable: () => {},
+  _setMetadataPath: () => {},
+}));
+
+// Mock OAuth2 flow (required by other handlers that may be loaded transitively)
+mock.module('../security/oauth2.js', () => ({
+  startOAuth2Flow: async () => ({}),
+  prepareOAuth2Flow: async () => ({}),
+}));
+
+import { handleMessage, type HandlerContext } from '../daemon/handlers.js';
+import type {
+  OAuthConnectStartRequest,
+  ServerMessage,
+} from '../daemon/ipc-contract.js';
+import { DebouncerMap } from '../util/debounce.js';
+
+function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
+  const sent: ServerMessage[] = [];
+  const ctx: HandlerContext = {
+    sessions: new Map(),
+    socketToSession: new Map(),
+    cuSessions: new Map(),
+    socketToCuSession: new Map(),
+    cuObservationParseSequence: new Map(),
+    socketSandboxOverride: new Map(),
+    sharedRequestTimestamps: [],
+    debounceTimers: new DebouncerMap({ defaultDelayMs: 200 }),
+    suppressConfigReload: false,
+    setSuppressConfigReload: () => {},
+    updateConfigFingerprint: () => {},
+    send: (_socket, msg) => { sent.push(msg); },
+    broadcast: () => {},
+    clearAllSessions: () => 0,
+    getOrCreateSession: () => { throw new Error('not implemented'); },
+    touchSession: () => {},
+  };
+  return { ctx, sent };
+}
+
+describe('OAuth connect handler', () => {
+  beforeEach(() => {
+    secureKeyStore = {};
+    orchestratorResult = null;
+    orchestratorError = null;
+    lastOrchestratorOptions = undefined;
+  });
+
+  test('missing service returns error', async () => {
+    const msg = { type: 'oauth_connect_start' } as unknown as OAuthConnectStartRequest;
+    const { ctx, sent } = createTestContext();
+    await handleMessage(msg, {} as net.Socket, ctx);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    const result = sent.find((m) => m.type === 'oauth_connect_result') as {
+      type: string;
+      success: boolean;
+      error?: string;
+    };
+    expect(result).toBeDefined();
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('service');
+  });
+
+  test('missing client_id returns error', async () => {
+    const msg: OAuthConnectStartRequest = {
+      type: 'oauth_connect_start',
+      service: 'gmail',
+    };
+    const { ctx, sent } = createTestContext();
+    await handleMessage(msg, {} as net.Socket, ctx);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    const result = sent.find((m) => m.type === 'oauth_connect_result') as {
+      type: string;
+      success: boolean;
+      error?: string;
+    };
+    expect(result).toBeDefined();
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('client_id');
+  });
+
+  test('successful orchestration returns correct IPC response', async () => {
+    secureKeyStore['credential:integration:gmail:client_id'] = 'test-client-id';
+    secureKeyStore['credential:integration:gmail:client_secret'] = 'test-client-secret';
+
+    orchestratorResult = {
+      success: true,
+      deferred: false,
+      grantedScopes: ['https://www.googleapis.com/auth/gmail.readonly'],
+      accountInfo: 'user@example.com',
+    };
+
+    const msg: OAuthConnectStartRequest = {
+      type: 'oauth_connect_start',
+      service: 'gmail',
+      requestedScopes: ['https://www.googleapis.com/auth/gmail.readonly'],
+    };
+    const { ctx, sent } = createTestContext();
+    await handleMessage(msg, {} as net.Socket, ctx);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const result = sent.find((m) => m.type === 'oauth_connect_result') as {
+      type: string;
+      success: boolean;
+      grantedScopes?: string[];
+      accountInfo?: string;
+    };
+    expect(result).toBeDefined();
+    expect(result.success).toBe(true);
+    expect(result.grantedScopes).toEqual(['https://www.googleapis.com/auth/gmail.readonly']);
+    expect(result.accountInfo).toBe('user@example.com');
+
+    // Verify orchestrator was called with correct options
+    expect(lastOrchestratorOptions).toBeDefined();
+    expect(lastOrchestratorOptions!.service).toBe('gmail');
+    expect(lastOrchestratorOptions!.clientId).toBe('test-client-id');
+    expect(lastOrchestratorOptions!.clientSecret).toBe('test-client-secret');
+    expect(lastOrchestratorOptions!.isInteractive).toBe(true);
+    expect(lastOrchestratorOptions!.requestedScopes).toEqual(['https://www.googleapis.com/auth/gmail.readonly']);
+  });
+
+  test('orchestrator error returns sanitized failure', async () => {
+    secureKeyStore['credential:integration:gmail:client_id'] = 'test-client-id';
+
+    orchestratorResult = {
+      success: false,
+      error: 'Scope "admin" is forbidden for integration:gmail',
+    };
+
+    const msg: OAuthConnectStartRequest = {
+      type: 'oauth_connect_start',
+      service: 'gmail',
+    };
+    const { ctx, sent } = createTestContext();
+    await handleMessage(msg, {} as net.Socket, ctx);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const result = sent.find((m) => m.type === 'oauth_connect_result') as {
+      type: string;
+      success: boolean;
+      error?: string;
+    };
+    expect(result).toBeDefined();
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('forbidden');
+  });
+
+  test('exception during orchestration returns generic error', async () => {
+    secureKeyStore['credential:integration:twitter:client_id'] = 'test-client-id';
+
+    orchestratorError = new Error('OAuth2 flow timed out waiting for user authorization');
+
+    const msg: OAuthConnectStartRequest = {
+      type: 'oauth_connect_start',
+      service: 'twitter',
+    };
+    const { ctx, sent } = createTestContext();
+    await handleMessage(msg, {} as net.Socket, ctx);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const result = sent.find((m) => m.type === 'oauth_connect_result') as {
+      type: string;
+      success: boolean;
+      error?: string;
+    };
+    expect(result).toBeDefined();
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('timed out');
+  });
+
+  test('oauth_client_id key variant is also checked', async () => {
+    // Store with the oauth_client_id variant
+    secureKeyStore['credential:integration:twitter:oauth_client_id'] = 'test-client-id-alt';
+
+    orchestratorResult = {
+      success: true,
+      deferred: false,
+      grantedScopes: ['tweet.read'],
+      accountInfo: '@testuser',
+    };
+
+    const msg: OAuthConnectStartRequest = {
+      type: 'oauth_connect_start',
+      service: 'twitter',
+    };
+    const { ctx, sent } = createTestContext();
+    await handleMessage(msg, {} as net.Socket, ctx);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const result = sent.find((m) => m.type === 'oauth_connect_result') as {
+      type: string;
+      success: boolean;
+    };
+    expect(result).toBeDefined();
+    expect(result.success).toBe(true);
+
+    // Verify the alt key was used
+    expect(lastOrchestratorOptions!.clientId).toBe('test-client-id-alt');
+  });
+
+  test('openUrl callback sends open_url IPC message', async () => {
+    secureKeyStore['credential:integration:gmail:client_id'] = 'test-client-id';
+
+    // We need to capture the openUrl callback and invoke it
+    orchestratorResult = {
+      success: true,
+      deferred: false,
+      grantedScopes: [],
+    };
+
+    // Override mock to call openUrl
+    const originalResult = orchestratorResult;
+    let capturedOpenUrl: ((url: string) => void) | undefined;
+    mock.module('../oauth/connect-orchestrator.js', () => ({
+      orchestrateOAuthConnect: async (options: Record<string, unknown>) => {
+        lastOrchestratorOptions = options;
+        capturedOpenUrl = options.openUrl as (url: string) => void;
+        if (capturedOpenUrl) {
+          capturedOpenUrl('https://accounts.google.com/o/oauth2/v2/auth?test=1');
+        }
+        return originalResult;
+      },
+    }));
+
+    const msg: OAuthConnectStartRequest = {
+      type: 'oauth_connect_start',
+      service: 'gmail',
+    };
+    const { ctx, sent } = createTestContext();
+
+    // Need to re-import to get the new mock
+    const { handleOAuthConnectStart } = await import('../daemon/handlers/oauth-connect.js');
+    await handleOAuthConnectStart(msg, {} as net.Socket, ctx);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const openUrlMsg = sent.find((m) => m.type === 'open_url');
+    expect(openUrlMsg).toBeDefined();
+  });
+});

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -14,6 +14,7 @@ import { documentHandlers } from './documents.js';
 import { homeBaseHandlers } from './home-base.js';
 import { identityHandlers } from './identity.js';
 import { miscHandlers } from './misc.js';
+import { oauthConnectHandlers } from './oauth-connect.js';
 import { handleOpenBundle } from './open-bundle-handler.js';
 import { pairingHandlers } from './pairing.js';
 import { publishHandlers } from './publish.js';
@@ -112,6 +113,7 @@ const handlers = {
   ...browserHandlers,
   ...signingHandlers,
   ...twitterAuthHandlers,
+  ...oauthConnectHandlers,
   ...workspaceFileHandlers,
   ...identityHandlers,
   ...dictationHandlers,

--- a/assistant/src/daemon/handlers/oauth-connect.ts
+++ b/assistant/src/daemon/handlers/oauth-connect.ts
@@ -3,6 +3,7 @@ import * as net from 'node:net';
 import { orchestrateOAuthConnect } from '../../oauth/connect-orchestrator.js';
 import { resolveService } from '../../oauth/provider-profiles.js';
 import { getSecureKey } from '../../security/secure-keys.js';
+import { assertMetadataWritable } from '../../tools/credentials/metadata-store.js';
 import type { OAuthConnectStartRequest } from '../ipc-protocol.js';
 import { defineHandlers, type HandlerContext, log } from './shared.js';
 
@@ -11,6 +12,17 @@ export async function handleOAuthConnectStart(
   socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
+  try {
+    assertMetadataWritable();
+  } catch {
+    ctx.send(socket, {
+      type: 'oauth_connect_result',
+      success: false,
+      error: 'Credential metadata file has an unrecognized version. Cannot store OAuth credentials.',
+    });
+    return;
+  }
+
   try {
     if (!msg.service) {
       ctx.send(socket, {

--- a/assistant/src/daemon/handlers/oauth-connect.ts
+++ b/assistant/src/daemon/handlers/oauth-connect.ts
@@ -1,0 +1,108 @@
+import * as net from 'node:net';
+
+import { orchestrateOAuthConnect } from '../../oauth/connect-orchestrator.js';
+import { resolveService } from '../../oauth/provider-profiles.js';
+import { getSecureKey } from '../../security/secure-keys.js';
+import type { OAuthConnectStartRequest } from '../ipc-protocol.js';
+import { defineHandlers, type HandlerContext, log } from './shared.js';
+
+export async function handleOAuthConnectStart(
+  msg: OAuthConnectStartRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  try {
+    if (!msg.service) {
+      ctx.send(socket, {
+        type: 'oauth_connect_result',
+        success: false,
+        error: 'Missing required field: service',
+      });
+      return;
+    }
+
+    const resolvedService = resolveService(msg.service);
+
+    // Look up client credentials from the keychain
+    const clientId =
+      getSecureKey(`credential:${resolvedService}:client_id`) ??
+      getSecureKey(`credential:${resolvedService}:oauth_client_id`);
+
+    if (!clientId) {
+      ctx.send(socket, {
+        type: 'oauth_connect_result',
+        success: false,
+        error: `No client_id found for "${msg.service}". Store it first via the credential vault.`,
+      });
+      return;
+    }
+
+    const clientSecret =
+      getSecureKey(`credential:${resolvedService}:client_secret`) ??
+      getSecureKey(`credential:${resolvedService}:oauth_client_secret`) ??
+      undefined;
+
+    const result = await orchestrateOAuthConnect({
+      service: msg.service,
+      requestedScopes: msg.requestedScopes,
+      clientId,
+      clientSecret,
+      isInteractive: true,
+      openUrl: (url: string) => {
+        ctx.send(socket, { type: 'open_url', url });
+      },
+    });
+
+    if (!result.success) {
+      ctx.send(socket, {
+        type: 'oauth_connect_result',
+        success: false,
+        error: result.error,
+      });
+      return;
+    }
+
+    if (result.deferred) {
+      // Deferred flows should not happen for interactive daemon connections,
+      // but handle gracefully by returning the auth URL as an error hint.
+      ctx.send(socket, {
+        type: 'oauth_connect_result',
+        success: false,
+        error: `OAuth flow was deferred. Open this URL to authorize: ${result.authUrl}`,
+      });
+      return;
+    }
+
+    ctx.send(socket, {
+      type: 'oauth_connect_result',
+      success: true,
+      grantedScopes: result.grantedScopes,
+      accountInfo: result.accountInfo,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err, service: msg.service }, 'OAuth connect flow failed');
+
+    let userError: string;
+    const lower = message.toLowerCase();
+    if (lower.includes('timed out')) {
+      userError = 'OAuth authentication timed out. Please try again.';
+    } else if (lower.includes('user_cancelled') || lower.includes('cancelled')) {
+      userError = 'OAuth authentication was cancelled.';
+    } else if (lower.includes('denied') || lower.includes('invalid_grant')) {
+      userError = 'The authorization request was denied. Please try again.';
+    } else {
+      userError = 'OAuth authentication failed. Please try again.';
+    }
+
+    ctx.send(socket, {
+      type: 'oauth_connect_result',
+      success: false,
+      error: userError,
+    });
+  }
+}
+
+export const oauthConnectHandlers = defineHandlers({
+  oauth_connect_start: handleOAuthConnectStart,
+});

--- a/assistant/src/daemon/handlers/oauth-connect.ts
+++ b/assistant/src/daemon/handlers/oauth-connect.ts
@@ -1,7 +1,7 @@
 import * as net from 'node:net';
 
 import { orchestrateOAuthConnect } from '../../oauth/connect-orchestrator.js';
-import { resolveService } from '../../oauth/provider-profiles.js';
+import { getProviderProfile, resolveService } from '../../oauth/provider-profiles.js';
 import { getSecureKey } from '../../security/secure-keys.js';
 import { assertMetadataWritable } from '../../tools/credentials/metadata-store.js';
 import type { OAuthConnectStartRequest } from '../ipc-protocol.js';
@@ -53,6 +53,21 @@ export async function handleOAuthConnectStart(
       getSecureKey(`credential:${resolvedService}:client_secret`) ??
       getSecureKey(`credential:${resolvedService}:oauth_client_secret`) ??
       undefined;
+
+    // Fail early when client_secret is required but missing — guide the
+    // user to collect it from the keychain rather than letting the OAuth
+    // flow proceed and fail at token exchange.
+    const profile = getProviderProfile(resolvedService);
+    const requiresSecret = profile?.setup?.requiresClientSecret
+      ?? !!(profile?.tokenEndpointAuthMethod || profile?.extraParams);
+    if (requiresSecret && !clientSecret) {
+      ctx.send(socket, {
+        type: 'oauth_connect_result',
+        success: false,
+        error: `client_secret is required for "${msg.service}" but not found in the keychain. Store it first via the credential vault.`,
+      });
+      return;
+    }
 
     const result = await orchestrateOAuthConnect({
       service: msg.service,

--- a/assistant/src/daemon/ipc-contract/integrations.ts
+++ b/assistant/src/daemon/ipc-contract/integrations.ts
@@ -113,6 +113,12 @@ export interface IntegrationDisconnectRequest {
   integrationId: string;
 }
 
+export interface OAuthConnectStartRequest {
+  type: 'oauth_connect_start';
+  service: string;
+  requestedScopes?: string[];
+}
+
 export interface LinkOpenRequest {
   type: 'link_open_request';
   url: string;
@@ -293,6 +299,14 @@ export interface IntegrationConnectResult {
   setupHint?: string;
 }
 
+export interface OAuthConnectResultResponse {
+  type: 'oauth_connect_result';
+  success: boolean;
+  grantedScopes?: string[];
+  accountInfo?: string;
+  error?: string;
+}
+
 export interface OpenUrl {
   type: 'open_url';
   url: string;
@@ -316,6 +330,7 @@ export type _IntegrationsClientMessages =
   | IntegrationListRequest
   | IntegrationConnectRequest
   | IntegrationDisconnectRequest
+  | OAuthConnectStartRequest
   | LinkOpenRequest;
 
 export type _IntegrationsServerMessages =
@@ -332,4 +347,5 @@ export type _IntegrationsServerMessages =
   | TwitterAuthStatusResponse
   | IntegrationListResponse
   | IntegrationConnectResult
+  | OAuthConnectResultResponse
   | OpenUrl;


### PR DESCRIPTION
Part of #8959. Adds oauth_connect_start/oauth_connect_result IPC messages and a generic daemon handler that uses the shared orchestrator for any registered OAuth provider. Supports daemon-requested scopes with policy enforcement. Closes #8962.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
