### PR TITLE
feat: show Telegram typing indicator during assistant responses

### DIFF
--- a/assistant/src/runtime/gateway-client.ts
+++ b/assistant/src/runtime/gateway-client.ts
@@ -12,6 +12,7 @@ export interface ChannelReplyPayload {
   assistantId?: string;
   attachments?: RuntimeAttachmentMetadata[];
   approval?: ApprovalUIMetadata;
+  chatAction?: 'typing';
 }
 
 export async function deliverChannelReply(
@@ -40,7 +41,14 @@ export async function deliverChannelReply(
     throw new Error(`Channel reply delivery failed (${response.status}): ${body}`);
   }
 
-  log.info({ chatId: payload.chatId, callbackUrl }, 'Channel reply delivered');
+  if (payload.chatAction) {
+    log.debug(
+      { chatId: payload.chatId, callbackUrl, chatAction: payload.chatAction },
+      'Channel action delivered',
+    );
+  } else {
+    log.info({ chatId: payload.chatId, callbackUrl }, 'Channel reply delivered');
+  }
 }
 
 /**

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -874,6 +874,54 @@ interface BackgroundProcessingParams {
   sourceLanguageCode?: string;
 }
 
+const TELEGRAM_TYPING_INTERVAL_MS = 4_000;
+
+function shouldEmitTelegramTyping(
+  sourceChannel: ChannelId,
+  replyCallbackUrl?: string,
+): boolean {
+  if (sourceChannel !== 'telegram' || !replyCallbackUrl) return false;
+  try {
+    return new URL(replyCallbackUrl).pathname.endsWith('/deliver/telegram');
+  } catch {
+    return replyCallbackUrl.endsWith('/deliver/telegram');
+  }
+}
+
+function startTelegramTypingHeartbeat(
+  callbackUrl: string,
+  chatId: string,
+  bearerToken?: string,
+  assistantId?: string,
+): () => void {
+  let active = true;
+  let inFlight = false;
+
+  const emitTyping = (): void => {
+    if (!active || inFlight) return;
+    inFlight = true;
+    void deliverChannelReply(
+      callbackUrl,
+      { chatId, chatAction: 'typing', assistantId },
+      bearerToken,
+    ).catch((err) => {
+      log.debug({ err, chatId }, 'Failed to deliver Telegram typing indicator');
+    }).finally(() => {
+      inFlight = false;
+    });
+  };
+
+  emitTyping();
+
+  const interval = setInterval(emitTyping, TELEGRAM_TYPING_INTERVAL_MS);
+  (interval as { unref?: () => void }).unref?.();
+
+  return () => {
+    active = false;
+    clearInterval(interval);
+  };
+}
+
 function processChannelMessageInBackground(params: BackgroundProcessingParams): void {
   const {
     processMessage,
@@ -895,6 +943,13 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
   } = params;
 
   (async () => {
+    const typingCallbackUrl = shouldEmitTelegramTyping(sourceChannel, replyCallbackUrl)
+      ? replyCallbackUrl
+      : undefined;
+    const stopTypingHeartbeat = typingCallbackUrl
+      ? startTelegramTypingHeartbeat(typingCallbackUrl, externalChatId, bearerToken, assistantId)
+      : undefined;
+
     try {
       const cmdIntent = commandIntent && typeof commandIntent.type === 'string'
         ? { type: commandIntent.type as string, ...(typeof commandIntent.payload === 'string' ? { payload: commandIntent.payload } : {}), ...(sourceLanguageCode ? { languageCode: sourceLanguageCode } : {}) }
@@ -931,6 +986,8 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
     } catch (err) {
       log.error({ err, conversationId }, 'Background channel message processing failed');
       channelDeliveryStore.recordProcessingFailure(eventId, err);
+    } finally {
+      stopTypingHeartbeat?.();
     }
   })();
 }

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -84,10 +84,10 @@ Inbound (user → assistant):
     (replyCallbackUrl = ${gatewayInternalBaseUrl}/deliver/telegram)
 
 Outbound reply (assistant → user, triggered by inbound):
-  Runtime callback → Gateway POST /deliver/telegram (bearer auth) → Telegram sendMessage/sendPhoto/sendDocument
+  Runtime callback → Gateway POST /deliver/telegram (bearer auth) → Telegram sendMessage/sendPhoto/sendDocument/sendChatAction
 
 Outbound proactive (assistant → user, initiated by messaging provider):
-  Runtime messaging provider → Gateway POST /deliver/telegram (bearer auth) → Telegram sendMessage
+  Runtime messaging provider → Gateway POST /deliver/telegram (bearer auth) → Telegram sendMessage/sendChatAction
 ```
 
 The `replyCallbackUrl` included in the inbound forward is built from the `gatewayInternalBaseUrl` config field, which defaults to `http://127.0.0.1:${GATEWAY_PORT}` and can be overridden via the `GATEWAY_INTERNAL_BASE_URL` environment variable. This allows distributed deployments where the gateway and runtime are not co-located (e.g., separate containers or hosts).

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -193,6 +193,14 @@ The `/deliver/telegram` endpoint accepts an optional `approval` field in the req
 
 **Fallback behavior:** For non-Telegram channels that do not support inline keyboards, the runtime substitutes the `plainTextFallback` string for the structured `promptText` before calling the delivery endpoint. The fallback includes plain-text instructions (e.g., "Reply yes/no/always") so the user can respond via text. The `channelSupportsRichApprovalUI()` function in the runtime determines which format to use; currently only `telegram` is classified as a rich channel.
 
+## Telegram Typing Indicator
+
+The `/deliver/telegram` endpoint also accepts an optional `chatAction` field for ephemeral Telegram chat actions. Current supported value:
+
+- `typing` — triggers Telegram `sendChatAction` with `action: "typing"` for the target `chatId`.
+
+This can be sent as an action-only payload (without `text` or `attachments`) when the runtime wants to show a typing indicator while an assistant response is still in progress.
+
 ## Public Ingress Routes
 
 The gateway serves as the single public ingress point for all external callbacks. The following routes are handled directly by the gateway before any proxy forwarding:

--- a/gateway/src/__tests__/schema.test.ts
+++ b/gateway/src/__tests__/schema.test.ts
@@ -124,4 +124,22 @@ describe("buildSchema()", () => {
     // THEN the round-tripped object equals the original
     expect(parsed).toEqual(schema);
   });
+
+  test("TelegramDeliverRequest supports typing chatAction payloads", () => {
+    const schema = buildSchema();
+    const components = schema.components as {
+      schemas: Record<string, {
+        properties?: Record<string, unknown>;
+        anyOf?: Array<Record<string, unknown>>;
+      }>;
+    };
+    const telegramDeliver = components.schemas.TelegramDeliverRequest;
+
+    expect(telegramDeliver.properties?.chatAction).toEqual({
+      type: "string",
+      enum: ["typing"],
+      description: "Optional Telegram chat action to emit (currently only `typing`)",
+    });
+    expect(telegramDeliver.anyOf).toContainEqual({ required: ["chatAction"] });
+  });
 });

--- a/gateway/src/http/routes/telegram-deliver.test.ts
+++ b/gateway/src/http/routes/telegram-deliver.test.ts
@@ -6,12 +6,17 @@ import { createTelegramDeliverHandler } from "./telegram-deliver.js";
 
 // Track calls to sendTelegramReply so we can assert on approval passthrough.
 let sendTelegramReplyCalls: Array<unknown[]> = [];
+let sendTypingIndicatorCalls: Array<unknown[]> = [];
 
 mock.module("../../telegram/send.js", () => ({
   sendTelegramReply: async (...args: unknown[]) => {
     sendTelegramReplyCalls.push(args);
   },
   sendTelegramAttachments: async () => {},
+  sendTypingIndicator: async (...args: unknown[]) => {
+    sendTypingIndicatorCalls.push(args);
+    return true;
+  },
 }));
 
 // ---- Helpers ----
@@ -42,7 +47,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     telegramInitialBackoffMs: 1000,
     telegramMaxRetries: 3,
     telegramTimeoutMs: 15000,
-    telegramWebhookSecret: "test-secret",
+    telegramWebhookSecret: undefined,
     twilioAuthToken: undefined,
     twilioAccountSid: undefined,
     twilioPhoneNumber: undefined,
@@ -81,6 +86,7 @@ function makeRequest(body: unknown, headers?: Record<string, string>): Request {
 describe("telegram-deliver endpoint basics", () => {
   beforeEach(() => {
     sendTelegramReplyCalls = [];
+    sendTypingIndicatorCalls = [];
   });
 
   it("rejects GET requests with 405", async () => {
@@ -168,7 +174,29 @@ describe("telegram-deliver endpoint basics", () => {
     const res = await handler(req);
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toBe("text or attachments required");
+    expect(body.error).toBe("text, attachments, or chatAction required");
+  });
+
+  it("returns 400 when chatAction is invalid", async () => {
+    const handler = createTelegramDeliverHandler(makeConfig());
+    const req = makeRequest({ chatId: "123", chatAction: "upload_photo" });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("chatAction must be \"typing\"");
+  });
+
+  it("accepts typing action-only payloads", async () => {
+    const handler = createTelegramDeliverHandler(makeConfig());
+    const req = makeRequest({ chatId: "42", chatAction: "typing" });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(sendTypingIndicatorCalls).toHaveLength(1);
+    const [, chatId] = sendTypingIndicatorCalls[0] as [unknown, string];
+    expect(chatId).toBe("42");
+    expect(sendTelegramReplyCalls).toHaveLength(0);
   });
 
   it("returns 400 when JSON is invalid", async () => {
@@ -199,6 +227,7 @@ describe("telegram-deliver endpoint basics", () => {
         throw new Error("Telegram API failure");
       },
       sendTelegramAttachments: async () => {},
+      sendTypingIndicator: async () => true,
     }));
 
     const { createTelegramDeliverHandler: createHandler } = await import(
@@ -217,6 +246,10 @@ describe("telegram-deliver endpoint basics", () => {
         sendTelegramReplyCalls.push(args);
       },
       sendTelegramAttachments: async () => {},
+      sendTypingIndicator: async (...args: unknown[]) => {
+        sendTypingIndicatorCalls.push(args);
+        return true;
+      },
     }));
   });
 

--- a/gateway/src/http/routes/telegram-deliver.ts
+++ b/gateway/src/http/routes/telegram-deliver.ts
@@ -2,7 +2,7 @@ import type { GatewayConfig } from "../../config.js";
 import { getLogger } from "../../logger.js";
 import { checkDeliverAuth } from "../middleware/deliver-auth.js";
 import type { RuntimeAttachmentMeta } from "../../runtime/client.js";
-import { sendTelegramAttachments, sendTelegramReply } from "../../telegram/send.js";
+import { sendTelegramAttachments, sendTelegramReply, sendTypingIndicator } from "../../telegram/send.js";
 
 const log = getLogger("telegram-deliver");
 
@@ -35,6 +35,7 @@ export function createTelegramDeliverHandler(config: GatewayConfig) {
       assistantId?: string;
       attachments?: RuntimeAttachmentMeta[];
       approval?: ApprovalPayload;
+      chatAction?: "typing";
     };
     try {
       body = (await req.json()) as typeof body;
@@ -42,14 +43,18 @@ export function createTelegramDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "Invalid JSON" }, { status: 400 });
     }
 
-    const { chatId, text, assistantId, attachments, approval } = body;
+    const { chatId, text, assistantId, attachments, approval, chatAction } = body;
 
     if (!chatId || typeof chatId !== "string") {
       return Response.json({ error: "chatId is required" }, { status: 400 });
     }
 
-    if (!text && (!attachments || attachments.length === 0)) {
-      return Response.json({ error: "text or attachments required" }, { status: 400 });
+    if (chatAction !== undefined && chatAction !== "typing") {
+      return Response.json({ error: "chatAction must be \"typing\"" }, { status: 400 });
+    }
+
+    if (!text && (!attachments || attachments.length === 0) && !chatAction) {
+      return Response.json({ error: "text, attachments, or chatAction required" }, { status: 400 });
     }
 
     // Validate attachment array shape and element types before accessing properties.
@@ -110,6 +115,10 @@ export function createTelegramDeliverHandler(config: GatewayConfig) {
     }
 
     try {
+      if (chatAction === "typing") {
+        await sendTypingIndicator(config, chatId);
+      }
+
       if (text) {
         await sendTelegramReply(config, chatId, text, approval);
       }
@@ -122,7 +131,10 @@ export function createTelegramDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "Delivery failed" }, { status: 502 });
     }
 
-    tlog.info({ chatId, hasText: !!text, attachmentCount: attachments?.length ?? 0 }, "Reply sent");
+    tlog.info(
+      { chatId, hasText: !!text, attachmentCount: attachments?.length ?? 0, chatAction },
+      "Reply sent",
+    );
     return Response.json({ ok: true });
   };
 }

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1113,11 +1113,16 @@ export function buildSchema(): Record<string, unknown> {
           type: "object",
           required: ["chatId"],
           description:
-            "Request to deliver a message to a Telegram chat. At least one of `text` or `attachments` must be provided.",
+            "Request to deliver a message or chat action to a Telegram chat. At least one of `text`, `attachments`, or `chatAction` must be provided.",
           properties: {
             chatId: { type: "string", description: "Telegram chat ID to deliver the message to" },
             text: { type: "string", description: "Text content to send", minLength: 1 },
             assistantId: { type: "string", description: "Assistant ID (optional — attachments are downloaded via the assistant-less endpoint when omitted)" },
+            chatAction: {
+              type: "string",
+              enum: ["typing"],
+              description: "Optional Telegram chat action to emit (currently only `typing`)",
+            },
             attachments: {
               type: "array",
               description: "Attachments to deliver (images sent via sendPhoto, others via sendDocument)",
@@ -1128,6 +1133,7 @@ export function buildSchema(): Record<string, unknown> {
           anyOf: [
             { required: ["text"] },
             { required: ["attachments"] },
+            { required: ["chatAction"] },
           ],
         },
         RuntimeAttachmentMeta: {


### PR DESCRIPTION
## Summary
- add Telegram `chatAction: "typing"` support on `/deliver/telegram`
- emit a Telegram typing heartbeat while background channel processing is running
- keep channel callback payloads extensible with optional `chatAction`
- update gateway schema/docs and tests for action-only typing payloads

## Validation
- `cd gateway && bun test src/http/routes/telegram-deliver.test.ts src/__tests__/schema.test.ts`
- `cd gateway && bunx tsc --noEmit`
- `cd assistant && bunx tsc --noEmit` *(fails due to unrelated pre-existing workspace errors)*
