### PR TITLE
feat(notifications): surface macOS notification permission failures in-thread

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -1426,6 +1426,12 @@ Notifications are delivered to two channel types:
 
 Connected channels are resolved at signal emission time: vellum is always included, and binding-based channels (Telegram) are included only when an active guardian binding exists for the assistant.
 
+For vellum deliveries, clients send `notification_intent_result` after
+`UNUserNotificationCenter.add()` succeeds or fails. The daemon persists this
+outcome on `notification_deliveries`; when the error code is
+`authorization_denied`, it appends an assistant fallback message to the paired
+notification conversation so the permission failure is visible in-thread.
+
 **Key modules:**
 
 | Module | Purpose |
@@ -1437,6 +1443,7 @@ Connected channels are resolved at signal emission time: vellum is always includ
 | `assistant/src/notifications/broadcaster.ts` | Dispatches decisions to channel adapters; emits `notification_thread_created` IPC |
 | `assistant/src/notifications/conversation-pairing.ts` | Materializes conversation + message per delivery based on channel strategy |
 | `assistant/src/notifications/adapters/macos.ts` | Vellum adapter — broadcasts `notification_intent` via IPC with deep-link metadata |
+| `assistant/src/notifications/intent-result-handler.ts` | Persists `notification_intent_result`; appends in-thread fallback note on authorization-denied client failures |
 | `assistant/src/notifications/adapters/telegram.ts` | Telegram adapter — POSTs to gateway `/deliver/telegram` |
 | `assistant/src/notifications/destination-resolver.ts` | Resolves per-channel endpoints (vellum IPC, Telegram chat ID from guardian binding) |
 | `assistant/src/notifications/copy-composer.ts` | Template-based fallback copy when LLM copy is unavailable |

--- a/assistant/src/__tests__/notification-intent-result-handler.test.ts
+++ b/assistant/src/__tests__/notification-intent-result-handler.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+let mockDelivery: {
+  id: string;
+  channel: string;
+  conversationId: string | null;
+  clientDeliveryStatus: string | null;
+} | null = null;
+let updateResult = true;
+
+const getDeliveryByIdMock = mock((_id: string) => mockDelivery);
+const updateDeliveryClientOutcomeMock = mock(
+  (_deliveryId: string, _success: boolean, _error?: { code?: string; message?: string }) => updateResult,
+);
+const addMessageMock = mock(
+  (
+    _conversationId: string,
+    _role: string,
+    _content: string,
+    _metadata?: unknown,
+    _opts?: unknown,
+  ) => ({ id: 'msg-feedback' }),
+);
+
+mock.module('../notifications/deliveries-store.js', () => ({
+  getDeliveryById: getDeliveryByIdMock,
+  updateDeliveryClientOutcome: updateDeliveryClientOutcomeMock,
+}));
+
+mock.module('../memory/conversation-store.js', () => ({
+  addMessage: addMessageMock,
+}));
+
+import { handleNotificationIntentResult } from '../notifications/intent-result-handler.js';
+
+describe('handleNotificationIntentResult', () => {
+  beforeEach(() => {
+    mockDelivery = {
+      id: 'delivery-1',
+      channel: 'vellum',
+      conversationId: 'conv-1',
+      clientDeliveryStatus: null,
+    };
+    updateResult = true;
+    getDeliveryByIdMock.mockClear();
+    updateDeliveryClientOutcomeMock.mockClear();
+    addMessageMock.mockClear();
+  });
+
+  test('persists client outcome for successful post and does not append thread note', () => {
+    handleNotificationIntentResult({
+      type: 'notification_intent_result',
+      deliveryId: 'delivery-1',
+      success: true,
+    });
+
+    expect(updateDeliveryClientOutcomeMock).toHaveBeenCalledTimes(1);
+    expect(updateDeliveryClientOutcomeMock).toHaveBeenCalledWith('delivery-1', true, undefined);
+    expect(addMessageMock).not.toHaveBeenCalled();
+  });
+
+  test('appends assistant thread note when client reports authorization_denied', () => {
+    handleNotificationIntentResult({
+      type: 'notification_intent_result',
+      deliveryId: 'delivery-1',
+      success: false,
+      errorCode: 'authorization_denied',
+      errorMessage: 'Notification authorization denied',
+    });
+
+    expect(updateDeliveryClientOutcomeMock).toHaveBeenCalledTimes(1);
+    expect(addMessageMock).toHaveBeenCalledTimes(1);
+    expect(addMessageMock).toHaveBeenCalledWith(
+      'conv-1',
+      'assistant',
+      expect.stringContaining('notifications are disabled for Vellum'),
+      expect.objectContaining({
+        assistantMessageChannel: 'vellum',
+        notificationDeliveryFeedback: expect.objectContaining({
+          deliveryId: 'delivery-1',
+          errorCode: 'authorization_denied',
+        }),
+      }),
+      { skipIndexing: true },
+    );
+  });
+
+  test('does not append note for non-authorization failures', () => {
+    handleNotificationIntentResult({
+      type: 'notification_intent_result',
+      deliveryId: 'delivery-1',
+      success: false,
+      errorCode: 'post_failed',
+      errorMessage: 'UNUserNotificationCenter.add failed',
+    });
+
+    expect(updateDeliveryClientOutcomeMock).toHaveBeenCalledTimes(1);
+    expect(addMessageMock).not.toHaveBeenCalled();
+  });
+
+  test('does not append note when delivery was already acknowledged', () => {
+    mockDelivery = {
+      id: 'delivery-1',
+      channel: 'vellum',
+      conversationId: 'conv-1',
+      clientDeliveryStatus: 'client_failed',
+    };
+
+    handleNotificationIntentResult({
+      type: 'notification_intent_result',
+      deliveryId: 'delivery-1',
+      success: false,
+      errorCode: 'authorization_denied',
+      errorMessage: 'Notification authorization denied',
+    });
+
+    expect(updateDeliveryClientOutcomeMock).toHaveBeenCalledTimes(1);
+    expect(addMessageMock).not.toHaveBeenCalled();
+  });
+
+  test('does not append note when delivery does not map to vellum conversation', () => {
+    mockDelivery = {
+      id: 'delivery-1',
+      channel: 'telegram',
+      conversationId: null,
+      clientDeliveryStatus: null,
+    };
+
+    handleNotificationIntentResult({
+      type: 'notification_intent_result',
+      deliveryId: 'delivery-1',
+      success: false,
+      errorCode: 'authorization_denied',
+      errorMessage: 'Notification authorization denied',
+    });
+
+    expect(updateDeliveryClientOutcomeMock).toHaveBeenCalledTimes(1);
+    expect(addMessageMock).not.toHaveBeenCalled();
+  });
+
+  test('returns early when the delivery row cannot be updated', () => {
+    updateResult = false;
+
+    handleNotificationIntentResult({
+      type: 'notification_intent_result',
+      deliveryId: 'missing-delivery',
+      success: false,
+      errorCode: 'authorization_denied',
+      errorMessage: 'Notification authorization denied',
+    });
+
+    expect(updateDeliveryClientOutcomeMock).toHaveBeenCalledTimes(1);
+    expect(addMessageMock).not.toHaveBeenCalled();
+  });
+
+  test('swallows addMessage failures so ack handling never crashes', () => {
+    addMessageMock.mockImplementationOnce(() => {
+      throw new Error('db locked');
+    });
+
+    expect(() =>
+      handleNotificationIntentResult({
+        type: 'notification_intent_result',
+        deliveryId: 'delivery-1',
+        success: false,
+        errorCode: 'authorization_denied',
+        errorMessage: 'Notification authorization denied',
+      }),
+    ).not.toThrow();
+  });
+});

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -1,7 +1,7 @@
 import * as net from 'node:net';
 
 import type { ClientMessage } from '../ipc-protocol.js';
-import { updateDeliveryClientOutcome } from '../../notifications/deliveries-store.js';
+import { handleNotificationIntentResult } from '../../notifications/intent-result-handler.js';
 import { handleRideShotgunStart, handleRideShotgunStop } from '../ride-shotgun-handler.js';
 import { handleWatchObservation } from '../watch-handler.js';
 import { appHandlers } from './apps.js';
@@ -104,20 +104,7 @@ const inlineHandlers = defineHandlers({
 
   // Client ack for notification delivery outcome (UNUserNotificationCenter.add result).
   notification_intent_result: (msg) => {
-    try {
-      const updated = updateDeliveryClientOutcome(
-        msg.deliveryId,
-        msg.success,
-        msg.errorMessage || msg.errorCode
-          ? { code: msg.errorCode, message: msg.errorMessage }
-          : undefined,
-      );
-      if (!updated) {
-        log.warn({ deliveryId: msg.deliveryId }, 'notification_intent_result: no delivery row found for deliveryId');
-      }
-    } catch (err) {
-      log.error({ err, deliveryId: msg.deliveryId }, 'notification_intent_result: failed to persist client delivery outcome');
-    }
+    handleNotificationIntentResult(msg);
   },
 
 });

--- a/assistant/src/notifications/README.md
+++ b/assistant/src/notifications/README.md
@@ -220,6 +220,11 @@ The ack populates three columns on `notification_deliveries`:
 | `client_delivery_error` | TEXT | Error description when the post failed (e.g. authorization denied) |
 | `client_delivery_at` | INTEGER | Epoch ms timestamp of when the client reported the outcome |
 
+When the client reports `errorCode: "authorization_denied"` for a vellum
+delivery, the daemon appends an assistant fallback note to the paired
+notification conversation. This keeps the failure visible in the same thread
+even when the native macOS banner cannot be shown.
+
 This means the audit trail can now answer three questions for each vellum delivery:
 
 1. **Was the intent broadcast?** -- existing `status` column (`sent`)

--- a/assistant/src/notifications/deliveries-store.ts
+++ b/assistant/src/notifications/deliveries-store.ts
@@ -180,6 +180,17 @@ export function updateDeliveryClientOutcome(
   return (result.changes ?? 0) > 0;
 }
 
+/** Get a single delivery row by ID. */
+export function getDeliveryById(id: string): NotificationDeliveryRow | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(notificationDeliveries)
+    .where(eq(notificationDeliveries.id, id))
+    .get();
+  return row ? rowToDelivery(row) : null;
+}
+
 /** List all delivery records for a given notification decision. */
 export function listDeliveries(decisionId: string): NotificationDeliveryRow[] {
   const db = getDb();

--- a/assistant/src/notifications/intent-result-handler.ts
+++ b/assistant/src/notifications/intent-result-handler.ts
@@ -1,0 +1,65 @@
+import type { NotificationIntentResult } from '../daemon/ipc-contract/notifications.js';
+import { addMessage } from '../memory/conversation-store.js';
+import { getLogger } from '../util/logger.js';
+import { getDeliveryById, updateDeliveryClientOutcome } from './deliveries-store.js';
+
+const log = getLogger('notification-intent-result-handler');
+
+const AUTHORIZATION_DENIED_THREAD_NOTE = [
+  "I could not show a macOS banner for this notification because notifications are disabled for Vellum.",
+  'You can still read the update here in this thread.',
+  'To enable banners: System Settings -> Notifications -> Vellum -> Allow Notifications.',
+].join('\n\n');
+
+/**
+ * Persist the client-side notification outcome and optionally add a
+ * conversation-visible fallback note when the OS blocks banner delivery.
+ */
+export function handleNotificationIntentResult(msg: NotificationIntentResult): void {
+  const delivery = getDeliveryById(msg.deliveryId);
+  const alreadyAcknowledged = delivery?.clientDeliveryStatus != null;
+
+  const updated = updateDeliveryClientOutcome(
+    msg.deliveryId,
+    msg.success,
+    msg.errorMessage || msg.errorCode
+      ? { code: msg.errorCode, message: msg.errorMessage }
+      : undefined,
+  );
+  if (!updated) {
+    log.warn({ deliveryId: msg.deliveryId }, 'notification_intent_result: no delivery row found for deliveryId');
+    return;
+  }
+
+  // Duplicate acks should not append duplicate conversation notes.
+  if (alreadyAcknowledged || msg.success) {
+    return;
+  }
+  if (msg.errorCode !== 'authorization_denied') {
+    return;
+  }
+  if (!delivery || delivery.channel !== 'vellum' || !delivery.conversationId) {
+    return;
+  }
+
+  try {
+    addMessage(
+      delivery.conversationId,
+      'assistant',
+      AUTHORIZATION_DENIED_THREAD_NOTE,
+      {
+        assistantMessageChannel: 'vellum',
+        notificationDeliveryFeedback: {
+          deliveryId: msg.deliveryId,
+          errorCode: msg.errorCode,
+        },
+      },
+      { skipIndexing: true },
+    );
+  } catch (err) {
+    log.error(
+      { err, deliveryId: msg.deliveryId, conversationId: delivery.conversationId },
+      'notification_intent_result: failed to append authorization-denied thread note',
+    );
+  }
+}

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -7,6 +7,7 @@ import os
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AppDelegate+Notifications")
 private let fallbackDedupWindowMs: Double = 30_000
 private let fallbackDelayNs: UInt64 = 750_000_000
+private let notificationPermissionToastCooldownMs: Double = 30_000
 
 extension AppDelegate {
 
@@ -17,13 +18,7 @@ extension AppDelegate {
         let center = UNUserNotificationCenter.current()
         center.delegate = self
 
-        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
-            if granted {
-                log.info("Notification authorization granted")
-            } else {
-                log.warning("Notification authorization denied (error: \(error?.localizedDescription ?? "none"))")
-            }
-        }
+        requestNotificationAuthorization(trigger: "app_launch", showDeniedToast: false)
 
         let viewAction = UNNotificationAction(
             identifier: "VIEW_ACTIVITY",
@@ -98,6 +93,73 @@ extension AppDelegate {
         ])
     }
 
+    /// Handles notification permission when a notification thread arrives while
+    /// the app is active. This provides user-visible context for the OS prompt
+    /// and gives an immediate recovery path when the app is already denied.
+    func maybePromptNotificationAuthorizationForThreadCreated() {
+        Task { @MainActor in
+            let settings = await UNUserNotificationCenter.current().notificationSettings()
+            switch settings.authorizationStatus {
+            case .authorized, .provisional, .ephemeral:
+                return
+            case .notDetermined:
+                guard !hasRequestedNotificationAuthorizationFromThreadSignal else { return }
+                hasRequestedNotificationAuthorizationFromThreadSignal = true
+                log.info("Requesting notification authorization from notification_thread_created signal")
+                requestNotificationAuthorization(trigger: "notification_thread_created", showDeniedToast: true)
+            case .denied:
+                showNotificationPermissionSettingsToastIfNeeded()
+            @unknown default:
+                return
+            }
+        }
+    }
+
+    private func requestNotificationAuthorization(trigger: String, showDeniedToast: Bool) {
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+            if granted {
+                log.info("Notification authorization granted (\(trigger))")
+                return
+            }
+
+            log.warning("Notification authorization denied (\(trigger), error: \(error?.localizedDescription ?? "none"))")
+            guard showDeniedToast else { return }
+
+            Task { @MainActor in
+                self.showNotificationPermissionSettingsToastIfNeeded()
+            }
+        }
+    }
+
+    private func showNotificationPermissionSettingsToastIfNeeded() {
+        let nowMs = Date().timeIntervalSince1970 * 1000
+        guard nowMs - lastNotificationPermissionToastAtMs > notificationPermissionToastCooldownMs else { return }
+        lastNotificationPermissionToastAtMs = nowMs
+
+        mainWindow?.windowState.showToast(
+            message: "Notifications are off for Vellum. Turn them on in System Settings to receive banners.",
+            style: .warning,
+            primaryAction: VToastAction(label: "Open Settings") { [weak self] in
+                self?.openNotificationSettings()
+            }
+        )
+    }
+
+    private func openNotificationSettings() {
+        let candidates = [
+            "x-apple.systempreferences:com.apple.preference.notifications",
+            "x-apple.systempreferences:com.apple.preference.notifications?id=\(Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant")",
+        ]
+        for candidate in candidates {
+            guard let url = URL(string: candidate) else { continue }
+            if NSWorkspace.shared.open(url) {
+                return
+            }
+        }
+        log.warning("Failed to open macOS Notification settings URL")
+    }
+
     private func normalizeNotificationUserInfoValue(_ value: Any?) -> Any? {
         switch value {
         case nil:
@@ -161,6 +223,9 @@ extension AppDelegate {
             return true
         case .denied:
             log.warning("Notification authorization status is denied — skipping notification post")
+            if NSApp.isActive {
+                showNotificationPermissionSettingsToastIfNeeded()
+            }
             return false
         case .notDetermined:
             log.info("Notification authorization status is notDetermined — attempting post anyway")

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -148,8 +148,8 @@ extension AppDelegate {
 
     private func openNotificationSettings() {
         let candidates = [
-            "x-apple.systempreferences:com.apple.preference.notifications",
             "x-apple.systempreferences:com.apple.preference.notifications?id=\(Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant")",
+            "x-apple.systempreferences:com.apple.preference.notifications",
         ]
         for candidate in candidates {
             guard let url = URL(string: candidate) else { continue }

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -251,6 +251,10 @@ extension AppDelegate {
             sourceEventName: msg.sourceEventName
         )
 
+        if NSApp.isActive {
+            maybePromptNotificationAuthorizationForThreadCreated()
+        }
+
         // Guardian questions get foregrounded immediately when the app is active.
         if msg.sourceEventName == "guardian.question" && NSApp.isActive {
             openConversationThread(conversationId: msg.conversationId)

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -164,6 +164,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// conversationId. Incoming notification_intent for the same conversation
     /// inside a short window is treated as a duplicate and suppressed.
     var fallbackDeliveredAtMs: [String: Double] = [:]
+    /// Guard to avoid repeatedly re-requesting notification authorization when
+    /// multiple notification threads are created in quick succession.
+    var hasRequestedNotificationAuthorizationFromThreadSignal = false
+    /// Last time we surfaced the denied-notification permission toast.
+    var lastNotificationPermissionToastAtMs: Double = 0
 
     /// Whether the current assistant runs remotely (cloud != "local").
     /// When true, local daemon hatching is skipped.


### PR DESCRIPTION
## Summary
- handle `notification_intent_result` in a dedicated notification module
- persist client delivery outcomes as before, and when the client reports `authorization_denied`, append an assistant fallback note directly into the paired notification conversation
- this gives the assistant in-thread context that macOS banner delivery failed due permissions, instead of silently creating only the thread

## Why
We were creating notification threads even when native banner delivery failed, but the thread itself did not explain the failure. This makes the assistant look unaware of the permission state. With this change, the thread now carries the delivery failure context.

## Behavior
- on successful ack: audit columns are updated; no extra thread message
- on failed ack with `errorCode !== authorization_denied`: audit columns are updated; no extra thread message
- on failed ack with `errorCode === authorization_denied` for a vellum delivery with a paired conversation: append a short assistant note with settings guidance, skipping memory indexing
- duplicate acks do not append duplicate notes

## Files
- `assistant/src/notifications/intent-result-handler.ts`
- `assistant/src/daemon/handlers/index.ts`
- `assistant/src/notifications/deliveries-store.ts`
- `assistant/src/__tests__/notification-intent-result-handler.test.ts`
- `assistant/src/notifications/README.md`
- `assistant/ARCHITECTURE.md`

## Validation
- `cd assistant && bun test src/__tests__/notification-intent-result-handler.test.ts`
- `cd assistant && bun test src/__tests__/notification-deep-link.test.ts src/__tests__/conversation-pairing.test.ts`
- `cd assistant && bunx tsc --noEmit` *(fails due pre-existing unrelated errors in repository, e.g. ipc snapshot coverage/types and duplicate type declarations in guardian approval path)*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
