### PR TITLE
fix: address review feedback on OAuth Integration Extensibility (#9067)

### DIFF
--- a/assistant/src/daemon/handlers/oauth-connect.ts
+++ b/assistant/src/daemon/handlers/oauth-connect.ts
@@ -3,9 +3,24 @@ import * as net from 'node:net';
 import { orchestrateOAuthConnect } from '../../oauth/connect-orchestrator.js';
 import { getProviderProfile, resolveService } from '../../oauth/provider-profiles.js';
 import { getSecureKey } from '../../security/secure-keys.js';
-import { assertMetadataWritable } from '../../tools/credentials/metadata-store.js';
+import { assertMetadataWritable, getCredentialMetadata } from '../../tools/credentials/metadata-store.js';
 import type { OAuthConnectStartRequest } from '../ipc-protocol.js';
 import { defineHandlers, type HandlerContext, log } from './shared.js';
+
+/** Map raw orchestrator/provider error messages to user-friendly strings. */
+function sanitizeOAuthError(message: string): string {
+  const lower = message.toLowerCase();
+  if (lower.includes('timed out')) {
+    return 'OAuth authentication timed out. Please try again.';
+  }
+  if (lower.includes('user_cancelled') || lower.includes('cancelled')) {
+    return 'OAuth authentication was cancelled.';
+  }
+  if (lower.includes('denied') || lower.includes('invalid_grant')) {
+    return 'The authorization request was denied. Please try again.';
+  }
+  return 'OAuth authentication failed. Please try again.';
+}
 
 export async function handleOAuthConnectStart(
   msg: OAuthConnectStartRequest,
@@ -48,6 +63,15 @@ export async function handleOAuthConnectStart(
         getSecureKey(`credential:${msg.service}:oauth_client_id`);
     }
 
+    // Fall back to credential metadata for legacy installs where client
+    // credentials were stored only in metadata (not in the keychain).
+    if (!clientId) {
+      const meta = getCredentialMetadata(resolvedService, 'access_token');
+      if (meta?.oauth2ClientId) {
+        clientId = meta.oauth2ClientId;
+      }
+    }
+
     if (!clientId) {
       ctx.send(socket, {
         type: 'oauth_connect_result',
@@ -67,6 +91,14 @@ export async function handleOAuthConnectStart(
         getSecureKey(`credential:${msg.service}:client_secret`) ??
         getSecureKey(`credential:${msg.service}:oauth_client_secret`) ??
         undefined;
+    }
+
+    // Fall back to credential metadata for legacy installs
+    if (!clientSecret) {
+      const meta = getCredentialMetadata(resolvedService, 'access_token');
+      if (meta?.oauth2ClientSecret) {
+        clientSecret = meta.oauth2ClientSecret;
+      }
     }
 
     // Fail early when client_secret is required but missing — guide the
@@ -96,10 +128,11 @@ export async function handleOAuthConnectStart(
     });
 
     if (!result.success) {
+      log.error({ error: result.error, service: msg.service }, 'OAuth connect orchestrator returned error');
       ctx.send(socket, {
         type: 'oauth_connect_result',
         success: false,
-        error: result.error,
+        error: sanitizeOAuthError(result.error),
       });
       return;
     }
@@ -125,22 +158,10 @@ export async function handleOAuthConnectStart(
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, service: msg.service }, 'OAuth connect flow failed');
 
-    let userError: string;
-    const lower = message.toLowerCase();
-    if (lower.includes('timed out')) {
-      userError = 'OAuth authentication timed out. Please try again.';
-    } else if (lower.includes('user_cancelled') || lower.includes('cancelled')) {
-      userError = 'OAuth authentication was cancelled.';
-    } else if (lower.includes('denied') || lower.includes('invalid_grant')) {
-      userError = 'The authorization request was denied. Please try again.';
-    } else {
-      userError = 'OAuth authentication failed. Please try again.';
-    }
-
     ctx.send(socket, {
       type: 'oauth_connect_result',
       success: false,
-      error: userError,
+      error: sanitizeOAuthError(message),
     });
   }
 }

--- a/assistant/src/daemon/handlers/twitter-auth.ts
+++ b/assistant/src/daemon/handlers/twitter-auth.ts
@@ -107,10 +107,11 @@ export async function handleTwitterAuthStart(
     });
 
     if (!result.success) {
+      log.error({ error: result.error }, 'Twitter OAuth orchestrator returned error');
       ctx.send(socket, {
         type: 'twitter_auth_result',
         success: false,
-        error: result.error,
+        error: sanitizeTwitterAuthError(result.error),
       });
       return;
     }


### PR DESCRIPTION
## Summary

Fixes issues identified by automated reviewers on PR #9067:

- **Sanitize orchestrator error messages** in both `twitter-auth.ts` and `oauth-connect.ts` handlers before forwarding to IPC client. Previously, when `orchestrateOAuthConnect` returned `{ success: false, error }`, the raw error string (which could contain secrets from provider responses) was sent directly to the IPC client. The catch blocks already sanitized, but the `result.error` path did not. Now both paths use sanitizer functions.
- **Add metadata fallback for legacy OAuth client credential resolution** in `oauth-connect.ts`. The `oauth_connect_start` handler only read `client_id` and `client_secret` from secure-key entries, so reconnect failed for legacy installs where OAuth client credentials were stored only in credential metadata. Now falls back to `getCredentialMetadata()` when keychain lookups return nothing.

## Test plan

- [ ] Verify that when `orchestrateOAuthConnect` returns an error, the IPC client receives a sanitized message (not raw orchestrator output)
- [ ] Verify that legacy installs with OAuth client credentials only in metadata can still reconnect via `oauth_connect_start`
- [ ] Verify that the catch-block error sanitization in `oauth-connect.ts` uses the shared `sanitizeOAuthError` function

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
