### PR TITLE
fix: set lastFailedMessageDisplayText in bootstrap failure paths for voice-mode retry

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -457,6 +457,7 @@ extension ChatViewModel {
                 if let pending = pendingUserMessage {
                     let attachments = pendingUserAttachments
                     pendingUserMessage = nil
+                    pendingUserMessageDisplayText = nil
                     pendingUserAttachments = nil
                     do {
                         try daemonClient.send(UserMessageMessage(

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -211,6 +211,10 @@ public final class ChatViewModel: ObservableObject {
     /// and sends a history request so the response is routed back properly.
     public var onReconnectHistoryNeeded: ((_ sessionId: String) -> Void)?
     var pendingUserMessage: String?
+    /// The display text (rawText) corresponding to pendingUserMessage.
+    /// In voice mode, pendingUserMessage contains the voice-prefixed text while
+    /// this stores the original user text used for message-bubble matching.
+    var pendingUserMessageDisplayText: String?
     /// Optional callback for sending notifications when tool-use messages complete
     public var onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)?
     /// Whether the current assistant response was triggered by a voice message.
@@ -538,6 +542,7 @@ public final class ChatViewModel: ObservableObject {
                 let attachments = pendingAttachments
                 pendingAttachments = []
                 pendingUserMessage = text
+                pendingUserMessageDisplayText = rawText
                 pendingUserAttachments = attachments.isEmpty ? nil : attachments.map {
                     IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
                 }
@@ -620,6 +625,7 @@ public final class ChatViewModel: ObservableObject {
 
         if sessionId == nil {
             // First message: need to bootstrap session
+            pendingUserMessageDisplayText = rawText
             bootstrapSession(userMessage: text, attachments: ipcAttachments)
         } else {
             // Subsequent messages: send directly (daemon queues if busy)
@@ -654,10 +660,12 @@ public final class ChatViewModel: ObservableObject {
                     self.isSending = false
                     self.bootstrapCorrelationId = nil
                     self.lastFailedMessageText = self.pendingUserMessage
+                    self.lastFailedMessageDisplayText = self.pendingUserMessageDisplayText
                     self.lastFailedMessageAttachments = self.pendingUserAttachments
                     self.lastFailedSendError = "Failed to connect to the assistant."
                     self.connectionDiagnosticHint = Self.connectionDiagnosticHint(for: error)
                     self.pendingUserMessage = nil
+                    self.pendingUserMessageDisplayText = nil
                     self.pendingUserAttachments = nil
                     self.errorText = self.lastFailedSendError
                     return
@@ -679,9 +687,11 @@ public final class ChatViewModel: ObservableObject {
                 self.isSending = false
                 self.bootstrapCorrelationId = nil
                 self.lastFailedMessageText = self.pendingUserMessage
+                self.lastFailedMessageDisplayText = self.pendingUserMessageDisplayText
                 self.lastFailedMessageAttachments = self.pendingUserAttachments
                 self.lastFailedSendError = "Failed to create session."
                 self.pendingUserMessage = nil
+                self.pendingUserMessageDisplayText = nil
                 self.pendingUserAttachments = nil
                 self.errorText = self.lastFailedSendError
             }
@@ -940,6 +950,7 @@ public final class ChatViewModel: ObservableObject {
     /// but preserve the correlation ID so the VM only claims its own session.
     public func cancelPendingMessage() {
         pendingUserMessage = nil
+        pendingUserMessageDisplayText = nil
         pendingUserAttachments = nil
         isWorkspaceRefinementInFlight = false
         refinementMessagePreview = nil
@@ -959,6 +970,7 @@ public final class ChatViewModel: ObservableObject {
         // cancel on the daemon side.
         if sessionId == nil {
             pendingUserMessage = nil
+            pendingUserMessageDisplayText = nil
             pendingUserAttachments = nil
             bootstrapCorrelationId = nil
             isWorkspaceRefinementInFlight = false
@@ -1405,6 +1417,7 @@ public final class ChatViewModel: ObservableObject {
         connectionDiagnosticHint = nil
 
         if sessionId == nil {
+            pendingUserMessageDisplayText = displayText
             bootstrapSession(userMessage: text, attachments: attachments)
         } else {
             // When retrying while another turn is in progress, the retried


### PR DESCRIPTION
Addresses review feedback on #9000. Sets display text before offline queue enqueue so retry lookup works.

Introduces `pendingUserMessageDisplayText` to carry the raw display text alongside `pendingUserMessage` (which may contain voice-prefixed text). Both bootstrap failure paths now set `lastFailedMessageDisplayText` so that `retryLastMessage()` can match the original message bubble by display text.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
