### PR TITLE
M4: Streaming Markdown Parse Dedup

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -398,4 +398,16 @@ struct ChatBubble: View {
     /// inline results (and vice versa) if they shared a dictionary.
     @MainActor static var inlineMarkdownCache = [String: (value: AttributedString, accessTime: Int)]()
     static let maxCacheSize = 100
+
+    // MARK: - Streaming Dedup Caches
+    //
+    // During streaming, the LRU caches above skip storing results to avoid
+    // filling up with intermediate text states. However SwiftUI reevaluates
+    // view bodies multiple times per token, often with identical text.
+    // These single-entry caches hold the last-parsed streaming result so
+    // redundant reevaluations return instantly without re-parsing.
+
+    @MainActor static var lastStreamingSegments: (text: String, value: [MarkdownSegment])?
+    @MainActor static var lastStreamingInlineMarkdown: (text: String, value: AttributedString)?
+    @MainActor static var lastStreamingMarkdown: (text: String, value: AttributedString)?
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -36,20 +36,29 @@ extension ChatBubble {
     /// Cached inline markdown AttributedString to avoid re-parsing on every render.
     /// Uses `inlineMarkdownCache` (not `markdownCache`) to avoid cross-contamination
     /// with `markdownText`, which applies slash-command highlighting before caching.
-    /// When `isStreaming` is true the result is computed but not stored, since
-    /// streaming text changes every token and caching intermediates wastes memory.
+    /// When `isStreaming` is true the result is not stored in the main LRU cache
+    /// (to avoid filling it with intermediate text states), but a single-entry
+    /// dedup cache returns the previous result when the text hasn't changed
+    /// between SwiftUI reevaluations.
     static func cachedInlineMarkdown(for text: String, isStreaming: Bool = false) -> AttributedString {
         if let cached = inlineMarkdownCache[text] {
             lruCounter += 1
             inlineMarkdownCache[text] = (cached.value, lruCounter)
             return cached.value
         }
+        // Streaming dedup: return the last-parsed result when text is unchanged.
+        if isStreaming, let last = lastStreamingInlineMarkdown, last.text == text {
+            return last.value
+        }
         let options = AttributedString.MarkdownParsingOptions(
             interpretedSyntax: .inlineOnlyPreservingWhitespace
         )
         let result = (try? AttributedString(markdown: text, options: options))
             ?? AttributedString(text)
-        if isStreaming { return result }
+        if isStreaming {
+            lastStreamingInlineMarkdown = (text, result)
+            return result
+        }
         if inlineMarkdownCache.count >= maxCacheSize {
             // Evict the least-recently-used entry (lowest accessTime).
             if let lruKey = inlineMarkdownCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
@@ -62,16 +71,25 @@ extension ChatBubble {
     }
 
     /// Cached markdown segment parser to avoid re-parsing on every render.
-    /// When `isStreaming` is true the result is computed but not stored, since
-    /// streaming text changes every token and caching intermediates wastes memory.
+    /// When `isStreaming` is true the result is not stored in the main LRU
+    /// cache (to avoid filling it with intermediate text states), but a
+    /// single-entry dedup cache returns the previous result when the text
+    /// hasn't changed between SwiftUI reevaluations.
     static func cachedSegments(for text: String, isStreaming: Bool = false) -> [MarkdownSegment] {
         if let cached = segmentCache[text] {
             lruCounter += 1
             segmentCache[text] = (cached.value, lruCounter)
             return cached.value
         }
+        // Streaming dedup: return the last-parsed result when text is unchanged.
+        if isStreaming, let last = lastStreamingSegments, last.text == text {
+            return last.value
+        }
         let result = parseMarkdownSegments(text)
-        if isStreaming { return result }
+        if isStreaming {
+            lastStreamingSegments = (text, result)
+            return result
+        }
         if segmentCache.count >= maxCacheSize {
             // Evict the least-recently-used entry (lowest accessTime).
             if let lruKey = segmentCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
@@ -84,8 +102,10 @@ extension ChatBubble {
     }
 
     /// Cached markdown parser to avoid re-parsing on every render.
-    /// Skips caching when the message is still streaming to avoid
-    /// filling the cache with intermediate text states.
+    /// When streaming, results are not stored in the main LRU cache (to
+    /// avoid filling it with intermediate text states), but a single-entry
+    /// dedup cache returns the previous result when the text hasn't changed
+    /// between SwiftUI reevaluations.
     var markdownText: AttributedString {
         let textToRender = message.text
         let trimmed = textToRender.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -95,6 +115,11 @@ extension ChatBubble {
             Self.lruCounter += 1
             Self.markdownCache[trimmed] = (cached.value, Self.lruCounter)
             return cached.value
+        }
+
+        // Streaming dedup: return the last-parsed result when text is unchanged.
+        if message.isStreaming, let last = Self.lastStreamingMarkdown, last.text == trimmed {
+            return last.value
         }
 
         // Parse markdown
@@ -113,8 +138,12 @@ extension ChatBubble {
             parsed[attrStart..<attrEnd].foregroundColor = VColor.slashCommand
         }
 
-        // Skip caching during streaming — intermediate text wastes cache slots
-        if message.isStreaming { return parsed }
+        // Skip main cache during streaming — intermediate text wastes cache slots.
+        // Store in the single-entry dedup cache instead.
+        if message.isStreaming {
+            Self.lastStreamingMarkdown = (trimmed, parsed)
+            return parsed
+        }
 
         // Store in cache with LRU eviction
         if Self.markdownCache.count >= Self.maxCacheSize {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -398,6 +398,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         ChatBubble.segmentCache.removeAll()
         ChatBubble.markdownCache.removeAll()
         ChatBubble.inlineMarkdownCache.removeAll()
+        ChatBubble.lastStreamingSegments = nil
+        ChatBubble.lastStreamingInlineMarkdown = nil
+        ChatBubble.lastStreamingMarkdown = nil
         MarkdownSegmentView.clearAttributedStringCache()
     }
 


### PR DESCRIPTION
Part of #9219. Adds dedup caching so markdown text that hasn't changed between SwiftUI reevaluations is not re-parsed. Reduces CPU during streaming.

## Summary

During streaming, SwiftUI reevaluates view bodies multiple times per token. The existing LRU caches deliberately skip storing streaming results (to avoid filling the cache with intermediate text states), but this means every reevaluation triggers a full markdown re-parse even when the text hasn't changed since the last parse.

This PR adds lightweight single-entry "last-parsed" dedup caches that sit alongside the existing LRU caches. When streaming text is identical to the previous parse, the cached result is returned instantly without re-parsing.

## Implementation

Three static single-entry caches added to `ChatBubble`:
- `lastStreamingSegments` — dedup for `cachedSegments(for:isStreaming:)`
- `lastStreamingInlineMarkdown` — dedup for `cachedInlineMarkdown(for:isStreaming:)`
- `lastStreamingMarkdown` — dedup for `markdownText`

Each stores a `(text: String, value: Result)` tuple. Before parsing, if `isStreaming` is true and the input text matches the cached text, the cached value is returned. When the text changes (new token), the result is parsed and the dedup entry is replaced.

The dedup caches are cleared alongside the existing LRU caches in `ThreadManager.clearRenderCaches()` on thread switch, close, and archive.

## Key Technical Choices

- **Single-entry tuple vs dictionary**: A single `(text, value)?` tuple per function is sufficient because during streaming only one message is actively being parsed at a time. This avoids any memory overhead from accumulating entries.
- **Separate from LRU cache**: The existing LRU caches correctly skip storing streaming intermediates to preserve cache quality. The dedup layer is orthogonal — it only prevents redundant re-parses within the same streaming state.
- **`MarkdownSegmentView.buildCombinedAttributedString` not modified**: It already caches unconditionally (no streaming skip), so it naturally deduplicates.

## Files Changed

- `clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift` — Added three streaming dedup cache declarations
- `clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift` — Added dedup checks in `cachedSegments`, `cachedInlineMarkdown`, and `markdownText`
- `clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift` — Clear dedup caches in `clearRenderCaches()`

## Testing

- Stream a long response and monitor CPU usage — should see reduced markdown parsing overhead
- Verify streaming text still renders correctly and updates with each new token
- Switch threads during streaming — dedup caches should be cleared
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
