### PR TITLE
fix: register phone-call tool executors in bundled-tool-registry (#9077)

### DIFF
--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -110,6 +110,10 @@ import * as messagingSearch from './bundled-skills/messaging/tools/messaging-sea
 import * as messagingSend from './bundled-skills/messaging/tools/messaging-send.js';
 // ── notifications ───────────────────────────────────────────────────────────
 import * as sendNotification from './bundled-skills/notifications/tools/send-notification.js';
+// ── phone-calls ─────────────────────────────────────────────────────────────
+import * as callEnd from './bundled-skills/phone-calls/tools/call-end.js';
+import * as callStart from './bundled-skills/phone-calls/tools/call-start.js';
+import * as callStatus from './bundled-skills/phone-calls/tools/call-status.js';
 import * as sequenceAnalytics from './bundled-skills/messaging/tools/sequence-analytics.js';
 import * as sequenceCancel from './bundled-skills/messaging/tools/sequence-cancel.js';
 import * as sequenceCreate from './bundled-skills/messaging/tools/sequence-create.js';
@@ -292,6 +296,11 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
 
   // notifications
   ['notifications:tools/send-notification.ts', sendNotification],
+
+  // phone-calls
+  ['phone-calls:tools/call-start.ts', callStart],
+  ['phone-calls:tools/call-status.ts', callStatus],
+  ['phone-calls:tools/call-end.ts', callEnd],
 
   // playbooks
   ['playbooks:tools/playbook-create.ts', playbookCreate],


### PR DESCRIPTION
Addresses Codex and Devin review feedback on #9077:\n- Added imports and registry entries for call-start, call-status, and call-end executors\n- Fixes compiled binary execution where dynamic import fallback fails
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
