### PR TITLE
fix: use async notification API to resolve actor-isolation warnings

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -219,14 +219,20 @@ extension AppDelegate {
                 return
             }
 
-            UNUserNotificationCenter.current().add(request) { error in
-                if let error {
-                    log.error("Failed to post notification intent (id: \(notificationId), source: \(sourceEventName)): \(error.localizedDescription)")
-                }
+            do {
+                try await UNUserNotificationCenter.current().add(request)
                 self.sendNotificationIntentResult(
                     deliveryId: deliveryId,
-                    success: error == nil,
-                    errorMessage: error?.localizedDescription,
+                    success: true,
+                    errorMessage: nil,
+                    errorCode: nil
+                )
+            } catch {
+                log.error("Failed to post notification intent (id: \(notificationId), source: \(sourceEventName)): \(error.localizedDescription)")
+                self.sendNotificationIntentResult(
+                    deliveryId: deliveryId,
+                    success: false,
+                    errorMessage: error.localizedDescription,
                     errorCode: nil
                 )
             }


### PR DESCRIPTION
## Summary
- Replaces the completion-handler `UNUserNotificationCenter.add(_:completionHandler:)` with `try await .add(_:)` in `AppDelegate+Notifications.swift`

The call site is already inside a `Task { }` block, so switching to the async API is a drop-in fix. This eliminates both warnings:
1. "consider using asynchronous alternative function" — now using the async overload
2. "call to main actor-isolated instance method in a synchronous nonisolated context" — the async context properly handles `@MainActor` dispatch to `sendNotificationIntentResult`

## Test plan
- [ ] `swift build --product vellum-assistant` compiles with no warnings from this file
- [ ] Notification intents still fire correctly (daemon → macOS notification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
