### PR TITLE
fix: show fallback text for empty heartbeat run summaries

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/HeartbeatSettingsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/HeartbeatSettingsTab.swift
@@ -223,7 +223,7 @@ struct HeartbeatSettingsTab: View {
                             .padding(VSpacing.sm)
 
                             if expandedRunId == run.id {
-                                Text(run.summary ?? "No summary available")
+                                Text(run.summary?.isEmpty == false ? run.summary! : "No summary available")
                                     .font(VFont.mono)
                                     .foregroundColor(VColor.textSecondary)
                                     .textSelection(.enabled)


### PR DESCRIPTION
## Summary
- Handle empty string summaries alongside nil — server sends `""` when the assistant responded with just a marker like `HEARTBEAT_OK`
- Without this, the expanded area shows blank text instead of "No summary available"

## Original prompt
Addresses review feedback from #9248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
