### PR TITLE
fix: remove duplicate unique index from migration 026

### DIFF
--- a/assistant/src/memory/migrations/026-embeddings-nullable-vector-json.ts
+++ b/assistant/src/memory/migrations/026-embeddings-nullable-vector-json.ts
@@ -72,8 +72,8 @@ export function migrateEmbeddingsNullableVectorJson(database: DrizzleDb): void {
     raw.exec(/*sql*/ `DROP TABLE memory_embeddings`);
     raw.exec(/*sql*/ `ALTER TABLE memory_embeddings_new RENAME TO memory_embeddings`);
 
-    // Recreate indexes destroyed by the DROP TABLE (createCoreIndexes ran earlier)
-    raw.exec(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_embeddings_target_provider_model ON memory_embeddings(target_type, target_id, provider, model)`);
+    // Recreate the content_hash index destroyed by the DROP TABLE (the UNIQUE
+    // constraint autoindex covers target_type+target_id+provider+model already)
     raw.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_content_hash ON memory_embeddings(content_hash, provider, model)`);
 
     raw.query(


### PR DESCRIPTION
Addresses review feedback on #9011. The CREATE TABLE already has UNIQUE(target_type, target_id, provider, model), so the explicit CREATE UNIQUE INDEX is redundant and wastes space. Removed the duplicate index creation while keeping the content_hash index.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
