### PR TITLE
fix(macos): move message action buttons to bottom, hide during streaming

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -43,7 +43,7 @@ struct ChatBubble: View {
         hasCopyableText || canReportMessage
     }
     private var showOverflowMenu: Bool {
-        hasOverflowActions && (isHovered || showCopyConfirmation)
+        hasOverflowActions && !message.isStreaming && (isHovered || showCopyConfirmation)
     }
 
     /// Composite identity for the `.task` modifier so it re-runs when either
@@ -77,7 +77,6 @@ struct ChatBubble: View {
 
     func bubbleChrome<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
         let isPlainAssistant = !isUser && !message.isError
-        let overflowOffset: CGFloat = message.isError ? -(24 + VSpacing.sm) : (24 + VSpacing.sm)
         return content()
             .padding(.horizontal, isPlainAssistant ? 0 : VSpacing.lg)
             .padding(.vertical, isPlainAssistant ? 0 : VSpacing.md)
@@ -88,14 +87,6 @@ struct ChatBubble: View {
             )
             .overlay {
                 bubbleBorderOverlay
-            }
-            .overlay(alignment: isUser ? .topLeading : .topTrailing) {
-                if hasOverflowActions {
-                    overflowMenuButton
-                        .opacity(showOverflowMenu ? 1 : 0)
-                        .animation(VAnimation.fast, value: showOverflowMenu)
-                        .offset(x: isUser ? -(24 + VSpacing.sm) : overflowOffset)
-                }
             }
             .frame(maxWidth: message.isError ? .infinity : 520, alignment: isUser ? .trailing : .leading)
     }
@@ -184,19 +175,17 @@ struct ChatBubble: View {
                     if !isUser {
                         trailingStatus
                     }
+
+                    if hasOverflowActions {
+                        overflowMenuButton
+                            .opacity(showOverflowMenu ? 1 : 0)
+                            .animation(VAnimation.fast, value: showOverflowMenu)
+                    }
                 }
                 // Prevent LazyVStack from compressing the bubble height, which causes the
                 // trailing tool-chip to overlap long text content.
                 .fixedSize(horizontal: false, vertical: true)
                 .contextMenu {}
-                .overlay(alignment: .topTrailing) {
-                    if !isUser && !shouldShowBubble && !hasInterleavedContent && hasOverflowActions {
-                        overflowMenuButton
-                            .opacity(showOverflowMenu ? 1 : 0)
-                            .animation(VAnimation.fast, value: showOverflowMenu)
-                            .offset(x: 24 + VSpacing.sm)
-                    }
-                }
                 .overlay(alignment: .topLeading) {
                     if !isUser && showAvatar {
                         Image(nsImage: appearance.chatAvatarImage)


### PR DESCRIPTION
## Summary
Move the copy and bug report inline buttons from side overlays to the bottom of the message content. Only show them after streaming completes.

**Before:** Buttons appeared as overlays to the right of the message bubble.
**After:** Buttons appear at the bottom of the message, inline with the content flow. Hidden during streaming.

## Changes
- Removed both `.overlay(alignment: .topTrailing)` placements of the action buttons
- Added buttons inside the content VStack after `trailingStatus`
- Added `!message.isStreaming` guard to `showOverflowMenu`
- Removed unused `overflowOffset` variable

## Testing
- Hover over a completed assistant message — copy/bug buttons appear at bottom
- During streaming — no buttons visible
- After stream completes and hover — buttons fade in at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
