### PR TITLE
fix(macos): make entire heartbeat run row tappable

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/HeartbeatSettingsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/HeartbeatSettingsTab.swift
@@ -198,49 +198,48 @@ struct HeartbeatSettingsTab: View {
                     .padding(.vertical, VSpacing.lg)
             } else {
                 ForEach(runs, id: \.id) { run in
-                    Button {
-                        withAnimation(VAnimation.fast) {
-                            expandedRunId = expandedRunId == run.id ? nil : run.id
-                        }
-                    } label: {
-                        VStack(alignment: .leading, spacing: 0) {
-                            HStack(spacing: VSpacing.md) {
-                                resultBadge(run.result)
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(run.title)
-                                        .font(VFont.body)
-                                        .foregroundColor(VColor.textPrimary)
-                                        .lineLimit(1)
-                                    Text(formatTimestamp(run.createdAt))
-                                        .font(VFont.caption)
-                                        .foregroundColor(VColor.textMuted)
-                                }
-                                Spacer()
-                                Image(systemName: expandedRunId == run.id ? "chevron.down" : "chevron.right")
-                                    .font(.system(size: 10, weight: .semibold))
+                    VStack(alignment: .leading, spacing: 0) {
+                        HStack(spacing: VSpacing.md) {
+                            resultBadge(run.result)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(run.title)
+                                    .font(VFont.body)
+                                    .foregroundColor(VColor.textPrimary)
+                                    .lineLimit(1)
+                                Text(formatTimestamp(run.createdAt))
+                                    .font(VFont.caption)
                                     .foregroundColor(VColor.textMuted)
                             }
-                            .padding(VSpacing.sm)
-
-                            if expandedRunId == run.id {
-                                Text(run.summary?.isEmpty == false ? run.summary! : "No summary available")
-                                    .font(VFont.mono)
-                                    .foregroundColor(VColor.textSecondary)
-                                    .textSelection(.enabled)
-                                    .padding(VSpacing.sm)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .background(VColor.surface)
-                                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: VRadius.md)
-                                            .stroke(VColor.surfaceBorder, lineWidth: 1)
-                                    )
-                                    .padding(.horizontal, VSpacing.sm)
-                                    .padding(.bottom, VSpacing.sm)
+                            Spacer()
+                            Image(systemName: expandedRunId == run.id ? "chevron.down" : "chevron.right")
+                                .font(.system(size: 10, weight: .semibold))
+                                .foregroundColor(VColor.textMuted)
+                        }
+                        .padding(VSpacing.sm)
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            withAnimation(VAnimation.fast) {
+                                expandedRunId = expandedRunId == run.id ? nil : run.id
                             }
                         }
+
+                        if expandedRunId == run.id {
+                            Text(run.summary?.isEmpty == false ? run.summary! : "No summary available")
+                                .font(VFont.mono)
+                                .foregroundColor(VColor.textSecondary)
+                                .textSelection(.enabled)
+                                .padding(VSpacing.sm)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background(VColor.surface)
+                                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: VRadius.md)
+                                        .stroke(VColor.surfaceBorder, lineWidth: 1)
+                                )
+                                .padding(.horizontal, VSpacing.sm)
+                                .padding(.bottom, VSpacing.sm)
+                        }
                     }
-                    .buttonStyle(.plain)
 
                     if run.id != runs.last?.id {
                         Divider().background(VColor.surfaceBorder)


### PR DESCRIPTION
## Summary
- Replaced `Button` with `onTapGesture` + `.contentShape(Rectangle())` on the heartbeat run row
- The entire row area now triggers expansion, not just the chevron icon

## Test plan
- [ ] Settings → Heartbeat → click anywhere on a run row → expands
- [ ] Click on the text, badge, or empty space → all expand/collapse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
