### PR TITLE
fix(chat): reconnect snapshot guard + latch timeout cleanup + post-reconnect message preservation

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -495,7 +495,12 @@ public final class ChatViewModel: ObservableObject {
                 // Snapshot pendingMessageIds before clearing so the debounced
                 // reconnect catch-up (which fires 500ms later) can still dedup
                 // local messages that were pending when the connection dropped.
-                self?.reconnectPendingSnapshot = self?.pendingMessageIds ?? []
+                // Only take a new snapshot if no debounce task is in flight —
+                // a rapid second reconnect must not overwrite the snapshot to
+                // empty while the first debounce is still pending.
+                if self?.reconnectDebounceTask == nil {
+                    self?.reconnectPendingSnapshot = self?.pendingMessageIds ?? []
+                }
                 self?.pendingQueuedCount = 0
                 self?.pendingMessageIds.removeAll()
                 self?.requestIdToMessageId.removeAll()
@@ -534,6 +539,8 @@ public final class ChatViewModel: ObservableObject {
                                 guard !Task.isCancelled, let self, self.isReconnectHistoryLoading else { return }
                                 log.warning("Reconnect history latch timed out after 10s — resetting")
                                 self.isReconnectHistoryLoading = false
+                                self.needsReconnectCatchUp = false
+                                self.reconnectPendingSnapshot = []
                             }
                             self.onReconnectHistoryNeeded?(sessionId)
                         }
@@ -1866,13 +1873,16 @@ public final class ChatViewModel: ObservableObject {
             // simple ID-based dedup won't work — use fuzzy matching instead
             // (role + text prefix + timestamp ±2s).
             needsReconnectCatchUp = false
-            // Use the snapshot captured at reconnect time — the live
-            // pendingMessageIds was already cleared when the reconnect
-            // observer fired, before this debounced handler ran.
+            // Use the snapshot captured at reconnect time, unioned with the
+            // current pendingMessageIds. The snapshot has IDs that were pending
+            // when the connection dropped (before clearing), while current
+            // pendingMessageIds captures any messages the user sent AFTER the
+            // reconnect but BEFORE this debounced handler ran.
             let snapshotIds = self.reconnectPendingSnapshot
+            let allPendingIds = Set(snapshotIds).union(self.pendingMessageIds)
             self.reconnectPendingSnapshot = []
             let localCandidates = self.messages.filter {
-                snapshotIds.contains($0.id) || $0.status == .pendingOffline
+                allPendingIds.contains($0.id) || $0.status == .pendingOffline
             }
             var localOnly: [ChatMessage] = []
             for local in localCandidates {


### PR DESCRIPTION
## Summary
Fixes 3 issues in reconnect history handling in ChatViewModel:

1. **Guard snapshot assignment behind debounce-in-flight check** — `reconnectPendingSnapshot` was assigned unconditionally at the top of the reconnect observer. A rapid second reconnect would overwrite it to empty while the first debounce task was still in flight. Now only takes a new snapshot when `reconnectDebounceTask == nil`.

2. **Reset `needsReconnectCatchUp` and clear snapshot in latch timeout handler** — When the 10-second `reconnectLatchTimeoutTask` fires, it reset `isReconnectHistoryLoading` but left `needsReconnectCatchUp = true` and the stale snapshot in place. If history never arrived, the next `populateFromHistory` call (possibly a normal session restore) would incorrectly use the reconnect catch-up branch. Now clears both flags.

3. **Union snapshot with current `pendingMessageIds` in catch-up merge** — Messages sent after the reconnect but before the debounced history response arrives were being dropped because they existed in `pendingMessageIds` but not in the snapshot (which was captured at reconnect time). Now unions both sets to preserve all pending messages.

## Files Changed
- `clients/shared/Features/Chat/ChatViewModel.swift` — All three fixes in the reconnect observer, latch timeout handler, and `populateFromHistory` method.

## Testing
- Verify reconnect history catch-up still works correctly for normal single-reconnect scenarios
- Verify rapid-fire reconnects don't lose the pending message snapshot
- Verify that if history never arrives (latch timeout), subsequent session restores work normally
- Verify messages sent during the 500ms debounce window after reconnect are preserved
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
