### PR TITLE
fix: resolve symlinks in recording file path validation

### DIFF
--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -1,5 +1,5 @@
 import * as net from 'node:net';
-import { existsSync, statSync } from 'node:fs';
+import { existsSync, realpathSync, statSync } from 'node:fs';
 import * as path from 'node:path';
 import { v4 as uuid } from 'uuid';
 import type { RecordingStatus, RecordingOptions } from '../ipc-protocol.js';
@@ -202,7 +202,14 @@ function handleRecordingStatus(
       if (msg.filePath) {
         // Restrict accepted file paths to the app's recordings directory to
         // prevent attachment of arbitrary files via crafted IPC messages.
-        const resolvedPath = path.resolve(msg.filePath);
+        let resolvedPath: string;
+        try {
+          resolvedPath = realpathSync(msg.filePath);
+        } catch {
+          // File doesn't exist (broken symlink or missing) — use path.resolve
+          // as fallback; the existsSync check below will handle the missing file.
+          resolvedPath = path.resolve(msg.filePath);
+        }
         const allowedDir = path.join(
           process.env.HOME ?? '',
           'Library/Application Support/vellum-assistant/recordings',

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -214,8 +214,14 @@ function handleRecordingStatus(
           process.env.HOME ?? '',
           'Library/Application Support/vellum-assistant/recordings',
         );
-        if (!resolvedPath.startsWith(allowedDir + path.sep) && resolvedPath !== allowedDir) {
-          log.warn({ recordingId, filePath: msg.filePath, allowedDir }, 'Recording file path outside allowed directory — rejecting');
+        let resolvedAllowedDir: string;
+        try {
+          resolvedAllowedDir = realpathSync(allowedDir);
+        } catch {
+          resolvedAllowedDir = allowedDir;
+        }
+        if (!resolvedPath.startsWith(resolvedAllowedDir + path.sep) && resolvedPath !== resolvedAllowedDir) {
+          log.warn({ recordingId, filePath: msg.filePath, allowedDir, resolvedAllowedDir }, 'Recording file path outside allowed directory — rejecting');
           if (notifySocket) {
             ctx.send(notifySocket, {
               type: 'assistant_text_delta',


### PR DESCRIPTION
Use realpathSync() instead of path.resolve() when canonicalizing recording file paths. path.resolve() only normalizes . and .. but does not resolve symlinks, which could allow path restriction bypass via crafted symlinks in the recordings directory.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
