### PR TITLE
M4: Migrate Twitter Auth to Generic Orchestrator

### DIFF
--- a/assistant/src/__tests__/twitter-auth-handler.test.ts
+++ b/assistant/src/__tests__/twitter-auth-handler.test.ts
@@ -3,7 +3,7 @@ import * as net from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { beforeEach,describe, expect, mock, test } from 'bun:test';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
 const testDir = mkdtempSync(join(tmpdir(), 'handlers-twitter-auth-test-'));
 
@@ -89,34 +89,32 @@ mock.module('../security/secure-keys.js', () => ({
   _setBackend: () => {},
 }));
 
-// Mock OAuth2 flow
-let oauthFlowResult: unknown = null;
-let oauthFlowError: Error | null = null;
-let lastOAuthFlowOptions: Record<string, unknown> | undefined;
+// Mock the orchestrator — the handler now delegates to orchestrateOAuthConnect
+import type { OAuthConnectResult } from '../oauth/connect-types.js';
 
-mock.module('../security/oauth2.js', () => ({
-  startOAuth2Flow: async (
-    _config: unknown,
-    callbacks: { openUrl: (url: string) => void },
-    options?: Record<string, unknown>,
-  ) => {
-    lastOAuthFlowOptions = options;
+let orchestratorResult: OAuthConnectResult | null = null;
+let orchestratorError: Error | null = null;
+let lastOrchestratorOptions: Record<string, unknown> | undefined;
+
+mock.module('../oauth/connect-orchestrator.js', () => ({
+  orchestrateOAuthConnect: async (options: Record<string, unknown>) => {
+    lastOrchestratorOptions = options;
     // Trigger the openUrl callback so tests can verify the open_url message is sent
-    callbacks.openUrl('https://twitter.com/i/oauth2/authorize?test=1');
-    if (oauthFlowError) throw oauthFlowError;
-    return oauthFlowResult;
+    if (typeof options.openUrl === 'function') {
+      (options.openUrl as (url: string) => void)('https://twitter.com/i/oauth2/authorize?test=1');
+    }
+    if (orchestratorError) throw orchestratorError;
+    return orchestratorResult;
   },
 }));
 
 // Mock credential metadata store
 let credentialMetadataStore: Array<{ service: string; field: string; accountInfo?: string }> = [];
-let lastUpsertPolicy: Record<string, unknown> | undefined;
 
 mock.module('../tools/credentials/metadata-store.js', () => ({
   getCredentialMetadata: (service: string, field: string) =>
     credentialMetadataStore.find((m) => m.service === service && m.field === field) ?? undefined,
   upsertCredentialMetadata: (service: string, field: string, policy?: Record<string, unknown>) => {
-    lastUpsertPolicy = policy;
     const existing = credentialMetadataStore.find((m) => m.service === service && m.field === field);
     if (existing) {
       if (policy?.accountInfo !== undefined) existing.accountInfo = policy.accountInfo as string;
@@ -147,13 +145,6 @@ import type {
 } from '../daemon/ipc-contract.js';
 import { DebouncerMap } from '../util/debounce.js';
 
-// Mock global fetch for Twitter /2/users/me
-const _originalFetch = globalThis.fetch;
-let mockFetchResponse: { ok: boolean; json: () => Promise<unknown> } = {
-  ok: true,
-  json: async () => ({ data: { username: 'testuser' } }),
-};
-
 function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
   const sent: ServerMessage[] = [];
   const ctx: HandlerContext = {
@@ -182,23 +173,11 @@ describe('Twitter auth handler', () => {
     rawConfigStore = {};
     secureKeyStore = {};
     credentialMetadataStore = [];
-    oauthFlowResult = null;
-    oauthFlowError = null;
-    lastUpsertPolicy = undefined;
-    lastOAuthFlowOptions = undefined;
+    orchestratorResult = null;
+    orchestratorError = null;
+    lastOrchestratorOptions = undefined;
     mockIngressPublicBaseUrl = 'https://test.example.com';
-    // Mock fetch for Twitter API
-    globalThis.fetch = (async (_url: string | URL | Request) => {
-      return mockFetchResponse;
-    }) as typeof fetch;
-    mockFetchResponse = {
-      ok: true,
-      json: async () => ({ data: { username: 'testuser' } }),
-    };
   });
-
-  // Restore original fetch after all tests
-  // (bun:test doesn't have afterAll in all versions, but the test process exits anyway)
 
   describe('twitter_auth_start', () => {
     test('fails if mode is not local_byo', async () => {
@@ -243,21 +222,16 @@ describe('Twitter auth handler', () => {
       expect(result.error).toContain('client credentials');
     });
 
-    test('succeeds with valid config (mock OAuth flow + Twitter API)', async () => {
+    test('succeeds with valid config (mock orchestrator)', async () => {
       rawConfigStore = { twitterIntegrationMode: 'local_byo' };
       secureKeyStore['credential:integration:twitter:oauth_client_id'] = 'test-client-id';
       secureKeyStore['credential:integration:twitter:oauth_client_secret'] = 'test-client-secret';
 
-      oauthFlowResult = {
-        tokens: {
-          accessToken: 'mock-access-token',
-          refreshToken: 'mock-refresh-token',
-          expiresIn: 7200,
-          scope: 'tweet.read users.read offline.access',
-          tokenType: 'bearer',
-        },
+      orchestratorResult = {
+        success: true,
+        deferred: false,
         grantedScopes: ['tweet.read', 'users.read', 'offline.access'],
-        rawTokenResponse: {},
+        accountInfo: '@testuser',
       };
 
       const msg: TwitterAuthStartRequest = { type: 'twitter_auth_start' };
@@ -278,33 +252,18 @@ describe('Twitter auth handler', () => {
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
       expect(result.accountInfo).toBe('@testuser');
-
-      // Verify tokens were stored
-      expect(secureKeyStore['credential:integration:twitter:access_token']).toBe('mock-access-token');
-      expect(secureKeyStore['credential:integration:twitter:refresh_token']).toBe('mock-refresh-token');
-
-      // Verify credential metadata was stored
-      const meta = credentialMetadataStore.find(
-        (m) => m.service === 'integration:twitter' && m.field === 'access_token',
-      );
-      expect(meta).toBeDefined();
-      expect(meta!.accountInfo).toBe('@testuser');
     });
 
-    test('passes callbackTransport: gateway to startOAuth2Flow', async () => {
+    test('delegates to orchestrateOAuthConnect with correct options', async () => {
       rawConfigStore = { twitterIntegrationMode: 'local_byo' };
       secureKeyStore['credential:integration:twitter:oauth_client_id'] = 'test-client-id';
+      secureKeyStore['credential:integration:twitter:oauth_client_secret'] = 'test-client-secret';
 
-      oauthFlowResult = {
-        tokens: {
-          accessToken: 'mock-access-token',
-          refreshToken: 'mock-refresh-token',
-          expiresIn: 7200,
-          scope: 'tweet.read users.read offline.access',
-          tokenType: 'bearer',
-        },
+      orchestratorResult = {
+        success: true,
+        deferred: false,
         grantedScopes: ['tweet.read', 'users.read', 'offline.access'],
-        rawTokenResponse: {},
+        accountInfo: '@testuser',
       };
 
       const msg: TwitterAuthStartRequest = { type: 'twitter_auth_start' };
@@ -313,9 +272,13 @@ describe('Twitter auth handler', () => {
 
       await new Promise((r) => setTimeout(r, 50));
 
-      // Verify startOAuth2Flow was called with gateway transport
-      expect(lastOAuthFlowOptions).toBeDefined();
-      expect(lastOAuthFlowOptions!.callbackTransport).toBe('gateway');
+      expect(lastOrchestratorOptions).toBeDefined();
+      expect(lastOrchestratorOptions!.service).toBe('integration:twitter');
+      expect(lastOrchestratorOptions!.clientId).toBe('test-client-id');
+      expect(lastOrchestratorOptions!.clientSecret).toBe('test-client-secret');
+      expect(lastOrchestratorOptions!.isInteractive).toBe(true);
+      expect(lastOrchestratorOptions!.allowedTools).toEqual(['twitter_post']);
+      expect(typeof lastOrchestratorOptions!.openUrl).toBe('function');
     });
 
     test('fails fast with actionable error when no ingress URL is configured', async () => {
@@ -323,10 +286,10 @@ describe('Twitter auth handler', () => {
       secureKeyStore['credential:integration:twitter:oauth_client_id'] = 'test-client-id';
       mockIngressPublicBaseUrl = undefined;
 
-      oauthFlowResult = {
-        tokens: { accessToken: 'should-not-reach', refreshToken: undefined },
+      orchestratorResult = {
+        success: true,
+        deferred: false,
         grantedScopes: [],
-        rawTokenResponse: {},
       };
 
       const msg: TwitterAuthStartRequest = { type: 'twitter_auth_start' };
@@ -335,7 +298,7 @@ describe('Twitter auth handler', () => {
 
       await new Promise((r) => setTimeout(r, 50));
 
-      // Should NOT have sent open_url — the flow should fail before reaching OAuth
+      // Should NOT have sent open_url — the flow should fail before reaching the orchestrator
       const openUrlMsg = sent.find((m) => m.type === 'open_url');
       expect(openUrlMsg).toBeUndefined();
 
@@ -350,8 +313,33 @@ describe('Twitter auth handler', () => {
       expect(result.error).toContain('INGRESS_PUBLIC_BASE_URL');
       expect(result.error).toContain('/webhooks/oauth/callback');
 
-      // startOAuth2Flow should not have been called
-      expect(lastOAuthFlowOptions).toBeUndefined();
+      // orchestrateOAuthConnect should not have been called
+      expect(lastOrchestratorOptions).toBeUndefined();
+    });
+
+    test('maps orchestrator error result to twitter_auth_result', async () => {
+      rawConfigStore = { twitterIntegrationMode: 'local_byo' };
+      secureKeyStore['credential:integration:twitter:oauth_client_id'] = 'test-client-id';
+
+      orchestratorResult = {
+        success: false,
+        error: 'Failed to verify Twitter identity. Please try again.',
+      };
+
+      const msg: TwitterAuthStartRequest = { type: 'twitter_auth_start' };
+      const { ctx, sent } = createTestContext();
+      await handleMessage(msg, {} as net.Socket, ctx);
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const result = sent.find((m) => m.type === 'twitter_auth_result') as {
+        type: string;
+        success: boolean;
+        error?: string;
+      };
+      expect(result).toBeDefined();
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Failed to verify Twitter identity. Please try again.');
     });
 
     describe('auth hardening', () => {
@@ -359,7 +347,7 @@ describe('Twitter auth handler', () => {
         rawConfigStore = { twitterIntegrationMode: 'local_byo' };
         secureKeyStore['credential:integration:twitter:oauth_client_id'] = 'test-client-id';
 
-        oauthFlowError = new Error('OAuth2 authorization denied: user_cancelled');
+        orchestratorError = new Error('OAuth2 authorization denied: user_cancelled');
 
         const msg: TwitterAuthStartRequest = { type: 'twitter_auth_start' };
         const { ctx, sent } = createTestContext();
@@ -375,20 +363,13 @@ describe('Twitter auth handler', () => {
         expect(result).toBeDefined();
         expect(result.success).toBe(false);
         expect(result.error).toBe('Twitter authentication was cancelled.');
-
-        // No tokens should have been stored
-        expect(secureKeyStore['credential:integration:twitter:access_token']).toBeUndefined();
-        expect(secureKeyStore['credential:integration:twitter:refresh_token']).toBeUndefined();
-
-        // No credential metadata should have been created
-        expect(credentialMetadataStore).toHaveLength(0);
       });
 
       test('OAuth timeout path returns sanitized failure', async () => {
         rawConfigStore = { twitterIntegrationMode: 'local_byo' };
         secureKeyStore['credential:integration:twitter:oauth_client_id'] = 'test-client-id';
 
-        oauthFlowError = new Error('OAuth2 flow timed out waiting for user authorization');
+        orchestratorError = new Error('OAuth2 flow timed out waiting for user authorization');
 
         const msg: TwitterAuthStartRequest = { type: 'twitter_auth_start' };
         const { ctx, sent } = createTestContext();
@@ -404,140 +385,13 @@ describe('Twitter auth handler', () => {
         expect(result).toBeDefined();
         expect(result.success).toBe(false);
         expect(result.error).toBe('Twitter authentication timed out. Please try again.');
-
-        // No tokens stored
-        expect(secureKeyStore['credential:integration:twitter:access_token']).toBeUndefined();
-        expect(secureKeyStore['credential:integration:twitter:refresh_token']).toBeUndefined();
-
-        // No metadata created
-        expect(credentialMetadataStore).toHaveLength(0);
-      });
-
-      test('verification endpoint non-2xx causes auth failure', async () => {
-        rawConfigStore = { twitterIntegrationMode: 'local_byo' };
-        secureKeyStore['credential:integration:twitter:oauth_client_id'] = 'test-client-id';
-
-        oauthFlowResult = {
-          tokens: {
-            accessToken: 'mock-access-token',
-            refreshToken: 'mock-refresh-token',
-            expiresIn: 7200,
-            scope: 'tweet.read users.read offline.access',
-            tokenType: 'bearer',
-          },
-          grantedScopes: ['tweet.read', 'users.read', 'offline.access'],
-          rawTokenResponse: {},
-        };
-
-        mockFetchResponse = { ok: false, json: async () => ({}) };
-
-        const msg: TwitterAuthStartRequest = { type: 'twitter_auth_start' };
-        const { ctx, sent } = createTestContext();
-        await handleMessage(msg, {} as net.Socket, ctx);
-
-        await new Promise((r) => setTimeout(r, 50));
-
-        const result = sent.find((m) => m.type === 'twitter_auth_result') as {
-          type: string;
-          success: boolean;
-          error?: string;
-        };
-        expect(result).toBeDefined();
-        expect(result.success).toBe(false);
-
-        // No tokens should have been persisted
-        expect(secureKeyStore['credential:integration:twitter:access_token']).toBeUndefined();
-        expect(secureKeyStore['credential:integration:twitter:refresh_token']).toBeUndefined();
-
-        // No credential metadata
-        expect(credentialMetadataStore).toHaveLength(0);
-      });
-
-      test('verification payload missing username causes auth failure', async () => {
-        rawConfigStore = { twitterIntegrationMode: 'local_byo' };
-        secureKeyStore['credential:integration:twitter:oauth_client_id'] = 'test-client-id';
-
-        oauthFlowResult = {
-          tokens: {
-            accessToken: 'mock-access-token',
-            refreshToken: 'mock-refresh-token',
-            expiresIn: 7200,
-            scope: 'tweet.read users.read offline.access',
-            tokenType: 'bearer',
-          },
-          grantedScopes: ['tweet.read', 'users.read', 'offline.access'],
-          rawTokenResponse: {},
-        };
-
-        mockFetchResponse = { ok: true, json: async () => ({ data: {} }) };
-
-        const msg: TwitterAuthStartRequest = { type: 'twitter_auth_start' };
-        const { ctx, sent } = createTestContext();
-        await handleMessage(msg, {} as net.Socket, ctx);
-
-        await new Promise((r) => setTimeout(r, 50));
-
-        const result = sent.find((m) => m.type === 'twitter_auth_result') as {
-          type: string;
-          success: boolean;
-          error?: string;
-        };
-        expect(result).toBeDefined();
-        expect(result.success).toBe(false);
-
-        // No tokens or metadata persisted
-        expect(secureKeyStore['credential:integration:twitter:access_token']).toBeUndefined();
-        expect(secureKeyStore['credential:integration:twitter:refresh_token']).toBeUndefined();
-        expect(credentialMetadataStore).toHaveLength(0);
-      });
-
-      test('re-auth without refresh token clears stale stored refresh token', async () => {
-        rawConfigStore = { twitterIntegrationMode: 'local_byo' };
-        secureKeyStore['credential:integration:twitter:oauth_client_id'] = 'test-client-id';
-        // Pre-populate a stale refresh token
-        secureKeyStore['credential:integration:twitter:refresh_token'] = 'old-stale-token';
-
-        oauthFlowResult = {
-          tokens: {
-            accessToken: 'new-access-token',
-            refreshToken: undefined,
-            expiresIn: 7200,
-            scope: 'tweet.read users.read offline.access',
-            tokenType: 'bearer',
-          },
-          grantedScopes: ['tweet.read', 'users.read', 'offline.access'],
-          rawTokenResponse: {},
-        };
-
-        mockFetchResponse = {
-          ok: true,
-          json: async () => ({ data: { username: 'testuser' } }),
-        };
-
-        const msg: TwitterAuthStartRequest = { type: 'twitter_auth_start' };
-        const { ctx, sent } = createTestContext();
-        await handleMessage(msg, {} as net.Socket, ctx);
-
-        await new Promise((r) => setTimeout(r, 50));
-
-        const result = sent.find((m) => m.type === 'twitter_auth_result') as {
-          type: string;
-          success: boolean;
-        };
-        expect(result).toBeDefined();
-        expect(result.success).toBe(true);
-
-        // New access token should be set
-        expect(secureKeyStore['credential:integration:twitter:access_token']).toBe('new-access-token');
-        // Stale refresh token should have been deleted, not left as 'old-stale-token'
-        expect(secureKeyStore['credential:integration:twitter:refresh_token']).toBeUndefined();
       });
 
       test('error payload never includes secrets or raw provider bodies', async () => {
         rawConfigStore = { twitterIntegrationMode: 'local_byo' };
         secureKeyStore['credential:integration:twitter:oauth_client_id'] = 'test-client-id';
 
-        oauthFlowError = new Error(
+        orchestratorError = new Error(
           'OAuth2 token exchange failed (403): {"error":"invalid_client","client_secret":"super-secret-123"}',
         );
 
@@ -565,26 +419,16 @@ describe('Twitter auth handler', () => {
         expect(result.error).toBe('Twitter authentication failed. Please try again.');
       });
 
-      test('full metadata fields are persisted on success', async () => {
+      test('succeeds even when identity verification returns no accountInfo', async () => {
         rawConfigStore = { twitterIntegrationMode: 'local_byo' };
-        secureKeyStore['credential:integration:twitter:oauth_client_id'] = 'my-client-id';
-        secureKeyStore['credential:integration:twitter:oauth_client_secret'] = 'my-client-secret';
+        secureKeyStore['credential:integration:twitter:oauth_client_id'] = 'test-client-id';
 
-        oauthFlowResult = {
-          tokens: {
-            accessToken: 'mock-access-token',
-            refreshToken: 'mock-refresh-token',
-            expiresIn: 7200,
-            scope: 'tweet.read users.read offline.access',
-            tokenType: 'bearer',
-          },
+        // Identity verification is non-fatal in the orchestrator — accountInfo may be undefined
+        orchestratorResult = {
+          success: true,
+          deferred: false,
           grantedScopes: ['tweet.read', 'users.read', 'offline.access'],
-          rawTokenResponse: {},
-        };
-
-        mockFetchResponse = {
-          ok: true,
-          json: async () => ({ data: { username: 'testuser' } }),
+          accountInfo: undefined,
         };
 
         const msg: TwitterAuthStartRequest = { type: 'twitter_auth_start' };
@@ -596,24 +440,12 @@ describe('Twitter auth handler', () => {
         const result = sent.find((m) => m.type === 'twitter_auth_result') as {
           type: string;
           success: boolean;
+          accountInfo?: string;
         };
         expect(result).toBeDefined();
         expect(result.success).toBe(true);
-
-        // Verify the full policy was captured
-        expect(lastUpsertPolicy).toBeDefined();
-        expect(lastUpsertPolicy!.oauth2TokenUrl).toBe('https://api.x.com/2/oauth2/token');
-        expect(lastUpsertPolicy!.oauth2ClientId).toBe('my-client-id');
-        expect(lastUpsertPolicy!.oauth2ClientSecret).toBe('my-client-secret');
-        expect(lastUpsertPolicy!.grantedScopes).toEqual(['tweet.read', 'users.read', 'offline.access']);
-        expect(lastUpsertPolicy!.allowedDomains).toEqual([]);
-        expect(lastUpsertPolicy!.allowedTools).toEqual(['twitter_post']);
-
-        // expiresAt should be roughly Date.now() + 7200 * 1000
-        const expiresAt = lastUpsertPolicy!.expiresAt as number;
-        expect(typeof expiresAt).toBe('number');
-        expect(expiresAt).toBeGreaterThan(Date.now() + 7100 * 1000);
-        expect(expiresAt).toBeLessThan(Date.now() + 7300 * 1000);
+        // accountInfo may be undefined when identity verification is not possible
+        expect(result.accountInfo).toBeUndefined();
       });
     });
   });

--- a/assistant/src/daemon/handlers/config-integrations.ts
+++ b/assistant/src/daemon/handlers/config-integrations.ts
@@ -211,6 +211,9 @@ export function handleTwitterIntegrationConfig(
       }
       deleteSecureKey('credential:integration:twitter:oauth_client_id');
       deleteSecureKey('credential:integration:twitter:oauth_client_secret');
+      // Also remove canonical-named keys persisted by storeOAuth2Tokens
+      deleteSecureKey('credential:integration:twitter:client_id');
+      deleteSecureKey('credential:integration:twitter:client_secret');
       ctx.send(socket, {
         type: 'twitter_integration_config_response',
         success: true,
@@ -222,6 +225,9 @@ export function handleTwitterIntegrationConfig(
       deleteSecureKey('credential:integration:twitter:access_token');
       deleteSecureKey('credential:integration:twitter:refresh_token');
       deleteCredentialMetadata('integration:twitter', 'access_token');
+      // Also remove canonical-named keys persisted by storeOAuth2Tokens
+      deleteSecureKey('credential:integration:twitter:client_id');
+      deleteSecureKey('credential:integration:twitter:client_secret');
       ctx.send(socket, {
         type: 'twitter_integration_config_response',
         success: true,

--- a/assistant/src/daemon/handlers/twitter-auth.ts
+++ b/assistant/src/daemon/handlers/twitter-auth.ts
@@ -3,8 +3,8 @@ import * as net from 'node:net';
 import { loadConfig, loadRawConfig } from '../../config/loader.js';
 import { getPublicBaseUrl } from '../../inbound/public-ingress-urls.js';
 import { orchestrateOAuthConnect } from '../../oauth/connect-orchestrator.js';
-import { getSecureKey } from '../../security/secure-keys.js';
-import { assertMetadataWritable, getCredentialMetadata } from '../../tools/credentials/metadata-store.js';
+import { deleteSecureKey, getSecureKey } from '../../security/secure-keys.js';
+import { assertMetadataWritable, deleteCredentialMetadata, getCredentialMetadata } from '../../tools/credentials/metadata-store.js';
 import { ConfigError } from '../../util/errors.js';
 import type { TwitterAuthStartRequest, TwitterAuthStatusRequest } from '../ipc-protocol.js';
 import { defineHandlers, type HandlerContext, log } from './shared.js';
@@ -91,6 +91,18 @@ export async function handleTwitterAuthStart(
       return;
     }
 
+    // Clear any stale refresh token before re-authenticating. The
+    // orchestrator's storeOAuth2Tokens only writes a refresh token when
+    // the provider returns one — it never deletes an existing entry. So
+    // a leftover token from a previous session can survive reconnects.
+    // Deleting it upfront ensures we only keep a fresh token.
+    deleteSecureKey('credential:integration:twitter:refresh_token');
+    try {
+      deleteCredentialMetadata('integration:twitter', 'refresh_token');
+    } catch {
+      // Non-fatal — metadata entry may not exist
+    }
+
     const result = await orchestrateOAuthConnect({
       service: 'integration:twitter',
       clientId,
@@ -106,7 +118,7 @@ export async function handleTwitterAuthStart(
       ctx.send(socket, {
         type: 'twitter_auth_result',
         success: false,
-        error: sanitizeTwitterAuthError(result.error),
+        error: result.error,
       });
       return;
     }

--- a/assistant/src/daemon/handlers/twitter-auth.ts
+++ b/assistant/src/daemon/handlers/twitter-auth.ts
@@ -9,6 +9,21 @@ import { ConfigError } from '../../util/errors.js';
 import type { TwitterAuthStartRequest, TwitterAuthStatusRequest } from '../ipc-protocol.js';
 import { defineHandlers, type HandlerContext, log } from './shared.js';
 
+/** Map raw orchestrator/provider error messages to user-friendly strings. */
+function sanitizeTwitterAuthError(message: string): string {
+  const lower = message.toLowerCase();
+  if (lower.includes('timed out')) {
+    return 'Twitter authentication timed out. Please try again.';
+  }
+  if (lower.includes('user_cancelled') || lower.includes('cancelled')) {
+    return 'Twitter authentication was cancelled.';
+  }
+  if (lower.includes('denied') || lower.includes('invalid_grant')) {
+    return 'Twitter denied the authorization request. Please try again.';
+  }
+  return 'Twitter authentication failed. Please try again.';
+}
+
 export async function handleTwitterAuthStart(
   _msg: TwitterAuthStartRequest,
   socket: net.Socket,
@@ -91,7 +106,7 @@ export async function handleTwitterAuthStart(
       ctx.send(socket, {
         type: 'twitter_auth_result',
         success: false,
-        error: result.error,
+        error: sanitizeTwitterAuthError(result.error),
       });
       return;
     }
@@ -114,22 +129,10 @@ export async function handleTwitterAuthStart(
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err }, 'Twitter OAuth flow failed');
 
-    let userError: string;
-    const lower = message.toLowerCase();
-    if (lower.includes('timed out')) {
-      userError = 'Twitter authentication timed out. Please try again.';
-    } else if (lower.includes('user_cancelled') || lower.includes('cancelled')) {
-      userError = 'Twitter authentication was cancelled.';
-    } else if (lower.includes('denied') || lower.includes('invalid_grant')) {
-      userError = 'Twitter denied the authorization request. Please try again.';
-    } else {
-      userError = 'Twitter authentication failed. Please try again.';
-    }
-
     ctx.send(socket, {
       type: 'twitter_auth_result',
       success: false,
-      error: userError,
+      error: sanitizeTwitterAuthError(message),
     });
   }
 }

--- a/assistant/src/daemon/handlers/twitter-auth.ts
+++ b/assistant/src/daemon/handlers/twitter-auth.ts
@@ -91,17 +91,11 @@ export async function handleTwitterAuthStart(
       return;
     }
 
-    // Clear any stale refresh token before re-authenticating. The
-    // orchestrator's storeOAuth2Tokens only writes a refresh token when
-    // the provider returns one — it never deletes an existing entry. So
-    // a leftover token from a previous session can survive reconnects.
-    // Deleting it upfront ensures we only keep a fresh token.
-    deleteSecureKey('credential:integration:twitter:refresh_token');
-    try {
-      deleteCredentialMetadata('integration:twitter', 'refresh_token');
-    } catch {
-      // Non-fatal — metadata entry may not exist
-    }
+    // Snapshot the old refresh token so we can detect whether the new
+    // auth provided a replacement. We defer deletion until after a
+    // successful flow to avoid destroying a valid token when re-auth
+    // fails (user cancels, timeout, etc.).
+    const previousRefreshToken = getSecureKey('credential:integration:twitter:refresh_token');
 
     const result = await orchestrateOAuthConnect({
       service: 'integration:twitter',
@@ -130,6 +124,21 @@ export async function handleTwitterAuthStart(
         error: `OAuth flow was deferred unexpectedly. Open this URL to authorize: ${result.authUrl}`,
       });
       return;
+    }
+
+    // storeOAuth2Tokens writes a new refresh token when the provider
+    // returns one, but never deletes an existing entry. If the new
+    // auth did NOT return a refresh token the stale one would linger
+    // and eventually fail on use. Clean it up only when the stored
+    // value is still the old one (i.e. no new token was written).
+    const currentRefreshToken = getSecureKey('credential:integration:twitter:refresh_token');
+    if (previousRefreshToken && currentRefreshToken === previousRefreshToken) {
+      deleteSecureKey('credential:integration:twitter:refresh_token');
+      try {
+        deleteCredentialMetadata('integration:twitter', 'refresh_token');
+      } catch {
+        // Non-fatal — metadata entry may not exist
+      }
     }
 
     ctx.send(socket, {

--- a/assistant/src/daemon/handlers/twitter-auth.ts
+++ b/assistant/src/daemon/handlers/twitter-auth.ts
@@ -1,20 +1,30 @@
 import * as net from 'node:net';
 
-import { loadConfig,loadRawConfig } from '../../config/loader.js';
+import { loadConfig, loadRawConfig } from '../../config/loader.js';
 import { getPublicBaseUrl } from '../../inbound/public-ingress-urls.js';
-import type { OAuth2Config } from '../../security/oauth2.js';
-import { startOAuth2Flow } from '../../security/oauth2.js';
-import { deleteSecureKey,getSecureKey, setSecureKey } from '../../security/secure-keys.js';
-import { getCredentialMetadata,upsertCredentialMetadata } from '../../tools/credentials/metadata-store.js';
+import { orchestrateOAuthConnect } from '../../oauth/connect-orchestrator.js';
+import { getSecureKey } from '../../security/secure-keys.js';
+import { assertMetadataWritable, getCredentialMetadata } from '../../tools/credentials/metadata-store.js';
 import { ConfigError } from '../../util/errors.js';
 import type { TwitterAuthStartRequest, TwitterAuthStatusRequest } from '../ipc-protocol.js';
-import { defineHandlers, type HandlerContext,log } from './shared.js';
+import { defineHandlers, type HandlerContext, log } from './shared.js';
 
 export async function handleTwitterAuthStart(
   _msg: TwitterAuthStartRequest,
   socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
+  try {
+    assertMetadataWritable();
+  } catch {
+    ctx.send(socket, {
+      type: 'twitter_auth_result',
+      success: false,
+      error: 'Credential metadata file has an unrecognized version. Cannot store OAuth credentials.',
+    });
+    return;
+  }
+
   try {
     const raw = loadRawConfig();
     const mode = (raw.twitterIntegrationMode as string | undefined) ?? 'local_byo';
@@ -66,82 +76,39 @@ export async function handleTwitterAuthStart(
       return;
     }
 
-    const oauthConfig: OAuth2Config = {
-      authUrl: 'https://twitter.com/i/oauth2/authorize',
-      tokenUrl: 'https://api.x.com/2/oauth2/token',
-      scopes: ['tweet.read', 'tweet.write', 'users.read', 'offline.access'],
+    const result = await orchestrateOAuthConnect({
+      service: 'integration:twitter',
       clientId,
       clientSecret,
-      extraParams: {},
-      tokenEndpointAuthMethod: clientSecret ? 'client_secret_basic' : undefined,
-    };
-
-    const result = await startOAuth2Flow(oauthConfig, {
+      isInteractive: true,
       openUrl: (url: string) => {
         ctx.send(socket, { type: 'open_url', url });
       },
-    }, { callbackTransport: 'gateway' });
+      allowedTools: ['twitter_post'],
+    });
 
-    // Verify identity via Twitter API before persisting any tokens
-    let accountInfo: string;
-    try {
-      const userResp = await fetch('https://api.x.com/2/users/me', {
-        headers: { Authorization: `Bearer ${result.tokens.accessToken}` },
-      });
-      if (!userResp.ok) {
-        log.error({ status: userResp.status }, 'Twitter identity verification returned non-2xx');
-        ctx.send(socket, {
-          type: 'twitter_auth_result',
-          success: false,
-          error: 'Failed to verify Twitter identity. Please try again.',
-        });
-        return;
-      }
-      const userData = (await userResp.json()) as { data?: { username?: string } };
-      if (!userData.data?.username) {
-        log.error({ userData }, 'Twitter identity verification returned no username');
-        ctx.send(socket, {
-          type: 'twitter_auth_result',
-          success: false,
-          error: 'Failed to verify Twitter identity. Please try again.',
-        });
-        return;
-      }
-      accountInfo = `@${userData.data.username}`;
-    } catch (err) {
-      log.error({ err }, 'Twitter identity verification fetch failed');
+    if (!result.success) {
       ctx.send(socket, {
         type: 'twitter_auth_result',
         success: false,
-        error: 'Failed to verify Twitter identity. Please try again.',
+        error: result.error,
       });
       return;
     }
 
-    // Persist tokens only after successful verification
-    setSecureKey('credential:integration:twitter:access_token', result.tokens.accessToken);
-    if (result.tokens.refreshToken) {
-      setSecureKey('credential:integration:twitter:refresh_token', result.tokens.refreshToken);
-    } else {
-      deleteSecureKey('credential:integration:twitter:refresh_token');
+    if (result.deferred) {
+      ctx.send(socket, {
+        type: 'twitter_auth_result',
+        success: false,
+        error: `OAuth flow was deferred unexpectedly. Open this URL to authorize: ${result.authUrl}`,
+      });
+      return;
     }
-
-    upsertCredentialMetadata('integration:twitter', 'access_token', {
-      accountInfo,
-      allowedTools: ['twitter_post'],
-      allowedDomains: [],
-      oauth2TokenUrl: 'https://api.x.com/2/oauth2/token',
-      oauth2ClientId: clientId,
-      oauth2ClientSecret: clientSecret ?? null,
-      oauth2TokenEndpointAuthMethod: clientSecret ? 'client_secret_basic' : undefined,
-      grantedScopes: result.grantedScopes,
-      expiresAt: result.tokens.expiresIn ? Date.now() + result.tokens.expiresIn * 1000 : null,
-    });
 
     ctx.send(socket, {
       type: 'twitter_auth_result',
       success: true,
-      accountInfo,
+      accountInfo: result.accountInfo,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Part of #8959. Replaces hardcoded Twitter OAuth config in twitter-auth.ts with orchestrateOAuthConnect from the shared orchestrator. Identity verification and token persistence are now handled by the provider profile and orchestrator respectively. Keeps twitter_auth_start/twitter_auth_result IPC compatibility. Closes #8963.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
