### PR TITLE
fix(threads): sort sidebar threads by most recent interaction

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -457,13 +457,6 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
     func updateLastInteracted(threadId: UUID) {
         guard let index = threads.firstIndex(where: { $0.id == threadId }) else { return }
-        // Don't reshuffle threads that are already visible in the collapsed sidebar.
-        // The sidebar shows regular threads (top 5) and schedule/reminder threads (top 3) separately.
-        let visible = visibleThreads
-        let regularIds = visible.filter { !$0.isScheduleThread }.prefix(5).map(\.id)
-        let scheduleIds = visible.filter { $0.isScheduleThread }.prefix(3).map(\.id)
-        let visibleIds = Set(regularIds + scheduleIds)
-        guard !visibleIds.contains(threadId) else { return }
         threads[index].lastInteractedAt = Date()
     }
 


### PR DESCRIPTION
## Summary
- Remove guard in `updateLastInteracted` that prevented already-visible threads from having their `lastInteractedAt` updated
- This ensures the most recently interacted thread always sorts to the top of the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
