### PR TITLE
fix(macos): remove if-let on non-optional tc.input

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1741,20 +1741,19 @@ public final class ChatViewModel: ObservableObject {
                     // when the user expands the tool call chip. Cap the raw dict size
                     // to prevent unbounded memory from large tool inputs (mirrors the
                     // 10k-char cap applied in formatAllToolInput).
-                    if let input = tc.input {
-                        let estimatedSize: Int
-                        if let data = try? JSONSerialization.data(withJSONObject: input.mapValues { $0.value ?? NSNull() }) {
-                            estimatedSize = data.count
-                        } else {
-                            estimatedSize = 0
-                        }
-                        if estimatedSize > 10_000 {
-                            // Too large — format eagerly (with truncation) rather than
-                            // retaining the full raw dictionary in memory.
-                            toolCall.inputFull = ToolCallData.formatAllToolInput(input)
-                        } else {
-                            toolCall.inputRawDict = input
-                        }
+                    let input = tc.input
+                    let estimatedSize: Int
+                    if let data = try? JSONSerialization.data(withJSONObject: input.mapValues { $0.value ?? NSNull() }) {
+                        estimatedSize = data.count
+                    } else {
+                        estimatedSize = 0
+                    }
+                    if estimatedSize > 10_000 {
+                        // Too large — format eagerly (with truncation) rather than
+                        // retaining the full raw dictionary in memory.
+                        toolCall.inputFull = ToolCallData.formatAllToolInput(input)
+                    } else {
+                        toolCall.inputRawDict = input
                     }
                     return toolCall
                 }


### PR DESCRIPTION
## Summary
- `IPCHistoryResponseToolCall.input` was changed to non-optional `[String: AnyCodable]`, but `ChatViewModel` still used `if let` binding on it, causing a Swift compilation error
- Removed the unnecessary optional binding so the build succeeds again

## Test plan
- [x] `./build.sh run` in `clients/macos` compiles and launches successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
