### PR TITLE
fix: requiresClientSecret heuristic + alias credential lookup

### DIFF
--- a/assistant/src/daemon/handlers/oauth-connect.ts
+++ b/assistant/src/daemon/handlers/oauth-connect.ts
@@ -35,10 +35,18 @@ export async function handleOAuthConnectStart(
 
     const resolvedService = resolveService(msg.service);
 
-    // Look up client credentials from the keychain
-    const clientId =
+    // Look up client credentials from the keychain under the canonical
+    // service name first, then fall back to the original (alias) name
+    // in case the user stored credentials under the unresolved key.
+    let clientId =
       getSecureKey(`credential:${resolvedService}:client_id`) ??
       getSecureKey(`credential:${resolvedService}:oauth_client_id`);
+
+    if (!clientId && resolvedService !== msg.service) {
+      clientId =
+        getSecureKey(`credential:${msg.service}:client_id`) ??
+        getSecureKey(`credential:${msg.service}:oauth_client_id`);
+    }
 
     if (!clientId) {
       ctx.send(socket, {
@@ -49,10 +57,17 @@ export async function handleOAuthConnectStart(
       return;
     }
 
-    const clientSecret =
+    let clientSecret =
       getSecureKey(`credential:${resolvedService}:client_secret`) ??
       getSecureKey(`credential:${resolvedService}:oauth_client_secret`) ??
       undefined;
+
+    if (!clientSecret && resolvedService !== msg.service) {
+      clientSecret =
+        getSecureKey(`credential:${msg.service}:client_secret`) ??
+        getSecureKey(`credential:${msg.service}:oauth_client_secret`) ??
+        undefined;
+    }
 
     // Fail early when client_secret is required but missing — guide the
     // user to collect it from the keychain rather than letting the OAuth

--- a/assistant/src/oauth/provider-profiles.ts
+++ b/assistant/src/oauth/provider-profiles.ts
@@ -97,6 +97,12 @@ export const PROVIDER_PROFILES: Record<string, OAuthProviderProfile> = {
     scopePolicy: DEFAULT_SCOPE_POLICY,
     tokenEndpointAuthMethod: 'client_secret_basic',
     callbackTransport: 'gateway',
+    setup: {
+      displayName: 'Twitter / X',
+      dashboardUrl: 'https://developer.x.com/en/portal/dashboard',
+      appType: 'App',
+      requiresClientSecret: false,
+    },
     identityVerifier: async (accessToken: string): Promise<string | undefined> => {
       try {
         const resp = await fetch('https://api.x.com/2/users/me', {


### PR DESCRIPTION
Fix two issues in oauth-connect handler: (1) Add setup.requiresClientSecret: false to Twitter provider profile so PKCE-only apps aren't blocked by the tokenEndpointAuthMethod heuristic. (2) Fall back to alias service name for credential lookup when canonical name yields no results.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
