### PR TITLE
fix(macos): recreate ChatViewModel when LRU-evicted thread is selected

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -387,6 +387,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             let viewModel = makeViewModel()
             viewModel.sessionId = thread.sessionId
             chatViewModels[id] = viewModel
+            evictStaleCachedViewModels()
         }
 
         touchVMAccessOrder(id)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -380,7 +380,15 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     func selectThread(id: UUID) {
-        guard threads.contains(where: { $0.id == id }) else { return }
+        guard let thread = threads.first(where: { $0.id == id }) else { return }
+
+        // Re-create the ViewModel if it was LRU-evicted.
+        if chatViewModels[id] == nil {
+            let viewModel = makeViewModel()
+            viewModel.sessionId = thread.sessionId
+            chatViewModels[id] = viewModel
+        }
+
         touchVMAccessOrder(id)
         activeThreadId = id
         // Switching threads is a natural point to shed cached render


### PR DESCRIPTION
## Summary
- When a user has more than 10 threads, older `ChatViewModel` instances get evicted from the LRU cache (`maxCachedViewModels = 10`)
- Selecting an evicted thread would set `activeThreadId` but `activeViewModel` would return `nil`, causing `chatView` in `PanelCoordinator` to render nothing — blank content area
- `selectThread()` now recreates the ViewModel with the correct `sessionId` when it's missing from the cache

## Test plan
- [ ] Open the app with 10+ threads
- [ ] Navigate to Home Base / Apps and back to threads
- [ ] Click on threads near the bottom of the list — verify conversation content renders
- [ ] Rapidly switch between many threads — verify no blank states

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
