### PR TITLE
fix(chat): nil reconnectDebounceTask after completion

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -524,6 +524,7 @@ public final class ChatViewModel: ObservableObject {
                     self?.discardStreamingBuffer()
                     self?.reconnectDebounceTask?.cancel()
                     self?.reconnectDebounceTask = Task { @MainActor [weak self] in
+                        defer { self?.reconnectDebounceTask = nil }
                         try? await Task.sleep(nanoseconds: 500_000_000) // 500ms
                         guard !Task.isCancelled else { return }
                         guard let self, !self.isReconnectHistoryLoading else { return }


### PR DESCRIPTION
Adds defer to nil reconnectDebounceTask when the debounce task body completes (or exits early). Without this, the completed Task reference stays non-nil, causing the snapshot guard to permanently block future reconnect snapshots.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
