### PR TITLE
fix: silence noisy migration duplicate-column errors on startup

### DIFF
--- a/assistant/src/memory/migrations/102-alter-table-columns.ts
+++ b/assistant/src/memory/migrations/102-alter-table-columns.ts
@@ -1,7 +1,4 @@
-import { getLogger } from '../../util/logger.js';
 import type { DrizzleDb } from '../db-connection.js';
-
-const log = getLogger('memory-db');
 
 /**
  * ALTER TABLE ADD COLUMN migrations for core tables.
@@ -9,11 +6,11 @@ const log = getLogger('memory-db');
  */
 export function addCoreColumns(database: DrizzleDb): void {
   // message_runs
-  try { database.run(/*sql*/ `ALTER TABLE message_runs ADD COLUMN pending_secret TEXT`); } catch (e) { log.debug({ err: e }, 'ALTER TABLE message_runs ADD COLUMN pending_secret (likely already exists)'); }
+  try { database.run(/*sql*/ `ALTER TABLE message_runs ADD COLUMN pending_secret TEXT`); } catch { /* already exists */ }
 
   // published_pages
-  try { database.run(/*sql*/ `ALTER TABLE published_pages ADD COLUMN app_id TEXT`); } catch (e) { log.debug({ err: e }, 'ALTER TABLE published_pages ADD COLUMN app_id (likely already exists)'); }
-  try { database.run(/*sql*/ `ALTER TABLE published_pages ADD COLUMN project_slug TEXT`); } catch (e) { log.debug({ err: e }, 'ALTER TABLE published_pages ADD COLUMN project_slug (likely already exists)'); }
+  try { database.run(/*sql*/ `ALTER TABLE published_pages ADD COLUMN app_id TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE published_pages ADD COLUMN project_slug TEXT`); } catch { /* already exists */ }
 
   // conversations
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN total_input_tokens INTEGER NOT NULL DEFAULT 0`); } catch { /* already exists */ }

--- a/assistant/src/memory/migrations/108-tasks-and-work-items.ts
+++ b/assistant/src/memory/migrations/108-tasks-and-work-items.ts
@@ -1,7 +1,4 @@
-import { getLogger } from '../../util/logger.js';
 import type { DrizzleDb } from '../db-connection.js';
-
-const log = getLogger('memory-db');
 
 /**
  * Tasks, task runs, task candidates, and work items tables with indexes.
@@ -69,11 +66,11 @@ export function createTasksAndWorkItemsTables(database: DrizzleDb): void {
   `);
 
   // Work item run contract snapshot
-  try { database.run(/*sql*/ `ALTER TABLE work_items ADD COLUMN required_tools TEXT`); } catch (e) { log.debug({ err: e }, 'ALTER TABLE work_items ADD COLUMN required_tools (likely already exists)'); }
+  try { database.run(/*sql*/ `ALTER TABLE work_items ADD COLUMN required_tools TEXT`); } catch { /* already exists */ }
 
   // Work item permission preflight columns
-  try { database.run(/*sql*/ `ALTER TABLE work_items ADD COLUMN approved_tools TEXT`); } catch (e) { log.debug({ err: e }, 'ALTER TABLE work_items ADD COLUMN approved_tools (likely already exists)'); }
-  try { database.run(/*sql*/ `ALTER TABLE work_items ADD COLUMN approval_status TEXT DEFAULT 'none'`); } catch (e) { log.debug({ err: e }, 'ALTER TABLE work_items ADD COLUMN approval_status (likely already exists)'); }
+  try { database.run(/*sql*/ `ALTER TABLE work_items ADD COLUMN approved_tools TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE work_items ADD COLUMN approval_status TEXT DEFAULT 'none'`); } catch { /* already exists */ }
 
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_work_items_status ON work_items(status)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_work_items_task_id ON work_items(task_id)`);


### PR DESCRIPTION
## Summary
- Silenced expected `duplicate column name` errors in migrations 102 and 108 that were being logged at debug level on every daemon startup
- Aligned catch blocks to use the same silent `catch { /* already exists */ }` pattern used by all other ALTER TABLE migrations
- Removed now-unused logger imports from both migration files

## Original prompt
Fix noisy DrizzleError/SQLiteError "duplicate column name" errors logged on daemon startup from migrations 102-alter-table-columns.ts and 108-tasks-and-work-items.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
