### PR TITLE
fix(macos): reinstall View menu items after main window shows

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1796,6 +1796,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     func showMainWindow(initialMessage: String? = nil, isFirstLaunch: Bool = false) {
         if let existing = mainWindow {
             existing.show()
+            // SwiftUI may (re)create the app menu after initial setup.
+            // Re-apply custom menu items whenever the main window is shown.
+            setupViewMenu()
+            DispatchQueue.main.async { [weak self] in
+                self?.setupViewMenu()
+            }
             return
         }
         let main = ensureMainWindowExists(isFirstLaunch: isFirstLaunch)
@@ -1812,6 +1818,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
         main.show()
+        // Run once immediately and once on the next runloop to cover cases
+        // where NSApp.mainMenu is initialized slightly after window display.
+        setupViewMenu()
+        DispatchQueue.main.async { [weak self] in
+            self?.setupViewMenu()
+        }
     }
 
     private func observeAssistantStatus() {


### PR DESCRIPTION
## Summary
- Fixes a lifecycle gap where custom View menu items could be missing at runtime, leaving only default entries like "Enter Full Screen" and causing `Cmd +/-/0` to beep as unhandled.
- Root cause: `setupViewMenu()` could run before `NSApp.mainMenu` was fully available and was not guaranteed to run again once the main menu was finalized.
- `showMainWindow()` now reapplies `setupViewMenu()`:
  - immediately after showing the window,
  - and once again on the next runloop tick.

## Why this works
This guarantees our View menu injection runs after menu initialization timing settles, while remaining safe/idempotent.

## Validation
- `cd clients/macos && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter ConversationZoomManagerTests`
- Result: pass (17/17)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
