### PR TITLE
fix: scope gateway detection in vellum ps to vellum-gateway only

### DIFF
--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -66,7 +66,7 @@ const SSH_OPTS = [
 const REMOTE_PS_CMD = [
   // List vellum-related processes: daemon, gateway, qdrant, and any bun children
   "ps ax -o pid=,ppid=,args=",
-  "| grep -E 'vellum|gateway|qdrant|openclaw'",
+  "| grep -E 'vellum|vellum-gateway|qdrant|openclaw'",
   "| grep -v grep",
 ].join(" ");
 
@@ -78,7 +78,7 @@ interface RemoteProcess {
 
 function classifyProcess(command: string): string {
   if (/qdrant/.test(command)) return "qdrant";
-  if (/gateway/.test(command)) return "gateway";
+  if (/vellum-gateway/.test(command)) return "gateway";
   if (/openclaw/.test(command)) return "openclaw-adapter";
   if (/vellum-daemon/.test(command)) return "daemon";
   if (/daemon\s+(start|restart)/.test(command)) return "daemon";
@@ -281,7 +281,7 @@ async function detectOrphanedProcesses(): Promise<OrphanedProcess[]> {
   try {
     const output = await execOutput("sh", [
       "-c",
-      "ps ax -o pid=,ppid=,args= | grep -E 'vellum|gateway|qdrant|openclaw' | grep -v grep",
+      "ps ax -o pid=,ppid=,args= | grep -E 'vellum|vellum-gateway|qdrant|openclaw' | grep -v grep",
     ]);
     const procs = parseRemotePs(output);
     const ownPid = String(process.pid);


### PR DESCRIPTION
## Summary
- `vellum ps` was matching any process with "gateway" in its name (e.g. "openclaw gateway") and reporting it as an orphaned vellum gateway process
- Changed `classifyProcess()` to match `/vellum-gateway/` instead of `/gateway/`, matching the actual binary name
- Updated grep patterns in both remote process listing and local orphaned detection

## Test plan
- [x] All 35 CLI tests pass
- [ ] `vellum ps` no longer reports non-vellum gateway processes as orphaned
- [ ] `vellum ps` still correctly detects actual `vellum-gateway` processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
