### PR TITLE
fix(chat): add trailing-edge scroll to streaming throttle

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -359,6 +359,12 @@ struct MessageListView: View {
                             }
                             try? await Task.sleep(nanoseconds: 200_000_000)
                             scrollDebounceTask = nil
+                            // Trailing edge: content may have changed during cooldown.
+                            if isNearBottom {
+                                withAnimation(VAnimation.fast) {
+                                    proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Adds a trailing-edge scroll after the 200ms throttle cooldown expires, ensuring the final streaming content is scrolled into view even if tokens stopped during the suppression window.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
