### PR TITLE
M2: Canonicalize guardian dispatch to notification pipeline

### DIFF
--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -3,18 +3,17 @@
  *
  * When a call controller detects ASK_GUARDIAN, this module:
  * 1. Creates a guardian_action_request
- * 2. Routes through the generic notification pipeline (emitNotificationSignal)
- * 3. Records guardian_action_delivery rows from pipeline delivery results
+ * 2. Routes through the canonical notification pipeline (emitNotificationSignal)
+ *
+ * All per-channel delivery (vellum, telegram, sms) is handled by the
+ * notification pipeline's adapters and broadcaster — no parallel delivery
+ * logic lives here.
  */
 
-import { getActiveBinding } from '../memory/channel-guardian-store.js';
 import {
-  createGuardianActionDelivery,
   createGuardianActionRequest,
-  updateDeliveryStatus,
 } from '../memory/guardian-action-store.js';
 import { emitNotificationSignal } from '../notifications/emit-signal.js';
-import type { NotificationDeliveryResult } from '../notifications/types.js';
 import { getLogger } from '../util/logger.js';
 import { getUserConsultationTimeoutMs } from './call-constants.js';
 import type { CallPendingQuestion } from './types.js';
@@ -28,18 +27,9 @@ export interface GuardianDispatchParams {
   pendingQuestion: CallPendingQuestion;
 }
 
-function applyDeliveryStatus(deliveryId: string, result: NotificationDeliveryResult): void {
-  if (result.status === 'sent') {
-    updateDeliveryStatus(deliveryId, 'sent');
-    return;
-  }
-  const errorMessage = result.errorMessage ?? `Notification delivery status: ${result.status}`;
-  updateDeliveryStatus(deliveryId, 'failed', errorMessage);
-}
-
 /**
  * Dispatch a guardian action request to all configured channels.
- * Fire-and-forget: errors are logged but do not propagate.
+ * Delivery is handled entirely by the canonical notification pipeline.
  */
 export async function dispatchGuardianQuestion(params: GuardianDispatchParams): Promise<void> {
   const {
@@ -52,7 +42,7 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
   try {
     const expiresAt = Date.now() + getUserConsultationTimeoutMs();
 
-    // Create the action request
+    // Create the action request record
     const request = createGuardianActionRequest({
       assistantId,
       kind: 'ask_guardian',
@@ -69,9 +59,9 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
       'Created guardian action request',
     );
 
-    // Route through the generic notification pipeline. The paired vellum
-    // conversation from this pipeline is the canonical guardian thread.
-    let vellumDeliveryId: string | null = null;
+    // Route through the canonical notification pipeline. The pipeline's
+    // adapters handle all per-channel delivery (vellum, telegram, etc.)
+    // and the broadcaster records delivery audit rows.
     const signalResult = await emitNotificationSignal({
       sourceEventName: 'guardian.question',
       sourceChannel: 'voice',
@@ -92,61 +82,12 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
         pendingQuestionId: pendingQuestion.id,
       },
       dedupeKey: `guardian:${request.id}`,
-      onThreadCreated: (info) => {
-        if (info.sourceEventName !== 'guardian.question' || vellumDeliveryId) return;
-        const delivery = createGuardianActionDelivery({
-          requestId: request.id,
-          destinationChannel: 'vellum',
-          destinationConversationId: info.conversationId,
-        });
-        vellumDeliveryId = delivery.id;
-      },
     });
 
-    const telegramBinding = getActiveBinding(assistantId, 'telegram');
-    const smsBinding = getActiveBinding(assistantId, 'sms');
-
-    for (const result of signalResult.deliveryResults) {
-      if (result.channel === 'vellum') {
-        if (!vellumDeliveryId) {
-          const delivery = createGuardianActionDelivery({
-            requestId: request.id,
-            destinationChannel: 'vellum',
-            destinationConversationId: result.conversationId,
-          });
-          vellumDeliveryId = delivery.id;
-        }
-        applyDeliveryStatus(vellumDeliveryId, result);
-        continue;
-      }
-
-      if (result.channel !== 'telegram' && result.channel !== 'sms') {
-        continue;
-      }
-
-      const binding = result.channel === 'telegram' ? telegramBinding : smsBinding;
-      const delivery = createGuardianActionDelivery({
-        requestId: request.id,
-        destinationChannel: result.channel,
-        destinationChatId: result.destination.length > 0 ? result.destination : undefined,
-        destinationExternalUserId: binding?.guardianExternalUserId,
-      });
-      applyDeliveryStatus(delivery.id, result);
-    }
-
-    if (!vellumDeliveryId) {
-      const fallback = createGuardianActionDelivery({
-        requestId: request.id,
-        destinationChannel: 'vellum',
-      });
-      updateDeliveryStatus(
-        fallback.id,
-        'failed',
-        `No vellum delivery result from notification pipeline (${signalResult.reason})`,
-      );
+    if (!signalResult.dispatched) {
       log.warn(
         { requestId: request.id, reason: signalResult.reason },
-        'Notification pipeline did not produce a vellum delivery result',
+        'Notification pipeline did not dispatch guardian question',
       );
     }
   } catch (err) {


### PR DESCRIPTION
## Summary
- Make emitNotificationSignal('guardian.question') the sole delivery mechanism in guardian-dispatch.ts
- Remove legacy per-channel delivery logic (conversation creation, delivery rows, guardian_request_thread_created broadcast)
- Part of #9116, epic #9114

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
