### PR TITLE
fix(chat): ChatViewModel deinit cleanup + refinement buffer throttle

### DIFF
--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -49,6 +49,9 @@ public final class ChatMessageManager: ObservableObject {
     /// after a refinement that produced no surface update.
     @Published public var refinementFailureText: String?
     public var refinementFailureDismissTask: Task<Void, Never>?
+    /// Coalesces refinement streaming text updates with a 50ms throttle,
+    /// preventing republishing the entire accumulated buffer on every token.
+    public var refinementFlushTask: Task<Void, Never>?
 
     // MARK: - Surface / undo
 

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -499,7 +499,15 @@ extension ChatViewModel {
             guard !isCancelling else { return }
             if isWorkspaceRefinementInFlight {
                 refinementTextBuffer += delta.text
-                refinementStreamingText = refinementTextBuffer
+                // Throttle refinement streaming updates with 50ms coalescing
+                // to prevent republishing the entire accumulated buffer on
+                // every single token (same pattern as message streaming flush).
+                refinementFlushTask?.cancel()
+                refinementFlushTask = Task { @MainActor [weak self] in
+                    try? await Task.sleep(nanoseconds: 50_000_000)
+                    guard !Task.isCancelled, let self else { return }
+                    self.refinementStreamingText = self.refinementTextBuffer
+                }
                 return
             }
             // Haptic on first text chunk (thinking → streaming transition)
@@ -556,6 +564,13 @@ extension ChatViewModel {
                 #if os(iOS)
                 UIImpactFeedbackGenerator(style: .medium).impactOccurred()
                 #endif
+            }
+            // Cancel the throttled refinement flush and do a final immediate
+            // flush so the complete buffer is available for the logic below.
+            refinementFlushTask?.cancel()
+            refinementFlushTask = nil
+            if wasRefinement {
+                refinementStreamingText = refinementTextBuffer
             }
             // Surface the AI's text response when a refinement produced no update
             if wasRefinement {
@@ -684,6 +699,8 @@ extension ChatViewModel {
             }
             pendingVoiceMessage = false
             isWorkspaceRefinementInFlight = false
+            refinementFlushTask?.cancel()
+            refinementFlushTask = nil
             refinementMessagePreview = nil
             refinementStreamingText = nil
             cancelledDuringRefinement = false
@@ -817,6 +834,8 @@ extension ChatViewModel {
                 return
             }
             isWorkspaceRefinementInFlight = false
+            refinementFlushTask?.cancel()
+            refinementFlushTask = nil
             refinementMessagePreview = nil
             refinementStreamingText = nil
             cancelledDuringRefinement = false
@@ -1242,6 +1261,8 @@ extension ChatViewModel {
             guard sessionId != nil, belongsToSession(msg.sessionId) else { return }
             log.error("Session error [\(msg.code.rawValue, privacy: .public)]: \(msg.userMessage, privacy: .private)")
             isWorkspaceRefinementInFlight = false
+            refinementFlushTask?.cancel()
+            refinementFlushTask = nil
             refinementMessagePreview = nil
             refinementStreamingText = nil
             cancelledDuringRefinement = false

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -101,6 +101,10 @@ public final class ChatViewModel: ObservableObject {
         get { messageManager.refinementFailureDismissTask }
         set { messageManager.refinementFailureDismissTask = newValue }
     }
+    var refinementFlushTask: Task<Void, Never>? {
+        get { messageManager.refinementFlushTask }
+        set { messageManager.refinementFlushTask = newValue }
+    }
     /// Number of undo steps available for the active workspace surface.
     public var surfaceUndoCount: Int {
         get { messageManager.surfaceUndoCount }
@@ -1851,6 +1855,10 @@ public final class ChatViewModel: ObservableObject {
 
     deinit {
         messageLoopTask?.cancel()
+        streamingFlushTask?.cancel()
+        cancelTimeoutTask?.cancel()
+        refinementFailureDismissTask?.cancel()
+        refinementFlushTask?.cancel()
         reconnectDebounceTask?.cancel()
         if let observer = reconnectObserver {
             NotificationCenter.default.removeObserver(observer)


### PR DESCRIPTION
## Summary
- Expand ChatViewModel deinit to cancel all Task properties and remove all NotificationCenter observers
- Throttle refinement streaming text with 50ms coalescing (same pattern as message streaming flush) to prevent republishing entire accumulated text on every token

Part of #9096
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
