### PR TITLE
fix: correct TimelineView API and deinit actor isolation errors

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatWidgetViews.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatWidgetViews.swift
@@ -40,7 +40,7 @@ struct RunningIndicator: View {
     }
 
     private var indicatorContent: some View {
-        TimelineView(.periodic(every: 0.4)) { context in
+        TimelineView(.periodic(from: .now, by: 0.4)) { context in
             let elapsed = context.date.timeIntervalSince(startDate)
             let phase = Int(elapsed / 0.4) % 3
             let currentLabel = displayLabel(elapsed: elapsed)

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1928,8 +1928,10 @@ public final class ChatViewModel: ObservableObject {
         messageLoopTask?.cancel()
         streamingFlushTask?.cancel()
         cancelTimeoutTask?.cancel()
-        refinementFailureDismissTask?.cancel()
-        refinementFlushTask?.cancel()
+        // refinementFailureDismissTask and refinementFlushTask are accessed via
+        // @MainActor computed properties (forwarded from ChatMessageManager), which
+        // cannot be referenced from nonisolated deinit. Both tasks use [weak self],
+        // so they will exit naturally when self is deallocated.
         reconnectLatchTimeoutTask?.cancel()
         reconnectDebounceTask?.cancel()
         if let observer = reconnectObserver {

--- a/clients/shared/Features/Chat/SubagentStatusChip.swift
+++ b/clients/shared/Features/Chat/SubagentStatusChip.swift
@@ -32,7 +32,7 @@ public struct SubagentStatusChip: View {
         if subagent.isTerminal {
             chipContent(phase: 0)
         } else {
-            TimelineView(.periodic(every: 0.4)) { context in
+            TimelineView(.periodic(from: .now, by: 0.4)) { context in
                 chipContent(phase: Int(context.date.timeIntervalSince1970 / 0.4) % 3)
             }
         }

--- a/clients/shared/Features/Chat/SubagentThreadView.swift
+++ b/clients/shared/Features/Chat/SubagentThreadView.swift
@@ -72,7 +72,7 @@ public struct SubagentThreadView: View {
     }
 
     public var body: some View {
-        TimelineView(.periodic(every: 0.4)) { context in
+        TimelineView(.periodic(from: .now, by: 0.4)) { context in
             let phase = isRunning ? Int(context.date.timeIntervalSince1970 / 0.4) % 3 : 0
             HStack(alignment: .center, spacing: 0) {
                 // L-shaped connector: vertical line from parent → curves right into the thread bar


### PR DESCRIPTION
## Summary
Fixes two build errors introduced by the chat memory fix PRs.

## Changes

### TimelineView API fix
`.periodic(every:)` doesn't exist — the correct SwiftUI API is `.periodic(from:by:)`. Fixed in:
- `SubagentThreadView.swift`
- `SubagentStatusChip.swift`
- `ChatWidgetViews.swift`

### Deinit actor isolation fix
`refinementFailureDismissTask` and `refinementFlushTask` are computed properties that forward to `@MainActor`-isolated `ChatMessageManager`. They can't be accessed from nonisolated `deinit`. Removed from deinit — both tasks use `[weak self]` and will exit naturally when the ViewModel deallocates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
