### PR TITLE
fix: route 413 ProviderError through context-too-large retry path

### DIFF
--- a/assistant/src/__tests__/session-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/session-provider-retry-repair.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { AgentEvent } from '../agent/loop.js';
 import type { UserMessageAttachment } from '../daemon/ipc-protocol.js';
 import type { Message, ProviderResponse } from '../providers/types.js';
+import { ProviderError } from '../util/errors.js';
 
 mock.module('../util/logger.js', () => ({
   getLogger: () => new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
@@ -135,7 +136,7 @@ mock.module('../context/window-manager.js', () => ({
 
 // Track how many times agentLoop.run was called
 let agentLoopRunCount = 0;
-let firstRunErrorMode: 'none' | 'ordering' | 'context_too_large' | 'context_too_large_phrase' = 'ordering';
+let firstRunErrorMode: 'none' | 'ordering' | 'context_too_large' | 'context_too_large_phrase' | 'context_too_large_413' = 'ordering';
 
 mock.module('../agent/loop.js', () => ({
   AgentLoop: class {
@@ -151,6 +152,9 @@ mock.module('../agent/loop.js', () => ({
           }
           if (firstRunErrorMode === 'context_too_large_phrase') {
             return new Error('The conversation is too long for the model to process.');
+          }
+          if (firstRunErrorMode === 'context_too_large_413') {
+            return new ProviderError('request entity too large', 'mock-provider', 413);
           }
           return new Error('context_length_exceeded: request has too many input tokens');
         })();
@@ -333,6 +337,32 @@ describe('provider ordering error retry', () => {
       (msg) => events.push(msg as unknown as Record<string, unknown>),
     );
 
+    expect(agentLoopRunCount).toBe(2);
+    expect(maybeCompactCalls).toEqual([
+      { force: false },
+      { force: true },
+    ]);
+    expect(events.some((e) => e.type === 'message_complete')).toBe(true);
+    expect(events.some((e) => e.type === 'session_error')).toBe(false);
+  });
+
+  test('ProviderError with statusCode 413 triggers forced-compaction retry via classifySessionError', async () => {
+    firstRunErrorMode = 'context_too_large_413';
+    forceCompactionEnabled = true;
+
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const events: Array<Record<string, unknown>> = [];
+    await session.processMessage(
+      'Please compare these images.',
+      makeImageAttachments(8),
+      (msg) => events.push(msg as unknown as Record<string, unknown>),
+    );
+
+    // The 413 ProviderError message "request entity too large" doesn't match
+    // the regex patterns, but classifySessionError recognizes statusCode 413
+    // as CONTEXT_TOO_LARGE and sets contextTooLargeDetected = true.
     expect(agentLoopRunCount).toBe(2);
     expect(maybeCompactCalls).toEqual([
       { force: false },

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -247,8 +247,12 @@ export function handleError(
     state.contextTooLargeDetected = true;
   } else {
     const classified = classifySessionError(event.error, { phase: 'agent_loop' });
-    deps.onEvent(buildSessionErrorMessage(deps.ctx.conversationId, classified));
-    state.providerErrorUserMessage = classified.userMessage;
+    if (classified.code === 'CONTEXT_TOO_LARGE') {
+      state.contextTooLargeDetected = true;
+    } else {
+      deps.onEvent(buildSessionErrorMessage(deps.ctx.conversationId, classified));
+      state.providerErrorUserMessage = classified.userMessage;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes a bug identified in the Devin review of PR #9204 where a `ProviderError` with `statusCode: 413` and a message like `"request entity too large"` bypassed the forced-compaction retry path.

- **`handleError` in `session-agent-loop-handlers.ts`**: After the regex check fails and the error falls through to `classifySessionError`, the function now checks if the classified error code is `CONTEXT_TOO_LARGE`. If so, it sets `state.contextTooLargeDetected = true` instead of emitting the error immediately — allowing the retry logic in `session-agent-loop.ts` to attempt forced compaction before surfacing the error.
- **New test case**: Added a test using a `ProviderError` with `statusCode: 413` and the message `"request entity too large"` (which doesn't match the existing regex patterns) to verify the retry path is triggered correctly.

## Test plan

- [x] Existing tests pass (8/8 in `session-provider-retry-repair.test.ts`)
- [x] New test case verifies that `ProviderError` with `statusCode: 413` triggers forced compaction retry (2 agent loop runs, force compaction called, no `session_error` emitted)
- [x] TypeScript type-check passes (no new errors introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
