### PR TITLE
fix: add missing subagentDetailStore to ChatView preview

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -572,7 +572,8 @@ private struct ChatViewPreviewWrapper: View {
                 onDismissSessionError: {},
                 onCopyDebugInfo: {},
                 watchSession: nil,
-                onStopWatch: {}
+                onStopWatch: {},
+                subagentDetailStore: SubagentDetailStore()
             )
         }
     }


### PR DESCRIPTION
## Summary
- Adds the missing `subagentDetailStore` parameter to the ChatView preview wrapper

PR #9111 (M1) changed `subagentDetailStore` from an optional to a required `@ObservedObject` parameter on `ChatView`, but the `#Preview` block wasn't updated, causing a build error:

```
ChatView.swift:575:32: error: missing argument for parameter 'subagentDetailStore' in call
```

## Test plan
- [ ] `swift build --product vellum-assistant` compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
