### PR TITLE
fix: replace dead-branch MIME type ternary with lookup map

### DIFF
--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -14,11 +14,11 @@ import { uploadFileBackedAttachment, linkAttachmentToMessage } from '../../memor
  *  from permanently blocking all future recordings. */
 const STOP_ACK_TIMEOUT_MS = 30_000;
 
-const RECORDING_MIME_TYPES: Record<string, string> = {
-  mov: 'video/quicktime',
-  mp4: 'video/mp4',
-  webm: 'video/webm',
-};
+const RECORDING_MIME_TYPES = new Map<string, string>([
+  ['mov', 'video/quicktime'],
+  ['mp4', 'video/mp4'],
+  ['webm', 'video/webm'],
+]);
 
 // ─── Deterministic maps ──────────────────────────────────────────────────────
 // These ensure stop resolves the exact active recording for a conversation,
@@ -246,7 +246,7 @@ function handleRecordingStatus(
 
             // Infer MIME type from extension
             const ext = filename.split('.').pop()?.toLowerCase();
-            const mimeType = (ext && RECORDING_MIME_TYPES[ext]) || 'video/mp4';
+            const mimeType = (ext && RECORDING_MIME_TYPES.get(ext)) || 'video/mp4';
 
             // Store as file-backed attachment (avoids reading large files into memory)
             const attachment = uploadFileBackedAttachment(filename, mimeType, resolvedPath, sizeBytes);

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -14,6 +14,12 @@ import { uploadFileBackedAttachment, linkAttachmentToMessage } from '../../memor
  *  from permanently blocking all future recordings. */
 const STOP_ACK_TIMEOUT_MS = 30_000;
 
+const RECORDING_MIME_TYPES: Record<string, string> = {
+  mov: 'video/quicktime',
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+};
+
 // ─── Deterministic maps ──────────────────────────────────────────────────────
 // These ensure stop resolves the exact active recording for a conversation,
 // prevent ambiguous cross-thread stop behavior, and maintain conversation
@@ -240,7 +246,7 @@ function handleRecordingStatus(
 
             // Infer MIME type from extension
             const ext = filename.split('.').pop()?.toLowerCase();
-            const mimeType = ext === 'mov' ? 'video/quicktime' : ext === 'mp4' ? 'video/mp4' : 'video/mp4';
+            const mimeType = (ext && RECORDING_MIME_TYPES[ext]) || 'video/mp4';
 
             // Store as file-backed attachment (avoids reading large files into memory)
             const attachment = uploadFileBackedAttachment(filename, mimeType, resolvedPath, sizeBytes);


### PR DESCRIPTION
The MIME type inference for recording files had a dead branch: the mp4 and default cases were identical. Replaced with a proper lookup map that covers mov, mp4, and webm, with a sensible default.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
