### PR TITLE
M2: Conversation Zoom Primitive + Typography Integration

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -144,17 +144,11 @@ extension AppDelegate {
         case .windowZoomReset:
             zoomManager.resetZoom()
         case .conversationZoomIn:
-            // Bridge: apply window zoom so the shortcut works immediately.
-            // The notification is kept so M2's ConversationZoomManager can
-            // subscribe and replace this bridge with per-conversation scaling.
-            zoomManager.zoomIn()
-            NotificationCenter.default.post(name: .conversationZoomIn, object: nil)
+            conversationZoomManager.zoomIn()
         case .conversationZoomOut:
-            zoomManager.zoomOut()
-            NotificationCenter.default.post(name: .conversationZoomOut, object: nil)
+            conversationZoomManager.zoomOut()
         case .conversationZoomReset:
-            zoomManager.resetZoom()
-            NotificationCenter.default.post(name: .conversationZoomReset, object: nil)
+            conversationZoomManager.resetZoom()
         }
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -125,6 +125,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var browserPiPManager: BrowserPiPManager { services.browserPiPManager }
     private var secretPromptManager: SecretPromptManager { services.secretPromptManager }
     var zoomManager: ZoomManager { services.zoomManager }
+    var conversationZoomManager: ConversationZoomManager { services.conversationZoomManager }
 
     let toolConfirmationNotificationService = ToolConfirmationNotificationService()
     lazy var recordingManager: RecordingManager = RecordingManager(daemonClient: daemonClient)

--- a/clients/macos/vellum-assistant/App/AppServices.swift
+++ b/clients/macos/vellum-assistant/App/AppServices.swift
@@ -11,6 +11,7 @@ public final class AppServices {
     let browserPiPManager = BrowserPiPManager()
     let secretPromptManager = SecretPromptManager()
     let zoomManager = ZoomManager()
+    let conversationZoomManager = ConversationZoomManager()
 
     /// Shared settings state consumed by SettingsPanel and its tab views.
     /// Lazy because it needs `ambientAgent` and `daemonClient` which are set above.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -30,6 +30,8 @@ struct ChatBubble: View {
     /// manager publishes any change (the "thundering herd" problem).
     var activeSurfaceId: String?
 
+    @Environment(\.conversationZoomScale) var conversationZoomScale
+
     var isUser: Bool { message.role == .user }
     private var canReportMessage: Bool {
         !isUser && onReportMessage != nil
@@ -282,11 +284,11 @@ struct ChatBubble: View {
                 if message.isError && hasText {
                     HStack(alignment: .top, spacing: VSpacing.sm) {
                         Image(systemName: "exclamationmark.triangle.fill")
-                            .font(.system(size: 13, weight: .medium))
+                            .font(.system(size: 13 * conversationZoomScale, weight: .medium))
                             .foregroundColor(VColor.error)
                             .padding(.top, 1)
                         Text(message.text)
-                            .font(.system(size: 13))
+                            .font(.system(size: 13 * conversationZoomScale))
                             .foregroundColor(VColor.textPrimary)
                             .textSelection(.enabled)
                             .fixedSize(horizontal: false, vertical: true)
@@ -312,7 +314,7 @@ struct ChatBubble: View {
                         )
                     } else {
                         Text(markdownText)
-                            .font(.system(size: 13))
+                            .font(.system(size: 13 * conversationZoomScale))
                             .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
                             .tint(isUser ? VColor.userBubbleText : VColor.accent)
                             .textSelection(.enabled)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -22,7 +22,7 @@ extension ChatBubble {
             } else {
                 let attributed = Self.cachedInlineMarkdown(for: segmentText, isStreaming: streaming)
                 Text(attributed)
-                    .font(.system(size: 13))
+                    .font(.system(size: 13 * conversationZoomScale))
                     .lineSpacing(3)
                     .foregroundColor(VColor.textPrimary)
                     .tint(VColor.accent)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -261,13 +261,15 @@ struct MarkdownTableView: View {
     let rows: [[String]]
     var maxWidth: CGFloat = 520
 
+    @Environment(\.conversationZoomScale) private var zoomScale
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Header row
             HStack(spacing: 0) {
                 ForEach(Array(headers.enumerated()), id: \.offset) { _, header in
                     Text(header)
-                        .font(VFont.captionMedium)
+                        .font(.custom("Inter-Medium", size: 11 * zoomScale))
                         .foregroundColor(VColor.textSecondary)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, VSpacing.sm)
@@ -309,7 +311,7 @@ struct MarkdownTableView: View {
         let attributed = (try? AttributedString(markdown: text, options: options))
             ?? AttributedString(text)
         return Text(attributed)
-            .font(VFont.body)
+            .font(.custom("Inter", size: 13 * zoomScale))
             .foregroundColor(VColor.textPrimary)
             .textSelection(.enabled)
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -56,6 +56,8 @@ struct ComposerView: View {
     /// Exposed to ChatView so composerReservedHeight stays in sync with the
     /// sticky expansion state (set true when text wraps, reset when text clears).
     @Binding var isComposerExpanded: Bool
+
+    @Environment(\.conversationZoomScale) private var zoomScale
     @State private var composerFocusRequestID: Int = 0
     @State private var isStopHovered = false
     @State private var isSendHovered = false
@@ -197,6 +199,7 @@ struct ComposerView: View {
             minHeight: composerCompactHeight,
             maxHeight: composerMaxHeight,
             focusRequestID: composerFocusRequestID,
+            zoomScale: zoomScale,
             onHeightChange: { height in
                 editorContentHeight = height
             },
@@ -220,11 +223,12 @@ struct ComposerView: View {
         .accessibilityLabel("Message")
         .overlay(alignment: .leading) {
             if let ghostSuffix {
+                let scaledBody = Font.custom("Inter", size: 13 * zoomScale)
                 (Text(inputText)
-                    .font(VFont.body)
+                    .font(scaledBody)
                     .foregroundColor(.clear)
                 + Text(ghostSuffix)
-                    .font(VFont.body)
+                    .font(scaledBody)
                     .foregroundColor(VColor.textSecondary.opacity(0.55)))
                     .lineLimit(1...12)
                     .fixedSize(horizontal: false, vertical: true)
@@ -557,6 +561,7 @@ private struct ComposerTextView: NSViewRepresentable {
     let minHeight: CGFloat
     let maxHeight: CGFloat
     let focusRequestID: Int
+    var zoomScale: CGFloat = 1.0
     let onHeightChange: (CGFloat) -> Void
     var onOverflowChange: ((Bool) -> Void)?
     let onFocusChange: (Bool) -> Void
@@ -602,7 +607,8 @@ private struct ComposerTextView: NSViewRepresentable {
         textView.isSelectable = true
         textView.drawsBackground = false
         textView.allowsUndo = true
-        textView.font = NSFont(name: "Inter", size: 13) ?? NSFont.systemFont(ofSize: 13)
+        let scaledFontSize: CGFloat = 13 * zoomScale
+        textView.font = NSFont(name: "Inter", size: scaledFontSize) ?? NSFont.systemFont(ofSize: scaledFontSize)
         textView.textColor = NSColor(VColor.textPrimary)
         textView.insertionPointColor = NSColor(VColor.accent)
         textView.textContainerInset = NSSize(width: 0, height: 8)
@@ -635,6 +641,16 @@ private struct ComposerTextView: NSViewRepresentable {
         guard let textView = context.coordinator.textView else { return }
 
         textView.isEditable = isEnabled
+
+        // Update font when zoom scale changes
+        let scaledFontSize: CGFloat = 13 * zoomScale
+        let targetFont = NSFont(name: "Inter", size: scaledFontSize) ?? NSFont.systemFont(ofSize: scaledFontSize)
+        if textView.font?.pointSize != targetFont.pointSize {
+            textView.font = targetFont
+            textView.needsDisplay = true
+            context.coordinator.syncHeight()
+        }
+
         let oldPlaceholder = textView.placeholderText
         let oldGhostSuffix = textView.hasGhostSuffix
         textView.placeholderText = placeholder

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -15,15 +15,19 @@ struct MarkdownSegmentView: View {
     var codeBackgroundColor: Color = VColor.backgroundSubtle
     var hrColor: Color = VColor.surfaceBorder
 
+    @Environment(\.conversationZoomScale) private var zoomScale
+
     var body: some View {
         let groups = groupedSegments
+        let scaledBodySize: CGFloat = 13 * zoomScale
+        let scaledCodeLabelSize: CGFloat = 11 * zoomScale
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             ForEach(Array(groups.enumerated()), id: \.offset) { _, group in
                 switch group {
                 case .selectableRun(let runSegments):
                     let attributed = buildCombinedAttributedString(from: runSegments)
                     Text(attributed)
-                        .font(.system(size: 13))
+                        .font(.system(size: scaledBodySize))
                         .lineSpacing(4)
                         .foregroundColor(textColor)
                         .tint(tintColor)
@@ -35,14 +39,14 @@ struct MarkdownSegmentView: View {
                     VStack(alignment: .leading, spacing: 0) {
                         if let language, !language.isEmpty {
                             Text(language)
-                                .font(.system(size: 11, weight: .medium))
+                                .font(.system(size: scaledCodeLabelSize, weight: .medium))
                                 .foregroundColor(mutedTextColor)
                                 .padding(.horizontal, VSpacing.sm)
                                 .padding(.top, VSpacing.xs)
                         }
                         ScrollView(.horizontal, showsIndicators: false) {
                             Text(code)
-                                .font(VFont.mono)
+                                .font(.custom("DMMono-Regular", size: 13 * zoomScale))
                                 .foregroundColor(textColor)
                                 .textSelection(.enabled)
                                 .fixedSize(horizontal: true, vertical: true)
@@ -142,12 +146,14 @@ struct MarkdownSegmentView: View {
     private func buildCombinedAttributedString(from segments: [MarkdownSegment]) -> AttributedString {
         // Build a stable cache key from the segment contents and style
         // inputs that affect the output (e.g. secondaryTextColor for list
-        // prefix coloring) so different visual contexts don't share entries.
+        // prefix coloring, zoomScale for font sizing) so different visual
+        // contexts don't share entries.
         var hasher = Hasher()
         for segment in segments {
             hasher.combine(String(describing: segment))
         }
         hasher.combine(secondaryTextColor.description)
+        hasher.combine(zoomScale)
         let cacheKey = hasher.finalize()
 
         if let cached = Self.attributedStringCache[cacheKey] {
@@ -156,7 +162,7 @@ struct MarkdownSegmentView: View {
             return cached.value
         }
 
-        let result = Self.buildAttributedStringUncached(from: segments, secondaryTextColor: secondaryTextColor)
+        let result = Self.buildAttributedStringUncached(from: segments, secondaryTextColor: secondaryTextColor, zoomScale: zoomScale)
 
         // Evict the least-recently-used entry when the cache is full.
         if Self.attributedStringCache.count >= Self.attributedStringCacheLimit {
@@ -172,7 +178,8 @@ struct MarkdownSegmentView: View {
     /// Pure builder with no side effects — separated for caching.
     private static func buildAttributedStringUncached(
         from segments: [MarkdownSegment],
-        secondaryTextColor: Color
+        secondaryTextColor: Color,
+        zoomScale: CGFloat = 1.0
     ) -> AttributedString {
         let mdOptions = AttributedString.MarkdownParsingOptions(
             interpretedSyntax: .inlineOnlyPreservingWhitespace
@@ -193,16 +200,17 @@ struct MarkdownSegmentView: View {
             case .heading(let level, let headingText):
                 var heading = AttributedString(headingText)
                 heading.font = switch level {
-                case 1: .system(size: 20, weight: .bold)
-                case 2: .system(size: 17, weight: .semibold)
-                case 3: .system(size: 14, weight: .semibold)
-                default: .system(size: 13, weight: .semibold)
+                case 1: .system(size: 20 * zoomScale, weight: .bold)
+                case 2: .system(size: 17 * zoomScale, weight: .semibold)
+                case 3: .system(size: 14 * zoomScale, weight: .semibold)
+                default: .system(size: 13 * zoomScale, weight: .semibold)
                 }
                 result += heading
 
             case .list(let items):
-                let indentStep: CGFloat = 16
-                let font = NSFont.systemFont(ofSize: 13)
+                let indentStep: CGFloat = 16 * zoomScale
+                let scaledSize: CGFloat = 13 * zoomScale
+                let font = NSFont.systemFont(ofSize: scaledSize)
 
                 for (itemIndex, item) in items.enumerated() {
                     if itemIndex > 0 {
@@ -224,7 +232,7 @@ struct MarkdownSegmentView: View {
 
                     var prefixAttr = AttributedString(prefix)
                     prefixAttr.foregroundColor = secondaryTextColor
-                    prefixAttr.font = .system(size: 13)
+                    prefixAttr.font = .system(size: scaledSize)
                     prefixAttr.applyParagraphStyle(paraStyle)
                     result += prefixAttr
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationZoomManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationZoomManager.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+/// Manages conversation-level text zoom (Cmd +/-/0), independent of the
+/// window-level zoom handled by `ZoomManager`.
+///
+/// The scale factor is applied to chat text surfaces (messages, markdown,
+/// code blocks, composer) via the `conversationZoomScale` environment value.
+/// Zoom level persists across app relaunches via `@AppStorage`.
+@MainActor
+@Observable
+final class ConversationZoomManager {
+    static let zoomSteps: [CGFloat] = [0.5, 0.75, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0]
+
+    var zoomLevel: CGFloat {
+        didSet { UserDefaults.standard.set(zoomLevel, forKey: "conversationTextZoomLevel") }
+    }
+    var showZoomIndicator = false
+
+    private var dismissTask: Task<Void, Never>?
+
+    var zoomPercentage: Int {
+        Int(round(zoomLevel * 100))
+    }
+
+    init() {
+        let stored = UserDefaults.standard.double(forKey: "conversationTextZoomLevel")
+        self.zoomLevel = stored > 0 ? stored : 1.0
+    }
+
+    func zoomIn() {
+        if let next = Self.zoomSteps.first(where: { $0 > zoomLevel + 0.001 }) {
+            zoomLevel = next
+            flashIndicator()
+        }
+    }
+
+    func zoomOut() {
+        if let prev = Self.zoomSteps.last(where: { $0 < zoomLevel - 0.001 }) {
+            zoomLevel = prev
+            flashIndicator()
+        }
+    }
+
+    func resetZoom() {
+        zoomLevel = 1.0
+        flashIndicator()
+    }
+
+    private func flashIndicator() {
+        dismissTask?.cancel()
+        showZoomIndicator = true
+        dismissTask = Task {
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            guard !Task.isCancelled else { return }
+            showZoomIndicator = false
+        }
+    }
+}
+
+// MARK: - SwiftUI Environment
+
+private struct ConversationZoomScaleKey: EnvironmentKey {
+    static let defaultValue: CGFloat = 1.0
+}
+
+extension EnvironmentValues {
+    /// The conversation text zoom scale factor. Chat text surfaces multiply
+    /// their base font sizes by this value to implement conversation zoom.
+    var conversationZoomScale: CGFloat {
+        get { self[ConversationZoomScaleKey.self] }
+        set { self[ConversationZoomScaleKey.self] = newValue }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -280,7 +280,7 @@ final class MainWindow {
             self.pendingWakeUpMessage = nil
         } : nil
 
-        let rootView = MainWindowView(threadManager: threadManager, appListManager: appListManager, zoomManager: zoomManager, traceStore: traceStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, documentManager: documentManager, avatarEvolutionState: avatarEvolutionState, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, onSendWakeUp: wakeUpCallback)
+        let rootView = MainWindowView(threadManager: threadManager, appListManager: appListManager, zoomManager: zoomManager, conversationZoomManager: services.conversationZoomManager, traceStore: traceStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, documentManager: documentManager, avatarEvolutionState: avatarEvolutionState, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, onSendWakeUp: wakeUpCallback)
         let hostingController = NonDraggableHostingController(rootView: rootView)
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -97,7 +97,7 @@ struct MainWindowView: View {
     /// Whether the "coming alive" overlay is currently showing.
     @State private var showComingAlive: Bool
 
-    init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, conversationZoomManager: ConversationZoomManager = ConversationZoomManager(), traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, avatarEvolutionState: AvatarEvolutionState? = nil, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager = VoiceModeManager(), onSendWakeUp: (() -> Void)? = nil) {
+    init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, conversationZoomManager: ConversationZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, avatarEvolutionState: AvatarEvolutionState? = nil, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager = VoiceModeManager(), onSendWakeUp: (() -> Void)? = nil) {
         self.threadManager = threadManager
         self.appListManager = appListManager
         self.zoomManager = zoomManager

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -52,6 +52,7 @@ struct MainWindowView: View {
     @ObservedObject var threadManager: ThreadManager
     @ObservedObject var appListManager: AppListManager
     var zoomManager: ZoomManager
+    var conversationZoomManager: ConversationZoomManager
     /// Plain `let` instead of `@ObservedObject` so SwiftUI doesn't observe
     /// TraceStore mutations when the DebugPanel isn't visible. DebugPanel
     /// itself uses `@ObservedObject` and is only instantiated when shown.
@@ -96,10 +97,11 @@ struct MainWindowView: View {
     /// Whether the "coming alive" overlay is currently showing.
     @State private var showComingAlive: Bool
 
-    init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, avatarEvolutionState: AvatarEvolutionState? = nil, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager = VoiceModeManager(), onSendWakeUp: (() -> Void)? = nil) {
+    init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, conversationZoomManager: ConversationZoomManager = ConversationZoomManager(), traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, avatarEvolutionState: AvatarEvolutionState? = nil, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager = VoiceModeManager(), onSendWakeUp: (() -> Void)? = nil) {
         self.threadManager = threadManager
         self.appListManager = appListManager
         self.zoomManager = zoomManager
+        self.conversationZoomManager = conversationZoomManager
         self.traceStore = traceStore
         self.daemonClient = daemonClient
         self.surfaceManager = surfaceManager

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -475,6 +475,15 @@ extension MainWindowView {
                 isTemporaryChat: activeThread?.kind == .private,
                 threadId: threadManager.activeThreadId
             )
+            .environment(\.conversationZoomScale, conversationZoomManager.zoomLevel)
+            .overlay(alignment: .top) {
+                if conversationZoomManager.showZoomIndicator {
+                    ZoomIndicatorView(percentage: conversationZoomManager.zoomPercentage)
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                        .padding(.top, VSpacing.xl)
+                }
+            }
+            .animation(VAnimation.fast, value: conversationZoomManager.showZoomIndicator)
             .overlay(alignment: .bottomTrailing) {
                 DemoOverlayView()
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -980,7 +980,7 @@ struct DynamicWorkspaceWrapper: View {
 struct MainWindowView_Previews: PreviewProvider {
     static var previews: some View {
         let dc = DaemonClient()
-        MainWindowView(threadManager: ThreadManager(daemonClient: dc), appListManager: AppListManager(), zoomManager: ZoomManager(), traceStore: TraceStore(), daemonClient: dc, surfaceManager: SurfaceManager(), ambientAgent: AmbientAgent(), settingsStore: SettingsStore(daemonClient: dc), authManager: AuthManager(), windowState: MainWindowState(), documentManager: DocumentManager())
+        MainWindowView(threadManager: ThreadManager(daemonClient: dc), appListManager: AppListManager(), zoomManager: ZoomManager(), conversationZoomManager: ConversationZoomManager(), traceStore: TraceStore(), daemonClient: dc, surfaceManager: SurfaceManager(), ambientAgent: AmbientAgent(), settingsStore: SettingsStore(daemonClient: dc), authManager: AuthManager(), windowState: MainWindowState(), documentManager: DocumentManager())
             .frame(width: 900, height: 600)
             .padding(.top, 36)
     }


### PR DESCRIPTION
Creates ConversationZoomManager with stepped zoom (0.5x-2.0x), persistence via UserDefaults, and flash indicator. Applies conversation zoom scale to all chat text surfaces including messages, markdown, code blocks, tables, lists, headings, and the NSTextView composer. Updates MarkdownSegmentView attributed-string cache keys to include zoom scale. Routes Cmd+/Cmd- shortcuts directly to ConversationZoomManager instead of M1's notification bridge. Part of #9123.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
