### PR TITLE
docs: add Linear ticket hygiene guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,19 @@ These are the most commonly used slash commands defined in `.claude/commands/`:
 | `/update` | Pull latest from main, restart the backend daemon, verify gateway health (fail fast on startup failure), rebuild/launch the macOS app, and print a startup summary. |
 
 
+## Linear Ticket Hygiene
+
+When working on a task sourced from a Linear ticket (via the Linear MCP), keep the ticket status in sync with your progress:
+
+- **Branch naming**: Include the Linear issue ID in the branch name (e.g., `feat/ABC-123-add-widget`). Linear automatically links branches, commits, and PRs that reference the issue ID.
+- **Commit messages**: Reference the issue ID in commits (e.g., `feat: add widget [ABC-123]`) so Linear links them automatically.
+- **Start of work**: Move the ticket to "In Progress" (or the equivalent active status).
+- **PR created**: Move the ticket to "In Review" if applicable. If you used the issue ID in the branch name, Linear will link the PR automatically — otherwise add the PR link manually.
+- **Work completed / PR merged**: Move the ticket to "Done".
+- **Blocked or abandoned**: Update the ticket status accordingly and leave a comment explaining why.
+
+Treat the Linear ticket as the source of truth for task status. Don't leave tickets in a stale state — if you touched it, update it.
+
 ## Track merged PRs
 
 Whenever you merge a PR, you MUST append its URL to `.private/UNREVIEWED_PRS.md` so that `/check-reviews` can pick it up for review triage.


### PR DESCRIPTION
## Summary
- Adds a "Linear Ticket Hygiene" section to AGENTS.md instructing agents to keep Linear ticket status in sync with their work progress
- Includes guidance on embedding issue IDs in branch names and commit messages for automatic Linear linking
- Covers the full lifecycle: In Progress → In Review → Done (plus blocked/abandoned)

## Test plan
- [x] Verify AGENTS.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
