### PR TITLE
fix: clear stale delivery errors, ack suppressed intents, handle errorCode

### DIFF
--- a/assistant/src/notifications/deliveries-store.ts
+++ b/assistant/src/notifications/deliveries-store.ts
@@ -160,10 +160,15 @@ export function updateDeliveryClientOutcome(
     updatedAt: now,
   };
 
-  if (error?.message) {
+  if (success) {
+    // Clear any stale error from previous failed attempts
+    updates.clientDeliveryError = null;
+  } else if (error?.message) {
     updates.clientDeliveryError = error.code
       ? `[${error.code}] ${error.message}`
       : error.message;
+  } else if (error?.code) {
+    updates.clientDeliveryError = error.code;
   }
 
   const result = db

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -265,6 +265,10 @@ extension AppDelegate {
             if let deliveredAt = fallbackDeliveredAtMs.removeValue(forKey: conversationId),
                nowMs - deliveredAt <= fallbackDedupWindowMs {
                 log.info("Suppressing duplicate notification_intent for conversation \(conversationId) (fallback already delivered)")
+                // Ack the suppressed intent so the delivery audit trail is complete
+                if let deliveryId = msg.deliveryId {
+                    sendNotificationIntentResult(deliveryId: deliveryId, success: true, errorMessage: nil, errorCode: nil)
+                }
                 return
             }
 


### PR DESCRIPTION
## Summary

Addresses review feedback from #9109:

- **Clear stale errors on success**: `updateDeliveryClientOutcome` now explicitly sets `clientDeliveryError = null` on successful acks, preventing stale error messages from previous failed attempts from persisting alongside a `delivered` status.
- **Ack suppressed intents**: When `deliverNotificationIntent` suppresses a `notification_intent` because a fallback was already delivered, it now sends a `notification_intent_result` ack so the delivery audit record is complete.
- **Handle errorCode without errorMessage**: Falls back to writing `errorCode` into `clientDeliveryError` when `errorMessage` is absent, preventing silent data loss.

## Test plan

- [ ] Verify `bunx tsc --noEmit` passes
- [ ] Verify `swift build` succeeds
- [ ] Manual: verify audit records are complete for both normal and fallback-suppressed notification flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
