### PR TITLE
fix: regenerate IPC Swift code for new OAuth connect types

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -2779,6 +2779,34 @@ public struct IPCNotificationThreadCreated: Codable, Sendable {
     }
 }
 
+public struct IPCOAuthConnectResultResponse: Codable, Sendable {
+    public let type: String
+    public let success: Bool
+    public let grantedScopes: [String]?
+    public let accountInfo: String?
+    public let error: String?
+
+    public init(type: String, success: Bool, grantedScopes: [String]? = nil, accountInfo: String? = nil, error: String? = nil) {
+        self.type = type
+        self.success = success
+        self.grantedScopes = grantedScopes
+        self.accountInfo = accountInfo
+        self.error = error
+    }
+}
+
+public struct IPCOAuthConnectStartRequest: Codable, Sendable {
+    public let type: String
+    public let service: String
+    public let requestedScopes: [String]?
+
+    public init(type: String, service: String, requestedScopes: [String]? = nil) {
+        self.type = type
+        self.service = service
+        self.requestedScopes = requestedScopes
+    }
+}
+
 public struct IPCOpenBundleRequest: Codable, Sendable {
     public let type: String
     public let filePath: String

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2259,6 +2259,7 @@ public enum ServerMessage: Decodable, Sendable {
     case openUrl(OpenUrlMessage)
     case integrationListResponse(IPCIntegrationListResponse)
     case integrationConnectResult(IPCIntegrationConnectResult)
+    case oauthConnectResult(IPCOAuthConnectResultResponse)
     case appFilesChanged(AppFilesChangedMessage)
     case getSigningIdentity(IPCGetSigningIdentityRequest)
     case diagnosticsExportResponse(DiagnosticsExportResponseMessage)
@@ -2602,6 +2603,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "integration_connect_result":
             let message = try IPCIntegrationConnectResult(from: decoder)
             self = .integrationConnectResult(message)
+        case "oauth_connect_result":
+            let message = try IPCOAuthConnectResultResponse(from: decoder)
+            self = .oauthConnectResult(message)
         case "app_files_changed":
             let message = try AppFilesChangedMessage(from: decoder)
             self = .appFilesChanged(message)


### PR DESCRIPTION
## Summary
- Regenerate `IPCContractGenerated.swift` to include the new `IPCOAuthConnectStartRequest` and `IPCOAuthConnectResultResponse` structs.
- Add `oauth_connect_result` decode case to `ServerMessage` in `IPCMessages.swift`.
- Fixes CI failure on main where `check:ipc-generated` was failing because the Swift code was out of date.

## Original prompt
fix: regenerate IPC Swift code for new OAuth connect types

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
