### PR TITLE
refactor: rename AgentHeartbeat → Heartbeat

### DIFF
--- a/assistant/scripts/ipc/check-swift-decoder-drift.ts
+++ b/assistant/scripts/ipc/check-swift-decoder-drift.ts
@@ -48,8 +48,8 @@ const SWIFT_OMIT_ALLOWLIST = new Set<string>([
   // Watcher messages — not yet consumed by the macOS client
   'watcher_escalation',
   'watcher_notification',
-  // Agent heartbeat alerts — not yet consumed by the macOS client
-  'agent_heartbeat_alert',
+  // Heartbeat alerts — not yet consumed by the macOS client
+  'heartbeat_alert',
   // Browser handoff — not yet consumed by the macOS client
   'browser_handoff_request',
   // Guardian verification — daemon-internal for Telegram channel setup

--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -10,6 +10,7 @@ exports[`IPC message snapshots ClientMessage types auth serializes to expected J
 exports[`IPC message snapshots ClientMessage types user_message serializes to expected JSON 1`] = `
 {
   "content": "Hello, assistant!",
+  "interface": "cli",
   "sessionId": "sess-001",
   "type": "user_message",
 }
@@ -41,6 +42,7 @@ exports[`IPC message snapshots ClientMessage types session_create serializes to 
     "hints": [
       "dashboard-capable",
     ],
+    "interfaceId": "macos",
     "uxBrief": "Prefer dashboard-first onboarding.",
   },
   "type": "session_create",
@@ -51,6 +53,14 @@ exports[`IPC message snapshots ClientMessage types session_switch serializes to 
 {
   "sessionId": "sess-002",
   "type": "session_switch",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types session_rename serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-002",
+  "title": "Renamed session",
+  "type": "session_rename",
 }
 `;
 
@@ -305,6 +315,31 @@ exports[`IPC message snapshots ClientMessage types skills_inspect serializes to 
 {
   "slug": "clawhub/my-skill",
   "type": "skills_inspect",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_draft serializes to expected JSON 1`] = `
+{
+  "sourceText": "Create a weather skill",
+  "type": "skills_draft",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_create serializes to expected JSON 1`] = `
+{
+  "bodyMarkdown": 
+"# Weather
+
+Fetches weather data."
+,
+  "description": "Fetches current weather",
+  "disableModelInvocation": false,
+  "emoji": "🌤️",
+  "name": "Weather Skill",
+  "overwrite": false,
+  "skillId": "weather-skill",
+  "type": "skills_create",
+  "userInvocable": true,
 }
 `;
 
@@ -586,6 +621,13 @@ exports[`IPC message snapshots ClientMessage types ingress_config serializes to 
 {
   "action": "get",
   "type": "ingress_config",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types platform_config serializes to expected JSON 1`] = `
+{
+  "action": "get",
+  "type": "platform_config",
 }
 `;
 
@@ -1033,6 +1075,33 @@ exports[`IPC message snapshots ClientMessage types assistant_inbox_reply seriali
   "content": "Hello from the assistant",
   "conversationId": "conv-001",
   "type": "assistant_inbox_reply",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types pairing_approval_response serializes to expected JSON 1`] = `
+{
+  "decision": "approve_once",
+  "pairingRequestId": "pair-001",
+  "type": "pairing_approval_response",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types approved_devices_list serializes to expected JSON 1`] = `
+{
+  "type": "approved_devices_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types approved_device_remove serializes to expected JSON 1`] = `
+{
+  "hashedDeviceId": "hashed-device-001",
+  "type": "approved_device_remove",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types approved_devices_clear serializes to expected JSON 1`] = `
+{
+  "type": "approved_devices_clear",
 }
 `;
 
@@ -1656,6 +1725,25 @@ Does things."
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types skills_draft_response serializes to expected JSON 1`] = `
+{
+  "draft": {
+    "bodyMarkdown": 
+"# Weather
+
+Fetches weather data."
+,
+    "description": "Fetches current weather",
+    "emoji": "🌤️",
+    "name": "Weather Skill",
+    "skillId": "weather-skill",
+  },
+  "success": true,
+  "type": "skills_draft_response",
+  "warnings": [],
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types suggestion_response serializes to expected JSON 1`] = `
 {
   "requestId": "req-suggest-001",
@@ -1699,6 +1787,18 @@ exports[`IPC message snapshots ServerMessage types reminder_fired serializes to 
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types notification_intent serializes to expected JSON 1`] = `
+{
+  "body": "Your assistant needs your input.",
+  "deepLinkMetadata": {
+    "conversationId": "conv-guardian-001",
+  },
+  "sourceEventName": "guardian.question",
+  "title": "⚠️ Attention needed",
+  "type": "notification_intent",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types schedule_complete serializes to expected JSON 1`] = `
 {
   "name": "Daily backup",
@@ -1723,11 +1823,11 @@ exports[`IPC message snapshots ServerMessage types watcher_escalation serializes
 }
 `;
 
-exports[`IPC message snapshots ServerMessage types agent_heartbeat_alert serializes to expected JSON 1`] = `
+exports[`IPC message snapshots ServerMessage types heartbeat_alert serializes to expected JSON 1`] = `
 {
   "body": "No activity detected in the last 60 minutes.",
-  "title": "Agent heartbeat stalled",
-  "type": "agent_heartbeat_alert",
+  "title": "Heartbeat stalled",
+  "type": "heartbeat_alert",
 }
 `;
 
@@ -2060,6 +2160,14 @@ exports[`IPC message snapshots ServerMessage types ingress_config_response seria
   "publicBaseUrl": "https://example.com",
   "success": true,
   "type": "ingress_config_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types platform_config_response serializes to expected JSON 1`] = `
+{
+  "baseUrl": "https://platform.vellum.ai",
+  "success": true,
+  "type": "platform_config_response",
 }
 `;
 
@@ -2881,33 +2989,6 @@ exports[`IPC message snapshots ServerMessage types assistant_inbox_reply_respons
 }
 `;
 
-exports[`IPC message snapshots ClientMessage types pairing_approval_response serializes to expected JSON 1`] = `
-{
-  "decision": "approve_once",
-  "pairingRequestId": "pair-001",
-  "type": "pairing_approval_response",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types approved_devices_list serializes to expected JSON 1`] = `
-{
-  "type": "approved_devices_list",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types approved_device_remove serializes to expected JSON 1`] = `
-{
-  "hashedDeviceId": "hashed-device-001",
-  "type": "approved_device_remove",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types approved_devices_clear serializes to expected JSON 1`] = `
-{
-  "type": "approved_devices_clear",
-}
-`;
-
 exports[`IPC message snapshots ServerMessage types pairing_approval_request serializes to expected JSON 1`] = `
 {
   "deviceId": "device-001",
@@ -2934,84 +3015,5 @@ exports[`IPC message snapshots ServerMessage types approved_device_remove_respon
 {
   "success": true,
   "type": "approved_device_remove_response",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types session_rename serializes to expected JSON 1`] = `
-{
-  "sessionId": "sess-002",
-  "title": "Renamed session",
-  "type": "session_rename",
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types notification_intent serializes to expected JSON 1`] = `
-{
-  "body": "Your assistant needs your input.",
-  "deepLinkMetadata": {
-    "conversationId": "conv-guardian-001",
-  },
-  "sourceEventName": "guardian.question",
-  "title": "⚠️ Attention needed",
-  "type": "notification_intent",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types skills_draft serializes to expected JSON 1`] = `
-{
-  "sourceText": "Create a weather skill",
-  "type": "skills_draft",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types skills_create serializes to expected JSON 1`] = `
-{
-  "bodyMarkdown": 
-"# Weather
-
-Fetches weather data."
-,
-  "description": "Fetches current weather",
-  "disableModelInvocation": false,
-  "emoji": "🌤️",
-  "name": "Weather Skill",
-  "overwrite": false,
-  "skillId": "weather-skill",
-  "type": "skills_create",
-  "userInvocable": true,
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types platform_config serializes to expected JSON 1`] = `
-{
-  "action": "get",
-  "type": "platform_config",
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types skills_draft_response serializes to expected JSON 1`] = `
-{
-  "draft": {
-    "bodyMarkdown": 
-"# Weather
-
-Fetches weather data."
-,
-    "description": "Fetches current weather",
-    "emoji": "🌤️",
-    "name": "Weather Skill",
-    "skillId": "weather-skill",
-  },
-  "success": true,
-  "type": "skills_draft_response",
-  "warnings": [],
-}
-`;
-
-exports[`IPC message snapshots ServerMessage types platform_config_response serializes to expected JSON 1`] = `
-{
-  "baseUrl": "https://platform.vellum.ai",
-  "success": true,
-  "type": "platform_config_response",
 }
 `;

--- a/assistant/src/__tests__/commit-guarantee.test.ts
+++ b/assistant/src/__tests__/commit-guarantee.test.ts
@@ -19,7 +19,7 @@ import {
 } from '../workspace/git-service.js';
 import {
   _resetHeartbeatState,
-  HeartbeatService,
+  WorkspaceHeartbeatService,
 } from '../workspace/heartbeat-service.js';
 import { commitTurnChanges } from '../workspace/turn-commit.js';
 
@@ -263,7 +263,7 @@ describe('Commit guarantees', () => {
       const services = new Map<string, WorkspaceGitService>();
       services.set(testDir, service);
 
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         getServices: () => services,
       });
 
@@ -297,7 +297,7 @@ describe('Commit guarantees', () => {
       const uninitService = new WorkspaceGitService(uninitDir);
       services.set(uninitDir, uninitService);
 
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         getServices: () => services,
       });
 
@@ -319,7 +319,7 @@ describe('Commit guarantees', () => {
       const services = new Map<string, WorkspaceGitService>();
       services.set(testDir, service);
 
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         getServices: () => services,
       });
 

--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -13,7 +13,7 @@ mock.module('../util/platform.js', () => ({
 
 // Mock config loader
 let mockConfig = {
-  agentHeartbeat: {
+  heartbeat: {
     enabled: true,
     intervalMs: 60_000,
     activeHoursStart: undefined as number | undefined,
@@ -55,14 +55,14 @@ mock.module('../memory/conversation-title-service.js', () => ({
 }));
 
 // Import after mocks are set up
-const { AgentHeartbeatService } = await import('../agent-heartbeat/agent-heartbeat-service.js');
+const { HeartbeatService } = await import('../heartbeat/heartbeat-service.js');
 
-describe('AgentHeartbeatService', () => {
+describe('HeartbeatService', () => {
   let processMessageCalls: Array<{ conversationId: string; content: string }>;
   let alerterCalls: Array<{ type: string; title: string; body: string }>;
 
   beforeEach(() => {
-    testWorkspaceDir = join(tmpdir(), `vellum-agent-hb-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    testWorkspaceDir = join(tmpdir(), `vellum-hb-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     mkdirSync(testWorkspaceDir, { recursive: true });
 
     processMessageCalls = [];
@@ -71,7 +71,7 @@ describe('AgentHeartbeatService', () => {
     conversationIdCounter = 0;
 
     mockConfig = {
-      agentHeartbeat: {
+      heartbeat: {
         enabled: true,
         intervalMs: 60_000,
         activeHoursStart: undefined,
@@ -84,7 +84,7 @@ describe('AgentHeartbeatService', () => {
     processMessage?: (id: string, content: string) => Promise<{ messageId: string }>;
     getCurrentHour?: () => number;
   }) {
-    return new AgentHeartbeatService({
+    return new HeartbeatService({
       processMessage: overrides?.processMessage ?? (async (conversationId: string, content: string) => {
         processMessageCalls.push({ conversationId, content });
         return { messageId: 'msg-1' };
@@ -138,8 +138,8 @@ describe('AgentHeartbeatService', () => {
   });
 
   test('active hours guard skips outside window', async () => {
-    mockConfig.agentHeartbeat.activeHoursStart = 9;
-    mockConfig.agentHeartbeat.activeHoursEnd = 17;
+    mockConfig.heartbeat.activeHoursStart = 9;
+    mockConfig.heartbeat.activeHoursEnd = 17;
 
     const service = createService({ getCurrentHour: () => 3 });
     await service.runOnce();
@@ -148,8 +148,8 @@ describe('AgentHeartbeatService', () => {
   });
 
   test('active hours guard allows within window', async () => {
-    mockConfig.agentHeartbeat.activeHoursStart = 9;
-    mockConfig.agentHeartbeat.activeHoursEnd = 17;
+    mockConfig.heartbeat.activeHoursStart = 9;
+    mockConfig.heartbeat.activeHoursEnd = 17;
 
     const service = createService({ getCurrentHour: () => 12 });
     await service.runOnce();
@@ -158,8 +158,8 @@ describe('AgentHeartbeatService', () => {
   });
 
   test('active hours handles overnight window', async () => {
-    mockConfig.agentHeartbeat.activeHoursStart = 22;
-    mockConfig.agentHeartbeat.activeHoursEnd = 6;
+    mockConfig.heartbeat.activeHoursStart = 22;
+    mockConfig.heartbeat.activeHoursEnd = 6;
 
     // 23:00 should be within the window
     const service = createService({ getCurrentHour: () => 23 });
@@ -203,7 +203,7 @@ describe('AgentHeartbeatService', () => {
   });
 
   test('disabled config prevents start', () => {
-    mockConfig.agentHeartbeat.enabled = false;
+    mockConfig.heartbeat.enabled = false;
     const service = createService();
     service.start();
     // No error, just a no-op. We can verify by calling stop which should also be a no-op.
@@ -212,7 +212,7 @@ describe('AgentHeartbeatService', () => {
   });
 
   test('disabled config prevents runOnce', async () => {
-    mockConfig.agentHeartbeat.enabled = false;
+    mockConfig.heartbeat.enabled = false;
     const service = createService();
     await service.runOnce();
 
@@ -229,8 +229,8 @@ describe('AgentHeartbeatService', () => {
     await service.runOnce();
 
     expect(alerterCalls).toHaveLength(1);
-    expect(alerterCalls[0].type).toBe('agent_heartbeat_alert');
-    expect(alerterCalls[0].title).toBe('Agent Heartbeat Failed');
+    expect(alerterCalls[0].type).toBe('heartbeat_alert');
+    expect(alerterCalls[0].title).toBe('Heartbeat Failed');
     expect(alerterCalls[0].body).toBe('LLM timeout');
   });
 

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -1127,9 +1127,9 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     title: 'Urgent email from Alice',
     body: 'Meeting rescheduled to 3pm today.',
   },
-  agent_heartbeat_alert: {
-    type: 'agent_heartbeat_alert',
-    title: 'Agent heartbeat stalled',
+  heartbeat_alert: {
+    type: 'heartbeat_alert',
+    title: 'Heartbeat stalled',
     body: 'No activity detected in the last 60 minutes.',
   },
   watch_started: {

--- a/assistant/src/__tests__/workspace-heartbeat-service.test.ts
+++ b/assistant/src/__tests__/workspace-heartbeat-service.test.ts
@@ -13,10 +13,10 @@ import {
 } from '../workspace/git-service.js';
 import {
   _resetHeartbeatState,
-  HeartbeatService,
+  WorkspaceHeartbeatService,
 } from '../workspace/heartbeat-service.js';
 
-describe('HeartbeatService', () => {
+describe('WorkspaceHeartbeatService', () => {
   let testDir: string;
   let service: WorkspaceGitService;
   let services: Map<string, WorkspaceGitService>;
@@ -50,7 +50,7 @@ describe('HeartbeatService', () => {
 
   describe('heartbeat check with age threshold', () => {
     test('does not commit when workspace is clean', async () => {
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         ageThresholdMs: 0, // Immediate
         fileThreshold: 1,
         getServices: () => services,
@@ -66,7 +66,7 @@ describe('HeartbeatService', () => {
     test('does not commit when changes are below age and file thresholds', async () => {
       writeFileSync(join(testDir, 'file.txt'), 'content');
 
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         ageThresholdMs: 10 * 60 * 1000, // 10 minutes
         fileThreshold: 100,
         getServices: () => services,
@@ -83,7 +83,7 @@ describe('HeartbeatService', () => {
       writeFileSync(join(testDir, 'file.txt'), 'content');
 
       let currentTime = 1000000;
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         ageThresholdMs: 5 * 60 * 1000, // 5 minutes
         fileThreshold: 100,
         getServices: () => services,
@@ -116,7 +116,7 @@ describe('HeartbeatService', () => {
         writeFileSync(join(testDir, `file${i}.txt`), `content ${i}`);
       }
 
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         ageThresholdMs: 10 * 60 * 1000, // 10 minutes (not yet)
         fileThreshold: 20,
         getServices: () => services,
@@ -137,7 +137,7 @@ describe('HeartbeatService', () => {
 
   describe('normal operation does not create spurious commits', () => {
     test('clean workspace produces no heartbeat commits', async () => {
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         ageThresholdMs: 0,
         fileThreshold: 1,
         getServices: () => services,
@@ -161,7 +161,7 @@ describe('HeartbeatService', () => {
       // Create a small number of files (below file threshold)
       writeFileSync(join(testDir, 'small-change.txt'), 'content');
 
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         ageThresholdMs: 10 * 60 * 1000, // 10 minutes
         fileThreshold: 100, // Very high
         getServices: () => services,
@@ -176,7 +176,7 @@ describe('HeartbeatService', () => {
       writeFileSync(join(testDir, 'file.txt'), 'content');
 
       let currentTime = 1000000;
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         ageThresholdMs: 5 * 60 * 1000,
         fileThreshold: 100,
         getServices: () => services,
@@ -203,7 +203,7 @@ describe('HeartbeatService', () => {
     test('commits pending changes on shutdown', async () => {
       writeFileSync(join(testDir, 'unsaved.txt'), 'uncommitted content');
 
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         getServices: () => services,
       });
 
@@ -223,7 +223,7 @@ describe('HeartbeatService', () => {
     });
 
     test('does not commit on shutdown when workspace is clean', async () => {
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         getServices: () => services,
       });
 
@@ -244,7 +244,7 @@ describe('HeartbeatService', () => {
       writeFileSync(join(testDir, 'file1.txt'), 'content1');
       writeFileSync(join(testDir2, 'file2.txt'), 'content2');
 
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         getServices: () => services,
       });
 
@@ -270,7 +270,7 @@ describe('HeartbeatService', () => {
 
       writeFileSync(join(testDir, 'file.txt'), 'content');
 
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         ageThresholdMs: 0,
         fileThreshold: 1,
         getServices: () => mixedServices,
@@ -292,7 +292,7 @@ describe('HeartbeatService', () => {
   describe('threshold behavior', () => {
     test('resets dirty tracking after successful commit', async () => {
       let currentTime = 1000000;
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         ageThresholdMs: 5 * 60 * 1000,
         fileThreshold: 100,
         getServices: () => services,
@@ -324,7 +324,7 @@ describe('HeartbeatService', () => {
     test('commit message includes trigger metadata', async () => {
       writeFileSync(join(testDir, 'file.txt'), 'content');
 
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         ageThresholdMs: 0,
         fileThreshold: 1,
         getServices: () => services,
@@ -344,7 +344,7 @@ describe('HeartbeatService', () => {
 
   describe('start and stop', () => {
     test('start and stop are idempotent', async () => {
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         intervalMs: 60000,
         getServices: () => services,
       });
@@ -371,7 +371,7 @@ describe('HeartbeatService', () => {
       };
 
       let currentTime = 1000000;
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         ageThresholdMs: 5 * 60 * 1000,
         fileThreshold: 100,
         getServices: () => services,
@@ -408,7 +408,7 @@ describe('HeartbeatService', () => {
         },
       };
 
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         getServices: () => services,
         commitMessageProvider: customProvider,
       });
@@ -437,7 +437,7 @@ describe('HeartbeatService', () => {
       };
 
       let currentTime = 1000000;
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         ageThresholdMs: 5 * 60 * 1000,
         fileThreshold: 100,
         getServices: () => services,
@@ -471,7 +471,7 @@ describe('HeartbeatService', () => {
         },
       };
 
-      const heartbeat = new HeartbeatService({
+      const heartbeat = new WorkspaceHeartbeatService({
         getServices: () => services,
         commitMessageProvider: customProvider,
       });

--- a/assistant/src/__tests__/workspace-lifecycle.test.ts
+++ b/assistant/src/__tests__/workspace-lifecycle.test.ts
@@ -2,7 +2,7 @@
  * Integration-style test that exercises the full git workspace lifecycle:
  *   lazy init → turn-boundary commits → heartbeat safety net → commit history verification.
  *
- * This test wires together WorkspaceGitService, commitTurnChanges, and HeartbeatService
+ * This test wires together WorkspaceGitService, commitTurnChanges, and WorkspaceHeartbeatService
  * in the same flow a real daemon session would follow.
  */
 import { execFileSync } from 'node:child_process';
@@ -19,7 +19,7 @@ import {
 } from '../workspace/git-service.js';
 import {
   _resetHeartbeatState,
-  HeartbeatService,
+  WorkspaceHeartbeatService,
 } from '../workspace/heartbeat-service.js';
 import { commitTurnChanges } from '../workspace/turn-commit.js';
 
@@ -153,7 +153,7 @@ describe('Workspace git lifecycle (integration)', () => {
     services.set(testDir, service);
 
     let fakeTime = 2_000_000;
-    const heartbeat = new HeartbeatService({
+    const heartbeat = new WorkspaceHeartbeatService({
       ageThresholdMs: 5 * 60 * 1000,
       fileThreshold: 100,
       getServices: () => services,
@@ -234,7 +234,7 @@ describe('Workspace git lifecycle (integration)', () => {
     const services = new Map<string, WorkspaceGitService>();
     services.set(testDir, service);
 
-    const heartbeat = new HeartbeatService({
+    const heartbeat = new WorkspaceHeartbeatService({
       ageThresholdMs: 0,
       fileThreshold: 1,
       getServices: () => services,

--- a/assistant/src/config/agent-schema.ts
+++ b/assistant/src/config/agent-schema.ts
@@ -1,25 +1,25 @@
 import { z } from 'zod';
 
-export const AgentHeartbeatConfigSchema = z.object({
+export const HeartbeatConfigSchema = z.object({
   enabled: z
-    .boolean({ error: 'agentHeartbeat.enabled must be a boolean' })
+    .boolean({ error: 'heartbeat.enabled must be a boolean' })
     .default(false),
   intervalMs: z
-    .number({ error: 'agentHeartbeat.intervalMs must be a number' })
-    .int('agentHeartbeat.intervalMs must be an integer')
-    .positive('agentHeartbeat.intervalMs must be a positive integer')
+    .number({ error: 'heartbeat.intervalMs must be a number' })
+    .int('heartbeat.intervalMs must be an integer')
+    .positive('heartbeat.intervalMs must be a positive integer')
     .default(3_600_000),
   activeHoursStart: z
-    .number({ error: 'agentHeartbeat.activeHoursStart must be a number' })
-    .int('agentHeartbeat.activeHoursStart must be an integer')
-    .min(0, 'agentHeartbeat.activeHoursStart must be >= 0')
-    .max(23, 'agentHeartbeat.activeHoursStart must be <= 23')
+    .number({ error: 'heartbeat.activeHoursStart must be a number' })
+    .int('heartbeat.activeHoursStart must be an integer')
+    .min(0, 'heartbeat.activeHoursStart must be >= 0')
+    .max(23, 'heartbeat.activeHoursStart must be <= 23')
     .optional(),
   activeHoursEnd: z
-    .number({ error: 'agentHeartbeat.activeHoursEnd must be a number' })
-    .int('agentHeartbeat.activeHoursEnd must be an integer')
-    .min(0, 'agentHeartbeat.activeHoursEnd must be >= 0')
-    .max(23, 'agentHeartbeat.activeHoursEnd must be <= 23')
+    .number({ error: 'heartbeat.activeHoursEnd must be a number' })
+    .int('heartbeat.activeHoursEnd must be an integer')
+    .min(0, 'heartbeat.activeHoursEnd must be >= 0')
+    .max(23, 'heartbeat.activeHoursEnd must be <= 23')
     .optional(),
 }).superRefine((config, ctx) => {
   const hasStart = config.activeHoursStart != null;
@@ -28,14 +28,14 @@ export const AgentHeartbeatConfigSchema = z.object({
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: [hasStart ? 'activeHoursEnd' : 'activeHoursStart'],
-      message: 'agentHeartbeat.activeHoursStart and agentHeartbeat.activeHoursEnd must both be set or both be omitted',
+      message: 'heartbeat.activeHoursStart and heartbeat.activeHoursEnd must both be set or both be omitted',
     });
   }
   if (hasStart && hasEnd && config.activeHoursStart === config.activeHoursEnd) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ['activeHoursEnd'],
-      message: 'agentHeartbeat.activeHoursStart and agentHeartbeat.activeHoursEnd must not be equal (would create an empty window)',
+      message: 'heartbeat.activeHoursStart and heartbeat.activeHoursEnd must not be equal (would create an empty window)',
     });
   }
 });
@@ -167,6 +167,6 @@ export const WorkspaceGitConfigSchema = z.object({
   }).default({} as any),
 });
 
-export type AgentHeartbeatConfig = z.infer<typeof AgentHeartbeatConfigSchema>;
+export type HeartbeatConfig = z.infer<typeof HeartbeatConfigSchema>;
 export type SwarmConfig = z.infer<typeof SwarmConfigSchema>;
 export type WorkspaceGitConfig = z.infer<typeof WorkspaceGitConfigSchema>;

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -4,12 +4,12 @@ import { getDataDir } from '../util/platform.js';
 
 // Re-export all domain schemas
 export type {
-  AgentHeartbeatConfig,
+  HeartbeatConfig,
   SwarmConfig,
   WorkspaceGitConfig,
 } from './agent-schema.js';
 export {
-  AgentHeartbeatConfigSchema,
+  HeartbeatConfigSchema,
   SwarmConfigSchema,
   WorkspaceGitConfigSchema,
 } from './agent-schema.js';
@@ -128,7 +128,7 @@ export {
 } from './skills-schema.js';
 
 // Imports for AssistantConfigSchema composition
-import { AgentHeartbeatConfigSchema, SwarmConfigSchema, WorkspaceGitConfigSchema } from './agent-schema.js';
+import { HeartbeatConfigSchema, SwarmConfigSchema, WorkspaceGitConfigSchema } from './agent-schema.js';
 import { CallsConfigSchema } from './calls-schema.js';
 import {
   AuditLogConfigSchema,
@@ -204,7 +204,7 @@ export const AssistantConfigSchema = z.object({
   pricingOverrides: z
     .array(ModelPricingOverrideSchema)
     .default([]),
-  agentHeartbeat: AgentHeartbeatConfigSchema.default({} as any),
+  heartbeat: HeartbeatConfigSchema.default({} as any),
   swarm: SwarmConfigSchema.default({} as any),
   skills: SkillsConfigSchema.default({} as any),
   workspaceGit: WorkspaceGitConfigSchema.default({} as any),

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -1,5 +1,4 @@
 export type {
-  AgentHeartbeatConfig,
   AssistantConfig,
   AuditLogConfig,
   CallerIdentityConfig,
@@ -11,6 +10,7 @@ export type {
   ContextWindowConfig,
   DaemonConfig,
   DockerConfig,
+  HeartbeatConfig,
   IngressConfig,
   LogFileConfig,
   MemoryConfig,

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -183,7 +183,7 @@
   ],
   "serverWireTypes": [
     "accept_starter_bundle_response",
-    "agent_heartbeat_alert",
+    "heartbeat_alert",
     "app_data_response",
     "app_diff_response",
     "app_file_at_version_response",

--- a/assistant/src/daemon/ipc-contract/schedules.ts
+++ b/assistant/src/daemon/ipc-contract/schedules.ts
@@ -90,8 +90,8 @@ export interface WatcherEscalation {
   body: string;
 }
 
-export interface AgentHeartbeatAlert {
-  type: 'agent_heartbeat_alert';
+export interface HeartbeatAlert {
+  type: 'heartbeat_alert';
   title: string;
   body: string;
 }
@@ -113,4 +113,4 @@ export type _SchedulesServerMessages =
   | ScheduleComplete
   | WatcherNotification
   | WatcherEscalation
-  | AgentHeartbeatAlert;
+  | HeartbeatAlert;

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -4,7 +4,6 @@ import { join } from 'node:path';
 
 import { config as dotenvConfig } from 'dotenv';
 
-import { AgentHeartbeatService } from '../agent-heartbeat/agent-heartbeat-service.js';
 import { reconcileCallsOnStartup } from '../calls/call-recovery.js';
 import { setRelayBroadcast } from '../calls/relay-server.js';
 import { TwilioConversationRelayProvider } from '../calls/twilio-provider.js';
@@ -18,6 +17,7 @@ import {
 } from '../config/env.js';
 import { loadConfig } from '../config/loader.js';
 import { ensurePromptFiles } from '../config/system-prompt.js';
+import { HeartbeatService } from '../heartbeat/heartbeat-service.js';
 import { getHookManager } from '../hooks/manager.js';
 import { installTemplates } from '../hooks/templates.js';
 import { initSentry } from '../instrument.js';
@@ -43,7 +43,7 @@ import {
   getSocketPath,
 } from '../util/platform.js';
 import { listWorkItems, updateWorkItem } from '../work-items/work-item-store.js';
-import { HeartbeatService } from '../workspace/heartbeat-service.js';
+import { WorkspaceHeartbeatService } from '../workspace/heartbeat-service.js';
 import { createApprovalConversationGenerator,createApprovalCopyGenerator } from './approval-generators.js';
 import { cleanupPidFile,writePid } from './daemon-control.js';
 import { initPairingHandlers } from './handlers/pairing.js';
@@ -359,20 +359,20 @@ export async function runDaemon(): Promise<void> {
     }
   }
 
-  const heartbeat = new HeartbeatService();
-  heartbeat.start();
+  const workspaceHeartbeat = new WorkspaceHeartbeatService();
+  workspaceHeartbeat.start();
 
-  const agentHeartbeat = new AgentHeartbeatService({
+  const heartbeat = new HeartbeatService({
     processMessage: (conversationId, content) =>
       server.processMessage(conversationId, content),
     alerter: (alert) => server.broadcast(alert),
   });
-  agentHeartbeat.start();
+  heartbeat.start();
 
   installShutdownHandlers({
     server,
+    workspaceHeartbeat,
     heartbeat,
-    agentHeartbeat,
     hookManager,
     runtimeHttp,
     scheduler,

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/node';
 
-import type { AgentHeartbeatService } from '../agent-heartbeat/agent-heartbeat-service.js';
+import type { HeartbeatService } from '../heartbeat/heartbeat-service.js';
 import type { HookManager } from '../hooks/manager.js';
 import { getSqlite, resetDb } from '../memory/db.js';
 import type { QdrantManager } from '../memory/qdrant-manager.js';
@@ -8,15 +8,15 @@ import type { RuntimeHttpServer } from '../runtime/http-server.js';
 import { browserManager } from '../tools/browser/browser-manager.js';
 import { getLogger } from '../util/logger.js';
 import { getEnrichmentService } from '../workspace/commit-message-enrichment-service.js';
-import type { HeartbeatService } from '../workspace/heartbeat-service.js';
+import type { WorkspaceHeartbeatService } from '../workspace/heartbeat-service.js';
 import type { DaemonServer } from './server.js';
 
 const log = getLogger('lifecycle');
 
 export interface ShutdownDeps {
   server: DaemonServer;
+  workspaceHeartbeat: WorkspaceHeartbeatService;
   heartbeat: HeartbeatService;
-  agentHeartbeat: AgentHeartbeatService;
   hookManager: HookManager;
   runtimeHttp: RuntimeHttpServer | null;
   scheduler: { stop(): void };
@@ -45,8 +45,8 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     }, 10_000);
     forceTimer.unref();
 
+    await deps.workspaceHeartbeat.stop();
     await deps.heartbeat.stop();
-    await deps.agentHeartbeat.stop();
 
     try {
       await deps.hookManager.trigger('daemon-stop', { pid: process.pid });
@@ -58,7 +58,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     // This ensures no workspace state is lost during graceful shutdown.
     try {
       log.info({ phase: 'pre_stop' }, 'Committing pending workspace changes');
-      await deps.heartbeat.commitAllPending();
+      await deps.workspaceHeartbeat.commitAllPending();
     } catch (err) {
       log.warn({ err, phase: 'pre_stop' }, 'Shutdown workspace commit failed');
     }
@@ -69,7 +69,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     // (e.g. in-flight tool executions completing during drain).
     try {
       log.info({ phase: 'post_stop' }, 'Final workspace commit sweep');
-      await deps.heartbeat.commitAllPending();
+      await deps.workspaceHeartbeat.commitAllPending();
     } catch (err) {
       log.warn({ err, phase: 'post_stop' }, 'Post-stop workspace commit failed');
     }

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -1,45 +1,45 @@
 import { getConfig } from '../config/loader.js';
-import type { AgentHeartbeatAlert } from '../daemon/ipc-contract.js';
+import type { HeartbeatAlert } from '../daemon/ipc-contract.js';
 import { createConversation } from '../memory/conversation-store.js';
 import { GENERATING_TITLE, queueGenerateConversationTitle } from '../memory/conversation-title-service.js';
 import { readTextFileSync } from '../util/fs.js';
 import { getLogger } from '../util/logger.js';
 import { getWorkspacePromptPath } from '../util/platform.js';
 
-const log = getLogger('agent-heartbeat');
+const log = getLogger('heartbeat-check');
 
 const DEFAULT_CHECKLIST = `- Check the current weather and note anything notable
 - Review any recent news headlines worth flagging
 - Look for calendar events or reminders coming up soon`;
 
-export interface AgentHeartbeatDeps {
+export interface HeartbeatDeps {
   processMessage: (conversationId: string, content: string) => Promise<{ messageId: string }>;
-  alerter: (alert: AgentHeartbeatAlert) => void;
+  alerter: (alert: HeartbeatAlert) => void;
   /** Override for current hour (0-23), for testing. */
   getCurrentHour?: () => number;
 }
 
-export class AgentHeartbeatService {
-  private readonly deps: AgentHeartbeatDeps;
+export class HeartbeatService {
+  private readonly deps: HeartbeatDeps;
   private timer: ReturnType<typeof setInterval> | null = null;
   private activeRun: Promise<void> | null = null;
 
-  constructor(deps: AgentHeartbeatDeps) {
+  constructor(deps: HeartbeatDeps) {
     this.deps = deps;
   }
 
   start(): void {
-    const config = getConfig().agentHeartbeat;
+    const config = getConfig().heartbeat;
     if (!config.enabled) {
-      log.info('Agent heartbeat disabled by config');
+      log.info('Heartbeat disabled by config');
       return;
     }
     if (this.timer) return;
 
-    log.info({ intervalMs: config.intervalMs }, 'Agent heartbeat service started');
+    log.info({ intervalMs: config.intervalMs }, 'Heartbeat service started');
     this.timer = setInterval(() => {
       this.runOnce().catch((err) => {
-        log.error({ err }, 'Agent heartbeat runOnce failed');
+        log.error({ err }, 'Heartbeat runOnce failed');
       });
     }, config.intervalMs);
   }
@@ -55,11 +55,11 @@ export class AgentHeartbeatService {
       await Promise.race([this.activeRun, timeout]);
       clearTimeout(timerId!);
     }
-    log.info('Agent heartbeat service stopped');
+    log.info('Heartbeat service stopped');
   }
 
   async runOnce(): Promise<void> {
-    const config = getConfig().agentHeartbeat;
+    const config = getConfig().heartbeat;
     if (!config.enabled) return;
 
     // Active hours guard — only applied when both bounds are set.
@@ -88,7 +88,7 @@ export class AgentHeartbeatService {
   }
 
   private async executeRun(): Promise<void> {
-    log.info('Running agent heartbeat');
+    log.info('Running heartbeat');
 
     try {
       const checklist = this.readChecklist();
@@ -100,17 +100,17 @@ export class AgentHeartbeatService {
       });
       queueGenerateConversationTitle({
         conversationId: conversation.id,
-        context: { origin: 'heartbeat', systemHint: 'Agent Heartbeat' },
+        context: { origin: 'heartbeat', systemHint: 'Heartbeat' },
       });
 
       await this.deps.processMessage(conversation.id, prompt);
-      log.info({ conversationId: conversation.id }, 'Agent heartbeat completed');
+      log.info({ conversationId: conversation.id }, 'Heartbeat completed');
     } catch (err) {
-      log.error({ err }, 'Agent heartbeat failed');
+      log.error({ err }, 'Heartbeat failed');
       try {
         this.deps.alerter({
-          type: 'agent_heartbeat_alert',
-          title: 'Agent Heartbeat Failed',
+          type: 'heartbeat_alert',
+          title: 'Heartbeat Failed',
           body: err instanceof Error ? err.message : String(err),
         });
       } catch (alertErr) {

--- a/assistant/src/workspace/heartbeat-service.ts
+++ b/assistant/src/workspace/heartbeat-service.ts
@@ -18,7 +18,7 @@ const DEFAULT_FILE_THRESHOLD = 20;
 /** How often the heartbeat runs (ms). Default: 5 minutes. */
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000;
 
-export interface HeartbeatServiceOptions {
+export interface WorkspaceHeartbeatServiceOptions {
   /** Maximum age of uncommitted changes before auto-commit (ms). */
   ageThresholdMs?: number;
   /** Maximum number of changed files before auto-commit. */
@@ -63,7 +63,7 @@ const firstSeenDirty = new Map<string, number>();
  * - Background processes that write to the workspace
  * - Forgotten state from crashed or interrupted sessions
  */
-export class HeartbeatService {
+export class WorkspaceHeartbeatService {
   private readonly ageThresholdMs: number;
   private readonly fileThreshold: number;
   private readonly intervalMs: number;
@@ -74,7 +74,7 @@ export class HeartbeatService {
   /** Tracks the currently in-flight check to prevent overlapping runs and allow clean shutdown. */
   private activeCheck: Promise<HeartbeatCheckResult> | null = null;
 
-  constructor(options?: HeartbeatServiceOptions) {
+  constructor(options?: WorkspaceHeartbeatServiceOptions) {
     this.ageThresholdMs = options?.ageThresholdMs ?? DEFAULT_AGE_THRESHOLD_MS;
     this.fileThreshold = options?.fileThreshold ?? DEFAULT_FILE_THRESHOLD;
     this.intervalMs = options?.intervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -54,7 +54,7 @@ public struct IPCAddTrustRule: Codable, Sendable {
     }
 }
 
-public struct IPCAgentHeartbeatAlert: Codable, Sendable {
+public struct IPCHeartbeatAlert: Codable, Sendable {
     public let type: String
     public let title: String
     public let body: String


### PR DESCRIPTION
## Summary
- Rename `AgentHeartbeatService` → `HeartbeatService` and move from `agent-heartbeat/` to `heartbeat/` directory
- Rename workspace `HeartbeatService` → `WorkspaceHeartbeatService` to resolve naming conflict
- Update config key from `agentHeartbeat` to `heartbeat` and wire type from `agent_heartbeat_alert` to `heartbeat_alert`
- Update all imports, tests, IPC contract, Swift codegen, and drift checker

## Test plan
- [x] All heartbeat service tests pass (`bun test heartbeat-service.test.ts`)
- [x] IPC snapshot tests pass and regenerated (`bun test ipc-snapshot.test.ts`)
- [x] Workspace heartbeat tests pass (`bun test workspace-heartbeat-service.test.ts commit-guarantee.test.ts workspace-lifecycle.test.ts`)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] No stale references to `AgentHeartbeat`, `agent_heartbeat`, or `agentHeartbeat` remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
