### PR TITLE
fix: add missing hasMore to IPC snapshot test

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -873,6 +873,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   history_response: {
     type: 'history_response',
     sessionId: 'sess-history-001',
+    hasMore: false,
     messages: [
       { role: 'user', text: 'Hello', timestamp: 1700000000 },
       {


### PR DESCRIPTION
## Summary

- Add missing `hasMore` property to `history_response` fixture in `ipc-snapshot.test.ts`
- The `HistoryResponse` type now requires `hasMore` (added in #9227), but the snapshot test was not updated

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22420661487

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
