### PR TITLE
M5: Docs, Architecture, and Regression Hardening

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4227,7 +4227,7 @@ sequenceDiagram
     alt ASK_GUARDIAN pattern detected
         Ctrl->>CallStore: createPendingQuestion()
         Ctrl->>GuardianDispatch: dispatchGuardianQuestion()
-        GuardianDispatch->>Mac: guardian_request_thread_created IPC
+        GuardianDispatch->>Mac: notification_thread_created IPC
         GuardianDispatch->>TG/SMS: POST /deliver/{channel}
         Note over Mac,TG/SMS: First channel to respond wins
         Mac/TG/SMS->>Routes: guardian answer
@@ -4409,7 +4409,7 @@ When the LLM emits `[ASK_GUARDIAN: question]` during a voice call, the controlle
 1. **Request creation**: A `guardian_action_request` row is created with a unique 6-character hex request code, the question text, a `pending` status, and an expiry timestamp.
 
 2. **Delivery fan-out**: Deliveries are created for each configured channel:
-   - **Mac (always)**: A server-side conversation is created with key `asst:${assistantId}:guardian:request:${request.id}`. The dispatch engine emits a `guardian_request_thread_created` IPC event so the desktop UI can display the question thread.
+   - **Mac (always)**: A server-side conversation is created with key `asst:${assistantId}:guardian:request:${request.id}`. The dispatch engine emits a `notification_thread_created` IPC event (via the notification pipeline's broadcast function) so the desktop UI can display the question thread.
    - **Telegram/SMS (if guardian binding exists)**: A `POST /deliver/{channel}` request is sent to the gateway with the question text and request code.
 
 3. **Answer resolution**: The first channel to respond wins. Answer resolution uses an atomic `WHERE status = 'pending'` check on the `guardian_action_requests` table -- only the first writer succeeds in transitioning the request to `answered` status. The winning answer text and responding channel are recorded on the request row.
@@ -4689,27 +4689,57 @@ Keep-alive heartbeats (every 30 s by default):
 The notification module (`assistant/src/notifications/`) uses a signal-based architecture where producers emit free-form events and an LLM-backed decision engine determines whether, where, and how to notify the user. See `assistant/src/notifications/README.md` for the full developer guide.
 
 ```
-Producer → NotificationSignal → Decision Engine (LLM) → Deterministic Checks → Broadcaster → Adapters → Delivery
-                                       ↑
-                               Preference Summary
+Producer → NotificationSignal → Decision Engine (LLM) → Deterministic Checks → Broadcaster → Conversation Pairing → Adapters → Delivery
+                                       ↑                                                            ↓
+                               Preference Summary                                    notification_thread_created IPC
 ```
+
+### Channel Policy Registry
+
+`assistant/src/channels/config.ts` is the **single source of truth** for per-channel notification behavior. Every `ChannelId` must have an entry in the `CHANNEL_POLICIES` map (enforced at compile time via `satisfies Record<ChannelId, ChannelNotificationPolicy>`). Each policy defines:
+
+- **`deliveryEnabled`** — whether the channel can receive notification deliveries. The `NotificationChannel` type is derived from this flag: only channels with `deliveryEnabled: true` are valid notification targets.
+- **`conversationStrategy`** — how the notification pipeline materializes conversations for the channel:
+  - `start_new_conversation` — creates a fresh conversation per delivery (e.g. vellum desktop/mobile threads)
+  - `continue_existing_conversation` — appends to an existing channel-scoped conversation (e.g. Telegram)
+  - `not_deliverable` — channel cannot receive notifications (e.g. voice)
+
+Helper functions: `getDeliverableChannels()`, `getChannelPolicy()`, `isNotificationDeliverable()`, `getConversationStrategy()`.
+
+### Conversation Pairing
+
+Every notification delivery materializes a conversation + seed message **before** the adapter sends it (`conversation-pairing.ts`). This ensures:
+
+1. Every delivery has an auditable conversation trail in the conversations table
+2. The macOS/iOS client can deep-link directly into the notification thread
+3. Delivery audit rows in `notification_deliveries` carry `conversation_id`, `message_id`, and `conversation_strategy` columns
+
+The pairing function (`pairDeliveryWithConversation`) is resilient — errors are caught and logged without breaking the delivery pipeline.
+
+### Thread Surfacing via `notification_thread_created` IPC
+
+When a vellum notification thread is paired with a conversation, the broadcaster emits a `notification_thread_created` IPC event **immediately** (before waiting for slower channel deliveries like Telegram). This pushes the thread to the macOS/iOS client so it can display the notification thread in the sidebar and deep-link to it.
+
+Callers that manage their own vellum conversations (e.g. `guardian-dispatch`) pass `skipVellumThread: true` to `emitNotificationSignal()` and emit `notification_thread_created` directly via the registered broadcast function.
 
 **Key modules:**
 
 | Module | Purpose |
 |--------|---------|
+| `assistant/src/channels/config.ts` | Channel policy registry — single source of truth for per-channel notification behavior |
 | `assistant/src/notifications/emit-signal.ts` | Single entry point for all producers; orchestrates the full pipeline |
 | `assistant/src/notifications/decision-engine.ts` | LLM-based routing decisions with deterministic fallback |
 | `assistant/src/notifications/deterministic-checks.ts` | Hard invariant checks (dedupe, source-active suppression, channel availability) |
-| `assistant/src/notifications/broadcaster.ts` | Dispatches decisions to channel adapters |
-| `assistant/src/notifications/adapters/` | Per-channel delivery (macOS IPC, Telegram gateway) |
+| `assistant/src/notifications/broadcaster.ts` | Dispatches decisions to channel adapters; emits `notification_thread_created` IPC |
+| `assistant/src/notifications/conversation-pairing.ts` | Materializes conversation + message per delivery |
+| `assistant/src/notifications/adapters/` | Per-channel delivery (vellum IPC, Telegram gateway) |
 | `assistant/src/notifications/preference-extractor.ts` | Detects preference statements in conversation messages |
 | `assistant/src/notifications/preferences-store.ts` | CRUD for user notification preferences |
 | `assistant/src/config/bundled-skills/messaging/tools/send-notification.ts` | Explicit producer tool for user-requested notifications; emits signals into the same routing pipeline |
 
-**Audit trail (SQLite):** `notification_events` → `notification_decisions` → `notification_deliveries`
+**Audit trail (SQLite):** `notification_events` → `notification_decisions` → `notification_deliveries` (with `conversation_id`, `message_id`, `conversation_strategy`)
 
-**Configuration:** `notifications.decisionModel` in `config.json`.
+**Configuration:** `notifications.decisionModelIntent` in `config.json`.
 
 ---
 

--- a/assistant/src/__tests__/channel-policy.test.ts
+++ b/assistant/src/__tests__/channel-policy.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Regression tests for the channel policy registry.
+ *
+ * Validates that every ChannelId has a policy entry, that helper functions
+ * return correct values, and that the compile-time exhaustiveness constraint
+ * is backed by runtime assertions.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import {
+  type ConversationStrategy,
+  getChannelPolicy,
+  getConversationStrategy,
+  getDeliverableChannels,
+  isNotificationDeliverable,
+} from '../channels/config.js';
+import { CHANNEL_IDS, type ChannelId } from '../channels/types.js';
+
+describe('channel policy registry', () => {
+  // ── Exhaustiveness ────────────────────────────────────────────────────
+
+  test('every ChannelId has a policy entry', () => {
+    for (const channelId of CHANNEL_IDS) {
+      const policy = getChannelPolicy(channelId);
+      expect(policy).toBeDefined();
+      expect(policy.notification).toBeDefined();
+      expect(typeof policy.notification.deliveryEnabled).toBe('boolean');
+      expect(typeof policy.notification.conversationStrategy).toBe('string');
+    }
+  });
+
+  test('CHANNEL_IDS contains at least one channel', () => {
+    expect(CHANNEL_IDS.length).toBeGreaterThan(0);
+  });
+
+  // ── getDeliverableChannels ────────────────────────────────────────────
+
+  test('getDeliverableChannels returns exactly the channels with deliveryEnabled: true', () => {
+    const deliverable = getDeliverableChannels();
+    const expected = CHANNEL_IDS.filter(
+      (id) => getChannelPolicy(id).notification.deliveryEnabled,
+    );
+
+    expect(deliverable).toHaveLength(expected.length);
+    for (const id of expected) {
+      expect(deliverable).toContain(id);
+    }
+  });
+
+  test('getDeliverableChannels returns a non-empty array', () => {
+    // At minimum, vellum should always be deliverable.
+    const deliverable = getDeliverableChannels();
+    expect(deliverable.length).toBeGreaterThan(0);
+    expect(deliverable).toContain('vellum');
+  });
+
+  test('getDeliverableChannels does not include channels with deliveryEnabled: false', () => {
+    const deliverable = getDeliverableChannels();
+    for (const id of CHANNEL_IDS) {
+      if (!getChannelPolicy(id).notification.deliveryEnabled) {
+        expect(deliverable).not.toContain(id);
+      }
+    }
+  });
+
+  // ── getChannelPolicy ─────────────────────────────────────────────────
+
+  test('getChannelPolicy returns valid policy for every ChannelId', () => {
+    const validStrategies = new Set([
+      'start_new_conversation',
+      'continue_existing_conversation',
+      'not_deliverable',
+    ]);
+
+    for (const channelId of CHANNEL_IDS) {
+      const policy = getChannelPolicy(channelId);
+      expect(validStrategies.has(policy.notification.conversationStrategy)).toBe(true);
+    }
+  });
+
+  // ── isNotificationDeliverable ─────────────────────────────────────────
+
+  test('isNotificationDeliverable reflects deliveryEnabled for every ChannelId', () => {
+    for (const channelId of CHANNEL_IDS) {
+      const policy = getChannelPolicy(channelId);
+      expect(isNotificationDeliverable(channelId)).toBe(
+        policy.notification.deliveryEnabled,
+      );
+    }
+  });
+
+  // ── getConversationStrategy ───────────────────────────────────────────
+
+  test('getConversationStrategy returns correct strategies per channel', () => {
+    // Known assertions for current policy (regression guard)
+    const expectedStrategies: [ChannelId, ConversationStrategy][] = [
+      ['vellum', 'start_new_conversation'],
+      ['telegram', 'continue_existing_conversation'],
+      ['voice', 'not_deliverable'],
+    ];
+
+    for (const [channelId, expected] of expectedStrategies) {
+      expect(getConversationStrategy(channelId)).toBe(expected);
+    }
+  });
+
+  test('getConversationStrategy returns a valid strategy for every ChannelId', () => {
+    const validStrategies = new Set([
+      'start_new_conversation',
+      'continue_existing_conversation',
+      'not_deliverable',
+    ]);
+
+    for (const channelId of CHANNEL_IDS) {
+      const strategy = getConversationStrategy(channelId);
+      expect(validStrategies.has(strategy)).toBe(true);
+    }
+  });
+
+  // ── Consistency checks ────────────────────────────────────────────────
+
+  test('channels with not_deliverable strategy have deliveryEnabled: false', () => {
+    for (const channelId of CHANNEL_IDS) {
+      const policy = getChannelPolicy(channelId);
+      if (policy.notification.conversationStrategy === 'not_deliverable') {
+        expect(policy.notification.deliveryEnabled).toBe(false);
+      }
+    }
+  });
+});

--- a/assistant/src/__tests__/conversation-pairing.test.ts
+++ b/assistant/src/__tests__/conversation-pairing.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Regression tests for notification conversation pairing.
+ *
+ * Validates that pairDeliveryWithConversation materializes conversations
+ * and messages according to the channel's conversation strategy, and that
+ * errors in pairing never break the notification pipeline.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// ── Mocks — declared before imports that depend on them ─────────────
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+let mockConversationId = 'conv-001';
+let mockMessageId = 'msg-001';
+let createConversationShouldThrow = false;
+let addMessageShouldThrow = false;
+
+const createConversationMock = mock((_opts?: unknown) => {
+  if (createConversationShouldThrow) throw new Error('DB write failed');
+  return { id: mockConversationId };
+});
+
+const addMessageMock = mock(
+  (
+    _conversationId: string,
+    _role: string,
+    _content: string,
+    _metadata?: unknown,
+    _opts?: unknown,
+  ) => {
+    if (addMessageShouldThrow) throw new Error('DB write failed');
+    return { id: mockMessageId };
+  },
+);
+
+mock.module('../memory/conversation-store.js', () => ({
+  createConversation: createConversationMock,
+  addMessage: addMessageMock,
+}));
+
+import { pairDeliveryWithConversation } from '../notifications/conversation-pairing.js';
+import type { NotificationSignal } from '../notifications/signal.js';
+import type { NotificationChannel, RenderedChannelCopy } from '../notifications/types.js';
+
+// ── Test helpers ────────────────────────────────────────────────────────
+
+function makeSignal(overrides?: Partial<NotificationSignal>): NotificationSignal {
+  return {
+    signalId: 'sig-test',
+    assistantId: 'self',
+    createdAt: Date.now(),
+    sourceChannel: 'scheduler',
+    sourceSessionId: 'sess-1',
+    sourceEventName: 'test.event',
+    contextPayload: {},
+    attentionHints: {
+      requiresAction: false,
+      urgency: 'medium',
+      isAsyncBackground: true,
+      visibleInSourceNow: false,
+    },
+    ...overrides,
+  };
+}
+
+function makeCopy(overrides?: Partial<RenderedChannelCopy>): RenderedChannelCopy {
+  return {
+    title: 'Test Notification',
+    body: 'Something happened.',
+    ...overrides,
+  };
+}
+
+describe('pairDeliveryWithConversation', () => {
+  beforeEach(() => {
+    createConversationMock.mockClear();
+    addMessageMock.mockClear();
+    mockConversationId = 'conv-001';
+    mockMessageId = 'msg-001';
+    createConversationShouldThrow = false;
+    addMessageShouldThrow = false;
+  });
+
+  // ── start_new_conversation (vellum) ─────────────────────────────────
+
+  test('creates a conversation and message for start_new_conversation strategy', () => {
+    const signal = makeSignal();
+    const copy = makeCopy({ threadTitle: 'Alert Thread' });
+
+    const result = pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
+
+    expect(result.conversationId).toBe('conv-001');
+    expect(result.messageId).toBe('msg-001');
+    expect(result.strategy).toBe('start_new_conversation');
+    expect(createConversationMock).toHaveBeenCalledTimes(1);
+    expect(addMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('uses threadTitle for conversation title when available', () => {
+    const signal = makeSignal();
+    const copy = makeCopy({ threadTitle: 'Custom Thread Title' });
+
+    pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
+
+    // Verify createConversation was called with the thread title
+    const callArgs = createConversationMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(callArgs.title).toBe('Custom Thread Title');
+  });
+
+  test('falls back to copy title when threadTitle is absent', () => {
+    const signal = makeSignal();
+    const copy = makeCopy({ title: 'Notification Title' });
+
+    pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
+
+    const callArgs = createConversationMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(callArgs.title).toBe('Notification Title');
+  });
+
+  test('uses threadSeedMessage for message content when available', () => {
+    const signal = makeSignal();
+    const copy = makeCopy({ threadSeedMessage: 'Custom seed message' });
+
+    pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
+
+    // addMessage second arg is role, third is content
+    const contentArg = addMessageMock.mock.calls[0]![2];
+    expect(contentArg).toBe('Custom seed message');
+  });
+
+  test('passes skipIndexing option to addMessage', () => {
+    const signal = makeSignal();
+    const copy = makeCopy();
+
+    pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
+
+    const optsArg = addMessageMock.mock.calls[0]![4] as Record<string, unknown>;
+    expect(optsArg.skipIndexing).toBe(true);
+  });
+
+  // ── continue_existing_conversation (telegram) ─────────────────────
+
+  test('creates a conversation for continue_existing_conversation strategy', () => {
+    const signal = makeSignal();
+    const copy = makeCopy();
+
+    const result = pairDeliveryWithConversation(signal, 'telegram' as NotificationChannel, copy);
+
+    // Currently creates a new conversation even for continue_existing_conversation
+    // (true continuation is planned for a future PR)
+    expect(result.conversationId).toBe('conv-001');
+    expect(result.messageId).toBe('msg-001');
+    expect(result.strategy).toBe('continue_existing_conversation');
+    expect(createConversationMock).toHaveBeenCalledTimes(1);
+  });
+
+  // ── not_deliverable (voice) ───────────────────────────────────────
+
+  test('returns null conversationId and messageId for not_deliverable strategy', () => {
+    const signal = makeSignal();
+    const copy = makeCopy();
+
+    // voice has not_deliverable strategy — need to cast since voice is
+    // not a NotificationChannel (deliveryEnabled: false), but the function
+    // accepts NotificationChannel which is then cast internally to ChannelId.
+    const result = pairDeliveryWithConversation(
+      signal,
+      'voice' as NotificationChannel,
+      copy,
+    );
+
+    expect(result.conversationId).toBeNull();
+    expect(result.messageId).toBeNull();
+    expect(result.strategy).toBe('not_deliverable');
+    expect(createConversationMock).not.toHaveBeenCalled();
+    expect(addMessageMock).not.toHaveBeenCalled();
+  });
+
+  // ── Error resilience ──────────────────────────────────────────────
+
+  test('catches createConversation errors and returns null IDs without throwing', () => {
+    createConversationShouldThrow = true;
+    const signal = makeSignal();
+    const copy = makeCopy();
+
+    // Should not throw
+    const result = pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
+
+    expect(result.conversationId).toBeNull();
+    expect(result.messageId).toBeNull();
+    // Strategy should still be resolved from the policy registry
+    expect(result.strategy).toBe('start_new_conversation');
+  });
+
+  test('catches addMessage errors and returns null IDs without throwing', () => {
+    addMessageShouldThrow = true;
+    const signal = makeSignal();
+    const copy = makeCopy();
+
+    const result = pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
+
+    expect(result.conversationId).toBeNull();
+    expect(result.messageId).toBeNull();
+    expect(result.strategy).toBe('start_new_conversation');
+  });
+
+  test('error in pairing does not break the pipeline (no throw)', () => {
+    createConversationShouldThrow = true;
+
+    // Calling multiple times should all succeed without throwing
+    for (let i = 0; i < 3; i++) {
+      const result = pairDeliveryWithConversation(
+        makeSignal({ signalId: `sig-${i}` }),
+        'vellum' as NotificationChannel,
+        makeCopy(),
+      );
+      expect(result.conversationId).toBeNull();
+    }
+  });
+});

--- a/assistant/src/notifications/README.md
+++ b/assistant/src/notifications/README.md
@@ -5,9 +5,9 @@ Signal-driven notification architecture where producers emit free-form events an
 ## Lifecycle
 
 ```
-Producer → NotificationSignal → Decision Engine (LLM) → Deterministic Checks → Broadcaster → Adapters → Delivery
-                                       ↑
-                               Preference Summary
+Producer → NotificationSignal → Decision Engine (LLM) → Deterministic Checks → Broadcaster → Conversation Pairing → Adapters → Delivery
+                                       ↑                                                            ↓
+                               Preference Summary                                    notification_thread_created IPC
 ```
 
 ### 1. Signal
@@ -33,24 +33,91 @@ Hard invariants that the LLM cannot override (`deterministic-checks.ts`):
 
 `runtime-dispatch.ts` handles two early-exit cases (shouldNotify=false, no channels), then delegates to the broadcaster.
 
-### 5. Broadcast and Delivery
+### 5. Broadcast, Conversation Pairing, and Delivery
 
-The broadcaster (`broadcaster.ts`) iterates over selected channels, resolves destinations via `destination-resolver.ts`, pulls rendered copy from the decision (falling back to `copy-composer.ts` templates), and dispatches through channel adapters. Each delivery attempt is recorded in `notification_deliveries`.
+The broadcaster (`broadcaster.ts`) iterates over selected channels (vellum first for fast IPC push), resolves destinations via `destination-resolver.ts`, pairs each delivery with a conversation via `conversation-pairing.ts`, pulls rendered copy from the decision (falling back to `copy-composer.ts` templates), and dispatches through channel adapters. Each delivery attempt is recorded in `notification_deliveries` with `conversation_id`, `message_id`, and `conversation_strategy` columns.
+
+## Channel Policy Registry
+
+`../channels/config.ts` is the **single source of truth** for per-channel notification behavior. Every `ChannelId` must have an entry in the `CHANNEL_POLICIES` map. The TypeScript `satisfies Record<ChannelId, ChannelNotificationPolicy>` constraint ensures that adding a new `ChannelId` to `channels/types.ts` will cause a compile error until a policy entry is added.
+
+Each policy defines:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `notification.deliveryEnabled` | `boolean` | Whether the channel can receive notification deliveries |
+| `notification.conversationStrategy` | `ConversationStrategy` | How conversations are materialized for deliveries on this channel |
+
+### Conversation Strategy Types
+
+| Strategy | Behavior | Used by |
+|----------|----------|---------|
+| `start_new_conversation` | Creates a fresh conversation per delivery. The thread is surfaced via IPC. | `vellum` |
+| `continue_existing_conversation` | Appends to an existing channel-scoped conversation (future: lookup by binding key). Currently creates a new conversation per delivery and records the intended strategy for audit. | `telegram`, `sms`, `whatsapp`, `slack`, `email` |
+| `not_deliverable` | Channel cannot receive notifications. Pairing returns null IDs. | `voice` |
+
+### Helper Functions
+
+- `getDeliverableChannels()` -- returns all `ChannelId` values where `deliveryEnabled` is true
+- `getChannelPolicy(channelId)` -- returns the full policy object for a channel
+- `isNotificationDeliverable(channelId)` -- boolean check for delivery eligibility
+- `getConversationStrategy(channelId)` -- returns the conversation strategy for a channel
+
+### How to Add a New Channel
+
+1. Add the channel to `CHANNEL_IDS` in `channels/types.ts`.
+2. Add a policy entry in `CHANNEL_POLICIES` in `channels/config.ts`. The compiler will enforce this.
+3. If `deliveryEnabled: true`, add an adapter in `adapters/` and register it in `emit-signal.ts` `getBroadcaster()`.
+4. Add a connectivity check in `getConnectedChannels()` in `emit-signal.ts`.
+5. Add a destination resolver case in `destination-resolver.ts`.
+
+## Conversation Pairing Invariant
+
+**Every notification delivery gets a conversation.** Before the adapter sends a notification, `pairDeliveryWithConversation()` (in `conversation-pairing.ts`) materializes a conversation and seed message based on the channel's conversation strategy:
+
+- **`start_new_conversation`**: Creates a new conversation with `threadType: 'standard'` and `source: 'notification'`, plus an assistant message containing the notification copy. Memory indexing is skipped on the seed message to prevent notification copy from polluting conversational recall.
+- **`continue_existing_conversation`**: Currently creates a new conversation per delivery (true continuation via binding key lookup is planned for a future PR). The audit trail records the intended strategy.
+- **`not_deliverable`**: Returns `{ conversationId: null, messageId: null }`.
+
+The pairing function is resilient -- errors are caught and logged. A pairing failure never breaks the delivery pipeline.
+
+## Thread Surfacing via `notification_thread_created` IPC
+
+When a vellum notification thread is paired with a conversation (strategy `start_new_conversation`), the broadcaster emits a `notification_thread_created` IPC event **immediately**, before waiting for slower channel deliveries (e.g. Telegram). This avoids a race where a slow Telegram delivery delays the IPC push past the macOS deep-link retry window.
+
+The IPC event payload:
+
+```ts
+{
+  type: 'notification_thread_created',
+  conversationId: string,
+  title: string,
+  sourceEventName: string,
+}
+```
+
+The macOS/iOS client listens for this event and surfaces the thread in the sidebar, enabling deep-link navigation to the notification thread.
+
+### `skipVellumThread` Option
+
+Callers that manage their own vellum conversations (e.g. `guardian-dispatch`, which creates a guardian question thread before entering the notification pipeline) pass `skipVellumThread: true` to `emitNotificationSignal()`. This suppresses the automatic `notification_thread_created` IPC push so the caller can emit the event directly with its own conversation ID.
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
+| `../channels/config.ts` | Channel policy registry -- single source of truth for per-channel notification behavior |
 | `emit-signal.ts` | Single entry point for producers; orchestrates the full pipeline |
 | `signal.ts` | `NotificationSignal` and `AttentionHints` type definitions |
 | `types.ts` | Channel adapter interfaces, delivery types, decision output contract |
+| `conversation-pairing.ts` | Materializes conversation + message per delivery based on channel strategy |
 | `decision-engine.ts` | LLM-based routing with forced tool_choice; deterministic fallback |
 | `deterministic-checks.ts` | Pre-send gate checks (dedupe, source-active, channel availability) |
 | `runtime-dispatch.ts` | Dispatch gating (no-op decisions, empty channels) |
-| `broadcaster.ts` | Fan-out to channel adapters with delivery audit trail |
+| `broadcaster.ts` | Fan-out to channel adapters with delivery audit trail; emits `notification_thread_created` IPC |
 | `copy-composer.ts` | Template-based fallback copy when LLM copy is unavailable |
-| `destination-resolver.ts` | Resolves per-channel endpoints (macOS IPC, Telegram chat ID) |
-| `adapters/macos.ts` | macOS adapter -- broadcasts `notification_intent` via IPC |
+| `destination-resolver.ts` | Resolves per-channel endpoints (vellum IPC, Telegram chat ID) |
+| `adapters/macos.ts` | Vellum adapter -- broadcasts `notification_intent` via IPC |
 | `adapters/telegram.ts` | Telegram adapter -- POSTs to gateway `/deliver/telegram` |
 | `preference-extractor.ts` | Detects notification preferences in conversation messages |
 | `preference-summary.ts` | Builds preference context string for the decision engine prompt |
@@ -91,7 +158,7 @@ Three SQLite tables form the audit chain:
 
 - **`notification_events`** -- every signal that entered the pipeline, with attention hints and context payload
 - **`notification_decisions`** -- the routing decision for each event (shouldNotify, selectedChannels, reasoning, confidence, whether fallback was used)
-- **`notification_deliveries`** -- per-channel delivery attempts with status (pending/sent/failed/skipped), rendered copy, and error details
+- **`notification_deliveries`** -- per-channel delivery attempts with status (pending/sent/failed/skipped), rendered copy, error details, and conversation pairing data (`conversation_id`, `message_id`, `conversation_strategy`)
 
 Query examples:
 
@@ -108,6 +175,12 @@ LIMIT 20;
 SELECT d.channel, d.error_message, d.rendered_title
 FROM notification_deliveries d
 WHERE d.status = 'failed'
+ORDER BY d.created_at DESC;
+
+-- Deliveries with conversation pairing
+SELECT d.channel, d.conversation_id, d.message_id, d.conversation_strategy, d.rendered_title
+FROM notification_deliveries d
+WHERE d.conversation_id IS NOT NULL
 ORDER BY d.created_at DESC;
 ```
 
@@ -129,4 +202,4 @@ All settings live under the `notifications` key in `config.json`:
 |-----|------|---------|-------------|
 | `notifications.decisionModelIntent` | string | `"latency-optimized"` | Model intent used for both the decision engine and preference extraction |
 
-The notification pipeline is always active — signals are processed and dispatched as soon as the daemon is running. The audit trail (events, decisions, deliveries) is written for every signal.
+The notification pipeline is always active -- signals are processed and dispatched as soon as the daemon is running. The audit trail (events, decisions, deliveries) is written for every signal.

--- a/assistant/src/notifications/destination-resolver.ts
+++ b/assistant/src/notifications/destination-resolver.ts
@@ -8,37 +8,41 @@
  */
 
 import { isNotificationDeliverable } from '../channels/config.js';
+import type { ChannelId } from '../channels/types.js';
 import { getActiveBinding } from '../memory/channel-guardian-store.js';
 import type { ChannelDestination, NotificationChannel } from './types.js';
 
 /**
  * Resolve destination information for each requested channel.
  *
- * Returns a map keyed by channel name. Channels that cannot be resolved
- * (e.g. no Telegram binding configured) are omitted from the result.
- * Channels that are not deliverable per the policy registry are skipped.
+ * Accepts the broad `ChannelId` union so that callers can pass any channel;
+ * the function skips non-deliverable channels via `isNotificationDeliverable`.
+ * Returns a map keyed by `NotificationChannel`. Channels that cannot be
+ * resolved (e.g. no Telegram binding configured) are omitted from the result.
  */
 export function resolveDestinations(
   assistantId: string,
-  channels: NotificationChannel[],
+  channels: readonly (ChannelId | NotificationChannel)[],
 ): Map<NotificationChannel, ChannelDestination> {
   const result = new Map<NotificationChannel, ChannelDestination>();
 
   for (const channel of channels) {
     if (!isNotificationDeliverable(channel)) continue;
 
-    switch (channel) {
+    // After the deliverability check, `channel` is guaranteed to be a
+    // NotificationChannel — TypeScript cannot infer this from the runtime
+    // guard, so we narrow with a switch over known deliverable values.
+    switch (channel as NotificationChannel) {
       case 'vellum': {
         // Vellum delivery is local IPC — no external endpoint required.
         result.set('vellum', { channel: 'vellum' });
         break;
       }
-      case 'telegram':
-      case 'sms': {
+      case 'telegram': {
         const binding = getActiveBinding(assistantId, channel);
         if (binding) {
-          result.set(channel, {
-            channel,
+          result.set(channel as NotificationChannel, {
+            channel: channel as NotificationChannel,
             endpoint: binding.guardianDeliveryChatId,
             metadata: {
               externalUserId: binding.guardianExternalUserId,
@@ -49,7 +53,7 @@ export function resolveDestinations(
         break;
       }
       default: {
-        // Channel with no resolver — skip silently.
+        // Future deliverable channels without a resolver — skip silently.
         break;
       }
     }

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -85,6 +85,9 @@ function getBroadcaster(): NotificationBroadcaster {
 function getConnectedChannels(assistantId: string): NotificationChannel[] {
   const channels: NotificationChannel[] = [];
 
+  // getDeliverableChannels() returns ChannelId[] but every returned channel
+  // has deliveryEnabled: true, making it a valid NotificationChannel at
+  // runtime. We iterate over the broad type and narrow via the switch.
   for (const channel of getDeliverableChannels()) {
     switch (channel) {
       case 'vellum':
@@ -93,7 +96,6 @@ function getConnectedChannels(assistantId: string): NotificationChannel[] {
         channels.push(channel);
         break;
       case 'telegram':
-      case 'sms':
         // Only report binding-based channels as connected when there is
         // an active guardian binding for this assistant. Without a
         // binding, the destination resolver will fail to resolve a
@@ -105,6 +107,8 @@ function getConnectedChannels(assistantId: string): NotificationChannel[] {
         }
         break;
       default:
+        // Future deliverable channels — skip until a connectivity check
+        // is implemented for them.
         break;
     }
   }


### PR DESCRIPTION
## Summary
- Update ARCHITECTURE.md with notification conversation materialization and channel policy registry
- Add/update notifications README with channel policy patterns and conversation pairing
- Add channel-policy.test.ts and conversation-pairing.test.ts regression tests
- Fix pre-existing type errors in destination-resolver.ts and emit-signal.ts

Closes #8857
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
