### PR TITLE
fix: cap FTS and LIKE search on distinct conversation IDs instead of raw message rows

### DIFF
--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -668,18 +668,19 @@ export function searchConversations(
   // LIKE pattern for title matching (FTS only covers message content).
   const titlePattern = `%${query.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_')}%`;
 
-  interface FtsMessageRow {
-    message_id: string;
+  interface ConvIdRow {
     conversation_id: string;
   }
 
   // Collect conversation IDs from FTS message matches and title LIKE matches,
   // then merge them to produce the final set of matching conversations.
+  // Both paths LIMIT on distinct conversation_id to prevent a single
+  // conversation with many matching messages from crowding out others.
   const ftsConvIds = new Set<string>();
   if (ftsMatch) {
     try {
-      const ftsRows = rawAll<FtsMessageRow>(`
-        SELECT f.message_id, m.conversation_id
+      const ftsRows = rawAll<ConvIdRow>(`
+        SELECT DISTINCT m.conversation_id
         FROM messages_fts f
         JOIN messages m ON m.id = f.message_id
         JOIN conversations c ON c.id = m.conversation_id
@@ -695,8 +696,8 @@ export function searchConversations(
     // LIKE-based message content search so queries like "你", "é", or "C++" still
     // match message text.
     const likePattern = `%${query.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_')}%`;
-    const likeRows = rawAll<FtsMessageRow>(`
-      SELECT m.id AS message_id, m.conversation_id
+    const likeRows = rawAll<ConvIdRow>(`
+      SELECT DISTINCT m.conversation_id
       FROM messages m
       JOIN conversations c ON c.id = m.conversation_id
       WHERE m.content LIKE ? ESCAPE '\\' AND c.thread_type != 'background'

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -54,18 +54,6 @@ public struct IPCAddTrustRule: Codable, Sendable {
     }
 }
 
-public struct IPCHeartbeatAlert: Codable, Sendable {
-    public let type: String
-    public let title: String
-    public let body: String
-
-    public init(type: String, title: String, body: String) {
-        self.type = type
-        self.title = title
-        self.body = body
-    }
-}
-
 public struct IPCAppDataRequest: Codable, Sendable {
     public let type: String
     public let surfaceId: String
@@ -1932,14 +1920,17 @@ public struct IPCGuardianVerificationRequest: Codable, Sendable {
     public let sessionId: String?
     public let assistantId: String?
     public let rebind: Bool?
+    /// E.164 phone number for SMS/voice, Telegram handle/chat-id. Used by outbound actions.
+    public let destination: String?
 
-    public init(type: String, action: String, channel: String? = nil, sessionId: String? = nil, assistantId: String? = nil, rebind: Bool? = nil) {
+    public init(type: String, action: String, channel: String? = nil, sessionId: String? = nil, assistantId: String? = nil, rebind: Bool? = nil, destination: String? = nil) {
         self.type = type
         self.action = action
         self.channel = channel
         self.sessionId = sessionId
         self.assistantId = assistantId
         self.rebind = rebind
+        self.destination = destination
     }
 }
 
@@ -1966,8 +1957,18 @@ public struct IPCGuardianVerificationResponse: Codable, Sendable {
     public let error: String?
     /// Human-readable error detail (e.g. for already_bound failures).
     public let message: String?
+    /// Session ID for outbound verification flows.
+    public let verificationSessionId: String?
+    /// Epoch ms when the verification session expires.
+    public let expiresAt: Int?
+    /// Epoch ms after which a resend is allowed.
+    public let nextResendAt: Int?
+    /// Number of SMS sends for this session.
+    public let sendCount: Int?
+    /// Telegram deep-link URL for bootstrap (M3 placeholder).
+    public let telegramBootstrapUrl: String?
 
-    public init(type: String, success: Bool, secret: String? = nil, instruction: String? = nil, bound: Bool? = nil, guardianExternalUserId: String? = nil, channel: String? = nil, assistantId: String? = nil, guardianDeliveryChatId: String? = nil, guardianUsername: String? = nil, guardianDisplayName: String? = nil, hasPendingChallenge: Bool? = nil, error: String? = nil, message: String? = nil) {
+    public init(type: String, success: Bool, secret: String? = nil, instruction: String? = nil, bound: Bool? = nil, guardianExternalUserId: String? = nil, channel: String? = nil, assistantId: String? = nil, guardianDeliveryChatId: String? = nil, guardianUsername: String? = nil, guardianDisplayName: String? = nil, hasPendingChallenge: Bool? = nil, error: String? = nil, message: String? = nil, verificationSessionId: String? = nil, expiresAt: Int? = nil, nextResendAt: Int? = nil, sendCount: Int? = nil, telegramBootstrapUrl: String? = nil) {
         self.type = type
         self.success = success
         self.secret = secret
@@ -1982,6 +1983,23 @@ public struct IPCGuardianVerificationResponse: Codable, Sendable {
         self.hasPendingChallenge = hasPendingChallenge
         self.error = error
         self.message = message
+        self.verificationSessionId = verificationSessionId
+        self.expiresAt = expiresAt
+        self.nextResendAt = nextResendAt
+        self.sendCount = sendCount
+        self.telegramBootstrapUrl = telegramBootstrapUrl
+    }
+}
+
+public struct IPCHeartbeatAlert: Codable, Sendable {
+    public let type: String
+    public let title: String
+    public let body: String
+
+    public init(type: String, title: String, body: String) {
+        self.type = type
+        self.title = title
+        self.body = body
     }
 }
 

--- a/gateway/src/__tests__/oauth-callback.test.ts
+++ b/gateway/src/__tests__/oauth-callback.test.ts
@@ -291,7 +291,7 @@ describe("OAuth callback handler", () => {
     expect(callCount).toBe(2);
   });
 
-  test("returns 503 when consumed-state map is at capacity", async () => {
+  test("evicts oldest entry when consumed-state map is at capacity", async () => {
     fetchMock = mock(async () =>
       Response.json({ ok: true }, { status: 200 }),
     );
@@ -308,17 +308,16 @@ describe("OAuth callback handler", () => {
       await handler(req);
     }
 
-    // Next callback should be rejected with 503
+    // Next callback should succeed — LRU eviction drops the oldest entry
     const req = new Request(
       `http://localhost:7830/webhooks/oauth/callback?state=${VALID_STATE}&code=code`,
       { method: "GET" },
     );
     const res = await handler(req);
-    expect(res.status).toBe(503);
-    expect(await res.text()).toContain("Service temporarily unavailable");
+    expect(res.status).toBe(200);
 
-    // Verify the rejected state was NOT forwarded to the runtime
-    expect(fetchMock.mock.calls.length).toBe(MAX_CONSUMED_STATES);
+    // The new state was forwarded to the runtime
+    expect(fetchMock.mock.calls.length).toBe(MAX_CONSUMED_STATES + 1);
   });
 
   test("omits Authorization header when runtimeBearerToken is undefined", async () => {


### PR DESCRIPTION
Addresses review feedback on #9027. Changes both FTS and LIKE fallback search paths to LIMIT on DISTINCT conversation_id rather than raw message rows, preventing a single conversation with many matches from crowding out other results.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
