### PR TITLE
fix: skip full video download for lazy attachment thumbnails

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -176,19 +176,11 @@ struct InlineVideoAttachmentView: View {
             let url = safeTempURL()
             do { try data.write(to: url) } catch { return }
             fileURL = url
-        } else if attachment.isLazyLoad,
-                  let port = daemonHttpPort,
-                  let attachmentId = attachment.id.isEmpty ? nil : attachment.id {
-            // File-backed attachment: fetch from content endpoint.
-            let url = safeTempURL()
-            do {
-                let bytes = try await fetchAttachmentContent(port: port, attachmentId: attachmentId)
-                try bytes.write(to: url)
-            } catch {
-                return
-            }
-            fileURL = url
         } else {
+            // For lazy (file-backed) attachments, don't download the full video
+            // just for a thumbnail — large recordings (100MB+) cause unnecessary
+            // network traffic and memory pressure. The view already shows a
+            // play-button placeholder when thumbnailImage is nil.
             return
         }
 


### PR DESCRIPTION
Remove the code path that downloads entire file-backed video attachments just to generate a thumbnail. For large recordings (100MB+), this caused unnecessary network traffic and memory pressure. The view already handles missing thumbnails gracefully with a play button overlay.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
