### PR TITLE
fix: add OAuth callback rate limiting and update capacity test for LRU eviction

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -54,18 +54,6 @@ public struct IPCAddTrustRule: Codable, Sendable {
     }
 }
 
-public struct IPCHeartbeatAlert: Codable, Sendable {
-    public let type: String
-    public let title: String
-    public let body: String
-
-    public init(type: String, title: String, body: String) {
-        self.type = type
-        self.title = title
-        self.body = body
-    }
-}
-
 public struct IPCAppDataRequest: Codable, Sendable {
     public let type: String
     public let surfaceId: String
@@ -1932,14 +1920,17 @@ public struct IPCGuardianVerificationRequest: Codable, Sendable {
     public let sessionId: String?
     public let assistantId: String?
     public let rebind: Bool?
+    /// E.164 phone number for SMS/voice, Telegram handle/chat-id. Used by outbound actions.
+    public let destination: String?
 
-    public init(type: String, action: String, channel: String? = nil, sessionId: String? = nil, assistantId: String? = nil, rebind: Bool? = nil) {
+    public init(type: String, action: String, channel: String? = nil, sessionId: String? = nil, assistantId: String? = nil, rebind: Bool? = nil, destination: String? = nil) {
         self.type = type
         self.action = action
         self.channel = channel
         self.sessionId = sessionId
         self.assistantId = assistantId
         self.rebind = rebind
+        self.destination = destination
     }
 }
 
@@ -1966,8 +1957,18 @@ public struct IPCGuardianVerificationResponse: Codable, Sendable {
     public let error: String?
     /// Human-readable error detail (e.g. for already_bound failures).
     public let message: String?
+    /// Session ID for outbound verification flows.
+    public let verificationSessionId: String?
+    /// Epoch ms when the verification session expires.
+    public let expiresAt: Int?
+    /// Epoch ms after which a resend is allowed.
+    public let nextResendAt: Int?
+    /// Number of SMS sends for this session.
+    public let sendCount: Int?
+    /// Telegram deep-link URL for bootstrap (M3 placeholder).
+    public let telegramBootstrapUrl: String?
 
-    public init(type: String, success: Bool, secret: String? = nil, instruction: String? = nil, bound: Bool? = nil, guardianExternalUserId: String? = nil, channel: String? = nil, assistantId: String? = nil, guardianDeliveryChatId: String? = nil, guardianUsername: String? = nil, guardianDisplayName: String? = nil, hasPendingChallenge: Bool? = nil, error: String? = nil, message: String? = nil) {
+    public init(type: String, success: Bool, secret: String? = nil, instruction: String? = nil, bound: Bool? = nil, guardianExternalUserId: String? = nil, channel: String? = nil, assistantId: String? = nil, guardianDeliveryChatId: String? = nil, guardianUsername: String? = nil, guardianDisplayName: String? = nil, hasPendingChallenge: Bool? = nil, error: String? = nil, message: String? = nil, verificationSessionId: String? = nil, expiresAt: Int? = nil, nextResendAt: Int? = nil, sendCount: Int? = nil, telegramBootstrapUrl: String? = nil) {
         self.type = type
         self.success = success
         self.secret = secret
@@ -1982,6 +1983,23 @@ public struct IPCGuardianVerificationResponse: Codable, Sendable {
         self.hasPendingChallenge = hasPendingChallenge
         self.error = error
         self.message = message
+        self.verificationSessionId = verificationSessionId
+        self.expiresAt = expiresAt
+        self.nextResendAt = nextResendAt
+        self.sendCount = sendCount
+        self.telegramBootstrapUrl = telegramBootstrapUrl
+    }
+}
+
+public struct IPCHeartbeatAlert: Codable, Sendable {
+    public let type: String
+    public let title: String
+    public let body: String
+
+    public init(type: String, title: String, body: String) {
+        self.type = type
+        self.title = title
+        self.body = body
     }
 }
 

--- a/gateway/src/__tests__/oauth-callback.test.ts
+++ b/gateway/src/__tests__/oauth-callback.test.ts
@@ -291,7 +291,7 @@ describe("OAuth callback handler", () => {
     expect(callCount).toBe(2);
   });
 
-  test("returns 503 when consumed-state map is at capacity", async () => {
+  test("evicts oldest entry when consumed-state map is at capacity", async () => {
     fetchMock = mock(async () =>
       Response.json({ ok: true }, { status: 200 }),
     );
@@ -308,17 +308,16 @@ describe("OAuth callback handler", () => {
       await handler(req);
     }
 
-    // Next callback should be rejected with 503
+    // Next callback should succeed — LRU eviction drops the oldest entry
     const req = new Request(
       `http://localhost:7830/webhooks/oauth/callback?state=${VALID_STATE}&code=code`,
       { method: "GET" },
     );
     const res = await handler(req);
-    expect(res.status).toBe(503);
-    expect(await res.text()).toContain("Service temporarily unavailable");
+    expect(res.status).toBe(200);
 
-    // Verify the rejected state was NOT forwarded to the runtime
-    expect(fetchMock.mock.calls.length).toBe(MAX_CONSUMED_STATES);
+    // The new state was forwarded to the runtime
+    expect(fetchMock.mock.calls.length).toBe(MAX_CONSUMED_STATES + 1);
   });
 
   test("omits Authorization header when runtimeBearerToken is undefined", async () => {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -165,19 +165,21 @@ function main() {
         return Response.json({ status: "ok" });
       }
 
-      // Rate-limit check for auth-protected and pairing endpoints.
-      // Checked early so blocked IPs are rejected before any work.
-      const isAuthRoute = url.pathname === "/integrations/status" ||
+      // Rate-limit check for auth-protected, pairing, and unauthenticated
+      // endpoints that forward to the runtime (OAuth callback is publicly
+      // reachable and forwards every valid-looking request).
+      const isRateLimitedRoute = url.pathname === "/integrations/status" ||
         url.pathname === "/deliver/telegram" ||
         url.pathname === "/deliver/sms" ||
         url.pathname === "/deliver/whatsapp" ||
         url.pathname.startsWith("/pairing/") ||
+        url.pathname === "/webhooks/oauth/callback" ||
         (url.pathname.startsWith("/v1/") &&
           url.pathname !== "/v1/calls/twilio/voice-webhook" &&
           url.pathname !== "/v1/calls/twilio/status" &&
           url.pathname !== "/v1/calls/twilio/connect-action" &&
           url.pathname !== "/v1/calls/relay");
-      if (isAuthRoute) {
+      if (isRateLimitedRoute) {
         const clientIp = getClientIp(req, svr, config.trustProxy);
         if (authRateLimiter.isBlocked(clientIp)) {
           log.warn({ ip: clientIp, path: url.pathname }, "Auth rate limit exceeded");
@@ -288,7 +290,11 @@ function main() {
       }
 
       if (url.pathname === "/webhooks/oauth/callback" && tracedReq.method === "GET") {
-        return handleOAuthCallback(tracedReq);
+        const res = await handleOAuthCallback(tracedReq);
+        if (res.status === 400) {
+          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+        }
+        return res;
       }
 
       if (url.pathname === "/integrations/status" && req.method === "GET") {


### PR DESCRIPTION
Addresses review feedback on #9021. Adds the OAuth callback route to the gateway rate limiter to prevent DoS via unbounded forwardOAuthCallback calls. Records 400 responses as auth failures so IPs sending repeated bad states get blocked. Updates the capacity test to verify LRU eviction behavior instead of the old 503 rejection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
