### PR TITLE
refactor: extract call tool execute() bodies into standalone functions

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1437,7 +1437,7 @@ describe('Call entrypoint gating', () => {
     // Force config reload
     loadConfig();
 
-    const { CallStartTool: _CallStartToolClass } = await import('../tools/calls/call-start.js') as { CallStartTool: new () => { execute: (input: Record<string, unknown>, context: { conversationId: string }) => Promise<{ content: string; isError: boolean }> } };
+    const { executeCallStart: _executeCallStart } = await import('../tools/calls/call-start.js');
 
     // The tool is registered via side effect. We need to test the gating logic directly.
     // Since the module registers itself, we test by loading config and checking behavior.

--- a/assistant/src/tools/calls/call-end.ts
+++ b/assistant/src/tools/calls/call-end.ts
@@ -23,6 +23,39 @@ const definition: ToolDefinition = {
   },
 };
 
+export async function executeCallEnd(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const callSessionId = input.call_session_id as string | undefined;
+  if (!callSessionId || typeof callSessionId !== 'string') {
+    return { content: 'Error: call_session_id is required and must be a string', isError: true };
+  }
+
+  const reason = input.reason as string | undefined;
+
+  const result = await cancelCall({ callSessionId, reason });
+
+  if (!result.ok) {
+    // If the call already ended, report it as a non-error for the tool
+    if (result.status === 409) {
+      return { content: result.error, isError: false };
+    }
+    return { content: `Error: ${result.error}`, isError: true };
+  }
+
+  const lines = [
+    'Call ended successfully.',
+    `  Call Session ID: ${callSessionId}`,
+    `  Status: cancelled`,
+  ];
+  if (reason) {
+    lines.push(`  Reason: ${reason}`);
+  }
+
+  return { content: lines.join('\n'), isError: false };
+}
+
 class CallEndTool implements Tool {
   name = 'call_end';
   description = definition.description;
@@ -33,34 +66,8 @@ class CallEndTool implements Tool {
     return definition;
   }
 
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    const callSessionId = input.call_session_id as string | undefined;
-    if (!callSessionId || typeof callSessionId !== 'string') {
-      return { content: 'Error: call_session_id is required and must be a string', isError: true };
-    }
-
-    const reason = input.reason as string | undefined;
-
-    const result = await cancelCall({ callSessionId, reason });
-
-    if (!result.ok) {
-      // If the call already ended, report it as a non-error for the tool
-      if (result.status === 409) {
-        return { content: result.error, isError: false };
-      }
-      return { content: `Error: ${result.error}`, isError: true };
-    }
-
-    const lines = [
-      'Call ended successfully.',
-      `  Call Session ID: ${callSessionId}`,
-      `  Status: cancelled`,
-    ];
-    if (reason) {
-      lines.push(`  Reason: ${reason}`);
-    }
-
-    return { content: lines.join('\n'), isError: false };
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    return executeCallEnd(input, context);
   }
 }
 

--- a/assistant/src/tools/calls/call-start.ts
+++ b/assistant/src/tools/calls/call-start.ts
@@ -34,6 +34,43 @@ const definition: ToolDefinition = {
   },
 };
 
+export async function executeCallStart(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  if (!getConfig().calls.enabled) {
+    return { content: 'Error: Calls feature is disabled via configuration. Set calls.enabled to true to use this feature.', isError: true };
+  }
+
+  const result = await startCall({
+    phoneNumber: input.phone_number as string,
+    task: input.task as string,
+    context: input.context as string | undefined,
+    conversationId: context.conversationId,
+    assistantId: context.assistantId,
+    callerIdentityMode: input.caller_identity_mode as 'assistant_number' | 'user_number' | undefined,
+  });
+
+  if (!result.ok) {
+    return { content: `Error: ${result.error}`, isError: true };
+  }
+
+  return {
+    content: [
+      'Call initiated successfully.',
+      `  Call Session ID: ${result.session.id}`,
+      `  Call SID: ${result.callSid}`,
+      `  To: ${result.session.toNumber}`,
+      `  From: ${result.session.fromNumber}`,
+      `  Caller Identity Mode: ${result.callerIdentityMode}`,
+      `  Status: initiated`,
+      '',
+      'The AI voice assistant is now placing the call. Use call_status to check progress.',
+    ].join('\n'),
+    isError: false,
+  };
+}
+
 class CallStartTool implements Tool {
   name = 'call_start';
   description = definition.description;
@@ -45,37 +82,7 @@ class CallStartTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    if (!getConfig().calls.enabled) {
-      return { content: 'Error: Calls feature is disabled via configuration. Set calls.enabled to true to use this feature.', isError: true };
-    }
-
-    const result = await startCall({
-      phoneNumber: input.phone_number as string,
-      task: input.task as string,
-      context: input.context as string | undefined,
-      conversationId: context.conversationId,
-      assistantId: context.assistantId,
-      callerIdentityMode: input.caller_identity_mode as 'assistant_number' | 'user_number' | undefined,
-    });
-
-    if (!result.ok) {
-      return { content: `Error: ${result.error}`, isError: true };
-    }
-
-    return {
-      content: [
-        'Call initiated successfully.',
-        `  Call Session ID: ${result.session.id}`,
-        `  Call SID: ${result.callSid}`,
-        `  To: ${result.session.toNumber}`,
-        `  From: ${result.session.fromNumber}`,
-        `  Caller Identity Mode: ${result.callerIdentityMode}`,
-        `  Status: initiated`,
-        '',
-        'The AI voice assistant is now placing the call. Use call_status to check progress.',
-      ].join('\n'),
-      isError: false,
-    };
+    return executeCallStart(input, context);
   }
 }
 

--- a/assistant/src/tools/calls/call-status.ts
+++ b/assistant/src/tools/calls/call-status.ts
@@ -19,6 +19,57 @@ const definition: ToolDefinition = {
   },
 };
 
+export async function executeCallStatus(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const callSessionId = input.call_session_id as string | undefined;
+
+  const result = getCallStatus(callSessionId, context.conversationId);
+
+  if (!result.ok) {
+    // When no active call is found and no specific ID was requested, it's not an error
+    if (!callSessionId && result.error === 'No active call found in the current conversation') {
+      return { content: result.error, isError: false };
+    }
+    return { content: `Error: ${result.error}`, isError: true };
+  }
+
+  const { session } = result;
+  const lines = [
+    `Call Session: ${session.id}`,
+    `  Status: ${session.status}`,
+    `  To: ${session.toNumber}`,
+    `  From: ${session.fromNumber}`,
+  ];
+
+  if (session.providerCallSid) {
+    lines.push(`  Call SID: ${session.providerCallSid}`);
+  }
+
+  if (session.task) {
+    lines.push(`  Task: ${session.task}`);
+  }
+
+  if (session.startedAt) {
+    const durationMs = (session.endedAt ?? Date.now()) - session.startedAt;
+    const durationSec = Math.round(durationMs / 1000);
+    lines.push(`  Duration: ${durationSec}s`);
+  }
+
+  if (session.lastError) {
+    lines.push(`  Last Error: ${session.lastError}`);
+  }
+
+  if (result.pendingQuestion) {
+    lines.push('');
+    lines.push(`  Pending Question: ${result.pendingQuestion.questionText}`);
+    lines.push(`  Question ID: ${result.pendingQuestion.id}`);
+  }
+
+  return { content: lines.join('\n'), isError: false };
+}
+
 class CallStatusTool implements Tool {
   name = 'call_status';
   description = definition.description;
@@ -30,51 +81,7 @@ class CallStatusTool implements Tool {
   }
 
   async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    const callSessionId = input.call_session_id as string | undefined;
-
-    const result = getCallStatus(callSessionId, context.conversationId);
-
-    if (!result.ok) {
-      // When no active call is found and no specific ID was requested, it's not an error
-      if (!callSessionId && result.error === 'No active call found in the current conversation') {
-        return { content: result.error, isError: false };
-      }
-      return { content: `Error: ${result.error}`, isError: true };
-    }
-
-    const { session } = result;
-    const lines = [
-      `Call Session: ${session.id}`,
-      `  Status: ${session.status}`,
-      `  To: ${session.toNumber}`,
-      `  From: ${session.fromNumber}`,
-    ];
-
-    if (session.providerCallSid) {
-      lines.push(`  Call SID: ${session.providerCallSid}`);
-    }
-
-    if (session.task) {
-      lines.push(`  Task: ${session.task}`);
-    }
-
-    if (session.startedAt) {
-      const durationMs = (session.endedAt ?? Date.now()) - session.startedAt;
-      const durationSec = Math.round(durationMs / 1000);
-      lines.push(`  Duration: ${durationSec}s`);
-    }
-
-    if (session.lastError) {
-      lines.push(`  Last Error: ${session.lastError}`);
-    }
-
-    if (result.pendingQuestion) {
-      lines.push('');
-      lines.push(`  Pending Question: ${result.pendingQuestion.questionText}`);
-      lines.push(`  Question ID: ${result.pendingQuestion.id}`);
-    }
-
-    return { content: lines.join('\n'), isError: false };
+    return executeCallStatus(input, context);
   }
 }
 


### PR DESCRIPTION
## Summary

- Extract `execute()` bodies from `CallStartTool`, `CallStatusTool`, and `CallEndTool` into exported standalone functions (`executeCallStart`, `executeCallStatus`, `executeCallEnd`)
- Each class now delegates to the extracted function — zero behavior change
- Update `config-schema.test.ts` to import the new `executeCallStart` function instead of the (never-exported) `CallStartTool` class

## Context

This is a pure refactor that prepares for migrating the call tools to a bundled skill in a follow-up PR. By extracting the logic into standalone functions, the skill can call them directly without needing to instantiate tool classes.

## Test plan

- [x] `bunx tsc --noEmit` passes (no new type errors introduced; pre-existing errors in unrelated files remain unchanged)
- [x] `bun test` — all call-related tests pass; pre-existing failures in unrelated test files are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
