### PR TITLE
M2: Code Model + Cooldown + API Surface

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -522,11 +522,13 @@ function handleStartOutboundTelegram(
 
     const telegramBootstrapUrl = `https://t.me/${botUsername}?start=gv_${bootstrapToken}`;
 
+    // Do not expose the secret in the pending_bootstrap response — the
+    // verification code must not be revealed until identity is bound
+    // through the deep-link bootstrap flow.
     ctx.send(socket, {
       type: 'guardian_verification_response',
       success: true,
       verificationSessionId: sessionResult.sessionId,
-      secret: sessionResult.secret,
       expiresAt: sessionResult.expiresAt,
       telegramBootstrapUrl,
       channel,

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -44,8 +44,8 @@ export type GuardianVerificationResult = Omit<GuardianVerificationResponse, 'typ
 /** Maximum SMS sends per verification session. */
 export const MAX_SENDS_PER_SESSION = 5;
 
-/** Cooldown between resends in milliseconds (60 seconds). */
-export const RESEND_COOLDOWN_MS = 60_000;
+/** Cooldown between resends in milliseconds (15 seconds). */
+export const RESEND_COOLDOWN_MS = 15_000;
 
 /** Maximum sends per destination within a rolling window. */
 export const MAX_SENDS_PER_DESTINATION_WINDOW = 10;
@@ -526,6 +526,7 @@ function handleStartOutboundTelegram(
       type: 'guardian_verification_response',
       success: true,
       verificationSessionId: sessionResult.sessionId,
+      secret: sessionResult.secret,
       expiresAt: sessionResult.expiresAt,
       telegramBootstrapUrl,
       channel,
@@ -737,6 +738,7 @@ function handleResendOutbound(
       type: 'guardian_verification_response',
       success: true,
       verificationSessionId: newSession.sessionId,
+      secret: newSession.secret,
       nextResendAt,
       sendCount: newSendCount,
       channel,
@@ -797,6 +799,7 @@ function handleResendOutbound(
       type: 'guardian_verification_response',
       success: true,
       verificationSessionId: newSession.sessionId,
+      secret: newSession.secret,
       nextResendAt,
       sendCount: newSendCount,
       channel,

--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -373,8 +373,8 @@ export interface CreateOutboundSessionResult {
  * Create an outbound verification session with expected identity pre-set.
  * Returns session info including the secret for outbound delivery.
  *
- * For voice channels, generates a numeric code with the specified digit count.
- * For text channels (SMS, Telegram), generates a hex secret.
+ * All outbound channels (SMS, Telegram, voice) use 6-digit numeric codes
+ * for consistency and ease of entry.
  */
 export function createOutboundSession(params: {
   assistantId: string;
@@ -389,8 +389,7 @@ export function createOutboundSession(params: {
   sessionId?: string;
   bootstrapTokenHash?: string;
 }): CreateOutboundSessionResult {
-  const isVoice = params.channel === 'voice';
-  const secret = isVoice ? generateVoiceSecret(params.codeDigits ?? 6) : randomBytes(32).toString('hex');
+  const secret = generateVoiceSecret(params.codeDigits ?? 6);
   const challengeHash = hashSecret(secret);
   const sessionId = params.sessionId ?? uuid();
   const expiresAt = Date.now() + CHALLENGE_TTL_MS;

--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -373,8 +373,11 @@ export interface CreateOutboundSessionResult {
  * Create an outbound verification session with expected identity pre-set.
  * Returns session info including the secret for outbound delivery.
  *
- * All outbound channels (SMS, Telegram, voice) use 6-digit numeric codes
- * for consistency and ease of entry.
+ * Channels where identity is pre-bound (SMS, voice, Telegram with known
+ * chat ID) use 6-digit numeric codes for ease of entry. Unbound bootstrap
+ * sessions (e.g. Telegram handle where identity is not yet known) use
+ * high-entropy 32-byte hex secrets to prevent brute-force guessing during
+ * the TTL window.
  */
 export function createOutboundSession(params: {
   assistantId: string;
@@ -389,7 +392,12 @@ export function createOutboundSession(params: {
   sessionId?: string;
   bootstrapTokenHash?: string;
 }): CreateOutboundSessionResult {
-  const secret = generateVoiceSecret(params.codeDigits ?? 6);
+  // Use high-entropy hex for unbound bootstrap sessions to prevent brute-force;
+  // 6-digit numeric codes are only safe when identity is already bound.
+  const isUnbound = params.identityBindingStatus === 'pending_bootstrap';
+  const secret = isUnbound
+    ? randomBytes(32).toString('hex')
+    : generateVoiceSecret(params.codeDigits ?? 6);
   const challengeHash = hashSecret(secret);
   const sessionId = params.sessionId ?? uuid();
   const expiresAt = Date.now() + CHALLENGE_TTL_MS;

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -38,6 +38,7 @@ import {
   updateSessionStatus,
   updateSessionDelivery,
 } from '../channel-guardian-service.js';
+import { RESEND_COOLDOWN_MS } from '../../daemon/handlers/config-channels.js';
 import { deliverChannelReply } from '../gateway-client.js';
 import {
   composeChannelVerifyReply,
@@ -564,7 +565,7 @@ export async function handleChannelInbound(
 
       // Update delivery tracking
       const now = Date.now();
-      updateSessionDelivery(newSession.sessionId, now, 1, now + 60_000);
+      updateSessionDelivery(newSession.sessionId, now, 1, now + RESEND_COOLDOWN_MS);
 
       return Response.json({
         accepted: true,


### PR DESCRIPTION
Part of #9213. Sets resend cooldown to 15s, ensures 6-digit numeric codes for all outbound channels, and ensures secret is returned in all outbound start and resend responses. Closes #9215.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
