### PR TITLE
fix: inline video playback retry and reconnect resilience

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -381,6 +381,9 @@ struct InlineVideoAttachmentView: View {
     }
 
     /// Poll `resolveDaemonPort()` at short intervals for up to `portWaitTimeout`.
+    /// Explicit `@MainActor` because `resolveDaemonPort` reads `DaemonClient.httpPort`
+    /// which is `@MainActor`-isolated.
+    @MainActor
     private func waitForPort() async -> Int? {
         let deadline = Date().addingTimeInterval(portWaitTimeout)
         while Date() < deadline {

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -366,16 +366,16 @@ struct InlineVideoAttachmentView: View {
             return
         }
 
+        // Resolve port on MainActor before entering the Task to avoid
+        // reading @MainActor-isolated DaemonClient.httpPort off-actor.
+        guard let port = resolveDaemonPort() else {
+            failureReason = .portMissing
+            return
+        }
+
         isLoading = true
         loadingMessage = "Loading video..."
         Task {
-            guard let port = resolveDaemonPort() else {
-                await MainActor.run {
-                    isLoading = false
-                    failureReason = .portMissing
-                }
-                return
-            }
             await doFetch(port: port)
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -56,6 +56,9 @@ struct InlineVideoAttachmentView: View {
     @State private var thumbnailImage: NSImage?
     /// Prevents multiple auto-retries from stacking up.
     @State private var hasAutoRetried = false
+    /// Tracks whether we already retried from the failed tile tap so the
+    /// next tap falls back to opening in an external player.
+    @State private var hasRetriedFromFailedTile = false
 
     init(attachment: ChatAttachment, resolveDaemonPort: @escaping () -> Int?) {
         self.attachment = attachment
@@ -133,6 +136,7 @@ struct InlineVideoAttachmentView: View {
             guard failureReason == .portMissing, !hasAutoRetried else { return }
             log.info("Daemon reconnected — auto-retrying playback for attachment \(self.attachment.id, privacy: .public)")
             hasAutoRetried = true
+            hasRetriedFromFailedTile = false
             failureReason = nil
             prepareAndPlay()
         }
@@ -201,9 +205,16 @@ struct InlineVideoAttachmentView: View {
 
     // MARK: - Retry Logic
 
-    /// Tap on failed tile: retry playback first, fall back to external player
-    /// if the retry also fails.
+    /// Tap on failed tile: retry playback first. If the view was already in a
+    /// failed state from a previous retry (i.e. this is the second consecutive
+    /// tap on a failed tile), open in an external player as a fallback.
     private func retryOrOpenExternal() {
+        if hasRetriedFromFailedTile {
+            // Second tap on failed tile — fall back to external player.
+            openInExternalPlayer()
+            return
+        }
+        hasRetriedFromFailedTile = true
         failureReason = nil
         prepareAndPlay()
     }
@@ -354,7 +365,13 @@ struct InlineVideoAttachmentView: View {
         isLoading = true
         loadingMessage = "Loading video..."
         Task {
-            let port = resolveDaemonPort()!
+            guard let port = resolveDaemonPort() else {
+                await MainActor.run {
+                    isLoading = false
+                    failureReason = .portMissing
+                }
+                return
+            }
             await doFetch(port: port)
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -5,14 +5,17 @@ import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "InlineVideoAttachment")
 
+/// How long to poll for daemon port availability before giving up.
+private let portWaitTimeout: TimeInterval = 4.0
+/// Interval between port availability polls.
+private let portPollInterval: UInt64 = 500_000_000 // 0.5s in nanoseconds
+
 /// Classifies playback failures so we can log specific root causes and show
 /// slightly more helpful messages to the user.
 private enum VideoPlaybackError: String {
     case portMissing = "port_missing"
     case fetchFailed = "fetch_failed"
     case invalidMedia = "invalid_media"
-    case decodeFailed = "decode_failed"
-    case unknown = "unknown"
 
     /// User-facing description shown in the failed-state overlay.
     var userMessage: String {
@@ -21,10 +24,14 @@ private enum VideoPlaybackError: String {
             return "Could not connect to video service"
         case .fetchFailed:
             return "Could not download video"
-        case .invalidMedia, .decodeFailed, .unknown:
+        case .invalidMedia:
             return "Could not play video"
         }
     }
+
+    /// Copy shown during the reconnecting/waiting phase, distinct from
+    /// the final failure message.
+    static let reconnectingMessage = "Reconnecting to video service..."
 }
 
 /// Inline video player for file-based video attachments (e.g. video/mp4).
@@ -41,11 +48,14 @@ struct InlineVideoAttachmentView: View {
     @State private var player: AVPlayer?
     @State private var isPlaying = false
     @State private var isLoading = false
+    @State private var loadingMessage = "Loading video..."
     @State private var failureReason: VideoPlaybackError?
     @State private var videoAspectRatio: CGFloat
     @State private var isHovering = false
     @State private var isSaving = false
     @State private var thumbnailImage: NSImage?
+    /// Prevents multiple auto-retries from stacking up.
+    @State private var hasAutoRetried = false
 
     init(attachment: ChatAttachment, resolveDaemonPort: @escaping () -> Int?) {
         self.attachment = attachment
@@ -118,6 +128,14 @@ struct InlineVideoAttachmentView: View {
             player = nil
             isPlaying = false
         }
+        .onReceive(NotificationCenter.default.publisher(for: .daemonDidReconnect)) { _ in
+            // Auto-retry once on daemon reconnect if the last failure was port_missing.
+            guard failureReason == .portMissing, !hasAutoRetried else { return }
+            log.info("Daemon reconnected — auto-retrying playback for attachment \(self.attachment.id, privacy: .public)")
+            hasAutoRetried = true
+            failureReason = nil
+            prepareAndPlay()
+        }
     }
 
     private var placeholderView: some View {
@@ -157,7 +175,7 @@ struct InlineVideoAttachmentView: View {
             ProgressView()
                 .controlSize(.regular)
 
-            Text("Loading video...")
+            Text(loadingMessage)
                 .font(VFont.caption)
                 .foregroundStyle(VColor.textSecondary)
         }
@@ -177,8 +195,17 @@ struct InlineVideoAttachmentView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .contentShape(Rectangle())
         .onTapGesture {
-            openInExternalPlayer()
+            retryOrOpenExternal()
         }
+    }
+
+    // MARK: - Retry Logic
+
+    /// Tap on failed tile: retry playback first, fall back to external player
+    /// if the retry also fails.
+    private func retryOrOpenExternal() {
+        failureReason = nil
+        prepareAndPlay()
     }
 
     /// Builds a safe temp-file URL by stripping path components from the filename
@@ -275,8 +302,8 @@ struct InlineVideoAttachmentView: View {
 
     private func playFromBase64(_ base64: String) async {
         guard let data = Data(base64Encoded: base64) else {
-            log.warning("Base64 decode failed for attachment \(self.attachment.id, privacy: .public) — category: \(VideoPlaybackError.decodeFailed.rawValue, privacy: .public)")
-            await MainActor.run { failureReason = .decodeFailed }
+            log.warning("Base64 decode failed for attachment \(self.attachment.id, privacy: .public) — category: \(VideoPlaybackError.invalidMedia.rawValue, privacy: .public)")
+            await MainActor.run { failureReason = .invalidMedia }
             return
         }
 
@@ -293,11 +320,31 @@ struct InlineVideoAttachmentView: View {
     }
 
     private func fetchAndPlay() {
-        guard let port = resolveDaemonPort() else {
-            log.warning("Daemon HTTP port unavailable — cannot fetch attachment \(self.attachment.id, privacy: .public) — category: \(VideoPlaybackError.portMissing.rawValue, privacy: .public)")
-            failureReason = .portMissing
+        // If port is nil, show a reconnecting state and poll for a short window
+        // before giving up. This handles the brief gap during daemon restart.
+        if resolveDaemonPort() == nil {
+            log.info("Daemon HTTP port unavailable — waiting for reconnect for attachment \(self.attachment.id, privacy: .public)")
+            isLoading = true
+            loadingMessage = VideoPlaybackError.reconnectingMessage
+            Task {
+                let port = await waitForPort()
+                guard let port else {
+                    log.warning("Daemon HTTP port still unavailable after wait — category: \(VideoPlaybackError.portMissing.rawValue, privacy: .public)")
+                    await MainActor.run {
+                        isLoading = false
+                        loadingMessage = "Loading video..."
+                        failureReason = .portMissing
+                    }
+                    return
+                }
+                await MainActor.run {
+                    loadingMessage = "Loading video..."
+                }
+                await doFetch(port: port)
+            }
             return
         }
+
         guard let attachmentId = attachment.id.isEmpty ? nil : attachment.id else {
             log.warning("Attachment ID is empty — cannot fetch — category: \(VideoPlaybackError.fetchFailed.rawValue, privacy: .public)")
             failureReason = .fetchFailed
@@ -305,19 +352,47 @@ struct InlineVideoAttachmentView: View {
         }
 
         isLoading = true
+        loadingMessage = "Loading video..."
         Task {
-            do {
-                let data = try await fetchAttachmentContent(port: port, attachmentId: attachmentId)
-                let fileURL = safeTempURL()
-                try data.write(to: fileURL)
-                await MainActor.run { isLoading = false }
-                await playFromFile(fileURL)
-            } catch {
-                log.error("Failed to fetch attachment \(attachmentId, privacy: .public): \(error.localizedDescription, privacy: .public) — category: \(VideoPlaybackError.fetchFailed.rawValue, privacy: .public)")
-                await MainActor.run {
-                    isLoading = false
-                    failureReason = .fetchFailed
-                }
+            let port = resolveDaemonPort()!
+            await doFetch(port: port)
+        }
+    }
+
+    /// Poll `resolveDaemonPort()` at short intervals for up to `portWaitTimeout`.
+    private func waitForPort() async -> Int? {
+        let deadline = Date().addingTimeInterval(portWaitTimeout)
+        while Date() < deadline {
+            if let port = resolveDaemonPort() {
+                return port
+            }
+            try? await Task.sleep(nanoseconds: portPollInterval)
+        }
+        return resolveDaemonPort()
+    }
+
+    /// Shared fetch-and-play logic used by fetchAndPlay after port resolution.
+    private func doFetch(port: Int) async {
+        guard let attachmentId = attachment.id.isEmpty ? nil : attachment.id else {
+            log.warning("Attachment ID is empty — cannot fetch — category: \(VideoPlaybackError.fetchFailed.rawValue, privacy: .public)")
+            await MainActor.run {
+                isLoading = false
+                failureReason = .fetchFailed
+            }
+            return
+        }
+
+        do {
+            let data = try await fetchAttachmentContent(port: port, attachmentId: attachmentId)
+            let fileURL = safeTempURL()
+            try data.write(to: fileURL)
+            await MainActor.run { isLoading = false }
+            await playFromFile(fileURL)
+        } catch {
+            log.error("Failed to fetch attachment \(attachmentId, privacy: .public): \(error.localizedDescription, privacy: .public) — category: \(VideoPlaybackError.fetchFailed.rawValue, privacy: .public)")
+            await MainActor.run {
+                isLoading = false
+                failureReason = .fetchFailed
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -307,6 +307,10 @@ struct InlineVideoAttachmentView: View {
         await MainActor.run {
             self.player = avPlayer
             self.isPlaying = true
+            // Reset retry flags on successful playback so future failures
+            // get a fresh retry cycle.
+            self.hasRetriedFromFailedTile = false
+            self.hasAutoRetried = false
             avPlayer.play()
         }
     }


### PR DESCRIPTION
## Summary
- **Port wait/retry**: When `resolveDaemonPort()` is nil in `fetchAndPlay()`, show "Reconnecting to video service..." loading state and poll for port availability for ~4s before setting `.portMissing`
- **Daemon reconnect auto-retry**: Subscribe to `.daemonDidReconnect` notification; if current failure is `.portMissing`, clear failure and auto-retry playback once
- **Failed-tile tap retry**: Change failed-state tap from `openInExternalPlayer()` to `retryOrOpenExternal()` which clears failure and retries `prepareAndPlay()` first
- **Simplified error buckets**: Consolidate to 3 UI-facing categories: `portMissing`, `fetchFailed`, `invalidMedia` (decode failures now map to `invalidMedia`). Removed `decodeFailed` and `unknown` cases. Reconnecting state uses distinct copy from final failure
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
