### PR TITLE
M4: Intent quality protection for first reply

### DIFF
--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -37,6 +37,21 @@ describe('onboarding template contracts', () => {
       expect(lower).toContain('avatar will start to reflect');
       expect(lower).toContain('happens automatically');
     });
+
+    test('contains naming intent markers so the first reply includes naming cues', () => {
+      const lower = bootstrap.toLowerCase();
+      // The template must prompt the assistant to ask about names.
+      // These keywords align with the client-side naming intent heuristic
+      // (ChatViewModel.replyContainsNamingIntent) so that the first reply
+      // naturally passes the quality check without triggering a corrective nudge.
+      expect(lower).toContain('name');
+      expect(lower).toContain('call');
+      // The example first message should include a naming question
+      expect(lower).toContain('what should i call myself');
+      // The conversation sequence must include identity/naming as the first step
+      expect(lower).toContain('who am i');
+      expect(lower).toContain('who are you');
+    });
   });
 
   describe('IDENTITY.md', () => {

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -580,14 +580,24 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Wires `onFirstAssistantReply` on the active ChatViewModel so bootstrap
     /// transitions to `.complete` when the daemon's first reply arrives.
+    /// Also wires a corrective follow-up nudge: if the first reply doesn't
+    /// include naming intent, one silent message is sent to steer the
+    /// conversation toward identity/naming.
     private func wireBootstrapFirstReplyCallback() {
         guard let viewModel = mainWindow?.activeViewModel else {
             log.warning("No active ChatViewModel to wire first-reply callback — completing bootstrap immediately")
             transitionBootstrap(to: .complete)
             return
         }
-        viewModel.onFirstAssistantReply = { [weak self] in
+        viewModel.onFirstAssistantReply = { [weak self] _ in
             self?.transitionBootstrap(to: .complete)
+        }
+        viewModel.onFirstReplyLacksNamingIntent = { [weak viewModel] in
+            guard let viewModel else { return }
+            log.info("First bootstrap reply lacked naming intent — sending corrective nudge")
+            viewModel.sendSilently(
+                "Before we get started, what should I call you? And is there a name you'd like me to go by?"
+            )
         }
     }
 

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -625,10 +625,19 @@ extension ChatViewModel {
             // exists, so cancellation-acknowledgement completions that
             // carry no assistant text don't prematurely close the gate.
             if let callback = onFirstAssistantReply {
-                let hasAssistantContent = messages.contains { $0.role == .assistant && !$0.text.isEmpty }
-                if hasAssistantContent {
+                if let firstAssistant = messages.first(where: { $0.role == .assistant && !$0.text.isEmpty }) {
+                    let replyText = firstAssistant.text
                     onFirstAssistantReply = nil
-                    callback()
+                    callback(replyText)
+
+                    // Check naming intent and fire the lacks-naming callback
+                    // once. The didSendNamingNudge flag prevents looping if
+                    // the corrective follow-up also lacks naming keywords.
+                    if !didSendNamingNudge && !ChatViewModel.replyContainsNamingIntent(replyText) {
+                        didSendNamingNudge = true
+                        onFirstReplyLacksNamingIntent?()
+                        onFirstReplyLacksNamingIntent = nil
+                    }
                 }
             }
             var completedToolCalls: [ToolCallData]?

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -243,8 +243,16 @@ public final class ChatViewModel: ObservableObject {
     /// Called when any assistant response completes, with a summary of the response text.
     public var onResponseComplete: ((String) -> Void)?
     /// Called once when the first complete assistant message arrives during bootstrap.
+    /// Passes the reply text so callers can inspect content (e.g. naming intent).
     /// Cleared after firing to ensure it only triggers once.
-    public var onFirstAssistantReply: (() -> Void)?
+    public var onFirstAssistantReply: ((String) -> Void)?
+    /// Called when the first assistant reply lacks naming intent (no mention of
+    /// name, identity, or naming questions). Fires at most once; used to trigger
+    /// a single corrective follow-up nudge during bootstrap.
+    public var onFirstReplyLacksNamingIntent: (() -> Void)?
+    /// Guards against looping: once a corrective naming nudge has been sent,
+    /// no further nudges are dispatched regardless of subsequent replies.
+    private var didSendNamingNudge = false
     /// Called with each streaming text delta during a voice-triggered response, for real-time TTS.
     public var onVoiceTextDelta: ((String) -> Void)?
     /// When true, messages are prefixed with a concise-response instruction for voice conversations.
@@ -982,6 +990,37 @@ public final class ChatViewModel: ObservableObject {
             self.threadType = threadType
         }
         bootstrapSession(userMessage: nil, attachments: nil)
+    }
+
+    // MARK: - Naming Intent Detection
+
+    /// Lightweight heuristic that checks whether a reply includes naming intent.
+    /// Returns true when the text contains common naming-related keywords or
+    /// phrases (e.g. "call me", "my name", "who are you", name questions).
+    /// This is a safety net, not full NLP -- simple keyword matching suffices.
+    static func replyContainsNamingIntent(_ text: String) -> Bool {
+        let lower = text.lowercased()
+        let namingPatterns: [String] = [
+            "call me",
+            "call myself",
+            "my name",
+            "name is",
+            "name me",
+            "who am i",
+            "who are you",
+            "what should i call",
+            "what should we call",
+            "what would you like to call",
+            "what do you want to be called",
+            "what's my name",
+            "pick a name",
+            "choose a name",
+            "give me a name",
+            "no name",
+            "don't have a name",
+            "no idea who i am",
+        ]
+        return namingPatterns.contains { lower.contains($0) }
     }
 
     // MARK: - Model


### PR DESCRIPTION
Add lightweight naming intent detection on first assistant reply, trigger corrective follow-up if missing, extend onboarding-template-contract test. Part of #9155, closes #9159.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
