### PR TITLE
fix(chat): refinement flush throttle pattern

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -501,12 +501,16 @@ extension ChatViewModel {
                 refinementTextBuffer += delta.text
                 // Throttle refinement streaming updates with 50ms coalescing
                 // to prevent republishing the entire accumulated buffer on
-                // every single token (same pattern as message streaming flush).
-                refinementFlushTask?.cancel()
-                refinementFlushTask = Task { @MainActor [weak self] in
-                    try? await Task.sleep(nanoseconds: 50_000_000)
-                    guard !Task.isCancelled, let self else { return }
-                    self.refinementStreamingText = self.refinementTextBuffer
+                // every single token (same guard-based throttle pattern as
+                // scheduleStreamingFlush — not debounce, so flushes fire
+                // during streaming even when tokens arrive faster than 50ms).
+                if refinementFlushTask == nil {
+                    refinementFlushTask = Task { @MainActor [weak self] in
+                        try? await Task.sleep(nanoseconds: 50_000_000)
+                        guard !Task.isCancelled, let self else { return }
+                        self.refinementFlushTask = nil
+                        self.refinementStreamingText = self.refinementTextBuffer
+                    }
                 }
                 return
             }


### PR DESCRIPTION
## Summary
Addresses review feedback from #9121:
- Change refinement streaming flush from debounce (cancel+recreate) to throttle (guard-based) pattern
- Matches the existing scheduleStreamingFlush() pattern so UI updates every 50ms during streaming

Part of #9096
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
