### PR TITLE
feat(macos): conversation zoom UX

### DIFF
--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -223,6 +223,23 @@ Grant these in System Settings → Privacy & Security.
 10. Responses stream in real-time from the daemon
 11. Click the stop button to cancel an in-progress generation
 
+### Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd +` | Conversation zoom in (text only) |
+| `Cmd -` | Conversation zoom out (text only) |
+| `Cmd 0` | Reset conversation zoom to 100% |
+| `Option+Cmd +` | Window zoom in (entire UI) |
+| `Option+Cmd -` | Window zoom out (entire UI) |
+| `Option+Cmd 0` | Reset window zoom to 100% |
+| `Cmd Shift G` | Open task input popover |
+| `Escape` | Cancel current session / close popover |
+
+**Conversation zoom** scales chat text (messages, markdown, code blocks, composer) independently of the window. A brief "Text 125%" indicator appears on each change. The zoom level persists across app relaunches.
+
+**Window zoom** scales the entire UI uniformly. A percentage indicator appears at the top of the window on each change.
+
 ### Opportunistic Message Queueing
 
 Users can send multiple messages while the assistant is busy. Messages are queued (FIFO, max 10) and processed automatically:

--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -7,12 +7,6 @@ extension Notification.Name {
     static let updateDynamicWorkspace = Notification.Name("MainWindow.updateDynamicWorkspace")
     static let dismissDynamicWorkspace = Notification.Name("MainWindow.dismissDynamicWorkspace")
     static let openDocumentEditor = Notification.Name("MainWindow.openDocumentEditor")
-
-    // Conversation zoom intents — posted by the View menu handlers,
-    // consumed by ConversationZoomManager (wired in M2).
-    static let conversationZoomIn = Notification.Name("MainWindow.conversationZoomIn")
-    static let conversationZoomOut = Notification.Name("MainWindow.conversationZoomOut")
-    static let conversationZoomReset = Notification.Name("MainWindow.conversationZoomReset")
 }
 
 /// Manages API keys in the macOS login keychain.

--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -7,6 +7,12 @@ extension Notification.Name {
     static let updateDynamicWorkspace = Notification.Name("MainWindow.updateDynamicWorkspace")
     static let dismissDynamicWorkspace = Notification.Name("MainWindow.dismissDynamicWorkspace")
     static let openDocumentEditor = Notification.Name("MainWindow.openDocumentEditor")
+
+    // Conversation zoom intents — posted by the View menu handlers,
+    // consumed by ConversationZoomManager (wired in M2).
+    static let conversationZoomIn = Notification.Name("MainWindow.conversationZoomIn")
+    static let conversationZoomOut = Notification.Name("MainWindow.conversationZoomOut")
+    static let conversationZoomReset = Notification.Name("MainWindow.conversationZoomReset")
 }
 
 /// Manages API keys in the macOS login keychain.

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -65,31 +65,122 @@ extension AppDelegate {
     func setupViewMenu() {
         guard let mainMenu = NSApp.mainMenu else { return }
 
+        // Avoid duplicate View menus on logout/re-login cycles
+        if mainMenu.indexOfItem(withTitle: "View") >= 0 { return }
+
         let viewMenu = NSMenu(title: "View")
 
-        let zoomInItem = NSMenuItem(title: "Zoom In", action: #selector(handleZoomIn), keyEquivalent: "=")
-        zoomInItem.keyEquivalentModifierMask = .command
-        zoomInItem.target = self
-        viewMenu.addItem(zoomInItem)
+        // Conversation Text Zoom: Cmd +, Cmd -, Cmd 0
+        let convZoomInItem = NSMenuItem(
+            title: "Conversation Zoom In",
+            action: #selector(handleConversationZoomIn),
+            keyEquivalent: "="
+        )
+        convZoomInItem.keyEquivalentModifierMask = .command
+        convZoomInItem.target = self
+        viewMenu.addItem(convZoomInItem)
 
-        let zoomOutItem = NSMenuItem(title: "Zoom Out", action: #selector(handleZoomOut), keyEquivalent: "-")
-        zoomOutItem.keyEquivalentModifierMask = .command
-        zoomOutItem.target = self
-        viewMenu.addItem(zoomOutItem)
+        let convZoomOutItem = NSMenuItem(
+            title: "Conversation Zoom Out",
+            action: #selector(handleConversationZoomOut),
+            keyEquivalent: "-"
+        )
+        convZoomOutItem.keyEquivalentModifierMask = .command
+        convZoomOutItem.target = self
+        viewMenu.addItem(convZoomOutItem)
 
-        let resetItem = NSMenuItem(title: "Actual Size", action: #selector(handleZoomReset), keyEquivalent: "0")
-        resetItem.keyEquivalentModifierMask = .command
-        resetItem.target = self
-        viewMenu.addItem(resetItem)
+        let convResetItem = NSMenuItem(
+            title: "Conversation Actual Size",
+            action: #selector(handleConversationZoomReset),
+            keyEquivalent: "0"
+        )
+        convResetItem.keyEquivalentModifierMask = .command
+        convResetItem.target = self
+        viewMenu.addItem(convResetItem)
+
+        viewMenu.addItem(NSMenuItem.separator())
+
+        // Window Zoom: Option+Cmd +, Option+Cmd -, Option+Cmd 0
+        let winZoomInItem = NSMenuItem(
+            title: "Window Zoom In",
+            action: #selector(handleWindowZoomIn),
+            keyEquivalent: "="
+        )
+        winZoomInItem.keyEquivalentModifierMask = [.command, .option]
+        winZoomInItem.target = self
+        viewMenu.addItem(winZoomInItem)
+
+        let winZoomOutItem = NSMenuItem(
+            title: "Window Zoom Out",
+            action: #selector(handleWindowZoomOut),
+            keyEquivalent: "-"
+        )
+        winZoomOutItem.keyEquivalentModifierMask = [.command, .option]
+        winZoomOutItem.target = self
+        viewMenu.addItem(winZoomOutItem)
+
+        let winResetItem = NSMenuItem(
+            title: "Window Actual Size",
+            action: #selector(handleWindowZoomReset),
+            keyEquivalent: "0"
+        )
+        winResetItem.keyEquivalentModifierMask = [.command, .option]
+        winResetItem.target = self
+        viewMenu.addItem(winResetItem)
 
         let viewMenuItem = NSMenuItem(title: "View", action: nil, keyEquivalent: "")
         viewMenuItem.submenu = viewMenu
         mainMenu.addItem(viewMenuItem)
     }
 
-    @objc func handleZoomIn() { zoomManager.zoomIn() }
-    @objc func handleZoomOut() { zoomManager.zoomOut() }
-    @objc func handleZoomReset() { zoomManager.resetZoom() }
+    // MARK: - Zoom Intent Routing
+
+    func routeZoomIntent(_ intent: VZoomCommandIntent) {
+        switch intent {
+        case .windowZoomIn:
+            zoomManager.zoomIn()
+        case .windowZoomOut:
+            zoomManager.zoomOut()
+        case .windowZoomReset:
+            zoomManager.resetZoom()
+        case .conversationZoomIn:
+            // Bridge: apply window zoom so the shortcut works immediately.
+            // The notification is kept so M2's ConversationZoomManager can
+            // subscribe and replace this bridge with per-conversation scaling.
+            zoomManager.zoomIn()
+            NotificationCenter.default.post(name: .conversationZoomIn, object: nil)
+        case .conversationZoomOut:
+            zoomManager.zoomOut()
+            NotificationCenter.default.post(name: .conversationZoomOut, object: nil)
+        case .conversationZoomReset:
+            zoomManager.resetZoom()
+            NotificationCenter.default.post(name: .conversationZoomReset, object: nil)
+        }
+    }
+
+    @objc func handleConversationZoomIn() { routeZoomIntent(.conversationZoomIn) }
+    @objc func handleConversationZoomOut() { routeZoomIntent(.conversationZoomOut) }
+    @objc func handleConversationZoomReset() { routeZoomIntent(.conversationZoomReset) }
+    @objc func handleWindowZoomIn() { routeZoomIntent(.windowZoomIn) }
+    @objc func handleWindowZoomOut() { routeZoomIntent(.windowZoomOut) }
+    @objc func handleWindowZoomReset() { routeZoomIntent(.windowZoomReset) }
+
+    // MARK: - Menu Item Validation
+
+    /// Disables conversation zoom shortcuts when no conversation is visible,
+    /// preventing accidental side effects in non-chat panels.
+    @objc func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        guard let action = menuItem.action else { return true }
+        let conversationZoomSelectors: Set<Selector> = [
+            #selector(handleConversationZoomIn),
+            #selector(handleConversationZoomOut),
+            #selector(handleConversationZoomReset),
+        ]
+        if conversationZoomSelectors.contains(action) {
+            return mainWindow?.windowState.isConversationVisible ?? false
+        }
+        return true
+    }
 
     func configureMenuBarIcon(_ button: NSStatusBarButton) {
         let iconSize: CGFloat = 18

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -144,17 +144,11 @@ extension AppDelegate {
         case .windowZoomReset:
             zoomManager.resetZoom()
         case .conversationZoomIn:
-            // Bridge: apply window zoom so the shortcut works immediately.
-            // The notification is kept so M2's ConversationZoomManager can
-            // subscribe and replace this bridge with per-conversation scaling.
-            zoomManager.zoomIn()
-            NotificationCenter.default.post(name: .conversationZoomIn, object: nil)
+            conversationZoomManager.zoomIn()
         case .conversationZoomOut:
-            zoomManager.zoomOut()
-            NotificationCenter.default.post(name: .conversationZoomOut, object: nil)
+            conversationZoomManager.zoomOut()
         case .conversationZoomReset:
-            zoomManager.resetZoom()
-            NotificationCenter.default.post(name: .conversationZoomReset, object: nil)
+            conversationZoomManager.resetZoom()
         }
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -125,6 +125,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var browserPiPManager: BrowserPiPManager { services.browserPiPManager }
     private var secretPromptManager: SecretPromptManager { services.secretPromptManager }
     var zoomManager: ZoomManager { services.zoomManager }
+    var conversationZoomManager: ConversationZoomManager { services.conversationZoomManager }
 
     let toolConfirmationNotificationService = ToolConfirmationNotificationService()
     lazy var recordingManager: RecordingManager = RecordingManager(daemonClient: daemonClient)

--- a/clients/macos/vellum-assistant/App/AppServices.swift
+++ b/clients/macos/vellum-assistant/App/AppServices.swift
@@ -11,6 +11,7 @@ public final class AppServices {
     let browserPiPManager = BrowserPiPManager()
     let secretPromptManager = SecretPromptManager()
     let zoomManager = ZoomManager()
+    let conversationZoomManager = ConversationZoomManager()
 
     /// Shared settings state consumed by SettingsPanel and its tab views.
     /// Lazy because it needs `ambientAgent` and `daemonClient` which are set above.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -30,6 +30,8 @@ struct ChatBubble: View {
     /// manager publishes any change (the "thundering herd" problem).
     var activeSurfaceId: String?
 
+    @Environment(\.conversationZoomScale) var conversationZoomScale
+
     var isUser: Bool { message.role == .user }
     private var canReportMessage: Bool {
         !isUser && onReportMessage != nil
@@ -282,11 +284,11 @@ struct ChatBubble: View {
                 if message.isError && hasText {
                     HStack(alignment: .top, spacing: VSpacing.sm) {
                         Image(systemName: "exclamationmark.triangle.fill")
-                            .font(.system(size: 13, weight: .medium))
+                            .font(.system(size: 13 * conversationZoomScale, weight: .medium))
                             .foregroundColor(VColor.error)
                             .padding(.top, 1)
                         Text(message.text)
-                            .font(.system(size: 13))
+                            .font(.system(size: 13 * conversationZoomScale))
                             .foregroundColor(VColor.textPrimary)
                             .textSelection(.enabled)
                             .fixedSize(horizontal: false, vertical: true)
@@ -312,7 +314,7 @@ struct ChatBubble: View {
                         )
                     } else {
                         Text(markdownText)
-                            .font(.system(size: 13))
+                            .font(.system(size: 13 * conversationZoomScale))
                             .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
                             .tint(isUser ? VColor.userBubbleText : VColor.accent)
                             .textSelection(.enabled)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -22,7 +22,7 @@ extension ChatBubble {
             } else {
                 let attributed = Self.cachedInlineMarkdown(for: segmentText, isStreaming: streaming)
                 Text(attributed)
-                    .font(.system(size: 13))
+                    .font(.system(size: 13 * conversationZoomScale))
                     .lineSpacing(3)
                     .foregroundColor(VColor.textPrimary)
                     .tint(VColor.accent)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -261,13 +261,15 @@ struct MarkdownTableView: View {
     let rows: [[String]]
     var maxWidth: CGFloat = 520
 
+    @Environment(\.conversationZoomScale) private var zoomScale
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Header row
             HStack(spacing: 0) {
                 ForEach(Array(headers.enumerated()), id: \.offset) { _, header in
                     Text(header)
-                        .font(VFont.captionMedium)
+                        .font(.custom("Inter-Medium", size: 11 * zoomScale))
                         .foregroundColor(VColor.textSecondary)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, VSpacing.sm)
@@ -309,7 +311,7 @@ struct MarkdownTableView: View {
         let attributed = (try? AttributedString(markdown: text, options: options))
             ?? AttributedString(text)
         return Text(attributed)
-            .font(VFont.body)
+            .font(.custom("Inter", size: 13 * zoomScale))
             .foregroundColor(VColor.textPrimary)
             .textSelection(.enabled)
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -56,6 +56,8 @@ struct ComposerView: View {
     /// Exposed to ChatView so composerReservedHeight stays in sync with the
     /// sticky expansion state (set true when text wraps, reset when text clears).
     @Binding var isComposerExpanded: Bool
+
+    @Environment(\.conversationZoomScale) private var zoomScale
     @State private var composerFocusRequestID: Int = 0
     @State private var isStopHovered = false
     @State private var isSendHovered = false
@@ -197,6 +199,7 @@ struct ComposerView: View {
             minHeight: composerCompactHeight,
             maxHeight: composerMaxHeight,
             focusRequestID: composerFocusRequestID,
+            zoomScale: zoomScale,
             onHeightChange: { height in
                 editorContentHeight = height
             },
@@ -220,11 +223,12 @@ struct ComposerView: View {
         .accessibilityLabel("Message")
         .overlay(alignment: .leading) {
             if let ghostSuffix {
+                let scaledBody = Font.custom("Inter", size: 13 * zoomScale)
                 (Text(inputText)
-                    .font(VFont.body)
+                    .font(scaledBody)
                     .foregroundColor(.clear)
                 + Text(ghostSuffix)
-                    .font(VFont.body)
+                    .font(scaledBody)
                     .foregroundColor(VColor.textSecondary.opacity(0.55)))
                     .lineLimit(1...12)
                     .fixedSize(horizontal: false, vertical: true)
@@ -557,6 +561,7 @@ private struct ComposerTextView: NSViewRepresentable {
     let minHeight: CGFloat
     let maxHeight: CGFloat
     let focusRequestID: Int
+    var zoomScale: CGFloat = 1.0
     let onHeightChange: (CGFloat) -> Void
     var onOverflowChange: ((Bool) -> Void)?
     let onFocusChange: (Bool) -> Void
@@ -602,7 +607,8 @@ private struct ComposerTextView: NSViewRepresentable {
         textView.isSelectable = true
         textView.drawsBackground = false
         textView.allowsUndo = true
-        textView.font = NSFont(name: "Inter", size: 13) ?? NSFont.systemFont(ofSize: 13)
+        let scaledFontSize: CGFloat = 13 * zoomScale
+        textView.font = NSFont(name: "Inter", size: scaledFontSize) ?? NSFont.systemFont(ofSize: scaledFontSize)
         textView.textColor = NSColor(VColor.textPrimary)
         textView.insertionPointColor = NSColor(VColor.accent)
         textView.textContainerInset = NSSize(width: 0, height: 8)
@@ -635,6 +641,16 @@ private struct ComposerTextView: NSViewRepresentable {
         guard let textView = context.coordinator.textView else { return }
 
         textView.isEditable = isEnabled
+
+        // Update font when zoom scale changes
+        let scaledFontSize: CGFloat = 13 * zoomScale
+        let targetFont = NSFont(name: "Inter", size: scaledFontSize) ?? NSFont.systemFont(ofSize: scaledFontSize)
+        if textView.font?.pointSize != targetFont.pointSize {
+            textView.font = targetFont
+            textView.needsDisplay = true
+            context.coordinator.syncHeight()
+        }
+
         let oldPlaceholder = textView.placeholderText
         let oldGhostSuffix = textView.hasGhostSuffix
         textView.placeholderText = placeholder

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -896,6 +896,17 @@ private final class ComposerNativeTextView: NSTextView {
                 return true
             }
         }
+
+        // Let zoom shortcuts propagate to the menu bar instead of being
+        // consumed by the text view. Cmd +/-/0 and Option+Cmd +/-/0 are
+        // handled by the View menu for conversation and window zoom.
+        if event.modifierFlags.contains(.command) {
+            let key = event.charactersIgnoringModifiers ?? ""
+            if key == "=" || key == "+" || key == "-" || key == "0" {
+                return false
+            }
+        }
+
         return super.performKeyEquivalent(with: event)
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -15,15 +15,19 @@ struct MarkdownSegmentView: View {
     var codeBackgroundColor: Color = VColor.backgroundSubtle
     var hrColor: Color = VColor.surfaceBorder
 
+    @Environment(\.conversationZoomScale) private var zoomScale
+
     var body: some View {
         let groups = groupedSegments
+        let scaledBodySize: CGFloat = 13 * zoomScale
+        let scaledCodeLabelSize: CGFloat = 11 * zoomScale
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             ForEach(Array(groups.enumerated()), id: \.offset) { _, group in
                 switch group {
                 case .selectableRun(let runSegments):
                     let attributed = buildCombinedAttributedString(from: runSegments)
                     Text(attributed)
-                        .font(.system(size: 13))
+                        .font(.system(size: scaledBodySize))
                         .lineSpacing(4)
                         .foregroundColor(textColor)
                         .tint(tintColor)
@@ -35,14 +39,14 @@ struct MarkdownSegmentView: View {
                     VStack(alignment: .leading, spacing: 0) {
                         if let language, !language.isEmpty {
                             Text(language)
-                                .font(.system(size: 11, weight: .medium))
+                                .font(.system(size: scaledCodeLabelSize, weight: .medium))
                                 .foregroundColor(mutedTextColor)
                                 .padding(.horizontal, VSpacing.sm)
                                 .padding(.top, VSpacing.xs)
                         }
                         ScrollView(.horizontal, showsIndicators: false) {
                             Text(code)
-                                .font(VFont.mono)
+                                .font(.custom("DMMono-Regular", size: 13 * zoomScale))
                                 .foregroundColor(textColor)
                                 .textSelection(.enabled)
                                 .fixedSize(horizontal: true, vertical: true)
@@ -142,12 +146,14 @@ struct MarkdownSegmentView: View {
     private func buildCombinedAttributedString(from segments: [MarkdownSegment]) -> AttributedString {
         // Build a stable cache key from the segment contents and style
         // inputs that affect the output (e.g. secondaryTextColor for list
-        // prefix coloring) so different visual contexts don't share entries.
+        // prefix coloring, zoomScale for font sizing) so different visual
+        // contexts don't share entries.
         var hasher = Hasher()
         for segment in segments {
             hasher.combine(String(describing: segment))
         }
         hasher.combine(secondaryTextColor.description)
+        hasher.combine(zoomScale)
         let cacheKey = hasher.finalize()
 
         if let cached = Self.attributedStringCache[cacheKey] {
@@ -156,7 +162,7 @@ struct MarkdownSegmentView: View {
             return cached.value
         }
 
-        let result = Self.buildAttributedStringUncached(from: segments, secondaryTextColor: secondaryTextColor)
+        let result = Self.buildAttributedStringUncached(from: segments, secondaryTextColor: secondaryTextColor, zoomScale: zoomScale)
 
         // Evict the least-recently-used entry when the cache is full.
         if Self.attributedStringCache.count >= Self.attributedStringCacheLimit {
@@ -172,7 +178,8 @@ struct MarkdownSegmentView: View {
     /// Pure builder with no side effects — separated for caching.
     private static func buildAttributedStringUncached(
         from segments: [MarkdownSegment],
-        secondaryTextColor: Color
+        secondaryTextColor: Color,
+        zoomScale: CGFloat = 1.0
     ) -> AttributedString {
         let mdOptions = AttributedString.MarkdownParsingOptions(
             interpretedSyntax: .inlineOnlyPreservingWhitespace
@@ -193,16 +200,17 @@ struct MarkdownSegmentView: View {
             case .heading(let level, let headingText):
                 var heading = AttributedString(headingText)
                 heading.font = switch level {
-                case 1: .system(size: 20, weight: .bold)
-                case 2: .system(size: 17, weight: .semibold)
-                case 3: .system(size: 14, weight: .semibold)
-                default: .system(size: 13, weight: .semibold)
+                case 1: .system(size: 20 * zoomScale, weight: .bold)
+                case 2: .system(size: 17 * zoomScale, weight: .semibold)
+                case 3: .system(size: 14 * zoomScale, weight: .semibold)
+                default: .system(size: 13 * zoomScale, weight: .semibold)
                 }
                 result += heading
 
             case .list(let items):
-                let indentStep: CGFloat = 16
-                let font = NSFont.systemFont(ofSize: 13)
+                let indentStep: CGFloat = 16 * zoomScale
+                let scaledSize: CGFloat = 13 * zoomScale
+                let font = NSFont.systemFont(ofSize: scaledSize)
 
                 for (itemIndex, item) in items.enumerated() {
                     if itemIndex > 0 {
@@ -224,7 +232,7 @@ struct MarkdownSegmentView: View {
 
                     var prefixAttr = AttributedString(prefix)
                     prefixAttr.foregroundColor = secondaryTextColor
-                    prefixAttr.font = .system(size: 13)
+                    prefixAttr.font = .system(size: scaledSize)
                     prefixAttr.applyParagraphStyle(paraStyle)
                     result += prefixAttr
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -24,6 +24,7 @@ struct MessageListView: View {
 
     var threadId: UUID?
     @Binding var isNearBottom: Bool
+    @Environment(\.conversationZoomScale) private var conversationZoomScale
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
     @AppStorage("completedConversationCount") private var completedConversationCount: Int = 0
     @State private var identity: IdentityInfo? = IdentityInfo.load()
@@ -315,6 +316,12 @@ struct MessageListView: View {
                         proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                     }
                 }
+            }
+            .onChange(of: conversationZoomScale) {
+                if isNearBottom {
+                    proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                }
+                // When mid-scroll, do nothing — let SwiftUI handle the text reflow naturally.
             }
         }
         .id(threadId)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationZoomManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationZoomManager.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+/// Manages conversation-level text zoom (Cmd +/-/0), independent of the
+/// window-level zoom handled by `ZoomManager`.
+///
+/// The scale factor is applied to chat text surfaces (messages, markdown,
+/// code blocks, composer) via the `conversationZoomScale` environment value.
+/// Zoom level persists across app relaunches via `@AppStorage`.
+@MainActor
+@Observable
+final class ConversationZoomManager {
+    static let zoomSteps: [CGFloat] = [0.5, 0.75, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0]
+
+    var zoomLevel: CGFloat {
+        didSet { UserDefaults.standard.set(zoomLevel, forKey: "conversationTextZoomLevel") }
+    }
+    var showZoomIndicator = false
+
+    private var dismissTask: Task<Void, Never>?
+
+    var zoomPercentage: Int {
+        Int(round(zoomLevel * 100))
+    }
+
+    init() {
+        let stored = UserDefaults.standard.double(forKey: "conversationTextZoomLevel")
+        self.zoomLevel = stored > 0 ? stored : 1.0
+    }
+
+    func zoomIn() {
+        if let next = Self.zoomSteps.first(where: { $0 > zoomLevel + 0.001 }) {
+            zoomLevel = next
+            flashIndicator()
+        }
+    }
+
+    func zoomOut() {
+        if let prev = Self.zoomSteps.last(where: { $0 < zoomLevel - 0.001 }) {
+            zoomLevel = prev
+            flashIndicator()
+        }
+    }
+
+    func resetZoom() {
+        zoomLevel = 1.0
+        flashIndicator()
+    }
+
+    private func flashIndicator() {
+        dismissTask?.cancel()
+        showZoomIndicator = true
+        dismissTask = Task {
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            guard !Task.isCancelled else { return }
+            showZoomIndicator = false
+        }
+    }
+}
+
+// MARK: - SwiftUI Environment
+
+private struct ConversationZoomScaleKey: EnvironmentKey {
+    static let defaultValue: CGFloat = 1.0
+}
+
+extension EnvironmentValues {
+    /// The conversation text zoom scale factor. Chat text surfaces multiply
+    /// their base font sizes by this value to implement conversation zoom.
+    var conversationZoomScale: CGFloat {
+        get { self[ConversationZoomScaleKey.self] }
+        set { self[ConversationZoomScaleKey.self] = newValue }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -280,7 +280,7 @@ final class MainWindow {
             self.pendingWakeUpMessage = nil
         } : nil
 
-        let rootView = MainWindowView(threadManager: threadManager, appListManager: appListManager, zoomManager: zoomManager, traceStore: traceStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, documentManager: documentManager, avatarEvolutionState: avatarEvolutionState, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, onSendWakeUp: wakeUpCallback)
+        let rootView = MainWindowView(threadManager: threadManager, appListManager: appListManager, zoomManager: zoomManager, conversationZoomManager: services.conversationZoomManager, traceStore: traceStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, documentManager: documentManager, avatarEvolutionState: avatarEvolutionState, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, onSendWakeUp: wakeUpCallback)
         let hostingController = NonDraggableHostingController(rootView: rootView)
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -16,6 +16,7 @@ final class MainWindowState: ObservableObject {
     @AppStorage("lastActivePanel") private var lastActivePanelString: String?
     @AppStorage("homeBaseDashboardDefaultEnabled") private var homeBaseDashboardDefaultEnabled: Bool = false
     @AppStorage("chatDockOpen") private var chatDockOpen = false
+    @AppStorage("isAppChatOpen") private var isAppChatOpen = false
 
     /// The single source of truth for what the main content area displays.
     @Published var selection: ViewSelection? {
@@ -80,13 +81,23 @@ final class MainWindowState: ObservableObject {
         }
     }
 
-    /// Whether a conversation is visible — true for thread mode and
-    /// app-editing mode (which shows a chat dock alongside the app).
+    /// Whether a conversation is visible — true for thread mode,
+    /// app-editing mode (which shows a chat dock alongside the app),
+    /// and panel mode when the chat bubble is enabled (split-view with
+    /// a live conversation alongside the panel).
     /// Used by zoom intent routing to decide whether Cmd+/- should
     /// target conversation text zoom or fall through to window zoom.
     var isConversationVisible: Bool {
         switch selection {
         case .thread, .none, .appEditing: return true
+        case .panel(let panelType):
+            // Voice mode and document editor have dedicated layouts that
+            // always include chat; other panels show chat only when the
+            // chat bubble toggle is active.
+            switch panelType {
+            case .voiceMode, .documentEditor: return true
+            default: return isAppChatOpen
+            }
         default: return false
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -80,6 +80,17 @@ final class MainWindowState: ObservableObject {
         }
     }
 
+    /// Whether a conversation is visible — true for thread mode and
+    /// app-editing mode (which shows a chat dock alongside the app).
+    /// Used by zoom intent routing to decide whether Cmd+/- should
+    /// target conversation text zoom or fall through to window zoom.
+    var isConversationVisible: Bool {
+        switch selection {
+        case .thread, .none, .appEditing: return true
+        default: return false
+        }
+    }
+
     /// Whether the dynamic workspace (app view) is expanded.
     var isDynamicExpanded: Bool {
         get {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -52,6 +52,7 @@ struct MainWindowView: View {
     @ObservedObject var threadManager: ThreadManager
     @ObservedObject var appListManager: AppListManager
     var zoomManager: ZoomManager
+    var conversationZoomManager: ConversationZoomManager
     /// Plain `let` instead of `@ObservedObject` so SwiftUI doesn't observe
     /// TraceStore mutations when the DebugPanel isn't visible. DebugPanel
     /// itself uses `@ObservedObject` and is only instantiated when shown.
@@ -96,10 +97,11 @@ struct MainWindowView: View {
     /// Whether the "coming alive" overlay is currently showing.
     @State private var showComingAlive: Bool
 
-    init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, avatarEvolutionState: AvatarEvolutionState? = nil, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager = VoiceModeManager(), onSendWakeUp: (() -> Void)? = nil) {
+    init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, conversationZoomManager: ConversationZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, avatarEvolutionState: AvatarEvolutionState? = nil, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager = VoiceModeManager(), onSendWakeUp: (() -> Void)? = nil) {
         self.threadManager = threadManager
         self.appListManager = appListManager
         self.zoomManager = zoomManager
+        self.conversationZoomManager = conversationZoomManager
         self.traceStore = traceStore
         self.daemonClient = daemonClient
         self.surfaceManager = surfaceManager

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1333,21 +1333,31 @@ struct MainWindowView: View {
 
 }
 
-private struct ZoomIndicatorView: View {
+struct ZoomIndicatorView: View {
     let percentage: Int
+    /// Optional prefix shown before the percentage (e.g. "Text" → "Text 125%").
+    var label: String? = nil
 
     var body: some View {
-        Text("\(percentage)%")
-            .font(VFont.bodyMedium)
-            .foregroundStyle(VColor.textPrimary)
-            .padding(.horizontal, VSpacing.lg)
-            .padding(.vertical, VSpacing.sm)
-            .background(VColor.surface)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .stroke(VColor.surfaceBorder, lineWidth: 1)
-            )
+        HStack(spacing: VSpacing.xs) {
+            if let label {
+                Text(label)
+                    .font(VFont.caption)
+                    .foregroundStyle(VColor.textSecondary)
+            }
+            Text("\(percentage)%")
+                .font(VFont.bodyMedium)
+                .foregroundStyle(VColor.textPrimary)
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+        .background(VColor.surface)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+        .accessibilityLabel("Zoom \(percentage) percent")
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -475,6 +475,15 @@ extension MainWindowView {
                 isTemporaryChat: activeThread?.kind == .private,
                 threadId: threadManager.activeThreadId
             )
+            .environment(\.conversationZoomScale, conversationZoomManager.zoomLevel)
+            .overlay(alignment: .top) {
+                if conversationZoomManager.showZoomIndicator {
+                    ZoomIndicatorView(percentage: conversationZoomManager.zoomPercentage)
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                        .padding(.top, VSpacing.xl)
+                }
+            }
+            .animation(VAnimation.fast, value: conversationZoomManager.showZoomIndicator)
             .overlay(alignment: .bottomTrailing) {
                 DemoOverlayView()
             }
@@ -971,7 +980,7 @@ struct DynamicWorkspaceWrapper: View {
 struct MainWindowView_Previews: PreviewProvider {
     static var previews: some View {
         let dc = DaemonClient()
-        MainWindowView(threadManager: ThreadManager(daemonClient: dc), appListManager: AppListManager(), zoomManager: ZoomManager(), traceStore: TraceStore(), daemonClient: dc, surfaceManager: SurfaceManager(), ambientAgent: AmbientAgent(), settingsStore: SettingsStore(daemonClient: dc), authManager: AuthManager(), windowState: MainWindowState(), documentManager: DocumentManager())
+        MainWindowView(threadManager: ThreadManager(daemonClient: dc), appListManager: AppListManager(), zoomManager: ZoomManager(), conversationZoomManager: ConversationZoomManager(), traceStore: TraceStore(), daemonClient: dc, surfaceManager: SurfaceManager(), ambientAgent: AmbientAgent(), settingsStore: SettingsStore(daemonClient: dc), authManager: AuthManager(), windowState: MainWindowState(), documentManager: DocumentManager())
             .frame(width: 900, height: 600)
             .padding(.top, 36)
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -478,7 +478,7 @@ extension MainWindowView {
             .environment(\.conversationZoomScale, conversationZoomManager.zoomLevel)
             .overlay(alignment: .top) {
                 if conversationZoomManager.showZoomIndicator {
-                    ZoomIndicatorView(percentage: conversationZoomManager.zoomPercentage)
+                    ZoomIndicatorView(percentage: conversationZoomManager.zoomPercentage, label: "Text")
                         .transition(.move(edge: .top).combined(with: .opacity))
                         .padding(.top, VSpacing.xl)
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/VZoomCommandIntent.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/VZoomCommandIntent.swift
@@ -1,0 +1,17 @@
+/// Explicit zoom command intents used by the menu bar to route
+/// keyboard shortcuts to the correct zoom target.
+///
+/// Conversation zoom intents (`conversationZoomIn/Out/Reset`) are fired
+/// by `Cmd +/-/0` and target the chat message text size. They are only
+/// meaningful when a conversation is visible (thread or app-editing mode).
+///
+/// Window zoom intents (`windowZoomIn/Out/Reset`) are fired by
+/// `Option+Cmd +/-/0` and always scale the entire window content.
+enum VZoomCommandIntent {
+    case conversationZoomIn
+    case conversationZoomOut
+    case conversationZoomReset
+    case windowZoomIn
+    case windowZoomOut
+    case windowZoomReset
+}

--- a/clients/macos/vellum-assistantTests/ConversationZoomManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationZoomManagerTests.swift
@@ -1,0 +1,220 @@
+import Foundation
+import Testing
+@testable import VellumAssistantLib
+
+@Suite("ConversationZoomManager")
+struct ConversationZoomManagerTests {
+
+    // MARK: - Default State
+
+    @Test @MainActor
+    func defaultZoomLevelIsOne() {
+        // Clear any persisted value so the manager starts fresh.
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        #expect(manager.zoomLevel == 1.0)
+        #expect(manager.zoomPercentage == 100)
+    }
+
+    // MARK: - Zoom In
+
+    @Test @MainActor
+    func zoomInAdvancesToNextStep() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        manager.zoomIn()
+        #expect(manager.zoomLevel == 1.1)
+        #expect(manager.zoomPercentage == 110)
+    }
+
+    @Test @MainActor
+    func zoomInMultipleSteps() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        manager.zoomIn() // 1.1
+        manager.zoomIn() // 1.25
+        manager.zoomIn() // 1.5
+        #expect(manager.zoomLevel == 1.5)
+        #expect(manager.zoomPercentage == 150)
+    }
+
+    // MARK: - Zoom Out
+
+    @Test @MainActor
+    func zoomOutRetreatsToLowerStep() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        manager.zoomOut()
+        #expect(manager.zoomLevel == 0.9)
+        #expect(manager.zoomPercentage == 90)
+    }
+
+    @Test @MainActor
+    func zoomOutMultipleSteps() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        manager.zoomOut() // 0.9
+        manager.zoomOut() // 0.75
+        manager.zoomOut() // 0.5
+        #expect(manager.zoomLevel == 0.5)
+        #expect(manager.zoomPercentage == 50)
+    }
+
+    // MARK: - Clamping at Maximum
+
+    @Test @MainActor
+    func zoomInClampsAtMaximum() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        let maxStep = ConversationZoomManager.zoomSteps.last!
+
+        // Zoom in until we hit the maximum step.
+        for _ in 0..<ConversationZoomManager.zoomSteps.count {
+            manager.zoomIn()
+        }
+        #expect(manager.zoomLevel == maxStep)
+
+        // One more zoomIn should not change the level.
+        manager.zoomIn()
+        #expect(manager.zoomLevel == maxStep)
+        #expect(manager.zoomPercentage == Int(round(maxStep * 100)))
+    }
+
+    // MARK: - Clamping at Minimum
+
+    @Test @MainActor
+    func zoomOutClampsAtMinimum() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        let minStep = ConversationZoomManager.zoomSteps.first!
+
+        // Zoom out until we hit the minimum step.
+        for _ in 0..<ConversationZoomManager.zoomSteps.count {
+            manager.zoomOut()
+        }
+        #expect(manager.zoomLevel == minStep)
+
+        // One more zoomOut should not change the level.
+        manager.zoomOut()
+        #expect(manager.zoomLevel == minStep)
+        #expect(manager.zoomPercentage == Int(round(minStep * 100)))
+    }
+
+    // MARK: - Reset Zoom
+
+    @Test @MainActor
+    func resetZoomRestoresDefault() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        manager.zoomIn()
+        manager.zoomIn()
+        #expect(manager.zoomLevel != 1.0)
+
+        manager.resetZoom()
+        #expect(manager.zoomLevel == 1.0)
+        #expect(manager.zoomPercentage == 100)
+    }
+
+    @Test @MainActor
+    func resetZoomFromZoomedOut() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        manager.zoomOut()
+        manager.zoomOut()
+        #expect(manager.zoomLevel < 1.0)
+
+        manager.resetZoom()
+        #expect(manager.zoomLevel == 1.0)
+    }
+
+    // MARK: - Persistence
+
+    @Test @MainActor
+    func zoomLevelPersistsAcrossInstances() {
+        let key = "conversationTextZoomLevel"
+        UserDefaults.standard.removeObject(forKey: key)
+
+        let first = ConversationZoomManager()
+        first.zoomIn() // 1.1
+        first.zoomIn() // 1.25
+        let savedLevel = first.zoomLevel
+
+        // A second instance should load the persisted value.
+        let second = ConversationZoomManager()
+        #expect(second.zoomLevel == savedLevel)
+        #expect(second.zoomPercentage == Int(round(savedLevel * 100)))
+
+        // Clean up.
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+
+    @Test @MainActor
+    func resetZoomPersists() {
+        let key = "conversationTextZoomLevel"
+        UserDefaults.standard.removeObject(forKey: key)
+
+        let first = ConversationZoomManager()
+        first.zoomIn()
+        first.resetZoom()
+
+        let second = ConversationZoomManager()
+        #expect(second.zoomLevel == 1.0)
+
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+
+    // MARK: - Indicator Flashing
+
+    @Test @MainActor
+    func zoomInShowsIndicator() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        #expect(!manager.showZoomIndicator)
+
+        manager.zoomIn()
+        #expect(manager.showZoomIndicator)
+    }
+
+    @Test @MainActor
+    func zoomOutShowsIndicator() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        manager.zoomOut()
+        #expect(manager.showZoomIndicator)
+    }
+
+    @Test @MainActor
+    func resetZoomShowsIndicator() {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        manager.resetZoom()
+        #expect(manager.showZoomIndicator)
+    }
+
+    @Test @MainActor
+    func indicatorAutoDismisses() async {
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+        let manager = ConversationZoomManager()
+        manager.zoomIn()
+        #expect(manager.showZoomIndicator)
+
+        // Wait for the 1.5s auto-dismiss plus a small buffer.
+        try? await Task.sleep(nanoseconds: 1_800_000_000)
+        #expect(!manager.showZoomIndicator)
+    }
+
+    // MARK: - Zoom Steps Invariants
+
+    @Test
+    func zoomStepsAreSortedAscending() {
+        let steps = ConversationZoomManager.zoomSteps
+        for i in 1..<steps.count {
+            #expect(steps[i] > steps[i - 1])
+        }
+    }
+
+    @Test
+    func zoomStepsContainDefaultLevel() {
+        #expect(ConversationZoomManager.zoomSteps.contains(1.0))
+    }
+}


### PR DESCRIPTION
## Summary
Adds a dedicated conversation text zoom system to the macOS app. Users can zoom chat text with Cmd +/−/0, independently from the existing full-window zoom (moved to Option+Cmd +/−/0). Zoom is persisted across relaunches, scales all chat surfaces consistently, and shows a smooth auto-dismiss indicator.

## Changes
- **M1 — Shortcut Reliability + Intent Routing:** Rewired View menu with separate conversation and window zoom shortcuts, added VZoomCommandIntent enum for explicit intent routing, overrode performKeyEquivalent in ComposerView to prevent shortcut swallowing, added MainWindowState.isConversationVisible
- **M2 — Conversation Zoom Primitive + Typography Integration:** Added ConversationZoomManager (stepped zoom 50%–200%, @AppStorage persistence), injected zoom scale via @Environment into all chat rendering (messages, markdown segments, code blocks, tables, composer), updated cache keys to include zoom scale
- **M3 — UX Polish, Accessibility, and Guardrail Tests:** Added zoom indicator overlay with auto-dismiss, scroll anchor preservation during zoom, 15 unit tests for ConversationZoomManager, keyboard shortcut documentation in README

## Milestone PRs (merged into feature branch)
- #9133: M1: Shortcut Reliability + Intent Routing
- #9150: M2: Conversation Zoom Primitive + Typography Integration
- #9176: M3: UX Polish, Accessibility, and Guardrail Tests

## Project issue
Closes #9123

## Test plan
- [ ] Cmd +/−/0 zoom chat text in thread view (composer focused and unfocused)
- [ ] Option+Cmd +/−/0 still control full-window zoom
- [ ] Zoom level persists across app relaunch
- [ ] All chat surfaces (messages, markdown, code blocks, tables, composer) scale together
- [ ] Zoom indicator appears and auto-dismisses on zoom change
- [ ] Scroll position preserved when zooming while mid-scroll
- [ ] No shortcut conflicts in non-chat panels (Settings, Debug)
- [ ] Unit tests pass: swift test --filter ConversationZoomManager

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
