### PR TITLE
fix: add missing exports to gateway test mocks

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.test.ts
+++ b/gateway/src/http/routes/telegram-webhook.test.ts
@@ -31,6 +31,7 @@ mock.module("../../runtime/client.js", () => ({
   resetConversation: resetConversationMock,
   uploadAttachment: mock(() => Promise.resolve({ id: "att-1" })),
   AttachmentValidationError: class extends Error {},
+  CircuitBreakerOpenError: class extends Error {},
 }));
 
 mock.module("../../telegram/verify.js", () => ({

--- a/gateway/src/http/routes/twilio-sms-webhook.test.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.test.ts
@@ -18,6 +18,7 @@ mock.module("../../handlers/handle-inbound.js", () => ({
 
 mock.module("../../runtime/client.js", () => ({
   resetConversation: resetConversationMock,
+  CircuitBreakerOpenError: class extends Error {},
 }));
 
 mock.module("../../twilio/send-sms.js", () => ({

--- a/gateway/src/http/routes/whatsapp-deliver.test.ts
+++ b/gateway/src/http/routes/whatsapp-deliver.test.ts
@@ -9,6 +9,7 @@ mock.module("../../whatsapp/send.js", () => ({
   sendWhatsAppReply: async (...args: unknown[]) => {
     sendWhatsAppReplyCalls.push(args);
   },
+  sendWhatsAppAttachments: mock(() => Promise.resolve({ allFailed: false, failureCount: 0, totalCount: 0 })),
 }));
 
 const { createWhatsAppDeliverHandler } = await import("./whatsapp-deliver.js");
@@ -197,7 +198,7 @@ describe("/deliver/whatsapp", () => {
     const res = await handler(req);
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toBe("text is required");
+    expect(body.error).toBe("text or attachments required");
   });
 
   it("returns 400 when JSON is invalid", async () => {
@@ -240,37 +241,34 @@ describe("/deliver/whatsapp", () => {
     expect(sendWhatsAppReplyCalls[0][1]).toBe("+15551111111");
   });
 
-  it("uses fallback text when attachments are present but text is missing", async () => {
+  it("delivers attachments when text is missing but attachments are present", async () => {
     const handler = createWhatsAppDeliverHandler(makeConfig());
     const req = makeRequest({
       to: "+15559876543",
-      attachments: [{ url: "https://example.com/image.png" }],
+      attachments: [{ id: "att-1", url: "https://example.com/image.png" }],
     });
     const res = await handler(req);
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.ok).toBe(true);
 
-    expect(sendWhatsAppReplyCalls).toHaveLength(1);
-    expect(sendWhatsAppReplyCalls[0][2]).toBe(
-      "I have a media attachment to share, but WhatsApp media delivery is not yet supported.",
-    );
+    // Text reply should NOT have been called — only attachments
+    expect(sendWhatsAppReplyCalls).toHaveLength(0);
   });
 
-  it("uses fallback text when text is empty string and attachments present", async () => {
+  it("delivers both text and attachments when both are present", async () => {
     const handler = createWhatsAppDeliverHandler(makeConfig());
     const req = makeRequest({
       to: "+15559876543",
-      text: "   ",
-      attachments: [{ url: "https://example.com/image.png" }],
+      text: "Here is a file",
+      attachments: [{ id: "att-1", url: "https://example.com/image.png" }],
     });
     const res = await handler(req);
     expect(res.status).toBe(200);
 
+    // Text reply should have been sent
     expect(sendWhatsAppReplyCalls).toHaveLength(1);
-    expect(sendWhatsAppReplyCalls[0][2]).toBe(
-      "I have a media attachment to share, but WhatsApp media delivery is not yet supported.",
-    );
+    expect(sendWhatsAppReplyCalls[0][2]).toBe("Here is a file");
   });
 
   it("returns 502 when sendWhatsAppReply throws", async () => {
@@ -279,6 +277,7 @@ describe("/deliver/whatsapp", () => {
       sendWhatsAppReply: async () => {
         throw new Error("WhatsApp API failure");
       },
+      sendWhatsAppAttachments: mock(() => Promise.resolve({ allFailed: false, failureCount: 0, totalCount: 0 })),
     }));
 
     // Re-import to get the handler with the throwing mock
@@ -297,6 +296,7 @@ describe("/deliver/whatsapp", () => {
       sendWhatsAppReply: async (...args: unknown[]) => {
         sendWhatsAppReplyCalls.push(args);
       },
+      sendWhatsAppAttachments: mock(() => Promise.resolve({ allFailed: false, failureCount: 0, totalCount: 0 })),
     }));
   });
 

--- a/gateway/src/http/routes/whatsapp-webhook.test.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.test.ts
@@ -14,10 +14,12 @@ mock.module('../../handlers/handle-inbound.js', () => ({
 
 mock.module('../../runtime/client.js', () => ({
   resetConversation: resetConversationMock,
+  CircuitBreakerOpenError: class extends Error {},
 }));
 
 mock.module('../../whatsapp/send.js', () => ({
   sendWhatsAppReply: sendWhatsAppReplyMock,
+  sendWhatsAppAttachments: mock(() => Promise.resolve({ allFailed: false, failureCount: 0, totalCount: 0 })),
 }));
 
 mock.module('../../whatsapp/api.js', () => ({


### PR DESCRIPTION
## Summary
- Added `CircuitBreakerOpenError` to `mock.module('runtime/client.js')` in telegram-webhook, twilio-sms-webhook, and whatsapp-webhook tests
- Added `sendWhatsAppAttachments` to `mock.module('whatsapp/send.js')` in whatsapp-deliver and whatsapp-webhook tests
- Updated stale whatsapp-deliver test expectations to match current handler behavior (native attachment delivery instead of fallback text)

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22407934328

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9038" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
