### PR TITLE
fix: regenerate IPC Swift types for Telegram config fields

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -4326,8 +4326,12 @@ public struct IPCTelegramConfigResponse: Codable, Sendable {
     public let hasWebhookSecret: Bool
     public let lastError: String?
     public let error: String?
+    /// Names of bot commands that were registered (present after set_commands or setup).
+    public let commandsRegistered: [String]?
+    /// Non-fatal warning (e.g. commands registration failed during setup but token was configured).
+    public let warning: String?
 
-    public init(type: String, success: Bool, hasBotToken: Bool, botUsername: String? = nil, connected: Bool, hasWebhookSecret: Bool, lastError: String? = nil, error: String? = nil) {
+    public init(type: String, success: Bool, hasBotToken: Bool, botUsername: String? = nil, connected: Bool, hasWebhookSecret: Bool, lastError: String? = nil, error: String? = nil, commandsRegistered: [String]? = nil, warning: String? = nil) {
         self.type = type
         self.success = success
         self.hasBotToken = hasBotToken
@@ -4336,6 +4340,8 @@ public struct IPCTelegramConfigResponse: Codable, Sendable {
         self.hasWebhookSecret = hasWebhookSecret
         self.lastError = lastError
         self.error = error
+        self.commandsRegistered = commandsRegistered
+        self.warning = warning
     }
 }
 


### PR DESCRIPTION
## Summary

- Regenerate `IPCContractGenerated.swift` to include `commandsRegistered` and `warning` fields added to `IPCTelegramConfigResponse` in #9188
- Fixes CI failure: `Verify IPC generated code is up to date` step was failing

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22418762461

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
