### PR TITLE
fix: guard nil daemonClient in heartbeat Run Now button

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/HeartbeatSettingsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/HeartbeatSettingsTab.swift
@@ -237,8 +237,13 @@ struct HeartbeatSettingsTab: View {
                     VButton(label: "Run Now", style: .primary) {
                         isRunning = true
                         runError = nil
+                        guard let client = daemonClient else {
+                            isRunning = false
+                            runError = "Daemon not available"
+                            return
+                        }
                         do {
-                            try daemonClient?.sendHeartbeatRunNow()
+                            try client.sendHeartbeatRunNow()
                         } catch {
                             isRunning = false
                             runError = "Failed to send run request"


### PR DESCRIPTION
## Summary
- Guard against nil `daemonClient` before sending heartbeat Run Now IPC
- Optional chaining (`?.`) doesn't throw when the receiver is nil, so the do/catch block succeeds silently and `isRunning` stays permanently stuck at `true`

## Original prompt
Addresses review feedback from #9207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
