### PR TITLE
M2: Client History Paging + Load More Fetch

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -422,7 +422,22 @@ class IOSThreadStore: ObservableObject {
     private func handleHistoryResponse(_ response: HistoryResponseMessage) {
         guard let threadId = pendingHistoryBySessionId.removeValue(forKey: response.sessionId) else { return }
         guard let vm = viewModels[threadId] else { return }
-        vm.populateFromHistory(response.messages)
+
+        let isPaginationLoad = vm.isHistoryLoaded && vm.isLoadingMoreMessages
+
+        vm.populateFromHistory(
+            response.messages,
+            hasMore: response.hasMore,
+            oldestTimestamp: response.oldestTimestamp,
+            isPaginationLoad: isPaginationLoad
+        )
+
+        // Wire up the onLoadMoreHistory callback if not already set.
+        if vm.onLoadMoreHistory == nil {
+            vm.onLoadMoreHistory = { [weak self] sessionId, beforeTimestamp in
+                self?.requestPaginatedHistory(sessionId: sessionId, beforeTimestamp: beforeTimestamp)
+            }
+        }
     }
 
     private func handleSubagentDetailResponse(_ response: IPCSubagentDetailResponse) {
@@ -443,7 +458,28 @@ class IOSThreadStore: ObservableObject {
               !vm.isHistoryLoaded else { return }
 
         pendingHistoryBySessionId[sessionId] = threadId
-        try? daemon.sendHistoryRequest(sessionId: sessionId)
+
+        // Wire up the "load more" callback for pagination.
+        vm.onLoadMoreHistory = { [weak self] sessionId, beforeTimestamp in
+            self?.requestPaginatedHistory(sessionId: sessionId, beforeTimestamp: beforeTimestamp)
+        }
+
+        try? daemon.sendHistoryRequest(sessionId: sessionId, limit: 50, mode: "light")
+    }
+
+    /// Request an older page of history for pagination.
+    private func requestPaginatedHistory(sessionId: String, beforeTimestamp: Double) {
+        guard let daemon = daemonClient as? DaemonClient,
+              let thread = threads.first(where: { $0.sessionId == sessionId }) else { return }
+        pendingHistoryBySessionId[sessionId] = thread.id
+        do {
+            try daemon.sendHistoryRequest(sessionId: sessionId, limit: 50, beforeTimestamp: beforeTimestamp, mode: "light")
+        } catch {
+            pendingHistoryBySessionId.removeValue(forKey: sessionId)
+            if let vm = viewModels[thread.id] {
+                vm.isLoadingMoreMessages = false
+            }
+        }
     }
 
     /// Return the ChatViewModel for the given thread, creating it if necessary.
@@ -480,7 +516,7 @@ class IOSThreadStore: ObservableObject {
         vm.onReconnectHistoryNeeded = { [weak self, weak vm] sessionId in
             guard let self, let _ = vm, let daemon = self.daemonClient as? DaemonClient else { return }
             self.pendingHistoryBySessionId[sessionId] = threadId
-            try? daemon.sendHistoryRequest(sessionId: sessionId)
+            try? daemon.sendHistoryRequest(sessionId: sessionId, limit: 50, mode: "light")
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -93,8 +93,14 @@ final class ThreadSessionRestorer {
 
         pendingHistoryBySessionId[sessionId] = threadId
 
+        // Wire up the "load more" callback so the view model can request
+        // older pages through the same pending-history tracking mechanism.
+        viewModel.onLoadMoreHistory = { [weak self] sessionId, beforeTimestamp in
+            self?.requestPaginatedHistory(sessionId: sessionId, beforeTimestamp: beforeTimestamp)
+        }
+
         do {
-            try daemonClient.sendHistoryRequest(sessionId: sessionId)
+            try daemonClient.sendHistoryRequest(sessionId: sessionId, limit: 50, mode: "light")
         } catch {
             log.error("Failed to send history_request: \(error.localizedDescription)")
             pendingHistoryBySessionId.removeValue(forKey: sessionId)
@@ -109,10 +115,28 @@ final class ThreadSessionRestorer {
         guard let thread = delegate.threads.first(where: { $0.sessionId == sessionId }) else { return }
         pendingHistoryBySessionId[sessionId] = thread.id
         do {
-            try daemonClient.sendHistoryRequest(sessionId: sessionId)
+            try daemonClient.sendHistoryRequest(sessionId: sessionId, limit: 50, mode: "light")
         } catch {
             log.error("Failed to send reconnect history_request: \(error.localizedDescription)")
             pendingHistoryBySessionId.removeValue(forKey: sessionId)
+        }
+    }
+
+    /// Request an older page of history for a session. Used by the "Load more"
+    /// trigger in the message list when all locally loaded messages are visible.
+    func requestPaginatedHistory(sessionId: String, beforeTimestamp: Double) {
+        guard let delegate else { return }
+        guard let thread = delegate.threads.first(where: { $0.sessionId == sessionId }) else { return }
+        pendingHistoryBySessionId[sessionId] = thread.id
+        do {
+            try daemonClient.sendHistoryRequest(sessionId: sessionId, limit: 50, beforeTimestamp: beforeTimestamp, mode: "light")
+        } catch {
+            log.error("Failed to send paginated history_request: \(error.localizedDescription)")
+            pendingHistoryBySessionId.removeValue(forKey: sessionId)
+            // Clear the loading indicator on the view model since the request failed.
+            if let vm = delegate.existingChatViewModel(for: thread.id) {
+                vm.isLoadingMoreMessages = false
+            }
         }
     }
 
@@ -200,8 +224,28 @@ final class ThreadSessionRestorer {
     func handleHistoryResponse(_ response: HistoryResponseMessage) {
         guard let threadId = pendingHistoryBySessionId.removeValue(forKey: response.sessionId) else { return }
         guard let viewModel = delegate?.chatViewModel(for: threadId) else { return }
-        viewModel.populateFromHistory(response.messages)
-        log.info("Loaded \(response.messages.count) history messages for thread \(threadId)")
+
+        // Determine whether this is a pagination load (older page) vs an initial
+        // or reconnect load. If the view model already has history loaded and
+        // isLoadingMoreMessages is true, the response is for a "Load more" request.
+        let isPaginationLoad = viewModel.isHistoryLoaded && viewModel.isLoadingMoreMessages
+
+        viewModel.populateFromHistory(
+            response.messages,
+            hasMore: response.hasMore,
+            oldestTimestamp: response.oldestTimestamp,
+            isPaginationLoad: isPaginationLoad
+        )
+
+        // Wire up the onLoadMoreHistory callback if not already set (e.g. for
+        // reconnect-restored threads that didn't go through loadHistoryIfNeeded).
+        if viewModel.onLoadMoreHistory == nil {
+            viewModel.onLoadMoreHistory = { [weak self] sessionId, beforeTimestamp in
+                self?.requestPaginatedHistory(sessionId: sessionId, beforeTimestamp: beforeTimestamp)
+            }
+        }
+
+        log.info("Loaded \(response.messages.count) history messages for thread \(threadId) (hasMore: \(response.hasMore), isPagination: \(isPaginationLoad))")
     }
 
     func handleSessionTitleUpdated(_ response: SessionTitleUpdatedMessage) {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -394,33 +394,68 @@ public final class ChatViewModel: ObservableObject {
     /// and other UI-only messages that the view filters before rendering).
     public var displayedMessages: [ChatMessage] { messages.filter { !$0.isSubagentNotification } }
 
+    // MARK: - Daemon History Pagination
+
+    /// Timestamp of the oldest loaded message (ms since epoch). Used as the
+    /// `beforeTimestamp` cursor when fetching the next older page from the daemon.
+    public var historyCursor: Double?
+
+    /// Whether the daemon has indicated that older messages exist beyond the
+    /// currently loaded page. Falls back to `false` for older daemons that don't
+    /// send `hasMore` in the history response.
+    @Published public var hasMoreHistory: Bool = false
+
     /// Whether there are more messages above the current display window.
-    /// Compares against the filtered (displayed) count so the "load more" sentinel
-    /// appears only when there are genuinely more visible messages to reveal.
-    /// When `displayedMessageCount == Int.max` (show-all mode), this is always false.
-    public var hasMoreMessages: Bool { displayedMessageCount < displayedMessages.count }
+    /// True when either:
+    ///   1. There are locally loaded messages outside the current display suffix, OR
+    ///   2. The daemon has older pages available to fetch.
+    /// When `displayedMessageCount == Int.max` (show-all mode), only daemon pages apply.
+    public var hasMoreMessages: Bool {
+        (displayedMessageCount < displayedMessages.count) || hasMoreHistory
+    }
+
+    /// Called when `loadPreviousMessagePage` needs to fetch an older page from the
+    /// daemon. The session restorer sets this so the daemon client request is
+    /// routed through the same pending-history tracking used for initial loads.
+    public var onLoadMoreHistory: ((_ sessionId: String, _ beforeTimestamp: Double) -> Void)?
 
     /// Load the previous page of messages by expanding the display window.
-    /// Returns `true` if there were additional messages to reveal.
+    /// When all locally loaded messages are already visible and the daemon has
+    /// more history available, requests the next older page from the daemon.
+    /// Returns `true` if there were additional messages to reveal or a fetch was started.
     @discardableResult
     public func loadPreviousMessagePage() async -> Bool {
         guard hasMoreMessages, !isLoadingMoreMessages else { return false }
+
+        // If the local display window can still grow, expand it first.
+        let locallyHasMore = displayedMessageCount < displayedMessages.count
+        if locallyHasMore {
+            isLoadingMoreMessages = true
+            // Brief delay so the loading indicator is visible before the list shifts.
+            try? await Task.sleep(nanoseconds: 150_000_000)
+            let next = displayedMessageCount + Self.messagePageSize
+            let total = displayedMessages.count
+            // When all messages fit within the expanded window, switch to show-all mode
+            // (Int.max) so future incoming messages don't shrink the visible history back
+            // to a suffix window — the regression described in the parent PR.
+            displayedMessageCount = next >= total ? Int.max : next
+            isLoadingMoreMessages = false
+            return true
+        }
+
+        // All local messages are visible — fetch the next page from the daemon.
+        guard hasMoreHistory, let cursor = historyCursor, let sessionId else { return false }
         isLoadingMoreMessages = true
-        // Brief delay so the loading indicator is visible before the list shifts.
-        try? await Task.sleep(nanoseconds: 150_000_000)
-        let next = displayedMessageCount + Self.messagePageSize
-        let total = displayedMessages.count
-        // When all messages fit within the expanded window, switch to show-all mode
-        // (Int.max) so future incoming messages don't shrink the visible history back
-        // to a suffix window — the regression described in the parent PR.
-        displayedMessageCount = next >= total ? Int.max : next
-        isLoadingMoreMessages = false
+        onLoadMoreHistory?(sessionId, cursor)
+        // The loading indicator is cleared by populateFromHistory when the response arrives.
         return true
     }
 
     /// Reset pagination when the thread switches or history is reloaded.
     public func resetMessagePagination() {
         displayedMessageCount = Self.messagePageSize
+        historyCursor = nil
+        hasMoreHistory = false
     }
 
     // MARK: - Message Trimming
@@ -1666,7 +1701,22 @@ public final class ChatViewModel: ObservableObject {
     /// If the user hasn't sent any messages yet, replaces messages entirely.
     /// If the user already sent messages (late history_response), prepends
     /// history before the existing messages so the user sees full context.
-    public func populateFromHistory(_ historyMessages: [HistoryResponseMessage.HistoryMessageItem]) {
+    ///
+    /// - Parameters:
+    ///   - historyMessages: The message items from the daemon's history response.
+    ///   - hasMore: Whether the daemon has older pages available. Defaults to `false`
+    ///     for backward compatibility with older daemons that don't send this field.
+    ///   - oldestTimestamp: The timestamp of the oldest message in the response (ms since epoch).
+    ///     Used as the cursor for the next pagination request.
+    ///   - isPaginationLoad: When `true`, messages are prepended to the existing list
+    ///     (older page fetched on demand). When `false`, the standard initial-load
+    ///     or reconnect-catch-up logic applies.
+    public func populateFromHistory(
+        _ historyMessages: [HistoryResponseMessage.HistoryMessageItem],
+        hasMore: Bool = false,
+        oldestTimestamp: Double? = nil,
+        isPaginationLoad: Bool = false
+    ) {
         var chatMessages: [ChatMessage] = []
         var reconstructedSubagents: [SubagentInfo] = []
         var spawnParentMap: [String: UUID] = [:]  // subagentId → spawning assistant message UUID
@@ -1866,6 +1916,29 @@ public final class ChatViewModel: ObservableObject {
             } catch {
                 log.error("Failed to send ModelGetRequest: \(error)")
             }
+        }
+
+        // Update daemon pagination cursor from the response metadata.
+        self.hasMoreHistory = hasMore
+        self.historyCursor = oldestTimestamp
+
+        if isPaginationLoad {
+            // Older page fetched on demand — prepend before existing messages
+            // and expand the display window so the newly loaded messages are
+            // visible. The loading indicator is cleared here.
+            self.messages = chatMessages + self.messages
+            // Expand the display window by the number of messages prepended so
+            // the user sees them immediately. Use Int.max if no more pages exist.
+            if hasMore {
+                displayedMessageCount = displayedMessageCount == Int.max
+                    ? Int.max
+                    : displayedMessageCount + chatMessages.count
+            } else {
+                displayedMessageCount = Int.max
+            }
+            self.isLoadingMoreMessages = false
+            trimOldMessagesIfNeeded()
+            return
         }
 
         self.isLoadingHistory = true

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -961,8 +961,13 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     }
 
     /// Request message history for a specific session.
-    public func sendHistoryRequest(sessionId: String) throws {
-        try send(HistoryRequestMessage(sessionId: sessionId))
+    /// - Parameters:
+    ///   - sessionId: The session to fetch history for.
+    ///   - limit: Max messages to return per page.
+    ///   - beforeTimestamp: Pagination cursor — only return messages before this timestamp (ms since epoch).
+    ///   - mode: `"light"` omits heavy payloads (attachments, tool images, surface data); `"full"` includes everything.
+    public func sendHistoryRequest(sessionId: String, limit: Int? = nil, beforeTimestamp: Double? = nil, mode: String? = nil) throws {
+        try send(HistoryRequestMessage(sessionId: sessionId, limit: limit, beforeTimestamp: beforeTimestamp, mode: mode))
     }
 
     // MARK: - Apps

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -488,7 +488,8 @@ final class HTTPTransport {
                     let historyPayload: [String: Any] = [
                         "type": "history_response",
                         "sessionId": sessionId,
-                        "messages": transformed
+                        "messages": transformed,
+                        "hasMore": false
                     ]
 
                     let historyData = try JSONSerialization.data(withJSONObject: historyPayload)

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -553,8 +553,14 @@ extension IPCRegenerateRequest {
 public typealias HistoryRequestMessage = IPCHistoryRequest
 
 extension IPCHistoryRequest {
-    public init(sessionId: String) {
-        self.init(type: "history_request", sessionId: sessionId)
+    public init(sessionId: String, limit: Int? = nil, beforeTimestamp: Double? = nil, mode: String? = nil) {
+        self.init(
+            type: "history_request",
+            sessionId: sessionId,
+            limit: limit.map { Double($0) },
+            beforeTimestamp: beforeTimestamp,
+            mode: mode
+        )
     }
 }
 


### PR DESCRIPTION
Part of #9219.

## Summary
Wires up the client (macOS and iOS) to use the daemon's new history pagination API (M1: #9227). Initial history loads request only the most recent 50 messages in light mode, and "Load more" triggers a daemon fetch for older pages instead of just revealing already-loaded messages.

## Implementation

### DaemonClient & IPC Messages
- `sendHistoryRequest` now accepts `limit`, `beforeTimestamp`, and `mode` parameters
- `IPCHistoryRequest` convenience init passes these through to the generated type
- All history request call sites now default to `limit: 50, mode: "light"`

### ChatViewModel Pagination State
- Added `historyCursor: Double?` — timestamp of oldest loaded message, used as `beforeTimestamp` for next page
- Added `hasMoreHistory: Bool` — whether daemon indicated older pages exist
- Added `onLoadMoreHistory` callback — session restorer wires this for daemon fetch routing
- `hasMoreMessages` now checks both local suffix window AND daemon pages
- `loadPreviousMessagePage()` first expands the local display window; when exhausted, fetches from daemon
- `resetMessagePagination()` clears cursor and hasMoreHistory

### populateFromHistory Updates
- Accepts `hasMore`, `oldestTimestamp`, and `isPaginationLoad` parameters (all default for backward compat)
- When `isPaginationLoad` is true, prepends messages and expands display window
- When `isPaginationLoad` is false, existing initial-load and reconnect logic is unchanged

### macOS ThreadSessionRestorer
- `loadHistoryIfNeeded` sends `limit: 50, mode: "light"` and wires `onLoadMoreHistory`
- `requestReconnectHistory` also uses paginated params
- New `requestPaginatedHistory` method for "Load more" fetches with `beforeTimestamp`
- `handleHistoryResponse` detects pagination loads and passes metadata to `populateFromHistory`

### iOS IOSThreadStore
- Mirror changes from macOS: paginated initial loads, reconnect, and load-more support
- `requestPaginatedHistory` added for daemon fetch routing

### HTTPTransport
- Includes `hasMore: false` in synthetic history response to satisfy non-optional field

## Key Design Choices
- **Two-phase pagination**: Local suffix window expansion (cheap) before daemon fetch (network). This preserves the existing smooth UX for conversations that fit in one page.
- **Callback-based fetch routing**: `onLoadMoreHistory` lets the session restorer route daemon requests through the same `pendingHistoryBySessionId` tracking used for initial loads, avoiding duplicate response routing.
- **Backward compatibility**: All new parameters have defaults. Test call sites (`populateFromHistory(items)`) compile unchanged.

## Files Changed
- `clients/shared/IPC/IPCMessages.swift` — Updated `IPCHistoryRequest` convenience init
- `clients/shared/IPC/DaemonClient.swift` — Updated `sendHistoryRequest` signature
- `clients/shared/IPC/HTTPDaemonClient.swift` — Added `hasMore` to synthetic response
- `clients/shared/Features/Chat/ChatViewModel.swift` — Pagination state + daemon fetch logic
- `clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift` — Paginated loads
- `clients/ios/App/IOSThreadStore.swift` — Paginated loads (iOS mirror)

## Testing
- Verify initial history load only fetches 50 messages
- Scroll to top of a long conversation and verify "Load more" sentinel triggers daemon fetch
- Verify older messages appear prepended above existing ones
- Verify pagination stops when `hasMore` is false
- Verify reconnect catch-up still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
