### PR TITLE
fix(chat): SurfaceRef reopen + attachment data preservation + dataLength fix

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -767,10 +767,12 @@ struct MainWindowView: View {
             } else if let ref = notification.userInfo?["surfaceRef"] as? SurfaceRef {
                 // Lightweight ref from inline surface click — the daemon will
                 // send a fresh ui_surface_show via live IPC with the full payload.
-                // Open by surfaceId to trigger the workspace view.
-                windowState.selection = .app(ref.surfaceId)
-                // Request the daemon to re-show the surface
-                try? daemonClient.sendAppOpen(appId: ref.surfaceId)
+                // Use the real appId for the app_open_request when available,
+                // because surfaceId is a daemon-generated identifier
+                // (e.g. "app-open-<uuid>") that doesn't match any real app.
+                let reopenId = ref.appId ?? ref.surfaceId
+                windowState.selection = .app(reopenId)
+                try? daemonClient.sendAppOpen(appId: reopenId)
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .openDocumentEditor)) { notification in

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -978,20 +978,31 @@ public struct SurfaceRef: Equatable {
     public let sessionId: String
     public let surfaceType: String
     public let title: String?
+    /// The real app ID from DynamicPageSurfaceData. Used for app_open_request
+    /// because surfaceId is a daemon-generated identifier (e.g. "app-open-<uuid>")
+    /// that doesn't match any real app.
+    public let appId: String?
 
-    public init(surfaceId: String, sessionId: String, surfaceType: String, title: String?) {
+    public init(surfaceId: String, sessionId: String, surfaceType: String, title: String?, appId: String? = nil) {
         self.surfaceId = surfaceId
         self.sessionId = sessionId
         self.surfaceType = surfaceType
         self.title = title
+        self.appId = appId
     }
 
-    /// Build from a UiSurfaceShowMessage, discarding the heavy data payload.
-    public init(from msg: UiSurfaceShowMessage) {
+    /// Build from a UiSurfaceShowMessage + parsed Surface, discarding the heavy data payload.
+    /// Extracts appId from DynamicPageSurfaceData when available.
+    public init(from msg: UiSurfaceShowMessage, surface: Surface? = nil) {
         self.surfaceId = msg.surfaceId
         self.sessionId = msg.sessionId
         self.surfaceType = msg.surfaceType
         self.title = msg.title
+        if let surface, case .dynamicPage(let dpData) = surface.data {
+            self.appId = dpData.appId
+        } else {
+            self.appId = nil
+        }
     }
 }
 
@@ -1056,7 +1067,8 @@ public struct ChatAttachment: Identifiable {
     /// Pre-computed length of `data` to avoid O(n) String.count during rendering.
     /// Swift's String.count iterates the entire string to count grapheme clusters,
     /// which is expensive for multi-MB base64 strings on every SwiftUI render pass.
-    public let dataLength: Int
+    /// Mutable so it can be zeroed when `data` is cleared for lazy-loadable attachments.
+    public var dataLength: Int
     /// Original file size in bytes. Non-nil when `data` is empty because the
     /// attachment was too large to inline in the history response.
     public let sizeBytes: Int?
@@ -1239,6 +1251,7 @@ public struct ChatMessage: Identifiable {
         }
         for i in attachments.indices {
             attachments[i].data = ""
+            attachments[i].dataLength = 0
         }
         for i in inlineSurfaces.indices {
             if inlineSurfaces[i].completionState != nil {

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -644,12 +644,17 @@ extension ChatViewModel {
             currentAssistantHasText = false
             lastContentWasToolCall = false
             // Reset processing messages to sent and drop attachment base64 data
-            // since the daemon has persisted it at this point.
+            // for lazy-loadable attachments (sizeBytes != nil means the daemon can
+            // re-serve them). Locally-added attachments (sizeBytes == nil) keep their
+            // data because openImageInPreview / saveFileAttachment rely on it.
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {
                     messages[i].status = .sent
                     for j in messages[i].attachments.indices {
-                        messages[i].attachments[j].data = ""
+                        if messages[i].attachments[j].sizeBytes != nil {
+                            messages[i].attachments[j].data = ""
+                            messages[i].attachments[j].dataLength = 0
+                        }
                     }
                 }
             }
@@ -1156,7 +1161,7 @@ extension ChatViewModel {
                 title: surface.title,
                 data: surface.data,
                 actions: surface.actions,
-                surfaceRef: SurfaceRef(from: msg)
+                surfaceRef: SurfaceRef(from: msg, surface: surface)
             )
 
             // If messageId is provided, attach to that specific message (rarely used now that

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1671,11 +1671,20 @@ public final class ChatViewModel: ObservableObject {
                         // clickable after the app restarts (history restore).
                         // The full UiSurfaceShowMessage is not retained to avoid
                         // keeping entire HTML payloads in memory.
+                        // Extract appId from DynamicPageSurfaceData so the
+                        // ref can re-open the real app via app_open_request.
+                        let appId: String? = {
+                            if case .dynamicPage(let dpData) = surface.data {
+                                return dpData.appId
+                            }
+                            return nil
+                        }()
                         let ref = SurfaceRef(
                             surfaceId: surf.surfaceId,
                             sessionId: sessionId,
                             surfaceType: surf.surfaceType,
-                            title: surf.title
+                            title: surf.title,
+                            appId: appId
                         )
                         let inlineSurface = InlineSurfaceData(
                             id: surface.id,


### PR DESCRIPTION
## Summary
Addresses review feedback from #9113:
- Store appId in SurfaceRef and use it for app_open_request instead of surfaceId
- Only clear attachment data for lazy-loadable attachments (sizeBytes != nil), preserving data needed for openImageInPreview/saveFileAttachment
- Make dataLength var and clear it when data is cleared

Part of #9096
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
