### PR TITLE
fix: restore forceStrictSideEffects for non-guardian/unverified channel actors

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -764,6 +764,20 @@ export class DaemonServer {
     const resolvedInterface = resolveTurnInterface(sourceInterface);
     session.setAssistantId(options?.assistantId ?? 'self');
     session.setGuardianContext(options?.guardianContext ?? null);
+
+    // Force strict side-effects for non-guardian and unverified_channel actors
+    // so all side-effect tools require guardian approval. This restores the
+    // invariant that was lost when the runs-store migration moved to
+    // processMessage — without it, these actors could execute side-effect
+    // tools without guaranteed guardian approval prompts.
+    const actorRole = options?.guardianContext?.actorRole;
+    if (actorRole === 'non-guardian' || actorRole === 'unverified_channel') {
+      session.memoryPolicy = {
+        ...session.memoryPolicy,
+        strictSideEffects: true,
+      };
+    }
+
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel, sourceInterface));
     session.setCommandIntent(options?.commandIntent ?? null);
     session.setTurnChannelContext({


### PR DESCRIPTION
## Summary

- Restores the `forceStrictSideEffects=true` override for `non-guardian` and `unverified_channel` actors in `prepareSessionForMessage` (daemon server)
- The migration from runs-store to pending-interactions (PR #8428) dropped this invariant, allowing these actors to potentially bypass forced-confirmation behavior and execute side-effect tools without guardian approval prompts
- Mirrors the existing pattern in `voice-session-bridge.ts` where strict side-effects are forced for non-guardian actors

## Test plan

- [x] Existing `daemon-server-session-init` tests pass
- [x] Existing `session-tool-setup-side-effect-flag` tests pass
- [x] Existing `voice-session-bridge` tests pass (16/16)
- [x] Type-check passes (no new errors introduced)
- [ ] Manual verification: non-guardian actor on a channel triggers approval prompts for side-effect tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
