### PR TITLE
Fix holistic review: ACL bypass, rate limits, status handler, timer, docs, tests

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4771,7 +4771,7 @@ Guardian verification binds a trusted human identity to a channel so the assista
 ### Channel-Specific Flows
 
 - **SMS**: User provides guardian's E.164 phone number. Daemon sends an outbound SMS with a verification code. Guardian replies to the assistant's Twilio number with the code. Session binds on code match.
-- **Telegram**: User provides guardian's Telegram handle or chat ID. Daemon generates a bootstrap deep-link URL (`https://t.me/<bot>?start=verify_<token>`). Guardian opens the link and sends the code to the bot. Session binds on code match.
+- **Telegram**: User provides guardian's Telegram handle or chat ID. Daemon generates a bootstrap deep-link URL (`https://t.me/<bot>?start=gv_<token>`). Guardian opens the link and sends the code to the bot. Session binds on code match.
 - **Voice**: User provides guardian's E.164 phone number. Daemon initiates an outbound call via Twilio ConversationRelay. Guardian answers and provides the code via DTMF or speech. Session binds on code match.
 
 ### Identity Binding

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -99,7 +99,9 @@ import {
   revokeBinding,
   updateApprovalDecision,
 } from '../memory/channel-guardian-store.js';
+import { eq } from 'drizzle-orm';
 import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { channelGuardianVerificationChallenges } from '../memory/schema.js';
 import {
   createVerificationChallenge,
   getGuardianBinding,
@@ -584,15 +586,18 @@ describe('guardian service challenge validation', () => {
     expect(oldBinding).not.toBeNull();
     expect(oldBinding!.guardianExternalUserId).toBe('old-user');
 
-    // Verify with a new user
+    // Attempt verification with a different user — should be rejected
+    // because a different guardian is already bound for this channel.
     const { secret } = createVerificationChallenge('asst-1', 'telegram');
-    validateAndConsumeChallenge('asst-1', 'telegram', secret, 'new-user', 'new-chat');
+    const result = validateAndConsumeChallenge('asst-1', 'telegram', secret, 'new-user', 'new-chat');
 
-    // The old binding should be revoked, new one active
-    const newBinding = getActiveBinding('asst-1', 'telegram');
-    expect(newBinding).not.toBeNull();
-    expect(newBinding!.guardianExternalUserId).toBe('new-user');
-    expect(newBinding!.guardianDeliveryChatId).toBe('new-chat');
+    // The different-user takeover should be blocked
+    expect(result.success).toBe(false);
+
+    // The original binding should remain active
+    const binding = getActiveBinding('asst-1', 'telegram');
+    expect(binding).not.toBeNull();
+    expect(binding!.guardianExternalUserId).toBe('old-user');
   });
 });
 
@@ -1548,9 +1553,8 @@ describe('voice guardian challenge generation', () => {
     expect(result.challengeId).toBeDefined();
     expect(result.secret).toBeDefined();
     expect(result.secret).toMatch(/^\d{6}$/);
-    const num = parseInt(result.secret, 10);
-    expect(num).toBeGreaterThanOrEqual(100000);
-    expect(num).toBeLessThanOrEqual(999999);
+    // Zero-padded: "079316" is valid, so check string length not numeric range
+    expect(result.secret.length).toBe(6);
   });
 
   test('createVerificationChallenge for non-voice returns 64-char hex secret', () => {
@@ -1709,13 +1713,17 @@ describe('voice guardian challenge validation', () => {
     expect(oldBinding).not.toBeNull();
     expect(oldBinding!.guardianExternalUserId).toBe('old-voice-user');
 
+    // Attempt verification with a different user — should be rejected
     const { secret } = createVerificationChallenge('asst-1', 'voice');
-    validateAndConsumeChallenge('asst-1', 'voice', secret, 'new-voice-user', 'new-voice-chat');
+    const result = validateAndConsumeChallenge('asst-1', 'voice', secret, 'new-voice-user', 'new-voice-chat');
 
-    const newBinding = getActiveBinding('asst-1', 'voice');
-    expect(newBinding).not.toBeNull();
-    expect(newBinding!.guardianExternalUserId).toBe('new-voice-user');
-    expect(newBinding!.guardianDeliveryChatId).toBe('new-voice-chat');
+    // The different-user takeover should be blocked
+    expect(result.success).toBe(false);
+
+    // The original binding should remain active
+    const binding = getActiveBinding('asst-1', 'voice');
+    expect(binding).not.toBeNull();
+    expect(binding!.guardianExternalUserId).toBe('old-voice-user');
   });
 });
 
@@ -2312,9 +2320,11 @@ describe('outbound verification sessions', () => {
 
     // First session should no longer be findable as active
     const db = getDb();
-    const firstRow = db.query.channelGuardianVerificationChallenges.findFirst({
-      where: (t, { eq: e }) => e(t.id, firstId),
-    });
+    const firstRow = db
+      .select()
+      .from(channelGuardianVerificationChallenges)
+      .where(eq(channelGuardianVerificationChallenges.id, firstId))
+      .get();
     expect(firstRow).toBeDefined();
     expect(firstRow!.status).toBe('revoked');
   });
@@ -3380,7 +3390,7 @@ describe('outbound voice verification', () => {
     expect(voiceCallInitCalls.length).toBeGreaterThanOrEqual(1);
     const lastCall = voiceCallInitCalls[voiceCallInitCalls.length - 1];
     expect(lastCall.phoneNumber).toBe('+15551234567');
-    expect(lastCall.guardianVerificationSessionId).toBe(resp!.verificationSessionId);
+    expect(lastCall.guardianVerificationSessionId).toBe(resp!.verificationSessionId!);
   });
 
   test('start_outbound for voice rejects invalid E.164', () => {
@@ -3484,13 +3494,19 @@ describe('outbound voice verification', () => {
     const now = Date.now();
     for (let i = 0; i < 10; i++) {
       // Insert sessions with recent lastSentAt to simulate sends
-      const sessionId = `rate-limit-voice-${i}`;
-      db.run(
-        `INSERT INTO channel_guardian_verification_challenges
-         (id, assistant_id, channel, challenge_hash, expires_at, status, destination_address, last_sent_at, send_count)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        [sessionId, 'self', 'voice', `hash-${i}`, now + 600_000, 'awaiting_response', '+15551234567', now - 1000, 1],
-      );
+      db.insert(channelGuardianVerificationChallenges).values({
+        id: `rate-limit-voice-${i}`,
+        assistantId: 'self',
+        channel: 'voice',
+        challengeHash: `hash-${i}`,
+        expiresAt: now + 600_000,
+        status: 'awaiting_response',
+        destinationAddress: '+15551234567',
+        lastSentAt: now - 1000,
+        sendCount: 1,
+        createdAt: now,
+        updatedAt: now,
+      }).run();
     }
 
     const { ctx, lastResponse } = createMockCtx();

--- a/assistant/src/calls/types.ts
+++ b/assistant/src/calls/types.ts
@@ -1,5 +1,5 @@
 export type CallStatus = 'initiated' | 'ringing' | 'in_progress' | 'waiting_on_user' | 'completed' | 'failed' | 'cancelled';
-export type CallEventType = 'call_started' | 'call_connected' | 'caller_spoke' | 'assistant_spoke' | 'user_question_asked' | 'user_answered' | 'user_instruction_relayed' | 'call_ended' | 'call_failed' | 'callee_verification_started' | 'callee_verification_succeeded' | 'callee_verification_failed' | 'guardian_voice_verification_started' | 'guardian_voice_verification_succeeded' | 'guardian_voice_verification_failed';
+export type CallEventType = 'call_started' | 'call_connected' | 'caller_spoke' | 'assistant_spoke' | 'user_question_asked' | 'user_answered' | 'user_instruction_relayed' | 'call_ended' | 'call_failed' | 'callee_verification_started' | 'callee_verification_succeeded' | 'callee_verification_failed' | 'guardian_voice_verification_started' | 'guardian_voice_verification_succeeded' | 'guardian_voice_verification_failed' | 'outbound_guardian_voice_verification_started' | 'outbound_guardian_voice_verification_succeeded' | 'outbound_guardian_voice_verification_failed';
 export type PendingQuestionStatus = 'pending' | 'answered' | 'expired' | 'cancelled';
 
 export interface CallSession {

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -168,6 +168,21 @@ export function handleGuardianVerification(
         }
       }
       const hasPendingChallenge = getPendingChallenge(assistantId, channel) != null;
+
+      // Include active outbound session state so the UI can resume
+      // after app restart and detect bootstrap completion.
+      const activeOutboundSession = findActiveSession(assistantId, channel);
+      const outboundFields: Record<string, unknown> = {};
+      if (activeOutboundSession) {
+        outboundFields.verificationSessionId = activeOutboundSession.id;
+        outboundFields.expiresAt = activeOutboundSession.expiresAt;
+        outboundFields.nextResendAt = activeOutboundSession.nextResendAt;
+        outboundFields.sendCount = activeOutboundSession.sendCount;
+        // Note: telegramBootstrapUrl is NOT included because the plaintext
+        // token is not stored (only the hash). If the client restarts during
+        // bootstrap, the user must cancel and restart the flow.
+      }
+
       ctx.send(socket, {
         type: 'guardian_verification_response',
         success: true,
@@ -179,6 +194,7 @@ export function handleGuardianVerification(
         assistantId,
         guardianDeliveryChatId: binding?.guardianDeliveryChatId,
         hasPendingChallenge,
+        ...outboundFields,
       });
     } else if (msg.action === 'revoke') {
       revokeGuardianBinding(assistantId, channel);
@@ -616,6 +632,22 @@ function handleResendOutbound(
       channel,
     });
     return;
+  }
+
+  // Enforce per-destination rate limit on resend (same as start_outbound)
+  const resendDestination = session.destinationAddress ?? session.expectedPhoneE164 ?? session.expectedChatId;
+  if (resendDestination) {
+    const recentDestSends = countRecentSendsToDestination(channel, resendDestination, DESTINATION_RATE_WINDOW_MS);
+    if (recentDestSends >= MAX_SENDS_PER_DESTINATION_WINDOW) {
+      ctx.send(socket, {
+        type: 'guardian_verification_response',
+        success: false,
+        error: 'rate_limited',
+        message: 'Too many verification attempts to this destination. Please try again later.',
+        channel,
+      });
+      return;
+    }
   }
 
   // We need the secret to compose the resend message, but the store only

--- a/assistant/src/memory/channel-guardian-store.ts
+++ b/assistant/src/memory/channel-guardian-store.ts
@@ -8,7 +8,7 @@
  * requests track per-run guardian approval decisions.
  */
 
-import { and, count, desc, eq, gt, gte, inArray, lte, or, sum } from 'drizzle-orm';
+import { and, count, desc, eq, gt, gte, inArray, lte, or } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
 import { getDb } from './db.js';
@@ -49,7 +49,7 @@ export interface VerificationChallenge {
   channel: string;
   challengeHash: string;
   expiresAt: number;
-  status: ChallengeStatus;
+  status: SessionStatus;
   createdBySessionId: string | null;
   consumedByExternalUserId: string | null;
   consumedByChatId: string | null;
@@ -355,7 +355,7 @@ export function findPendingChallengeForChannel(
       and(
         eq(channelGuardianVerificationChallenges.assistantId, assistantId),
         eq(channelGuardianVerificationChallenges.channel, channel),
-        eq(channelGuardianVerificationChallenges.status, 'pending'),
+        inArray(channelGuardianVerificationChallenges.status, ['pending', 'pending_bootstrap', 'awaiting_response']),
         gt(channelGuardianVerificationChallenges.expiresAt, now),
       ),
     )
@@ -617,10 +617,11 @@ export function updateSessionDelivery(
 }
 
 /**
- * Count SMS sends to a specific destination across all sessions within a
- * rolling time window. Used to enforce per-destination rate limits that
- * span across sessions, preventing circumvention via repeated
- * start_outbound calls.
+ * Count actual sends to a specific destination across all sessions within a
+ * rolling time window. Uses COUNT of rows with a last_sent_at timestamp
+ * inside the window rather than SUM(send_count) to avoid double-counting
+ * cumulative session counters when resend creates new sessions that carry
+ * forward the cumulative count.
  */
 export function countRecentSendsToDestination(
   channel: string,
@@ -631,18 +632,18 @@ export function countRecentSendsToDestination(
   const cutoff = Date.now() - windowMs;
 
   const result = db
-    .select({ total: sum(channelGuardianVerificationChallenges.sendCount) })
+    .select({ total: count() })
     .from(channelGuardianVerificationChallenges)
     .where(
       and(
         eq(channelGuardianVerificationChallenges.channel, channel),
         eq(channelGuardianVerificationChallenges.destinationAddress, destinationAddress),
-        gte(channelGuardianVerificationChallenges.createdAt, cutoff),
+        gte(channelGuardianVerificationChallenges.lastSentAt, cutoff),
       ),
     )
     .get();
 
-  return result?.total != null ? Number(result.total) : 0;
+  return result?.total ?? 0;
 }
 
 /**

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -38,6 +38,7 @@ import {
 } from '../channel-approvals.js';
 import {
   createOutboundSession,
+  findActiveSession,
   getGuardianBinding,
   getPendingChallenge,
   validateAndConsumeChallenge,
@@ -221,12 +222,17 @@ export async function handleChannelInbound(
       // active guardian binding for this (assistantId, channel).
       let denyNonMember = true;
       if (isGuardianVerifyCommand) {
-        const hasActiveBinding = !!getGuardianBinding(canonicalAssistantId, sourceChannel);
+        // Allow bypass when there is any consumable challenge or active
+        // outbound session.  The !hasActiveBinding guard is intentionally
+        // omitted: rebind sessions create a consumable challenge while a
+        // binding already exists, and the identity check inside
+        // validateAndConsumeChallenge prevents unauthorized takeovers.
         const hasPendingChallenge = !!getPendingChallenge(canonicalAssistantId, sourceChannel);
-        if (!hasActiveBinding && hasPendingChallenge) {
+        const hasActiveOutboundSession = !!findActiveSession(canonicalAssistantId, sourceChannel);
+        if (hasPendingChallenge || hasActiveOutboundSession) {
           denyNonMember = false;
         } else {
-          log.info({ sourceChannel, hasActiveBinding, hasPendingChallenge }, 'Ingress ACL: guardian_verify bypass denied');
+          log.info({ sourceChannel, hasPendingChallenge, hasActiveOutboundSession }, 'Ingress ACL: guardian_verify bypass denied');
         }
       }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -45,9 +45,11 @@ struct SettingsConnectTab: View {
     // Outbound guardian verification destination input (keyed by channel)
     @State private var guardianDestinationText: [String: String] = [:]
 
-    // Countdown timer for outbound verification expiry
+    // Countdown timer for outbound verification expiry (ref-counted so
+    // closing one channel row doesn't stop the timer for remaining rows)
     @State private var countdownNow: Date = Date()
     @State private var countdownTimer: Timer?
+    @State private var countdownTimerRefCount: Int = 0
 
     // Token regeneration state
     @State private var isRegeneratingToken: Bool = false
@@ -1304,6 +1306,7 @@ struct SettingsConnectTab: View {
     // MARK: - Countdown Timer
 
     private func startCountdownTimer() {
+        countdownTimerRefCount += 1
         guard countdownTimer == nil else { return }
         countdownNow = Date()
         countdownTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
@@ -1314,6 +1317,8 @@ struct SettingsConnectTab: View {
     }
 
     private func stopCountdownTimer() {
+        countdownTimerRefCount = max(countdownTimerRefCount - 1, 0)
+        guard countdownTimerRefCount == 0 else { return }
         countdownTimer?.invalidate()
         countdownTimer = nil
     }


### PR DESCRIPTION
## Summary
Addresses feedback from Codex review and human review on PR #9081.

### P1 Fixes
- **ACL bypass for outbound sessions**: `findPendingChallengeForChannel` now matches `pending_bootstrap` and `awaiting_response` statuses (not just `pending`). Removed `!hasActiveBinding` guard from ACL bypass to support rebind flows.
- **Re-enable resend after Telegram bootstrap**: Status handler now includes active outbound session state, so status polling detects bootstrap completion and clears `bootstrapUrl` via existing `applyOutboundResponseState` logic.

### P2 Fixes
- **Destination rate limit on resend**: Added `countRecentSendsToDestination` check to `handleResendOutbound` (was only on `start_outbound`).
- **Over-counting fix**: Changed `countRecentSendsToDestination` from `SUM(send_count)` to `COUNT` of rows with `last_sent_at` in window, preventing double-counting from cumulative session counters.
- **Status handler exposes outbound session state**: Extended `status` IPC handler to return active outbound session info (`verificationSessionId`, `expiresAt`, `nextResendAt`, `sendCount`). UI survives app restart.
- **Countdown timer ref-counting**: Timer now uses reference counting so closing one verified channel row doesn't stop the timer for remaining pending rows.

### P3 Fixes
- **Architecture docs**: Fixed `verify_<token>` → `gv_<token>` prefix in ARCHITECTURE.md.
- **Type fixes**: Changed `VerificationChallenge.status` from `ChallengeStatus` to `SessionStatus` (fixes 6 pre-existing type errors). Added outbound call event types to `CallEventType`.
- **Test fixes**: Fixed 4 failing tests — updated rebind assertions to match new security behavior, replaced async drizzle query with sync API, added missing timestamp columns to raw SQL, fixed flaky zero-padded code assertion.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
