### PR TITLE
M3: Wire handlers, add integration tests, update SKILL.md

### DIFF
--- a/assistant/src/__tests__/recording-intent-handler.test.ts
+++ b/assistant/src/__tests__/recording-intent-handler.test.ts
@@ -1,0 +1,472 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import * as net from 'node:net';
+
+// ─── Mocks (must be before any imports that depend on them) ─────────────────
+
+const noop = () => {};
+const noopLogger = {
+  info: noop, warn: noop, error: noop, debug: noop, trace: noop, fatal: noop,
+  child: () => noopLogger,
+};
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => noopLogger,
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    daemon: { standaloneRecording: true },
+    provider: 'mock-provider',
+    model: 'mock-model',
+    permissions: { mode: 'legacy' },
+    apiKeys: {},
+    sandbox: { enabled: false },
+    timeouts: { toolExecutionTimeoutSec: 30, permissionTimeoutSec: 5 },
+    skills: { load: { extraDirs: [] } },
+    secretDetection: { enabled: false, allowOneTimeSend: false },
+    contextWindow: {
+      enabled: true,
+      maxInputTokens: 180000,
+      targetInputTokens: 110000,
+      compactThreshold: 0.8,
+      preserveRecentUserTurns: 8,
+      summaryMaxTokens: 1200,
+      chunkTokens: 12000,
+    },
+  }),
+  invalidateConfigCache: noop,
+  loadConfig: noop,
+  saveConfig: noop,
+  loadRawConfig: () => ({}),
+  saveRawConfig: noop,
+  getNestedValue: () => undefined,
+  setNestedValue: noop,
+}));
+
+// ── Mock identity-helpers ──────────────────────────────────────────────────
+
+let mockAssistantName: string | null = null;
+
+mock.module('../daemon/identity-helpers.js', () => ({
+  getAssistantName: () => mockAssistantName,
+}));
+
+// ── Mock recording-intent — we control the classification result ───────────
+
+let mockClassifyResult: 'start_only' | 'stop_only' | 'mixed' | 'none' = 'none';
+
+mock.module('../daemon/recording-intent.js', () => ({
+  classifyRecordingIntent: () => mockClassifyResult,
+  // Keep legacy exports in case anything references them transitively
+  isRecordingOnly: () => false,
+  isStopRecordingOnly: () => false,
+  detectRecordingIntent: () => false,
+  detectStopRecordingIntent: () => false,
+  stripRecordingIntent: (t: string) => t,
+  stripStopRecordingIntent: (t: string) => t,
+}));
+
+// ── Mock recording handlers ────────────────────────────────────────────────
+
+let recordingStartCalled = false;
+let recordingStopCalled = false;
+
+mock.module('../daemon/handlers/recording.js', () => ({
+  handleRecordingStart: () => {
+    recordingStartCalled = true;
+    return 'mock-recording-id';
+  },
+  handleRecordingStop: () => {
+    recordingStopCalled = true;
+    return 'mock-recording-id';
+  },
+  recordingHandlers: {},
+  __resetRecordingState: noop,
+}));
+
+// ── Mock conversation store ────────────────────────────────────────────────
+
+mock.module('../memory/conversation-store.js', () => ({
+  getMessages: () => [],
+  addMessage: () => ({ id: 'msg-mock', role: 'assistant', content: '' }),
+  createConversation: (title?: string) => ({ id: 'conv-mock', title: title ?? 'Untitled' }),
+  getConversation: () => ({ id: 'conv-mock' }),
+  updateConversationTitle: noop,
+  clearAll: noop,
+  listConversations: () => [],
+  countConversations: () => 0,
+  searchConversations: () => [],
+  deleteConversation: noop,
+}));
+
+mock.module('../memory/conversation-title-service.js', () => ({
+  GENERATING_TITLE: '(generating…)',
+  queueGenerateConversationTitle: noop,
+  UNTITLED_FALLBACK: 'Untitled',
+}));
+
+mock.module('../memory/attachments-store.js', () => ({
+  getAttachmentsForMessage: () => [],
+  uploadFileBackedAttachment: () => ({ id: 'att-mock' }),
+  linkAttachmentToMessage: noop,
+  setAttachmentThumbnail: noop,
+}));
+
+// ── Mock security ──────────────────────────────────────────────────────────
+
+mock.module('../security/secret-ingress.js', () => ({
+  checkIngressForSecrets: () => ({ blocked: false }),
+}));
+
+// ── Mock classifier (for task_submit fallthrough) ──────────────────────────
+
+let classifierCalled = false;
+
+mock.module('../daemon/classifier.js', () => ({
+  classifyInteraction: async () => {
+    classifierCalled = true;
+    return 'text_qa';
+  },
+}));
+
+// ── Mock slash commands ────────────────────────────────────────────────────
+
+mock.module('../skills/slash-commands.js', () => ({
+  parseSlashCandidate: () => ({ kind: 'none' }),
+}));
+
+// ── Mock computer-use handler ──────────────────────────────────────────────
+
+mock.module('../daemon/handlers/computer-use.js', () => ({
+  handleCuSessionCreate: noop,
+}));
+
+// ── Mock provider ──────────────────────────────────────────────────────────
+
+mock.module('../providers/provider-send-message.js', () => ({
+  getConfiguredProvider: () => null,
+}));
+
+// ── Mock external conversation store ───────────────────────────────────────
+
+mock.module('../memory/external-conversation-store.js', () => ({
+  getBindingsForConversations: () => new Map(),
+}));
+
+// ── Mock subagent manager ──────────────────────────────────────────────────
+
+mock.module('../subagent/index.js', () => ({
+  getSubagentManager: () => ({
+    abortAllForParent: noop,
+  }),
+}));
+
+// ── Mock IPC protocol helpers ──────────────────────────────────────────────
+
+mock.module('../daemon/ipc-protocol.js', () => ({
+  normalizeThreadType: (t: string) => t ?? 'primary',
+}));
+
+// ── Mock session error helpers ─────────────────────────────────────────────
+
+mock.module('../daemon/session-error.js', () => ({
+  classifySessionError: () => ({ code: 'UNKNOWN', userMessage: 'error', retryable: false }),
+  buildSessionErrorMessage: () => ({ type: 'error', message: 'error' }),
+}));
+
+// ── Mock video thumbnail ───────────────────────────────────────────────────
+
+mock.module('../daemon/video-thumbnail.js', () => ({
+  generateVideoThumbnail: async () => null,
+}));
+
+// ── Mock IPC blob store ────────────────────────────────────────────────────
+
+mock.module('../daemon/ipc-blob-store.js', () => ({
+  isValidBlobId: () => false,
+  resolveBlobPath: () => '',
+  deleteBlob: noop,
+}));
+
+// ── Mock channels/types ────────────────────────────────────────────────────
+
+mock.module('../channels/types.js', () => ({
+  parseChannelId: () => 'vellum',
+  parseInterfaceId: () => 'vellum',
+  isChannelId: () => true,
+}));
+
+// ─── Imports (after mocks) ──────────────────────────────────────────────────
+
+import type { HandlerContext } from '../daemon/handlers/shared.js';
+import { DebouncerMap } from '../util/debounce.js';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function createCtx(overrides?: Partial<HandlerContext>): {
+  ctx: HandlerContext;
+  sent: Array<{ type: string; [k: string]: unknown }>;
+  fakeSocket: net.Socket;
+} {
+  const sent: Array<{ type: string; [k: string]: unknown }> = [];
+  const fakeSocket = {} as net.Socket;
+  const socketToSession = new Map<net.Socket, string>();
+
+  // Create a fake session that fulfills minimum interface for handleUserMessage
+  const fakeSession = {
+    hasEscalationHandler: () => true,
+    traceEmitter: { emit: noop },
+    enqueueMessage: () => ({ rejected: false, queued: false }),
+    setTurnChannelContext: noop,
+    setTurnInterfaceContext: noop,
+    setAssistantId: noop,
+    setGuardianContext: noop,
+    setCommandIntent: noop,
+    processMessage: async () => {},
+    getQueueDepth: () => 0,
+    setPreactivatedSkillIds: noop,
+    redirectToSecurePrompt: noop,
+  };
+
+  const sessions = new Map<string, any>();
+
+  const ctx: HandlerContext = {
+    sessions,
+    socketToSession,
+    cuSessions: new Map(),
+    socketToCuSession: new Map(),
+    cuObservationParseSequence: new Map(),
+    socketSandboxOverride: new Map(),
+    sharedRequestTimestamps: [],
+    debounceTimers: new DebouncerMap({ defaultDelayMs: 200 }),
+    suppressConfigReload: false,
+    setSuppressConfigReload: noop,
+    updateConfigFingerprint: noop,
+    send: (_socket, msg) => { sent.push(msg as { type: string; [k: string]: unknown }); },
+    broadcast: noop,
+    clearAllSessions: () => 0,
+    getOrCreateSession: async (conversationId: string) => {
+      sessions.set(conversationId, fakeSession);
+      return fakeSession as any;
+    },
+    touchSession: noop,
+    ...overrides,
+  };
+
+  return { ctx, sent, fakeSocket };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('recording intent handler integration — handleTaskSubmit', () => {
+  beforeEach(() => {
+    mockClassifyResult = 'none';
+    mockAssistantName = null;
+    recordingStartCalled = false;
+    recordingStopCalled = false;
+    classifierCalled = false;
+  });
+
+  test('start_only → calls handleRecordingStart, sends task_routed + text_delta + message_complete, returns early', async () => {
+    mockClassifyResult = 'start_only';
+    const { ctx, sent, fakeSocket } = createCtx();
+
+    const { handleTaskSubmit } = await import('../daemon/handlers/misc.js');
+    await handleTaskSubmit(
+      { type: 'task_submit', task: 'record my screen', source: 'voice' } as any,
+      fakeSocket,
+      ctx,
+    );
+
+    expect(recordingStartCalled).toBe(true);
+    expect(recordingStopCalled).toBe(false);
+    expect(classifierCalled).toBe(false);
+
+    const types = sent.map((m) => m.type);
+    expect(types).toContain('task_routed');
+    expect(types).toContain('assistant_text_delta');
+    expect(types).toContain('message_complete');
+  });
+
+  test('stop_only → calls handleRecordingStop, sends task_routed + text_delta + message_complete, returns early', async () => {
+    mockClassifyResult = 'stop_only';
+    const { ctx, sent, fakeSocket } = createCtx();
+
+    const { handleTaskSubmit } = await import('../daemon/handlers/misc.js');
+    await handleTaskSubmit(
+      { type: 'task_submit', task: 'stop recording', source: 'voice' } as any,
+      fakeSocket,
+      ctx,
+    );
+
+    expect(recordingStopCalled).toBe(true);
+    expect(recordingStartCalled).toBe(false);
+    expect(classifierCalled).toBe(false);
+
+    const types = sent.map((m) => m.type);
+    expect(types).toContain('task_routed');
+    expect(types).toContain('assistant_text_delta');
+    expect(types).toContain('message_complete');
+  });
+
+  test('mixed → does NOT call handleRecordingStart/Stop, falls through to classifier', async () => {
+    mockClassifyResult = 'mixed';
+    const { ctx, sent, fakeSocket } = createCtx();
+
+    const { handleTaskSubmit } = await import('../daemon/handlers/misc.js');
+    await handleTaskSubmit(
+      { type: 'task_submit', task: 'open Safari and record my screen', source: 'voice' } as any,
+      fakeSocket,
+      ctx,
+    );
+
+    expect(recordingStartCalled).toBe(false);
+    expect(recordingStopCalled).toBe(false);
+    expect(classifierCalled).toBe(true);
+
+    // Should NOT have recording-specific messages before the classifier output
+    const recordingSpecific = sent.filter(
+      (m) => m.type === 'assistant_text_delta' && typeof m.text === 'string' &&
+        (m.text.includes('Starting screen recording') || m.text.includes('Stopping the recording')),
+    );
+    expect(recordingSpecific).toHaveLength(0);
+  });
+
+  test('none → does NOT call handleRecordingStart/Stop, falls through to classifier', async () => {
+    mockClassifyResult = 'none';
+    const { ctx, sent, fakeSocket } = createCtx();
+
+    const { handleTaskSubmit } = await import('../daemon/handlers/misc.js');
+    await handleTaskSubmit(
+      { type: 'task_submit', task: 'hello world', source: 'voice' } as any,
+      fakeSocket,
+      ctx,
+    );
+
+    expect(recordingStartCalled).toBe(false);
+    expect(recordingStopCalled).toBe(false);
+    expect(classifierCalled).toBe(true);
+  });
+});
+
+describe('recording intent handler integration — handleUserMessage', () => {
+  beforeEach(() => {
+    mockClassifyResult = 'none';
+    mockAssistantName = null;
+    recordingStartCalled = false;
+    recordingStopCalled = false;
+    classifierCalled = false;
+  });
+
+  test('start_only → calls handleRecordingStart, sends text_delta + message_complete, returns early', async () => {
+    mockClassifyResult = 'start_only';
+    const { ctx, sent, fakeSocket } = createCtx();
+
+    const { handleUserMessage } = await import('../daemon/handlers/sessions.js');
+    await handleUserMessage(
+      {
+        type: 'user_message',
+        sessionId: 'test-session',
+        content: 'record my screen',
+        interface: 'vellum',
+      } as any,
+      fakeSocket,
+      ctx,
+    );
+
+    expect(recordingStartCalled).toBe(true);
+    expect(recordingStopCalled).toBe(false);
+
+    const types = sent.map((m) => m.type);
+    expect(types).toContain('assistant_text_delta');
+    expect(types).toContain('message_complete');
+
+    // Should not proceed to enqueueMessage — the message_complete means it returned early
+    // The absence of enqueueMessage side effects is hard to test directly,
+    // but we verify message_complete was the last message sent.
+    const lastMsg = sent[sent.length - 1];
+    expect(lastMsg.type).toBe('message_complete');
+  });
+
+  test('stop_only → calls handleRecordingStop, sends text_delta + message_complete, returns early', async () => {
+    mockClassifyResult = 'stop_only';
+    const { ctx, sent, fakeSocket } = createCtx();
+
+    const { handleUserMessage } = await import('../daemon/handlers/sessions.js');
+    await handleUserMessage(
+      {
+        type: 'user_message',
+        sessionId: 'test-session',
+        content: 'stop recording',
+        interface: 'vellum',
+      } as any,
+      fakeSocket,
+      ctx,
+    );
+
+    expect(recordingStopCalled).toBe(true);
+    expect(recordingStartCalled).toBe(false);
+
+    const types = sent.map((m) => m.type);
+    expect(types).toContain('assistant_text_delta');
+    expect(types).toContain('message_complete');
+
+    const lastMsg = sent[sent.length - 1];
+    expect(lastMsg.type).toBe('message_complete');
+  });
+
+  test('mixed → does NOT intercept, proceeds to normal message processing', async () => {
+    mockClassifyResult = 'mixed';
+    const { ctx, sent, fakeSocket } = createCtx();
+
+    const { handleUserMessage } = await import('../daemon/handlers/sessions.js');
+    await handleUserMessage(
+      {
+        type: 'user_message',
+        sessionId: 'test-session',
+        content: 'open Safari and record my screen',
+        interface: 'vellum',
+      } as any,
+      fakeSocket,
+      ctx,
+    );
+
+    expect(recordingStartCalled).toBe(false);
+    expect(recordingStopCalled).toBe(false);
+
+    // Should NOT have recording-specific messages
+    const recordingSpecific = sent.filter(
+      (m) => m.type === 'assistant_text_delta' && typeof m.text === 'string' &&
+        (m.text.includes('Starting screen recording') || m.text.includes('Stopping the recording')),
+    );
+    expect(recordingSpecific).toHaveLength(0);
+  });
+
+  test('none → does NOT intercept, proceeds to normal message processing', async () => {
+    mockClassifyResult = 'none';
+    const { ctx, sent, fakeSocket } = createCtx();
+
+    const { handleUserMessage } = await import('../daemon/handlers/sessions.js');
+    await handleUserMessage(
+      {
+        type: 'user_message',
+        sessionId: 'test-session',
+        content: 'hello world',
+        interface: 'vellum',
+      } as any,
+      fakeSocket,
+      ctx,
+    );
+
+    expect(recordingStartCalled).toBe(false);
+    expect(recordingStopCalled).toBe(false);
+
+    // Should NOT have recording-specific messages
+    const recordingSpecific = sent.filter(
+      (m) => m.type === 'assistant_text_delta' && typeof m.text === 'string' &&
+        (m.text.includes('Starting screen recording') || m.text.includes('Stopping the recording')),
+    );
+    expect(recordingSpecific).toHaveLength(0);
+  });
+});

--- a/assistant/src/config/bundled-skills/screen-recording/SKILL.md
+++ b/assistant/src/config/bundled-skills/screen-recording/SKILL.md
@@ -17,12 +17,25 @@ This skill activates when the user asks to record their screen. Common phrases:
 - "capture my screen"
 - "capture my display"
 - "make a recording"
+- "Nova, record my screen" (where Nova is the assistant's identity name)
+- "hey Nova, start recording"
 
 **Stop recording:**
 - "stop recording"
 - "end recording"
 - "finish recording"
 - "halt recording"
+
+## Classification
+
+Recording prompts are classified into four intent types:
+
+- **start_only** — Pure recording request with no additional task (e.g., "record my screen"). Handled by standalone recording route.
+- **stop_only** — Pure stop request with no additional task (e.g., "stop recording"). Handled by standalone recording route.
+- **mixed** — Recording intent embedded in a broader task (e.g., "open Safari and record my screen"). Not intercepted; routed to normal processing.
+- **none** — No recording intent detected. Normal routing.
+
+Dynamic name prefixes (from IDENTITY.md) are stripped during classification, so "Nova, record my screen" classifies the same as "record my screen".
 
 ## Routing
 
@@ -38,6 +51,7 @@ Recording-only requests are handled by the **standalone recording route** — th
 2. **One recording at a time.** If a recording is already active, starting another returns an "already recording" message.
 3. **Conversation-scoped.** Each recording is linked to the conversation that started it. Stopping in a different thread does not affect unrelated recordings.
 4. **Permission required.** Screen recording requires macOS Screen Recording permission. If denied, the user sees actionable guidance to enable it in System Settings.
+5. **Mixed-intent prompts** (recording + other task) are NOT intercepted by the standalone route.
 
 ## What This Skill Does NOT Do
 

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -13,7 +13,8 @@ import { parseSlashCandidate } from '../../skills/slash-commands.js';
 import { classifyInteraction } from '../classifier.js';
 import { deleteBlob, isValidBlobId, resolveBlobPath } from '../ipc-blob-store.js';
 import { getConfig } from '../../config/loader.js';
-import { isRecordingOnly, isStopRecordingOnly } from '../recording-intent.js';
+import { getAssistantName } from '../identity-helpers.js';
+import { classifyRecordingIntent } from '../recording-intent.js';
 import { handleRecordingStart, handleRecordingStop } from './recording.js';
 import type {
   CuSessionCreate,
@@ -75,56 +76,66 @@ export async function handleTaskSubmit(
     // session and routes it to the standalone recording flow instead.
     const config = getConfig();
     if (config.daemon.standaloneRecording) {
-      if (isStopRecordingOnly(msg.task)) {
-        // Find the active session for this socket so we can resolve the
-        // conversation that owns the recording.
-        let activeSessionId = ctx.socketToSession.get(socket);
-        // Ensure we have a sessionId for message_complete even if no prior session exists
-        if (!activeSessionId) {
+      const name = getAssistantName();
+      const dynamicNames = [name].filter(Boolean) as string[];
+      const intentClass = classifyRecordingIntent(msg.task, dynamicNames);
+
+      switch (intentClass) {
+        case 'stop_only': {
+          // Find the active session for this socket so we can resolve the
+          // conversation that owns the recording.
+          let activeSessionId = ctx.socketToSession.get(socket);
+          // Ensure we have a sessionId for message_complete even if no prior session exists
+          if (!activeSessionId) {
+            const conversation = conversationStore.createConversation(msg.task);
+            activeSessionId = conversation.id;
+            ctx.socketToSession.set(socket, activeSessionId);
+          }
+          // Always attempt stop — handleRecordingStop has a global fallback that
+          // resolves to the active recording even if this conversation doesn't own it.
+          const stopped = handleRecordingStop(activeSessionId, ctx) !== undefined;
+          rlog.info('Recording stop intent intercepted');
+          ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
+          ctx.send(socket, {
+            type: 'assistant_text_delta',
+            text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',
+            sessionId: activeSessionId,
+          });
+          ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+          return;
+        }
+        case 'start_only': {
+          // Create a conversation so the recording can be attached later (M4).
           const conversation = conversationStore.createConversation(msg.task);
-          activeSessionId = conversation.id;
-          ctx.socketToSession.set(socket, activeSessionId);
+          ctx.socketToSession.set(socket, conversation.id);
+
+          const recordingId = handleRecordingStart(conversation.id, { promptForSource: true }, socket, ctx);
+
+          if (recordingId) {
+            ctx.send(socket, { type: 'task_routed', sessionId: conversation.id, interactionType: 'text_qa' });
+            ctx.send(socket, { type: 'assistant_text_delta', text: 'Starting screen recording.', sessionId: conversation.id });
+          } else {
+            // Recording was rejected (already active) — clean up the orphaned conversation
+            ctx.send(socket, { type: 'task_routed', sessionId: conversation.id, interactionType: 'text_qa' });
+            ctx.send(socket, { type: 'assistant_text_delta', text: 'A recording is already active.', sessionId: conversation.id });
+          }
+          ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
+
+          if (!recordingId) {
+            // Unbind the socket so the ephemeral rejection session doesn't block
+            // future task_submit routing, but keep the conversation in the DB so
+            // the client can still send follow-up messages to the routed sessionId.
+            ctx.socketToSession.delete(socket);
+          }
+
+          rlog.info({ sessionId: conversation.id }, 'Recording-only intent intercepted — routed to standalone recording');
+          return;
         }
-        // Always attempt stop — handleRecordingStop has a global fallback that
-        // resolves to the active recording even if this conversation doesn't own it.
-        const stopped = handleRecordingStop(activeSessionId, ctx) !== undefined;
-        rlog.info('Recording stop intent intercepted');
-        ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
-        ctx.send(socket, {
-          type: 'assistant_text_delta',
-          text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',
-          sessionId: activeSessionId,
-        });
-        ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
-        return;
-      }
-
-      if (isRecordingOnly(msg.task)) {
-        // Create a conversation so the recording can be attached later (M4).
-        const conversation = conversationStore.createConversation(msg.task);
-        ctx.socketToSession.set(socket, conversation.id);
-
-        const recordingId = handleRecordingStart(conversation.id, { promptForSource: true }, socket, ctx);
-
-        if (recordingId) {
-          ctx.send(socket, { type: 'task_routed', sessionId: conversation.id, interactionType: 'text_qa' });
-          ctx.send(socket, { type: 'assistant_text_delta', text: 'Starting screen recording.', sessionId: conversation.id });
-        } else {
-          // Recording was rejected (already active) — clean up the orphaned conversation
-          ctx.send(socket, { type: 'task_routed', sessionId: conversation.id, interactionType: 'text_qa' });
-          ctx.send(socket, { type: 'assistant_text_delta', text: 'A recording is already active.', sessionId: conversation.id });
-        }
-        ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
-
-        if (!recordingId) {
-          // Unbind the socket so the ephemeral rejection session doesn't block
-          // future task_submit routing, but keep the conversation in the DB so
-          // the client can still send follow-up messages to the routed sessionId.
-          ctx.socketToSession.delete(socket);
-        }
-
-        rlog.info({ sessionId: conversation.id }, 'Recording-only intent intercepted — routed to standalone recording');
-        return;
+        case 'mixed':
+          rlog.info('Mixed recording intent detected in task_submit — not intercepting');
+          break;
+        case 'none':
+          break;
       }
     }
 

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -13,7 +13,8 @@ import { getSubagentManager } from '../../subagent/index.js';
 import { silentlyWithLog } from '../../util/silently.js';
 import { truncate } from '../../util/truncate.js';
 import type { UserMessageAttachment } from '../ipc-contract.js';
-import { isRecordingOnly, isStopRecordingOnly } from '../recording-intent.js';
+import { getAssistantName } from '../identity-helpers.js';
+import { classifyRecordingIntent } from '../recording-intent.js';
 import { handleRecordingStart, handleRecordingStop } from './recording.js';
 import type {
   CancelRequest,
@@ -93,29 +94,39 @@ export async function handleUserMessage(
     const config = getConfig();
     const messageText = msg.content ?? '';
     if (config.daemon.standaloneRecording && messageText) {
-      if (isStopRecordingOnly(messageText)) {
-        const stopped = handleRecordingStop(msg.sessionId, ctx) !== undefined;
-        rlog.info('Recording stop intent intercepted in user_message');
-        ctx.send(socket, {
-          type: 'assistant_text_delta',
-          text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',
-          sessionId: msg.sessionId,
-        });
-        ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
-        return;
-      }
+      const name = getAssistantName();
+      const dynamicNames = [name].filter(Boolean) as string[];
+      const intentClass = classifyRecordingIntent(messageText, dynamicNames);
 
-      if (isRecordingOnly(messageText)) {
-        const recordingId = handleRecordingStart(msg.sessionId, { promptForSource: true }, socket, ctx);
-        rlog.info('Recording-only intent intercepted in user_message');
-
-        if (recordingId) {
-          ctx.send(socket, { type: 'assistant_text_delta', text: 'Starting screen recording.', sessionId: msg.sessionId });
-        } else {
-          ctx.send(socket, { type: 'assistant_text_delta', text: 'A recording is already active.', sessionId: msg.sessionId });
+      switch (intentClass) {
+        case 'stop_only': {
+          const stopped = handleRecordingStop(msg.sessionId, ctx) !== undefined;
+          rlog.info('Recording stop intent intercepted in user_message');
+          ctx.send(socket, {
+            type: 'assistant_text_delta',
+            text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',
+            sessionId: msg.sessionId,
+          });
+          ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+          return;
         }
-        ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
-        return;
+        case 'start_only': {
+          const recordingId = handleRecordingStart(msg.sessionId, { promptForSource: true }, socket, ctx);
+          rlog.info('Recording-only intent intercepted in user_message');
+
+          if (recordingId) {
+            ctx.send(socket, { type: 'assistant_text_delta', text: 'Starting screen recording.', sessionId: msg.sessionId });
+          } else {
+            ctx.send(socket, { type: 'assistant_text_delta', text: 'A recording is already active.', sessionId: msg.sessionId });
+          }
+          ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+          return;
+        }
+        case 'mixed':
+          rlog.info('Mixed recording intent detected in user_message — not intercepting');
+          break;
+        case 'none':
+          break;
       }
     }
 


### PR DESCRIPTION
## Summary

- Replace boolean recording intent checks (`isRecordingOnly`, `isStopRecordingOnly`) with unified `classifyRecordingIntent` classifier in both `handleTaskSubmit` (misc.ts) and `handleUserMessage` (sessions.ts)
- Import and use `getAssistantName()` to pass dynamic names for name-prefix stripping during classification
- Add 8 handler-level integration tests verifying the classification-to-action mapping: `start_only` and `stop_only` intercept; `mixed` and `none` fall through
- Update screen-recording SKILL.md with Classification section documenting intent types, dynamic name examples, and mixed-intent behavior rule

## Test plan

- [x] `bun test src/__tests__/recording-intent.test.ts` — 103 tests pass
- [x] `bun test src/__tests__/recording-intent-handler.test.ts` — 8 tests pass
- [x] Typecheck confirms no new errors in changed files

Part of #9161, closes #9164.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
