### PR TITLE
M3: UX Polish, Accessibility, and Guardrail Tests

### DIFF
--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -223,6 +223,23 @@ Grant these in System Settings → Privacy & Security.
 10. Responses stream in real-time from the daemon
 11. Click the stop button to cancel an in-progress generation
 
+### Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd +` | Conversation zoom in (text only) |
+| `Cmd -` | Conversation zoom out (text only) |
+| `Cmd 0` | Reset conversation zoom to 100% |
+| `Option+Cmd +` | Window zoom in (entire UI) |
+| `Option+Cmd -` | Window zoom out (entire UI) |
+| `Option+Cmd 0` | Reset window zoom to 100% |
+| `Cmd Shift G` | Open task input popover |
+| `Escape` | Cancel current session / close popover |
+
+**Conversation zoom** scales chat text (messages, markdown, code blocks, composer) independently of the window. A brief "Text 125%" indicator appears on each change. The zoom level persists across app relaunches.
+
+**Window zoom** scales the entire UI uniformly. A percentage indicator appears at the top of the window on each change.
+
 ### Opportunistic Message Queueing
 
 Users can send multiple messages while the assistant is busy. Messages are queued (FIFO, max 10) and processed automatically:

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -24,6 +24,7 @@ struct MessageListView: View {
 
     var threadId: UUID?
     @Binding var isNearBottom: Bool
+    @Environment(\.conversationZoomScale) private var conversationZoomScale
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
     @AppStorage("completedConversationCount") private var completedConversationCount: Int = 0
     @State private var identity: IdentityInfo? = IdentityInfo.load()
@@ -314,6 +315,16 @@ struct MessageListView: View {
                     withAnimation(VAnimation.fast) {
                         proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                     }
+                }
+            }
+            .onChange(of: conversationZoomScale) {
+                // Re-anchor scroll position after zoom changes to avoid jarring
+                // jumps caused by reflowing text at a different scale.
+                if isNearBottom {
+                    proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                } else if let lastVisibleId = messages.last?.id {
+                    // Mid-scroll: anchor to the last message to keep content stable.
+                    proxy.scrollTo(lastVisibleId, anchor: .bottom)
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -318,14 +318,10 @@ struct MessageListView: View {
                 }
             }
             .onChange(of: conversationZoomScale) {
-                // Re-anchor scroll position after zoom changes to avoid jarring
-                // jumps caused by reflowing text at a different scale.
                 if isNearBottom {
                     proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
-                } else if let lastVisibleId = messages.last?.id {
-                    // Mid-scroll: anchor to the last message to keep content stable.
-                    proxy.scrollTo(lastVisibleId, anchor: .bottom)
                 }
+                // When mid-scroll, do nothing — let SwiftUI handle the text reflow naturally.
             }
         }
         .id(threadId)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1333,21 +1333,31 @@ struct MainWindowView: View {
 
 }
 
-private struct ZoomIndicatorView: View {
+struct ZoomIndicatorView: View {
     let percentage: Int
+    /// Optional prefix shown before the percentage (e.g. "Text" → "Text 125%").
+    var label: String? = nil
 
     var body: some View {
-        Text("\(percentage)%")
-            .font(VFont.bodyMedium)
-            .foregroundStyle(VColor.textPrimary)
-            .padding(.horizontal, VSpacing.lg)
-            .padding(.vertical, VSpacing.sm)
-            .background(VColor.surface)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .stroke(VColor.surfaceBorder, lineWidth: 1)
-            )
+        HStack(spacing: VSpacing.xs) {
+            if let label {
+                Text(label)
+                    .font(VFont.caption)
+                    .foregroundStyle(VColor.textSecondary)
+            }
+            Text("\(percentage)%")
+                .font(VFont.bodyMedium)
+                .foregroundStyle(VColor.textPrimary)
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+        .background(VColor.surface)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+        .accessibilityLabel("Zoom \(percentage) percent")
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -478,7 +478,7 @@ extension MainWindowView {
             .environment(\.conversationZoomScale, conversationZoomManager.zoomLevel)
             .overlay(alignment: .top) {
                 if conversationZoomManager.showZoomIndicator {
-                    ZoomIndicatorView(percentage: conversationZoomManager.zoomPercentage)
+                    ZoomIndicatorView(percentage: conversationZoomManager.zoomPercentage, label: "Text")
                         .transition(.move(edge: .top).combined(with: .opacity))
                         .padding(.top, VSpacing.xl)
                 }

--- a/clients/macos/vellum-assistantTests/ConversationZoomManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationZoomManagerTests.swift
@@ -1,0 +1,220 @@
+import Foundation
+import Testing
+@testable import VellumAssistantLib
+
+@Suite("ConversationZoomManager")
+struct ConversationZoomManagerTests {
+
+    // MARK: - Default State
+
+    @Test @MainActor
+    func defaultZoomLevelIsOne() {
+        // Clear any persisted value so the manager starts fresh.
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        #expect(manager.zoomLevel == 1.0)
+        #expect(manager.zoomPercentage == 100)
+    }
+
+    // MARK: - Zoom In
+
+    @Test @MainActor
+    func zoomInAdvancesToNextStep() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        manager.zoomIn()
+        #expect(manager.zoomLevel == 1.1)
+        #expect(manager.zoomPercentage == 110)
+    }
+
+    @Test @MainActor
+    func zoomInMultipleSteps() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        manager.zoomIn() // 1.1
+        manager.zoomIn() // 1.25
+        manager.zoomIn() // 1.5
+        #expect(manager.zoomLevel == 1.5)
+        #expect(manager.zoomPercentage == 150)
+    }
+
+    // MARK: - Zoom Out
+
+    @Test @MainActor
+    func zoomOutRetreatsToLowerStep() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        manager.zoomOut()
+        #expect(manager.zoomLevel == 0.9)
+        #expect(manager.zoomPercentage == 90)
+    }
+
+    @Test @MainActor
+    func zoomOutMultipleSteps() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        manager.zoomOut() // 0.9
+        manager.zoomOut() // 0.75
+        manager.zoomOut() // 0.5
+        #expect(manager.zoomLevel == 0.5)
+        #expect(manager.zoomPercentage == 50)
+    }
+
+    // MARK: - Clamping at Maximum
+
+    @Test @MainActor
+    func zoomInClampsAtMaximum() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        let maxStep = ConversationZoomManager.zoomSteps.last!
+
+        // Zoom in until we hit the maximum step.
+        for _ in 0..<ConversationZoomManager.zoomSteps.count {
+            manager.zoomIn()
+        }
+        #expect(manager.zoomLevel == maxStep)
+
+        // One more zoomIn should not change the level.
+        manager.zoomIn()
+        #expect(manager.zoomLevel == maxStep)
+        #expect(manager.zoomPercentage == Int(round(maxStep * 100)))
+    }
+
+    // MARK: - Clamping at Minimum
+
+    @Test @MainActor
+    func zoomOutClampsAtMinimum() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        let minStep = ConversationZoomManager.zoomSteps.first!
+
+        // Zoom out until we hit the minimum step.
+        for _ in 0..<ConversationZoomManager.zoomSteps.count {
+            manager.zoomOut()
+        }
+        #expect(manager.zoomLevel == minStep)
+
+        // One more zoomOut should not change the level.
+        manager.zoomOut()
+        #expect(manager.zoomLevel == minStep)
+        #expect(manager.zoomPercentage == Int(round(minStep * 100)))
+    }
+
+    // MARK: - Reset Zoom
+
+    @Test @MainActor
+    func resetZoomRestoresDefault() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        manager.zoomIn()
+        manager.zoomIn()
+        #expect(manager.zoomLevel != 1.0)
+
+        manager.resetZoom()
+        #expect(manager.zoomLevel == 1.0)
+        #expect(manager.zoomPercentage == 100)
+    }
+
+    @Test @MainActor
+    func resetZoomFromZoomedOut() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        manager.zoomOut()
+        manager.zoomOut()
+        #expect(manager.zoomLevel < 1.0)
+
+        manager.resetZoom()
+        #expect(manager.zoomLevel == 1.0)
+    }
+
+    // MARK: - Persistence
+
+    @Test @MainActor
+    func zoomLevelPersistsAcrossInstances() {
+        let key = "conversationTextZoomLevel"
+        UserDefaults.standard.removeObject(forKey: key)
+
+        let first = ConversationZoomManager()
+        first.zoomIn() // 1.1
+        first.zoomIn() // 1.25
+        let savedLevel = first.zoomLevel
+
+        // A second instance should load the persisted value.
+        let second = ConversationZoomManager()
+        #expect(second.zoomLevel == savedLevel)
+        #expect(second.zoomPercentage == Int(round(savedLevel * 100)))
+
+        // Clean up.
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+
+    @Test @MainActor
+    func resetZoomPersists() {
+        let key = "conversationTextZoomLevel"
+        UserDefaults.standard.removeObject(forKey: key)
+
+        let first = ConversationZoomManager()
+        first.zoomIn()
+        first.resetZoom()
+
+        let second = ConversationZoomManager()
+        #expect(second.zoomLevel == 1.0)
+
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+
+    // MARK: - Indicator Flashing
+
+    @Test @MainActor
+    func zoomInShowsIndicator() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        #expect(!manager.showZoomIndicator)
+
+        manager.zoomIn()
+        #expect(manager.showZoomIndicator)
+    }
+
+    @Test @MainActor
+    func zoomOutShowsIndicator() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        manager.zoomOut()
+        #expect(manager.showZoomIndicator)
+    }
+
+    @Test @MainActor
+    func resetZoomShowsIndicator() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        manager.resetZoom()
+        #expect(manager.showZoomIndicator)
+    }
+
+    @Test @MainActor
+    func indicatorAutoDismisses() async {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        manager.zoomIn()
+        #expect(manager.showZoomIndicator)
+
+        // Wait for the 1.5s auto-dismiss plus a small buffer.
+        try? await Task.sleep(nanoseconds: 1_800_000_000)
+        #expect(!manager.showZoomIndicator)
+    }
+
+    // MARK: - Zoom Steps Invariants
+
+    @Test
+    func zoomStepsAreSortedAscending() {
+        let steps = ConversationZoomManager.zoomSteps
+        for i in 1..<steps.count {
+            #expect(steps[i] > steps[i - 1])
+        }
+    }
+
+    @Test
+    func zoomStepsContainDefaultLevel() {
+        #expect(ConversationZoomManager.zoomSteps.contains(1.0))
+    }
+}


### PR DESCRIPTION
Adds conversation zoom percentage indicator with auto-dismiss overlay, preserves scroll anchor during zoom changes, adds ConversationZoomManager unit tests for step clamping and persistence, and documents keyboard shortcuts in the macOS README. Part of #9123.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
