### PR TITLE
M1: Extract shared getAssistantName helper from session-slash.ts

### DIFF
--- a/assistant/src/daemon/identity-helpers.ts
+++ b/assistant/src/daemon/identity-helpers.ts
@@ -1,0 +1,16 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+import { getWorkspacePromptPath } from '../util/platform.js';
+
+/** Read the assistant's name from IDENTITY.md for personalized responses. */
+export function getAssistantName(): string | null {
+  try {
+    const path = getWorkspacePromptPath('IDENTITY.md');
+    if (!existsSync(path)) return null;
+    const content = readFileSync(path, 'utf-8');
+    const match = content.match(/\*\*Name:\*\*\s*(.+)/);
+    return match?.[1]?.trim() || null;
+  } catch {
+    return null;
+  }
+}

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -1,5 +1,3 @@
-import { existsSync,readFileSync } from 'node:fs';
-
 import { getConfig, loadRawConfig, saveRawConfig } from '../config/loader.js';
 import { resolveSkillStates } from '../config/skill-state.js';
 import { loadSkillCatalog } from '../config/skills.js';
@@ -9,7 +7,8 @@ import {
   resolveSlashSkillCommand,
   rewriteKnownSlashCommandPrompt,
 } from '../skills/slash-commands.js';
-import { getWorkspacePromptPath } from '../util/platform.js';
+
+import { getAssistantName } from './identity-helpers.js';
 
 export type SlashResolution =
   | { kind: 'passthrough'; content: string }
@@ -73,19 +72,6 @@ const PROVIDER_MODEL_SHORTCUTS: Record<string, { provider: string; model: string
 export const MODEL_TO_PROVIDER: Record<string, string> = Object.fromEntries(
   Object.values(PROVIDER_MODEL_SHORTCUTS).map(({ model, provider }) => [model, provider]),
 );
-
-/** Read the assistant's name from IDENTITY.md for personalized responses. */
-function getAssistantName(): string | null {
-  try {
-    const path = getWorkspacePromptPath('IDENTITY.md');
-    if (!existsSync(path)) return null;
-    const content = readFileSync(path, 'utf-8');
-    const match = content.match(/\*\*Name:\*\*\s*(.+)/);
-    return match?.[1]?.trim() || null;
-  } catch {
-    return null;
-  }
-}
 
 /** Partial-match a user input like "opus", "sonnet", "haiku" to a full model ID. */
 function matchModel(input: string): string | undefined {


### PR DESCRIPTION
Extract getAssistantName() from session-slash.ts into a new shared identity-helpers.ts utility so it can be reused by recording-intent.ts in M2. Pure refactor, no behavior changes. Part of #9161, closes #9162.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
