### PR TITLE
Fix secure credential redirect to continue conversation and preserve key mapping

### DIFF
--- a/assistant/src/__tests__/handle-user-message-secret-resume.test.ts
+++ b/assistant/src/__tests__/handle-user-message-secret-resume.test.ts
@@ -1,0 +1,82 @@
+import * as net from 'node:net';
+
+import { describe, expect, test } from 'bun:test';
+
+const { handleUserMessage } = await import('../daemon/handlers/sessions.js');
+
+describe('handleUserMessage secret redirect continuation', () => {
+  test('resumes the request after secure save with redacted continuation text', async () => {
+    const sentMessages: Array<Record<string, unknown>> = [];
+    const enqueueCalls: Array<Record<string, unknown>> = [];
+    const processCalls: Array<Record<string, unknown>> = [];
+
+    const session = {
+      hasEscalationHandler: () => true,
+      redirectToSecurePrompt: (
+        _detectedTypes: string[],
+        options?: { onStored?: (record: { service: string; field: string; label: string; delivery: 'store' | 'transient_send' }) => void },
+      ) => {
+        options?.onStored?.({
+          service: 'telegram',
+          field: 'bot_token',
+          label: 'Telegram Bot Token',
+          delivery: 'store',
+        });
+      },
+      traceEmitter: { emit: () => {} },
+      enqueueMessage: (
+        content: string,
+        _attachments: unknown[],
+        _onEvent: unknown,
+        requestId: string,
+      ) => {
+        enqueueCalls.push({ content, requestId });
+        return { queued: false, requestId };
+      },
+      getQueueDepth: () => 0,
+      setTurnChannelContext: () => {},
+      setTurnInterfaceContext: () => {},
+      setAssistantId: () => {},
+      setGuardianContext: () => {},
+      setCommandIntent: () => {},
+      processMessage: (content: string, _attachments: unknown[], _onEvent: unknown, requestId: string) => {
+        processCalls.push({ content, requestId });
+        return Promise.resolve();
+      },
+    };
+
+    const ctx = {
+      socketToSession: new Map<net.Socket, string>(),
+      sessions: new Map(),
+      cuSessions: new Map(),
+      getOrCreateSession: async () => session,
+      send: (_socket: net.Socket, message: Record<string, unknown>) => {
+        sentMessages.push(message);
+      },
+    };
+
+    await handleUserMessage(
+      {
+        type: 'user_message',
+        sessionId: 'sess-1',
+        content: 'Set up Telegram with my bot token 123456789:ABCDefGHIJklmnopQRSTuvwxyz012345678',
+        interface: 'cli',
+      },
+      new net.Socket(),
+      ctx as never,
+    );
+
+    expect(sentMessages[0]).toMatchObject({
+      type: 'error',
+      category: 'secret_blocked',
+    });
+    expect(sentMessages.some((msg) => msg.type === 'assistant_text_delta')).toBe(true);
+    expect(sentMessages.some((msg) => msg.type === 'message_complete')).toBe(true);
+
+    expect(enqueueCalls).toHaveLength(1);
+    expect(processCalls).toHaveLength(1);
+    expect(enqueueCalls[0].content as string).toContain('<redacted type="Telegram Bot Token" />');
+    expect(enqueueCalls[0].content as string).toContain('credential telegram/bot_token');
+    expect(processCalls[0].content).toBe(enqueueCalls[0].content);
+  });
+});

--- a/assistant/src/__tests__/session-messaging-secret-redirect.test.ts
+++ b/assistant/src/__tests__/session-messaging-secret-redirect.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+import type { SecretPrompter } from '../permissions/secret-prompter.js';
+import { redirectToSecurePrompt, type RedirectedSecretRecord } from '../daemon/session-messaging.js';
+
+const setSecureKeyMock = mock((_key?: string, _value?: string) => true);
+const upsertCredentialMetadataMock = mock((_service?: string, _field?: string, _metadata?: unknown) => {});
+const metadataByKey = new Map<string, {
+  credentialId: string;
+  service: string;
+  field: string;
+  allowedTools: string[];
+  allowedDomains: string[];
+  createdAt: number;
+  updatedAt: number;
+}>();
+
+mock.module('../security/secure-keys.js', () => ({
+  getSecureKey: () => undefined,
+  setSecureKey: setSecureKeyMock,
+  deleteSecureKey: () => true,
+  listSecureKeys: () => [],
+  getBackendType: () => null,
+  isDowngradedFromKeychain: () => false,
+  _resetBackend: () => {},
+  _setBackend: () => {},
+}));
+
+mock.module('../tools/credentials/metadata-store.js', () => ({
+  assertMetadataWritable: () => {},
+  upsertCredentialMetadata: (
+    service: string,
+    field: string,
+  ) => {
+    upsertCredentialMetadataMock(service, field, {});
+    const key = `${service}:${field}`;
+    const now = Date.now();
+    metadataByKey.set(key, {
+      credentialId: `cred-${service}-${field}`,
+      service,
+      field,
+      allowedTools: [],
+      allowedDomains: [],
+      createdAt: now,
+      updatedAt: now,
+    });
+  },
+  getCredentialMetadata: (service: string, field: string) => metadataByKey.get(`${service}:${field}`),
+  getCredentialMetadataById: (credentialId: string) => (
+    Array.from(metadataByKey.values()).find((m) => m.credentialId === credentialId)
+  ),
+  listCredentialMetadata: () => Array.from(metadataByKey.values()),
+  deleteCredentialMetadata: (service: string, field: string) => {
+    metadataByKey.delete(`${service}:${field}`);
+  },
+  _setMetadataPath: () => {},
+}));
+
+describe('session-messaging secret redirect', () => {
+  beforeEach(() => {
+    setSecureKeyMock.mockReset();
+    upsertCredentialMetadataMock.mockReset();
+    metadataByKey.clear();
+    setSecureKeyMock.mockImplementation(() => true);
+  });
+
+  test('maps Telegram Bot Token to canonical credential key and emits stored callback', async () => {
+    const promptCalls: Array<{ service: string; field: string; label: string }> = [];
+    const fakePrompter = {
+      prompt: (
+        service: string,
+        field: string,
+        label: string,
+      ) => {
+        promptCalls.push({ service, field, label });
+        return Promise.resolve({ value: '123456789:ABCDefGHIJklmnopQRSTuvwxyz012345678', delivery: 'store' as const });
+      },
+    } as unknown as SecretPrompter;
+
+    let callbackRecord: RedirectedSecretRecord | undefined;
+
+    await new Promise<void>((resolve) => {
+      redirectToSecurePrompt('conv-1', fakePrompter, ['Telegram Bot Token'], {
+        onStored: (record) => {
+          callbackRecord = record;
+          resolve();
+        },
+      });
+    });
+
+    expect(promptCalls).toHaveLength(1);
+    expect(promptCalls[0]).toEqual({
+      service: 'telegram',
+      field: 'bot_token',
+      label: 'Telegram Bot Token',
+    });
+    expect(setSecureKeyMock).toHaveBeenCalledWith(
+      'credential:telegram:bot_token',
+      '123456789:ABCDefGHIJklmnopQRSTuvwxyz012345678',
+    );
+    expect(upsertCredentialMetadataMock).toHaveBeenCalledWith('telegram', 'bot_token', {});
+    expect(callbackRecord).toEqual({
+      service: 'telegram',
+      field: 'bot_token',
+      label: 'Telegram Bot Token',
+      delivery: 'store',
+    });
+  });
+
+  test('prefers canonical target when one mapped type is detected alongside generic detections', async () => {
+    const promptCalls: Array<{ service: string; field: string; label: string }> = [];
+    const fakePrompter = {
+      prompt: (
+        service: string,
+        field: string,
+        label: string,
+      ) => {
+        promptCalls.push({ service, field, label });
+        return Promise.resolve({ value: '123456789:ABCDefGHIJklmnopQRSTuvwxyz012345678', delivery: 'store' as const });
+      },
+    } as unknown as SecretPrompter;
+
+    await new Promise<void>((resolve) => {
+      redirectToSecurePrompt('conv-1', fakePrompter, ['Telegram Bot Token', 'High-Entropy Base64 Token'], {
+        onStored: () => resolve(),
+      });
+    });
+
+    expect(promptCalls).toHaveLength(1);
+    expect(promptCalls[0]).toEqual({
+      service: 'telegram',
+      field: 'bot_token',
+      label: 'Telegram Bot Token',
+    });
+    expect(setSecureKeyMock).toHaveBeenCalledWith(
+      'credential:telegram:bot_token',
+      '123456789:ABCDefGHIJklmnopQRSTuvwxyz012345678',
+    );
+  });
+
+  test('maps encoded known types to canonical credential key', async () => {
+    const promptCalls: Array<{ service: string; field: string; label: string }> = [];
+    const fakePrompter = {
+      prompt: (
+        service: string,
+        field: string,
+        label: string,
+      ) => {
+        promptCalls.push({ service, field, label });
+        return Promise.resolve({ value: '123456789:ABCDefGHIJklmnopQRSTuvwxyz012345678', delivery: 'store' as const });
+      },
+    } as unknown as SecretPrompter;
+
+    await new Promise<void>((resolve) => {
+      redirectToSecurePrompt('conv-1', fakePrompter, ['Telegram Bot Token (base64-encoded)'], {
+        onStored: () => resolve(),
+      });
+    });
+
+    expect(promptCalls).toHaveLength(1);
+    expect(promptCalls[0]).toEqual({
+      service: 'telegram',
+      field: 'bot_token',
+      label: 'Telegram Bot Token',
+    });
+    expect(setSecureKeyMock).toHaveBeenCalledWith(
+      'credential:telegram:bot_token',
+      '123456789:ABCDefGHIJklmnopQRSTuvwxyz012345678',
+    );
+  });
+
+  test('falls back to detected credential namespace for unknown secret types', async () => {
+    const promptCalls: Array<{ service: string; field: string; label: string }> = [];
+    const fakePrompter = {
+      prompt: (
+        service: string,
+        field: string,
+        label: string,
+      ) => {
+        promptCalls.push({ service, field, label });
+        return Promise.resolve({ value: 'opaque-secret', delivery: 'store' as const });
+      },
+    } as unknown as SecretPrompter;
+
+    await new Promise<void>((resolve) => {
+      redirectToSecurePrompt('conv-1', fakePrompter, ['Some Unknown Secret'], {
+        onStored: () => resolve(),
+      });
+    });
+
+    expect(promptCalls).toHaveLength(1);
+    expect(promptCalls[0]).toEqual({
+      service: 'detected',
+      field: 'Some Unknown Secret',
+      label: 'Secure Credential Entry',
+    });
+    expect(setSecureKeyMock).toHaveBeenCalledWith('credential:detected:Some Unknown Secret', 'opaque-secret');
+    expect(upsertCredentialMetadataMock).toHaveBeenCalledWith('detected', 'Some Unknown Secret', {});
+  });
+});

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -51,7 +51,7 @@ export async function handleTaskSubmit(
       const conversation = conversationStore.createConversation('(blocked — secret detected)');
       ctx.socketToSession.set(socket, conversation.id);
       const session = await ctx.getOrCreateSession(conversation.id, socket, true);
-      session.redirectToSecurePrompt(taskIngressCheck.detectedTypes, () => {
+      session.redirectToSecurePrompt(taskIngressCheck.detectedTypes, { onComplete: () => {
         conversationStore.deleteConversation(conversation.id);
         // Clean up in-memory session and socket binding so the ephemeral
         // session doesn't accumulate in the daemon's session map.
@@ -65,7 +65,7 @@ export async function handleTaskSubmit(
         if (ctx.socketToSession.get(socket) === conversation.id) {
           ctx.socketToSession.delete(socket);
         }
-      });
+      } });
       return;
     }
 

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -9,6 +9,7 @@ import * as conversationStore from '../../memory/conversation-store.js';
 import { GENERATING_TITLE, queueGenerateConversationTitle, UNTITLED_FALLBACK } from '../../memory/conversation-title-service.js';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
+import { redactSecrets } from '../../security/secret-scanner.js';
 import { getSubagentManager } from '../../subagent/index.js';
 import { silentlyWithLog } from '../../util/silently.js';
 import { truncate } from '../../util/truncate.js';
@@ -66,10 +67,116 @@ export async function handleUserMessage(
     }
 
     const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
+    const ipcChannel = parseChannelId(msg.channel) ?? 'vellum';
+    const ipcInterface = parseInterfaceId(msg.interface);
+    if (!ipcInterface) {
+      ctx.send(socket, {
+        type: 'error',
+        message: 'Invalid user_message: interface is required and must be valid',
+      });
+      return;
+    }
+    const queuedChannelMetadata = {
+      userMessageChannel: ipcChannel,
+      assistantMessageChannel: ipcChannel,
+      userMessageInterface: ipcInterface,
+      assistantMessageInterface: ipcInterface,
+    };
+
+    const dispatchUserMessage = (
+      content: string,
+      attachments: UserMessageAttachment[],
+      dispatchRequestId: string,
+      source: 'user_message' | 'secure_redirect_resume',
+      activeSurfaceId?: string,
+      currentPage?: string,
+    ): void => {
+      const receivedDescription = source === 'user_message'
+        ? 'User message received'
+        : 'Resuming message after secure credential save';
+      const queuedDescription = source === 'user_message'
+        ? 'Message queued (session busy)'
+        : 'Resumed message queued (session busy)';
+
+      session.traceEmitter.emit('request_received', receivedDescription, {
+        requestId: dispatchRequestId,
+        status: 'info',
+        attributes: { source },
+      });
+
+      const result = session.enqueueMessage(
+        content,
+        attachments,
+        sendEvent,
+        dispatchRequestId,
+        activeSurfaceId,
+        currentPage,
+        queuedChannelMetadata,
+      );
+      if (result.rejected) {
+        rlog.warn({ source }, 'Message rejected — queue is full');
+        session.traceEmitter.emit('request_error', 'Message rejected — queue is full', {
+          requestId: dispatchRequestId,
+          status: 'error',
+          attributes: { reason: 'queue_full', queueDepth: session.getQueueDepth(), source },
+        });
+        ctx.send(socket, buildSessionErrorMessage(msg.sessionId, {
+          code: 'QUEUE_FULL',
+          userMessage: 'Message queue is full (max depth: 10). Please wait for current messages to be processed.',
+          retryable: true,
+          debugDetails: 'Message rejected — session queue is full',
+        }));
+        return;
+      }
+      if (result.queued) {
+        const position = session.getQueueDepth();
+        rlog.info({ source, position }, queuedDescription);
+        session.traceEmitter.emit('request_queued', `Message queued at position ${position}`, {
+          requestId: dispatchRequestId,
+          status: 'info',
+          attributes: { position, source },
+        });
+        ctx.send(socket, {
+          type: 'message_queued',
+          sessionId: msg.sessionId,
+          requestId: dispatchRequestId,
+          position,
+        });
+        return;
+      }
+
+      rlog.info({ source }, 'Processing user message');
+      session.setTurnChannelContext({
+        userMessageChannel: ipcChannel,
+        assistantMessageChannel: ipcChannel,
+      });
+      session.setTurnInterfaceContext({
+        userMessageInterface: ipcInterface,
+        assistantMessageInterface: ipcInterface,
+      });
+      session.setAssistantId('self');
+      // IPC/desktop user IS the guardian — default to guardian role so messages
+      // are not tagged 'unverified_channel' (which blocks memory extraction).
+      session.setGuardianContext({ actorRole: 'guardian', sourceChannel: ipcChannel });
+      session.setCommandIntent(null);
+      // Fire-and-forget: don't block the IPC handler so the connection can
+      // continue receiving messages (e.g. cancel, confirmations, or
+      // additional user_message that will be queued by the session).
+      session.processMessage(content, attachments, sendEvent, dispatchRequestId, activeSurfaceId, currentPage).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        rlog.error({ err, source }, 'Error processing user message (session or provider failure)');
+        ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });
+        const classified = classifySessionError(err, { phase: 'agent_loop' });
+        ctx.send(socket, buildSessionErrorMessage(msg.sessionId, classified));
+      });
+    };
+
+    const config = getConfig();
+    const messageText = msg.content ?? '';
 
     // Block inbound messages that contain secrets and redirect to secure prompt
     if (!msg.bypassSecretCheck) {
-      const ingressCheck = checkIngressForSecrets(msg.content ?? '');
+      const ingressCheck = checkIngressForSecrets(messageText);
       if (ingressCheck.blocked) {
         rlog.warn({ detectedTypes: ingressCheck.detectedTypes }, 'Blocked user message containing secrets');
         ctx.send(socket, {
@@ -77,21 +184,47 @@ export async function handleUserMessage(
           message: ingressCheck.userNotice!,
           category: 'secret_blocked',
         });
-        // Redirect: trigger a secure prompt so the user can enter the secret safely
-        session.redirectToSecurePrompt(ingressCheck.detectedTypes);
+
+        const redactedMessageText = redactSecrets(messageText, {
+          enabled: true,
+          base64Threshold: config.secretDetection.entropyThreshold,
+        }).trim();
+
+        // Redirect: trigger a secure prompt so the user can enter the secret safely.
+        // After save, continue the same request with redacted text so the model keeps
+        // user intent without ever receiving the raw secret value.
+        session.redirectToSecurePrompt(ingressCheck.detectedTypes, {
+          onStored: (record) => {
+            ctx.send(socket, {
+              type: 'assistant_text_delta',
+              sessionId: msg.sessionId,
+              text: 'Saved your secret securely. Continuing with your request.',
+            });
+            ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+
+            const continuationParts: string[] = [];
+            if (redactedMessageText.length > 0) continuationParts.push(redactedMessageText);
+            continuationParts.push(
+              `I entered the redacted secret via the Secure Credential UI and saved it as credential ${record.service}/${record.field}. ` +
+              'Continue with my request using that stored credential and do not ask me to paste the secret again.',
+            );
+            const continuationMessage = continuationParts.join('\n\n');
+            const continuationRequestId = uuid();
+            dispatchUserMessage(
+              continuationMessage,
+              msg.attachments ?? [],
+              continuationRequestId,
+              'secure_redirect_resume',
+              msg.activeSurfaceId,
+              msg.currentPage,
+            );
+          },
+        });
         return;
       }
     }
 
-    session.traceEmitter.emit('request_received', 'User message received', {
-      requestId,
-      status: 'info',
-      attributes: { source: 'user_message' },
-    });
-
     // ── Standalone recording intent interception ──────────────────────────
-    const config = getConfig();
-    const messageText = msg.content ?? '';
     if (config.daemon.standaloneRecording && messageText) {
       if (isStopRecordingOnly(messageText)) {
         const stopped = handleRecordingStop(msg.sessionId, ctx) !== undefined;
@@ -119,86 +252,14 @@ export async function handleUserMessage(
       }
     }
 
-    const ipcChannel = parseChannelId(msg.channel) ?? 'vellum';
-    const ipcInterface = parseInterfaceId(msg.interface);
-    if (!ipcInterface) {
-      ctx.send(socket, {
-        type: 'error',
-        message: 'Invalid user_message: interface is required and must be valid',
-      });
-      return;
-    }
-    const queuedChannelMetadata = {
-      userMessageChannel: ipcChannel,
-      assistantMessageChannel: ipcChannel,
-      userMessageInterface: ipcInterface,
-      assistantMessageInterface: ipcInterface,
-    };
-    const result = session.enqueueMessage(
-      msg.content ?? '',
+    dispatchUserMessage(
+      messageText,
       msg.attachments ?? [],
-      sendEvent,
       requestId,
+      'user_message',
       msg.activeSurfaceId,
       msg.currentPage,
-      queuedChannelMetadata,
     );
-    if (result.rejected) {
-      rlog.warn('Message rejected — queue is full');
-      session.traceEmitter.emit('request_error', 'Message rejected — queue is full', {
-        requestId,
-        status: 'error',
-        attributes: { reason: 'queue_full', queueDepth: session.getQueueDepth() },
-      });
-      ctx.send(socket, buildSessionErrorMessage(msg.sessionId, {
-        code: 'QUEUE_FULL',
-        userMessage: 'Message queue is full (max depth: 10). Please wait for current messages to be processed.',
-        retryable: true,
-        debugDetails: 'Message rejected — session queue is full',
-      }));
-      return;
-    }
-    if (result.queued) {
-      const position = session.getQueueDepth();
-      rlog.info({ position }, 'Message queued (session busy)');
-      session.traceEmitter.emit('request_queued', `Message queued at position ${position}`, {
-        requestId,
-        status: 'info',
-        attributes: { position },
-      });
-      ctx.send(socket, {
-        type: 'message_queued',
-        sessionId: msg.sessionId,
-        requestId,
-        position,
-      });
-      return; // Don't await — message will be processed when current one finishes
-    }
-
-    rlog.info('Processing user message');
-    session.setTurnChannelContext({
-      userMessageChannel: ipcChannel,
-      assistantMessageChannel: ipcChannel,
-    });
-    session.setTurnInterfaceContext({
-      userMessageInterface: ipcInterface,
-      assistantMessageInterface: ipcInterface,
-    });
-    session.setAssistantId('self');
-    // IPC/desktop user IS the guardian — default to guardian role so messages
-    // are not tagged 'unverified_channel' (which blocks memory extraction).
-    session.setGuardianContext({ actorRole: 'guardian', sourceChannel: ipcChannel });
-    session.setCommandIntent(null);
-    // Fire-and-forget: don't block the IPC handler so the connection can
-    // continue receiving messages (e.g. cancel, confirmations, or
-    // additional user_message that will be queued by the session).
-    session.processMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId, msg.activeSurfaceId, msg.currentPage).catch((err) => {
-      const message = err instanceof Error ? err.message : String(err);
-      rlog.error({ err }, 'Error processing user message (session or provider failure)');
-      ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });
-      const classified = classifySessionError(err, { phase: 'agent_loop' });
-      ctx.send(socket, buildSessionErrorMessage(msg.sessionId, classified));
-    });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     rlog.error({ err }, 'Error setting up user message processing');

--- a/assistant/src/daemon/session-messaging.ts
+++ b/assistant/src/daemon/session-messaging.ts
@@ -21,6 +21,67 @@ import type { GuardianRuntimeContext } from './session-runtime-assembly.js';
 
 const log = getLogger('session-messaging');
 
+interface IngressSecretTarget {
+  service: string;
+  field: string;
+  label: string;
+}
+
+const INGRESS_SECRET_TARGETS: Record<string, IngressSecretTarget> = {
+  'Anthropic API Key': { service: 'anthropic', field: 'api_key', label: 'Anthropic API Key' },
+  'GitHub Fine-Grained PAT': { service: 'github', field: 'token', label: 'GitHub Token' },
+  'GitHub Token': { service: 'github', field: 'token', label: 'GitHub Token' },
+  'GitLab Token': { service: 'gitlab', field: 'token', label: 'GitLab Token' },
+  'Google API Key': { service: 'google', field: 'api_key', label: 'Google API Key' },
+  'Google OAuth Client Secret': { service: 'google', field: 'client_secret', label: 'Google OAuth Client Secret' },
+  'Mailgun API Key': { service: 'mailgun', field: 'api_key', label: 'Mailgun API Key' },
+  'OpenAI API Key': { service: 'openai', field: 'api_key', label: 'OpenAI API Key' },
+  'OpenAI Project Key': { service: 'openai', field: 'api_key', label: 'OpenAI API Key' },
+  'PyPI API Token': { service: 'pypi', field: 'api_token', label: 'PyPI API Token' },
+  'SendGrid API Key': { service: 'sendgrid', field: 'api_key', label: 'SendGrid API Key' },
+  'Slack Bot Token': { service: 'slack', field: 'bot_token', label: 'Slack Bot Token' },
+  'Slack User Token': { service: 'slack', field: 'user_token', label: 'Slack User Token' },
+  'Slack Webhook': { service: 'slack', field: 'webhook_url', label: 'Slack Webhook URL' },
+  'Stripe Restricted Key': { service: 'stripe', field: 'restricted_key', label: 'Stripe Restricted Key' },
+  'Stripe Secret Key': { service: 'stripe', field: 'secret_key', label: 'Stripe Secret Key' },
+  'Telegram Bot Token': { service: 'telegram', field: 'bot_token', label: 'Telegram Bot Token' },
+  'Twilio API Key': { service: 'twilio', field: 'api_key', label: 'Twilio API Key' },
+  'npm Token': { service: 'npm', field: 'token', label: 'npm Token' },
+};
+
+export interface RedirectedSecretRecord {
+  service: string;
+  field: string;
+  label: string;
+  delivery: 'store' | 'transient_send';
+}
+
+export interface RedirectToSecurePromptOptions {
+  onStored?: (record: RedirectedSecretRecord) => void | Promise<void>;
+  onComplete?: () => void;
+}
+
+function normalizeIngressSecretTypeLabel(detectedType: string): string {
+  return detectedType.replace(/\s+\([^)]+\)$/u, '');
+}
+
+function resolveIngressSecretTarget(detectedTypes: string[]): IngressSecretTarget {
+  const mappedTargets = new Map<string, IngressSecretTarget>();
+  for (const detectedType of detectedTypes) {
+    const normalizedType = normalizeIngressSecretTypeLabel(detectedType);
+    const mapped = INGRESS_SECRET_TARGETS[normalizedType];
+    if (!mapped) continue;
+    mappedTargets.set(`${mapped.service}:${mapped.field}`, mapped);
+  }
+  if (mappedTargets.size === 1) return mappedTargets.values().next().value!;
+
+  return {
+    service: 'detected',
+    field: detectedTypes.join(','),
+    label: 'Secure Credential Entry',
+  };
+}
+
 // ── Context Interface ────────────────────────────────────────────────
 
 export interface MessagingSessionContext {
@@ -175,37 +236,57 @@ export function redirectToSecurePrompt(
   conversationId: string,
   secretPrompter: SecretPrompter,
   detectedTypes: string[],
-  onComplete?: () => void,
+  options?: RedirectToSecurePromptOptions,
 ): void {
-  const service = 'detected';
-  const field = detectedTypes.join(',');
+  const target = resolveIngressSecretTarget(detectedTypes);
+
   secretPrompter.prompt(
-    service, field,
-    'Secure Credential Entry',
+    target.service, target.field,
+    target.label,
     'Your message contained a secret. Please enter it here instead — it will be stored securely and never sent to the AI.',
     undefined, conversationId,
-  ).then(async (result) => {
+  ).then(async (result): Promise<void> => {
     if (!result.value) return;
 
     const { setSecureKey } = await import('../security/secure-keys.js');
     const { upsertCredentialMetadata } = await import('../tools/credentials/metadata-store.js');
 
+    let wasStored = false;
     if (result.delivery === 'transient_send') {
       const { credentialBroker } = await import('../tools/credentials/broker.js');
-      credentialBroker.injectTransient(service, field, result.value);
-      try { upsertCredentialMetadata(service, field, {}); } catch (e) { log.debug({ err: e, service, field }, 'Non-critical credential metadata upsert failed'); }
-      log.info({ service, field, delivery: 'transient_send' }, 'Ingress redirect: transient credential injected');
+      credentialBroker.injectTransient(target.service, target.field, result.value);
+      try {
+        upsertCredentialMetadata(target.service, target.field, {});
+      } catch (e) {
+        log.debug({ err: e, service: target.service, field: target.field }, 'Non-critical credential metadata upsert failed');
+      }
+      wasStored = true;
+      log.info({ service: target.service, field: target.field, delivery: 'transient_send' }, 'Ingress redirect: transient credential injected');
     } else {
-      const key = `credential:${service}:${field}`;
+      const key = `credential:${target.service}:${target.field}`;
       const stored = setSecureKey(key, result.value);
       if (stored) {
-        try { upsertCredentialMetadata(service, field, {}); } catch (e) { log.debug({ err: e, service, field }, 'Non-critical credential metadata upsert failed'); }
-        log.info({ service, field }, 'Ingress redirect: credential stored');
+        try {
+          upsertCredentialMetadata(target.service, target.field, {});
+        } catch (e) {
+          log.debug({ err: e, service: target.service, field: target.field }, 'Non-critical credential metadata upsert failed');
+        }
+        wasStored = true;
+        log.info({ service: target.service, field: target.field }, 'Ingress redirect: credential stored');
       } else {
-        log.warn({ service, field }, 'Ingress redirect: secure storage write failed');
+        log.warn({ service: target.service, field: target.field }, 'Ingress redirect: secure storage write failed');
       }
     }
+
+    if (wasStored) {
+      await options?.onStored?.({
+        service: target.service,
+        field: target.field,
+        label: target.label,
+        delivery: result.delivery,
+      });
+    }
   }).catch(() => { /* prompt timeout or cancel is fine */ }).finally(() => {
-    onComplete?.();
+    options?.onComplete?.();
   });
 }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -61,6 +61,7 @@ import {
   enqueueMessage as enqueueMessageImpl,
   persistUserMessage as persistUserMessageImpl,
   redirectToSecurePrompt as redirectToSecurePromptImpl,
+  type RedirectToSecurePromptOptions,
 } from './session-messaging.js';
 // Extracted modules
 import { registerSessionNotifiers } from './session-notifiers.js';
@@ -378,8 +379,8 @@ export class Session {
 
   // ── Messaging ────────────────────────────────────────────────────
 
-  redirectToSecurePrompt(detectedTypes: string[], onComplete?: () => void): void {
-    redirectToSecurePromptImpl(this.conversationId, this.secretPrompter, detectedTypes, onComplete);
+  redirectToSecurePrompt(detectedTypes: string[], options?: RedirectToSecurePromptOptions): void {
+    redirectToSecurePromptImpl(this.conversationId, this.secretPrompter, detectedTypes, options);
   }
 
   enqueueMessage(

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -878,23 +878,48 @@ extension ChatViewModel {
                 // stash the full send context so "Send Anyway" can reconstruct
                 // the original UserMessageMessage with attachments and surface metadata.
                 if err.category == "secret_blocked" {
+                    let blockedMessageIndex: Int? = {
+                        let normalizedTurnText = savedTurnUserText?.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if let normalizedTurnText, !normalizedTurnText.isEmpty {
+                            return messages.lastIndex(where: {
+                                $0.role == .user
+                                    && $0.text.trimmingCharacters(in: .whitespacesAndNewlines) == normalizedTurnText
+                            })
+                        }
+                        return messages.lastIndex(where: { $0.role == .user })
+                    }()
+                    let blockedUserMessage = blockedMessageIndex.map { messages[$0] }
+
                     // Prefer the snapshotted turn text (the text that was actually sent)
                     // over the transcript lookup, which can miss workspace refinements
                     // that don't append a user chat message.
                     if let sendText = savedTurnUserText {
                         secretBlockedMessageText = sendText
-                    } else if let lastUserMsg = messages.last(where: { $0.role == .user }) {
-                        secretBlockedMessageText = lastUserMsg.text
+                    } else if let blockedUserMessage {
+                        secretBlockedMessageText = blockedUserMessage.text
                     }
-                    // Reconstruct IPC attachments from the last user message's ChatAttachments
-                    if let lastUserMsg = messages.last(where: { $0.role == .user }),
-                       !lastUserMsg.attachments.isEmpty {
-                        secretBlockedAttachments = lastUserMsg.attachments.map {
+                    // Reconstruct IPC attachments from the blocked user message's ChatAttachments
+                    if let blockedUserMessage, !blockedUserMessage.attachments.isEmpty {
+                        secretBlockedAttachments = blockedUserMessage.attachments.map {
                             IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
                         }
                     }
                     secretBlockedActiveSurfaceId = activeSurfaceId
                     secretBlockedCurrentPage = currentPage
+
+                    // Remove the blocked user bubble so secret-like text is not
+                    // retained in chat history after secure save redirect.
+                    if let blockedMessageIndex {
+                        let blockedMessage = messages[blockedMessageIndex]
+                        let blockedMessageId = blockedMessage.id
+                        if case .queued = blockedMessage.status {
+                            pendingQueuedCount = max(0, pendingQueuedCount - 1)
+                        }
+                        pendingMessageIds.removeAll { $0 == blockedMessageId }
+                        requestIdToMessageId = requestIdToMessageId.filter { $0.value != blockedMessageId }
+                        pendingLocalDeletions.remove(blockedMessageId)
+                        messages.remove(at: blockedMessageIndex)
+                    }
                 }
             }
             // Reset processing messages to sent

--- a/clients/shared/Tests/ChatViewModelSecretBlockedTests.swift
+++ b/clients/shared/Tests/ChatViewModelSecretBlockedTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import VellumAssistantShared
+
+@MainActor
+final class ChatViewModelSecretBlockedTests: XCTestCase {
+
+    private var daemonClient: MockDaemonClient!
+    private var viewModel: ChatViewModel!
+
+    override func setUp() {
+        super.setUp()
+        daemonClient = MockDaemonClient()
+        daemonClient.isConnected = true
+        viewModel = ChatViewModel(daemonClient: daemonClient)
+        viewModel.sessionId = "sess-1"
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        daemonClient = nil
+        super.tearDown()
+    }
+
+    func testSecretBlockedErrorRemovesBlockedUserMessage() {
+        viewModel.inputText = "Here is my token 123456789:ABCDefGHIJklmnopQRSTuvwxyz012345678"
+        viewModel.sendMessage()
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        XCTAssertEqual(viewModel.messages[0].role, .user)
+
+        viewModel.handleServerMessage(.error(ErrorMessage(
+            message: "Blocked for secrets",
+            category: "secret_blocked"
+        )))
+
+        XCTAssertEqual(viewModel.messages.count, 0, "Blocked user message should be removed from chat history")
+        XCTAssertTrue(viewModel.isSecretBlockError, "Secret-blocked state should still be available")
+        XCTAssertEqual(
+            viewModel.secretBlockedMessageText,
+            "Here is my token 123456789:ABCDefGHIJklmnopQRSTuvwxyz012345678"
+        )
+    }
+
+    func testSecretBlockedErrorCleansQueuedBookkeepingForRemovedMessage() {
+        viewModel.isSending = true
+        viewModel.isThinking = true
+        viewModel.pendingQueuedCount = 1
+        viewModel.currentTurnUserText = "secret queued message"
+
+        let queuedMessage = ChatMessage(role: .user, text: "secret queued message", status: .queued(position: 0))
+        viewModel.messages.append(queuedMessage)
+        viewModel.pendingMessageIds = [queuedMessage.id]
+        viewModel.requestIdToMessageId = ["req-secret-1": queuedMessage.id]
+
+        viewModel.handleServerMessage(.error(ErrorMessage(
+            message: "Blocked for secrets",
+            category: "secret_blocked"
+        )))
+
+        XCTAssertEqual(viewModel.messages.count, 0, "Blocked queued message should be removed")
+        XCTAssertEqual(viewModel.pendingQueuedCount, 0, "Queue count should drop for removed blocked message")
+        XCTAssertTrue(viewModel.pendingMessageIds.isEmpty, "Pending message IDs should remove the blocked message")
+        XCTAssertTrue(viewModel.requestIdToMessageId.isEmpty, "Request mapping should remove the blocked message")
+    }
+}


### PR DESCRIPTION
## Summary
- resume the original request automatically after the ingress secret-blocked secure credential modal is saved
- map known secret types to canonical credential keys (for example `Telegram Bot Token` -> `credential:telegram:bot_token`) even when generic detections are also present
- keep fallback behavior for unknown types under `detected/...`
- remove the blocked user bubble and clean queue bookkeeping in shared `ChatViewModel` after `secret_blocked`

## Why
In the banner-triggered secure-save flow, saving the secret did not continue the conversation. This made the secure flow feel broken compared to agent-triggered secret prompts.

## What changed
- `session-messaging.redirectToSecurePrompt(...)` now accepts structured options (`onStored`, `onComplete`) and reports stored credential target info
- ingress secret redirect target resolution now:
  - prefers a canonical mapped target when exactly one known mapped type is detected
  - handles encoded type labels like `... (base64-encoded)`
  - falls back to `detected/<types>` when no single canonical target is available
- `handleUserMessage` now:
  - redacts the blocked text
  - opens secure prompt
  - on successful save, emits a short acknowledgement and dispatches a continuation message that tells the assistant to keep going with the stored credential
- shared client message handling now removes the blocked user message and associated pending/queued bookkeeping state

## Tests
- `cd assistant && bun test src/__tests__/session-messaging-secret-redirect.test.ts src/__tests__/handle-user-message-secret-resume.test.ts src/__tests__/secret-ingress-handler.test.ts`
- `cd assistant && bunx tsc --noEmit` *(fails due pre-existing unrelated repo-wide errors in ipc snapshot/deep-link/conflict-store/guardian-approval files)*
- `cd clients && swift test --filter ChatViewModelSecretBlockedTests` *(fails due pre-existing unrelated compile issue in `clients/macos/.../ChatView.swift` missing `subagentDetailStore` in a preview call)*

Linear: https://linear.app/vellum/issue/JARVIS-44/reduce-friction-after-saving-a-secret-via-secure-credential-ui

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
