### PR TITLE
fix(chat): remove subagent objectWillChange storm + SubagentDetailStore cap

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -53,7 +53,7 @@ struct ChatView: View {
     var activeSubagents: [SubagentInfo] = []
     var onAbortSubagent: ((String) -> Void)?
     var onSubagentTap: ((String) -> Void)?
-    var subagentDetailStore: SubagentDetailStore?
+    @ObservedObject var subagentDetailStore: SubagentDetailStore
     var daemonHttpPort: Int?
     var isHistoryLoaded: Bool = true
     var dismissedDocumentSurfaceIds: Set<String> = []

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -20,7 +20,7 @@ struct MessageListView: View {
     var onModelPickerSelect: ((UUID, String) -> Void)?
     var onAbortSubagent: ((String) -> Void)?
     var onSubagentTap: ((String) -> Void)?
-    var subagentDetailStore: SubagentDetailStore?
+    @ObservedObject var subagentDetailStore: SubagentDetailStore
 
     var threadId: UUID?
     @Binding var isNearBottom: Bool
@@ -160,7 +160,7 @@ struct MessageListView: View {
                         ForEach(activeSubagents.filter { $0.parentMessageId == message.id }) { subagent in
                             SubagentThreadView(
                                 subagent: subagent,
-                                events: subagentDetailStore?.eventsBySubagent[subagent.id] ?? [],
+                                events: subagentDetailStore.eventsBySubagent[subagent.id] ?? [],
                                 onAbort: { onAbortSubagent?(subagent.id) },
                                 onTap: { onSubagentTap?(subagent.id) }
                             )
@@ -174,7 +174,7 @@ struct MessageListView: View {
                     ForEach(activeSubagents.filter { $0.parentMessageId == nil }) { subagent in
                         SubagentThreadView(
                             subagent: subagent,
-                            events: subagentDetailStore?.eventsBySubagent[subagent.id] ?? [],
+                            events: subagentDetailStore.eventsBySubagent[subagent.id] ?? [],
                             onAbort: { onAbortSubagent?(subagent.id) },
                             onTap: { onSubagentTap?(subagent.id) }
                         )

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1347,8 +1347,6 @@ extension ChatViewModel {
         case .subagentEvent(let msg):
             guard activeSubagents.contains(where: { $0.id == msg.subagentId }) else { break }
             subagentDetailStore.handleEvent(subagentId: msg.subagentId, event: msg.event)
-            // Notify SwiftUI so SubagentThreadView re-renders with updated events
-            objectWillChange.send()
 
         case .modelInfo(let msg):
             selectedModel = msg.model

--- a/clients/shared/Features/Chat/SubagentDetailStore.swift
+++ b/clients/shared/Features/Chat/SubagentDetailStore.swift
@@ -50,6 +50,11 @@ public struct SubagentUsageStats {
 /// Stores subagent detail data (events, objectives, usage) for display in the side panel.
 @MainActor
 public final class SubagentDetailStore: ObservableObject {
+    /// Maximum number of events retained per subagent to prevent unbounded memory growth.
+    static let eventRetentionCap = 500
+    /// Maximum UTF-8 byte count for accumulated text content before truncation.
+    static let textByteCap = 50_000
+
     @Published public var eventsBySubagent: [String: [SubagentEventItem]] = [:]
     @Published public var objectives: [String: String] = [:]
     @Published public var usageStats: [String: SubagentUsageStats] = [:]
@@ -83,11 +88,19 @@ public final class SubagentDetailStore: ObservableObject {
             if var events = eventsBySubagent[subagentId],
                let last = events.last,
                case .text = last.kind {
-                events[events.count - 1].content += delta.text
+                var content = events[events.count - 1].content
+                content += delta.text
+                // Cap text concatenation to prevent unbounded string accumulation.
+                // Use character-based prefix to safely truncate at character boundaries.
+                if content.utf8.count > Self.textByteCap {
+                    content = "[truncated] " + String(content.prefix(Self.textByteCap))
+                }
+                events[events.count - 1].content = content
                 eventsBySubagent[subagentId] = events
             } else {
                 let item = SubagentEventItem(timestamp: Date(), kind: .text, content: delta.text)
                 eventsBySubagent[subagentId, default: []].append(item)
+                trimEvents(for: subagentId)
             }
 
         case .toolUseStart(let msg):
@@ -97,6 +110,7 @@ public final class SubagentDetailStore: ObservableObject {
                 content: summarizeToolInput(msg.input)
             )
             eventsBySubagent[subagentId, default: []].append(item)
+            trimEvents(for: subagentId)
 
         case .toolResult(let msg):
             let truncated = msg.result.count > 500 ? String(msg.result.prefix(497)) + "..." : msg.result
@@ -106,6 +120,7 @@ public final class SubagentDetailStore: ObservableObject {
                 content: truncated
             )
             eventsBySubagent[subagentId, default: []].append(item)
+            trimEvents(for: subagentId)
 
         case .error(let err):
             let item = SubagentEventItem(
@@ -114,10 +129,19 @@ public final class SubagentDetailStore: ObservableObject {
                 content: err.message
             )
             eventsBySubagent[subagentId, default: []].append(item)
+            trimEvents(for: subagentId)
 
         default:
             break
         }
+    }
+
+    /// Trim events for a subagent to stay within the retention cap.
+    private func trimEvents(for subagentId: String) {
+        guard var events = eventsBySubagent[subagentId],
+              events.count > Self.eventRetentionCap else { return }
+        events.removeFirst(events.count - Self.eventRetentionCap)
+        eventsBySubagent[subagentId] = events
     }
 
     /// Populate events from a lazy-loaded `subagent_detail_response`.


### PR DESCRIPTION
## Summary
- Remove redundant objectWillChange.send() in .subagentEvent handler — SubagentDetailStore is already ObservableObject, so broadcasting through ChatViewModel caused 50+ unnecessary full view-tree re-evaluations per second during streaming
- Add eventRetentionCap (500 events) to SubagentDetailStore to prevent unbounded memory growth
- Cap text concatenation at 50KB to prevent unbounded string accumulation
- Upgrade MessageListView and ChatView to observe SubagentDetailStore directly via @ObservedObject, replacing the indirect ChatViewModel objectWillChange broadcast

Part of #9096
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
