### PR TITLE
fix: address PR review feedback for heartbeat settings tab

### DIFF
--- a/assistant/src/daemon/handlers/config-heartbeat.ts
+++ b/assistant/src/daemon/handlers/config-heartbeat.ts
@@ -43,8 +43,12 @@ export function handleHeartbeatConfig(
       const hb = (raw?.heartbeat ?? {}) as Record<string, unknown>;
       if (msg.enabled !== undefined) hb.enabled = msg.enabled;
       if (msg.intervalMs !== undefined) hb.intervalMs = msg.intervalMs;
-      if (msg.activeHoursStart !== undefined) hb.activeHoursStart = msg.activeHoursStart ?? undefined;
-      if (msg.activeHoursEnd !== undefined) hb.activeHoursEnd = msg.activeHoursEnd ?? undefined;
+      if (msg.activeHoursStart !== undefined) {
+        hb.activeHoursStart = (msg.activeHoursStart === -1 ? undefined : msg.activeHoursStart) ?? undefined;
+      }
+      if (msg.activeHoursEnd !== undefined) {
+        hb.activeHoursEnd = (msg.activeHoursEnd === -1 ? undefined : msg.activeHoursEnd) ?? undefined;
+      }
 
       const wasSuppressed = ctx.suppressConfigReload;
       ctx.setSuppressConfigReload(true);
@@ -104,10 +108,10 @@ export function handleHeartbeatRunsList(
 ): void {
   try {
     const limit = msg.limit ?? 20;
-    // Get all conversations including background, then filter to background only
+    // Get background conversations and filter to heartbeat-origin only
     const all = conversationStore.listConversations(limit * 5, true);
     const bgConversations = all
-      .filter((c) => c.threadType === 'background')
+      .filter((c) => c.source === 'heartbeat')
       .slice(0, limit);
 
     const runs = bgConversations.map((conv) => {

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -97,6 +97,7 @@ export class HeartbeatService {
       const conversation = createConversation({
         title: GENERATING_TITLE,
         threadType: 'background',
+        source: 'heartbeat',
       });
       queueGenerateConversationTitle({
         conversationId: conversation.id,

--- a/clients/macos/vellum-assistant/Features/Settings/HeartbeatSettingsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/HeartbeatSettingsTab.swift
@@ -26,6 +26,7 @@ struct HeartbeatSettingsTab: View {
 
     // -- Loading --
     @State private var isLoading: Bool = true
+    @State private var isUpdatingFromServer: Bool = false
 
     private static let intervalOptions: [(label: String, ms: Double)] = [
         ("5 min", 300_000),
@@ -63,6 +64,7 @@ struct HeartbeatSettingsTab: View {
                     .toggleStyle(.switch)
                     .labelsHidden()
                     .onChange(of: isEnabled) { _, newValue in
+                        guard !isUpdatingFromServer else { return }
                         try? daemonClient?.sendHeartbeatConfigSet(enabled: newValue)
                     }
             }
@@ -84,6 +86,7 @@ struct HeartbeatSettingsTab: View {
                     .labelsHidden()
                     .fixedSize()
                     .onChange(of: intervalMs) { _, newValue in
+                        guard !isUpdatingFromServer else { return }
                         try? daemonClient?.sendHeartbeatConfigSet(intervalMs: newValue)
                     }
                 }
@@ -100,6 +103,7 @@ struct HeartbeatSettingsTab: View {
                         .toggleStyle(.switch)
                         .labelsHidden()
                         .onChange(of: useActiveHours) { _, newValue in
+                            guard !isUpdatingFromServer else { return }
                             if newValue {
                                 let start = activeHoursStart ?? 8
                                 let end = activeHoursEnd ?? 22
@@ -109,10 +113,10 @@ struct HeartbeatSettingsTab: View {
                             } else {
                                 activeHoursStart = nil
                                 activeHoursEnd = nil
-                                // Send nil to clear — use a special sentinel via the IPC
+                                // Send -1 sentinel to clear — Swift JSONEncoder omits nil optionals
                                 try? daemonClient?.sendHeartbeatConfigSet(
-                                    activeHoursStart: nil,
-                                    activeHoursEnd: nil
+                                    activeHoursStart: -1,
+                                    activeHoursEnd: -1
                                 )
                             }
                         }
@@ -338,6 +342,7 @@ struct HeartbeatSettingsTab: View {
     private func setupCallbacks() {
         daemonClient?.onHeartbeatConfigResponse = { response in
             Task { @MainActor in
+                self.isUpdatingFromServer = true
                 self.isEnabled = response.enabled
                 self.intervalMs = response.intervalMs
                 self.activeHoursStart = response.activeHoursStart
@@ -345,6 +350,7 @@ struct HeartbeatSettingsTab: View {
                 self.useActiveHours = response.activeHoursStart != nil && response.activeHoursEnd != nil
                 self.nextRunAt = response.nextRunAt
                 self.isLoading = false
+                self.isUpdatingFromServer = false
             }
         }
         daemonClient?.onHeartbeatChecklistResponse = { response in


### PR DESCRIPTION
## Summary
- Fix active hours clearing: use sentinel value `-1` instead of `nil` since Swift's JSONEncoder omits nil optionals (daemon treats -1 as "clear")
- Fix redundant IPC round-trips on load: add `isUpdatingFromServer` guard flag so `.onChange` handlers don't fire when state is populated from server response
- Fix run history showing unrelated background threads: filter by `source === 'heartbeat'` instead of `threadType === 'background'`, and tag heartbeat conversations with `source: 'heartbeat'`

Addresses review feedback from #9076.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
