### PR TITLE
M1: Shortcut Reliability + Intent Routing

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -7,6 +7,12 @@ extension Notification.Name {
     static let updateDynamicWorkspace = Notification.Name("MainWindow.updateDynamicWorkspace")
     static let dismissDynamicWorkspace = Notification.Name("MainWindow.dismissDynamicWorkspace")
     static let openDocumentEditor = Notification.Name("MainWindow.openDocumentEditor")
+
+    // Conversation zoom intents — posted by the View menu handlers,
+    // consumed by ConversationZoomManager (wired in M2).
+    static let conversationZoomIn = Notification.Name("MainWindow.conversationZoomIn")
+    static let conversationZoomOut = Notification.Name("MainWindow.conversationZoomOut")
+    static let conversationZoomReset = Notification.Name("MainWindow.conversationZoomReset")
 }
 
 /// Manages API keys in the macOS login keychain.

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -144,11 +144,16 @@ extension AppDelegate {
         case .windowZoomReset:
             zoomManager.resetZoom()
         case .conversationZoomIn:
-            // Placeholder: ConversationZoomManager will be wired in M2.
+            // Bridge: apply window zoom so the shortcut works immediately.
+            // The notification is kept so M2's ConversationZoomManager can
+            // subscribe and replace this bridge with per-conversation scaling.
+            zoomManager.zoomIn()
             NotificationCenter.default.post(name: .conversationZoomIn, object: nil)
         case .conversationZoomOut:
+            zoomManager.zoomOut()
             NotificationCenter.default.post(name: .conversationZoomOut, object: nil)
         case .conversationZoomReset:
+            zoomManager.resetZoom()
             NotificationCenter.default.post(name: .conversationZoomReset, object: nil)
         }
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -65,31 +65,117 @@ extension AppDelegate {
     func setupViewMenu() {
         guard let mainMenu = NSApp.mainMenu else { return }
 
+        // Avoid duplicate View menus on logout/re-login cycles
+        if mainMenu.indexOfItem(withTitle: "View") >= 0 { return }
+
         let viewMenu = NSMenu(title: "View")
 
-        let zoomInItem = NSMenuItem(title: "Zoom In", action: #selector(handleZoomIn), keyEquivalent: "=")
-        zoomInItem.keyEquivalentModifierMask = .command
-        zoomInItem.target = self
-        viewMenu.addItem(zoomInItem)
+        // Conversation Text Zoom: Cmd +, Cmd -, Cmd 0
+        let convZoomInItem = NSMenuItem(
+            title: "Conversation Zoom In",
+            action: #selector(handleConversationZoomIn),
+            keyEquivalent: "="
+        )
+        convZoomInItem.keyEquivalentModifierMask = .command
+        convZoomInItem.target = self
+        viewMenu.addItem(convZoomInItem)
 
-        let zoomOutItem = NSMenuItem(title: "Zoom Out", action: #selector(handleZoomOut), keyEquivalent: "-")
-        zoomOutItem.keyEquivalentModifierMask = .command
-        zoomOutItem.target = self
-        viewMenu.addItem(zoomOutItem)
+        let convZoomOutItem = NSMenuItem(
+            title: "Conversation Zoom Out",
+            action: #selector(handleConversationZoomOut),
+            keyEquivalent: "-"
+        )
+        convZoomOutItem.keyEquivalentModifierMask = .command
+        convZoomOutItem.target = self
+        viewMenu.addItem(convZoomOutItem)
 
-        let resetItem = NSMenuItem(title: "Actual Size", action: #selector(handleZoomReset), keyEquivalent: "0")
-        resetItem.keyEquivalentModifierMask = .command
-        resetItem.target = self
-        viewMenu.addItem(resetItem)
+        let convResetItem = NSMenuItem(
+            title: "Conversation Actual Size",
+            action: #selector(handleConversationZoomReset),
+            keyEquivalent: "0"
+        )
+        convResetItem.keyEquivalentModifierMask = .command
+        convResetItem.target = self
+        viewMenu.addItem(convResetItem)
+
+        viewMenu.addItem(NSMenuItem.separator())
+
+        // Window Zoom: Option+Cmd +, Option+Cmd -, Option+Cmd 0
+        let winZoomInItem = NSMenuItem(
+            title: "Window Zoom In",
+            action: #selector(handleWindowZoomIn),
+            keyEquivalent: "="
+        )
+        winZoomInItem.keyEquivalentModifierMask = [.command, .option]
+        winZoomInItem.target = self
+        viewMenu.addItem(winZoomInItem)
+
+        let winZoomOutItem = NSMenuItem(
+            title: "Window Zoom Out",
+            action: #selector(handleWindowZoomOut),
+            keyEquivalent: "-"
+        )
+        winZoomOutItem.keyEquivalentModifierMask = [.command, .option]
+        winZoomOutItem.target = self
+        viewMenu.addItem(winZoomOutItem)
+
+        let winResetItem = NSMenuItem(
+            title: "Window Actual Size",
+            action: #selector(handleWindowZoomReset),
+            keyEquivalent: "0"
+        )
+        winResetItem.keyEquivalentModifierMask = [.command, .option]
+        winResetItem.target = self
+        viewMenu.addItem(winResetItem)
 
         let viewMenuItem = NSMenuItem(title: "View", action: nil, keyEquivalent: "")
         viewMenuItem.submenu = viewMenu
         mainMenu.addItem(viewMenuItem)
     }
 
-    @objc func handleZoomIn() { zoomManager.zoomIn() }
-    @objc func handleZoomOut() { zoomManager.zoomOut() }
-    @objc func handleZoomReset() { zoomManager.resetZoom() }
+    // MARK: - Zoom Intent Routing
+
+    func routeZoomIntent(_ intent: VZoomCommandIntent) {
+        switch intent {
+        case .windowZoomIn:
+            zoomManager.zoomIn()
+        case .windowZoomOut:
+            zoomManager.zoomOut()
+        case .windowZoomReset:
+            zoomManager.resetZoom()
+        case .conversationZoomIn:
+            // Placeholder: ConversationZoomManager will be wired in M2.
+            NotificationCenter.default.post(name: .conversationZoomIn, object: nil)
+        case .conversationZoomOut:
+            NotificationCenter.default.post(name: .conversationZoomOut, object: nil)
+        case .conversationZoomReset:
+            NotificationCenter.default.post(name: .conversationZoomReset, object: nil)
+        }
+    }
+
+    @objc func handleConversationZoomIn() { routeZoomIntent(.conversationZoomIn) }
+    @objc func handleConversationZoomOut() { routeZoomIntent(.conversationZoomOut) }
+    @objc func handleConversationZoomReset() { routeZoomIntent(.conversationZoomReset) }
+    @objc func handleWindowZoomIn() { routeZoomIntent(.windowZoomIn) }
+    @objc func handleWindowZoomOut() { routeZoomIntent(.windowZoomOut) }
+    @objc func handleWindowZoomReset() { routeZoomIntent(.windowZoomReset) }
+
+    // MARK: - Menu Item Validation
+
+    /// Disables conversation zoom shortcuts when no conversation is visible,
+    /// preventing accidental side effects in non-chat panels.
+    @objc func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        guard let action = menuItem.action else { return true }
+        let conversationZoomSelectors: Set<Selector> = [
+            #selector(handleConversationZoomIn),
+            #selector(handleConversationZoomOut),
+            #selector(handleConversationZoomReset),
+        ]
+        if conversationZoomSelectors.contains(action) {
+            return mainWindow?.windowState.isConversationVisible ?? false
+        }
+        return true
+    }
 
     func configureMenuBarIcon(_ button: NSStatusBarButton) {
         let iconSize: CGFloat = 18

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -896,6 +896,17 @@ private final class ComposerNativeTextView: NSTextView {
                 return true
             }
         }
+
+        // Let zoom shortcuts propagate to the menu bar instead of being
+        // consumed by the text view. Cmd +/-/0 and Option+Cmd +/-/0 are
+        // handled by the View menu for conversation and window zoom.
+        if event.modifierFlags.contains(.command) {
+            let key = event.charactersIgnoringModifiers ?? ""
+            if key == "=" || key == "+" || key == "-" || key == "0" {
+                return false
+            }
+        }
+
         return super.performKeyEquivalent(with: event)
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -80,6 +80,17 @@ final class MainWindowState: ObservableObject {
         }
     }
 
+    /// Whether a conversation is visible — true for thread mode and
+    /// app-editing mode (which shows a chat dock alongside the app).
+    /// Used by zoom intent routing to decide whether Cmd+/- should
+    /// target conversation text zoom or fall through to window zoom.
+    var isConversationVisible: Bool {
+        switch selection {
+        case .thread, .none, .appEditing: return true
+        default: return false
+        }
+    }
+
     /// Whether the dynamic workspace (app view) is expanded.
     var isDynamicExpanded: Bool {
         get {

--- a/clients/macos/vellum-assistant/Features/MainWindow/VZoomCommandIntent.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/VZoomCommandIntent.swift
@@ -1,0 +1,17 @@
+/// Explicit zoom command intents used by the menu bar to route
+/// keyboard shortcuts to the correct zoom target.
+///
+/// Conversation zoom intents (`conversationZoomIn/Out/Reset`) are fired
+/// by `Cmd +/-/0` and target the chat message text size. They are only
+/// meaningful when a conversation is visible (thread or app-editing mode).
+///
+/// Window zoom intents (`windowZoomIn/Out/Reset`) are fired by
+/// `Option+Cmd +/-/0` and always scale the entire window content.
+enum VZoomCommandIntent {
+    case conversationZoomIn
+    case conversationZoomOut
+    case conversationZoomReset
+    case windowZoomIn
+    case windowZoomOut
+    case windowZoomReset
+}


### PR DESCRIPTION
Introduces explicit conversation vs window zoom command routing. Cmd+/- now targets conversation text zoom when chat is visible, while Option+Cmd+/- controls window zoom. Adds MainWindowState helper for conversation context detection. Part of #9123.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
