### PR TITLE
fix: lazy ChatViewModel creation to prevent memory spike with many chats

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -32,7 +32,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 // Notify the daemon so it rebinds the socket to this thread's session.
                 // Without this, socketToSession stays stale after thread switches,
                 // causing ownership checks (e.g. subagent abort) to fail.
-                if let sessionId = chatViewModels[activeThreadId]?.sessionId {
+                if let sessionId = getOrCreateViewModel(for: activeThreadId)?.sessionId {
                     do {
                         try daemonClient.send(IPCSessionSwitchRequest(sessionId: sessionId))
                     } catch {
@@ -86,8 +86,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     var activeViewModel: ChatViewModel? {
-        guard let activeThreadId else { return nil}
-        return chatViewModels[activeThreadId]
+        guard let activeThreadId else { return nil }
+        return getOrCreateViewModel(for: activeThreadId)
     }
 
     init(daemonClient: DaemonClient, activityNotificationService: ActivityNotificationService? = nil, isFirstLaunch: Bool = false) {
@@ -303,14 +303,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
         threads[index].isArchived = false
 
-        // Re-create the ChatViewModel since it was removed on archive.
-        if chatViewModels[id] == nil {
-            let viewModel = makeViewModel()
-            viewModel.sessionId = threads[index].sessionId
-            chatViewModels[id] = viewModel
-            touchVMAccessOrder(id)
-            evictStaleCachedViewModels()
-        }
+        // Ensure a ChatViewModel exists (lazily created if it was evicted on archive).
+        getOrCreateViewModel(for: id)
 
         if let sessionId = threads[index].sessionId {
             var archived = archivedSessionIds
@@ -359,10 +353,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 kind: session.threadType == "private" ? .private : .standard,
                 source: session.source
             )
-            let viewModel = makeViewModel()
-            viewModel.sessionId = session.id
-            chatViewModels[thread.id] = viewModel
-            touchVMAccessOrder(thread.id)
+            // VM creation is lazy — getOrCreateViewModel() will instantiate
+            // when the thread is first accessed (e.g. selected by the user).
             threads.append(thread)
         }
 
@@ -405,9 +397,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         chatViewModels[id]?.messages.contains(where: { $0.role == .user }) ?? false
     }
 
-    /// Update confirmation state across ALL chat view models, not just the active one.
-    /// This ensures that when the floating panel responds, the originating thread's
-    /// inline confirmation is updated even if the user switched threads.
+    /// Update confirmation state across all *existing* chat view models, not just
+    /// the active one. Only iterates VMs that are already instantiated — does not
+    /// trigger lazy creation for threads that have never been accessed.
     func updateConfirmationStateAcrossThreads(requestId: String, decision: String) {
         for viewModel in chatViewModels.values {
             viewModel.updateConfirmationState(requestId: requestId, decision: decision)
@@ -507,11 +499,13 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     // MARK: - ThreadRestorerDelegate
 
     func chatViewModel(for threadId: UUID) -> ChatViewModel? {
-        if let vm = chatViewModels[threadId] {
-            touchVMAccessOrder(threadId)
-            return vm
-        }
-        return nil
+        return getOrCreateViewModel(for: threadId)
+    }
+
+    func existingChatViewModel(for threadId: UUID) -> ChatViewModel? {
+        guard let vm = chatViewModels[threadId] else { return nil }
+        touchVMAccessOrder(threadId)
+        return vm
     }
 
     func setChatViewModel(_ vm: ChatViewModel, for threadId: UUID) {
@@ -643,6 +637,30 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             chatViewModels.removeValue(forKey: threadId)
             vmAccessOrder.removeAll { $0 == threadId }
         }
+    }
+
+    // MARK: - Lazy VM Creation
+
+    /// Returns an existing ChatViewModel or lazily creates one for the given thread.
+    /// This is the single entry point for VM access — `appendThreads` and session
+    /// restoration no longer eagerly create VMs for every loaded session.
+    @discardableResult
+    private func getOrCreateViewModel(for threadId: UUID) -> ChatViewModel? {
+        if let vm = chatViewModels[threadId] {
+            touchVMAccessOrder(threadId)
+            return vm
+        }
+        // Only create if the thread exists
+        guard let thread = threads.first(where: { $0.id == threadId }) else { return nil }
+        let viewModel = makeViewModel()
+        viewModel.sessionId = thread.sessionId
+        if thread.sessionId == nil {
+            viewModel.isHistoryLoaded = true
+        }
+        chatViewModels[threadId] = viewModel
+        touchVMAccessOrder(threadId)
+        evictStaleCachedViewModels()
+        return viewModel
     }
 
     // MARK: - VM LRU Cache Management

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -14,7 +14,10 @@ protocol ThreadRestorerDelegate: AnyObject {
     var isLoadingMoreThreads: Bool { get set }
     var hasMoreThreads: Bool { get set }
     var serverOffset: Int { get set }
+    /// Returns or lazily creates a ChatViewModel for the given thread.
     func chatViewModel(for threadId: UUID) -> ChatViewModel?
+    /// Returns an existing ChatViewModel without creating one (avoids triggering lazy init).
+    func existingChatViewModel(for threadId: UUID) -> ChatViewModel?
     func setChatViewModel(_ vm: ChatViewModel, for threadId: UUID)
     func removeChatViewModel(for threadId: UUID)
     func makeViewModel() -> ChatViewModel
@@ -164,9 +167,8 @@ final class ThreadSessionRestorer {
                 kind: kind,
                 source: session.source
             )
-            let viewModel = delegate.makeViewModel()
-            viewModel.sessionId = session.id
-            delegate.setChatViewModel(viewModel, for: thread.id)
+            // VM creation is lazy — only the active thread will get a VM via
+            // getOrCreateViewModel() when it's first accessed.
             restoredThreads.append(thread)
         }
 
@@ -210,9 +212,11 @@ final class ThreadSessionRestorer {
 
     func handleSubagentDetailResponse(_ response: IPCSubagentDetailResponse) {
         guard let delegate else { return }
-        // Find the ChatViewModel that owns this subagent
+        // Only check threads that already have a VM — subagent events are only
+        // relevant to active conversations, so we must not trigger lazy VM
+        // creation for every thread in the list.
         for thread in delegate.threads {
-            guard let viewModel = delegate.chatViewModel(for: thread.id) else { continue }
+            guard let viewModel = delegate.existingChatViewModel(for: thread.id) else { continue }
             if viewModel.activeSubagents.contains(where: { $0.id == response.subagentId }) {
                 viewModel.subagentDetailStore.populateFromDetailResponse(response)
                 return

--- a/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
@@ -26,6 +26,10 @@ final class MockThreadRestorerDelegate: ThreadRestorerDelegate {
         viewModels[threadId]
     }
 
+    func existingChatViewModel(for threadId: UUID) -> ChatViewModel? {
+        viewModels[threadId]
+    }
+
     func setChatViewModel(_ vm: ChatViewModel, for threadId: UUID) {
         viewModels[threadId] = vm
     }
@@ -283,11 +287,9 @@ struct ThreadSessionRestorerTests {
         #expect(delegate.threads[1].sessionId == "s2")
         #expect(delegate.threads[0].title == "Chat 1")
 
-        // View models were created and assigned session IDs
-        let vm1 = delegate.viewModels[delegate.threads[0].id]
-        let vm2 = delegate.viewModels[delegate.threads[1].id]
-        #expect(vm1?.sessionId == "s1")
-        #expect(vm2?.sessionId == "s2")
+        // VMs are lazily created — not eagerly allocated during restore
+        #expect(delegate.viewModels[delegate.threads[0].id] == nil)
+        #expect(delegate.viewModels[delegate.threads[1].id] == nil)
 
         // Most recent thread should be activated
         #expect(delegate.activatedThreadId == delegate.threads[0].id)


### PR DESCRIPTION
## Summary
- Makes ChatViewModel creation lazy — VMs are only instantiated when a thread is first accessed, not when the session list is loaded

## Problem
When the daemon returns the session list (50 sessions per page), `ThreadManager.appendThreads()` and `ThreadSessionRestorer.handleSessionListResponse()` were eagerly creating a full `ChatViewModel` for every session. Each VM allocates Combine subscriptions, closure callbacks, a `ChatMessageManager`, and various task references. With 100+ chats, this caused 100+ VMs to be allocated simultaneously before LRU eviction could prune them to 10, causing a memory spike that crashed the app.

## Implementation
- **`getOrCreateViewModel(for:)`** — new single entry point for VM access. Creates a VM on-demand when a thread is first accessed (selected by user, history requested, etc.)
- **`appendThreads()`** — no longer creates VMs; only creates lightweight `ThreadModel` structs
- **`handleSessionListResponse()`** — same: threads only, no VMs
- **`existingChatViewModel(for:)`** — returns an already-instantiated VM without triggering lazy creation, used by `handleSubagentDetailResponse` to avoid allocating VMs for every thread just to check subagent membership
- **`activeViewModel`** and `activeThreadId.didSet` — route through lazy creation so the active thread always has a VM

## Files Changed
- `ThreadManager.swift` — lazy VM creation, `getOrCreateViewModel()`, `existingChatViewModel()`
- `ThreadSessionRestorer.swift` — protocol update, lazy restore, safe subagent iteration
- `ThreadSessionRestorerTests.swift` — mock update, test expectations adjusted for lazy semantics

## Testing
- All 16 `ThreadSessionRestorerTests` pass
- All 7 `PrivateThreadPersistenceTests` pass
- `swift build --product vellum-assistant` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
