### PR TITLE
Add client-wide agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Bun + TypeScript monorepo with multiple packages:
 
 - `assistant/` — Main backend service (Bun + TypeScript)
 - `gateway/` — Telegram webhook gateway (Bun + TypeScript)
-- `clients/macos/` — Native macOS desktop app (Swift/SwiftUI, see `clients/macos/CLAUDE.md`)
+- `clients/` — Client apps (macOS/iOS/etc). See `clients/AGENTS.md` and platform docs like `clients/macos/CLAUDE.md`.
 - `scripts/` — Utility scripts
 - `.claude/` — Claude Code slash commands and helper scripts (see `.claude/README.md`)
 

--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -1,0 +1,39 @@
+# Clients - Agent Guidance
+
+## Scope and precedence
+- Applies to all client code in `clients/` (macOS, iOS, iPadOS, watchOS, tvOS, browser extensions, shared).
+- Platform-specific docs (for example `clients/macos/CLAUDE.md`, `clients/ios/README.md`) override or extend this file.
+- `AGENTS.md` at repo root still applies; if guidance conflicts, follow the most specific document.
+
+## Research protocol (Apple platform work)
+- Verify decisions against current Apple sources (Developer Documentation, HIG, WWDC sessions, Swift Evolution).
+- Check deprecations and availability for targeted OS versions before adopting APIs.
+- Prefer Apple-recommended patterns for SwiftUI, concurrency, accessibility, privacy, and app lifecycle.
+- Note in the PR summary or commit message: `Apple refs checked (YYYY-MM-DD): ...`.
+- If guidance is ambiguous, include a short rationale in the PR summary.
+
+## SwiftUI + Apple platform practices (guidance)
+- Follow SwiftUI data flow and state ownership; keep state minimal and localized.
+- Keep UI work on the main actor; use async/await and structured concurrency when possible.
+- Avoid deprecated APIs; use availability checks for multi-platform code.
+- Respect HIG defaults for layout, typography, and controls; only customize when user value is clear.
+- Accessibility is required: labels for icon-only controls, Dynamic Type support, VoiceOver-friendly order.
+- Localize user-facing strings; format dates/units with locale-aware formatters.
+- Performance: avoid heavy work in view bodies; prefer lazy containers for large lists; measure before optimizing.
+- Privacy: request the minimum permissions; never log sensitive user content.
+
+## Non-Apple clients
+- Follow platform-specific best practices for the target (for example, Chrome extension guidelines).
+- Keep shared client logic in `clients/shared` when it is platform-agnostic.
+
+## Architecture and shared code
+- Put cross-platform logic in `clients/shared`.
+- Do not introduce platform-specific dependencies into shared targets.
+- Prefer dependency injection for platform services to keep logic testable.
+
+## Testing and quality
+- Add or update tests when behavior changes; favor the testing patterns already used in that client.
+- Keep builds and linting clean; run relevant tests when feasible.
+
+## Maintenance
+- Refresh this guidance after major Apple OS or SwiftUI releases (for example, post-WWDC).


### PR DESCRIPTION
## Summary
- add client-wide agent guidance covering Apple research protocol and cross-platform practices
- clarify precedence for client and platform-specific docs
- point root AGENTS.md to the new clients guidance

## Testing
- Not run (doc-only changes)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
