### PR TITLE
fix: add ORDER BY to migration 026 INSERT OR IGNORE to keep newest embedding

### DIFF
--- a/assistant/src/memory/migrations/026-embeddings-nullable-vector-json.ts
+++ b/assistant/src/memory/migrations/026-embeddings-nullable-vector-json.ts
@@ -67,6 +67,7 @@ export function migrateEmbeddingsNullableVectorJson(database: DrizzleDb): void {
         id, target_type, target_id, provider, model, dimensions,
         vector_json, vector_blob, content_hash, created_at, updated_at
       FROM memory_embeddings
+      ORDER BY updated_at DESC
     `);
     raw.exec(/*sql*/ `DROP TABLE memory_embeddings`);
     raw.exec(/*sql*/ `ALTER TABLE memory_embeddings_new RENAME TO memory_embeddings`);


### PR DESCRIPTION
Addresses review feedback on #9008. Ensures the most recent embedding is retained during deduplication by adding ORDER BY updated_at DESC to the INSERT OR IGNORE SELECT.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
