### PR TITLE
fix: add cleanup guard for post-write validation/rename failures in stop()

### DIFF
--- a/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
+++ b/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
@@ -731,25 +731,40 @@ final class ScreenRecorder: NSObject {
             throw RecorderError.writerFailed(status: Int(writerStatus.rawValue))
         }
 
-        // Playability integrity gate: validate that the output file has a positive
-        // duration, catching corrupt files that exist on disk but aren't playable.
-        let asset = AVURLAsset(url: outputURL)
-        let duration = try await asset.load(.duration)
-        guard duration.seconds > 0 else {
-            log.error("Stop: output file has zero or negative duration — discarding as invalid")
+        // Playability integrity gate + atomic file publication.
+        // Both asset.load(.duration) and moveItem can throw — ensure
+        // cleanup (file removal, writer/telemetry reset) always runs
+        // on error so we don't leak .tmp.mov files or stale state.
+        let finalURL: URL
+        do {
+            let asset = AVURLAsset(url: outputURL)
+            let duration = try await asset.load(.duration)
+            guard duration.seconds > 0 else {
+                log.error("Stop: output file has zero or negative duration — discarding as invalid")
+                try? FileManager.default.removeItem(at: outputURL)
+                cleanUpWriter()
+                clearTelemetryState()
+                throw RecorderError.invalidOutputFile
+            }
+
+            // Atomic file publication: rename from .tmp.mov to .mov now that the
+            // file is validated. Clients observing the recordings directory will
+            // only see the final file after it is complete and playable.
+            let dest = outputURL.deletingPathExtension().deletingPathExtension()
+                .appendingPathExtension("mov")
+            try FileManager.default.moveItem(at: outputURL, to: dest)
+            log.info("Atomically renamed recording: \(outputURL.lastPathComponent, privacy: .public) → \(dest.lastPathComponent, privacy: .public)")
+            finalURL = dest
+        } catch let error as RecorderError {
+            // RecorderError.invalidOutputFile already cleaned up above — rethrow as-is.
+            throw error
+        } catch {
+            log.error("Stop: post-write validation/rename failed — \(error.localizedDescription, privacy: .public)")
             try? FileManager.default.removeItem(at: outputURL)
             cleanUpWriter()
             clearTelemetryState()
             throw RecorderError.invalidOutputFile
         }
-
-        // Atomic file publication: rename from .tmp.mov to .mov now that the
-        // file is validated. Clients observing the recordings directory will
-        // only see the final file after it is complete and playable.
-        let finalURL = outputURL.deletingPathExtension().deletingPathExtension()
-            .appendingPathExtension("mov")
-        try FileManager.default.moveItem(at: outputURL, to: finalURL)
-        log.info("Atomically renamed recording: \(outputURL.lastPathComponent, privacy: .public) → \(finalURL.lastPathComponent, privacy: .public)")
 
         let durationMs: Int
         if let startDate = recordingStartDate {


### PR DESCRIPTION
## Summary
- Wraps the post-write validation (`asset.load(.duration)`) and atomic rename (`moveItem`) in a `do/catch` block in `ScreenRecorder.stop()`
- Ensures `.tmp.mov` file removal, `cleanUpWriter()`, and `clearTelemetryState()` always run on error
- Prevents orphaned temp files and stale recorder state when these operations throw

Addresses review feedback from PR #8980.

## Test plan
- [ ] Verify existing recording tests still pass
- [ ] Manual: complete a normal recording — should produce `.mov` as before
- [ ] Edge case: if `moveItem` fails (e.g., disk full), no `.tmp.mov` leak

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
