### PR TITLE
fix: use host_bash exclusively for CLI discovery skill (#9070)

### DIFF
--- a/assistant/src/config/bundled-skills/cli-discover/SKILL.md
+++ b/assistant/src/config/bundled-skills/cli-discover/SKILL.md
@@ -7,7 +7,7 @@ metadata: {"vellum": {"emoji": "🔍"}}
 
 # CLI Discovery
 
-When you need to discover what CLI tools are available on the system, use `bash` or `host_bash` to check directly.
+When you need to discover what CLI tools are available on the system, use `host_bash` to check directly. Do not use sandboxed `bash` for discovery — it may not see host-installed CLIs or auth state, leading to false negatives.
 
 ## Checking if a CLI exists
 


### PR DESCRIPTION
Addresses Codex review feedback on #9070:\n- Changed cli-discover SKILL.md to use host_bash exclusively instead of bash/host_bash, since sandboxed bash returns false negatives for CLI discovery
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
