### PR TITLE
fix: delete files only for confirmed orphans and suppress non-owner stop status

### DIFF
--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -6,9 +6,10 @@
  */
 
 import { eq } from 'drizzle-orm';
+import { unlinkSync } from 'node:fs';
 import { v4 as uuid } from 'uuid';
 
-import { getDb, rawGet, rawRun } from './db.js';
+import { getDb, rawAll, rawGet, rawRun } from './db.js';
 import { attachments, messageAttachments } from './schema.js';
 
 export interface StoredAttachment {
@@ -461,9 +462,28 @@ export function getAttachmentById(
  */
 export function deleteOrphanAttachments(candidateIds: string[]): number {
   if (candidateIds.length === 0) return 0;
+
+  // Identify truly orphaned attachment IDs first (not referenced by any message)
   const placeholders = candidateIds.map(() => '?').join(', ');
-  return rawRun(
-    `DELETE FROM attachments WHERE id IN (${placeholders}) AND id NOT IN (SELECT attachment_id FROM message_attachments)`,
+  const orphanIds = rawAll<{ id: string }>(
+    `SELECT id FROM attachments WHERE id IN (${placeholders}) AND id NOT IN (SELECT attachment_id FROM message_attachments)`,
     ...candidateIds,
+  ).map(row => row.id);
+
+  if (orphanIds.length === 0) return 0;
+
+  // Clean up on-disk files only for confirmed orphans
+  for (const id of orphanIds) {
+    const filePath = getFilePathForAttachment(id);
+    if (filePath) {
+      try { unlinkSync(filePath); } catch { /* file may already be gone */ }
+    }
+  }
+
+  // Delete the orphaned DB rows
+  const orphanPlaceholders = orphanIds.map(() => '?').join(', ');
+  return rawRun(
+    `DELETE FROM attachments WHERE id IN (${orphanPlaceholders})`,
+    ...orphanIds,
   );
 }


### PR DESCRIPTION
Two fixes from PR #8980 review feedback: (1) deleteOrphanAttachments now identifies orphaned IDs before deleting files, preventing data loss for still-referenced file-backed attachments. (2) RecordingManager.stop() no longer sends a failed status for non-owner mismatches, preventing false error messages in unrelated conversations.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
