### PR TITLE
refactor: migrate call tools to phone-calls bundled skill

### DIFF
--- a/assistant/src/config/bundled-skills/phone-calls/TOOLS.json
+++ b/assistant/src/config/bundled-skills/phone-calls/TOOLS.json
@@ -1,0 +1,76 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "call_start",
+      "description": "Place an outbound phone call via AI voice. The assistant will converse with the callee on behalf of the user.",
+      "category": "communication",
+      "risk": "high",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "phone_number": {
+            "type": "string",
+            "description": "E.164 formatted phone number (e.g. +14155551234)"
+          },
+          "task": {
+            "type": "string",
+            "description": "What the call should accomplish"
+          },
+          "context": {
+            "type": "string",
+            "description": "Additional context for the conversation"
+          },
+          "caller_identity_mode": {
+            "type": "string",
+            "enum": ["assistant_number", "user_number"],
+            "description": "Which phone number to use as the caller ID. assistant_number uses the AI assistant's Twilio number; user_number uses the user's verified personal number."
+          }
+        },
+        "required": ["phone_number", "task"]
+      },
+      "executor": "tools/call-start.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "call_status",
+      "description": "Check the status of an active or recent phone call",
+      "category": "communication",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "call_session_id": {
+            "type": "string",
+            "description": "Specific call session ID to check. If omitted, checks for an active call in the current conversation."
+          }
+        },
+        "required": []
+      },
+      "executor": "tools/call-status.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "call_end",
+      "description": "End an active phone call",
+      "category": "communication",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "call_session_id": {
+            "type": "string",
+            "description": "The call session ID to end"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Reason for ending the call"
+          }
+        },
+        "required": ["call_session_id"]
+      },
+      "executor": "tools/call-end.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/phone-calls/tools/call-end.ts
+++ b/assistant/src/config/bundled-skills/phone-calls/tools/call-end.ts
@@ -1,0 +1,3 @@
+import { executeCallEnd } from '../../../../tools/calls/call-end.js';
+
+export { executeCallEnd as run };

--- a/assistant/src/config/bundled-skills/phone-calls/tools/call-start.ts
+++ b/assistant/src/config/bundled-skills/phone-calls/tools/call-start.ts
@@ -1,0 +1,3 @@
+import { executeCallStart } from '../../../../tools/calls/call-start.js';
+
+export { executeCallStart as run };

--- a/assistant/src/config/bundled-skills/phone-calls/tools/call-status.ts
+++ b/assistant/src/config/bundled-skills/phone-calls/tools/call-status.ts
@@ -1,0 +1,3 @@
+import { executeCallStatus } from '../../../../tools/calls/call-status.js';
+
+export { executeCallStatus as run };

--- a/assistant/src/tools/calls/call-end.ts
+++ b/assistant/src/tools/calls/call-end.ts
@@ -1,27 +1,5 @@
 import { cancelCall } from '../../calls/call-domain.js';
-import { RiskLevel } from '../../permissions/types.js';
-import type { ToolDefinition } from '../../providers/types.js';
-import { registerTool } from '../registry.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-
-const definition: ToolDefinition = {
-  name: 'call_end',
-  description: 'End an active phone call',
-  input_schema: {
-    type: 'object',
-    properties: {
-      call_session_id: {
-        type: 'string',
-        description: 'The call session ID to end',
-      },
-      reason: {
-        type: 'string',
-        description: 'Reason for ending the call',
-      },
-    },
-    required: ['call_session_id'],
-  },
-};
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 
 export async function executeCallEnd(
   input: Record<string, unknown>,
@@ -55,20 +33,3 @@ export async function executeCallEnd(
 
   return { content: lines.join('\n'), isError: false };
 }
-
-class CallEndTool implements Tool {
-  name = 'call_end';
-  description = definition.description;
-  category = 'communication';
-  defaultRiskLevel = RiskLevel.Medium;
-
-  getDefinition(): ToolDefinition {
-    return definition;
-  }
-
-  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    return executeCallEnd(input, context);
-  }
-}
-
-registerTool(new CallEndTool());

--- a/assistant/src/tools/calls/call-start.ts
+++ b/assistant/src/tools/calls/call-start.ts
@@ -1,38 +1,6 @@
 import { startCall } from '../../calls/call-domain.js';
 import { getConfig } from '../../config/loader.js';
-import { RiskLevel } from '../../permissions/types.js';
-import type { ToolDefinition } from '../../providers/types.js';
-import { registerTool } from '../registry.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-
-const definition: ToolDefinition = {
-  name: 'call_start',
-  description:
-    'Place an outbound phone call via AI voice. The assistant will converse with the callee on behalf of the user.',
-  input_schema: {
-    type: 'object',
-    properties: {
-      phone_number: {
-        type: 'string',
-        description: 'E.164 formatted phone number (e.g. +14155551234)',
-      },
-      task: {
-        type: 'string',
-        description: 'What the call should accomplish',
-      },
-      context: {
-        type: 'string',
-        description: 'Additional context for the conversation',
-      },
-      caller_identity_mode: {
-        type: 'string',
-        enum: ['assistant_number', 'user_number'],
-        description: 'Which phone number to use as the caller ID. assistant_number uses the AI assistant\'s Twilio number; user_number uses the user\'s verified personal number.',
-      },
-    },
-    required: ['phone_number', 'task'],
-  },
-};
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 
 export async function executeCallStart(
   input: Record<string, unknown>,
@@ -70,20 +38,3 @@ export async function executeCallStart(
     isError: false,
   };
 }
-
-class CallStartTool implements Tool {
-  name = 'call_start';
-  description = definition.description;
-  category = 'communication';
-  defaultRiskLevel = RiskLevel.High;
-
-  getDefinition(): ToolDefinition {
-    return definition;
-  }
-
-  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    return executeCallStart(input, context);
-  }
-}
-
-registerTool(new CallStartTool());

--- a/assistant/src/tools/calls/call-status.ts
+++ b/assistant/src/tools/calls/call-status.ts
@@ -1,23 +1,5 @@
 import { getCallStatus } from '../../calls/call-domain.js';
-import { RiskLevel } from '../../permissions/types.js';
-import type { ToolDefinition } from '../../providers/types.js';
-import { registerTool } from '../registry.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-
-const definition: ToolDefinition = {
-  name: 'call_status',
-  description: 'Check the status of an active or recent phone call',
-  input_schema: {
-    type: 'object',
-    properties: {
-      call_session_id: {
-        type: 'string',
-        description: 'Specific call session ID to check. If omitted, checks for an active call in the current conversation.',
-      },
-    },
-    required: [],
-  },
-};
+import type { ToolContext, ToolExecutionResult } from '../types.js';
 
 export async function executeCallStatus(
   input: Record<string, unknown>,
@@ -69,20 +51,3 @@ export async function executeCallStatus(
 
   return { content: lines.join('\n'), isError: false };
 }
-
-class CallStatusTool implements Tool {
-  name = 'call_status';
-  description = definition.description;
-  category = 'communication';
-  defaultRiskLevel = RiskLevel.Low;
-
-  getDefinition(): ToolDefinition {
-    return definition;
-  }
-
-  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
-    return executeCallStatus(input, context);
-  }
-}
-
-registerTool(new CallStatusTool());

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -31,9 +31,6 @@ export async function loadEagerModules(): Promise<void> {
   await import('./assets/search.js');
   await import('./assets/materialize.js');
   await import('./filesystem/view-image.js');
-  await import('./calls/call-start.js');
-  await import('./calls/call-status.js');
-  await import('./calls/call-end.js');
   await import('./system/version.js');
 }
 
@@ -54,9 +51,6 @@ export const eagerModuleToolNames: string[] = [
   'asset_search',
   'asset_materialize',
   'view_image',
-  'call_start',
-  'call_status',
-  'call_end',
   'version',
 ];
 


### PR DESCRIPTION
## Summary

- Moves `call_start`, `call_status`, and `call_end` from class-based tool registrations to the existing `phone-calls` bundled skill via `TOOLS.json` executors
- The domain logic stays in `calls/call-domain.ts`; only the registration mechanism changes
- The extracted functions from PR #9073 are now imported by thin skill executor scripts that re-export them as `run`
- Removes `CallStartTool`, `CallStatusTool`, `CallEndTool` classes and their `registerTool()` calls
- Removes the three eager module imports and `eagerModuleToolNames` entries from `tool-manifest.ts`

This is PR 4 in the call tools migration plan.

## Test plan

- [x] `bunx tsc --noEmit` passes (all errors are pre-existing, none in changed files)
- [x] `bun test --test-name-pattern "call_start"` passes
- [x] No dangling references to `CallStartTool`, `CallStatusTool`, or `CallEndTool`
- [x] Skill executor scripts follow the established `export { fn as run }` pattern (matching contacts skill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
