### PR TITLE
M3: macOS UX: Code Visibility + Telegram Input Guidance

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -45,6 +45,9 @@ struct SettingsConnectTab: View {
     // Outbound guardian verification destination input (keyed by channel)
     @State private var guardianDestinationText: [String: String] = [:]
 
+    // Outbound verification code copy state (tracks which channel's code was just copied)
+    @State private var outboundCodeCopiedChannel: String?
+
     // Countdown timer for outbound verification expiry (ref-counted so
     // closing one channel row doesn't stop the timer for remaining rows)
     @State private var countdownNow: Date = Date()
@@ -1069,6 +1072,14 @@ struct SettingsConnectTab: View {
             }
         }()
         let bootstrapUrl: String? = channel == "telegram" ? store.telegramBootstrapUrl : nil
+        let outboundCode: String? = {
+            switch channel {
+            case "telegram": return store.telegramOutboundCode
+            case "sms": return store.smsOutboundCode
+            case "voice": return store.voiceOutboundCode
+            default: return nil
+            }
+        }()
         let primaryIdentity = guardianPrimaryIdentity(channel: channel, identity: identity)
         let secondaryIdentity = guardianSecondaryIdentity(primary: primaryIdentity, identity: identity)
         let telegramProfileURL: URL? = channel == "telegram"
@@ -1132,7 +1143,8 @@ struct SettingsConnectTab: View {
                     expiresAt: outboundExpiresAt,
                     nextResendAt: outboundNextResendAt,
                     sendCount: outboundSendCount,
-                    bootstrapUrl: bootstrapUrl
+                    bootstrapUrl: bootstrapUrl,
+                    outboundCode: outboundCode
                 )
             } else if let instruction {
                 guardianInstructionView(channel: channel, instruction: instruction)
@@ -1185,18 +1197,44 @@ struct SettingsConnectTab: View {
                     .lineLimit(1)
             }
 
-            HStack(spacing: VSpacing.sm) {
-                TextField(placeholder, text: destinationBinding)
-                    .font(VFont.body)
-                    .textFieldStyle(.roundedBorder)
-                    .frame(maxWidth: 200)
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                HStack(spacing: VSpacing.sm) {
+                    TextField(placeholder, text: destinationBinding)
+                        .font(VFont.body)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: 200)
 
-                VButton(label: "Send verification", style: .secondary) {
-                    store.startOutboundGuardianVerification(channel: channel, destination: destination)
+                    VButton(label: "Send verification", style: .secondary) {
+                        store.startOutboundGuardianVerification(channel: channel, destination: destination)
+                    }
+                    .disabled(destination.isEmpty)
+
+                    Spacer()
                 }
-                .disabled(destination.isEmpty)
 
-                Spacer()
+                if channel == "telegram" {
+                    Text("Enter a Telegram @username (e.g. @janedoe) or numeric chat ID for the guardian.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+
+                    Button {
+                        if let url = URL(string: "https://web.telegram.org/k/#@userinfobot") {
+                            NSWorkspace.shared.open(url)
+                        }
+                    } label: {
+                        HStack(spacing: VSpacing.xs) {
+                            Image(systemName: "questionmark.circle")
+                                .font(.system(size: 11))
+                            Text("Find your Telegram username or chat ID")
+                                .font(VFont.caption)
+                        }
+                        .foregroundColor(VColor.accent)
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { hovering in
+                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                    }
+                }
             }
             .padding(.leading, 90 + VSpacing.sm)
         }
@@ -1210,8 +1248,11 @@ struct SettingsConnectTab: View {
         expiresAt: Date?,
         nextResendAt: Date?,
         sendCount: Int,
-        bootstrapUrl: String?
+        bootstrapUrl: String?,
+        outboundCode: String?
     ) -> some View {
+        let isCodeCopied = outboundCodeCopiedChannel == channel
+
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             HStack(spacing: VSpacing.sm) {
                 guardianLabel
@@ -1228,6 +1269,55 @@ struct SettingsConnectTab: View {
             }
 
             VStack(alignment: .leading, spacing: VSpacing.xs) {
+                // Verification code display
+                if let outboundCode {
+                    Text("Your verification code:")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+
+                    HStack(spacing: VSpacing.sm) {
+                        Text(outboundCode)
+                            .font(VFont.mono)
+                            .foregroundColor(VColor.textPrimary)
+                            .textSelection(.enabled)
+                            .lineLimit(1)
+
+                        Spacer()
+
+                        Button {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(outboundCode, forType: .string)
+                            outboundCodeCopiedChannel = channel
+                            Task {
+                                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                                if outboundCodeCopiedChannel == channel {
+                                    outboundCodeCopiedChannel = nil
+                                }
+                            }
+                        } label: {
+                            HStack(spacing: VSpacing.xs) {
+                                Image(systemName: isCodeCopied ? "checkmark" : "doc.on.doc")
+                                    .font(.system(size: 12, weight: .medium))
+                                Text(isCodeCopied ? "Copied" : "Copy")
+                                    .font(VFont.caption)
+                            }
+                            .foregroundColor(isCodeCopied ? VColor.success : VColor.textSecondary)
+                            .frame(height: 28)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Copy verification code")
+                        .help("Copy code")
+                    }
+                    .padding(VSpacing.md)
+                    .background(VColor.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                    )
+                }
+
                 // Countdown to expiry
                 if let expiresAt {
                     let remaining = expiresAt.timeIntervalSince(countdownNow)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1260,6 +1260,7 @@ public final class SettingsStore: ObservableObject {
             if sessionId != telegramOutboundSessionId {
                 telegramOutboundNextResendAt = nil
                 telegramOutboundSendCount = 0
+                telegramOutboundCode = nil
             }
             telegramOutboundSessionId = sessionId
             if let expiresAt { telegramOutboundExpiresAt = expiresAt }
@@ -1281,6 +1282,7 @@ public final class SettingsStore: ObservableObject {
             if sessionId != smsOutboundSessionId {
                 smsOutboundNextResendAt = nil
                 smsOutboundSendCount = 0
+                smsOutboundCode = nil
             }
             smsOutboundSessionId = sessionId
             if let expiresAt { smsOutboundExpiresAt = expiresAt }
@@ -1291,6 +1293,7 @@ public final class SettingsStore: ObservableObject {
             if sessionId != voiceOutboundSessionId {
                 voiceOutboundNextResendAt = nil
                 voiceOutboundSendCount = 0
+                voiceOutboundCode = nil
             }
             voiceOutboundSessionId = sessionId
             if let expiresAt { voiceOutboundExpiresAt = expiresAt }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -137,6 +137,7 @@ public final class SettingsStore: ObservableObject {
     @Published var telegramOutboundNextResendAt: Date?
     @Published var telegramOutboundSendCount: Int = 0
     @Published var telegramBootstrapUrl: String?
+    @Published var telegramOutboundCode: String?
 
     // MARK: - Outbound Guardian Session State (SMS)
 
@@ -144,6 +145,7 @@ public final class SettingsStore: ObservableObject {
     @Published var smsOutboundExpiresAt: Date?
     @Published var smsOutboundNextResendAt: Date?
     @Published var smsOutboundSendCount: Int = 0
+    @Published var smsOutboundCode: String?
 
     // MARK: - Outbound Guardian Session State (Voice)
 
@@ -151,6 +153,7 @@ public final class SettingsStore: ObservableObject {
     @Published var voiceOutboundExpiresAt: Date?
     @Published var voiceOutboundNextResendAt: Date?
     @Published var voiceOutboundSendCount: Int = 0
+    @Published var voiceOutboundCode: String?
 
     // MARK: - Email Integration State
 
@@ -1219,16 +1222,19 @@ public final class SettingsStore: ObservableObject {
             telegramOutboundNextResendAt = nil
             telegramOutboundSendCount = 0
             telegramBootstrapUrl = nil
+            telegramOutboundCode = nil
         case "sms":
             smsOutboundSessionId = nil
             smsOutboundExpiresAt = nil
             smsOutboundNextResendAt = nil
             smsOutboundSendCount = 0
+            smsOutboundCode = nil
         case "voice":
             voiceOutboundSessionId = nil
             voiceOutboundExpiresAt = nil
             voiceOutboundNextResendAt = nil
             voiceOutboundSendCount = 0
+            voiceOutboundCode = nil
         default:
             break
         }
@@ -1243,6 +1249,9 @@ public final class SettingsStore: ObservableObject {
         let nextResendAt = response.nextResendAt.map { Date(timeIntervalSince1970: TimeInterval($0) / 1000.0) }
         let sendCount = response.sendCount
         let bootstrapUrl = response.telegramBootstrapUrl
+        // The secret is returned on start/resend but not on status polls.
+        // Persist it so the UI can display the verification code.
+        let secret = response.secret
 
         switch channel {
         case "telegram":
@@ -1256,6 +1265,7 @@ public final class SettingsStore: ObservableObject {
             if let expiresAt { telegramOutboundExpiresAt = expiresAt }
             if let nextResendAt { telegramOutboundNextResendAt = nextResendAt }
             if let sendCount { telegramOutboundSendCount = sendCount }
+            if let secret { telegramOutboundCode = secret }
             if let bootstrapUrl {
                 telegramBootstrapUrl = bootstrapUrl
             } else if response.pendingBootstrap == true {
@@ -1276,6 +1286,7 @@ public final class SettingsStore: ObservableObject {
             if let expiresAt { smsOutboundExpiresAt = expiresAt }
             if let nextResendAt { smsOutboundNextResendAt = nextResendAt }
             if let sendCount { smsOutboundSendCount = sendCount }
+            if let secret { smsOutboundCode = secret }
         case "voice":
             if sessionId != voiceOutboundSessionId {
                 voiceOutboundNextResendAt = nil
@@ -1285,6 +1296,7 @@ public final class SettingsStore: ObservableObject {
             if let expiresAt { voiceOutboundExpiresAt = expiresAt }
             if let nextResendAt { voiceOutboundNextResendAt = nextResendAt }
             if let sendCount { voiceOutboundSendCount = sendCount }
+            if let secret { voiceOutboundCode = secret }
         default:
             break
         }


### PR DESCRIPTION
Part of #9213. Shows the verification code in the macOS settings UI immediately after send/resend. Adds copy affordance for the code. Improves Telegram destination input with helper text and discovery link. Closes #9216.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
