### PR TITLE
fix(chat): SubagentDetailStore truncation fix

### DIFF
--- a/clients/shared/Features/Chat/SubagentDetailStore.swift
+++ b/clients/shared/Features/Chat/SubagentDetailStore.swift
@@ -89,16 +89,21 @@ public final class SubagentDetailStore: ObservableObject {
                let last = events.last,
                case .text = last.kind {
                 var content = events[events.count - 1].content
+                // Stop accumulating once text has been capped.
+                guard content.utf8.count <= Self.textByteCap else { return }
                 content += delta.text
                 // Cap text concatenation to prevent unbounded string accumulation.
-                // Use character-based prefix to safely truncate at character boundaries.
                 if content.utf8.count > Self.textByteCap {
-                    content = "[truncated] " + String(content.prefix(Self.textByteCap))
+                    content = String(content.prefix(Self.textByteCap)) + " [truncated]"
                 }
                 events[events.count - 1].content = content
                 eventsBySubagent[subagentId] = events
             } else {
-                let item = SubagentEventItem(timestamp: Date(), kind: .text, content: delta.text)
+                var text = delta.text
+                if text.utf8.count > Self.textByteCap {
+                    text = String(text.prefix(Self.textByteCap)) + " [truncated]"
+                }
+                let item = SubagentEventItem(timestamp: Date(), kind: .text, content: text)
                 eventsBySubagent[subagentId, default: []].append(item)
                 trimEvents(for: subagentId)
             }


### PR DESCRIPTION
## Summary
Addresses review feedback from #9111:
- Stop accumulating text once capped (early return when already at textByteCap)
- Move truncation marker to suffix instead of prefix to prevent corruption
- Apply text cap to initial chunk creation, not just appends

Part of #9096
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
