### PR TITLE
fix: anchor safe-line key-path regex to end of line to prevent secret bypass

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -79,7 +79,7 @@ declare -a SAFE_LINE_PATTERNS=(
     # `getSecureKey('credential:integration:twitter:oauth_client_secret')`.
     # Allows either no quoted args, or quoted args containing `:` (key paths).
     # Raw alphanumeric strings like `"sk_live_..."` are still rejected.
-    "(client[_-]?[Ss]ecret|[Pp]rivate[_-]?[Kk]ey)[[:space:]]*=[[:space:]]*(get[A-Za-z]*|create[A-Za-z]*|load[A-Za-z]*|read[A-Za-z]*|delete[A-Za-z]*|set[A-Za-z]*)\(([^\"']*$|[^\"']*[\"'][^\"']*:[^\"']*[\"'])"
+    "(client[_-]?[Ss]ecret|[Pp]rivate[_-]?[Kk]ey)[[:space:]]*=[[:space:]]*(get[A-Za-z]*|create[A-Za-z]*|load[A-Za-z]*|read[A-Za-z]*|delete[A-Za-z]*|set[A-Za-z]*)\(([^\"']*$|[^\"']*[\"'][^\"']*:[^\"']*[\"'][^\"']*$)"
     # TS/JS: property key followed by type annotation or opening brace.
     # E.g. `requiresClientSecret: boolean;` or `client_secret: {`.
     "[Cc]lient[_-]?[Ss]ecret['\"]?:[[:space:]]*(boolean|number)[[:space:]]*[;,]?"
@@ -187,6 +187,8 @@ if [ "${1:-}" = "--self-test" ]; then
     SAFE_CREATE_PRIVATE_KEY='const key = createPrivateKey(keyPem)'
     # Function-call with quoted key path (colon-separated identifier) — must be whitelisted
     SAFE_FUNC_CALL_KEY_PATH="const clientSecret = getSecureKey('credential:integration:twitter:oauth_client_secret') || undefined;"
+    # Function-call with key path followed by a hardcoded secret fallback — must NOT be whitelisted
+    UNSAFE_FUNC_CALL_KEY_PATH_FALLBACK="const clientSecret = getSecureKey('credential:integration:twitter:oauth_client_secret') || \"sk_live_12345678901234567890\""
     # Function-call with literal secret in args — must NOT be whitelisted
     UNSAFE_FUNC_CALL_LITERAL='const clientSecret = getSecureKey("sk_live_12345678901234567890")'
     UNSAFE_FUNC_CALL_SINGLE_QUOTE="const privateKey = loadPrivateKey('real_secret_key_value_12345')"
@@ -388,6 +390,10 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$SAFE_FUNC_CALL_KEY_PATH" && ! matches_safe_line_pattern "$SAFE_FUNC_CALL_KEY_PATH"; then
         echo -e "${RED}Self-test failed:${NC} function-call with quoted key path false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$UNSAFE_FUNC_CALL_KEY_PATH_FALLBACK" && matches_safe_line_pattern "$UNSAFE_FUNC_CALL_KEY_PATH_FALLBACK"; then
+        echo -e "${RED}Self-test failed:${NC} function-call with key-path arg and hardcoded fallback was incorrectly whitelisted"
         exit 1
     fi
     if matches_secret_pattern "$UNSAFE_FUNC_CALL_LITERAL" && matches_safe_line_pattern "$UNSAFE_FUNC_CALL_LITERAL"; then

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -54,18 +54,6 @@ public struct IPCAddTrustRule: Codable, Sendable {
     }
 }
 
-public struct IPCHeartbeatAlert: Codable, Sendable {
-    public let type: String
-    public let title: String
-    public let body: String
-
-    public init(type: String, title: String, body: String) {
-        self.type = type
-        self.title = title
-        self.body = body
-    }
-}
-
 public struct IPCAppDataRequest: Codable, Sendable {
     public let type: String
     public let surfaceId: String
@@ -1932,14 +1920,17 @@ public struct IPCGuardianVerificationRequest: Codable, Sendable {
     public let sessionId: String?
     public let assistantId: String?
     public let rebind: Bool?
+    /// E.164 phone number for SMS/voice, Telegram handle/chat-id. Used by outbound actions.
+    public let destination: String?
 
-    public init(type: String, action: String, channel: String? = nil, sessionId: String? = nil, assistantId: String? = nil, rebind: Bool? = nil) {
+    public init(type: String, action: String, channel: String? = nil, sessionId: String? = nil, assistantId: String? = nil, rebind: Bool? = nil, destination: String? = nil) {
         self.type = type
         self.action = action
         self.channel = channel
         self.sessionId = sessionId
         self.assistantId = assistantId
         self.rebind = rebind
+        self.destination = destination
     }
 }
 
@@ -1966,8 +1957,18 @@ public struct IPCGuardianVerificationResponse: Codable, Sendable {
     public let error: String?
     /// Human-readable error detail (e.g. for already_bound failures).
     public let message: String?
+    /// Session ID for outbound verification flows.
+    public let verificationSessionId: String?
+    /// Epoch ms when the verification session expires.
+    public let expiresAt: Int?
+    /// Epoch ms after which a resend is allowed.
+    public let nextResendAt: Int?
+    /// Number of SMS sends for this session.
+    public let sendCount: Int?
+    /// Telegram deep-link URL for bootstrap (M3 placeholder).
+    public let telegramBootstrapUrl: String?
 
-    public init(type: String, success: Bool, secret: String? = nil, instruction: String? = nil, bound: Bool? = nil, guardianExternalUserId: String? = nil, channel: String? = nil, assistantId: String? = nil, guardianDeliveryChatId: String? = nil, guardianUsername: String? = nil, guardianDisplayName: String? = nil, hasPendingChallenge: Bool? = nil, error: String? = nil, message: String? = nil) {
+    public init(type: String, success: Bool, secret: String? = nil, instruction: String? = nil, bound: Bool? = nil, guardianExternalUserId: String? = nil, channel: String? = nil, assistantId: String? = nil, guardianDeliveryChatId: String? = nil, guardianUsername: String? = nil, guardianDisplayName: String? = nil, hasPendingChallenge: Bool? = nil, error: String? = nil, message: String? = nil, verificationSessionId: String? = nil, expiresAt: Int? = nil, nextResendAt: Int? = nil, sendCount: Int? = nil, telegramBootstrapUrl: String? = nil) {
         self.type = type
         self.success = success
         self.secret = secret
@@ -1982,6 +1983,23 @@ public struct IPCGuardianVerificationResponse: Codable, Sendable {
         self.hasPendingChallenge = hasPendingChallenge
         self.error = error
         self.message = message
+        self.verificationSessionId = verificationSessionId
+        self.expiresAt = expiresAt
+        self.nextResendAt = nextResendAt
+        self.sendCount = sendCount
+        self.telegramBootstrapUrl = telegramBootstrapUrl
+    }
+}
+
+public struct IPCHeartbeatAlert: Codable, Sendable {
+    public let type: String
+    public let title: String
+    public let body: String
+
+    public init(type: String, title: String, body: String) {
+        self.type = type
+        self.title = title
+        self.body = body
     }
 }
 


### PR DESCRIPTION
Addresses review feedback on #9034. Adds missing end-of-line anchor to the key-path alternative in the safe-line regex, preventing lines like `getSecureKey('key:path') || 'sk_live_...'` from bypassing secret detection. Adds a self-test case for this attack vector.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
