### PR TITLE
fix: allow notification posting during notDetermined auth and fix fallback comment

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -163,8 +163,8 @@ extension AppDelegate {
             log.warning("Notification authorization status is denied — skipping notification post")
             return false
         case .notDetermined:
-            log.warning("Notification authorization status is notDetermined — skipping notification post")
-            return false
+            log.info("Notification authorization status is notDetermined — attempting post anyway")
+            return true
         @unknown default:
             log.warning("Notification authorization status is unknown (\(settings.authorizationStatus.rawValue)) — skipping notification post")
             return false

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -257,10 +257,11 @@ extension AppDelegate {
             return
         }
 
-        // When the app is in the background (or for non-guardian events even when
-        // active), schedule a fallback notification. notification_intent is normally
-        // emitted moments later by the vellum adapter; if it arrives in time the
-        // fallback is cancelled to prevent duplicates.
+        // When the app is in the background, schedule a fallback notification.
+        // notification_intent is normally emitted moments later by the vellum
+        // adapter; if it arrives in time the fallback is cancelled to prevent
+        // duplicates. When active, the thread is already visible in the sidebar
+        // so no fallback is needed.
         guard !NSApp.isActive else { return }
 
         scheduleNotificationFallback(


### PR DESCRIPTION
## Summary

Addresses review feedback from #9092:

- **`.notDetermined` auth handling**: `checkNotificationAuthorization()` now returns `true` for `.notDetermined` instead of `false`. `UNUserNotificationCenter.add()` works even when authorization is undetermined — the OS queues notifications and delivers them once granted. The previous behavior silently dropped first-run notifications while the permission prompt was pending.
- **Comment fix**: Updated the comment in `handleNotificationThreadCreated` to accurately describe that fallback scheduling only happens when the app is backgrounded, not for non-guardian events when active.

## Test plan

- [ ] Verify `swift build` succeeds
- [ ] Manual: on first launch (before granting notification permission), verify notifications are queued and delivered after granting permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
