### PR TITLE
fix: align META_CLARIFICATION_PATTERN with actual conflict-gate question format

### DIFF
--- a/assistant/src/memory/conflict-policy.ts
+++ b/assistant/src/memory/conflict-policy.ts
@@ -37,7 +37,7 @@ const TRACKING_LANGUAGE_PATTERN = /\b(?:this pr|that issue|while we wait|current
 // extracted from previous conflict-gate interactions — not durable facts.
 // Allowing them into the conflict pipeline creates self-reinforcing loops.
 // Patterns are kept narrow to avoid filtering legitimate durable instructions.
-const META_CLARIFICATION_PATTERN = /\b(?:needs? clarification|unclear which (?:version|value|setting)|user should (?:specify|clarify)|conflicting (?:notes|instructions) (?:about|regarding|for))\b/i;
+const META_CLARIFICATION_PATTERN = /\b(?:needs? clarification\b|unclear which (?:version|value|setting)\b|user should (?:specify|clarify)\b|conflicting (?:notes|instructions)(?:\s*[:."]|\s+(?:about|regarding|for)\b))/i;
 
 /**
  * Returns true when a statement looks like a transient tracking note


### PR DESCRIPTION
Addresses review feedback on #9012. Fixes regex to match the generated conflict-gate question text ("I have conflicting notes: ..." with colon+quote instead of about/regarding/for). Moves trailing word boundary anchors to individual alternatives so punctuation-terminated patterns match correctly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
