### PR TITLE
fix: restore session eviction note in dynamic skill workflow prompt (#9130)

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -672,6 +672,7 @@ function buildDynamicSkillWorkflowSection(): string {
     '5. Load with `skill_load` before use.',
     '',
     '**Never persist or delete skills without explicit user confirmation.** To remove: `delete_managed_skill`.',
+    'After a skill is written or deleted, the next turn may run in a recreated session due to file-watcher eviction. Continue normally.',
     '',
     '### Browser Skill Prerequisite',
     'If you need browser capabilities (navigating web pages, clicking elements, extracting content) and `browser_*` tools are not available, load the "browser" skill first using `skill_load`.',


### PR DESCRIPTION
Addresses Devin review feedback on #9130:\n- Re-added the 'recreated session' eviction note that was accidentally dropped during the typescript-eval skill migration rewrite\n- Fixes failing test assertion in dynamic-skill-workflow-prompt.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
