### PR TITLE
fix: display fractional-hour heartbeat intervals correctly

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/HeartbeatSettingsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/HeartbeatSettingsTab.swift
@@ -260,7 +260,11 @@ struct HeartbeatSettingsTab: View {
             return "\(minutes) min"
         }
         let hours = minutes / 60
-        return hours == 1 ? "1 hour" : "\(hours) hours"
+        let remainingMinutes = minutes % 60
+        if remainingMinutes == 0 {
+            return hours == 1 ? "1 hour" : "\(hours) hours"
+        }
+        return "\(hours)h \(remainingMinutes)m"
     }
 
     private func formatHour(_ hour: Int) -> String {


### PR DESCRIPTION
## Summary
- Fix `formatInterval` to handle non-whole-hour values (e.g., 90 min was truncated to "1 hour", now shows "1h 30m")
- Whole-hour values still display cleanly ("1 hour", "2 hours")

## Original prompt
Addresses review feedback from #9239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
