### PR TITLE
feat(macos): add inline expansion for heartbeat run summaries

### DIFF
--- a/assistant/src/daemon/handlers/config-heartbeat.ts
+++ b/assistant/src/daemon/handlers/config-heartbeat.ts
@@ -120,6 +120,7 @@ export function handleHeartbeatRunsList(
     const runs = bgConversations.map((conv) => {
       // Try to determine result from the last message
       let result = 'unknown';
+      let summary = '';
       try {
         const messages = conversationStore.getMessages(conv.id);
         const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant');
@@ -127,6 +128,11 @@ export function handleHeartbeatRunsList(
           const content = typeof lastAssistant.content === 'string' ? lastAssistant.content : '';
           if (content.includes('HEARTBEAT_OK')) result = 'ok';
           else if (content.includes('HEARTBEAT_ALERT')) result = 'alert';
+          // Strip the HEARTBEAT_OK / HEARTBEAT_ALERT marker to get the summary
+          summary = content
+            .replace(/HEARTBEAT_OK\s*/g, '')
+            .replace(/HEARTBEAT_ALERT\s*/g, '')
+            .trim();
         }
       } catch {
         // Ignore message read errors
@@ -136,6 +142,7 @@ export function handleHeartbeatRunsList(
         title: conv.title ?? 'Heartbeat',
         createdAt: conv.createdAt,
         result,
+        summary,
       };
     });
 

--- a/assistant/src/daemon/ipc-contract/schedules.ts
+++ b/assistant/src/daemon/ipc-contract/schedules.ts
@@ -116,7 +116,7 @@ export interface HeartbeatRunsListResponse {
     title: string;
     createdAt: number;
     result: string;
-    summary: string;
+    summary?: string;
   }>;
 }
 

--- a/assistant/src/daemon/ipc-contract/schedules.ts
+++ b/assistant/src/daemon/ipc-contract/schedules.ts
@@ -116,6 +116,7 @@ export interface HeartbeatRunsListResponse {
     title: string;
     createdAt: number;
     result: string;
+    summary: string;
   }>;
 }
 

--- a/clients/macos/vellum-assistant/Features/Settings/HeartbeatSettingsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/HeartbeatSettingsTab.swift
@@ -24,6 +24,9 @@ struct HeartbeatSettingsTab: View {
     @State private var isRunning: Bool = false
     @State private var runError: String?
 
+    // -- Expansion state --
+    @State private var expandedRunId: String?
+
     // -- Loading --
     @State private var isLoading: Bool = true
     @State private var isUpdatingFromServer: Bool = false
@@ -266,20 +269,49 @@ struct HeartbeatSettingsTab: View {
                     .padding(.vertical, VSpacing.lg)
             } else {
                 ForEach(runs, id: \.id) { run in
-                    HStack(spacing: VSpacing.md) {
-                        resultBadge(run.result)
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(run.title)
-                                .font(VFont.body)
-                                .foregroundColor(VColor.textPrimary)
-                                .lineLimit(1)
-                            Text(formatTimestamp(run.createdAt))
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textMuted)
+                    Button {
+                        withAnimation(VAnimation.fast) {
+                            expandedRunId = expandedRunId == run.id ? nil : run.id
                         }
-                        Spacer()
+                    } label: {
+                        VStack(alignment: .leading, spacing: 0) {
+                            HStack(spacing: VSpacing.md) {
+                                resultBadge(run.result)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(run.title)
+                                        .font(VFont.body)
+                                        .foregroundColor(VColor.textPrimary)
+                                        .lineLimit(1)
+                                    Text(formatTimestamp(run.createdAt))
+                                        .font(VFont.caption)
+                                        .foregroundColor(VColor.textMuted)
+                                }
+                                Spacer()
+                                Image(systemName: expandedRunId == run.id ? "chevron.down" : "chevron.right")
+                                    .font(.system(size: 10, weight: .semibold))
+                                    .foregroundColor(VColor.textMuted)
+                            }
+                            .padding(VSpacing.sm)
+
+                            if expandedRunId == run.id {
+                                Text(run.summary)
+                                    .font(VFont.mono)
+                                    .foregroundColor(VColor.textSecondary)
+                                    .textSelection(.enabled)
+                                    .padding(VSpacing.sm)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .background(VColor.surface)
+                                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: VRadius.md)
+                                            .stroke(VColor.surfaceBorder, lineWidth: 1)
+                                    )
+                                    .padding(.horizontal, VSpacing.sm)
+                                    .padding(.bottom, VSpacing.sm)
+                            }
+                        }
                     }
-                    .padding(VSpacing.sm)
+                    .buttonStyle(.plain)
 
                     if run.id != runs.last?.id {
                         Divider().background(VColor.surfaceBorder)

--- a/clients/macos/vellum-assistant/Features/Settings/HeartbeatSettingsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/HeartbeatSettingsTab.swift
@@ -294,7 +294,7 @@ struct HeartbeatSettingsTab: View {
                             .padding(VSpacing.sm)
 
                             if expandedRunId == run.id {
-                                Text(run.summary)
+                                Text(run.summary ?? "No summary available")
                                     .font(VFont.mono)
                                     .foregroundColor(VColor.textSecondary)
                                     .textSelection(.enabled)

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1928,9 +1928,9 @@ public struct IPCHeartbeatRunsListResponseRun: Codable, Sendable {
     public let title: String
     public let createdAt: Int
     public let result: String
-    public let summary: String
+    public let summary: String?
 
-    public init(id: String, title: String, createdAt: Int, result: String, summary: String) {
+    public init(id: String, title: String, createdAt: Int, result: String, summary: String? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1928,12 +1928,14 @@ public struct IPCHeartbeatRunsListResponseRun: Codable, Sendable {
     public let title: String
     public let createdAt: Int
     public let result: String
+    public let summary: String
 
-    public init(id: String, title: String, createdAt: Int, result: String) {
+    public init(id: String, title: String, createdAt: Int, result: String, summary: String) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
         self.result = result
+        self.summary = summary
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds a `summary` field to the heartbeat runs IPC response, stripping HEARTBEAT_OK/HEARTBEAT_ALERT markers from the assistant's last message
- Makes heartbeat run rows tappable in Settings — clicking expands inline to show the full summary text
- Clicking again (or a different run) collapses the expansion

## Test plan
- [ ] Restart daemon, open Settings → Heartbeat tab
- [ ] Click a run row → expands showing summary text with chevron rotating down
- [ ] Click again → collapses
- [ ] Click a different run → previous collapses, new one expands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
