### PR TITLE
fix(settings): reset stale resend metadata on session change

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1246,6 +1246,12 @@ public final class SettingsStore: ObservableObject {
 
         switch channel {
         case "telegram":
+            // When the session changes, reset resend metadata so stale cooldown/counter
+            // values from the old session don't persist through the if-let guards below.
+            if sessionId != telegramOutboundSessionId {
+                telegramOutboundNextResendAt = nil
+                telegramOutboundSendCount = 0
+            }
             telegramOutboundSessionId = sessionId
             if let expiresAt { telegramOutboundExpiresAt = expiresAt }
             if let nextResendAt { telegramOutboundNextResendAt = nextResendAt }
@@ -1262,11 +1268,19 @@ public final class SettingsStore: ObservableObject {
                 telegramBootstrapUrl = nil
             }
         case "sms":
+            if sessionId != smsOutboundSessionId {
+                smsOutboundNextResendAt = nil
+                smsOutboundSendCount = 0
+            }
             smsOutboundSessionId = sessionId
             if let expiresAt { smsOutboundExpiresAt = expiresAt }
             if let nextResendAt { smsOutboundNextResendAt = nextResendAt }
             if let sendCount { smsOutboundSendCount = sendCount }
         case "voice":
+            if sessionId != voiceOutboundSessionId {
+                voiceOutboundNextResendAt = nil
+                voiceOutboundSendCount = 0
+            }
             voiceOutboundSessionId = sessionId
             if let expiresAt { voiceOutboundExpiresAt = expiresAt }
             if let nextResendAt { voiceOutboundNextResendAt = nextResendAt }


### PR DESCRIPTION
When applyOutboundResponseState receives a new verificationSessionId, reset nextResendAt and sendCount to defaults before applying if-let guards. This prevents stale cooldown/counter values from an old session persisting when a new session starts. Addresses feedback from #9141.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
