### PR TITLE
fix: regenerate Swift IPC contract

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -54,18 +54,6 @@ public struct IPCAddTrustRule: Codable, Sendable {
     }
 }
 
-public struct IPCHeartbeatAlert: Codable, Sendable {
-    public let type: String
-    public let title: String
-    public let body: String
-
-    public init(type: String, title: String, body: String) {
-        self.type = type
-        self.title = title
-        self.body = body
-    }
-}
-
 public struct IPCAppDataRequest: Codable, Sendable {
     public let type: String
     public let surfaceId: String
@@ -1932,14 +1920,17 @@ public struct IPCGuardianVerificationRequest: Codable, Sendable {
     public let sessionId: String?
     public let assistantId: String?
     public let rebind: Bool?
+    /// E.164 phone number for SMS/voice, Telegram handle/chat-id. Used by outbound actions.
+    public let destination: String?
 
-    public init(type: String, action: String, channel: String? = nil, sessionId: String? = nil, assistantId: String? = nil, rebind: Bool? = nil) {
+    public init(type: String, action: String, channel: String? = nil, sessionId: String? = nil, assistantId: String? = nil, rebind: Bool? = nil, destination: String? = nil) {
         self.type = type
         self.action = action
         self.channel = channel
         self.sessionId = sessionId
         self.assistantId = assistantId
         self.rebind = rebind
+        self.destination = destination
     }
 }
 
@@ -1966,8 +1957,18 @@ public struct IPCGuardianVerificationResponse: Codable, Sendable {
     public let error: String?
     /// Human-readable error detail (e.g. for already_bound failures).
     public let message: String?
+    /// Session ID for outbound verification flows.
+    public let verificationSessionId: String?
+    /// Epoch ms when the verification session expires.
+    public let expiresAt: Int?
+    /// Epoch ms after which a resend is allowed.
+    public let nextResendAt: Int?
+    /// Number of SMS sends for this session.
+    public let sendCount: Int?
+    /// Telegram deep-link URL for bootstrap (M3 placeholder).
+    public let telegramBootstrapUrl: String?
 
-    public init(type: String, success: Bool, secret: String? = nil, instruction: String? = nil, bound: Bool? = nil, guardianExternalUserId: String? = nil, channel: String? = nil, assistantId: String? = nil, guardianDeliveryChatId: String? = nil, guardianUsername: String? = nil, guardianDisplayName: String? = nil, hasPendingChallenge: Bool? = nil, error: String? = nil, message: String? = nil) {
+    public init(type: String, success: Bool, secret: String? = nil, instruction: String? = nil, bound: Bool? = nil, guardianExternalUserId: String? = nil, channel: String? = nil, assistantId: String? = nil, guardianDeliveryChatId: String? = nil, guardianUsername: String? = nil, guardianDisplayName: String? = nil, hasPendingChallenge: Bool? = nil, error: String? = nil, message: String? = nil, verificationSessionId: String? = nil, expiresAt: Int? = nil, nextResendAt: Int? = nil, sendCount: Int? = nil, telegramBootstrapUrl: String? = nil) {
         self.type = type
         self.success = success
         self.secret = secret
@@ -1982,6 +1983,23 @@ public struct IPCGuardianVerificationResponse: Codable, Sendable {
         self.hasPendingChallenge = hasPendingChallenge
         self.error = error
         self.message = message
+        self.verificationSessionId = verificationSessionId
+        self.expiresAt = expiresAt
+        self.nextResendAt = nextResendAt
+        self.sendCount = sendCount
+        self.telegramBootstrapUrl = telegramBootstrapUrl
+    }
+}
+
+public struct IPCHeartbeatAlert: Codable, Sendable {
+    public let type: String
+    public let title: String
+    public let body: String
+
+    public init(type: String, title: String, body: String) {
+        self.type = type
+        self.title = title
+        self.body = body
     }
 }
 


### PR DESCRIPTION
## Summary
- Regenerates `IPCContractGenerated.swift` to match recent TypeScript IPC contract changes (new fields on `GuardianVerificationRequest`/`Response`, struct reordering)
- Fixes CI failure: https://github.com/vellum-ai/vellum-assistant/actions/runs/22411412754

## Test plan
- [x] `bun run check:ipc-generated` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
