### PR TITLE
fix: use LRU eviction for OAuth consumed-state map instead of hard rejection

### DIFF
--- a/gateway/src/http/routes/oauth-callback.ts
+++ b/gateway/src/http/routes/oauth-callback.ts
@@ -15,7 +15,24 @@ const CONSUMED_STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 export const MAX_CONSUMED_STATES = 1000;
 const consumedStates = new Map<string, ReturnType<typeof setTimeout>>();
 
+function evictOldestConsumedState(): void {
+  // Map iteration order is insertion order — first key is the oldest entry.
+  const oldest = consumedStates.keys().next().value;
+  if (oldest !== undefined) {
+    const timer = consumedStates.get(oldest);
+    if (timer !== undefined) clearTimeout(timer);
+    consumedStates.delete(oldest);
+  }
+}
+
 function markStateConsumed(state: string): void {
+  // LRU eviction: if the map is at capacity, drop the oldest entry rather than
+  // rejecting the request. Consumed states only exist to prevent replay within
+  // their TTL window — losing the oldest is acceptable since it's closest to
+  // expiry anyway, and hard-rejecting creates a DoS vector.
+  if (consumedStates.size >= MAX_CONSUMED_STATES) {
+    evictOldestConsumedState();
+  }
   const timer = setTimeout(() => {
     consumedStates.delete(state);
   }, CONSUMED_STATE_TTL_MS);
@@ -66,17 +83,6 @@ export function createOAuthCallbackHandler(config: GatewayConfig) {
         status: 400,
         headers: { "Content-Type": "text/html" },
       });
-    }
-
-    // Reject when the consumed-state map is full rather than evicting entries.
-    // Eviction would let an attacker flood with fake states to clear legitimate
-    // entries and replay a real callback.
-    if (consumedStates.size >= MAX_CONSUMED_STATES) {
-      log.warn("OAuth consumed-state map at capacity, rejecting callback");
-      return new Response(
-        renderErrorPage("Service temporarily unavailable. Please try again later."),
-        { status: 503, headers: { "Content-Type": "text/html" } },
-      );
     }
 
     // Optimistically mark consumed so concurrent duplicate callbacks are


### PR DESCRIPTION
Addresses review feedback on #8991. Replaces 503 rejection with LRU eviction of oldest consumed state to prevent DoS.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
