### PR TITLE
fix(settings): guard partial outbound response fields and fix countdown timer lifecycle

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1236,19 +1236,20 @@ public final class SettingsStore: ObservableObject {
 
     private func applyOutboundResponseState(channel: String, response: GuardianVerificationResponseMessage) {
         let sessionId = response.verificationSessionId
-        // Only convert expiresAt when the response includes it; resend success payloads
-        // omit expiresAt, and overwriting with nil would lose countdown tracking.
+        // Only update fields when the response includes them; partial payloads (e.g. resend
+        // success) omit fields like expiresAt, sendCount, and nextResendAt. Overwriting with
+        // nil/zero would lose countdown tracking and UI state.
         let expiresAt = response.expiresAt.map { Date(timeIntervalSince1970: TimeInterval($0) / 1000.0) }
         let nextResendAt = response.nextResendAt.map { Date(timeIntervalSince1970: TimeInterval($0) / 1000.0) }
-        let sendCount = response.sendCount ?? 0
+        let sendCount = response.sendCount
         let bootstrapUrl = response.telegramBootstrapUrl
 
         switch channel {
         case "telegram":
             telegramOutboundSessionId = sessionId
             if let expiresAt { telegramOutboundExpiresAt = expiresAt }
-            telegramOutboundNextResendAt = nextResendAt
-            telegramOutboundSendCount = sendCount
+            if let nextResendAt { telegramOutboundNextResendAt = nextResendAt }
+            if let sendCount { telegramOutboundSendCount = sendCount }
             if let bootstrapUrl {
                 telegramBootstrapUrl = bootstrapUrl
             } else if sessionId != nil {
@@ -1258,13 +1259,13 @@ public final class SettingsStore: ObservableObject {
         case "sms":
             smsOutboundSessionId = sessionId
             if let expiresAt { smsOutboundExpiresAt = expiresAt }
-            smsOutboundNextResendAt = nextResendAt
-            smsOutboundSendCount = sendCount
+            if let nextResendAt { smsOutboundNextResendAt = nextResendAt }
+            if let sendCount { smsOutboundSendCount = sendCount }
         case "voice":
             voiceOutboundSessionId = sessionId
             if let expiresAt { voiceOutboundExpiresAt = expiresAt }
-            voiceOutboundNextResendAt = nextResendAt
-            voiceOutboundSendCount = sendCount
+            if let nextResendAt { voiceOutboundNextResendAt = nextResendAt }
+            if let sendCount { voiceOutboundSendCount = sendCount }
         default:
             break
         }


### PR DESCRIPTION
## Summary
- Guard sendCount, nextResendAt, and telegramBootstrapUrl with if-let on partial outbound responses
- Disable resend button for pending_bootstrap sessions
- Fix shared countdown timer invalidation across multiple pending rows

Addresses review feedback from #9075
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
