### PR TITLE
fix: align CI bun-version pins with .tool-versions 1.3.9

### DIFF
--- a/.github/workflows/ci-benchmarks.yaml
+++ b/.github/workflows/ci-benchmarks.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.8'
+          bun-version: '1.3.9'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.8'
+          bun-version: '1.3.9'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/ci-main-cli.yaml
+++ b/.github/workflows/ci-main-cli.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.8'
+          bun-version: '1.3.9'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/ci-main-gateway.yaml
+++ b/.github/workflows/ci-main-gateway.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.8'
+          bun-version: '1.3.9'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.8'
+          bun-version: '1.3.9'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/pr-cli.yaml
+++ b/.github/workflows/pr-cli.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.8'
+          bun-version: '1.3.9'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/pr-gateway.yaml
+++ b/.github/workflows/pr-gateway.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.8'
+          bun-version: '1.3.9'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
Addresses review feedback on #8988. Updates all CI workflow bun-version pins from 1.3.8 to 1.3.9 to match .tool-versions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
