### PR TITLE
fix: address review feedback on guardian verification (#9081)

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -88,6 +88,17 @@ function isTelegramChatId(destination: string): boolean {
 }
 
 /**
+ * Normalize a Telegram destination for consistent rate-limit lookups.
+ * Strips leading '@' and lowercases handles so that "@Username" and
+ * "@username" count against the same per-destination rate window.
+ * Numeric chat IDs are returned as-is.
+ */
+function normalizeTelegramDestination(destination: string): string {
+  if (isTelegramChatId(destination)) return destination;
+  return destination.replace(/^@/, '').toLowerCase();
+}
+
+/**
  * Get the Telegram bot username from credential metadata.
  * Falls back to process.env.TELEGRAM_BOT_USERNAME.
  */
@@ -178,9 +189,14 @@ export function handleGuardianVerification(
         outboundFields.expiresAt = activeOutboundSession.expiresAt;
         outboundFields.nextResendAt = activeOutboundSession.nextResendAt;
         outboundFields.sendCount = activeOutboundSession.sendCount;
-        // Note: telegramBootstrapUrl is NOT included because the plaintext
-        // token is not stored (only the hash). If the client restarts during
-        // bootstrap, the user must cancel and restart the flow.
+        // Signal to the client that the session is still in pending_bootstrap
+        // state so it does not clear the bootstrap URL during status polling.
+        // The plaintext token is NOT stored (only the hash), so the URL
+        // itself cannot be reconstructed; the client must preserve whatever
+        // URL it received from the initial start_outbound response.
+        if (activeOutboundSession.status === 'pending_bootstrap') {
+          outboundFields.pendingBootstrap = true;
+        }
       }
 
       ctx.send(socket, {
@@ -389,8 +405,13 @@ function handleStartOutboundTelegram(
     return;
   }
 
+  // Normalize destination for consistent rate-limit lookups. Strips
+  // leading '@' and lowercases handles so "@User" and "@user" share a
+  // single per-destination counter.
+  const normalizedDestination = normalizeTelegramDestination(destination);
+
   // Enforce per-destination rate limit across all sessions
-  const recentSendCount = countRecentSendsToDestination(channel, destination, DESTINATION_RATE_WINDOW_MS);
+  const recentSendCount = countRecentSendsToDestination(channel, normalizedDestination, DESTINATION_RATE_WINDOW_MS);
   if (recentSendCount >= MAX_SENDS_PER_DESTINATION_WINDOW) {
     ctx.send(socket, {
       type: 'guardian_verification_response',
@@ -422,7 +443,7 @@ function handleStartOutboundTelegram(
       channel,
       expectedChatId: destination,
       identityBindingStatus: 'bound',
-      destinationAddress: destination,
+      destinationAddress: normalizedDestination,
     });
 
     const telegramBody = composeVerificationTelegram(
@@ -473,7 +494,7 @@ function handleStartOutboundTelegram(
       assistantId,
       channel,
       identityBindingStatus: 'pending_bootstrap',
-      destinationAddress: destination,
+      destinationAddress: normalizedDestination,
       bootstrapTokenHash,
     });
 

--- a/assistant/src/daemon/ipc-contract/integrations.ts
+++ b/assistant/src/daemon/ipc-contract/integrations.ts
@@ -272,6 +272,8 @@ export interface GuardianVerificationResponse {
   sendCount?: number;
   /** Telegram deep-link URL for bootstrap (M3 placeholder). */
   telegramBootstrapUrl?: string;
+  /** True when the outbound session is still in pending_bootstrap state (Telegram handle flow). Prevents the client from clearing the bootstrap URL during status polling. */
+  pendingBootstrap?: boolean;
 }
 
 export interface TwitterAuthResult {

--- a/assistant/src/memory/channel-guardian-store.ts
+++ b/assistant/src/memory/channel-guardian-store.ts
@@ -120,7 +120,7 @@ function rowToChallenge(row: typeof channelGuardianVerificationChallenges.$infer
     channel: row.channel,
     challengeHash: row.challengeHash,
     expiresAt: row.expiresAt,
-    status: row.status as ChallengeStatus,
+    status: row.status as SessionStatus,
     createdBySessionId: row.createdBySessionId,
     consumedByExternalUserId: row.consumedByExternalUserId,
     consumedByChatId: row.consumedByChatId,
@@ -340,8 +340,12 @@ export function findPendingChallengeByHash(
 }
 
 /**
- * Find any pending (non-expired) challenge for a given (assistantId, channel).
- * Used by relay setup to detect whether a voice verification session is active.
+ * Find any pending inbound (non-expired) challenge for a given (assistantId, channel).
+ * Scoped to 'pending' status only — this is the inbound verification path used by
+ * the relay-server to gate incoming voice calls. Outbound session states
+ * (pending_bootstrap, awaiting_response) are excluded so that an active outbound
+ * verification does not inadvertently force unrelated inbound callers into the
+ * guardian verification flow.
  */
 export function findPendingChallengeForChannel(
   assistantId: string,
@@ -357,7 +361,7 @@ export function findPendingChallengeForChannel(
       and(
         eq(channelGuardianVerificationChallenges.assistantId, assistantId),
         eq(channelGuardianVerificationChallenges.channel, channel),
-        inArray(channelGuardianVerificationChallenges.status, ['pending', 'pending_bootstrap', 'awaiting_response']),
+        eq(channelGuardianVerificationChallenges.status, 'pending'),
         gt(channelGuardianVerificationChallenges.expiresAt, now),
       ),
     )

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1251,6 +1251,11 @@ public final class SettingsStore: ObservableObject {
             telegramOutboundSendCount = sendCount
             if let bootstrapUrl {
                 telegramBootstrapUrl = bootstrapUrl
+            } else if response.pendingBootstrap == true {
+                // Session is still in pending_bootstrap state — preserve the
+                // existing bootstrap URL so the deep link stays visible. The
+                // status handler cannot reconstruct the URL (only the hash is
+                // stored), so we must not overwrite what we received earlier.
             } else if sessionId != nil {
                 // Bootstrap complete — clear the URL so resend becomes available
                 telegramBootstrapUrl = nil

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1948,8 +1948,10 @@ public struct IPCGuardianVerificationResponse: Codable, Sendable {
     public let sendCount: Int?
     /// Telegram deep-link URL for bootstrap (M3 placeholder).
     public let telegramBootstrapUrl: String?
+    /// True when the outbound session is still in pending_bootstrap state (Telegram handle flow). Prevents the client from clearing the bootstrap URL during status polling.
+    public let pendingBootstrap: Bool?
 
-    public init(type: String, success: Bool, secret: String? = nil, instruction: String? = nil, bound: Bool? = nil, guardianExternalUserId: String? = nil, channel: String? = nil, assistantId: String? = nil, guardianDeliveryChatId: String? = nil, guardianUsername: String? = nil, guardianDisplayName: String? = nil, hasPendingChallenge: Bool? = nil, error: String? = nil, message: String? = nil, verificationSessionId: String? = nil, expiresAt: Int? = nil, nextResendAt: Int? = nil, sendCount: Int? = nil, telegramBootstrapUrl: String? = nil) {
+    public init(type: String, success: Bool, secret: String? = nil, instruction: String? = nil, bound: Bool? = nil, guardianExternalUserId: String? = nil, channel: String? = nil, assistantId: String? = nil, guardianDeliveryChatId: String? = nil, guardianUsername: String? = nil, guardianDisplayName: String? = nil, hasPendingChallenge: Bool? = nil, error: String? = nil, message: String? = nil, verificationSessionId: String? = nil, expiresAt: Int? = nil, nextResendAt: Int? = nil, sendCount: Int? = nil, telegramBootstrapUrl: String? = nil, pendingBootstrap: Bool? = nil) {
         self.type = type
         self.success = success
         self.secret = secret
@@ -1969,6 +1971,7 @@ public struct IPCGuardianVerificationResponse: Codable, Sendable {
         self.nextResendAt = nextResendAt
         self.sendCount = sendCount
         self.telegramBootstrapUrl = telegramBootstrapUrl
+        self.pendingBootstrap = pendingBootstrap
     }
 }
 


### PR DESCRIPTION
## Summary

Addresses remaining unresolved review feedback from #9081 (and follow-up PRs #9093, #9122):

- **Fix `rowToChallenge` type cast**: Changed `as ChallengeStatus` to `as SessionStatus` in `channel-guardian-store.ts` so the type assertion matches the actual `VerificationChallenge.status` field type, preventing silent type mismatches in exhaustive checks.
- **Scope `findPendingChallengeForChannel` to inbound-only**: Restricted the query to `pending` status only (excluding `pending_bootstrap` and `awaiting_response`), preventing active outbound voice verification sessions from incorrectly forcing unrelated inbound callers into guardian verification.
- **Normalize Telegram destination for rate-limit consistency**: Added `normalizeTelegramDestination()` that strips leading `@` and lowercases handles, ensuring `@Username` and `@username` count against the same per-destination rate window. Applied to both the rate-limit lookup and `destinationAddress` storage.
- **Preserve bootstrap URL during status polling**: Added `pendingBootstrap` flag to the IPC contract and status response. The macOS client now preserves the existing bootstrap URL when the daemon signals the session is still in `pending_bootstrap` state, instead of clearing it on the first status poll (which would leave users without the deep link).

Addresses review feedback from #9081
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
