### PR TITLE
fix: close post-#9020 notification cleanup gaps

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4776,7 +4776,7 @@ Producer → NotificationSignal → Decision Engine (LLM) → Deterministic Chec
 - **`deliveryEnabled`** — whether the channel can receive notification deliveries. The `NotificationChannel` type is derived from this flag: only channels with `deliveryEnabled: true` are valid notification targets.
 - **`conversationStrategy`** — how the notification pipeline materializes conversations for the channel:
   - `start_new_conversation` — creates a fresh conversation per delivery (e.g. vellum desktop/mobile threads)
-  - `continue_existing_conversation` — appends to an existing channel-scoped conversation (e.g. Telegram)
+  - `continue_existing_conversation` — intended to append to an existing channel-scoped conversation; currently materializes a background audit conversation per delivery (e.g. Telegram)
   - `not_deliverable` — channel cannot receive notifications (e.g. voice)
 
 Helper functions: `getDeliverableChannels()`, `getChannelPolicy()`, `isNotificationDeliverable()`, `getConversationStrategy()`.

--- a/assistant/src/__tests__/conversation-pairing.test.ts
+++ b/assistant/src/__tests__/conversation-pairing.test.ts
@@ -101,6 +101,8 @@ describe('pairDeliveryWithConversation', () => {
     expect(result.strategy).toBe('start_new_conversation');
     expect(createConversationMock).toHaveBeenCalledTimes(1);
     expect(addMessageMock).toHaveBeenCalledTimes(1);
+    const callArgs = createConversationMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(callArgs.threadType).toBe('standard');
   });
 
   test('uses threadTitle for conversation title when available', () => {
@@ -159,6 +161,8 @@ describe('pairDeliveryWithConversation', () => {
     expect(result.messageId).toBe('msg-001');
     expect(result.strategy).toBe('continue_existing_conversation');
     expect(createConversationMock).toHaveBeenCalledTimes(1);
+    const callArgs = createConversationMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(callArgs.threadType).toBe('background');
   });
 
   // ── not_deliverable (voice) ───────────────────────────────────────

--- a/assistant/src/notifications/README.md
+++ b/assistant/src/notifications/README.md
@@ -53,7 +53,7 @@ Each policy defines:
 | Strategy | Behavior | Used by |
 |----------|----------|---------|
 | `start_new_conversation` | Creates a fresh conversation per delivery. The thread is surfaced via IPC. | `vellum` |
-| `continue_existing_conversation` | Appends to an existing channel-scoped conversation (future: lookup by binding key). Currently creates a new conversation per delivery and records the intended strategy for audit. | `telegram`, `sms`, `whatsapp`, `slack`, `email` |
+| `continue_existing_conversation` | Appends to an existing channel-scoped conversation (future: lookup by binding key). Currently materializes a background audit conversation per delivery and records the intended strategy. | `telegram`, `sms`, `whatsapp`, `slack`, `email` |
 | `not_deliverable` | Channel cannot receive notifications. Pairing returns null IDs. | `voice` |
 
 ### Helper Functions
@@ -76,7 +76,7 @@ Each policy defines:
 **Every notification delivery gets a conversation.** Before the adapter sends a notification, `pairDeliveryWithConversation()` (in `conversation-pairing.ts`) materializes a conversation and seed message based on the channel's conversation strategy:
 
 - **`start_new_conversation`**: Creates a new conversation with `threadType: 'standard'` and `source: 'notification'`, plus an assistant message containing the notification copy. Memory indexing is skipped on the seed message to prevent notification copy from polluting conversational recall.
-- **`continue_existing_conversation`**: Currently creates a new conversation per delivery (true continuation via binding key lookup is planned for a future PR). The audit trail records the intended strategy.
+- **`continue_existing_conversation`**: Currently materializes a background audit conversation per delivery (true continuation via binding key lookup is planned for a future PR). The audit trail records the intended strategy without adding visible sidebar threads.
 - **`not_deliverable`**: Returns `{ conversationId: null, messageId: null }`.
 
 The pairing function is resilient -- errors are caught and logged. A pairing failure never breaks the delivery pipeline.

--- a/assistant/src/notifications/conversation-pairing.ts
+++ b/assistant/src/notifications/conversation-pairing.ts
@@ -55,13 +55,17 @@ export function pairDeliveryWithConversation(
     // record the intended strategy so the audit trail is complete.
     const title = copy.threadTitle ?? copy.title ?? signal.sourceEventName;
 
-    // Use 'standard' threadType so notification threads remain visible in
-    // conversation listings and deep-linkable from notification intents.
+    // Only start_new_conversation threads should be user-visible. For channels
+    // that intend to continue an existing external conversation (e.g. Telegram),
+    // we still materialize an auditable row but keep it background-only until
+    // true continuation-by-key is implemented.
+    const threadType = strategy === 'start_new_conversation' ? 'standard' : 'background';
+
     // Memory indexing is skipped on the seed message below to prevent
     // notification copy from polluting conversational recall.
     const conversation = createConversation({
       title,
-      threadType: 'standard',
+      threadType,
       source: 'notification',
     });
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -5,6 +5,8 @@ import VellumAssistantShared
 import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AppDelegate+Notifications")
+private let guardianFallbackDedupWindowMs: Double = 30_000
+private let guardianFallbackDelayNs: UInt64 = 750_000_000
 
 extension AppDelegate {
 
@@ -132,19 +134,40 @@ extension AppDelegate {
         }
     }
 
-    func deliverNotificationIntent(_ msg: NotificationIntentMessage) {
+    private func conversationId(from deepLinkMetadata: [String: AnyCodable]?) -> String? {
+        if let direct = deepLinkMetadata?["conversationId"]?.value as? String {
+            return direct
+        }
+        if let snake = deepLinkMetadata?["conversation_id"]?.value as? String {
+            return snake
+        }
+        return nil
+    }
+
+    private func pruneGuardianFallbackMarkers(nowMs: Double) {
+        guardianFallbackDeliveredAtMs = guardianFallbackDeliveredAtMs.filter { _, deliveredAt in
+            nowMs - deliveredAt <= guardianFallbackDedupWindowMs
+        }
+    }
+
+    private func postNotificationIntent(
+        sourceEventName: String,
+        title: String,
+        body: String,
+        deepLinkMetadata: [String: AnyCodable]?
+    ) {
         let content = UNMutableNotificationContent()
-        content.title = msg.title
-        content.body = msg.body
+        content.title = title
+        content.body = body
         content.sound = .default
         content.categoryIdentifier = "NOTIFICATION_INTENT"
 
         var userInfo: [String: Any] = [
-            "sourceEventName": msg.sourceEventName,
+            "sourceEventName": sourceEventName,
         ]
-        if let metadata = msg.deepLinkMetadata {
+        if let metadata = deepLinkMetadata {
             for (key, wrapped) in metadata {
-                // Keep sourceEventName authoritative from the daemon envelope.
+                // Keep sourceEventName authoritative from the envelope.
                 if key == "sourceEventName" {
                     continue
                 }
@@ -164,6 +187,55 @@ extension AppDelegate {
             if let error {
                 log.error("Failed to post notification intent: \(error.localizedDescription)")
             }
+        }
+    }
+
+    func deliverNotificationIntent(_ msg: NotificationIntentMessage) {
+        if msg.sourceEventName == "guardian.question" {
+            let nowMs = Date().timeIntervalSince1970 * 1000
+            pruneGuardianFallbackMarkers(nowMs: nowMs)
+
+            if let conversationId = conversationId(from: msg.deepLinkMetadata) {
+                // If we already posted the fallback alert for this conversation,
+                // suppress the later notification_intent duplicate.
+                if let deliveredAt = guardianFallbackDeliveredAtMs.removeValue(forKey: conversationId),
+                   nowMs - deliveredAt <= guardianFallbackDedupWindowMs {
+                    return
+                }
+
+                // notification_intent arrived in time; invalidate pending fallback.
+                pendingGuardianFallbackNotifications.removeValue(forKey: conversationId)
+            }
+        }
+
+        postNotificationIntent(
+            sourceEventName: msg.sourceEventName,
+            title: msg.title,
+            body: msg.body,
+            deepLinkMetadata: msg.deepLinkMetadata
+        )
+    }
+
+    func scheduleGuardianNotificationFallback(conversationId: String, title: String) {
+        let token = UUID()
+        pendingGuardianFallbackNotifications[conversationId] = token
+
+        Task { [weak self] in
+            try? await Task.sleep(nanoseconds: guardianFallbackDelayNs)
+            guard let self else { return }
+            guard self.pendingGuardianFallbackNotifications[conversationId] == token else { return }
+
+            self.pendingGuardianFallbackNotifications.removeValue(forKey: conversationId)
+            let nowMs = Date().timeIntervalSince1970 * 1000
+            self.guardianFallbackDeliveredAtMs[conversationId] = nowMs
+            self.pruneGuardianFallbackMarkers(nowMs: nowMs)
+
+            self.postNotificationIntent(
+                sourceEventName: "guardian.question",
+                title: title,
+                body: "A guardian question needs your attention.",
+                deepLinkMetadata: ["conversationId": AnyCodable(conversationId)]
+            )
         }
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -257,14 +257,12 @@ extension AppDelegate {
             return
         }
 
-        deliverNotificationIntent(
-            NotificationIntentMessage(
-                type: "notification_intent",
-                sourceEventName: msg.sourceEventName,
-                title: msg.title,
-                body: "A guardian question needs your attention.",
-                deepLinkMetadata: ["conversationId": AnyCodable(msg.conversationId)]
-            )
+        // notification_intent is normally emitted moments later by the
+        // vellum adapter. Schedule a fallback so guardian alerts are still
+        // guaranteed if that intent fails to arrive.
+        scheduleGuardianNotificationFallback(
+            conversationId: msg.conversationId,
+            title: msg.title
         )
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -157,6 +157,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var refreshSkillsTask: Task<Void, Never>?
     var cachedApps: [AppItem] = []
     var refreshAppsTask: Task<Void, Never>?
+    /// Pending guardian fallback notification tokens, keyed by conversationId.
+    /// Used to avoid duplicate native alerts when notification_intent arrives.
+    var pendingGuardianFallbackNotifications: [String: UUID] = [:]
+    /// Recently delivered guardian fallback notifications (epoch ms), keyed by
+    /// conversationId. Incoming notification_intent for the same conversation
+    /// inside a short window is treated as a duplicate and suppressed.
+    var guardianFallbackDeliveredAtMs: [String: Double] = [:]
 
     /// Whether the current assistant runs remotely (cloud != "local").
     /// When true, local daemon hatching is skipped.


### PR DESCRIPTION
## Summary
- prevent duplicate macOS native alerts for background `guardian.question` events by deduping `notification_thread_created` fallback vs `notification_intent` delivery
- keep guardian alert reliability by scheduling a short fallback notification only when `notification_intent` does not arrive
- reduce sidebar clutter for channels configured with `continue_existing_conversation` by materializing those interim audit conversations as `threadType: 'background'`
- update notification docs/architecture notes and pairing tests to match the new behavior

## Validation
- `cd assistant && bun test src/__tests__/conversation-pairing.test.ts src/__tests__/guardian-dispatch.test.ts src/__tests__/notification-guardian-path.test.ts src/__tests__/notification-deep-link.test.ts src/__tests__/ipc-snapshot.test.ts src/__tests__/channel-policy.test.ts`
- `cd assistant && bunx tsc --noEmit` *(fails on pre-existing unrelated baseline errors in channel-guardian/ipc-snapshot/notification-deep-link/conflict-store)*