### PR TITLE
fix: address review feedback on heartbeat settings PR #9076

### DIFF
--- a/assistant/src/daemon/handlers/config-heartbeat.ts
+++ b/assistant/src/daemon/handlers/config-heartbeat.ts
@@ -112,7 +112,7 @@ export function handleHeartbeatRunsList(
   try {
     const limit = msg.limit ?? 20;
     // Get background conversations and filter to heartbeat-origin only
-    const all = conversationStore.listConversations(limit * 5, true);
+    const all = conversationStore.listConversations(limit * 20, true);
     const bgConversations = all
       .filter((c) => c.source === 'heartbeat')
       .slice(0, limit);

--- a/clients/macos/vellum-assistant/Features/Settings/HeartbeatSettingsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/HeartbeatSettingsTab.swift
@@ -237,7 +237,12 @@ struct HeartbeatSettingsTab: View {
                     VButton(label: "Run Now", style: .primary) {
                         isRunning = true
                         runError = nil
-                        try? daemonClient?.sendHeartbeatRunNow()
+                        do {
+                            try daemonClient?.sendHeartbeatRunNow()
+                        } catch {
+                            isRunning = false
+                            runError = "Failed to send run request"
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Increase heartbeat runs fetch multiplier from `limit * 5` to `limit * 20` to reduce chance of missing entries when many non-heartbeat conversations exist
- Handle Run Now send failures with do/catch instead of `try?` to avoid permanently stuck "Running..." state when daemon is disconnected

## Original prompt
Addresses review feedback from #9076.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
