### PR TITLE
docs: add notification architecture docs and regression tests (M5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,12 @@ Returning `undefined` is acceptable only for **lookup functions** where "not fou
 | Filesystem tools (`path-policy.ts`, `edit-engine.ts`) | Discriminated union (`{ ok, reason }`) | Validation outcomes that the caller must handle (out of bounds, not found, ambiguous) |
 | Subagent manager (`subagent/manager.ts`) | Throws for precondition violations, string literal unions for expected outcomes | Depth limit exceeded is a bug; `sendMessage` returns `'not_found' | 'terminal' | 'queue_full'` as expected states |
 
+## Notification Pipeline
+
+All notification producers **MUST** go through `emitNotificationSignal()` in `notifications/emit-signal.ts`. Do not bypass the pipeline by broadcasting IPC events directly -- the pipeline handles event persistence, deduplication, decision routing, and delivery audit.
+
+When a notification flow creates a server-side conversation (e.g. guardian question threads, task run threads), the conversation and initial message **MUST** be persisted before the IPC thread-created event is emitted. This ensures the macOS/iOS client can immediately fetch the conversation contents when it receives the event.
+
 ## Memory Provenance Invariant
 
 All memory extraction and retrieval decisions must consider actor-role provenance. Untrusted actors (non-guardian, unverified_channel) must not trigger profile extraction or receive memory recall/conflict disclosures. This invariant is enforced in `indexer.ts` (write gate) and `session-memory.ts` (read gate).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4408,8 +4408,8 @@ When the LLM emits `[ASK_GUARDIAN: question]` during a voice call, the controlle
 
 1. **Request creation**: A `guardian_action_request` row is created with a unique 6-character hex request code, the question text, a `pending` status, and an expiry timestamp.
 
-2. **Delivery fan-out**: Deliveries are created for each configured channel:
-   - **Mac (always)**: A server-side conversation is created with key `asst:${assistantId}:guardian:request:${request.id}`. The dispatch engine emits a `guardian_request_thread_created` IPC event so the desktop UI can display the question thread.
+2. **Delivery fan-out**: Deliveries are created for each configured channel. The guardian dispatch also fires `emitNotificationSignal()` (fire-and-forget) into the generic notification pipeline for logging and potential future routing to additional channels.
+   - **Vellum (always)**: A server-side conversation is created with key `asst:${assistantId}:guardian:request:${request.id}`. The dispatch engine emits a `guardian_request_thread_created` IPC event so the desktop UI can display the question thread. LLM-generated copy (thread title and initial message) is awaited only for this branch to avoid delaying external channel dispatch.
    - **Telegram/SMS (if guardian binding exists)**: A `POST /deliver/{channel}` request is sent to the gateway with the question text and request code.
 
 3. **Answer resolution**: The first channel to respond wins. Answer resolution uses an atomic `WHERE status = 'pending'` check on the `guardian_action_requests` table -- only the first writer succeeds in transitioning the request to `answered` status. The winning answer text and responding channel are recorded on the request row.
@@ -4690,9 +4690,40 @@ The notification module (`assistant/src/notifications/`) uses a signal-based arc
 
 ```
 Producer → NotificationSignal → Decision Engine (LLM) → Deterministic Checks → Broadcaster → Adapters → Delivery
-                                       ↑
-                               Preference Summary
+                                       ↑                                                        ↓
+                               Preference Summary                              notification_intent IPC (vellum)
 ```
+
+### Notification Conversation Materialization
+
+The notification pipeline supports two conversation materialization paths depending on the producer:
+
+1. **Generic notification pipeline** (`emitNotificationSignal` → decision engine → broadcaster → adapters): The broadcaster dispatches a `notification_intent` IPC event via the Vellum adapter. The IPC payload includes `deepLinkMetadata` (e.g. `{ conversationId }`) so the macOS/iOS client can deep-link to the relevant context when the user taps the notification.
+
+2. **Guardian dispatch** (`dispatchGuardianQuestion`): Creates a server-side conversation **before** entering the notification pipeline. The guardian dispatch:
+   - Creates a `guardian_action_request` row with a unique request code
+   - Creates a dedicated conversation via `getOrCreateConversation()`
+   - Adds the guardian question as the initial message in the thread
+   - Emits a `guardian_request_thread_created` IPC event so the macOS client surfaces the thread immediately
+   - Also fires `emitNotificationSignal()` (fire-and-forget) for the LLM decision engine to potentially route to additional channels
+
+### IPC Thread-Created Events
+
+Two IPC push events surface new threads in the macOS/iOS client sidebar:
+
+- **`guardian_request_thread_created`** — Emitted by `guardian-dispatch.ts` when a voice call ASK_GUARDIAN question creates a vellum thread. Payload: `{ conversationId, requestId, callSessionId, title, questionText }`.
+- **`task_run_thread_created`** — Emitted by `work-item-runner.ts` when a task run creates a conversation. Payload: `{ conversationId, workItemId, title }`.
+
+Both events follow the same pattern: the daemon creates a server-side conversation, persists an initial message, and broadcasts the IPC event so the macOS `ThreadManager` can create a visible thread in the sidebar.
+
+### Channel Delivery
+
+Notifications are delivered to two channel types:
+
+- **Vellum (always connected)**: Local IPC via the daemon's broadcast mechanism. The `VellumAdapter` emits a `notification_intent` message with rendered copy and optional `deepLinkMetadata`.
+- **Telegram (when guardian binding exists)**: HTTP POST to the gateway's `/deliver/telegram` endpoint. Requires an active guardian binding for the assistant.
+
+Connected channels are resolved at signal emission time: vellum is always included, and binding-based channels (Telegram) are included only when an active guardian binding exists for the assistant.
 
 **Key modules:**
 
@@ -4702,14 +4733,18 @@ Producer → NotificationSignal → Decision Engine (LLM) → Deterministic Chec
 | `assistant/src/notifications/decision-engine.ts` | LLM-based routing decisions with deterministic fallback |
 | `assistant/src/notifications/deterministic-checks.ts` | Hard invariant checks (dedupe, source-active suppression, channel availability) |
 | `assistant/src/notifications/broadcaster.ts` | Dispatches decisions to channel adapters |
-| `assistant/src/notifications/adapters/` | Per-channel delivery (macOS IPC, Telegram gateway) |
+| `assistant/src/notifications/adapters/macos.ts` | Vellum adapter — broadcasts `notification_intent` via IPC with deep-link metadata |
+| `assistant/src/notifications/adapters/telegram.ts` | Telegram adapter — POSTs to gateway `/deliver/telegram` |
+| `assistant/src/notifications/destination-resolver.ts` | Resolves per-channel endpoints (vellum IPC, Telegram chat ID from guardian binding) |
+| `assistant/src/notifications/copy-composer.ts` | Template-based fallback copy when LLM copy is unavailable |
 | `assistant/src/notifications/preference-extractor.ts` | Detects preference statements in conversation messages |
 | `assistant/src/notifications/preferences-store.ts` | CRUD for user notification preferences |
 | `assistant/src/config/bundled-skills/messaging/tools/send-notification.ts` | Explicit producer tool for user-requested notifications; emits signals into the same routing pipeline |
+| `assistant/src/calls/guardian-dispatch.ts` | Guardian question dispatch with dedicated conversation materialization and `guardian_request_thread_created` IPC |
 
 **Audit trail (SQLite):** `notification_events` → `notification_decisions` → `notification_deliveries`
 
-**Configuration:** `notifications.decisionModel` in `config.json`.
+**Configuration:** `notifications.decisionModelIntent` in `config.json`.
 
 ---
 

--- a/assistant/src/__tests__/notification-broadcaster.test.ts
+++ b/assistant/src/__tests__/notification-broadcaster.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Regression tests for the notification broadcaster.
+ *
+ * Validates that the broadcaster correctly:
+ * - Dispatches to registered adapters
+ * - Handles missing adapters gracefully
+ * - Falls back to copy-composer when decision copy is missing
+ * - Reports delivery results per channel
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+
+// -- Mocks (must be declared before importing modules that depend on them) ----
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Mock destination-resolver to return a destination for every requested channel
+mock.module('../notifications/destination-resolver.js', () => ({
+  resolveDestinations: (_assistantId: string, channels: string[]) => {
+    const m = new Map();
+    for (const ch of channels) {
+      m.set(ch, { channel: ch, endpoint: `mock-${ch}` });
+    }
+    return m;
+  },
+}));
+
+// Mock deliveries-store to avoid DB access
+mock.module('../notifications/deliveries-store.js', () => ({
+  createDelivery: () => {},
+  updateDeliveryStatus: () => {},
+}));
+
+import { NotificationBroadcaster } from '../notifications/broadcaster.js';
+import type { NotificationSignal } from '../notifications/signal.js';
+import type {
+  ChannelAdapter,
+  ChannelDeliveryPayload,
+  ChannelDestination,
+  DeliveryResult,
+  NotificationChannel,
+  NotificationDecision,
+} from '../notifications/types.js';
+
+// -- Helpers -----------------------------------------------------------------
+
+function makeSignal(overrides?: Partial<NotificationSignal>): NotificationSignal {
+  return {
+    signalId: 'sig-broadcast-001',
+    assistantId: 'self',
+    createdAt: Date.now(),
+    sourceChannel: 'scheduler',
+    sourceSessionId: 'sess-001',
+    sourceEventName: 'test.event',
+    contextPayload: {},
+    attentionHints: {
+      requiresAction: false,
+      urgency: 'medium',
+      isAsyncBackground: true,
+      visibleInSourceNow: false,
+    },
+    ...overrides,
+  };
+}
+
+function makeDecision(overrides?: Partial<NotificationDecision>): NotificationDecision {
+  return {
+    shouldNotify: true,
+    selectedChannels: ['vellum'],
+    reasoningSummary: 'Test decision',
+    renderedCopy: {
+      vellum: { title: 'Test Alert', body: 'Something happened' },
+    },
+    dedupeKey: 'broadcast-test-001',
+    confidence: 0.9,
+    fallbackUsed: false,
+    ...overrides,
+  };
+}
+
+class MockAdapter implements ChannelAdapter {
+  readonly channel: NotificationChannel;
+  sent: ChannelDeliveryPayload[] = [];
+  shouldFail = false;
+
+  constructor(channel: NotificationChannel) {
+    this.channel = channel;
+  }
+
+  async send(payload: ChannelDeliveryPayload, _dest: ChannelDestination): Promise<DeliveryResult> {
+    this.sent.push(payload);
+    if (this.shouldFail) return { success: false, error: 'Mock failure' };
+    return { success: true };
+  }
+}
+
+// -- Tests -------------------------------------------------------------------
+
+describe('notification broadcaster', () => {
+  test('dispatches to the vellum adapter when selected', async () => {
+    const vellumAdapter = new MockAdapter('vellum');
+    const broadcaster = new NotificationBroadcaster([vellumAdapter]);
+
+    const signal = makeSignal();
+    const decision = makeDecision();
+
+    const results = await broadcaster.broadcastDecision(signal, decision);
+
+    expect(vellumAdapter.sent).toHaveLength(1);
+    expect(vellumAdapter.sent[0].copy.title).toBe('Test Alert');
+    expect(results.some(r => r.channel === 'vellum' && r.status === 'sent')).toBe(true);
+  });
+
+  test('skips channels without registered adapters', async () => {
+    // Register only vellum, but decision selects both
+    const vellumAdapter = new MockAdapter('vellum');
+    const broadcaster = new NotificationBroadcaster([vellumAdapter]);
+
+    const signal = makeSignal();
+    const decision = makeDecision({
+      selectedChannels: ['vellum', 'telegram'],
+      renderedCopy: {
+        vellum: { title: 'Test', body: 'Body' },
+        telegram: { title: 'Test', body: 'Body' },
+      },
+    });
+
+    const results = await broadcaster.broadcastDecision(signal, decision);
+
+    // Vellum should succeed, telegram should be skipped (no adapter registered)
+    expect(results).toHaveLength(2);
+    const vellumResult = results.find(r => r.channel === 'vellum');
+    const telegramResult = results.find(r => r.channel === 'telegram');
+    expect(vellumResult?.status).toBe('sent');
+    expect(telegramResult?.status).toBe('skipped');
+  });
+
+  test('reports failed delivery when adapter returns error', async () => {
+    const vellumAdapter = new MockAdapter('vellum');
+    vellumAdapter.shouldFail = true;
+    const broadcaster = new NotificationBroadcaster([vellumAdapter]);
+
+    const signal = makeSignal();
+    const decision = makeDecision();
+
+    const results = await broadcaster.broadcastDecision(signal, decision);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('failed');
+    expect(results[0].errorMessage).toContain('Mock failure');
+  });
+
+  test('passes deepLinkTarget through to adapter payload', async () => {
+    const vellumAdapter = new MockAdapter('vellum');
+    const broadcaster = new NotificationBroadcaster([vellumAdapter]);
+
+    const signal = makeSignal();
+    const decision = makeDecision({
+      deepLinkTarget: { conversationId: 'conv-123', screen: 'thread' },
+    });
+
+    await broadcaster.broadcastDecision(signal, decision);
+
+    expect(vellumAdapter.sent).toHaveLength(1);
+    expect(vellumAdapter.sent[0].deepLinkTarget).toEqual({
+      conversationId: 'conv-123',
+      screen: 'thread',
+    });
+  });
+
+  test('multiple channels receive independent copy from the decision', async () => {
+    const vellumAdapter = new MockAdapter('vellum');
+    const telegramAdapter = new MockAdapter('telegram');
+    const broadcaster = new NotificationBroadcaster([vellumAdapter, telegramAdapter]);
+
+    const signal = makeSignal();
+    const decision = makeDecision({
+      selectedChannels: ['vellum', 'telegram'],
+      renderedCopy: {
+        vellum: { title: 'Desktop Alert', body: 'For desktop' },
+        telegram: { title: 'Mobile Alert', body: 'For mobile' },
+      },
+    });
+
+    await broadcaster.broadcastDecision(signal, decision);
+
+    expect(vellumAdapter.sent).toHaveLength(1);
+    expect(vellumAdapter.sent[0].copy.title).toBe('Desktop Alert');
+
+    expect(telegramAdapter.sent).toHaveLength(1);
+    expect(telegramAdapter.sent[0].copy.title).toBe('Mobile Alert');
+  });
+
+  test('uses fallback copy when decision is missing copy for a channel', async () => {
+    const vellumAdapter = new MockAdapter('vellum');
+    const broadcaster = new NotificationBroadcaster([vellumAdapter]);
+
+    const signal = makeSignal({ sourceEventName: 'reminder.fired' });
+    const decision = makeDecision({
+      renderedCopy: {}, // No rendered copy
+      fallbackUsed: true,
+    });
+
+    await broadcaster.broadcastDecision(signal, decision);
+
+    expect(vellumAdapter.sent).toHaveLength(1);
+    // The fallback should produce some copy (either from template or generic)
+    expect(vellumAdapter.sent[0].copy.title).toBeDefined();
+    expect(vellumAdapter.sent[0].copy.body).toBeDefined();
+  });
+
+  test('empty selectedChannels produces no deliveries', async () => {
+    const vellumAdapter = new MockAdapter('vellum');
+    const broadcaster = new NotificationBroadcaster([vellumAdapter]);
+
+    const signal = makeSignal();
+    const decision = makeDecision({
+      selectedChannels: [],
+    });
+
+    const results = await broadcaster.broadcastDecision(signal, decision);
+
+    expect(results).toHaveLength(0);
+    expect(vellumAdapter.sent).toHaveLength(0);
+  });
+});

--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Regression tests for the notification decision engine's strategy selection.
+ *
+ * Validates that the deterministic fallback correctly classifies signals based
+ * on urgency + requiresAction, that channel selection respects connected channels,
+ * and that the copy-composer generates correct fallback copy for known event names.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { composeFallbackCopy } from '../notifications/copy-composer.js';
+import type { NotificationSignal } from '../notifications/signal.js';
+import type { NotificationChannel } from '../notifications/types.js';
+
+// -- Helpers -----------------------------------------------------------------
+
+function makeSignal(overrides?: Partial<NotificationSignal>): NotificationSignal {
+  return {
+    signalId: 'sig-test-001',
+    assistantId: 'self',
+    createdAt: Date.now(),
+    sourceChannel: 'scheduler',
+    sourceSessionId: 'sess-001',
+    sourceEventName: 'test.event',
+    contextPayload: {},
+    attentionHints: {
+      requiresAction: false,
+      urgency: 'medium',
+      isAsyncBackground: true,
+      visibleInSourceNow: false,
+    },
+    ...overrides,
+  };
+}
+
+// -- Tests -------------------------------------------------------------------
+
+describe('notification decision strategy', () => {
+  // -- Copy composer exhaustiveness ------------------------------------------
+
+  describe('copy-composer fallback templates', () => {
+    const channels: NotificationChannel[] = ['vellum', 'telegram'];
+
+    test('guardian.question template includes question text from payload', () => {
+      const signal = makeSignal({
+        sourceEventName: 'guardian.question',
+        contextPayload: { questionText: 'What is the gate code?' },
+      });
+
+      const copy = composeFallbackCopy(signal, channels);
+      expect(copy.vellum).toBeDefined();
+      expect(copy.vellum!.body).toContain('What is the gate code?');
+    });
+
+    test('reminder.fired template uses message from payload', () => {
+      const signal = makeSignal({
+        sourceEventName: 'reminder.fired',
+        contextPayload: { message: 'Take out the trash' },
+      });
+
+      const copy = composeFallbackCopy(signal, channels);
+      expect(copy.vellum).toBeDefined();
+      expect(copy.vellum!.body).toBe('Take out the trash');
+      expect(copy.vellum!.title).toBe('Reminder');
+    });
+
+    test('schedule.complete template uses name from payload', () => {
+      const signal = makeSignal({
+        sourceEventName: 'schedule.complete',
+        contextPayload: { name: 'Daily backup' },
+      });
+
+      const copy = composeFallbackCopy(signal, channels);
+      expect(copy.vellum).toBeDefined();
+      expect(copy.vellum!.body).toContain('Daily backup');
+    });
+
+    test('unknown event name produces generic copy with urgency prefix', () => {
+      const signal = makeSignal({
+        sourceEventName: 'some_novel.event',
+        attentionHints: {
+          requiresAction: true,
+          urgency: 'high',
+          isAsyncBackground: false,
+          visibleInSourceNow: false,
+        },
+      });
+
+      const copy = composeFallbackCopy(signal, channels);
+      expect(copy.vellum).toBeDefined();
+      expect(copy.vellum!.title).toBe('Notification');
+      expect(copy.vellum!.body).toContain('Urgent:');
+      expect(copy.vellum!.body).toContain('action required');
+    });
+
+    test('unknown event name without urgency produces clean generic copy', () => {
+      const signal = makeSignal({
+        sourceEventName: 'background.sync_complete',
+        attentionHints: {
+          requiresAction: false,
+          urgency: 'low',
+          isAsyncBackground: true,
+          visibleInSourceNow: false,
+        },
+      });
+
+      const copy = composeFallbackCopy(signal, channels);
+      expect(copy.vellum).toBeDefined();
+      expect(copy.vellum!.body).not.toContain('Urgent:');
+      expect(copy.vellum!.body).not.toContain('action required');
+      // Dots and underscores in event name are replaced with spaces
+      expect(copy.vellum!.body).toContain('background sync complete');
+    });
+
+    test('fallback copy is generated for every requested channel', () => {
+      const signal = makeSignal({
+        sourceEventName: 'reminder.fired',
+        contextPayload: { message: 'Test' },
+      });
+
+      const copy = composeFallbackCopy(signal, channels);
+      expect(copy.vellum).toBeDefined();
+      expect(copy.telegram).toBeDefined();
+      // Both channels get the same copy
+      expect(copy.vellum!.title).toBe(copy.telegram!.title);
+      expect(copy.vellum!.body).toBe(copy.telegram!.body);
+    });
+
+    test('empty payload falls back to default text in template', () => {
+      const signal = makeSignal({
+        sourceEventName: 'guardian.question',
+        contextPayload: {},
+      });
+
+      const copy = composeFallbackCopy(signal, channels);
+      expect(copy.vellum).toBeDefined();
+      expect(copy.vellum!.body).toBe('A guardian question needs your attention');
+    });
+  });
+
+  // -- NotificationChannel type correctness ----------------------------------
+
+  describe('NotificationChannel type', () => {
+    test('vellum and telegram are valid notification channels', () => {
+      // This validates the type definition at runtime.
+      const channels: NotificationChannel[] = ['vellum', 'telegram'];
+      expect(channels).toHaveLength(2);
+    });
+  });
+
+  // -- AttentionHints urgency levels ------------------------------------------
+
+  describe('attention hints urgency levels', () => {
+    test('all three urgency levels are valid', () => {
+      for (const urgency of ['low', 'medium', 'high'] as const) {
+        const signal = makeSignal({
+          attentionHints: {
+            requiresAction: false,
+            urgency,
+            isAsyncBackground: true,
+            visibleInSourceNow: false,
+          },
+        });
+        expect(signal.attentionHints.urgency).toBe(urgency);
+      }
+    });
+  });
+});

--- a/assistant/src/__tests__/notification-deep-link.test.ts
+++ b/assistant/src/__tests__/notification-deep-link.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Regression tests for Vellum notification deep-link metadata.
+ *
+ * Validates that the VellumAdapter broadcasts notification_intent with
+ * deepLinkMetadata, and that the broadcaster correctly passes deepLinkTarget
+ * from the decision through to the adapter payload.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+
+// -- Mocks (must be declared before importing modules that depend on them) ----
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import type { ServerMessage } from '../daemon/ipc-contract.js';
+import { VellumAdapter } from '../notifications/adapters/macos.js';
+
+// -- Tests -------------------------------------------------------------------
+
+describe('notification deep-link metadata', () => {
+  describe('VellumAdapter', () => {
+    test('broadcasts notification_intent with deepLinkMetadata from payload', async () => {
+      const messages: ServerMessage[] = [];
+      const adapter = new VellumAdapter((msg) => messages.push(msg));
+
+      await adapter.send(
+        {
+          sourceEventName: 'test.event',
+          copy: { title: 'Alert', body: 'Something happened' },
+          deepLinkTarget: { conversationId: 'conv-123', threadType: 'notification' },
+        },
+        { channel: 'vellum' },
+      );
+
+      expect(messages).toHaveLength(1);
+      const msg = messages[0] as Record<string, unknown>;
+      expect(msg.type).toBe('notification_intent');
+      expect(msg.title).toBe('Alert');
+      expect(msg.body).toBe('Something happened');
+      expect(msg.deepLinkMetadata).toEqual({
+        conversationId: 'conv-123',
+        threadType: 'notification',
+      });
+    });
+
+    test('broadcasts notification_intent without deepLinkMetadata when absent', async () => {
+      const messages: ServerMessage[] = [];
+      const adapter = new VellumAdapter((msg) => messages.push(msg));
+
+      await adapter.send(
+        {
+          sourceEventName: 'test.event',
+          copy: { title: 'Alert', body: 'No deep link' },
+        },
+        { channel: 'vellum' },
+      );
+
+      expect(messages).toHaveLength(1);
+      const msg = messages[0] as Record<string, unknown>;
+      expect(msg.type).toBe('notification_intent');
+      expect(msg.deepLinkMetadata).toBeUndefined();
+    });
+
+    test('includes conversationId in deepLinkMetadata for navigation', async () => {
+      const messages: ServerMessage[] = [];
+      const adapter = new VellumAdapter((msg) => messages.push(msg));
+
+      const conversationId = 'conv-deep-link-test';
+      await adapter.send(
+        {
+          sourceEventName: 'guardian.question',
+          copy: { title: 'Guardian Question', body: 'What is the code?' },
+          deepLinkTarget: { conversationId },
+        },
+        { channel: 'vellum' },
+      );
+
+      const msg = messages[0] as Record<string, unknown>;
+      const metadata = msg.deepLinkMetadata as Record<string, unknown>;
+      expect(metadata.conversationId).toBe(conversationId);
+    });
+
+    test('returns success: true on successful broadcast', async () => {
+      const adapter = new VellumAdapter(() => {});
+
+      const result = await adapter.send(
+        {
+          sourceEventName: 'test.event',
+          copy: { title: 'T', body: 'B' },
+        },
+        { channel: 'vellum' },
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    test('returns success: false when broadcast throws', async () => {
+      const adapter = new VellumAdapter(() => {
+        throw new Error('IPC connection lost');
+      });
+
+      const result = await adapter.send(
+        {
+          sourceEventName: 'test.event',
+          copy: { title: 'T', body: 'B' },
+        },
+        { channel: 'vellum' },
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('IPC connection lost');
+    });
+
+    test('sourceEventName is included in the IPC payload', async () => {
+      const messages: ServerMessage[] = [];
+      const adapter = new VellumAdapter((msg) => messages.push(msg));
+
+      await adapter.send(
+        {
+          sourceEventName: 'guardian.question',
+          copy: { title: 'Alert', body: 'Body' },
+        },
+        { channel: 'vellum' },
+      );
+
+      const msg = messages[0] as Record<string, unknown>;
+      expect(msg.sourceEventName).toBe('guardian.question');
+    });
+
+    test('deepLinkMetadata with conversationId enables client-side navigation', async () => {
+      const messages: ServerMessage[] = [];
+      const adapter = new VellumAdapter((msg) => messages.push(msg));
+
+      // Simulate a notification that should deep-link to a specific conversation
+      await adapter.send(
+        {
+          sourceEventName: 'activity.complete',
+          copy: { title: 'Task Done', body: 'Your task has completed' },
+          deepLinkTarget: {
+            conversationId: 'conv-task-run-42',
+            workItemId: 'work-item-7',
+          },
+        },
+        { channel: 'vellum' },
+      );
+
+      const msg = messages[0] as Record<string, unknown>;
+      const metadata = msg.deepLinkMetadata as Record<string, unknown>;
+      expect(metadata.conversationId).toBe('conv-task-run-42');
+      expect(metadata.workItemId).toBe('work-item-7');
+    });
+  });
+});

--- a/assistant/src/__tests__/notification-guardian-path.test.ts
+++ b/assistant/src/__tests__/notification-guardian-path.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Regression tests for the ASK_GUARDIAN notification path.
+ *
+ * Validates that guardian dispatch:
+ * 1. Emits a notification signal through the standard notification pipeline
+ * 2. Creates a server-side conversation BEFORE emitting the IPC event
+ * 3. Emits guardian_request_thread_created IPC (not a special notification type)
+ * 4. LLM-generated copy is used for the thread title and initial message
+ *
+ * The ASK_GUARDIAN flow uses the same `emitNotificationSignal()` entry point
+ * as all other producers, plus its own conversation materialization for the
+ * vellum channel. This test validates the canonical path has no special-casing
+ * beyond what's needed for the guardian-specific conversation thread.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'notification-guardian-path-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  readHttpToken: () => null,
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module('../config/env.js', () => ({
+  getGatewayInternalBaseUrl: () => 'http://localhost:3000',
+}));
+
+mock.module('../memory/channel-guardian-store.js', () => ({
+  getActiveBinding: () => null,
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    calls: {
+      userConsultTimeoutSeconds: 120,
+    },
+  }),
+}));
+
+mock.module('../runtime/gateway-client.js', () => ({
+  deliverChannelReply: async () => {},
+}));
+
+mock.module('../calls/guardian-question-copy.js', () => ({
+  generateGuardianCopy: async (questionText: string) => ({
+    threadTitle: `Test: ${questionText.slice(0, 30)}`,
+    initialMessage: `Test message for: ${questionText}`,
+  }),
+  buildFallbackCopy: (questionText: string) => ({
+    threadTitle: `Fallback: ${questionText.slice(0, 30)}`,
+    initialMessage: `Fallback message for: ${questionText}`,
+  }),
+}));
+
+// Track calls to emitNotificationSignal
+const emitCalls: unknown[] = [];
+mock.module('../notifications/emit-signal.js', () => ({
+  emitNotificationSignal: async (params: unknown) => {
+    emitCalls.push(params);
+  },
+  registerBroadcastFn: () => {},
+}));
+
+import { createCallSession, createPendingQuestion } from '../calls/call-store.js';
+import { dispatchGuardianQuestion } from '../calls/guardian-dispatch.js';
+import { getMessages } from '../memory/conversation-store.js';
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { conversations } from '../memory/schema.js';
+
+initializeDb();
+
+function ensureConversation(id: string): void {
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations).values({
+    id,
+    title: `Conversation ${id}`,
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+}
+
+function resetTables(): void {
+  const db = getDb();
+  db.run('DELETE FROM guardian_action_deliveries');
+  db.run('DELETE FROM guardian_action_requests');
+  db.run('DELETE FROM call_pending_questions');
+  db.run('DELETE FROM call_events');
+  db.run('DELETE FROM call_sessions');
+  db.run('DELETE FROM messages');
+  db.run('DELETE FROM conversations');
+  emitCalls.length = 0;
+}
+
+describe('ASK_GUARDIAN canonical notification path', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  afterAll(() => {
+    resetDb();
+    try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+  });
+
+  test('guardian dispatch emits a notification signal through the standard pipeline', async () => {
+    const convId = 'conv-guardian-notif-1';
+    ensureConversation(convId);
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15550002222',
+    });
+    const pq = createPendingQuestion(session.id, 'What is the gate code?');
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: 'self',
+      pendingQuestion: pq,
+    });
+
+    // The dispatch should have called emitNotificationSignal
+    expect(emitCalls.length).toBeGreaterThanOrEqual(1);
+    const signalParams = emitCalls[0] as Record<string, unknown>;
+    expect(signalParams.sourceEventName).toBe('guardian.question');
+    expect(signalParams.sourceChannel).toBe('voice');
+  });
+
+  test('notification signal includes correct attention hints for guardian questions', async () => {
+    const convId = 'conv-guardian-notif-2';
+    ensureConversation(convId);
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15550002222',
+    });
+    const pq = createPendingQuestion(session.id, 'Should I proceed?');
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: 'self',
+      pendingQuestion: pq,
+    });
+
+    const signalParams = emitCalls[0] as Record<string, unknown>;
+    const hints = signalParams.attentionHints as Record<string, unknown>;
+
+    // Guardian questions are high urgency and require action
+    expect(hints.requiresAction).toBe(true);
+    expect(hints.urgency).toBe('high');
+    expect(hints.isAsyncBackground).toBe(false);
+    expect(hints.visibleInSourceNow).toBe(false);
+  });
+
+  test('notification signal context payload includes request metadata', async () => {
+    const convId = 'conv-guardian-notif-3';
+    ensureConversation(convId);
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15550002222',
+    });
+    const pq = createPendingQuestion(session.id, 'What is the WiFi password?');
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: 'self',
+      pendingQuestion: pq,
+    });
+
+    const signalParams = emitCalls[0] as Record<string, unknown>;
+    const payload = signalParams.contextPayload as Record<string, unknown>;
+
+    expect(payload.questionText).toBe('What is the WiFi password?');
+    expect(payload.callSessionId).toBe(session.id);
+    expect(payload.requestId).toBeDefined();
+    expect(payload.requestCode).toBeDefined();
+  });
+
+  test('notification signal has a dedupe key based on the request ID', async () => {
+    const convId = 'conv-guardian-notif-4';
+    ensureConversation(convId);
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15550002222',
+    });
+    const pq = createPendingQuestion(session.id, 'Approve entry?');
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: 'self',
+      pendingQuestion: pq,
+    });
+
+    const signalParams = emitCalls[0] as Record<string, unknown>;
+    expect(signalParams.dedupeKey).toBeDefined();
+    expect(typeof signalParams.dedupeKey).toBe('string');
+    // The dedupe key should include 'guardian:' prefix
+    expect((signalParams.dedupeKey as string).startsWith('guardian:')).toBe(true);
+  });
+
+  test('guardian dispatch creates conversation before IPC event', async () => {
+    const convId = 'conv-guardian-notif-5';
+    ensureConversation(convId);
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15550002222',
+    });
+    const pq = createPendingQuestion(session.id, 'What is the passcode?');
+
+    let ipcConversationId: string | null = null;
+    const broadcastFn = (msg: unknown) => {
+      const m = msg as Record<string, unknown>;
+      if (m.type === 'guardian_request_thread_created') {
+        ipcConversationId = m.conversationId as string;
+
+        // At this point, the conversation and message should already exist
+        const messages = getMessages(ipcConversationId);
+        expect(messages.length).toBeGreaterThanOrEqual(1);
+      }
+    };
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: 'self',
+      pendingQuestion: pq,
+      broadcast: broadcastFn,
+    });
+
+    // The IPC event should have been emitted
+    expect(ipcConversationId).not.toBeNull();
+  });
+
+  test('IPC event type is guardian_request_thread_created (not a generic notification event)', async () => {
+    const convId = 'conv-guardian-notif-6';
+    ensureConversation(convId);
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15550002222',
+    });
+    const pq = createPendingQuestion(session.id, 'Grant access?');
+
+    const broadcastedMessages: unknown[] = [];
+    const broadcastFn = (msg: unknown) => { broadcastedMessages.push(msg); };
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: 'self',
+      pendingQuestion: pq,
+      broadcast: broadcastFn,
+    });
+
+    expect(broadcastedMessages).toHaveLength(1);
+    const msg = broadcastedMessages[0] as Record<string, unknown>;
+
+    // The IPC event is the specific guardian_request_thread_created type,
+    // not a generic notification_intent or notification_thread_created
+    expect(msg.type).toBe('guardian_request_thread_created');
+    expect(msg.conversationId).toBeDefined();
+    expect(msg.requestId).toBeDefined();
+    expect(msg.callSessionId).toBe(session.id);
+    expect(msg.title).toBeDefined();
+    expect(msg.questionText).toBe('Grant access?');
+  });
+
+  test('guardian dispatch is fire-and-forget (no throw on errors)', async () => {
+    const convId = 'conv-guardian-notif-7';
+    ensureConversation(convId);
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15550002222',
+    });
+    const pq = createPendingQuestion(session.id, 'Error test');
+
+    // Should complete without throwing
+    await expect(dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: 'self',
+      pendingQuestion: pq,
+    })).resolves.toBeUndefined();
+  });
+});

--- a/assistant/src/notifications/README.md
+++ b/assistant/src/notifications/README.md
@@ -6,8 +6,8 @@ Signal-driven notification architecture where producers emit free-form events an
 
 ```
 Producer → NotificationSignal → Decision Engine (LLM) → Deterministic Checks → Broadcaster → Adapters → Delivery
-                                       ↑
-                               Preference Summary
+                                       ↑                                                        ↓
+                               Preference Summary                              notification_intent IPC (vellum)
 ```
 
 ### 1. Signal
@@ -37,6 +37,55 @@ Hard invariants that the LLM cannot override (`deterministic-checks.ts`):
 
 The broadcaster (`broadcaster.ts`) iterates over selected channels, resolves destinations via `destination-resolver.ts`, pulls rendered copy from the decision (falling back to `copy-composer.ts` templates), and dispatches through channel adapters. Each delivery attempt is recorded in `notification_deliveries`.
 
+## Channel Delivery Architecture
+
+The notification system delivers to two channel types:
+
+### Vellum (always connected)
+
+Local IPC via the daemon's broadcast mechanism. The `VellumAdapter` emits a `notification_intent` message containing:
+
+- `sourceEventName` -- the event that triggered the notification
+- `title` and `body` -- rendered notification copy
+- `deepLinkMetadata` -- optional metadata for navigating to the relevant context (e.g. `{ conversationId }`)
+
+The macOS/iOS client posts a native `UNUserNotificationCenter` notification from this payload. When the user taps the notification, the client uses `deepLinkMetadata` to navigate to the relevant thread.
+
+### Telegram (when guardian binding exists)
+
+HTTP POST to the gateway's `/deliver/telegram` endpoint. The `TelegramAdapter` formats the notification copy as plain text and sends it to the guardian's chat ID (resolved from the active guardian binding).
+
+### Channel Connectivity
+
+Connected channels are resolved at signal emission time by `getConnectedChannels()` in `emit-signal.ts`:
+
+- **Vellum** is always considered connected (IPC socket is always available when the daemon is running)
+- **Telegram** is considered connected only when an active guardian binding exists for the assistant (checked via `getActiveBinding()`)
+
+## Conversation Materialization
+
+The system supports two conversation materialization patterns:
+
+### 1. Generic notifications (notification_intent IPC)
+
+The standard pipeline emits `notification_intent` via the Vellum adapter. The decision engine can include `deepLinkTarget` metadata in the decision, which is passed through to the adapter as `deepLinkMetadata`. This allows the client to deep-link to an existing conversation or context without the daemon creating a new conversation.
+
+### 2. Guardian dispatch (guardian_request_thread_created IPC)
+
+The guardian dispatch (`calls/guardian-dispatch.ts`) creates a dedicated server-side conversation **before** entering the notification pipeline:
+
+1. Creates a `guardian_action_request` row
+2. Fires `emitNotificationSignal()` (fire-and-forget) for the LLM decision engine
+3. Creates a conversation via `getOrCreateConversation()` with key `asst:${assistantId}:guardian:request:${request.id}`
+4. Persists the LLM-generated initial message and thread title
+5. Emits `guardian_request_thread_created` IPC event with `{ conversationId, requestId, callSessionId, title, questionText }`
+
+The macOS `ThreadManager` listens for this event and creates a visible thread bound to the conversation.
+
+### Conversation Pairing Invariant
+
+For notification flows that create conversations (guardian dispatch, task runs), the conversation must be created **before** the IPC event is emitted. This ensures the macOS client can immediately fetch the conversation contents when it receives the thread-created event.
+
 ## Key Files
 
 | File | Purpose |
@@ -49,8 +98,8 @@ The broadcaster (`broadcaster.ts`) iterates over selected channels, resolves des
 | `runtime-dispatch.ts` | Dispatch gating (no-op decisions, empty channels) |
 | `broadcaster.ts` | Fan-out to channel adapters with delivery audit trail |
 | `copy-composer.ts` | Template-based fallback copy when LLM copy is unavailable |
-| `destination-resolver.ts` | Resolves per-channel endpoints (macOS IPC, Telegram chat ID) |
-| `adapters/macos.ts` | macOS adapter -- broadcasts `notification_intent` via IPC |
+| `destination-resolver.ts` | Resolves per-channel endpoints (vellum IPC, Telegram chat ID) |
+| `adapters/macos.ts` | Vellum adapter -- broadcasts `notification_intent` via IPC with deep-link metadata |
 | `adapters/telegram.ts` | Telegram adapter -- POSTs to gateway `/deliver/telegram` |
 | `preference-extractor.ts` | Detects notification preferences in conversation messages |
 | `preference-summary.ts` | Builds preference context string for the decision engine prompt |
@@ -84,6 +133,15 @@ await emitNotificationSignal({
 3. Optionally add a fallback copy template in `copy-composer.ts` keyed by your `sourceEventName`. Without a template, the generic fallback produces a human-readable version of the event name.
 
 The call is fire-and-forget safe by default -- errors are caught and logged internally unless you pass `throwOnError: true`.
+
+## How to Add a New Channel
+
+1. Add the channel to `CHANNEL_IDS` in `channels/types.ts`.
+2. Create an adapter in `adapters/` implementing the `ChannelAdapter` interface.
+3. Register the adapter in `emit-signal.ts` `getBroadcaster()`.
+4. Add a connectivity check in `getConnectedChannels()` in `emit-signal.ts`.
+5. Add a destination resolver case in `destination-resolver.ts`.
+6. Add the channel to the `NotificationChannel` union in `types.ts`.
 
 ## Audit Trail
 
@@ -129,4 +187,4 @@ All settings live under the `notifications` key in `config.json`:
 |-----|------|---------|-------------|
 | `notifications.decisionModelIntent` | string | `"latency-optimized"` | Model intent used for both the decision engine and preference extraction |
 
-The notification pipeline is always active — signals are processed and dispatched as soon as the daemon is running. The audit trail (events, decisions, deliveries) is written for every signal.
+The notification pipeline is always active -- signals are processed and dispatched as soon as the daemon is running. The audit trail (events, decisions, deliveries) is written for every signal.


### PR DESCRIPTION
## Summary
- Update ARCHITECTURE.md with notification conversation materialization flow and IPC thread-created events
- Update notifications README documenting channel delivery architecture, deep-link metadata, and conversation pairing invariant
- Add regression tests for broadcaster, decision strategy, deep-link metadata, and ASK_GUARDIAN canonical path
- Update AGENTS.md with notification pipeline invariant

Closes #8857
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
