### PR TITLE
fix(memory): ensure unique index on memory_embeddings for ON CONFLICT upserts

### DIFF
--- a/assistant/src/memory/migrations/104-core-indexes.ts
+++ b/assistant/src/memory/migrations/104-core-indexes.ts
@@ -54,10 +54,12 @@ export function createCoreIndexes(database: DrizzleDb): void {
   }
   database.run(/*sql*/ `DROP INDEX IF EXISTS idx_memory_embeddings_target`);
   database.run(/*sql*/ `DROP INDEX IF EXISTS idx_memory_embeddings_provider_model`);
-  // The table-level UNIQUE(target_type, target_id, provider, model) in 100-core-tables.ts already
-  // creates an autoindex that SQLite uses for ON CONFLICT upserts. Drop the explicit index if a
-  // previous run of this migration created it, to avoid a duplicate B-tree.
-  database.run(/*sql*/ `DROP INDEX IF EXISTS idx_memory_embeddings_target_provider_model`);
+  // Ensure a unique constraint exists on (target_type, target_id, provider, model).
+  // New databases get this via the table-level UNIQUE in 100-core-tables.ts (autoindex),
+  // but for pre-100 databases where CREATE TABLE IF NOT EXISTS was a no-op, the autoindex
+  // doesn't exist. Always create the named index — it's a no-op if it already exists and
+  // harmless if an autoindex also covers these columns.
+  database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_embeddings_target_provider_model ON memory_embeddings(target_type, target_id, provider, model)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_content_hash ON memory_embeddings(content_hash, provider, model)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_jobs_status_run_after ON memory_jobs(status, run_after)`);
   database.run(/*sql*/ `


### PR DESCRIPTION
## Summary
- Migration 104 dropped the named unique index on `memory_embeddings` assuming the table-level UNIQUE constraint from migration 100 would provide an autoindex
- But `CREATE TABLE IF NOT EXISTS` in migration 100 is a no-op for pre-existing databases, so the autoindex was never created
- Replace `DROP INDEX IF EXISTS` with `CREATE UNIQUE INDEX IF NOT EXISTS` to guarantee the constraint exists regardless of migration path

## Original prompt
fix this: {"level":40,"time":1772055289253,"pid":54350,"hostname":"MacBook-Pro-4.local","module":"memory-jobs-worker","err":{"name":"SQLiteError","message":"ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint","stack":"SQLiteError: ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint\n    at prepare (unknown)\n    at prepare (bun:sqlite:331:37)\n    at prepareQuery (/Users/sidd/vocify/vellum-assistant/assistant/node_modules/drizzle-orm/bun-sqlite/session.js:20:30)\n    at run (/Users/sidd/vocify/vellum-assistant/assistant/node_modules/drizzle-orm/sqlite-core/query-builders/insert.js:152:17)\n    at embedAndUpsert (/Users/sidd/vocify/vellum-assistant/assistant/src/memory/job-utils.ts:203:8)\n    at async embedItemJob (/Users/sidd/vocify/vellum-assistant/assistant/src/memory/job-handlers/embedding.ts:37:9)\n    at async processJob (/Users/sidd/vocify/vellum-assistant/assistant/src/memory/jobs-worker.ts:206:13)\n    at async <anonymous> (/Users/sidd/vocify/vellum-assistant/assistant/src/memory/jobs-worker.ts:121:15)\n    at processTicksAndRejections (native:7:39)","errno":1,"byteOffset":-1},"targetType":"item","targetId":"4e70e168-a59b-4571-abb0-a0908284bf01","msg":"Failed to write embedding cache"}

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
