### PR TITLE
Automate context compaction retry for long-conversation provider errors

### DIFF
--- a/.private/UNREVIEWED_PRS.md
+++ b/.private/UNREVIEWED_PRS.md
@@ -1,5 +1,0 @@
-https://github.com/vellum-ai/vellum-assistant/pull/9186
-https://github.com/vellum-ai/vellum-assistant/pull/9188
-https://github.com/vellum-ai/vellum-assistant/pull/9191
-https://github.com/vellum-ai/vellum-assistant/pull/9192
-https://github.com/vellum-ai/vellum-assistant/pull/9204

--- a/.private/UNREVIEWED_PRS.md
+++ b/.private/UNREVIEWED_PRS.md
@@ -1,0 +1,5 @@
+https://github.com/vellum-ai/vellum-assistant/pull/9186
+https://github.com/vellum-ai/vellum-assistant/pull/9188
+https://github.com/vellum-ai/vellum-assistant/pull/9191
+https://github.com/vellum-ai/vellum-assistant/pull/9192
+https://github.com/vellum-ai/vellum-assistant/pull/9204

--- a/assistant/src/__tests__/session-error.test.ts
+++ b/assistant/src/__tests__/session-error.test.ts
@@ -153,6 +153,7 @@ describe('classifySessionError', () => {
       'token_limit_exceeded: too many tokens in request',
       'token limit exceeded',
       'prompt is too long',
+      'The conversation is too long for the model to process.',
       'Request too large for model',
       'too many input tokens: 250000',
       'max_tokens exceeded',
@@ -170,6 +171,13 @@ describe('classifySessionError', () => {
   describe('context-too-large via ProviderError (400)', () => {
     it('classifies ProviderError 400 with context length message as CONTEXT_TOO_LARGE', () => {
       const err = new ProviderError('context_length_exceeded: your prompt is too long', 'anthropic', 400);
+      const result = classifySessionError(err, baseCtx);
+      expect(result.code).toBe('CONTEXT_TOO_LARGE');
+      expect(result.retryable).toBe(false);
+    });
+
+    it('classifies ProviderError 413 as CONTEXT_TOO_LARGE', () => {
+      const err = new ProviderError('request entity too large', 'anthropic', 413);
       const result = classifySessionError(err, baseCtx);
       expect(result.code).toBe('CONTEXT_TOO_LARGE');
       expect(result.retryable).toBe(false);

--- a/assistant/src/__tests__/session-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/session-provider-retry-repair.test.ts
@@ -81,6 +81,9 @@ mock.module('../memory/conversation-store.js', () => ({
   updateConversationUsage: () => {},
   updateConversationTitle: () => {},
   updateConversationContextWindow: () => {},
+  getConversationOriginChannel: () => null,
+  getConversationOriginInterface: () => null,
+  provenanceFromGuardianContext: () => ({}),
 }));
 
 mock.module('../memory/retriever.js', () => ({
@@ -132,7 +135,7 @@ mock.module('../context/window-manager.js', () => ({
 
 // Track how many times agentLoop.run was called
 let agentLoopRunCount = 0;
-let firstRunErrorMode: 'none' | 'ordering' | 'context_too_large' = 'ordering';
+let firstRunErrorMode: 'none' | 'ordering' | 'context_too_large' | 'context_too_large_phrase' = 'ordering';
 
 mock.module('../agent/loop.js', () => ({
   AgentLoop: class {
@@ -142,10 +145,15 @@ mock.module('../agent/loop.js', () => ({
 
       if (agentLoopRunCount === 1 && firstRunErrorMode !== 'none') {
         onEvent({ type: 'usage', inputTokens: 0, outputTokens: 0, model: 'mock', providerDurationMs: 0 });
-        const error =
-          firstRunErrorMode === 'ordering'
-            ? new Error('tool_result blocks that are not immediately after a tool_use block')
-            : new Error('context_length_exceeded: request has too many input tokens');
+        const error = (() => {
+          if (firstRunErrorMode === 'ordering') {
+            return new Error('tool_result blocks that are not immediately after a tool_use block');
+          }
+          if (firstRunErrorMode === 'context_too_large_phrase') {
+            return new Error('The conversation is too long for the model to process.');
+          }
+          return new Error('context_length_exceeded: request has too many input tokens');
+        })();
         onEvent({ type: 'error', error });
         return [...messages]; // Return unchanged — no progress
       }
@@ -309,5 +317,28 @@ describe('provider ordering error retry', () => {
     ]);
     const sessionError = events.find((e) => e.type === 'session_error') as { code?: string } | undefined;
     expect(sessionError?.code).toBe('CONTEXT_TOO_LARGE');
+  });
+
+  test('context-too-large phrase also triggers one forced-compaction retry', async () => {
+    firstRunErrorMode = 'context_too_large_phrase';
+    forceCompactionEnabled = true;
+
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const events: Array<Record<string, unknown>> = [];
+    await session.processMessage(
+      'Please compare these images.',
+      makeImageAttachments(4),
+      (msg) => events.push(msg as unknown as Record<string, unknown>),
+    );
+
+    expect(agentLoopRunCount).toBe(2);
+    expect(maybeCompactCalls).toEqual([
+      { force: false },
+      { force: true },
+    ]);
+    expect(events.some((e) => e.type === 'message_complete')).toBe(true);
+    expect(events.some((e) => e.type === 'session_error')).toBe(false);
   });
 });

--- a/assistant/src/daemon/session-error.ts
+++ b/assistant/src/daemon/session-error.ts
@@ -39,6 +39,8 @@ const CONTEXT_TOO_LARGE_PATTERNS = [
   /maximum.?context.?length/i,
   /token.?limit.?exceeded/i,
   /prompt.?is.?too.?long/i,
+  /conversation.*too long.*model.*process/i,
+  /too long for the model to process/i,
   /request too large/i,
   /too many.*input.*tokens/i,
   /max_tokens.*exceeded/i,
@@ -158,6 +160,13 @@ function classifyCore(
 ): Omit<ClassifiedSessionError, 'debugDetails'> {
   // ProviderError with statusCode — deterministic classification
   if (error instanceof ProviderError && error.statusCode !== undefined) {
+    if (error.statusCode === 413) {
+      return {
+        code: 'CONTEXT_TOO_LARGE',
+        userMessage: 'This conversation exceeds the model\'s context limit.',
+        retryable: false,
+      };
+    }
     if (error.statusCode === 429) {
       return {
         code: 'PROVIDER_RATE_LIMIT',


### PR DESCRIPTION
## Summary
- expand context-too-large detection to include provider phrasing like "The conversation is too long for the model to process"
- classify `ProviderError` status `413` as `CONTEXT_TOO_LARGE`
- add regression tests for classification and forced-compaction retry path

## Validation
- `cd assistant && bun test src/__tests__/session-error.test.ts src/__tests__/session-provider-retry-repair.test.ts`

Linear: https://linear.app/vellum/issue/JARVIS-45/automate-compaction-for-long-conversations

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
