### PR TITLE
M2: Implement classifyRecordingIntent with dynamic name normalization

### DIFF
--- a/assistant/src/__tests__/recording-intent.test.ts
+++ b/assistant/src/__tests__/recording-intent.test.ts
@@ -6,6 +6,7 @@ import {
   stripRecordingIntent,
   stripStopRecordingIntent,
   isStopRecordingOnly,
+  classifyRecordingIntent,
 } from '../daemon/recording-intent.js';
 
 // ─── detectRecordingIntent ──────────────────────────────────────────────────
@@ -261,5 +262,80 @@ describe('isStopRecordingOnly', () => {
     expect(isStopRecordingOnly('stop recording!')).toBe(true);
     expect(isStopRecordingOnly('stop recording.')).toBe(true);
     expect(isStopRecordingOnly('end the recording?')).toBe(true);
+  });
+});
+
+// ─── classifyRecordingIntent ────────────────────────────────────────────────
+
+describe('classifyRecordingIntent', () => {
+  // Basic classification
+  test.each([
+    ['record my screen', 'start_only'],
+    ['stop recording', 'stop_only'],
+    ['open Safari and record my screen', 'mixed'],
+    ['hello world', 'none'],
+    ['', 'none'],
+  ] as const)('basic: "%s" → %s', (text, expected) => {
+    expect(classifyRecordingIntent(text)).toBe(expected);
+  });
+
+  // Dynamic name stripping
+  test.each([
+    ['Nova, record my screen', ['Nova'], 'start_only'],
+    ['hey Nova, start recording', ['Nova'], 'start_only'],
+    ['Nova, stop recording', ['Nova'], 'stop_only'],
+    ['Nova, open Safari and record my screen', ['Nova'], 'mixed'],
+    ['Nova, hello', ['Nova'], 'none'],
+  ] as const)('dynamic names: "%s" with %j → %s', (text, names, expected) => {
+    expect(classifyRecordingIntent(text, [...names])).toBe(expected);
+  });
+
+  // No dynamic names (backwards compat)
+  test('works without dynamic names parameter', () => {
+    expect(classifyRecordingIntent('record my screen')).toBe('start_only');
+    expect(classifyRecordingIntent('stop recording')).toBe('stop_only');
+  });
+
+  // With fillers
+  test('handles filler words correctly', () => {
+    expect(classifyRecordingIntent('please record my screen')).toBe('start_only');
+    expect(classifyRecordingIntent('can you stop recording?')).toBe('stop_only');
+  });
+
+  // Both start and stop → mixed
+  test('classifies as mixed when both start and stop patterns are present', () => {
+    expect(classifyRecordingIntent('start recording and then stop recording')).toBe('mixed');
+    expect(classifyRecordingIntent('record my screen and stop recording')).toBe('mixed');
+  });
+
+  // Edge cases
+  test('classifies as mixed when stop-recording has additional task', () => {
+    expect(classifyRecordingIntent('stop recording and open Chrome')).toBe('mixed');
+  });
+
+  // Case insensitivity with dynamic names
+  test('dynamic name stripping is case-insensitive', () => {
+    expect(classifyRecordingIntent('nova, record my screen', ['Nova'])).toBe('start_only');
+    expect(classifyRecordingIntent('NOVA, stop recording', ['Nova'])).toBe('stop_only');
+    expect(classifyRecordingIntent('Hey NOVA, start recording', ['nova'])).toBe('start_only');
+  });
+
+  // Multiple dynamic names
+  test('handles multiple dynamic names', () => {
+    expect(classifyRecordingIntent('Jarvis, record my screen', ['Nova', 'Jarvis'])).toBe(
+      'start_only',
+    );
+    expect(classifyRecordingIntent('Nova, stop recording', ['Nova', 'Jarvis'])).toBe('stop_only');
+  });
+
+  // Empty dynamic names array
+  test('handles empty dynamic names array', () => {
+    expect(classifyRecordingIntent('record my screen', [])).toBe('start_only');
+    expect(classifyRecordingIntent('stop recording', [])).toBe('stop_only');
+  });
+
+  // Name with colon separator
+  test('handles colon separator after name', () => {
+    expect(classifyRecordingIntent('Nova: record my screen', ['Nova'])).toBe('start_only');
   });
 });

--- a/assistant/src/__tests__/recording-intent.test.ts
+++ b/assistant/src/__tests__/recording-intent.test.ts
@@ -283,6 +283,7 @@ describe('classifyRecordingIntent', () => {
   test.each([
     ['Nova, record my screen', ['Nova'], 'start_only'],
     ['hey Nova, start recording', ['Nova'], 'start_only'],
+    ['hey, Nova, start recording', ['Nova'], 'start_only'],
     ['Nova, stop recording', ['Nova'], 'stop_only'],
     ['Nova, open Safari and record my screen', ['Nova'], 'mixed'],
     ['Nova, hello', ['Nova'], 'none'],

--- a/assistant/src/daemon/recording-intent.ts
+++ b/assistant/src/daemon/recording-intent.ts
@@ -134,14 +134,14 @@ export function isStopRecordingOnly(taskText: string): boolean {
 
 /**
  * Strips dynamic assistant name aliases from the beginning of text.
- * Handles patterns like "Nova, ...", "Nova ...", "hey Nova, ..." (case-insensitive).
+ * Handles patterns like "Nova, ...", "Nova ...", "hey Nova, ...", "hey, Nova, ..." (case-insensitive).
  */
 function stripDynamicNames(text: string, dynamicNames: string[]): string {
   let result = text;
   for (const name of dynamicNames) {
     const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    // "hey <name>, ..." or "hey <name> ..."
-    const heyPattern = new RegExp(`^hey\\s+${escaped}[,:]?\\s*`, 'i');
+    // "hey <name>, ..." / "hey <name> ..." / "hey, <name>, ..."
+    const heyPattern = new RegExp(`^hey[,\\s]+${escaped}[,:]?\\s*`, 'i');
     // "<name>, ..." or "<name> ..."
     const namePattern = new RegExp(`^${escaped}[,:]?\\s*`, 'i');
     result = result.replace(heyPattern, '');

--- a/assistant/src/daemon/recording-intent.ts
+++ b/assistant/src/daemon/recording-intent.ts
@@ -2,6 +2,8 @@
 // Used by task/message handlers to intercept recording-related prompts
 // before they reach the classifier or create a CU session.
 
+export type RecordingIntentClass = 'start_only' | 'stop_only' | 'mixed' | 'none';
+
 // ─── Start recording patterns ────────────────────────────────────────────────
 
 const START_RECORDING_PATTERNS: RegExp[] = [
@@ -126,4 +128,63 @@ export function isStopRecordingOnly(taskText: string): boolean {
   // Also remove common polite/filler words that don't change the intent
   const withoutFillers = stripped.replace(FILLER_PATTERN, '');
   return withoutFillers.replace(/[.,;!?\s]+/g, '').length === 0;
+}
+
+// ─── Dynamic name normalization ─────────────────────────────────────────────
+
+/**
+ * Strips dynamic assistant name aliases from the beginning of text.
+ * Handles patterns like "Nova, ...", "Nova ...", "hey Nova, ..." (case-insensitive).
+ */
+function stripDynamicNames(text: string, dynamicNames: string[]): string {
+  let result = text;
+  for (const name of dynamicNames) {
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // "hey <name>, ..." or "hey <name> ..."
+    const heyPattern = new RegExp(`^hey\\s+${escaped}[,:]?\\s*`, 'i');
+    // "<name>, ..." or "<name> ..."
+    const namePattern = new RegExp(`^${escaped}[,:]?\\s*`, 'i');
+    result = result.replace(heyPattern, '');
+    result = result.replace(namePattern, '');
+  }
+  return result.trim();
+}
+
+// ─── Unified classification ─────────────────────────────────────────────────
+
+/**
+ * Classifies the recording intent of a user message into one of four categories:
+ * - 'start_only': the prompt is purely about starting a recording
+ * - 'stop_only': the prompt is purely about stopping a recording
+ * - 'mixed': the prompt contains recording intent mixed with other tasks,
+ *            or contains both start and stop recording patterns
+ * - 'none': no recording intent detected
+ *
+ * If `dynamicNames` are provided, they are stripped from the beginning of the
+ * text before classification (e.g., "Nova, record my screen" -> "record my screen").
+ */
+export function classifyRecordingIntent(
+  taskText: string,
+  dynamicNames?: string[],
+): RecordingIntentClass {
+  const normalized =
+    dynamicNames && dynamicNames.length > 0
+      ? stripDynamicNames(taskText, dynamicNames)
+      : taskText;
+
+  const hasStart = detectRecordingIntent(normalized);
+  const hasStop = detectStopRecordingIntent(normalized);
+
+  // Both start and stop patterns present -> mixed
+  if (hasStart && hasStop) return 'mixed';
+
+  if (hasStop) {
+    return isStopRecordingOnly(normalized) ? 'stop_only' : 'mixed';
+  }
+
+  if (hasStart) {
+    return isRecordingOnly(normalized) ? 'start_only' : 'mixed';
+  }
+
+  return 'none';
 }


### PR DESCRIPTION
Add unified classifyRecordingIntent() returning start_only|stop_only|mixed|none. Includes normalization pipeline that strips dynamic name aliases before pattern matching. Comprehensive unit tests added. Part of #9161, closes #9163.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
