### PR TITLE
fix(chat): guard reconnectDebounceTask nil-out with isCancelled check

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -524,7 +524,7 @@ public final class ChatViewModel: ObservableObject {
                     self?.discardStreamingBuffer()
                     self?.reconnectDebounceTask?.cancel()
                     self?.reconnectDebounceTask = Task { @MainActor [weak self] in
-                        defer { self?.reconnectDebounceTask = nil }
+                        defer { if !Task.isCancelled { self?.reconnectDebounceTask = nil } }
                         try? await Task.sleep(nanoseconds: 500_000_000) // 500ms
                         guard !Task.isCancelled else { return }
                         guard let self, !self.isReconnectHistoryLoading else { return }


### PR DESCRIPTION
Guards the defer that nils reconnectDebounceTask with a Task.isCancelled check. Without this, when a debounce task is cancelled and replaced by a new one, the old task's defer would nil out the replacement task reference.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
