### PR TITLE
fix: enforce per-destination rate limiting for outbound SMS verification

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -3,6 +3,7 @@ import * as net from 'node:net';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
 import {
   createVerificationChallenge,
+  countRecentSendsToDestination,
   getGuardianBinding,
   getPendingChallenge,
   revokeBinding as revokeGuardianBinding,
@@ -241,6 +242,20 @@ function handleStartOutbound(
       success: false,
       error: 'already_bound',
       message: 'A guardian is already bound for this channel. Set rebind: true to replace.',
+      channel,
+    });
+    return;
+  }
+
+  // Enforce per-destination rate limit across all sessions to prevent
+  // circumvention by repeatedly calling start_outbound for the same number.
+  const recentSendCount = countRecentSendsToDestination(channel, destination, DESTINATION_RATE_WINDOW_MS);
+  if (recentSendCount >= MAX_SENDS_PER_DESTINATION_WINDOW) {
+    ctx.send(socket, {
+      type: 'guardian_verification_response',
+      success: false,
+      error: 'rate_limited',
+      message: 'Too many verification attempts to this phone number. Please try again later.',
       channel,
     });
     return;

--- a/assistant/src/memory/channel-guardian-store.ts
+++ b/assistant/src/memory/channel-guardian-store.ts
@@ -8,7 +8,7 @@
  * requests track per-run guardian approval decisions.
  */
 
-import { and, count, desc, eq, gt, inArray, lte, or } from 'drizzle-orm';
+import { and, count, desc, eq, gt, gte, inArray, lte, or, sum } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
 import { getDb } from './db.js';
@@ -579,6 +579,35 @@ export function updateSessionDelivery(
     })
     .where(eq(channelGuardianVerificationChallenges.id, id))
     .run();
+}
+
+/**
+ * Count SMS sends to a specific destination across all sessions within a
+ * rolling time window. Used to enforce per-destination rate limits that
+ * span across sessions, preventing circumvention via repeated
+ * start_outbound calls.
+ */
+export function countRecentSendsToDestination(
+  channel: string,
+  destinationAddress: string,
+  windowMs: number,
+): number {
+  const db = getDb();
+  const cutoff = Date.now() - windowMs;
+
+  const result = db
+    .select({ total: sum(channelGuardianVerificationChallenges.sendCount) })
+    .from(channelGuardianVerificationChallenges)
+    .where(
+      and(
+        eq(channelGuardianVerificationChallenges.channel, channel),
+        eq(channelGuardianVerificationChallenges.destinationAddress, destinationAddress),
+        gte(channelGuardianVerificationChallenges.createdAt, cutoff),
+      ),
+    )
+    .get();
+
+  return result?.total != null ? Number(result.total) : 0;
 }
 
 /**

--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -26,6 +26,7 @@ import {
   updateSessionStatus as storeUpdateSessionStatus,
   updateSessionDelivery as storeUpdateSessionDelivery,
   bindSessionIdentity as storeBindSessionIdentity,
+  countRecentSendsToDestination as storeCountRecentSendsToDestination,
   revokeBinding as storeRevokeBinding,
   revokePendingChallenges as storeRevokePendingChallenges,
 } from '../memory/channel-guardian-store.js';
@@ -465,6 +466,19 @@ export function updateSessionDelivery(
   nextResendAt: number | null,
 ): void {
   storeUpdateSessionDelivery(id, lastSentAt, sendCount, nextResendAt);
+}
+
+/**
+ * Count total SMS sends to a destination across all sessions within a
+ * rolling time window. Prevents circumvention of per-session limits by
+ * repeatedly creating new sessions to the same phone number.
+ */
+export function countRecentSendsToDestination(
+  channel: string,
+  destinationAddress: string,
+  windowMs: number,
+): number {
+  return storeCountRecentSendsToDestination(channel, destinationAddress, windowMs);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Enforce MAX_SENDS_PER_DESTINATION_WINDOW and DESTINATION_RATE_WINDOW_MS in handleStartOutbound
- Query recent sends to the target phone number across all sessions within the rate window
- Return rate_limited error when the per-destination limit is exceeded

Addresses feedback from PR #8987.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
