### PR TITLE
fix: use actual row ID for embed_summary job after upsert race

### DIFF
--- a/assistant/src/memory/job-handlers/summarization.ts
+++ b/assistant/src/memory/job-handlers/summarization.ts
@@ -108,7 +108,19 @@ export async function buildConversationSummaryJob(job: MemoryJob, config: Assist
       updatedAt: now,
     },
   }).run();
-  enqueueMemoryJob('embed_summary', { summaryId });
+
+  // Re-query to get the actual persisted row ID — during a race the ON CONFLICT
+  // path keeps the winner's ID, not the pre-generated UUID from the loser.
+  const actualRow = db.select({ id: memorySummaries.id })
+    .from(memorySummaries)
+    .where(and(
+      eq(memorySummaries.scope, 'conversation'),
+      eq(memorySummaries.scopeKey, conversationId),
+    ))
+    .get();
+  if (actualRow) {
+    enqueueMemoryJob('embed_summary', { summaryId: actualRow.id });
+  }
 }
 
 export async function buildGlobalSummaryJob(scope: 'weekly_global' | 'monthly_global', config: AssistantConfig): Promise<void> {
@@ -206,7 +218,19 @@ export async function buildGlobalSummaryJob(scope: 'weekly_global' | 'monthly_gl
       updatedAt: ts,
     },
   }).run();
-  enqueueMemoryJob('embed_summary', { summaryId });
+
+  // Re-query to get the actual persisted row ID — during a race the ON CONFLICT
+  // path keeps the winner's ID, not the pre-generated UUID from the loser.
+  const actualRow = db.select({ id: memorySummaries.id })
+    .from(memorySummaries)
+    .where(and(
+      eq(memorySummaries.scope, scope),
+      eq(memorySummaries.scopeKey, scopeKey),
+    ))
+    .get();
+  if (actualRow) {
+    enqueueMemoryJob('embed_summary', { summaryId: actualRow.id });
+  }
 }
 
 async function summarizeWithLLM(


### PR DESCRIPTION
Addresses review feedback on #8999. When two concurrent summary jobs race and the upsert takes the ON CONFLICT DO UPDATE path, the pre-generated UUID does not match the actual row ID. This fix re-queries the database after upsert to get the persisted row ID before enqueuing the embed_summary job. Applied to both buildConversationSummaryJob and buildGlobalSummaryJob.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
