### PR TITLE
fix(macos): auto-check gateway and tunnel status on Connect page load

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -78,6 +78,8 @@ struct SettingsConnectTab: View {
             store.refreshChannelGuardianStatus(channel: "sms")
             store.refreshChannelGuardianStatus(channel: "voice")
             gatewayExpanded = store.ingressPublicBaseUrl.isEmpty
+            Task { await store.testGatewayOnly() }
+            Task { await store.testTunnelOnly() }
         }
         .onChange(of: store.ingressPublicBaseUrl) { _, newValue in
             if !isGatewayUrlFocused {


### PR DESCRIPTION
## Summary
- Add `testGatewayOnly()` and `testTunnelOnly()` calls to the Connect tab's `onAppear` block
- Gateway and Tunnel status rows now auto-check on mount instead of showing "Unknown" until manual refresh
- Refresh buttons still work for re-checking on demand

## Original prompt
Within the past 24 hrs I merged a PR that changes how our diagnostic checks worked for Gateway and Tunnel and Target on the Connect page. Now, they always show "Unknown". Help me make the diagnostic status check a better user experience. It should auto check the status on component mount and have a refresh button to refetch status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
