### PR TITLE
Fix: Restore tokenEndpointAuthMethod for Twitter

### DIFF
--- a/assistant/src/oauth/provider-profiles.ts
+++ b/assistant/src/oauth/provider-profiles.ts
@@ -95,6 +95,7 @@ export const PROVIDER_PROFILES: Record<string, OAuthProviderProfile> = {
     tokenUrl: 'https://api.x.com/2/oauth2/token',
     defaultScopes: ['tweet.read', 'tweet.write', 'users.read', 'offline.access'],
     scopePolicy: DEFAULT_SCOPE_POLICY,
+    tokenEndpointAuthMethod: 'client_secret_basic',
     callbackTransport: 'gateway',
     identityVerifier: async (accessToken: string): Promise<string | undefined> => {
       try {


### PR DESCRIPTION
Restore client_secret_basic as the tokenEndpointAuthMethod for the Twitter provider profile. Without this, confidential clients default to client_secret_post, changing the token exchange behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
