### PR TITLE
fix: address review feedback on typescript-eval skill migration (#9069)

### DIFF
--- a/assistant/src/config/bundled-skills/typescript-eval/SKILL.md
+++ b/assistant/src/config/bundled-skills/typescript-eval/SKILL.md
@@ -7,14 +7,16 @@ metadata: {"vellum": {"emoji": "🧪"}}
 
 # TypeScript Evaluation
 
-When you need to test a TypeScript snippet before persisting it as a managed skill, use `file_write` and `bash` directly.
+When you need to test a TypeScript snippet before persisting it as a managed skill, use `bash` directly.
 
 ## Workflow
 
 ### 1. Write the snippet to a temp file
 
 ```
-file_write path=/tmp/vellum-eval/snippet.ts content="<your code here>"
+bash command="mkdir -p /tmp/vellum-eval && cat > /tmp/vellum-eval/snippet.ts << 'SNIPPET_EOF'
+<your code here>
+SNIPPET_EOF"
 ```
 
 ### 2. Run it with bun
@@ -28,12 +30,13 @@ bash command="bun run /tmp/vellum-eval/snippet.ts" timeout_seconds=10
 If the snippet exports a `default` or `run` function, write a runner script:
 
 ```
-file_write path=/tmp/vellum-eval/runner.ts content="
-import fn from './snippet.ts';
+bash command="cat > /tmp/vellum-eval/runner.ts << 'RUNNER_EOF'
+import * as mod from './snippet.ts';
+const fn = (mod as any).default ?? (mod as any).run;
 const input = {}; // mock input
 const result = await fn(input);
 console.log(JSON.stringify(result, null, 2));
-"
+RUNNER_EOF"
 ```
 
 Then run the runner:

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -667,7 +667,7 @@ function buildDynamicSkillWorkflowSection(): string {
     'When no existing tool or skill can satisfy a request:',
     '1. Validate the gap — confirm no existing tool/skill covers it.',
     '2. Draft a TypeScript snippet exporting a `default` or `run` function (`(input: unknown) => unknown | Promise<unknown>`).',
-    '3. Test the snippet by writing it to a temp file and running it with `bash command="bun run /tmp/vellum-eval/snippet.ts"`. Iterate until it passes (max 3 attempts, then ask the user). Clean up temp files after.',
+    '3. Test the snippet by writing it to a temp file with `bash` (e.g., `bash command="mkdir -p /tmp/vellum-eval && cat > /tmp/vellum-eval/snippet.ts << \'SNIPPET_EOF\'\\n...\\nSNIPPET_EOF"`) and running it with `bash command="bun run /tmp/vellum-eval/snippet.ts"`. Do not use `file_write` for temp files outside the working directory. Iterate until it passes (max 3 attempts, then ask the user). Clean up temp files after.',
     '4. Persist with `scaffold_managed_skill` only after user consent.',
     '5. Load with `skill_load` before use.',
     '',


### PR DESCRIPTION
Addresses Codex review feedback on #9069:
- P1: Replace file_write with bash for writing temp files (avoids path policy rejection)
- P2: Update runner template to handle both default and run exports
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
