### PR TITLE
fix: narrow Twilio rate-limit exemption to explicit webhook paths

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -173,7 +173,9 @@ function main() {
         url.pathname === "/deliver/whatsapp" ||
         url.pathname.startsWith("/pairing/") ||
         (url.pathname.startsWith("/v1/") &&
-          !url.pathname.startsWith("/v1/calls/twilio/") &&
+          url.pathname !== "/v1/calls/twilio/voice-webhook" &&
+          url.pathname !== "/v1/calls/twilio/status" &&
+          url.pathname !== "/v1/calls/twilio/connect-action" &&
           url.pathname !== "/v1/calls/relay");
       if (isAuthRoute) {
         const clientIp = getClientIp(req, svr, config.trustProxy);


### PR DESCRIPTION
Addresses review feedback on #9013. Replaces broad `startsWith("/v1/calls/twilio/")` prefix check with explicit path matching for the three known Twilio webhook paths: `voice-webhook`, `status`, and `connect-action`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
