### PR TITLE
fix: clear stale oauth2ClientSecret on PKCE re-auth

### DIFF
--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -92,7 +92,7 @@ export async function storeOAuth2Tokens(params: StoreOAuth2TokensParams): Promis
     accountInfo: accountInfo ?? params.identityAccountInfo ?? null,
     oauth2TokenUrl: tokenUrl,
     oauth2ClientId: clientId,
-    ...(clientSecret ? { oauth2ClientSecret: clientSecret } : {}),
+    oauth2ClientSecret: clientSecret ?? null,
     ...(tokenEndpointAuthMethod ? { oauth2TokenEndpointAuthMethod: tokenEndpointAuthMethod } : {}),
     ...(wellKnownInjectionTemplates ? { injectionTemplates: wellKnownInjectionTemplates } : {}),
   });


### PR DESCRIPTION
When re-authing without a clientSecret (PKCE path), the metadata upsert omitted oauth2ClientSecret instead of clearing it. Since upsertCredentialMetadata preserves existing fields, any previously stored secret persisted and token-manager would use it for refresh, causing invalid_client failures. Now explicitly sets oauth2ClientSecret: null when no secret is provided.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
