### PR TITLE
feat: add vellum login/logout/whoami commands

### DIFF
--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -1,0 +1,68 @@
+import {
+  clearPlatformToken,
+  fetchCurrentUser,
+  readPlatformToken,
+  savePlatformToken,
+} from "../lib/platform-client";
+
+export async function login(): Promise<void> {
+  const args = process.argv.slice(3);
+  let token: string | null = null;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--token") {
+      token = args[i + 1];
+      if (!token) {
+        console.error("Error: --token requires a value");
+        process.exit(1);
+      }
+      break;
+    }
+  }
+
+  if (!token) {
+    console.error("Usage: vellum login --token <session-token>");
+    console.error("");
+    console.error("To get your session token:");
+    console.error("  1. Log in to the Vellum platform in your browser");
+    console.error("  2. Open Developer Tools → Application → Cookies");
+    console.error("  3. Copy the value of the session token");
+    process.exit(1);
+  }
+
+  console.log("Validating token...");
+
+  try {
+    const user = await fetchCurrentUser(token);
+    savePlatformToken(token);
+    console.log(`✅ Logged in as ${user.email}`);
+  } catch (error) {
+    console.error(`❌ Login failed: ${error instanceof Error ? error.message : error}`);
+    process.exit(1);
+  }
+}
+
+export async function logout(): Promise<void> {
+  clearPlatformToken();
+  console.log("Logged out. Platform token removed.");
+}
+
+export async function whoami(): Promise<void> {
+  const token = readPlatformToken();
+  if (!token) {
+    console.error("Not logged in. Run `vellum login --token <token>` first.");
+    process.exit(1);
+  }
+
+  try {
+    const user = await fetchCurrentUser(token);
+    console.log(`Email: ${user.email}`);
+    if (user.first_name || user.last_name) {
+      console.log(`Name:  ${[user.first_name, user.last_name].filter(Boolean).join(" ")}`);
+    }
+    console.log(`ID:    ${user.id}`);
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : error}`);
+    process.exit(1);
+  }
+}

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -57,8 +57,8 @@ export async function whoami(): Promise<void> {
   try {
     const user = await fetchCurrentUser(token);
     console.log(`Email: ${user.email}`);
-    if (user.first_name || user.last_name) {
-      console.log(`Name:  ${[user.first_name, user.last_name].filter(Boolean).join(" ")}`);
+    if (user.display) {
+      console.log(`Name:  ${user.display}`);
     }
     console.log(`ID:    ${user.id}`);
   } catch (error) {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -11,6 +11,7 @@ import { config } from "./commands/config";
 import { contacts } from "./commands/contacts";
 import { email } from "./commands/email";
 import { hatch } from "./commands/hatch";
+import { login, logout, whoami } from "./commands/login";
 import { ps } from "./commands/ps";
 import { recover } from "./commands/recover";
 import { retire } from "./commands/retire";
@@ -25,12 +26,15 @@ const commands = {
   contacts,
   email,
   hatch,
+  login,
+  logout,
   ps,
   recover,
   retire,
   sleep,
   ssh,
   wake,
+  whoami,
 } as const;
 
 type CommandName = keyof typeof commands;
@@ -75,12 +79,15 @@ async function main() {
     console.log("  contacts Manage the contact graph");
     console.log("  email    Email operations (status, create inbox)");
     console.log("  hatch    Create a new assistant instance");
+    console.log("  login    Log in to the Vellum platform");
+    console.log("  logout   Log out of the Vellum platform");
     console.log("  ps       List assistants (or processes for a specific assistant)");
     console.log("  recover  Restore a previously retired local assistant");
     console.log("  retire   Delete an assistant instance");
     console.log("  sleep    Stop the daemon process");
     console.log("  ssh      SSH into a remote assistant instance");
     console.log("  wake     Start the daemon and gateway");
+    console.log("  whoami   Show current logged-in user");
     process.exit(0);
   }
 

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -36,26 +36,33 @@ export function clearPlatformToken(): void {
 export interface PlatformUser {
   id: string;
   email: string;
-  first_name: string;
-  last_name: string;
+  display: string;
+}
+
+interface AllauthSessionResponse {
+  status: number;
+  data: {
+    user: {
+      id: string;
+      email: string;
+      display: string;
+    };
+  };
 }
 
 export async function fetchCurrentUser(token: string): Promise<PlatformUser> {
-  const url = `${getPlatformUrl()}/v1/users/`;
+  const url = `${getPlatformUrl()}/_allauth/app/v1/auth/session`;
   const response = await fetch(url, {
     headers: { "X-Session-Token": token },
   });
 
   if (!response.ok) {
-    if (response.status === 401 || response.status === 403) {
+    if (response.status === 401 || response.status === 403 || response.status === 410) {
       throw new Error("Invalid or expired token. Please login again.");
     }
     throw new Error(`Platform API error: ${response.status} ${response.statusText}`);
   }
 
-  const data = (await response.json()) as PlatformUser[];
-  if (!data.length) {
-    throw new Error("No user found for this token.");
-  }
-  return data[0];
+  const body = (await response.json()) as AllauthSessionResponse;
+  return body.data.user;
 }

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -1,9 +1,13 @@
-import { readFileSync, writeFileSync, unlinkSync, existsSync, mkdirSync } from "fs";
+import { chmodSync, readFileSync, writeFileSync, unlinkSync, existsSync, mkdirSync } from "fs";
 import { homedir } from "os";
 import { join, dirname } from "path";
 
-const PLATFORM_TOKEN_PATH = join(homedir(), ".vellum", "platform-token");
 const DEFAULT_PLATFORM_URL = "https://platform.vellum.ai";
+
+function getPlatformTokenPath(): string {
+  const base = process.env.BASE_DATA_DIR || homedir();
+  return join(base, ".vellum", "platform-token");
+}
 
 export function getPlatformUrl(): string {
   return process.env.VELLUM_PLATFORM_URL ?? DEFAULT_PLATFORM_URL;
@@ -11,23 +15,25 @@ export function getPlatformUrl(): string {
 
 export function readPlatformToken(): string | null {
   try {
-    return readFileSync(PLATFORM_TOKEN_PATH, "utf-8").trim();
+    return readFileSync(getPlatformTokenPath(), "utf-8").trim();
   } catch {
     return null;
   }
 }
 
 export function savePlatformToken(token: string): void {
-  const dir = dirname(PLATFORM_TOKEN_PATH);
+  const tokenPath = getPlatformTokenPath();
+  const dir = dirname(tokenPath);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
-  writeFileSync(PLATFORM_TOKEN_PATH, token + "\n", { mode: 0o600 });
+  writeFileSync(tokenPath, token + "\n", { mode: 0o600 });
+  chmodSync(tokenPath, 0o600);
 }
 
 export function clearPlatformToken(): void {
   try {
-    unlinkSync(PLATFORM_TOKEN_PATH);
+    unlinkSync(getPlatformTokenPath());
   } catch {
     // already doesn't exist
   }

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -1,0 +1,61 @@
+import { readFileSync, writeFileSync, unlinkSync, existsSync, mkdirSync } from "fs";
+import { homedir } from "os";
+import { join, dirname } from "path";
+
+const PLATFORM_TOKEN_PATH = join(homedir(), ".vellum", "platform-token");
+const DEFAULT_PLATFORM_URL = "https://platform.vellum.ai";
+
+export function getPlatformUrl(): string {
+  return process.env.VELLUM_PLATFORM_URL ?? DEFAULT_PLATFORM_URL;
+}
+
+export function readPlatformToken(): string | null {
+  try {
+    return readFileSync(PLATFORM_TOKEN_PATH, "utf-8").trim();
+  } catch {
+    return null;
+  }
+}
+
+export function savePlatformToken(token: string): void {
+  const dir = dirname(PLATFORM_TOKEN_PATH);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+  writeFileSync(PLATFORM_TOKEN_PATH, token + "\n", { mode: 0o600 });
+}
+
+export function clearPlatformToken(): void {
+  try {
+    unlinkSync(PLATFORM_TOKEN_PATH);
+  } catch {
+    // already doesn't exist
+  }
+}
+
+export interface PlatformUser {
+  id: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+}
+
+export async function fetchCurrentUser(token: string): Promise<PlatformUser> {
+  const url = `${getPlatformUrl()}/v1/users/`;
+  const response = await fetch(url, {
+    headers: { "X-Session-Token": token },
+  });
+
+  if (!response.ok) {
+    if (response.status === 401 || response.status === 403) {
+      throw new Error("Invalid or expired token. Please login again.");
+    }
+    throw new Error(`Platform API error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as PlatformUser[];
+  if (!data.length) {
+    throw new Error("No user found for this token.");
+  }
+  return data[0];
+}


### PR DESCRIPTION
## Summary
- Adds `vellum login --token <token>` to validate and store a platform session token at `~/.vellum/platform-token`
- Adds `vellum logout` to clear the stored token
- Adds `vellum whoami` to display the currently authenticated user
- Platform client (`cli/src/lib/platform-client.ts`) handles token storage and `GET /v1/users/` API calls using `X-Session-Token` auth

This enables `vel import --remote vellum` (in the platform repo) to filter assistants by the logged-in user rather than showing all Kubernetes instances.

## Test plan
- [ ] Run `vellum login --token <valid-token>` — should store token and print user email
- [ ] Run `vellum whoami` — should print user email, name, and ID
- [ ] Run `vellum login --token <invalid-token>` — should show auth error
- [ ] Run `vellum logout` — should remove token file
- [ ] Run `vellum whoami` after logout — should show "not logged in" error
- [ ] Verify token file is created with 0600 permissions at `~/.vellum/platform-token`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
