### PR TITLE
M3: First-reply gate + empty state suppression

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -556,11 +556,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             // successfully, consider the send successful.
             if mainWindow != nil {
                 log.info("Wake-up greeting sent successfully (attempt \(attempt + 1))")
-                // Transition to pendingFirstReply — M3 will handle the
-                // .complete transition when the first assistant reply arrives.
                 transitionBootstrap(to: .pendingFirstReply)
-                // TODO(M3): Remove this — transition to .complete should happen when first assistant reply arrives
-                transitionBootstrap(to: .complete)
+                wireBootstrapFirstReplyCallback()
                 setupWakeWordCoordinator()
                 debugStateWriter.start(appDelegate: self)
                 return
@@ -579,6 +576,19 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             errorMessage: "Could not connect after \(maxAttempts) attempts. Please try again.",
             isRetrying: false
         )
+    }
+
+    /// Wires `onFirstAssistantReply` on the active ChatViewModel so bootstrap
+    /// transitions to `.complete` when the daemon's first reply arrives.
+    private func wireBootstrapFirstReplyCallback() {
+        guard let viewModel = mainWindow?.activeViewModel else {
+            log.warning("No active ChatViewModel to wire first-reply callback — completing bootstrap immediately")
+            transitionBootstrap(to: .complete)
+            return
+        }
+        viewModel.onFirstAssistantReply = { [weak self] in
+            self?.transitionBootstrap(to: .complete)
+        }
     }
 
     private func showAuthWindow() {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -70,6 +70,10 @@ struct ChatView: View {
     var isLoadingMoreMessages: Bool = false
     var loadPreviousMessagePage: (() async -> Bool)?
 
+    /// When true, suppresses `ChatEmptyStateView` during first-launch bootstrap
+    /// and shows a loading panel instead.
+    var isBootstrapping: Bool = false
+
     @State private var isNearBottom = true
     @State private var isDropTargeted = false
     @State private var editorContentHeight: CGFloat = 20
@@ -114,6 +118,11 @@ struct ChatView: View {
                         Spacer()
                     }
                     Spacer()
+                } else if isEmptyState && isBootstrapping {
+                    // During first-launch bootstrap, suppress the empty state
+                    // and show a simple loading panel until the first assistant
+                    // reply arrives and populates the chat.
+                    ChatBootstrapLoadingView()
                 } else if isEmptyState {
                     if isTemporaryChat {
                         ChatTemporaryChatEmptyStateView(
@@ -353,6 +362,33 @@ struct ChatView: View {
             if !urls.isEmpty { onDropFiles(urls) }
         }
         return true
+    }
+}
+
+// MARK: - Bootstrap Loading View
+
+/// Minimal loading panel shown during first-launch bootstrap while the
+/// assistant's first reply is pending. Replaces `ChatEmptyStateView` so
+/// the user sees a calm loading state instead of the usual empty chat.
+private struct ChatBootstrapLoadingView: View {
+    @State private var visible = false
+
+    var body: some View {
+        VStack(spacing: VSpacing.lg) {
+            Spacer()
+            VLoadingIndicator(size: 24, color: VColor.accent)
+            Text("Getting ready...")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .opacity(visible ? 1 : 0)
+        .onAppear {
+            withAnimation(VAnimation.standard) {
+                visible = true
+            }
+        }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -647,6 +647,11 @@ struct ActiveChatViewWrapper: View {
     var isTemporaryChat: Bool = false
     var threadId: UUID?
 
+    /// Reads the persisted bootstrap state so the chat view can suppress
+    /// the empty state during first-launch bootstrap.
+    @AppStorage("bootstrapState") private var bootstrapStateRaw: String = "complete"
+    private var isBootstrapping: Bool { bootstrapStateRaw != "complete" }
+
     var body: some View {
         ChatView(
             messages: viewModel.messages,
@@ -752,7 +757,8 @@ struct ActiveChatViewWrapper: View {
             displayedMessageCount: viewModel.displayedMessageCount,
             hasMoreMessages: viewModel.hasMoreMessages,
             isLoadingMoreMessages: viewModel.isLoadingMoreMessages,
-            loadPreviousMessagePage: { await viewModel.loadPreviousMessagePage() }
+            loadPreviousMessagePage: { await viewModel.loadPreviousMessagePage() },
+            isBootstrapping: isBootstrapping
         )
     }
 }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -621,9 +621,15 @@ extension ChatViewModel {
             }
             // Fire first-reply callback once when the first complete
             // assistant message arrives (used for bootstrap gate).
+            // Guard: only fire if an actual assistant message with content
+            // exists, so cancellation-acknowledgement completions that
+            // carry no assistant text don't prematurely close the gate.
             if let callback = onFirstAssistantReply {
-                onFirstAssistantReply = nil
-                callback()
+                let hasAssistantContent = messages.contains { $0.role == .assistant && !$0.text.isEmpty }
+                if hasAssistantContent {
+                    onFirstAssistantReply = nil
+                    callback()
+                }
             }
             var completedToolCalls: [ToolCallData]?
             if let existingId = currentAssistantMessageId,

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -619,6 +619,12 @@ extension ChatViewModel {
                     onVoiceResponseComplete?(responseText)
                 }
             }
+            // Fire first-reply callback once when the first complete
+            // assistant message arrives (used for bootstrap gate).
+            if let callback = onFirstAssistantReply {
+                onFirstAssistantReply = nil
+                callback()
+            }
             var completedToolCalls: [ToolCallData]?
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -242,6 +242,9 @@ public final class ChatViewModel: ObservableObject {
     public var onVoiceResponseComplete: ((String) -> Void)?
     /// Called when any assistant response completes, with a summary of the response text.
     public var onResponseComplete: ((String) -> Void)?
+    /// Called once when the first complete assistant message arrives during bootstrap.
+    /// Cleared after firing to ensure it only triggers once.
+    public var onFirstAssistantReply: (() -> Void)?
     /// Called with each streaming text delta during a voice-triggered response, for real-time TTS.
     public var onVoiceTextDelta: ((String) -> Void)?
     /// When true, messages are prefixed with a concise-response instruction for voice conversations.


### PR DESCRIPTION
Detect first assistant reply in ChatViewModel, transition to .complete only on first reply, suppress ChatEmptyStateView during bootstrap with loading panel. Part of #9155, closes #9158.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
