### PR TITLE
fix: regenerate IPC Swift code to include tollfreePhoneNumberSid field

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -4836,6 +4836,7 @@ public struct IPCTwilioConfigResponse: Codable, Sendable {
 
 public struct IPCTwilioConfigResponseCompliance: Codable, Sendable {
     public let numberType: String?
+    public let tollfreePhoneNumberSid: String?
     public let verificationSid: String?
     public let verificationStatus: String?
     public let rejectionReason: String?
@@ -4844,8 +4845,9 @@ public struct IPCTwilioConfigResponseCompliance: Codable, Sendable {
     public let editAllowed: Bool?
     public let editExpiration: String?
 
-    public init(numberType: String? = nil, verificationSid: String? = nil, verificationStatus: String? = nil, rejectionReason: String? = nil, rejectionReasons: [String]? = nil, errorCode: String? = nil, editAllowed: Bool? = nil, editExpiration: String? = nil) {
+    public init(numberType: String? = nil, tollfreePhoneNumberSid: String? = nil, verificationSid: String? = nil, verificationStatus: String? = nil, rejectionReason: String? = nil, rejectionReasons: [String]? = nil, errorCode: String? = nil, editAllowed: Bool? = nil, editExpiration: String? = nil) {
         self.numberType = numberType
+        self.tollfreePhoneNumberSid = tollfreePhoneNumberSid
         self.verificationSid = verificationSid
         self.verificationStatus = verificationStatus
         self.rejectionReason = rejectionReason


### PR DESCRIPTION
## Summary
- Regenerate `IPCContractGenerated.swift` to include the `tollfreePhoneNumberSid` field added to `IPCTwilioConfigResponseCompliance`
- Fixes CI failure in `Verify IPC generated code is up to date` step

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22413435078

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
