### PR TITLE
fix: restore ack-stripping in stripMemoryRecallMessages fallback path

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -670,8 +670,18 @@ export function stripMemoryRecallMessages<T extends { role: 'user' | 'assistant'
   }
   if (targetIndex === -1) return messages;
 
+  // Strip the adjacent assistant ack when the injection strategy used a
+  // separate context message (or is unknown). This mirrors the canonical
+  // pair removal above but covers repair-merged cases where the user
+  // message has multiple content blocks.
+  const ackIndex =
+    injectionStrategy !== 'prepend_user_block' && targetIndex + 1 < messages.length && isAck(messages[targetIndex + 1])
+      ? targetIndex + 1
+      : -1;
+
   const cleaned: T[] = [];
   for (let i = 0; i < messages.length; i++) {
+    if (i === ackIndex) continue;
     if (i !== targetIndex) {
       cleaned.push(messages[i]);
       continue;


### PR DESCRIPTION
Addresses review feedback on #8993. Restores the adjacent ack removal in the fallback text-match path so that repair-merged separate_context_message pairs don't leave an orphan assistant ack in conversation history.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
