### PR TITLE
feat: expose guardian verification as HTTP endpoints

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -29,8 +29,13 @@ import type { ChannelId } from '../../channels/types.js';
 import type {
   ChannelReadinessRequest,
   GuardianVerificationRequest,
+  GuardianVerificationResponse,
 } from '../ipc-protocol.js';
 import { defineHandlers, type HandlerContext, log } from './shared.js';
+
+// -- Transport-agnostic result type (omits the IPC `type` discriminant) --
+
+export type GuardianVerificationResult = Omit<GuardianVerificationResponse, 'type'>;
 
 // ---------------------------------------------------------------------------
 // Rate limit constants for outbound verification
@@ -111,6 +116,104 @@ function getTelegramBotUsername(): string | undefined {
 }
 
 // ---------------------------------------------------------------------------
+// Extracted business logic functions
+// ---------------------------------------------------------------------------
+
+export function createGuardianChallenge(
+  channel?: ChannelId,
+  assistantId?: string,
+  rebind?: boolean,
+  sessionId?: string,
+): GuardianVerificationResult {
+  const resolvedAssistantId = normalizeAssistantId(assistantId ?? 'self');
+  const resolvedChannel = channel ?? 'telegram';
+
+  const existingBinding = getGuardianBinding(resolvedAssistantId, resolvedChannel);
+  if (existingBinding && !rebind) {
+    return {
+      success: false,
+      error: 'already_bound',
+      message: 'A guardian is already bound for this channel. Revoke the existing binding first, or set rebind: true to replace.',
+      channel: resolvedChannel,
+    };
+  }
+
+  const result = createVerificationChallenge(resolvedAssistantId, resolvedChannel, sessionId);
+
+  return {
+    success: true,
+    secret: result.secret,
+    instruction: result.instruction,
+    channel: resolvedChannel,
+  };
+}
+
+export function getGuardianStatus(
+  channel?: ChannelId,
+  assistantId?: string,
+): GuardianVerificationResult {
+  const resolvedAssistantId = normalizeAssistantId(assistantId ?? 'self');
+  const resolvedChannel = channel ?? 'telegram';
+
+  const binding = getGuardianBinding(resolvedAssistantId, resolvedChannel);
+  let guardianUsername: string | undefined;
+  let guardianDisplayName: string | undefined;
+  if (binding?.metadataJson) {
+    try {
+      const parsed = JSON.parse(binding.metadataJson) as Record<string, unknown>;
+      if (typeof parsed.username === 'string' && parsed.username.trim().length > 0) {
+        guardianUsername = parsed.username.trim();
+      }
+      if (typeof parsed.displayName === 'string' && parsed.displayName.trim().length > 0) {
+        guardianDisplayName = parsed.displayName.trim();
+      }
+    } catch {
+      // ignore malformed metadata
+    }
+  }
+  if (binding?.guardianDeliveryChatId && (!guardianUsername || !guardianDisplayName)) {
+    const ext = externalConversationStore.getBindingByChannelChat(
+      resolvedChannel,
+      binding.guardianDeliveryChatId,
+    );
+    if (!guardianUsername && ext?.username) {
+      guardianUsername = ext.username;
+    }
+    if (!guardianDisplayName && ext?.displayName) {
+      guardianDisplayName = ext.displayName;
+    }
+  }
+  const hasPendingChallenge = getPendingChallenge(resolvedAssistantId, resolvedChannel) != null;
+
+  // Include active outbound session state so the UI can resume
+  // after app restart and detect bootstrap completion.
+  const activeOutboundSession = findActiveSession(resolvedAssistantId, resolvedChannel);
+  const outboundFields: Record<string, unknown> = {};
+  if (activeOutboundSession) {
+    outboundFields.verificationSessionId = activeOutboundSession.id;
+    outboundFields.expiresAt = activeOutboundSession.expiresAt;
+    outboundFields.nextResendAt = activeOutboundSession.nextResendAt;
+    outboundFields.sendCount = activeOutboundSession.sendCount;
+    if (activeOutboundSession.status === 'pending_bootstrap') {
+      outboundFields.pendingBootstrap = true;
+    }
+  }
+
+  return {
+    success: true,
+    bound: binding != null,
+    guardianExternalUserId: binding?.guardianExternalUserId,
+    guardianUsername,
+    guardianDisplayName,
+    channel: resolvedChannel,
+    assistantId: resolvedAssistantId,
+    guardianDeliveryChatId: binding?.guardianDeliveryChatId,
+    hasPendingChallenge,
+    ...outboundFields,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Guardian verification handler
 // ---------------------------------------------------------------------------
 
@@ -126,92 +229,11 @@ export function handleGuardianVerification(
 
   try {
     if (msg.action === 'create_challenge') {
-      // Fail by default if a guardian is already bound, unless the caller
-      // explicitly opts in to rebinding by setting rebind: true.
-      const existingBinding = getGuardianBinding(assistantId, channel);
-      if (existingBinding && !msg.rebind) {
-        ctx.send(socket, {
-          type: 'guardian_verification_response',
-          success: false,
-          error: 'already_bound',
-          message: 'A guardian is already bound for this channel. Revoke the existing binding first, or set rebind: true to replace.',
-          channel,
-        });
-        return;
-      }
-
-      const result = createVerificationChallenge(assistantId, channel, msg.sessionId);
-
-      ctx.send(socket, {
-        type: 'guardian_verification_response',
-        success: true,
-        secret: result.secret,
-        instruction: result.instruction,
-        channel,
-      });
+      const result = createGuardianChallenge(channel, assistantId, msg.rebind, msg.sessionId);
+      ctx.send(socket, { type: 'guardian_verification_response', ...result });
     } else if (msg.action === 'status') {
-      const binding = getGuardianBinding(assistantId, channel);
-      let guardianUsername: string | undefined;
-      let guardianDisplayName: string | undefined;
-      if (binding?.metadataJson) {
-        try {
-          const parsed = JSON.parse(binding.metadataJson) as Record<string, unknown>;
-          if (typeof parsed.username === 'string' && parsed.username.trim().length > 0) {
-            guardianUsername = parsed.username.trim();
-          }
-          if (typeof parsed.displayName === 'string' && parsed.displayName.trim().length > 0) {
-            guardianDisplayName = parsed.displayName.trim();
-          }
-        } catch {
-          // ignore malformed metadata
-        }
-      }
-      if (binding?.guardianDeliveryChatId && (!guardianUsername || !guardianDisplayName)) {
-        const ext = externalConversationStore.getBindingByChannelChat(
-          channel,
-          binding.guardianDeliveryChatId,
-        );
-        if (!guardianUsername && ext?.username) {
-          guardianUsername = ext.username;
-        }
-        if (!guardianDisplayName && ext?.displayName) {
-          guardianDisplayName = ext.displayName;
-        }
-      }
-      const hasPendingChallenge = getPendingChallenge(assistantId, channel) != null;
-
-      // Include active outbound session state so the UI can resume
-      // after app restart and detect bootstrap completion.
-      const activeOutboundSession = findActiveSession(assistantId, channel);
-      const outboundFields: Record<string, unknown> = {};
-      if (activeOutboundSession) {
-        outboundFields.verificationSessionId = activeOutboundSession.id;
-        outboundFields.expiresAt = activeOutboundSession.expiresAt;
-        outboundFields.nextResendAt = activeOutboundSession.nextResendAt;
-        outboundFields.sendCount = activeOutboundSession.sendCount;
-        // Signal to the client that the session is still in pending_bootstrap
-        // state so it does not clear the bootstrap URL during status polling.
-        // The plaintext token is NOT stored (only the hash), so the URL
-        // itself cannot be reconstructed; the client must preserve whatever
-        // URL it received from the initial start_outbound response.
-        if (activeOutboundSession.status === 'pending_bootstrap') {
-          outboundFields.pendingBootstrap = true;
-        }
-      }
-
-      ctx.send(socket, {
-        type: 'guardian_verification_response',
-        success: true,
-        bound: binding != null,
-        guardianExternalUserId: binding?.guardianExternalUserId,
-        guardianUsername,
-        guardianDisplayName,
-        channel,
-        assistantId,
-        guardianDeliveryChatId: binding?.guardianDeliveryChatId,
-        hasPendingChallenge,
-        ...outboundFields,
-      });
+      const result = getGuardianStatus(channel, assistantId);
+      ctx.send(socket, { type: 'guardian_verification_response', ...result });
     } else if (msg.action === 'revoke') {
       revokeGuardianBinding(assistantId, channel);
       revokePendingChallenges(assistantId, channel);

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -112,6 +112,8 @@ import {
 } from './routes/pairing-routes.js';
 import {
   handleClearTelegramConfig,
+  handleCreateGuardianChallenge,
+  handleGetGuardianStatus,
   handleGetTelegramConfig,
   handleSetTelegramCommands,
   handleSetTelegramConfig,
@@ -590,6 +592,10 @@ export class RuntimeHttpServer {
       if (endpoint === 'integrations/telegram/config' && req.method === 'DELETE') return await handleClearTelegramConfig();
       if (endpoint === 'integrations/telegram/commands' && req.method === 'POST') return await handleSetTelegramCommands(req);
       if (endpoint === 'integrations/telegram/setup' && req.method === 'POST') return await handleSetupTelegram(req);
+
+      // Integrations — Guardian verification
+      if (endpoint === 'integrations/guardian/challenge' && req.method === 'POST') return await handleCreateGuardianChallenge(req);
+      if (endpoint === 'integrations/guardian/status' && req.method === 'GET') return handleGetGuardianStatus(url);
 
       if (endpoint === 'attachments' && req.method === 'POST') return await handleUploadAttachment(req);
       if (endpoint === 'attachments' && req.method === 'DELETE') return await handleDeleteAttachment(req);

--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -1,13 +1,23 @@
 /**
- * Route handlers for Telegram integration config endpoints.
+ * Route handlers for integration config endpoints.
  *
+ * Telegram:
  * GET    /v1/integrations/telegram/config   — get current config status
  * POST   /v1/integrations/telegram/config   — set bot token and configure webhook
  * DELETE /v1/integrations/telegram/config   — clear credentials and deregister webhook
  * POST   /v1/integrations/telegram/commands — register bot commands
  * POST   /v1/integrations/telegram/setup    — composite: set config + register commands
+ *
+ * Guardian verification:
+ * POST   /v1/integrations/guardian/challenge — create a verification challenge
+ * GET    /v1/integrations/guardian/status    — check guardian binding status
  */
 
+import {
+  createGuardianChallenge,
+  getGuardianStatus,
+} from '../../daemon/handlers/config-channels.js';
+import type { ChannelId } from '../../channels/types.js';
 import {
   clearTelegramConfig,
   getTelegramConfig,
@@ -71,4 +81,37 @@ export async function handleSetupTelegram(req: Request): Promise<Response> {
   const result = await setupTelegram(body.commands, body.botToken);
   const status = result.success ? 200 : 400;
   return Response.json(result, { status });
+}
+
+// ---------------------------------------------------------------------------
+// Guardian verification
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /v1/integrations/guardian/challenge
+ *
+ * Body: { channel?: ChannelId; assistantId?: string; rebind?: boolean; sessionId?: string }
+ */
+export async function handleCreateGuardianChallenge(req: Request): Promise<Response> {
+  const body = (await req.json()) as {
+    channel?: ChannelId;
+    assistantId?: string;
+    rebind?: boolean;
+    sessionId?: string;
+  };
+  const result = createGuardianChallenge(body.channel, body.assistantId, body.rebind, body.sessionId);
+  const status = result.success ? 200 : 400;
+  return Response.json(result, { status });
+}
+
+/**
+ * GET /v1/integrations/guardian/status
+ *
+ * Query params: channel?, assistantId?
+ */
+export function handleGetGuardianStatus(url: URL): Response {
+  const channel = (url.searchParams.get('channel') as ChannelId | null) ?? undefined;
+  const assistantId = url.searchParams.get('assistantId') ?? undefined;
+  const result = getGuardianStatus(channel, assistantId);
+  return Response.json(result);
 }


### PR DESCRIPTION
Expose guardian verification create_challenge and status actions as HTTP endpoints on the runtime server, completing the HTTP migration for the Telegram setup skill.

Endpoints added:
- POST /v1/integrations/guardian/challenge
- GET /v1/integrations/guardian/status

Follows the same pattern as the Telegram config HTTP endpoints from PR #9188.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
