### PR TITLE
fix(macos): prompt for notification permission on thread-created

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -7,6 +7,7 @@ import os
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AppDelegate+Notifications")
 private let fallbackDedupWindowMs: Double = 30_000
 private let fallbackDelayNs: UInt64 = 750_000_000
+private let notificationPermissionToastCooldownMs: Double = 30_000
 
 extension AppDelegate {
 
@@ -17,13 +18,7 @@ extension AppDelegate {
         let center = UNUserNotificationCenter.current()
         center.delegate = self
 
-        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
-            if granted {
-                log.info("Notification authorization granted")
-            } else {
-                log.warning("Notification authorization denied (error: \(error?.localizedDescription ?? "none"))")
-            }
-        }
+        requestNotificationAuthorization(trigger: "app_launch", showDeniedToast: false)
 
         let viewAction = UNNotificationAction(
             identifier: "VIEW_ACTIVITY",
@@ -98,6 +93,73 @@ extension AppDelegate {
         ])
     }
 
+    /// Handles notification permission when a notification thread arrives while
+    /// the app is active. This provides user-visible context for the OS prompt
+    /// and gives an immediate recovery path when the app is already denied.
+    func maybePromptNotificationAuthorizationForThreadCreated() {
+        Task { @MainActor in
+            let settings = await UNUserNotificationCenter.current().notificationSettings()
+            switch settings.authorizationStatus {
+            case .authorized, .provisional, .ephemeral:
+                return
+            case .notDetermined:
+                guard !hasRequestedNotificationAuthorizationFromThreadSignal else { return }
+                hasRequestedNotificationAuthorizationFromThreadSignal = true
+                log.info("Requesting notification authorization from notification_thread_created signal")
+                requestNotificationAuthorization(trigger: "notification_thread_created", showDeniedToast: true)
+            case .denied:
+                showNotificationPermissionSettingsToastIfNeeded()
+            @unknown default:
+                return
+            }
+        }
+    }
+
+    private func requestNotificationAuthorization(trigger: String, showDeniedToast: Bool) {
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+            if granted {
+                log.info("Notification authorization granted (\(trigger))")
+                return
+            }
+
+            log.warning("Notification authorization denied (\(trigger), error: \(error?.localizedDescription ?? "none"))")
+            guard showDeniedToast else { return }
+
+            Task { @MainActor in
+                self.showNotificationPermissionSettingsToastIfNeeded()
+            }
+        }
+    }
+
+    private func showNotificationPermissionSettingsToastIfNeeded() {
+        let nowMs = Date().timeIntervalSince1970 * 1000
+        guard nowMs - lastNotificationPermissionToastAtMs > notificationPermissionToastCooldownMs else { return }
+        lastNotificationPermissionToastAtMs = nowMs
+
+        mainWindow?.windowState.showToast(
+            message: "Notifications are off for Vellum. Turn them on in System Settings to receive banners.",
+            style: .warning,
+            primaryAction: VToastAction(label: "Open Settings") { [weak self] in
+                self?.openNotificationSettings()
+            }
+        )
+    }
+
+    private func openNotificationSettings() {
+        let candidates = [
+            "x-apple.systempreferences:com.apple.preference.notifications",
+            "x-apple.systempreferences:com.apple.preference.notifications?id=\(Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant")",
+        ]
+        for candidate in candidates {
+            guard let url = URL(string: candidate) else { continue }
+            if NSWorkspace.shared.open(url) {
+                return
+            }
+        }
+        log.warning("Failed to open macOS Notification settings URL")
+    }
+
     private func normalizeNotificationUserInfoValue(_ value: Any?) -> Any? {
         switch value {
         case nil:
@@ -161,6 +223,9 @@ extension AppDelegate {
             return true
         case .denied:
             log.warning("Notification authorization status is denied — skipping notification post")
+            if NSApp.isActive {
+                showNotificationPermissionSettingsToastIfNeeded()
+            }
             return false
         case .notDetermined:
             log.info("Notification authorization status is notDetermined — attempting post anyway")

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -148,8 +148,8 @@ extension AppDelegate {
 
     private func openNotificationSettings() {
         let candidates = [
-            "x-apple.systempreferences:com.apple.preference.notifications",
             "x-apple.systempreferences:com.apple.preference.notifications?id=\(Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant")",
+            "x-apple.systempreferences:com.apple.preference.notifications",
         ]
         for candidate in candidates {
             guard let url = URL(string: candidate) else { continue }

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -251,6 +251,10 @@ extension AppDelegate {
             sourceEventName: msg.sourceEventName
         )
 
+        if NSApp.isActive {
+            maybePromptNotificationAuthorizationForThreadCreated()
+        }
+
         // Guardian questions get foregrounded immediately when the app is active.
         if msg.sourceEventName == "guardian.question" && NSApp.isActive {
             openConversationThread(conversationId: msg.conversationId)

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -164,6 +164,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// conversationId. Incoming notification_intent for the same conversation
     /// inside a short window is treated as a duplicate and suppressed.
     var fallbackDeliveredAtMs: [String: Double] = [:]
+    /// Guard to avoid repeatedly re-requesting notification authorization when
+    /// multiple notification threads are created in quick succession.
+    var hasRequestedNotificationAuthorizationFromThreadSignal = false
+    /// Last time we surfaced the denied-notification permission toast.
+    var lastNotificationPermissionToastAtMs: Double = 0
 
     /// Whether the current assistant runs remotely (cloud != "local").
     /// When true, local daemon hatching is skipped.


### PR DESCRIPTION
## Summary
- add a just-in-time notification permission check when `notification_thread_created` arrives while the macOS app is active
- if status is `.notDetermined`, request authorization in-context and dedupe repeat prompts
- if status is `.denied`, surface a warning toast with an `Open Settings` action to recover quickly
- keep existing startup permission request, but route it through a shared helper for consistent logging

## Root cause addressed
The notification router and thread-creation path were working, but macOS banner delivery was skipped when notification authorization was denied. Users had no immediate in-app recovery path at the moment a notification thread arrived.

## Files changed
- `clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift`
- `clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift`
- `clients/macos/vellum-assistant/App/AppDelegate.swift`

## Validation
- attempted: `cd clients/macos && ./build.sh lint`
- result: fails due to pre-existing compile errors unrelated to this PR (e.g. `SubagentThreadView.swift` uses `TimelineView(.periodic(every: 0.4))`, which does not match the current API)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
