### PR TITLE
fix(macos): replace message action popup menu with inline buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -241,30 +241,35 @@ struct ChatBubble: View {
     }
 
     private var overflowMenuButton: some View {
-        Menu {
+        HStack(spacing: 2) {
             if hasCopyableText {
-                Button("Copy message") {
+                Button {
                     copyMessageText()
+                } label: {
+                    Image(systemName: showCopyConfirmation ? "checkmark" : "doc.on.doc")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(showCopyConfirmation ? VColor.success : VColor.textMuted)
+                        .frame(width: 24, height: 24)
+                        .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
+                .accessibilityLabel(showCopyConfirmation ? "Copied" : "Copy message")
+                .animation(VAnimation.fast, value: showCopyConfirmation)
             }
             if let onReportMessage, !isUser {
-                Button("Export response for diagnostics") {
+                Button {
                     onReportMessage(message.daemonMessageId)
+                } label: {
+                    Image(systemName: "ladybug")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(VColor.textMuted)
+                        .frame(width: 24, height: 24)
+                        .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Report message")
             }
-        } label: {
-            Image(systemName: showCopyConfirmation ? "checkmark" : "ellipsis")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(showCopyConfirmation ? VColor.success : VColor.textMuted)
-                .frame(width: 24, height: 24)
-                .contentShape(Rectangle())
         }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        .tint(showCopyConfirmation ? VColor.success : VColor.textMuted)
-        .frame(width: 24, height: 24)
-        .accessibilityLabel("Message actions")
-        .animation(VAnimation.fast, value: showCopyConfirmation)
     }
 
     // MARK: - Bubble Content


### PR DESCRIPTION
## Summary
Replace the "..." overflow menu dropdown on chat message bubbles with direct inline icon buttons that appear on hover.

**Before:** Clicking "..." opened a `Menu` dropdown with "Copy message" and "Export response for diagnostics" options.

**After:** Two small icon buttons appear directly on hover:
- **Copy** (`doc.on.doc` icon) — copies message text, shows checkmark confirmation for 1.5s
- **Bug report** (`ladybug` icon) — triggers diagnostic export directly on click

This removes the popup interaction entirely, making both actions single-click.

## Files Changed
- `clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift` — replaced `Menu` with `HStack` of plain `Button`s

## Testing
- Hover over any assistant message — copy and bug icons appear
- Click copy — checkmark confirmation shows for 1.5s
- Click ladybug — diagnostic export triggers
- Hover over user messages — only copy icon appears (no bug icon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
