### PR TITLE
M3: Lazy Tool Input Formatting

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -84,8 +84,17 @@ private struct UsedToolsRow: View {
     @State private var isImageHovered = false
     @Environment(\.displayScale) private var displayScale
 
+    /// Lazily resolved full input text. If `inputFull` was deferred during history
+    /// load, compute it from the raw dictionary on first access (when the user
+    /// expands the row) instead of during `populateFromHistory`.
+    private var resolvedInputFull: String {
+        if !toolCall.inputFull.isEmpty { return toolCall.inputFull }
+        if let dict = toolCall.inputRawDict { return ToolCallData.formatAllToolInput(dict) }
+        return ""
+    }
+
     private var hasDetails: Bool {
-        !toolCall.inputFull.isEmpty ||
+        !toolCall.inputFull.isEmpty || toolCall.inputRawDict != nil ||
         (toolCall.result != nil && !(toolCall.result?.isEmpty ?? true)) ||
         toolCall.cachedImage != nil ||
         !toolCall.claudeCodeSteps.isEmpty
@@ -158,8 +167,8 @@ private struct UsedToolsRow: View {
                             Text(toolCall.friendlyName)
                                 .font(VFont.captionMedium)
                                 .foregroundColor(VColor.textSecondary)
-                            if !toolCall.inputFull.isEmpty {
-                                Text(toolCall.inputFull)
+                            if !resolvedInputFull.isEmpty {
+                                Text(resolvedInputFull)
                                     .font(VFont.monoSmall)
                                     .foregroundColor(VColor.textSecondary)
                                     .textSelection(.enabled)

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -593,6 +593,10 @@ public struct ToolCallData: Identifiable, Equatable {
     public var result: String?
     public var isError: Bool
     public var isComplete: Bool
+    /// Raw decoded tool input dictionary, stored for lazy formatting of `inputFull`.
+    /// When non-nil and `inputFull` is empty, the formatted string has not yet been
+    /// computed — call `ToolCallData.formatAllToolInput(_:)` on demand.
+    public var inputRawDict: [String: AnyCodable]?
     /// Whether this tool call arrived before any text content in the message.
     /// Used to render pre-text tool calls above and post-text tool calls below the bubble.
     public var arrivedBeforeText: Bool
@@ -967,6 +971,131 @@ public struct ToolCallData: Identifiable, Equatable {
 
     private func truncated(_ s: String, to length: Int) -> String {
         s.count > length ? String(s.prefix(length - 1)) + "…" : s
+    }
+
+    // MARK: - Lazy tool input formatting
+
+    /// Priority list of input keys whose values are most useful as a tool call summary.
+    private static let toolInputPriorityKeys = [
+        "command", "file_path", "path", "query", "url", "pattern", "glob"
+    ]
+
+    /// Argument keys whose values may contain credentials and must be redacted.
+    private static let sensitiveKeys: Set<String> = [
+        "value", "secret", "password", "token", "client_secret", "api_key",
+        "authorization", "access_token", "refresh_token", "api_secret",
+        "accesstoken", "refreshtoken", "apikey", "apisecret", "clientsecret",
+        "x-api-key"
+    ]
+
+    private static func isSensitiveKey(_ key: String) -> Bool {
+        sensitiveKeys.contains(key.lowercased())
+    }
+
+    /// Format all tool input arguments for display in expanded details.
+    /// This is a self-contained static method so views can call it without
+    /// needing a ChatViewModel reference (used for lazy formatting on expand).
+    public static func formatAllToolInput(_ input: [String: AnyCodable]) -> String {
+        guard !input.isEmpty else { return "" }
+
+        let primaryKey = toolInputPriorityKeys.first(where: { input[$0] != nil })
+            ?? input.keys.sorted().first
+
+        let orderedKeys: [String]
+        if let pk = primaryKey {
+            orderedKeys = [pk] + input.keys.filter { $0 != pk }.sorted()
+        } else {
+            orderedKeys = input.keys.sorted()
+        }
+
+        var lines: [String] = []
+        for key in orderedKeys {
+            guard let value = input[key] else { continue }
+            if isSensitiveKey(key) {
+                lines.append("\(key): [redacted]")
+            } else {
+                lines.append("\(key): \(redactingStringifyValue(value))")
+            }
+        }
+
+        var result = lines.joined(separator: "\n")
+        if result.count > 10_000 { result = String(result.prefix(10_000)) + "... [truncated]" }
+        return result
+    }
+
+    /// If `inputFull` is empty and `inputRawDict` is available, compute the
+    /// formatted input on demand. Call this before displaying `inputFull`.
+    public mutating func ensureInputFullFormatted() {
+        guard inputFull.isEmpty, let dict = inputRawDict else { return }
+        inputFull = Self.formatAllToolInput(dict)
+        inputRawDict = nil
+    }
+
+    private static func stringifyValue(_ value: AnyCodable) -> String {
+        if let s = value.value as? String { return s }
+        if let b = value.value as? Bool { return b ? "true" : "false" }
+        if let n = value.value as? Int { return String(n) }
+        if let n = value.value as? Double { return String(n) }
+        if let encoder = try? JSONEncoder().encode(value),
+           let json = String(data: encoder, encoding: .utf8) {
+            return json
+        }
+        return String(describing: value.value ?? "")
+    }
+
+    private static func redactingStringifyValue(_ value: AnyCodable) -> String {
+        if let dict = value.value as? [String: Any] {
+            return redactDictionary(dict)
+        }
+        if let array = value.value as? [Any] {
+            return redactArray(array)
+        }
+        return stringifyValue(value)
+    }
+
+    private static func redactDictionary(_ dict: [String: Any]) -> String {
+        let redacted = redactDictionaryAsObject(dict)
+        if let data = try? JSONSerialization.data(withJSONObject: redacted, options: [.sortedKeys]),
+           let json = String(data: data, encoding: .utf8) {
+            return json
+        }
+        return String(describing: redacted)
+    }
+
+    private static func redactArray(_ array: [Any]) -> String {
+        let redacted = redactArrayAsObject(array)
+        if let data = try? JSONSerialization.data(withJSONObject: redacted, options: [.sortedKeys]),
+           let json = String(data: data, encoding: .utf8) {
+            return json
+        }
+        return String(describing: redacted)
+    }
+
+    private static func redactDictionaryAsObject(_ dict: [String: Any]) -> [String: Any] {
+        var redacted: [String: Any] = [:]
+        for (key, val) in dict {
+            if isSensitiveKey(key) {
+                redacted[key] = "[redacted]"
+            } else if let nested = val as? [String: Any] {
+                redacted[key] = redactDictionaryAsObject(nested)
+            } else if let nested = val as? [Any] {
+                redacted[key] = redactArrayAsObject(nested)
+            } else {
+                redacted[key] = val
+            }
+        }
+        return redacted
+    }
+
+    private static func redactArrayAsObject(_ array: [Any]) -> [Any] {
+        return array.map { element -> Any in
+            if let dict = element as? [String: Any] {
+                return redactDictionaryAsObject(dict)
+            } else if let nested = element as? [Any] {
+                return redactArrayAsObject(nested)
+            }
+            return element
+        }
     }
 }
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1676,10 +1676,10 @@ public final class ChatViewModel: ObservableObject {
             let toolsBeforeText = item.toolCallsBeforeText ?? true
             if let historyToolCalls = item.toolCalls {
                 toolCalls = historyToolCalls.map { tc in
-                    ToolCallData(
+                    var toolCall = ToolCallData(
                         toolName: tc.name,
                         inputSummary: summarizeToolInput(tc.input),
-                        inputFull: formatAllToolInput(tc.input),
+                        inputFull: "",
                         inputRawValue: extractToolInput(tc.input),
                         result: tc.result,
                         isError: tc.isError ?? false,
@@ -1687,6 +1687,10 @@ public final class ChatViewModel: ObservableObject {
                         arrivedBeforeText: toolsBeforeText,
                         imageData: tc.imageData
                     )
+                    // Defer expensive formatting — store the raw dict for lazy computation
+                    // when the user expands the tool call chip.
+                    toolCall.inputRawDict = tc.input
+                    return toolCall
                 }
             }
             let attachments: [ChatAttachment] = mapIPCAttachments(item.attachments ?? [])

--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -15,6 +15,15 @@ public struct ToolCallChip: View {
         toolCall.result != nil || toolCall.cachedImage != nil
     }
 
+    /// Lazily resolved full input text. If `inputFull` was deferred during history
+    /// load, compute it from the raw dictionary on first access (when the user
+    /// expands the chip) instead of during `populateFromHistory`.
+    private var resolvedInputFull: String {
+        if !toolCall.inputFull.isEmpty { return toolCall.inputFull }
+        if let dict = toolCall.inputRawDict { return ToolCallData.formatAllToolInput(dict) }
+        return ""
+    }
+
     public var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Chip header (always visible)
@@ -71,8 +80,8 @@ public struct ToolCallChip: View {
                             Text(toolCall.friendlyName)
                                 .font(VFont.captionMedium)
                                 .foregroundColor(VColor.textSecondary)
-                            if !toolCall.inputFull.isEmpty {
-                                Text(toolCall.inputFull)
+                            if !resolvedInputFull.isEmpty {
+                                Text(resolvedInputFull)
                                     .font(VFont.monoSmall)
                                     .foregroundColor(VColor.textSecondary)
                                     .textSelection(.enabled)


### PR DESCRIPTION
Part of #9219. Defers expensive tool input formatting during history load. Stores raw input dictionary and computes inputFull lazily when the user expands a tool call chip. Reduces memory and CPU during populateFromHistory.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
