### PR TITLE
fix: preserve caller-owned conversationId when thread push is skipped

### DIFF
--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -121,8 +121,10 @@ export class NotificationBroadcaster {
 
       // For the vellum channel, merge the conversationId into deep-link metadata
       // so the macOS/iOS client can navigate directly to the notification thread.
+      // Skip when skipThreadPush is true — the caller manages its own conversation
+      // and deep-link metadata (e.g., guardian-dispatch).
       let deepLinkTarget = decision.deepLinkTarget;
-      if (channel === 'vellum' && pairing.conversationId) {
+      if (channel === 'vellum' && pairing.conversationId && !options?.skipThreadPush) {
         deepLinkTarget = { ...deepLinkTarget, conversationId: pairing.conversationId };
 
         // Emit notification_thread_created immediately when the vellum


### PR DESCRIPTION
## Summary
- When `skipThreadPush` is true (guardian flow), skip overwriting `deepLinkTarget.conversationId` with the pipeline-paired conversation ID
- Prevents `notification_intent` deep link from opening the wrong conversation in the guardian path
- Guardian-dispatch manages its own conversation and deep-link metadata

Addresses Codex feedback on #9020
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
