### PR TITLE
fix: extract only last text block for heartbeat run summary

### DIFF
--- a/assistant/src/daemon/handlers/config-heartbeat.ts
+++ b/assistant/src/daemon/handlers/config-heartbeat.ts
@@ -125,11 +125,33 @@ export function handleHeartbeatRunsList(
         const messages = conversationStore.getMessages(conv.id);
         const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant');
         if (lastAssistant) {
-          const content = typeof lastAssistant.content === 'string' ? lastAssistant.content : '';
-          if (content.includes('HEARTBEAT_OK')) result = 'ok';
-          else if (content.includes('HEARTBEAT_ALERT')) result = 'alert';
-          // Strip the HEARTBEAT_OK / HEARTBEAT_ALERT marker to get the summary
-          summary = content
+          const raw = lastAssistant.content;
+          // Content may be a plain string or a JSON-stringified array of content blocks
+          let fullText = '';
+          let lastText = '';
+          if (typeof raw === 'string') {
+            try {
+              const blocks = JSON.parse(raw) as Array<{ type: string; text?: string }>;
+              if (Array.isArray(blocks)) {
+                for (const block of blocks) {
+                  if (block.type === 'text' && block.text) {
+                    fullText += block.text;
+                    lastText = block.text;
+                  }
+                }
+              } else {
+                fullText = raw;
+                lastText = raw;
+              }
+            } catch {
+              fullText = raw;
+              lastText = raw;
+            }
+          }
+          if (fullText.includes('HEARTBEAT_OK')) result = 'ok';
+          else if (fullText.includes('HEARTBEAT_ALERT')) result = 'alert';
+          // Use only the last text block, stripped of the status marker
+          summary = lastText
             .replace(/HEARTBEAT_OK\s*/g, '')
             .replace(/HEARTBEAT_ALERT\s*/g, '')
             .trim();


### PR DESCRIPTION
## Summary
- Parses the JSON-stringified content block array in assistant messages instead of using the raw string
- Uses only the last `text` block for the summary, filtering out tool_use and earlier text blocks
- Follows up on #9248 which added inline expansion for heartbeat runs

## Test plan
- [ ] Restart daemon, open Settings → Heartbeat → click a run
- [ ] Summary should show only the final text response, not tool call content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
