### PR TITLE
fix: resolve CI type-check failures

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -681,6 +681,28 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     deliveryId: 'delivery-001',
     success: true,
   },
+  recording_status: {
+    type: 'recording_status',
+    sessionId: 'rec-001',
+    status: 'started',
+  },
+  heartbeat_config: {
+    type: 'heartbeat_config',
+    action: 'get',
+  },
+  heartbeat_runs_list: {
+    type: 'heartbeat_runs_list',
+  },
+  heartbeat_run_now: {
+    type: 'heartbeat_run_now',
+  },
+  heartbeat_checklist_read: {
+    type: 'heartbeat_checklist_read',
+  },
+  heartbeat_checklist_write: {
+    type: 'heartbeat_checklist_write',
+    content: '- [ ] Check email\n- [ ] Review PRs',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -1883,6 +1905,45 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   },
   approved_device_remove_response: {
     type: 'approved_device_remove_response',
+    success: true,
+  },
+  recording_start: {
+    type: 'recording_start',
+    recordingId: 'rec-001',
+  },
+  recording_stop: {
+    type: 'recording_stop',
+    recordingId: 'rec-001',
+  },
+  heartbeat_config_response: {
+    type: 'heartbeat_config_response',
+    enabled: true,
+    intervalMs: 3600000,
+    activeHoursStart: 9,
+    activeHoursEnd: 17,
+    nextRunAt: 1700003600000,
+    success: true,
+  },
+  heartbeat_runs_list_response: {
+    type: 'heartbeat_runs_list_response',
+    runs: [{
+      id: 'hb-run-001',
+      title: 'Morning heartbeat',
+      createdAt: 1700000000000,
+      result: 'All systems nominal',
+    }],
+  },
+  heartbeat_run_now_response: {
+    type: 'heartbeat_run_now_response',
+    success: true,
+  },
+  heartbeat_checklist_response: {
+    type: 'heartbeat_checklist_response',
+    content: '- [ ] Check email\n- [ ] Review PRs',
+    isDefault: false,
+  },
+  heartbeat_checklist_write_response: {
+    type: 'heartbeat_checklist_write_response',
     success: true,
   },
 };

--- a/assistant/src/__tests__/notification-deep-link.test.ts
+++ b/assistant/src/__tests__/notification-deep-link.test.ts
@@ -38,7 +38,7 @@ describe('notification deep-link metadata', () => {
       );
 
       expect(messages).toHaveLength(1);
-      const msg = messages[0] as Record<string, unknown>;
+      const msg = messages[0] as unknown as Record<string, unknown>;
       expect(msg.type).toBe('notification_intent');
       expect(msg.title).toBe('Alert');
       expect(msg.body).toBe('Something happened');
@@ -61,7 +61,7 @@ describe('notification deep-link metadata', () => {
       );
 
       expect(messages).toHaveLength(1);
-      const msg = messages[0] as Record<string, unknown>;
+      const msg = messages[0] as unknown as Record<string, unknown>;
       expect(msg.type).toBe('notification_intent');
       expect(msg.deepLinkMetadata).toBeUndefined();
     });
@@ -80,7 +80,7 @@ describe('notification deep-link metadata', () => {
         { channel: 'vellum' },
       );
 
-      const msg = messages[0] as Record<string, unknown>;
+      const msg = messages[0] as unknown as Record<string, unknown>;
       const metadata = msg.deepLinkMetadata as Record<string, unknown>;
       expect(metadata.conversationId).toBe(conversationId);
     });
@@ -128,7 +128,7 @@ describe('notification deep-link metadata', () => {
         { channel: 'vellum' },
       );
 
-      const msg = messages[0] as Record<string, unknown>;
+      const msg = messages[0] as unknown as Record<string, unknown>;
       expect(msg.sourceEventName).toBe('guardian.question');
     });
 
@@ -149,7 +149,7 @@ describe('notification deep-link metadata', () => {
         { channel: 'vellum' },
       );
 
-      const msg = messages[0] as Record<string, unknown>;
+      const msg = messages[0] as unknown as Record<string, unknown>;
       const metadata = msg.deepLinkMetadata as Record<string, unknown>;
       expect(metadata.conversationId).toBe('conv-task-run-42');
       expect(metadata.workItemId).toBe('work-item-7');

--- a/assistant/src/memory/conflict-store.ts
+++ b/assistant/src/memory/conflict-store.ts
@@ -188,7 +188,7 @@ export function listPendingConflictDetails(
   const cursorClause = cursor
     ? `AND (c.created_at > ? OR (c.created_at = ? AND c.id > ?))`
     : '';
-  const params: unknown[] = cursor
+  const params: (string | number)[] = cursor
     ? [scopeId, cursor.createdAt, cursor.createdAt, cursor.id, limit]
     : [scopeId, limit];
   const rows = rawAll<ConflictDetailRow>(`

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -24,9 +24,6 @@ import {
 } from '../channel-approvals.js';
 import { deliverChannelReply } from '../gateway-client.js';
 import type {
-  ApprovalDecisionResult,
-} from '../channel-approval-types.js';
-import type {
   ApprovalConversationContext,
   ApprovalConversationGenerator,
   ApprovalCopyGenerator,


### PR DESCRIPTION
## Summary
- Add missing IPC snapshot entries for 6 new client message types (recording_status, heartbeat_config, heartbeat_runs_list, heartbeat_run_now, heartbeat_checklist_read, heartbeat_checklist_write) and 7 new server message types (recording_start, recording_stop, heartbeat_config_response, heartbeat_runs_list_response, heartbeat_run_now_response, heartbeat_checklist_response, heartbeat_checklist_write_response)
- Fix `as Record<string, unknown>` casts in notification-deep-link test by routing through `unknown` first (SubagentEvent lacks index signature)
- Type raw SQL params as `(string | number)[]` instead of `unknown[]` in conflict-store
- Remove duplicate `ApprovalDecisionResult` import in guardian-approval-interception

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22419452468

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
