### PR TITLE
fix: use IPC path for tollfreePhoneNumberSid in sms-setup skill

### DIFF
--- a/assistant/src/config/vellum-skills/sms-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/sms-setup/SKILL.md
@@ -76,7 +76,7 @@ When the remote check returns `toll_free_verification` as a failing check, use t
 }
 ```
 
-The response includes a `compliance` object with `numberType`, `verificationSid`, `verificationStatus`, `rejectionReason`, `rejectionReasons`, `editAllowed`, and `editExpiration` fields.
+The response includes a `compliance` object with `numberType`, `tollfreePhoneNumberSid`, `verificationSid`, `verificationStatus`, `rejectionReason`, `rejectionReasons`, `editAllowed`, and `editExpiration` fields. For toll-free numbers, `tollfreePhoneNumberSid` contains the Twilio phone number SID needed for verification submission.
 
 - If `verificationStatus` is `PENDING_REVIEW` or `IN_REVIEW`, tell the user verification is already in progress and skip submission.
 - If `verificationStatus` is `TWILIO_APPROVED`, compliance is complete — proceed to Step 4.
@@ -98,20 +98,7 @@ The response includes a `compliance` object with `numberType`, `verificationSid`
 | Opt-in type | `optInType` | `VERBAL`, `WEB_FORM`, `PAPER_FORM`, `VIA_TEXT`, `MOBILE_QR_CODE` |
 | Opt-in image URL | `optInImageUrls` | Array of URLs showing opt-in mechanism (can be website URL) |
 
-The `tollfreePhoneNumberSid` is **not** returned by `sms_compliance_status` (that response only contains verification metadata). To obtain it, look up the configured phone number's SID using the `getPhoneNumberSid` helper via the IPC client:
-
-```bash
-cd "$(git rev-parse --show-toplevel)/assistant" && bun -e '
-import { getPhoneNumberSid } from "./src/calls/twilio-rest.js";
-import { getSecureKey } from "./src/security/secure-keys.js";
-const sid = getSecureKey("credential:twilio:account_sid");
-const token = getSecureKey("credential:twilio:auth_token");
-const phoneSid = await getPhoneNumberSid(sid!, token!, "<configured phone number>");
-console.log(phoneSid);
-'
-```
-
-Replace `<configured phone number>` with the `phoneNumber` from the `sms_compliance_status` response. Do NOT ask for EIN, business registration number, or business registration authority. Explain that Twilio labels some fields as "business" fields even for individual submitters.
+The `tollfreePhoneNumberSid` is returned by the `sms_compliance_status` response in the `compliance` object. Use `compliance.tollfreePhoneNumberSid` from the Step 3a response as the value for `verificationParams.tollfreePhoneNumberSid` when submitting. Do NOT ask for EIN, business registration number, or business registration authority. Explain that Twilio labels some fields as "business" fields even for individual submitters.
 
 **Step 3c: Submit verification:**
 
@@ -120,7 +107,7 @@ Replace `<configured phone number>` with the `phoneNumber` from the `sms_complia
   "type": "twilio_config",
   "action": "sms_submit_tollfree_verification",
   "verificationParams": {
-    "tollfreePhoneNumberSid": "<PN SID from getPhoneNumberSid lookup above>",
+    "tollfreePhoneNumberSid": "<compliance.tollfreePhoneNumberSid from Step 3a>",
     "businessName": "...",
     "businessWebsite": "...",
     "notificationEmail": "...",

--- a/assistant/src/daemon/handlers/config-twilio.ts
+++ b/assistant/src/daemon/handlers/config-twilio.ts
@@ -454,6 +454,7 @@ export async function handleTwilioConfig(
         phoneNumber,
         compliance: {
           numberType,
+          tollfreePhoneNumberSid: phoneSid,
           verificationSid: verification?.sid,
           verificationStatus: verification?.status,
           rejectionReason: verification?.rejectionReason,

--- a/assistant/src/daemon/ipc-contract/integrations.ts
+++ b/assistant/src/daemon/ipc-contract/integrations.ts
@@ -190,6 +190,7 @@ export interface TwilioConfigResponse {
   warning?: string;
   compliance?: {
     numberType?: string;
+    tollfreePhoneNumberSid?: string;
     verificationSid?: string;
     verificationStatus?: string;
     rejectionReason?: string;

--- a/skills/sms-setup/SKILL.md
+++ b/skills/sms-setup/SKILL.md
@@ -76,7 +76,7 @@ When the remote check returns `toll_free_verification` as a failing check, use t
 }
 ```
 
-The response includes a `compliance` object with `numberType`, `verificationSid`, `verificationStatus`, `rejectionReason`, `rejectionReasons`, `editAllowed`, and `editExpiration` fields.
+The response includes a `compliance` object with `numberType`, `tollfreePhoneNumberSid`, `verificationSid`, `verificationStatus`, `rejectionReason`, `rejectionReasons`, `editAllowed`, and `editExpiration` fields. For toll-free numbers, `tollfreePhoneNumberSid` contains the Twilio phone number SID needed for verification submission.
 
 - If `verificationStatus` is `PENDING_REVIEW` or `IN_REVIEW`, tell the user verification is already in progress and skip submission.
 - If `verificationStatus` is `TWILIO_APPROVED`, compliance is complete — proceed to Step 4.
@@ -98,20 +98,7 @@ The response includes a `compliance` object with `numberType`, `verificationSid`
 | Opt-in type | `optInType` | `VERBAL`, `WEB_FORM`, `PAPER_FORM`, `VIA_TEXT`, `MOBILE_QR_CODE` |
 | Opt-in image URL | `optInImageUrls` | Array of URLs showing opt-in mechanism (can be website URL) |
 
-The `tollfreePhoneNumberSid` is **not** returned by `sms_compliance_status` (that response only contains verification metadata). To obtain it, look up the configured phone number's SID using the `getPhoneNumberSid` helper via the IPC client:
-
-```bash
-cd "$(git rev-parse --show-toplevel)/assistant" && bun -e '
-import { getPhoneNumberSid } from "./src/calls/twilio-rest.js";
-import { getSecureKey } from "./src/security/secure-keys.js";
-const sid = getSecureKey("credential:twilio:account_sid");
-const token = getSecureKey("credential:twilio:auth_token");
-const phoneSid = await getPhoneNumberSid(sid!, token!, "<configured phone number>");
-console.log(phoneSid);
-'
-```
-
-Replace `<configured phone number>` with the `phoneNumber` from the `sms_compliance_status` response. Do NOT ask for EIN, business registration number, or business registration authority. Explain that Twilio labels some fields as "business" fields even for individual submitters.
+The `tollfreePhoneNumberSid` is returned by the `sms_compliance_status` response in the `compliance` object. Use `compliance.tollfreePhoneNumberSid` from the Step 3a response as the value for `verificationParams.tollfreePhoneNumberSid` when submitting. Do NOT ask for EIN, business registration number, or business registration authority. Explain that Twilio labels some fields as "business" fields even for individual submitters.
 
 **Step 3c: Submit verification:**
 
@@ -120,7 +107,7 @@ Replace `<configured phone number>` with the `phoneNumber` from the `sms_complia
   "type": "twilio_config",
   "action": "sms_submit_tollfree_verification",
   "verificationParams": {
-    "tollfreePhoneNumberSid": "<PN SID from getPhoneNumberSid lookup above>",
+    "tollfreePhoneNumberSid": "<compliance.tollfreePhoneNumberSid from Step 3a>",
     "businessName": "...",
     "businessWebsite": "...",
     "notificationEmail": "...",


### PR DESCRIPTION
Addresses review feedback on #9059. Replaces direct twilio-rest/secure-keys imports with the IPC path for obtaining the phone number SID, consistent with how the skill uses IPC for all other Twilio operations.

Changes:
- Added `tollfreePhoneNumberSid` to the `sms_compliance_status` IPC response (the handler already resolved the phone SID internally, now it includes it in the response)
- Updated the IPC contract type to include the new field
- Updated both copies of the sms-setup SKILL.md to use `compliance.tollfreePhoneNumberSid` from the IPC response instead of a direct `bun -e` script that imported twilio-rest.js and secure-keys.js
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
