### PR TITLE
fix(chat): cache hygiene + DebugPanel gating + TraceStore throttle + ImageCache sizing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -292,7 +292,7 @@ struct ChatBubble: View {
                             .fixedSize(horizontal: false, vertical: true)
                     }
                 } else if hasText {
-                    let segments = Self.cachedSegments(for: message.text)
+                    let segments = Self.cachedSegments(for: message.text, isStreaming: message.isStreaming)
                     let hasRichContent = segments.contains(where: {
                         switch $0 {
                         case .table, .image, .heading, .codeBlock, .horizontalRule, .list: return true
@@ -380,14 +380,20 @@ struct ChatBubble: View {
         }
     }
 
-    // MARK: - Caches
+    // MARK: - LRU Caches
+    //
+    // Each cache entry stores (value, accessTime) where accessTime is a
+    // monotonically increasing counter. On eviction the entry with the
+    // lowest accessTime is removed (least-recently-used).
 
-    @MainActor static var segmentCache = [String: [MarkdownSegment]]()
-    @MainActor static var markdownCache = [String: AttributedString]()
+    @MainActor static var lruCounter: Int = 0
+
+    @MainActor static var segmentCache = [String: (value: [MarkdownSegment], accessTime: Int)]()
+    @MainActor static var markdownCache = [String: (value: AttributedString, accessTime: Int)]()
     /// Separate cache for inline markdown (used by interleaved text segments).
     /// Kept distinct from `markdownCache` because `markdownText` applies
     /// slash-command highlighting before caching, which would contaminate
     /// inline results (and vice versa) if they shared a dictionary.
-    @MainActor static var inlineMarkdownCache = [String: AttributedString]()
+    @MainActor static var inlineMarkdownCache = [String: (value: AttributedString, accessTime: Int)]()
     static let maxCacheSize = 100
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -7,7 +7,8 @@ extension ChatBubble {
     /// Render a single text segment as a styled bubble, with table and image support.
     @ViewBuilder
     func textBubble(for segmentText: String) -> some View {
-        let segments = Self.cachedSegments(for: segmentText)
+        let streaming = message.isStreaming
+        let segments = Self.cachedSegments(for: segmentText, isStreaming: streaming)
         let hasRichContent = segments.contains(where: {
             switch $0 {
             case .table, .image, .heading, .codeBlock, .horizontalRule, .list: return true
@@ -19,7 +20,7 @@ extension ChatBubble {
             if hasRichContent {
                 MarkdownSegmentView(segments: segments)
             } else {
-                let attributed = Self.cachedInlineMarkdown(for: segmentText)
+                let attributed = Self.cachedInlineMarkdown(for: segmentText, isStreaming: streaming)
                 Text(attributed)
                     .font(.system(size: 13))
                     .lineSpacing(3)
@@ -35,41 +36,65 @@ extension ChatBubble {
     /// Cached inline markdown AttributedString to avoid re-parsing on every render.
     /// Uses `inlineMarkdownCache` (not `markdownCache`) to avoid cross-contamination
     /// with `markdownText`, which applies slash-command highlighting before caching.
-    static func cachedInlineMarkdown(for text: String) -> AttributedString {
-        if let cached = inlineMarkdownCache[text] { return cached }
+    /// When `isStreaming` is true the result is computed but not stored, since
+    /// streaming text changes every token and caching intermediates wastes memory.
+    static func cachedInlineMarkdown(for text: String, isStreaming: Bool = false) -> AttributedString {
+        if let cached = inlineMarkdownCache[text] {
+            lruCounter += 1
+            inlineMarkdownCache[text] = (cached.value, lruCounter)
+            return cached.value
+        }
         let options = AttributedString.MarkdownParsingOptions(
             interpretedSyntax: .inlineOnlyPreservingWhitespace
         )
         let result = (try? AttributedString(markdown: text, options: options))
             ?? AttributedString(text)
+        if isStreaming { return result }
         if inlineMarkdownCache.count >= maxCacheSize {
-            // Dictionary iteration order is unspecified; this evicts an arbitrary entry.
-            if let first = inlineMarkdownCache.keys.first { inlineMarkdownCache.removeValue(forKey: first) }
+            // Evict the least-recently-used entry (lowest accessTime).
+            if let lruKey = inlineMarkdownCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
+                inlineMarkdownCache.removeValue(forKey: lruKey)
+            }
         }
-        inlineMarkdownCache[text] = result
+        lruCounter += 1
+        inlineMarkdownCache[text] = (result, lruCounter)
         return result
     }
 
     /// Cached markdown segment parser to avoid re-parsing on every render.
-    static func cachedSegments(for text: String) -> [MarkdownSegment] {
-        if let cached = segmentCache[text] { return cached }
-        let result = parseMarkdownSegments(text)
-        if segmentCache.count >= maxCacheSize {
-            // Dictionary iteration order is unspecified; this evicts an arbitrary entry.
-            if let first = segmentCache.keys.first { segmentCache.removeValue(forKey: first) }
+    /// When `isStreaming` is true the result is computed but not stored, since
+    /// streaming text changes every token and caching intermediates wastes memory.
+    static func cachedSegments(for text: String, isStreaming: Bool = false) -> [MarkdownSegment] {
+        if let cached = segmentCache[text] {
+            lruCounter += 1
+            segmentCache[text] = (cached.value, lruCounter)
+            return cached.value
         }
-        segmentCache[text] = result
+        let result = parseMarkdownSegments(text)
+        if isStreaming { return result }
+        if segmentCache.count >= maxCacheSize {
+            // Evict the least-recently-used entry (lowest accessTime).
+            if let lruKey = segmentCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
+                segmentCache.removeValue(forKey: lruKey)
+            }
+        }
+        lruCounter += 1
+        segmentCache[text] = (result, lruCounter)
         return result
     }
 
     /// Cached markdown parser to avoid re-parsing on every render.
+    /// Skips caching when the message is still streaming to avoid
+    /// filling the cache with intermediate text states.
     var markdownText: AttributedString {
         let textToRender = message.text
         let trimmed = textToRender.trimmingCharacters(in: .whitespacesAndNewlines)
 
         // Return cached value if available
         if let cached = Self.markdownCache[trimmed] {
-            return cached
+            Self.lruCounter += 1
+            Self.markdownCache[trimmed] = (cached.value, Self.lruCounter)
+            return cached.value
         }
 
         // Parse markdown
@@ -88,14 +113,17 @@ extension ChatBubble {
             parsed[attrStart..<attrEnd].foregroundColor = VColor.slashCommand
         }
 
-        // Store in cache (with size limit to prevent unbounded growth)
+        // Skip caching during streaming — intermediate text wastes cache slots
+        if message.isStreaming { return parsed }
+
+        // Store in cache with LRU eviction
         if Self.markdownCache.count >= Self.maxCacheSize {
-            // Dictionary iteration order is unspecified; this evicts an arbitrary entry.
-            if let firstKey = Self.markdownCache.keys.first {
-                Self.markdownCache.removeValue(forKey: firstKey)
+            if let lruKey = Self.markdownCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
+                Self.markdownCache.removeValue(forKey: lruKey)
             }
         }
-        Self.markdownCache[trimmed] = parsed
+        Self.lruCounter += 1
+        Self.markdownCache[trimmed] = (parsed, Self.lruCounter)
 
         return parsed
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -126,7 +126,9 @@ struct MarkdownSegmentView: View {
     /// Keyed by a hash of the segment descriptions so identical segment
     /// arrays return the cached value instead of re-parsing markdown and
     /// re-creating `AttributedString` on every SwiftUI body evaluation.
-    @MainActor private static var attributedStringCache: [Int: AttributedString] = [:]
+    /// Each entry stores (value, accessTime) for LRU eviction.
+    @MainActor private static var attributedStringCache: [Int: (value: AttributedString, accessTime: Int)] = [:]
+    @MainActor private static var lruCounter: Int = 0
     private static let attributedStringCacheLimit = 200
 
     /// Clears the attributed string cache.  Called when switching threads
@@ -149,19 +151,21 @@ struct MarkdownSegmentView: View {
         let cacheKey = hasher.finalize()
 
         if let cached = Self.attributedStringCache[cacheKey] {
-            return cached
+            Self.lruCounter += 1
+            Self.attributedStringCache[cacheKey] = (cached.value, Self.lruCounter)
+            return cached.value
         }
 
         let result = Self.buildAttributedStringUncached(from: segments, secondaryTextColor: secondaryTextColor)
 
-        // Evict an arbitrary entry when the cache is full (Dictionary
-        // iteration order is unspecified, so this is not strictly FIFO).
+        // Evict the least-recently-used entry when the cache is full.
         if Self.attributedStringCache.count >= Self.attributedStringCacheLimit {
-            if let firstKey = Self.attributedStringCache.keys.first {
-                Self.attributedStringCache.removeValue(forKey: firstKey)
+            if let lruKey = Self.attributedStringCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
+                Self.attributedStringCache.removeValue(forKey: lruKey)
             }
         }
-        Self.attributedStringCache[cacheKey] = result
+        Self.lruCounter += 1
+        Self.attributedStringCache[cacheKey] = (result, Self.lruCounter)
         return result
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -52,7 +52,10 @@ struct MainWindowView: View {
     @ObservedObject var threadManager: ThreadManager
     @ObservedObject var appListManager: AppListManager
     var zoomManager: ZoomManager
-    @ObservedObject var traceStore: TraceStore
+    /// Plain `let` instead of `@ObservedObject` so SwiftUI doesn't observe
+    /// TraceStore mutations when the DebugPanel isn't visible. DebugPanel
+    /// itself uses `@ObservedObject` and is only instantiated when shown.
+    let traceStore: TraceStore
     @ObservedObject var windowState: MainWindowState
     @State private var selectedThreadId: UUID?
     @State var sharing = SharingState()

--- a/clients/shared/Features/Chat/ImageCache.swift
+++ b/clients/shared/Features/Chat/ImageCache.swift
@@ -15,6 +15,9 @@ public actor ImageCache {
 
     private init() {
         dataCache.countLimit = 250
+        // 100 MB byte ceiling so large images don't blow out memory even
+        // when the count is under 250.
+        dataCache.totalCostLimit = 100 * 1024 * 1024
     }
 
     /// Returns raw `Data` for the URL (needed for GIF animation frames).
@@ -47,7 +50,7 @@ public actor ImageCache {
 
         do {
             let data = try await task.value
-            dataCache.setObject(data as NSData, forKey: nsURL)
+            dataCache.setObject(data as NSData, forKey: nsURL, cost: data.count)
             inFlight[url] = nil
             return data
         } catch {

--- a/clients/shared/Features/TraceStore.swift
+++ b/clients/shared/Features/TraceStore.swift
@@ -29,17 +29,32 @@ public final class TraceStore: ObservableObject {
     // MARK: - State
 
     /// All events per session, in stable order.
-    @Published public private(set) var eventsBySession: [String: [StoredEvent]] = [:]
+    /// Not @Published — updates are coalesced via `schedulePublish()` to avoid
+    /// firing objectWillChange on every individual trace event during bursts.
+    public private(set) var eventsBySession: [String: [StoredEvent]] = [:]
 
     /// The ID of the most recently ingested event per session. Unlike `eventsBySession[sid]?.count`,
     /// this always changes on ingestion even when the retention cap holds count constant.
-    @Published public private(set) var latestEventIdBySession: [String: String] = [:]
+    public private(set) var latestEventIdBySession: [String: String] = [:]
 
     /// Set of seen eventIds per session for dedup.
     private var seenIds: [String: Set<String>] = [:]
 
     /// Monotonic counter for insertion ordering tiebreaks.
     private var nextInsertionIndex: Int = 0
+
+    /// Coalesces rapid objectWillChange notifications into a single publish
+    /// per 100ms window so SwiftUI doesn't re-evaluate on every trace event.
+    private var publishTask: Task<Void, Never>?
+
+    private func schedulePublish() {
+        guard publishTask == nil else { return }
+        publishTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            self?.objectWillChange.send()
+            self?.publishTask = nil
+        }
+    }
 
     /// Maximum events retained per session.
     public static let retentionCap = 5000
@@ -85,6 +100,7 @@ public final class TraceStore: ObservableObject {
 
         eventsBySession[sid] = events
         latestEventIdBySession[sid] = event.id
+        schedulePublish()
     }
 
     // MARK: - Queries
@@ -209,6 +225,7 @@ public final class TraceStore: ObservableObject {
         eventsBySession.removeValue(forKey: sessionId)
         latestEventIdBySession.removeValue(forKey: sessionId)
         seenIds.removeValue(forKey: sessionId)
+        schedulePublish()
     }
 
     /// Remove all events for all sessions.
@@ -217,6 +234,7 @@ public final class TraceStore: ObservableObject {
         latestEventIdBySession.removeAll()
         seenIds.removeAll()
         nextInsertionIndex = 0
+        schedulePublish()
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary
- Replace random-eviction (Dictionary.keys.first) caches with LRU using access-counter approach
- Skip caching during streaming (isStreaming parameter) — intermediate text wastes cache slots
- Make DebugPanel TraceStore observation lazy — only observe when panel is visible
- Coalesce TraceStore objectWillChange with 100ms batching instead of per-event @Published
- Add 100MB byte limit to ImageCache (was count-only, no byte awareness)

Part of #9096
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
