### PR TITLE
fix(chat): scroll throttle + terminal subagent chip optimization

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -344,12 +344,21 @@ struct MessageListView: View {
             }
             .onChange(of: streamingScrollTrigger) {
                 if isNearBottom {
-                    scrollDebounceTask?.cancel()
-                    scrollDebounceTask = Task {
-                        try? await Task.sleep(nanoseconds: 200_000_000)
-                        guard !Task.isCancelled else { return }
-                        withAnimation(VAnimation.fast) {
-                            proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                    // Throttle pattern: fire immediately then suppress for 200ms.
+                    // Unlike debounce (cancel+recreate), this guarantees scrolls
+                    // execute during active streaming, not only after the last token.
+                    if scrollDebounceTask == nil {
+                        scrollDebounceTask = Task {
+                            // Re-check after the sleep — user may have scrolled away.
+                            guard isNearBottom else {
+                                scrollDebounceTask = nil
+                                return
+                            }
+                            withAnimation(VAnimation.fast) {
+                                proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                            }
+                            try? await Task.sleep(nanoseconds: 200_000_000)
+                            scrollDebounceTask = nil
                         }
                     }
                 }

--- a/clients/shared/Features/Chat/SubagentStatusChip.swift
+++ b/clients/shared/Features/Chat/SubagentStatusChip.swift
@@ -29,61 +29,69 @@ public struct SubagentStatusChip: View {
     }
 
     public var body: some View {
-        TimelineView(.periodic(every: 0.4)) { context in
-            let phase = !subagent.isTerminal ? Int(context.date.timeIntervalSince1970 / 0.4) % 3 : 0
-            HStack(spacing: VSpacing.sm) {
-                Image(systemName: statusIcon)
-                    .font(.system(size: 11))
-                    .foregroundColor(statusColor)
+        if subagent.isTerminal {
+            chipContent(phase: 0)
+        } else {
+            TimelineView(.periodic(every: 0.4)) { context in
+                chipContent(phase: Int(context.date.timeIntervalSince1970 / 0.4) % 3)
+            }
+        }
+    }
 
-                VStack(alignment: .leading, spacing: 1) {
-                    HStack(spacing: VSpacing.xs) {
-                        Text(subagent.label)
-                            .font(VFont.captionMedium)
-                            .foregroundColor(VColor.textPrimary)
+    @ViewBuilder
+    private func chipContent(phase: Int) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            Image(systemName: statusIcon)
+                .font(.system(size: 11))
+                .foregroundColor(statusColor)
 
-                        if !subagent.isTerminal {
-                            // Animated dots
-                            HStack(spacing: 2) {
-                                ForEach(0..<3, id: \.self) { index in
-                                    Circle()
-                                        .fill(VColor.textSecondary)
-                                        .frame(width: 4, height: 4)
-                                        .opacity(phase % 3 == index ? 1.0 : 0.3)
-                                }
+            VStack(alignment: .leading, spacing: 1) {
+                HStack(spacing: VSpacing.xs) {
+                    Text(subagent.label)
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textPrimary)
+
+                    if !subagent.isTerminal {
+                        // Animated dots
+                        HStack(spacing: 2) {
+                            ForEach(0..<3, id: \.self) { index in
+                                Circle()
+                                    .fill(VColor.textSecondary)
+                                    .frame(width: 4, height: 4)
+                                    .opacity(phase % 3 == index ? 1.0 : 0.3)
                             }
                         }
                     }
-
-                    if let error = subagent.error, !error.isEmpty {
-                        Text(error)
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.error)
-                            .lineLimit(2)
-                    }
                 }
 
-                Spacer()
-
-                if !subagent.isTerminal, let onAbort {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 9, weight: .bold))
-                        .foregroundColor(VColor.textMuted)
-                        .padding(VSpacing.xs)
-                        .contentShape(Rectangle())
-                        .highPriorityGesture(TapGesture().onEnded { onAbort() })
-                        .accessibilityAddTraits(.isButton)
-                        .accessibilityLabel("Abort subagent")
+                if let error = subagent.error, !error.isEmpty {
+                    Text(error)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.error)
+                        .lineLimit(2)
                 }
             }
-            .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, VSpacing.xs)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .fill(VColor.backgroundSubtle.opacity(0.3))
-            )
-            .contentShape(Rectangle())
-            .onTapGesture { onTap?() }
+
+            Spacer()
+
+            if !subagent.isTerminal, let onAbort {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundColor(VColor.textMuted)
+                    .padding(VSpacing.xs)
+                    .contentShape(Rectangle())
+                    .highPriorityGesture(TapGesture().onEnded { onAbort() })
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityLabel("Abort subagent")
+            }
         }
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.backgroundSubtle.opacity(0.3))
+        )
+        .contentShape(Rectangle())
+        .onTapGesture { onTap?() }
     }
 }


### PR DESCRIPTION
## Summary
Addresses review feedback from #9110:
- Change streaming scroll from debounce to throttle pattern so scroll fires during active streaming
- Re-check isNearBottom before scrolling after delay
- Only use TimelineView for running subagent chips; terminal chips render static content

Part of #9096
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
