### PR TITLE
fix(chat): NSView leak fixes + TimelineView throttle

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
@@ -122,4 +122,9 @@ private struct GIFView: NSViewRepresentable {
     func updateNSView(_ nsView: NSImageView, context: Context) {
         // Data is immutable per GIF URL — no updates needed
     }
+
+    static func dismantleNSView(_ nsView: NSImageView, coordinator: ()) {
+        nsView.animates = false
+        nsView.image = nil
+    }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
@@ -68,6 +68,12 @@ struct InlineVideoWebView: NSViewRepresentable {
         context.coordinator.onLoadFailure = onLoadFailure
     }
 
+    static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
+        webView.stopLoading()
+        webView.navigationDelegate = nil
+        webView.uiDelegate = nil
+    }
+
     /// Build a WKWebView with the privacy-hardened configuration used for embeds.
     /// Factored out so policy tests can verify settings without a full SwiftUI context.
     static func makeConfiguredWebView() -> WKWebView {

--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -104,7 +104,7 @@ public struct MessageBubbleView: View {
 
                 // Streaming indicator
                 if message.isStreaming {
-                    TimelineView(.animation(minimumInterval: 0.05)) { context in
+                    TimelineView(.animation(minimumInterval: 0.2)) { context in
                         HStack(spacing: VSpacing.xs) {
                             ForEach(0..<3, id: \.self) { index in
                                 Circle()


### PR DESCRIPTION
## Summary
- Add dismantleNSView to InlineVideoWebView: stops loading, nils delegates to prevent WKWebView leak
- Add dismantleNSView to AnimatedImageView/GIFView: stops animation, nils image to prevent GIF memory leak
- Reduce MessageBubbleView TimelineView from 20fps (0.05s) to 5fps (0.2s) — visually identical for dot animation, significantly reduces view updates

Part of #9096
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
