### PR TITLE
fix: allow quoted strings in safe-line function call arguments in pre-commit regex

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -74,11 +74,12 @@ declare -a SAFE_LINE_PATTERNS=(
     # `//` comments — prevents masking real fallback assignments like
     # `clientSecret: config.clientSecret || "real_secret"`.
     "[.?]+[a-zA-Z0-9_]*[Cc]lient[Ss]ecret([^\"'/]*$|[^\"'/]*//.*)$"
-    # TS/JS: secret/key variable assigned from a function call (no string literal).
-    # E.g. `const clientSecret = getSecureKey(keyVault)`.
-    # The [^"']* after `(` ensures the call args contain no quoted strings,
-    # preventing `getSecureKey("sk_live_...")` from being whitelisted.
-    "(client[_-]?[Ss]ecret|[Pp]rivate[_-]?[Kk]ey)[[:space:]]*=[[:space:]]*(get[A-Za-z]*|create[A-Za-z]*|load[A-Za-z]*|read[A-Za-z]*|delete[A-Za-z]*|set[A-Za-z]*)\([^\"']*$"
+    # TS/JS: secret/key variable assigned from a function call.
+    # E.g. `const clientSecret = getSecureKey(keyVault)` or
+    # `getSecureKey('credential:integration:twitter:oauth_client_secret')`.
+    # Allows either no quoted args, or quoted args containing `:` (key paths).
+    # Raw alphanumeric strings like `"sk_live_..."` are still rejected.
+    "(client[_-]?[Ss]ecret|[Pp]rivate[_-]?[Kk]ey)[[:space:]]*=[[:space:]]*(get[A-Za-z]*|create[A-Za-z]*|load[A-Za-z]*|read[A-Za-z]*|delete[A-Za-z]*|set[A-Za-z]*)\(([^\"']*$|[^\"']*[\"'][^\"']*:[^\"']*[\"'])"
     # TS/JS: property key followed by type annotation or opening brace.
     # E.g. `requiresClientSecret: boolean;` or `client_secret: {`.
     "[Cc]lient[_-]?[Ss]ecret['\"]?:[[:space:]]*(boolean|number)[[:space:]]*[;,]?"
@@ -184,6 +185,8 @@ if [ "${1:-}" = "--self-test" ]; then
     # Function-call assignments (false positives to whitelist)
     SAFE_FUNC_CALL_SECRET='const clientSecret = getSecureKey(keyVault)'
     SAFE_CREATE_PRIVATE_KEY='const key = createPrivateKey(keyPem)'
+    # Function-call with quoted key path (colon-separated identifier) — must be whitelisted
+    SAFE_FUNC_CALL_KEY_PATH="const clientSecret = getSecureKey('credential:integration:twitter:oauth_client_secret') || undefined;"
     # Function-call with literal secret in args — must NOT be whitelisted
     UNSAFE_FUNC_CALL_LITERAL='const clientSecret = getSecureKey("sk_live_12345678901234567890")'
     UNSAFE_FUNC_CALL_SINGLE_QUOTE="const privateKey = loadPrivateKey('real_secret_key_value_12345')"
@@ -381,6 +384,10 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$SAFE_CREATE_PRIVATE_KEY" && ! matches_safe_line_pattern "$SAFE_CREATE_PRIVATE_KEY"; then
         echo -e "${RED}Self-test failed:${NC} createPrivateKey function-call false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_FUNC_CALL_KEY_PATH" && ! matches_safe_line_pattern "$SAFE_FUNC_CALL_KEY_PATH"; then
+        echo -e "${RED}Self-test failed:${NC} function-call with quoted key path false positive"
         exit 1
     fi
     if matches_secret_pattern "$UNSAFE_FUNC_CALL_LITERAL" && matches_safe_line_pattern "$UNSAFE_FUNC_CALL_LITERAL"; then


### PR DESCRIPTION
Addresses review feedback on #9007. Adjusts regex to not reject safe patterns with quoted key-path arguments (e.g. `getSecureKey('credential:integration:twitter:oauth_client_secret')`) while still rejecting raw secret literals.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
