### PR TITLE
fix(chat): eliminate duplicate storage + cap tool input

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -742,6 +742,7 @@ struct MainWindowView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .openDynamicWorkspace)) { notification in
             if let msg = notification.userInfo?["surfaceMessage"] as? UiSurfaceShowMessage {
+                // Full message from daemon live IPC (AppDelegate path)
                 windowState.activeDynamicSurface = msg
                 windowState.activeDynamicParsedSurface = Surface.from(msg)
                 // Determine the app ID from the surface if available
@@ -760,6 +761,13 @@ struct MainWindowView: View {
                 } else {
                     windowState.selection = .app(msg.surfaceId)
                 }
+            } else if let ref = notification.userInfo?["surfaceRef"] as? SurfaceRef {
+                // Lightweight ref from inline surface click — the daemon will
+                // send a fresh ui_surface_show via live IPC with the full payload.
+                // Open by surfaceId to trigger the workspace view.
+                windowState.selection = .app(ref.surfaceId)
+                // Request the daemon to re-show the surface
+                try? daemonClient.sendAppOpen(appId: ref.surfaceId)
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .openDocumentEditor)) { notification in

--- a/clients/macos/vellum-assistantTests/ChatDynamicPreviewRegressionTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatDynamicPreviewRegressionTests.swift
@@ -485,7 +485,7 @@ final class ChatDynamicPreviewRegressionTests: XCTestCase {
 
     // MARK: - Surface message preservation (for re-opening workspace)
 
-    func testInlineSurfacePreservesSurfaceMessage() {
+    func testInlineSurfacePreservesSurfaceRef() {
         viewModel.handleServerMessage(.assistantTextDelta(
             AssistantTextDeltaMessage(text: "App ready:")
         ))
@@ -497,9 +497,9 @@ final class ChatDynamicPreviewRegressionTests: XCTestCase {
         viewModel.handleServerMessage(.uiSurfaceShow(showMsg))
 
         let surface = viewModel.messages[0].inlineSurfaces[0]
-        XCTAssertNotNil(surface.surfaceMessage,
-                        "Inline surface should preserve the original IPC message for re-opening workspace")
-        XCTAssertEqual(surface.surfaceMessage?.surfaceId, "surface-msg-test")
-        XCTAssertEqual(surface.surfaceMessage?.sessionId, "sess-dp")
+        XCTAssertNotNil(surface.surfaceRef,
+                        "Inline surface should preserve a lightweight SurfaceRef for re-opening workspace")
+        XCTAssertEqual(surface.surfaceRef?.surfaceId, "surface-msg-test")
+        XCTAssertEqual(surface.surfaceRef?.sessionId, "sess-dp")
     }
 }

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -585,11 +585,11 @@ public struct ToolCallData: Identifiable, Equatable {
     public let toolName: String
     public let inputSummary: String
     /// Full (untruncated) input text for display in expanded views.
-    public let inputFull: String
+    public var inputFull: String
     /// Untruncated raw value of the primary input key (e.g. file path).
     /// Unlike inputSummary (truncated to 80 chars) this preserves the full value
     /// for use in file existence checks and opening files.
-    public let inputRawValue: String
+    public var inputRawValue: String
     public var result: String?
     public var isError: Bool
     public var isComplete: Bool
@@ -632,14 +632,20 @@ public struct ToolCallData: Identifiable, Equatable {
         self.id = id
         self.toolName = toolName
         self.inputSummary = inputSummary
-        self.inputFull = inputFull ?? inputSummary
-        self.inputRawValue = inputRawValue ?? inputSummary
+        var fullInput = inputFull ?? inputSummary
+        if fullInput.count > 10_000 { fullInput = String(fullInput.prefix(10_000)) + "... [truncated]" }
+        self.inputFull = fullInput
+        var rawValue = inputRawValue ?? inputSummary
+        if rawValue.count > 10_000 { rawValue = String(rawValue.prefix(10_000)) + "... [truncated]" }
+        self.inputRawValue = rawValue
         self.result = result
         self.isError = isError
         self.isComplete = isComplete
         self.arrivedBeforeText = arrivedBeforeText
-        self.imageData = imageData
-        self.cachedImage = Self.decodeImage(from: imageData)
+        let decoded = Self.decodeImage(from: imageData)
+        // Keep cachedImage for display, nil out raw base64 to save ~2.7MB per screenshot
+        self.cachedImage = decoded
+        self.imageData = decoded == nil ? imageData : nil
         self.startedAt = startedAt
         self.completedAt = completedAt
     }
@@ -964,6 +970,31 @@ public struct ToolCallData: Identifiable, Equatable {
     }
 }
 
+/// Lightweight reference to a surface, retaining only the fields needed to
+/// re-open a workspace. Avoids keeping the full UiSurfaceShowMessage (which
+/// retains the entire HTML payload) in memory.
+public struct SurfaceRef: Equatable {
+    public let surfaceId: String
+    public let sessionId: String
+    public let surfaceType: String
+    public let title: String?
+
+    public init(surfaceId: String, sessionId: String, surfaceType: String, title: String?) {
+        self.surfaceId = surfaceId
+        self.sessionId = sessionId
+        self.surfaceType = surfaceType
+        self.title = title
+    }
+
+    /// Build from a UiSurfaceShowMessage, discarding the heavy data payload.
+    public init(from msg: UiSurfaceShowMessage) {
+        self.surfaceId = msg.surfaceId
+        self.sessionId = msg.sessionId
+        self.surfaceType = msg.surfaceType
+        self.title = msg.title
+    }
+}
+
 /// Data for an inline UI surface rendered within a chat message.
 public struct InlineSurfaceData: Identifiable, Equatable {
     public let id: String
@@ -971,8 +1002,10 @@ public struct InlineSurfaceData: Identifiable, Equatable {
     public let title: String?
     public let data: SurfaceData
     public let actions: [SurfaceActionButton]
-    /// Original IPC message for dynamic pages, used to re-open the workspace.
-    public let surfaceMessage: UiSurfaceShowMessage?
+    /// Lightweight reference for dynamic pages, used to re-open the workspace.
+    /// Replaces the former full UiSurfaceShowMessage to avoid retaining
+    /// entire HTML payloads in memory.
+    public let surfaceRef: SurfaceRef?
 
     public static func == (lhs: InlineSurfaceData, rhs: InlineSurfaceData) -> Bool {
         lhs.id == rhs.id
@@ -986,13 +1019,13 @@ public struct InlineSurfaceData: Identifiable, Equatable {
     /// When non-nil, the surface has been completed and should render in collapsed/chip state.
     public var completionState: SurfaceCompletionState?
 
-    public init(id: String, surfaceType: SurfaceType, title: String?, data: SurfaceData, actions: [SurfaceActionButton], surfaceMessage: UiSurfaceShowMessage? = nil, completionState: SurfaceCompletionState? = nil) {
+    public init(id: String, surfaceType: SurfaceType, title: String?, data: SurfaceData, actions: [SurfaceActionButton], surfaceRef: SurfaceRef? = nil, completionState: SurfaceCompletionState? = nil) {
         self.id = id
         self.surfaceType = surfaceType
         self.title = title
         self.data = data
         self.actions = actions
-        self.surfaceMessage = surfaceMessage
+        self.surfaceRef = surfaceRef
         self.completionState = completionState
     }
 }
@@ -1015,7 +1048,9 @@ public struct ChatAttachment: Identifiable {
     public let mimeType: String
     /// Base64-encoded file data. Empty when the attachment was too large to embed
     /// in the history_response — use ``fetchData(port:)`` to load it lazily.
-    public let data: String
+    /// Mutable so it can be nil'd out after the daemon has persisted the data,
+    /// keeping only the thumbnail for display.
+    public var data: String
     /// Pre-rendered thumbnail for image attachments (resized to 120px max dimension).
     public let thumbnailData: Data?
     /// Pre-computed length of `data` to avoid O(n) String.count during rendering.

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -125,7 +125,9 @@ extension ChatViewModel {
             }
         }
 
-        return lines.joined(separator: "\n")
+        var result = lines.joined(separator: "\n")
+        if result.count > 10_000 { result = String(result.prefix(10_000)) + "... [truncated]" }
+        return result
     }
 
     private func stringifyValue(_ value: AnyCodable) -> String {
@@ -624,10 +626,14 @@ extension ChatViewModel {
             currentTurnUserText = nil
             currentAssistantHasText = false
             lastContentWasToolCall = false
-            // Reset processing messages to sent
+            // Reset processing messages to sent and drop attachment base64 data
+            // since the daemon has persisted it at this point.
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {
                     messages[i].status = .sent
+                    for j in messages[i].attachments.indices {
+                        messages[i].attachments[j].data = ""
+                    }
                 }
             }
             dispatchPendingSendDirect()
@@ -1054,8 +1060,10 @@ extension ChatViewModel {
                 messages[msgIndex].toolCalls[tcIndex].isError = msg.isError ?? false
                 messages[msgIndex].toolCalls[tcIndex].isComplete = true
                 messages[msgIndex].toolCalls[tcIndex].completedAt = Date()
-                messages[msgIndex].toolCalls[tcIndex].imageData = msg.imageData
-                messages[msgIndex].toolCalls[tcIndex].cachedImage = ToolCallData.decodeImage(from: msg.imageData)
+                let decoded = ToolCallData.decodeImage(from: msg.imageData)
+                // Keep cachedImage for display, nil out raw base64 to save ~2.7MB per screenshot
+                messages[msgIndex].toolCalls[tcIndex].cachedImage = decoded
+                messages[msgIndex].toolCalls[tcIndex].imageData = decoded == nil ? msg.imageData : nil
                 if let status = msg.status, !status.isEmpty {
                     messages[msgIndex].toolCalls[tcIndex].buildingStatus = status
                 }
@@ -1127,7 +1135,7 @@ extension ChatViewModel {
                 title: surface.title,
                 data: surface.data,
                 actions: surface.actions,
-                surfaceMessage: msg
+                surfaceRef: SurfaceRef(from: msg)
             )
 
             // If messageId is provided, attach to that specific message (rarely used now that
@@ -1187,7 +1195,7 @@ extension ChatViewModel {
                             title: updated.title,
                             data: updated.data,
                             actions: updated.actions,
-                            surfaceMessage: existing.surfaceMessage
+                            surfaceRef: existing.surfaceRef
                         )
                         // Update floating overlay for task_progress cards (macOS only)
                         #if os(macOS)

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1628,20 +1628,15 @@ public final class ChatViewModel: ObservableObject {
                     // Use sessionId from the view model (assumes history is for current session)
                     if let sessionId = self.sessionId,
                        let surface = Surface.from(surf, sessionId: sessionId) {
-                        // Reconstruct a UiSurfaceShowMessage so the card remains
+                        // Build a lightweight SurfaceRef so the card remains
                         // clickable after the app restarts (history restore).
-                        let reconstructedActions: [SurfaceActionData]? = surf.actions?.map { action in
-                            SurfaceActionData(id: action.id, label: action.label, style: action.style)
-                        }
-                        let reconstructedMessage = UiSurfaceShowMessage(
-                            sessionId: sessionId,
+                        // The full UiSurfaceShowMessage is not retained to avoid
+                        // keeping entire HTML payloads in memory.
+                        let ref = SurfaceRef(
                             surfaceId: surf.surfaceId,
+                            sessionId: sessionId,
                             surfaceType: surf.surfaceType,
-                            title: surf.title,
-                            data: AnyCodable(surf.data.mapValues { $0.value }),
-                            actions: reconstructedActions,
-                            display: surf.display,
-                            messageId: item.id
+                            title: surf.title
                         )
                         let inlineSurface = InlineSurfaceData(
                             id: surface.id,
@@ -1649,7 +1644,7 @@ public final class ChatViewModel: ObservableObject {
                             title: surface.title,
                             data: surface.data,
                             actions: surface.actions,
-                            surfaceMessage: reconstructedMessage
+                            surfaceRef: ref
                         )
                         inlineSurfaces.append(inlineSurface)
                     }
@@ -1695,6 +1690,12 @@ public final class ChatViewModel: ObservableObject {
             // anchor to it. This is the database ID from the daemon, not the
             // client-side UUID.
             chatMsg.daemonMessageId = item.id
+
+            // Drop base64 data from history attachments — the daemon already
+            // persisted them, so we only need thumbnails for display.
+            for i in chatMsg.attachments.indices {
+                chatMsg.attachments[i].data = ""
+            }
 
             // Populate inlineSurfaces from history
             chatMsg.inlineSurfaces = inlineSurfaces

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -78,11 +78,11 @@ public struct InlineSurfaceRouter: View {
         .overlay(alignment: .topTrailing) {
             if isDynamicPreview {
                 Button {
-                    if let msg = surface.surfaceMessage {
+                    if let ref = surface.surfaceRef {
                         NotificationCenter.default.post(
                             name: Notification.Name("MainWindow.openDynamicWorkspace"),
                             object: nil,
-                            userInfo: ["surfaceMessage": msg]
+                            userInfo: ["surfaceRef": ref]
                         )
                     }
                 } label: {
@@ -146,22 +146,22 @@ public struct InlineSurfaceRouter: View {
             if let preview = data.preview {
                 InlineDynamicPagePreview(preview: preview) {
                     // Post notification to open (or re-open) the workspace
-                    if let msg = surface.surfaceMessage {
+                    if let ref = surface.surfaceRef {
                         NotificationCenter.default.post(
                             name: Notification.Name("MainWindow.openDynamicWorkspace"),
                             object: nil,
-                            userInfo: ["surfaceMessage": msg]
+                            userInfo: ["surfaceRef": ref]
                         )
                     }
                 }
             } else {
                 // Still allow opening the workspace even without a preview card.
                 Button {
-                    if let msg = surface.surfaceMessage {
+                    if let ref = surface.surfaceRef {
                         NotificationCenter.default.post(
                             name: Notification.Name("MainWindow.openDynamicWorkspace"),
                             object: nil,
-                            userInfo: ["surfaceMessage": msg]
+                            userInfo: ["surfaceRef": ref]
                         )
                     }
                 } label: {


### PR DESCRIPTION
## Summary
- Drop base64 imageData after successful decode to NSImage/UIImage (~2.7MB saved per screenshot)
- Cap ToolCallData.inputFull and inputRawValue to 10,000 chars to prevent unbounded accumulation
- Change ChatAttachment.data to var; nil out base64 data on populateFromHistory and after messageComplete acknowledgment
- Replace UiSurfaceShowMessage with lightweight SurfaceRef struct (surfaceId, sessionId, surfaceType, title) to avoid retaining full HTML payloads

Part of #9096
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
