### PR TITLE
fix(chat): timer consolidation + scroll/onChange throttle

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatWidgetViews.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatWidgetViews.swift
@@ -16,15 +16,13 @@ struct RunningIndicator: View {
     /// Optional tap handler — when set, the indicator becomes a clickable button.
     var onTap: (() -> Void)?
 
-    @State private var phase: Int = 0
-    @State private var timer: Timer?
-    @State private var currentLabelIndex: Int = 0
-    @State private var labelTimer: Timer?
+    @State private var startDate: Date = Date()
     @State private var isHovered: Bool = false
 
-    private var displayLabel: String {
+    private func displayLabel(elapsed: TimeInterval) -> String {
         if progressiveLabels.isEmpty { return label }
-        return progressiveLabels[min(currentLabelIndex, progressiveLabels.count - 1)]
+        let index = min(Int(elapsed / labelInterval), progressiveLabels.count - 1)
+        return progressiveLabels[index]
     }
 
     var body: some View {
@@ -42,68 +40,48 @@ struct RunningIndicator: View {
     }
 
     private var indicatorContent: some View {
-        HStack(spacing: VSpacing.xs) {
-            if showIcon {
-                Image(systemName: "terminal")
-                    .font(.system(size: 10))
+        TimelineView(.periodic(every: 0.4)) { context in
+            let elapsed = context.date.timeIntervalSince(startDate)
+            let phase = Int(elapsed / 0.4) % 3
+            let currentLabel = displayLabel(elapsed: elapsed)
+            let labelIndex = progressiveLabels.isEmpty ? 0 : min(Int(elapsed / labelInterval), progressiveLabels.count - 1)
+            HStack(spacing: VSpacing.xs) {
+                if showIcon {
+                    Image(systemName: "terminal")
+                        .font(.system(size: 10))
+                        .foregroundColor(VColor.textSecondary)
+                }
+
+                Text(currentLabel)
+                    .font(VFont.caption)
                     .foregroundColor(VColor.textSecondary)
+                    .animation(.easeInOut(duration: 0.3), value: labelIndex)
+
+                ForEach(0..<3, id: \.self) { index in
+                    Circle()
+                        .fill(VColor.textSecondary)
+                        .frame(width: 5, height: 5)
+                        .opacity(phase == index ? 1.0 : 0.4)
+                }
+
+                if onTap != nil {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(VColor.textMuted)
+                }
+
+                Spacer()
             }
-
-            Text(displayLabel)
-                .font(VFont.caption)
-                .foregroundColor(VColor.textSecondary)
-                .animation(.easeInOut(duration: 0.3), value: currentLabelIndex)
-
-            ForEach(0..<3, id: \.self) { index in
-                Circle()
-                    .fill(VColor.textSecondary)
-                    .frame(width: 5, height: 5)
-                    .opacity(dotOpacity(for: index))
-            }
-
-            if onTap != nil {
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 9, weight: .semibold))
-                    .foregroundColor(VColor.textMuted)
-            }
-
-            Spacer()
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .fill(isHovered ? VColor.backgroundSubtle.opacity(0.6) : Color.clear)
+            )
+            .contentShape(RoundedRectangle(cornerRadius: VRadius.lg))
         }
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.xs)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(isHovered ? VColor.backgroundSubtle.opacity(0.6) : Color.clear)
-        )
-        .contentShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .onAppear {
-            startDotAnimation()
-            startLabelCycling()
-        }
-        .onDisappear {
-            timer?.invalidate()
-            labelTimer?.invalidate()
-        }
-    }
-
-    private func dotOpacity(for index: Int) -> Double {
-        phase == index ? 1.0 : 0.4
-    }
-
-    private func startDotAnimation() {
-        timer = Timer.scheduledTimer(withTimeInterval: 0.4, repeats: true) { _ in
-            withAnimation(.easeInOut(duration: 0.3)) {
-                phase = (phase + 1) % 3
-            }
-        }
-    }
-
-    private func startLabelCycling() {
-        guard !progressiveLabels.isEmpty else { return }
-        labelTimer = Timer.scheduledTimer(withTimeInterval: labelInterval, repeats: true) { _ in
-            if currentLabelIndex < progressiveLabels.count - 1 {
-                currentLabelIndex += 1
-            }
+            startDate = Date()
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -30,6 +30,7 @@ struct MessageListView: View {
     @State private var appearance = AvatarAppearanceManager.shared
     /// Read once at the list level and passed down to each ChatBubble so that
     /// individual bubbles don't each subscribe to the shared ObservableObject.
+    @State private var scrollDebounceTask: Task<Void, Never>?
     @ObservedObject private var taskProgressOverlay = TaskProgressOverlayManager.shared
     private var activeSurfaceId: String? { taskProgressOverlay.activeSurfaceId }
 
@@ -298,8 +299,13 @@ struct MessageListView: View {
             }
             .onChange(of: streamingScrollTrigger) {
                 if isNearBottom {
-                    withAnimation(VAnimation.fast) {
-                        proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                    scrollDebounceTask?.cancel()
+                    scrollDebounceTask = Task {
+                        try? await Task.sleep(nanoseconds: 200_000_000)
+                        guard !Task.isCancelled else { return }
+                        withAnimation(VAnimation.fast) {
+                            proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                        }
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -499,7 +499,7 @@ struct MainWindowView: View {
                     threadManager.activeViewModel?.activeSurfaceId = surfaceId
                 }
             }
-            .onChange(of: threadManager.activeViewModel?.messages.map(\.id)) { _, _ in
+            .onChange(of: threadManager.activeViewModel?.messages.count) { _, _ in
                 // Bootstrap avatar: apply milestones based on assistant turn count
                 if let evoState = avatarEvolutionState, evoState.stage != .stabilized,
                    let viewModel = threadManager.activeViewModel {

--- a/clients/shared/Features/Chat/SubagentStatusChip.swift
+++ b/clients/shared/Features/Chat/SubagentStatusChip.swift
@@ -5,9 +5,6 @@ public struct SubagentStatusChip: View {
     var onAbort: (() -> Void)?
     var onTap: (() -> Void)?
 
-    @State private var phase: Int = 0
-    @State private var timer: Timer?
-
     private var statusColor: Color {
         switch subagent.status {
         case .completed: return VColor.success
@@ -32,80 +29,61 @@ public struct SubagentStatusChip: View {
     }
 
     public var body: some View {
-        HStack(spacing: VSpacing.sm) {
-            Image(systemName: statusIcon)
-                .font(.system(size: 11))
-                .foregroundColor(statusColor)
+        TimelineView(.periodic(every: 0.4)) { context in
+            let phase = !subagent.isTerminal ? Int(context.date.timeIntervalSince1970 / 0.4) % 3 : 0
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: statusIcon)
+                    .font(.system(size: 11))
+                    .foregroundColor(statusColor)
 
-            VStack(alignment: .leading, spacing: 1) {
-                HStack(spacing: VSpacing.xs) {
-                    Text(subagent.label)
-                        .font(VFont.captionMedium)
-                        .foregroundColor(VColor.textPrimary)
+                VStack(alignment: .leading, spacing: 1) {
+                    HStack(spacing: VSpacing.xs) {
+                        Text(subagent.label)
+                            .font(VFont.captionMedium)
+                            .foregroundColor(VColor.textPrimary)
 
-                    if !subagent.isTerminal {
-                        // Animated dots
-                        HStack(spacing: 2) {
-                            ForEach(0..<3, id: \.self) { index in
-                                Circle()
-                                    .fill(VColor.textSecondary)
-                                    .frame(width: 4, height: 4)
-                                    .opacity(dotOpacity(for: index))
+                        if !subagent.isTerminal {
+                            // Animated dots
+                            HStack(spacing: 2) {
+                                ForEach(0..<3, id: \.self) { index in
+                                    Circle()
+                                        .fill(VColor.textSecondary)
+                                        .frame(width: 4, height: 4)
+                                        .opacity(phase % 3 == index ? 1.0 : 0.3)
+                                }
                             }
                         }
                     }
+
+                    if let error = subagent.error, !error.isEmpty {
+                        Text(error)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.error)
+                            .lineLimit(2)
+                    }
                 }
 
-                if let error = subagent.error, !error.isEmpty {
-                    Text(error)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.error)
-                        .lineLimit(2)
+                Spacer()
+
+                if !subagent.isTerminal, let onAbort {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundColor(VColor.textMuted)
+                        .padding(VSpacing.xs)
+                        .contentShape(Rectangle())
+                        .highPriorityGesture(TapGesture().onEnded { onAbort() })
+                        .accessibilityAddTraits(.isButton)
+                        .accessibilityLabel("Abort subagent")
                 }
             }
-
-            Spacer()
-
-            if !subagent.isTerminal, let onAbort {
-                Image(systemName: "xmark")
-                    .font(.system(size: 9, weight: .bold))
-                    .foregroundColor(VColor.textMuted)
-                    .padding(VSpacing.xs)
-                    .contentShape(Rectangle())
-                    .highPriorityGesture(TapGesture().onEnded { onAbort() })
-                    .accessibilityAddTraits(.isButton)
-                    .accessibilityLabel("Abort subagent")
-            }
-        }
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.xs)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.md)
-                .fill(VColor.backgroundSubtle.opacity(0.3))
-        )
-        .contentShape(Rectangle())
-        .onTapGesture { onTap?() }
-        .onAppear { startDotAnimation() }
-        .onDisappear { timer?.invalidate() }
-        .onChange(of: subagent.status) {
-            if subagent.status.isTerminal {
-                timer?.invalidate()
-                timer = nil
-            }
-        }
-    }
-
-    private func dotOpacity(for index: Int) -> Double {
-        let active = phase % 3
-        return index == active ? 1.0 : 0.3
-    }
-
-    private func startDotAnimation() {
-        guard !subagent.isTerminal else { return }
-        timer = Timer.scheduledTimer(withTimeInterval: 0.4, repeats: true) { _ in
-            withAnimation(VAnimation.standard) {
-                phase += 1
-            }
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(VColor.backgroundSubtle.opacity(0.3))
+            )
+            .contentShape(Rectangle())
+            .onTapGesture { onTap?() }
         }
     }
 }

--- a/clients/shared/Features/Chat/SubagentThreadView.swift
+++ b/clients/shared/Features/Chat/SubagentThreadView.swift
@@ -15,8 +15,6 @@ public struct SubagentThreadView: View {
     var onTap: (() -> Void)?
 
     @State private var isHovered: Bool = false
-    @State private var phase: Int = 0
-    @State private var timer: Timer?
 
     private var isRunning: Bool { !subagent.isTerminal }
 
@@ -74,29 +72,24 @@ public struct SubagentThreadView: View {
     }
 
     public var body: some View {
-        HStack(alignment: .center, spacing: 0) {
-            // L-shaped connector: vertical line from parent → curves right into the thread bar
-            LConnector()
-                .stroke(statusColor.opacity(0.4), style: StrokeStyle(lineWidth: 2, lineCap: .round))
-                .frame(width: 14, height: 28)
-                .padding(.trailing, VSpacing.xs)
+        TimelineView(.periodic(every: 0.4)) { context in
+            let phase = isRunning ? Int(context.date.timeIntervalSince1970 / 0.4) % 3 : 0
+            HStack(alignment: .center, spacing: 0) {
+                // L-shaped connector: vertical line from parent → curves right into the thread bar
+                LConnector()
+                    .stroke(statusColor.opacity(0.4), style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                    .frame(width: 14, height: 28)
+                    .padding(.trailing, VSpacing.xs)
 
-            // Thread indicator content
-            threadBar
-        }
-        .onAppear { startDotAnimation() }
-        .onDisappear { timer?.invalidate() }
-        .onChange(of: subagent.status) {
-            if subagent.status.isTerminal {
-                timer?.invalidate()
-                timer = nil
+                // Thread indicator content
+                threadBar(phase: phase)
             }
         }
     }
 
     // MARK: - Thread Bar
 
-    private var threadBar: some View {
+    private func threadBar(phase: Int) -> some View {
         HStack(spacing: VSpacing.sm) {
             // Label (clickable, turns blue on hover like Slack)
             Text(subagent.label)
@@ -110,7 +103,7 @@ public struct SubagentThreadView: View {
 
             // Animated dots while running
             if isRunning {
-                animatedDots
+                animatedDots(phase: phase)
             }
 
             Spacer(minLength: VSpacing.xs)
@@ -169,22 +162,13 @@ public struct SubagentThreadView: View {
 
     // MARK: - Animated Dots
 
-    private var animatedDots: some View {
+    private func animatedDots(phase: Int) -> some View {
         HStack(spacing: 2) {
             ForEach(0..<3, id: \.self) { index in
                 Circle()
                     .fill(VColor.textSecondary)
                     .frame(width: 4, height: 4)
                     .opacity(phase % 3 == index ? 1.0 : 0.3)
-            }
-        }
-    }
-
-    private func startDotAnimation() {
-        guard isRunning else { return }
-        timer = Timer.scheduledTimer(withTimeInterval: 0.4, repeats: true) { _ in
-            withAnimation(VAnimation.standard) {
-                phase += 1
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replace per-instance Timer.scheduledTimer with TimelineView in SubagentThreadView, SubagentStatusChip, and RunningIndicator — SwiftUI manages lifecycle automatically, no more leaked timers
- Debounce streaming scroll in MessageListView with 200ms delay to prevent per-token scrollTo calls
- Throttle MainWindowView onChange from O(n) messages.map(\.id) to O(1) messages.count

Part of #9096
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
