### PR TITLE
Fix holistic review: Telegram rate limits, group chat rejection, bootstrap URL clearing

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -373,7 +373,33 @@ function handleStartOutboundTelegram(
     return;
   }
 
+  // Enforce per-destination rate limit across all sessions
+  const recentSendCount = countRecentSendsToDestination(channel, destination, DESTINATION_RATE_WINDOW_MS);
+  if (recentSendCount >= MAX_SENDS_PER_DESTINATION_WINDOW) {
+    ctx.send(socket, {
+      type: 'guardian_verification_response',
+      success: false,
+      error: 'rate_limited',
+      message: 'Too many verification attempts to this destination. Please try again later.',
+      channel,
+    });
+    return;
+  }
+
   if (isTelegramChatId(destination)) {
+    // Reject group chats (negative IDs) — verification must target a private chat
+    const chatIdNum = parseInt(destination, 10);
+    if (isNaN(chatIdNum) || chatIdNum < 0) {
+      ctx.send(socket, {
+        type: 'guardian_verification_response',
+        success: false,
+        error: 'invalid_destination',
+        message: 'Telegram group chats are not supported for verification. Use a private chat ID or @handle.',
+        channel,
+      });
+      return;
+    }
+
     // Known numeric chat ID: create a bound session and send message immediately
     const sessionResult = createOutboundSession({
       assistantId,

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1249,7 +1249,12 @@ public final class SettingsStore: ObservableObject {
             if let expiresAt { telegramOutboundExpiresAt = expiresAt }
             telegramOutboundNextResendAt = nextResendAt
             telegramOutboundSendCount = sendCount
-            telegramBootstrapUrl = bootstrapUrl
+            if let bootstrapUrl {
+                telegramBootstrapUrl = bootstrapUrl
+            } else if sessionId != nil {
+                // Bootstrap complete — clear the URL so resend becomes available
+                telegramBootstrapUrl = nil
+            }
         case "sms":
             smsOutboundSessionId = sessionId
             if let expiresAt { smsOutboundExpiresAt = expiresAt }


### PR DESCRIPTION
Addresses feedback from holistic review on PR #9081: (1) adds per-destination rate limit for Telegram outbound matching SMS/voice, (2) rejects negative chat IDs (group chats) for verification, (3) clears bootstrap URL in macOS UI when bootstrap completes so resend becomes available.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
