### PR TITLE
M4: Phone Input Normalization + Validation Loosening

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -2823,20 +2823,51 @@ describe('outbound SMS verification', () => {
     expect(resp!.error).toBe('missing_destination');
   });
 
-  test('start_outbound rejects invalid E.164 number', () => {
+  test('start_outbound rejects unparseable phone number', () => {
     const { ctx, lastResponse } = createMockCtx();
     handleGuardianVerification({
       type: 'guardian_verification',
       action: 'start_outbound',
       channel: 'sms',
       assistantId: 'self',
-      destination: '5551234567', // missing + prefix
+      destination: 'not-a-phone',
     }, mockSocket, ctx);
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
     expect(resp!.error).toBe('invalid_destination');
+  });
+
+  test('start_outbound normalizes formatted phone number for SMS', async () => {
+    const { ctx, lastResponse } = createMockCtx();
+    handleGuardianVerification({
+      type: 'guardian_verification',
+      action: 'start_outbound',
+      channel: 'sms',
+      assistantId: 'self',
+      destination: '(555) 123-4567',
+    }, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(true);
+    expect(resp!.verificationSessionId).toBeDefined();
+    expect(resp!.secret).toBeDefined();
+
+    // Verify the session was created with the normalized E.164 number
+    const session = serviceFindActiveSession('self', 'sms');
+    expect(session).not.toBeNull();
+    expect(session!.expectedPhoneE164).toBe('+15551234567');
+    expect(session!.destinationAddress).toBe('+15551234567');
+
+    // Allow fire-and-forget SMS delivery to complete
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Verify SMS was sent to the normalized number
+    expect(smsSendCalls.length).toBeGreaterThanOrEqual(1);
+    const lastSms = smsSendCalls[smsSendCalls.length - 1];
+    expect(lastSms.to).toBe('+15551234567');
   });
 
   test('template composer includes assistantName when provided', () => {
@@ -3393,7 +3424,7 @@ describe('outbound voice verification', () => {
     expect(lastCall.guardianVerificationSessionId).toBe(resp!.verificationSessionId!);
   });
 
-  test('start_outbound for voice rejects invalid E.164', () => {
+  test('start_outbound for voice rejects unparseable phone number', () => {
     const { ctx, lastResponse } = createMockCtx();
     handleGuardianVerification({
       type: 'guardian_verification',
@@ -3407,6 +3438,39 @@ describe('outbound voice verification', () => {
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
     expect(resp!.error).toBe('invalid_destination');
+  });
+
+  test('start_outbound for voice normalizes formatted phone number', async () => {
+    const { ctx, lastResponse } = createMockCtx();
+    handleGuardianVerification({
+      type: 'guardian_verification',
+      action: 'start_outbound',
+      channel: 'voice',
+      assistantId: 'self',
+      destination: '555-123-4567',
+    }, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(true);
+    expect(resp!.verificationSessionId).toBeDefined();
+    expect(resp!.secret).toBeDefined();
+    // Voice codes are 6 digits
+    expect(resp!.secret!.length).toBe(6);
+
+    // Verify the session was created with the normalized E.164 number
+    const session = serviceFindActiveSession('self', 'voice');
+    expect(session).not.toBeNull();
+    expect(session!.expectedPhoneE164).toBe('+15551234567');
+    expect(session!.destinationAddress).toBe('+15551234567');
+
+    // Allow fire-and-forget call initiation to complete
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Verify the call was initiated with the normalized number
+    expect(voiceCallInitCalls.length).toBeGreaterThanOrEqual(1);
+    const lastCall = voiceCallInitCalls[voiceCallInitCalls.length - 1];
+    expect(lastCall.phoneNumber).toBe('+15551234567');
   });
 
   test('start_outbound for voice rejects when binding exists (rebind=false)', () => {

--- a/assistant/src/__tests__/phone.test.ts
+++ b/assistant/src/__tests__/phone.test.ts
@@ -31,6 +31,18 @@ describe('normalizePhoneNumber', () => {
     expect(normalizePhoneNumber('+44 20 7946 0958')).toBe('+442079460958');
   });
 
+  test('international with trunk-zero (0) — UK format', () => {
+    expect(normalizePhoneNumber('+44 (0)20 7946 0958')).toBe('+442079460958');
+  });
+
+  test('international with trunk-zero (0) — German format', () => {
+    expect(normalizePhoneNumber('+49 (0)30 1234 5678')).toBe('+493012345678');
+  });
+
+  test('international with trunk-zero (0) — no spaces', () => {
+    expect(normalizePhoneNumber('+44(0)2079460958')).toBe('+442079460958');
+  });
+
   test('too short — returns null', () => {
     expect(normalizePhoneNumber('123')).toBeNull();
   });

--- a/assistant/src/__tests__/phone.test.ts
+++ b/assistant/src/__tests__/phone.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isValidE164, normalizePhoneNumber } from '../util/phone.js';
+
+describe('normalizePhoneNumber', () => {
+  test('already E.164 — returned as-is', () => {
+    expect(normalizePhoneNumber('+15551234567')).toBe('+15551234567');
+  });
+
+  test('10-digit US number — prepends +1', () => {
+    expect(normalizePhoneNumber('5551234567')).toBe('+15551234567');
+  });
+
+  test('11-digit number starting with 1 — prepends +', () => {
+    expect(normalizePhoneNumber('15551234567')).toBe('+15551234567');
+  });
+
+  test('strips parentheses and spaces', () => {
+    expect(normalizePhoneNumber('(555) 123-4567')).toBe('+15551234567');
+  });
+
+  test('strips dots', () => {
+    expect(normalizePhoneNumber('555.123.4567')).toBe('+15551234567');
+  });
+
+  test('strips dashes', () => {
+    expect(normalizePhoneNumber('555-123-4567')).toBe('+15551234567');
+  });
+
+  test('international with spaces', () => {
+    expect(normalizePhoneNumber('+44 20 7946 0958')).toBe('+442079460958');
+  });
+
+  test('too short — returns null', () => {
+    expect(normalizePhoneNumber('123')).toBeNull();
+  });
+
+  test('non-numeric — returns null', () => {
+    expect(normalizePhoneNumber('abc')).toBeNull();
+  });
+
+  test('empty string — returns null', () => {
+    expect(normalizePhoneNumber('')).toBeNull();
+  });
+});
+
+describe('isValidE164', () => {
+  test('valid E.164 number', () => {
+    expect(isValidE164('+15551234567')).toBe(true);
+  });
+
+  test('missing + prefix', () => {
+    expect(isValidE164('5551234567')).toBe(false);
+  });
+
+  test('too short', () => {
+    expect(isValidE164('+123')).toBe(false);
+  });
+});

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -24,6 +24,7 @@ import { startGuardianVerificationCall } from '../../calls/call-domain.js';
 import { sendMessage as sendSms } from '../../messaging/providers/sms/client.js';
 import { getGatewayInternalBaseUrl } from '../../config/env.js';
 import { getCredentialMetadata } from '../../tools/credentials/metadata-store.js';
+import { normalizePhoneNumber } from '../../util/phone.js';
 import { normalizeAssistantId, readHttpToken } from '../../util/platform.js';
 import type { ChannelId } from '../../channels/types.js';
 import type {
@@ -67,17 +68,6 @@ export function getReadinessService(): ChannelReadinessService {
     _readinessService = createReadinessService();
   }
   return _readinessService;
-}
-
-// ---------------------------------------------------------------------------
-// E.164 validation
-// ---------------------------------------------------------------------------
-
-/**
- * Basic E.164 phone number validation: starts with +, followed by 10-15 digits.
- */
-function isValidE164(phone: string): boolean {
-  return /^\+\d{10,15}$/.test(phone);
 }
 
 // ---------------------------------------------------------------------------
@@ -305,8 +295,8 @@ function handleStartOutboundSms(
   channel: ChannelId,
 ): void {
   // Validate destination
-  const destination = msg.destination;
-  if (!destination) {
+  const rawDestination = msg.destination;
+  if (!rawDestination) {
     ctx.send(socket, {
       type: 'guardian_verification_response',
       success: false,
@@ -317,12 +307,14 @@ function handleStartOutboundSms(
     return;
   }
 
-  if (!isValidE164(destination)) {
+  // Normalize loose phone formats (e.g. "(555) 123-4567") to E.164
+  const destination = normalizePhoneNumber(rawDestination);
+  if (!destination) {
     ctx.send(socket, {
       type: 'guardian_verification_response',
       success: false,
       error: 'invalid_destination',
-      message: 'Destination must be a valid E.164 phone number (e.g. +15551234567).',
+      message: 'Could not parse phone number. Please enter a valid number (e.g. +15551234567, (555) 123-4567, or 555-123-4567).',
       channel,
     });
     return;
@@ -543,8 +535,8 @@ function handleStartOutboundVoice(
   assistantId: string,
   channel: ChannelId,
 ): void {
-  const destination = msg.destination;
-  if (!destination) {
+  const rawDestination = msg.destination;
+  if (!rawDestination) {
     ctx.send(socket, {
       type: 'guardian_verification_response',
       success: false,
@@ -555,12 +547,14 @@ function handleStartOutboundVoice(
     return;
   }
 
-  if (!isValidE164(destination)) {
+  // Normalize loose phone formats (e.g. "555-123-4567") to E.164
+  const destination = normalizePhoneNumber(rawDestination);
+  if (!destination) {
     ctx.send(socket, {
       type: 'guardian_verification_response',
       success: false,
       error: 'invalid_destination',
-      message: 'Destination must be a valid E.164 phone number (e.g. +15551234567).',
+      message: 'Could not parse phone number. Please enter a valid number (e.g. +15551234567, (555) 123-4567, or 555-123-4567).',
       channel,
     });
     return;

--- a/assistant/src/util/phone.ts
+++ b/assistant/src/util/phone.ts
@@ -22,8 +22,12 @@ export function isValidE164(phone: string): boolean {
  *   - Otherwise -> return null (invalid)
  */
 export function normalizePhoneNumber(input: string): string | null {
+  // Strip optional trunk-zero notation "(0)" used in international formats
+  // like "+44 (0)20 7946 0958" before any other processing.
+  const withoutTrunkZero = input.replace(/\(0\)/g, '');
+
   // Strip formatting characters: spaces, dashes, parentheses, dots
-  const stripped = input.replace(/[\s\-().]/g, '');
+  const stripped = withoutTrunkZero.replace(/[\s\-().]/g, '');
 
   if (stripped.length === 0) return null;
 

--- a/assistant/src/util/phone.ts
+++ b/assistant/src/util/phone.ts
@@ -1,0 +1,50 @@
+/**
+ * Phone number normalization and validation utilities.
+ *
+ * Accepts common US and international phone number formats and normalizes
+ * them to E.164 before validation, rate-limit lookups, or storage.
+ */
+
+/**
+ * Basic E.164 phone number validation: starts with +, followed by 10-15 digits.
+ */
+export function isValidE164(phone: string): boolean {
+  return /^\+\d{10,15}$/.test(phone);
+}
+
+/**
+ * Normalize a phone number string to E.164 format.
+ *
+ * Strips spaces, dashes, parentheses, and dots, then applies:
+ *   - Already starts with `+` and has 10-15 digits -> return as-is
+ *   - 10 digits (no +) -> prepend `+1` (assume US)
+ *   - 11 digits starting with `1` (no +) -> prepend `+`
+ *   - Otherwise -> return null (invalid)
+ */
+export function normalizePhoneNumber(input: string): string | null {
+  // Strip formatting characters: spaces, dashes, parentheses, dots
+  const stripped = input.replace(/[\s\-().]/g, '');
+
+  if (stripped.length === 0) return null;
+
+  if (stripped.startsWith('+')) {
+    const digits = stripped.slice(1);
+    if (/^\d{10,15}$/.test(digits)) {
+      return stripped;
+    }
+    return null;
+  }
+
+  // No + prefix — must be all digits
+  if (!/^\d+$/.test(stripped)) return null;
+
+  if (stripped.length === 10) {
+    return `+1${stripped}`;
+  }
+
+  if (stripped.length === 11 && stripped.startsWith('1')) {
+    return `+${stripped}`;
+  }
+
+  return null;
+}


### PR DESCRIPTION
Add normalizePhoneNumber utility that strips formatting (spaces, dashes, parens, dots) and normalizes to E.164. Applied in SMS and voice outbound handlers before validation/rate-limit/session-creation. Includes unit tests for the normalizer and integration tests for loose format acceptance.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
