### PR TITLE
fix: stale refresh token cleanup + identity accountInfo persistence

### DIFF
--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -180,6 +180,7 @@ export async function orchestrateOAuthConnect(options: OAuthConnectOptions): Pro
             tokens: result.tokens,
             grantedScopes: result.grantedScopes,
             rawTokenResponse: result.rawTokenResponse,
+            identityAccountInfo: accountInfo,
           });
           log.info(
             { service: resolvedService, accountInfo: stored.accountInfo ?? accountInfo },
@@ -240,6 +241,7 @@ export async function orchestrateOAuthConnect(options: OAuthConnectOptions): Pro
       tokens,
       grantedScopes,
       rawTokenResponse,
+      identityAccountInfo: verifiedIdentity,
     });
 
     return {

--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -7,9 +7,9 @@
  */
 
 import type { OAuth2FlowResult, TokenEndpointAuthMethod } from '../security/oauth2.js';
-import { setSecureKey } from '../security/secure-keys.js';
+import { deleteSecureKey, setSecureKey } from '../security/secure-keys.js';
 import type { CredentialInjectionTemplate } from '../tools/credentials/policy-types.js';
-import { upsertCredentialMetadata } from '../tools/credentials/metadata-store.js';
+import { deleteCredentialMetadata, upsertCredentialMetadata } from '../tools/credentials/metadata-store.js';
 import { runPostConnectHook } from '../tools/credentials/post-connect-hooks.js';
 
 // ---------------------------------------------------------------------------
@@ -28,6 +28,8 @@ export interface StoreOAuth2TokensParams {
   userinfoUrl?: string;
   allowedTools?: string[];
   wellKnownInjectionTemplates?: CredentialInjectionTemplate[];
+  /** Fallback account info from an identity verifier (e.g. Twitter @username). */
+  identityAccountInfo?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -87,7 +89,7 @@ export async function storeOAuth2Tokens(params: StoreOAuth2TokensParams): Promis
     allowedTools: allowedTools ?? [],
     expiresAt,
     grantedScopes,
-    accountInfo: accountInfo ?? null,
+    accountInfo: accountInfo ?? params.identityAccountInfo ?? null,
     oauth2TokenUrl: tokenUrl,
     oauth2ClientId: clientId,
     ...(clientSecret ? { oauth2ClientSecret: clientSecret } : {}),
@@ -100,10 +102,16 @@ export async function storeOAuth2Tokens(params: StoreOAuth2TokensParams): Promis
     if (refreshStored) {
       upsertCredentialMetadata(service, 'refresh_token', {});
     }
+  } else {
+    // Re-auth grants that omit refresh_token must clear any stale stored
+    // token — otherwise withValidToken() will attempt refresh with invalid
+    // credentials.
+    deleteSecureKey(`credential:${service}:refresh_token`);
+    deleteCredentialMetadata(service, 'refresh_token');
   }
 
   // Run any provider-specific post-connect actions (e.g. Slack welcome DM)
   await runPostConnectHook({ service, rawTokenResponse });
 
-  return { accountInfo };
+  return { accountInfo: accountInfo ?? params.identityAccountInfo };
 }


### PR DESCRIPTION
Fix two token-persistence issues: (1) Delete existing refresh_token key when reauth grant omits refresh_token, preventing stale token refresh failures. (2) Accept identityAccountInfo in storeOAuth2Tokens params and use as fallback for metadata accountInfo, ensuring identity verifier results (e.g. Twitter @username) are persisted for all callers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
