### PR TITLE
fix: batch dismiss-conflicts to handle >1000 pending conflicts

### DIFF
--- a/assistant/src/cli/config-commands.ts
+++ b/assistant/src/cli/config-commands.ts
@@ -17,7 +17,7 @@ import {
 } from '../memory/admin.js';
 import { listPendingConflictDetails } from '../memory/conflict-store.js';
 import { listConversations } from '../memory/conversation-store.js';
-import { initializeDb } from '../memory/db.js';
+import { initializeDb, rawGet } from '../memory/db.js';
 import {
   clearAllRules,
   getAllRules,
@@ -354,16 +354,29 @@ export function registerMemoryCommand(program: Command): void {
 
       if (opts.dryRun) {
         const scopeId = opts.scope ?? 'default';
-        const pending = listPendingConflictDetails(scopeId, 1000);
+        const totalPending = rawGet<{ c: number }>(
+          `SELECT COUNT(*) AS c FROM memory_item_conflicts WHERE scope_id = ? AND status = 'pending_clarification'`,
+          scopeId,
+        )?.c ?? 0;
+
+        // Show a sample of conflicts (can't paginate without dismissing)
+        const sample = listPendingConflictDetails(scopeId, 1000);
         let matchCount = 0;
-        for (const conflict of pending) {
+        for (const conflict of sample) {
           const matches = opts.all
             || (pattern && (pattern.test(conflict.existingStatement) || pattern.test(conflict.candidateStatement)));
           if (!matches) continue;
           matchCount++;
           log.info(`  [${conflict.id.slice(0, SHORT_HASH_LENGTH)}] "${conflict.existingStatement}" vs "${conflict.candidateStatement}"`);
         }
-        log.info(`\nDry run: ${matchCount} of ${pending.length} pending conflicts would be dismissed.`);
+
+        if (opts.all) {
+          // --all matches everything, so matchCount is just the sample size
+          log.info(`\nDry run: ${totalPending} of ${totalPending} pending conflicts would be dismissed.`);
+        } else {
+          const moreNote = totalPending > sample.length ? ` (showing first ${sample.length} of ${totalPending})` : '';
+          log.info(`\nDry run: ${matchCount} of ${totalPending} pending conflicts would be dismissed.${moreNote}`);
+        }
         return;
       }
 

--- a/assistant/src/memory/admin.ts
+++ b/assistant/src/memory/admin.ts
@@ -216,34 +216,50 @@ export function dismissPendingConflicts(
   options: { all?: boolean; pattern?: RegExp; scopeId?: string },
 ): DismissConflictsResult {
   const scopeId = options.scopeId ?? 'default';
-  const pending = listPendingConflictDetails(scopeId, 1000);
   const dismissed: DismissConflictsResult['details'] = [];
+  const BATCH_SIZE = 1000;
 
-  for (const conflict of pending) {
-    const matches = options.all
-      || (options.pattern && (
-        options.pattern.test(conflict.existingStatement)
-        || options.pattern.test(conflict.candidateStatement)
-      ));
-    if (!matches) continue;
+  // Fetch and dismiss in batches to handle arbitrarily large backlogs
+  let batch = listPendingConflictDetails(scopeId, BATCH_SIZE);
+  while (batch.length > 0) {
+    let batchHadMatch = false;
+    for (const conflict of batch) {
+      const matches = options.all
+        || (options.pattern && (
+          options.pattern.test(conflict.existingStatement)
+          || options.pattern.test(conflict.candidateStatement)
+        ));
+      if (!matches) continue;
 
-    resolveConflict(conflict.id, {
-      status: 'dismissed',
-      resolutionNote: options.all
-        ? 'Bulk dismissed via CLI (dismiss-conflicts --all).'
-        : `Dismissed via CLI (pattern: ${options.pattern?.source}).`,
-    });
-    dismissed.push({
-      id: conflict.id,
-      existingStatement: conflict.existingStatement,
-      candidateStatement: conflict.candidateStatement,
-    });
+      batchHadMatch = true;
+      resolveConflict(conflict.id, {
+        status: 'dismissed',
+        resolutionNote: options.all
+          ? 'Bulk dismissed via CLI (dismiss-conflicts --all).'
+          : `Dismissed via CLI (pattern: ${options.pattern?.source}).`,
+      });
+      dismissed.push({
+        id: conflict.id,
+        existingStatement: conflict.existingStatement,
+        candidateStatement: conflict.candidateStatement,
+      });
+    }
+    // If nothing matched in this batch, no point fetching more — remaining
+    // conflicts won't match either (pattern mode) or we already got them all.
+    if (!batchHadMatch) break;
+    batch = listPendingConflictDetails(scopeId, BATCH_SIZE);
   }
 
-  log.info({ dismissed: dismissed.length, remaining: pending.length - dismissed.length, scopeId }, 'Dismissed pending conflicts');
+  // Get true remaining count via SQL to avoid batch-size truncation
+  const remaining = rawGet<{ c: number }>(
+    `SELECT COUNT(*) AS c FROM memory_item_conflicts WHERE scope_id = ? AND status = 'pending_clarification'`,
+    scopeId,
+  )?.c ?? 0;
+
+  log.info({ dismissed: dismissed.length, remaining, scopeId }, 'Dismissed pending conflicts');
   return {
     dismissed: dismissed.length,
-    remaining: pending.length - dismissed.length,
+    remaining,
     details: dismissed,
   };
 }


### PR DESCRIPTION
Addresses review feedback on #8984. Loops until all conflicts are dismissed instead of capping at 1000.

- `dismissPendingConflicts` in `admin.ts`: now fetches and dismisses in batches of 1000, looping until no more matches. Uses a SQL COUNT(*) query for accurate remaining count.
- Dry-run path in `config-commands.ts`: uses SQL COUNT(*) for total pending count and indicates when there are more than the displayed sample.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
