### PR TITLE
fix: use cursor-based pagination in dismiss-conflicts pattern mode

### DIFF
--- a/assistant/src/memory/admin.ts
+++ b/assistant/src/memory/admin.ts
@@ -219,10 +219,12 @@ export function dismissPendingConflicts(
   const dismissed: DismissConflictsResult['details'] = [];
   const BATCH_SIZE = 1000;
 
-  // Fetch and dismiss in batches to handle arbitrarily large backlogs
+  // Cursor-based pagination: track last seen (createdAt, id) to advance past
+  // previously inspected rows. This ensures pattern mode scans all pending
+  // conflicts even when non-matching rows outnumber the batch size.
+  let cursor: { createdAt: number; id: string } | undefined;
   let batch = listPendingConflictDetails(scopeId, BATCH_SIZE);
   while (batch.length > 0) {
-    let batchHadMatch = false;
     for (const conflict of batch) {
       const matches = options.all
         || (options.pattern && (
@@ -231,7 +233,6 @@ export function dismissPendingConflicts(
         ));
       if (!matches) continue;
 
-      batchHadMatch = true;
       resolveConflict(conflict.id, {
         status: 'dismissed',
         resolutionNote: options.all
@@ -244,10 +245,11 @@ export function dismissPendingConflicts(
         candidateStatement: conflict.candidateStatement,
       });
     }
-    // If nothing matched in this batch, no point fetching more — remaining
-    // conflicts won't match either (pattern mode) or we already got them all.
-    if (!batchHadMatch) break;
-    batch = listPendingConflictDetails(scopeId, BATCH_SIZE);
+    // No more rows to inspect
+    if (batch.length < BATCH_SIZE) break;
+    const lastRow = batch[batch.length - 1];
+    cursor = { createdAt: lastRow.createdAt, id: lastRow.id };
+    batch = listPendingConflictDetails(scopeId, BATCH_SIZE, cursor);
   }
 
   // Get true remaining count via SQL to avoid batch-size truncation

--- a/assistant/src/memory/conflict-store.ts
+++ b/assistant/src/memory/conflict-store.ts
@@ -161,7 +161,11 @@ export function listPendingConflicts(scopeId: string, limit = 100): MemoryItemCo
   return rows.map(toConflict);
 }
 
-export function listPendingConflictDetails(scopeId: string, limit = 100): PendingConflictDetail[] {
+export function listPendingConflictDetails(
+  scopeId: string,
+  limit = 100,
+  cursor?: { createdAt: number; id: string },
+): PendingConflictDetail[] {
   if (limit <= 0) return [];
   interface ConflictDetailRow {
     id: string;
@@ -181,6 +185,12 @@ export function listPendingConflictDetails(scopeId: string, limit = 100): Pendin
     existing_kind: string;
     candidate_kind: string;
   }
+  const cursorClause = cursor
+    ? `AND (c.created_at > ? OR (c.created_at = ? AND c.id > ?))`
+    : '';
+  const params: unknown[] = cursor
+    ? [scopeId, cursor.createdAt, cursor.createdAt, cursor.id, limit]
+    : [scopeId, limit];
   const rows = rawAll<ConflictDetailRow>(`
     SELECT
       c.id,
@@ -204,9 +214,10 @@ export function listPendingConflictDetails(scopeId: string, limit = 100): Pendin
     INNER JOIN memory_items candidate_item ON candidate_item.id = c.candidate_item_id
     WHERE c.scope_id = ?
       AND c.status = 'pending_clarification'
-    ORDER BY c.created_at ASC
+      ${cursorClause}
+    ORDER BY c.created_at ASC, c.id ASC
     LIMIT ?
-  `, scopeId, limit);
+  `, ...params);
 
   return rows.map((row) => ({
     id: row.id,

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -54,18 +54,6 @@ public struct IPCAddTrustRule: Codable, Sendable {
     }
 }
 
-public struct IPCHeartbeatAlert: Codable, Sendable {
-    public let type: String
-    public let title: String
-    public let body: String
-
-    public init(type: String, title: String, body: String) {
-        self.type = type
-        self.title = title
-        self.body = body
-    }
-}
-
 public struct IPCAppDataRequest: Codable, Sendable {
     public let type: String
     public let surfaceId: String
@@ -1932,14 +1920,17 @@ public struct IPCGuardianVerificationRequest: Codable, Sendable {
     public let sessionId: String?
     public let assistantId: String?
     public let rebind: Bool?
+    /// E.164 phone number for SMS/voice, Telegram handle/chat-id. Used by outbound actions.
+    public let destination: String?
 
-    public init(type: String, action: String, channel: String? = nil, sessionId: String? = nil, assistantId: String? = nil, rebind: Bool? = nil) {
+    public init(type: String, action: String, channel: String? = nil, sessionId: String? = nil, assistantId: String? = nil, rebind: Bool? = nil, destination: String? = nil) {
         self.type = type
         self.action = action
         self.channel = channel
         self.sessionId = sessionId
         self.assistantId = assistantId
         self.rebind = rebind
+        self.destination = destination
     }
 }
 
@@ -1966,8 +1957,18 @@ public struct IPCGuardianVerificationResponse: Codable, Sendable {
     public let error: String?
     /// Human-readable error detail (e.g. for already_bound failures).
     public let message: String?
+    /// Session ID for outbound verification flows.
+    public let verificationSessionId: String?
+    /// Epoch ms when the verification session expires.
+    public let expiresAt: Int?
+    /// Epoch ms after which a resend is allowed.
+    public let nextResendAt: Int?
+    /// Number of SMS sends for this session.
+    public let sendCount: Int?
+    /// Telegram deep-link URL for bootstrap (M3 placeholder).
+    public let telegramBootstrapUrl: String?
 
-    public init(type: String, success: Bool, secret: String? = nil, instruction: String? = nil, bound: Bool? = nil, guardianExternalUserId: String? = nil, channel: String? = nil, assistantId: String? = nil, guardianDeliveryChatId: String? = nil, guardianUsername: String? = nil, guardianDisplayName: String? = nil, hasPendingChallenge: Bool? = nil, error: String? = nil, message: String? = nil) {
+    public init(type: String, success: Bool, secret: String? = nil, instruction: String? = nil, bound: Bool? = nil, guardianExternalUserId: String? = nil, channel: String? = nil, assistantId: String? = nil, guardianDeliveryChatId: String? = nil, guardianUsername: String? = nil, guardianDisplayName: String? = nil, hasPendingChallenge: Bool? = nil, error: String? = nil, message: String? = nil, verificationSessionId: String? = nil, expiresAt: Int? = nil, nextResendAt: Int? = nil, sendCount: Int? = nil, telegramBootstrapUrl: String? = nil) {
         self.type = type
         self.success = success
         self.secret = secret
@@ -1982,6 +1983,23 @@ public struct IPCGuardianVerificationResponse: Codable, Sendable {
         self.hasPendingChallenge = hasPendingChallenge
         self.error = error
         self.message = message
+        self.verificationSessionId = verificationSessionId
+        self.expiresAt = expiresAt
+        self.nextResendAt = nextResendAt
+        self.sendCount = sendCount
+        self.telegramBootstrapUrl = telegramBootstrapUrl
+    }
+}
+
+public struct IPCHeartbeatAlert: Codable, Sendable {
+    public let type: String
+    public let title: String
+    public let body: String
+
+    public init(type: String, title: String, body: String) {
+        self.type = type
+        self.title = title
+        self.body = body
     }
 }
 


### PR DESCRIPTION
Addresses review feedback on #9030. Replaces the batchHadMatch early break with cursor-based pagination so pattern mode scans all pending conflicts, not just the first batch.

When using pattern mode, the previous implementation would stop scanning if a batch had zero matches. Since the query always returns the oldest pending conflicts and non-matching ones are never dismissed, batches after non-matching rows were never reached. Now uses (created_at, id) cursor to advance through all rows regardless of match status.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
