### PR TITLE
fix(notifications): preserve localized copy in thread seed fallback

### DIFF
--- a/assistant/src/__tests__/conversation-pairing.test.ts
+++ b/assistant/src/__tests__/conversation-pairing.test.ts
@@ -142,16 +142,19 @@ describe('pairDeliveryWithConversation', () => {
       sourceEventName: 'reminder.fired',
       contextPayload: { message: 'Daily standup' },
     });
-    const copy = makeCopy({ threadSeedMessage: '{"raw": "json dump payload"}' });
+    const copy = makeCopy({
+      title: 'Reminder',
+      body: 'Daily standup',
+      threadSeedMessage: '{"raw": "json dump payload"}',
+    });
 
     pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
 
     const contentArg = addMessageMock.mock.calls[0]![2] as string;
     // Should NOT be the JSON dump
     expect(contentArg).not.toContain('"raw"');
-    // Should be the runtime-composed seed from the reminder template
+    // Should be the runtime-composed seed from copy.title/body
     expect(contentArg).toContain('Reminder');
-    expect(contentArg).toContain('Daily standup');
   });
 
   test('rejects very short threadSeedMessage and uses runtime composer', () => {
@@ -159,12 +162,13 @@ describe('pairDeliveryWithConversation', () => {
       sourceEventName: 'reminder.fired',
       contextPayload: { message: 'Test' },
     });
-    const copy = makeCopy({ threadSeedMessage: 'Hi' });
+    const copy = makeCopy({ title: 'Reminder', body: 'Test reminder', threadSeedMessage: 'Hi' });
 
     pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
 
     const contentArg = addMessageMock.mock.calls[0]![2] as string;
     expect(contentArg).not.toBe('Hi');
+    // Runtime composer builds from copy.title/body
     expect(contentArg).toContain('Reminder');
   });
 

--- a/assistant/src/__tests__/thread-seed-composer.test.ts
+++ b/assistant/src/__tests__/thread-seed-composer.test.ts
@@ -1,8 +1,8 @@
 /**
  * Tests for the thread seed composer.
  *
- * Validates surface-aware verbosity resolution, event-specific seed
- * templates, generic fallback, and the threadSeedMessage sanity check.
+ * Validates surface-aware verbosity resolution, copy-based seed
+ * composition, and the threadSeedMessage sanity check.
  */
 
 import { describe, expect, test } from 'bun:test';
@@ -110,8 +110,18 @@ describe('isThreadSeedSane', () => {
     expect(isThreadSeedSane('')).toBe(false);
   });
 
-  test('rejects very short string', () => {
+  test('rejects very short string (1-2 chars)', () => {
     expect(isThreadSeedSane('Hi')).toBe(false);
+  });
+
+  test('accepts short CJK text (>= 3 chars)', () => {
+    // CJK characters pack more meaning per character
+    expect(isThreadSeedSane('リマインダー')).toBe(true);
+    expect(isThreadSeedSane('提醒您')).toBe(true);
+  });
+
+  test('accepts string at min boundary (3 chars)', () => {
+    expect(isThreadSeedSane('abc')).toBe(true);
   });
 
   test('rejects JSON object dump', () => {
@@ -135,204 +145,55 @@ describe('isThreadSeedSane', () => {
   test('accepts string at max boundary', () => {
     expect(isThreadSeedSane('x'.repeat(2000))).toBe(true);
   });
-
-  test('accepts string at min boundary', () => {
-    expect(isThreadSeedSane('0123456789')).toBe(true);
-  });
 });
 
-// ── composeThreadSeed — event-specific templates ───────────────────────
+// ── composeThreadSeed — copy-based composition ─────────────────────────
 
 describe('composeThreadSeed', () => {
-  describe('reminder.fired', () => {
-    test('rich verbosity includes reminder message', () => {
-      const signal = makeSignal({
-        sourceEventName: 'reminder.fired',
-        contextPayload: { message: 'Take out the trash' },
-      });
-      const seed = composeThreadSeed(signal, 'vellum' as NotificationChannel, makeCopy());
-      expect(seed).toContain('Take out the trash');
-      expect(seed).toContain('Reminder');
-    });
-
-    test('rich verbosity with requiresAction includes attention note', () => {
-      const signal = makeSignal({
-        sourceEventName: 'reminder.fired',
-        contextPayload: { message: 'Call the doctor' },
-        attentionHints: {
-          requiresAction: true,
-          urgency: 'high',
-          isAsyncBackground: false,
-          visibleInSourceNow: false,
-        },
-      });
-      const seed = composeThreadSeed(signal, 'vellum' as NotificationChannel, makeCopy());
-      expect(seed).toContain('Call the doctor');
-      expect(seed).toContain('attention');
-    });
-
-    test('compact verbosity is shorter', () => {
-      const signal = makeSignal({
-        sourceEventName: 'reminder.fired',
-        contextPayload: { message: 'Take out the trash' },
-      });
-      const richSeed = composeThreadSeed(signal, 'vellum' as NotificationChannel, makeCopy());
-      const compactSeed = composeThreadSeed(signal, 'telegram' as NotificationChannel, makeCopy());
-      expect(compactSeed.length).toBeLessThanOrEqual(richSeed.length);
-      expect(compactSeed).toContain('Take out the trash');
-    });
-
-    test('compact with requiresAction appends action marker', () => {
-      const signal = makeSignal({
-        sourceEventName: 'reminder.fired',
-        contextPayload: { message: 'Respond to email' },
-        attentionHints: {
-          requiresAction: true,
-          urgency: 'high',
-          isAsyncBackground: false,
-          visibleInSourceNow: false,
-        },
-      });
-      const seed = composeThreadSeed(signal, 'telegram' as NotificationChannel, makeCopy());
-      expect(seed).toContain('action needed');
-    });
-
-    test('falls back to label when message is missing', () => {
-      const signal = makeSignal({
-        sourceEventName: 'reminder.fired',
-        contextPayload: { label: 'My labeled reminder' },
-      });
-      const seed = composeThreadSeed(signal, 'vellum' as NotificationChannel, makeCopy());
-      expect(seed).toContain('My labeled reminder');
-    });
-
-    test('uses default text when both message and label are missing', () => {
-      const signal = makeSignal({
-        sourceEventName: 'reminder.fired',
-        contextPayload: {},
-      });
-      const seed = composeThreadSeed(signal, 'vellum' as NotificationChannel, makeCopy());
-      expect(seed).toContain('reminder has fired');
-    });
-  });
-
-  describe('guardian.question', () => {
-    test('rich includes question text and reply instruction', () => {
-      const signal = makeSignal({
-        sourceEventName: 'guardian.question',
-        contextPayload: { questionText: 'What is the gate code?' },
-      });
-      const seed = composeThreadSeed(signal, 'vellum' as NotificationChannel, makeCopy());
-      expect(seed).toContain('What is the gate code?');
-      expect(seed).toContain('Reply');
-    });
-
-    test('compact is shorter', () => {
-      const signal = makeSignal({
-        sourceEventName: 'guardian.question',
-        contextPayload: { questionText: 'What is the gate code?' },
-      });
-      const seed = composeThreadSeed(signal, 'telegram' as NotificationChannel, makeCopy());
-      expect(seed).toContain('What is the gate code?');
-      expect(seed).not.toContain('Reply in this thread');
-    });
-  });
-
-  describe('tool_confirmation.required_action', () => {
-    test('rich mentions tool name and includes review instruction', () => {
-      const signal = makeSignal({
-        sourceEventName: 'tool_confirmation.required_action',
-        contextPayload: { toolName: 'send_email' },
-      });
-      const seed = composeThreadSeed(signal, 'vellum' as NotificationChannel, makeCopy());
-      expect(seed).toContain('send_email');
-      expect(seed).toContain('confirmation');
-    });
-
-    test('compact is concise', () => {
-      const signal = makeSignal({
-        sourceEventName: 'tool_confirmation.required_action',
-        contextPayload: { toolName: 'send_email' },
-      });
-      const seed = composeThreadSeed(signal, 'telegram' as NotificationChannel, makeCopy());
-      expect(seed).toContain('send_email');
-      expect(seed).toContain('confirmation');
-      expect(seed.length).toBeLessThan(50);
-    });
-  });
-
-  describe('ingress.escalation', () => {
-    test('rich includes sender, preview, and action instruction', () => {
-      const signal = makeSignal({
-        sourceEventName: 'ingress.escalation',
-        contextPayload: { senderIdentifier: 'Alice', preview: 'Can you help me?' },
-        attentionHints: {
-          requiresAction: true,
-          urgency: 'high',
-          isAsyncBackground: false,
-          visibleInSourceNow: false,
-        },
-      });
-      const seed = composeThreadSeed(signal, 'vellum' as NotificationChannel, makeCopy());
-      expect(seed).toContain('Alice');
-      expect(seed).toContain('Can you help me?');
-      expect(seed).toContain('review');
-    });
-
-    test('compact omits detailed instructions', () => {
-      const signal = makeSignal({
-        sourceEventName: 'ingress.escalation',
-        contextPayload: { senderIdentifier: 'Bob' },
-      });
-      const seed = composeThreadSeed(signal, 'telegram' as NotificationChannel, makeCopy());
-      expect(seed).toContain('Bob');
-      expect(seed).toContain('attention');
-    });
-  });
-
-  // ── Generic fallback ─────────────────────────────────────────────────
-
-  describe('generic fallback (unknown event)', () => {
-    test('rich generic includes copy title and body with action note', () => {
-      const signal = makeSignal({
-        sourceEventName: 'some.unknown_event',
-        attentionHints: {
-          requiresAction: true,
-          urgency: 'medium',
-          isAsyncBackground: false,
-          visibleInSourceNow: false,
-        },
-      });
-      const copy = makeCopy({ title: 'Custom Title', body: 'Event details here.' });
+  describe('rich verbosity (vellum/macos)', () => {
+    test('combines title and body into flowing prose', () => {
+      const signal = makeSignal();
+      const copy = makeCopy({ title: 'Reminder', body: 'Take out the trash' });
       const seed = composeThreadSeed(signal, 'vellum' as NotificationChannel, copy);
-      expect(seed).toContain('Custom Title');
-      expect(seed).toContain('Event details here');
+      expect(seed).toContain('Reminder');
+      expect(seed).toContain('Take out the trash');
+      // Should be flowing prose (joined with ". "), not newline-separated
+      expect(seed).not.toContain('\n');
+    });
+
+    test('appends "Action required." when requiresAction is true', () => {
+      const signal = makeSignal({
+        attentionHints: {
+          requiresAction: true,
+          urgency: 'high',
+          isAsyncBackground: false,
+          visibleInSourceNow: false,
+        },
+      });
+      const copy = makeCopy({ title: 'Reminder', body: 'Call the doctor' });
+      const seed = composeThreadSeed(signal, 'vellum' as NotificationChannel, copy);
       expect(seed).toContain('Action required');
     });
 
-    test('rich generic skips "Notification" title', () => {
-      const signal = makeSignal({ sourceEventName: 'novel.event' });
+    test('omits "Notification" generic title', () => {
+      const signal = makeSignal();
       const copy = makeCopy({ title: 'Notification', body: 'Something new.' });
       const seed = composeThreadSeed(signal, 'vellum' as NotificationChannel, copy);
       expect(seed).not.toMatch(/^Notification/);
       expect(seed).toContain('Something new');
     });
+  });
 
-    test('compact generic preserves title/body format', () => {
-      const signal = makeSignal({ sourceEventName: 'novel.event' });
+  describe('compact verbosity (telegram)', () => {
+    test('preserves title/body format with newline separator', () => {
+      const signal = makeSignal();
       const copy = makeCopy({ title: 'Alert', body: 'Details here.' });
       const seed = composeThreadSeed(signal, 'telegram' as NotificationChannel, copy);
       expect(seed).toBe('Alert\n\nDetails here.');
     });
-  });
 
-  // ── Surface-aware verbosity ──────────────────────────────────────────
-
-  describe('surface-aware verbosity', () => {
-    test('vellum seeds are longer than telegram seeds for same signal', () => {
+    test('does not append action markers', () => {
       const signal = makeSignal({
-        sourceEventName: 'reminder.fired',
-        contextPayload: { message: 'Important meeting at 3pm' },
         attentionHints: {
           requiresAction: true,
           urgency: 'high',
@@ -340,52 +201,99 @@ describe('composeThreadSeed', () => {
           visibleInSourceNow: false,
         },
       });
-      const richSeed = composeThreadSeed(signal, 'vellum' as NotificationChannel, makeCopy());
-      const compactSeed = composeThreadSeed(signal, 'telegram' as NotificationChannel, makeCopy());
-      expect(richSeed.length).toBeGreaterThan(compactSeed.length);
+      const copy = makeCopy({ title: 'Reminder', body: 'Respond to email' });
+      const seed = composeThreadSeed(signal, 'telegram' as NotificationChannel, copy);
+      expect(seed).toBe('Reminder\n\nRespond to email');
+    });
+  });
+
+  describe('localization preservation', () => {
+    test('preserves localized LLM copy on vellum (rich)', () => {
+      const signal = makeSignal();
+      const copy = makeCopy({
+        title: 'リマインダー',
+        body: 'ゴミを出してください',
+      });
+      const seed = composeThreadSeed(signal, 'vellum' as NotificationChannel, copy);
+      expect(seed).toContain('リマインダー');
+      expect(seed).toContain('ゴミを出してください');
+    });
+
+    test('preserves localized LLM copy on telegram (compact)', () => {
+      const signal = makeSignal();
+      const copy = makeCopy({
+        title: 'リマインダー',
+        body: 'ゴミを出してください',
+      });
+      const seed = composeThreadSeed(signal, 'telegram' as NotificationChannel, copy);
+      expect(seed).toBe('リマインダー\n\nゴミを出してください');
+    });
+
+    test('does not inject English template strings into localized copy', () => {
+      const signal = makeSignal({
+        sourceEventName: 'guardian.question',
+        attentionHints: {
+          requiresAction: true,
+          urgency: 'high',
+          isAsyncBackground: false,
+          visibleInSourceNow: false,
+        },
+      });
+      const copy = makeCopy({
+        title: 'ガーディアンの質問',
+        body: 'ゲートコードは何ですか？',
+      });
+      const seed = composeThreadSeed(signal, 'vellum' as NotificationChannel, copy);
+      expect(seed).toContain('ガーディアンの質問');
+      expect(seed).toContain('ゲートコードは何ですか？');
+      // The only English that may appear is "Action required." which is
+      // an intentional structural marker, not a content replacement
+    });
+  });
+
+  describe('surface-aware verbosity', () => {
+    test('vellum seeds are formatted differently than telegram seeds', () => {
+      const signal = makeSignal({
+        attentionHints: {
+          requiresAction: true,
+          urgency: 'high',
+          isAsyncBackground: false,
+          visibleInSourceNow: false,
+        },
+      });
+      const copy = makeCopy({ title: 'Reminder', body: 'Important meeting at 3pm' });
+      const richSeed = composeThreadSeed(signal, 'vellum' as NotificationChannel, copy);
+      const compactSeed = composeThreadSeed(signal, 'telegram' as NotificationChannel, copy);
+      // Rich has action note, compact does not
+      expect(richSeed).toContain('Action required');
+      expect(compactSeed).not.toContain('Action required');
     });
 
     test('interfaceHint in contextPayload overrides channel default', () => {
       const signal = makeSignal({
-        sourceEventName: 'reminder.fired',
-        contextPayload: { message: 'Test', interfaceHint: 'telegram' },
-        attentionHints: {
-          requiresAction: true,
-          urgency: 'high',
-          isAsyncBackground: false,
-          visibleInSourceNow: false,
-        },
+        contextPayload: { interfaceHint: 'telegram' },
       });
-      // Even though channel is vellum, interfaceHint says telegram → compact
-      const seed = composeThreadSeed(signal, 'vellum' as NotificationChannel, makeCopy());
-      // Compact reminder with action marker
-      expect(seed).toContain('action needed');
+      const copy = makeCopy({ title: 'Alert', body: 'Details.' });
+      // Channel is vellum but interfaceHint says telegram → compact format
+      const seed = composeThreadSeed(signal, 'vellum' as NotificationChannel, copy);
+      expect(seed).toBe('Alert\n\nDetails.');
     });
   });
 
-  // ── Edge cases ───────────────────────────────────────────────────────
-
   describe('edge cases', () => {
-    test('empty contextPayload produces usable seed', () => {
-      const signal = makeSignal({
-        sourceEventName: 'reminder.fired',
-        contextPayload: {},
-      });
-      const seed = composeThreadSeed(signal, 'vellum' as NotificationChannel, makeCopy());
-      expect(seed.length).toBeGreaterThan(10);
-      expect(seed).not.toContain('{');
+    test('handles empty copy body gracefully', () => {
+      const signal = makeSignal();
+      const copy = makeCopy({ title: 'Alert', body: '' });
+      const seed = composeThreadSeed(signal, 'vellum' as NotificationChannel, copy);
+      expect(seed.length).toBeGreaterThan(0);
     });
 
     test('never produces raw JSON in output', () => {
-      const signal = makeSignal({
-        sourceEventName: 'reminder.fired',
-        contextPayload: { message: '{"nested": "json"}', extra: { deep: true } },
-      });
-      const seed = composeThreadSeed(signal, 'vellum' as NotificationChannel, makeCopy());
-      // The message field is a string that happens to look like JSON — it should
-      // be treated as a string (which it is, since str() just returns it).
-      // The point is the seed itself isn't a JSON dump.
-      expect(seed).toContain('Reminder');
+      const signal = makeSignal();
+      const copy = makeCopy({ title: 'Alert', body: 'Check the results.' });
+      const seed = composeThreadSeed(signal, 'vellum' as NotificationChannel, copy);
+      expect(seed).not.toMatch(/^\{/);
+      expect(seed).not.toMatch(/^\[/);
     });
   });
 });

--- a/assistant/src/notifications/thread-seed-composer.ts
+++ b/assistant/src/notifications/thread-seed-composer.ts
@@ -3,7 +3,10 @@
  *
  * Generates richer seed content for notification threads than the concise
  * title/body used in native notification popups. Verbosity adapts to the
- * delivery surface: vellum/macos gets 2-4 sentences, telegram gets 1-2.
+ * delivery surface: vellum/macos gets flowing prose, telegram gets compact.
+ *
+ * Composes from `copy.title/body` rather than hardcoded English templates
+ * so LLM-localized copy is preserved for non-English users.
  *
  * This runs in the daemon runtime (not via skills), ensuring every
  * notification thread has a readable seed message regardless of whether
@@ -55,141 +58,24 @@ export function resolveVerbosity(
  * Check whether a model-provided threadSeedMessage is usable.
  *
  * Rejects empty strings, raw JSON dumps, and excessively long content.
+ * Min-length is 3 (not higher) to support concise CJK text.
  */
 export function isThreadSeedSane(value: unknown): value is string {
   if (typeof value !== 'string') return false;
   const trimmed = value.trim();
-  if (trimmed.length < 10) return false;
+  if (trimmed.length < 3) return false;
   if (trimmed.length > 2000) return false;
   // Reject raw JSON dumps
   if (trimmed.startsWith('{') || trimmed.startsWith('[')) return false;
   return true;
 }
 
-function str(value: unknown, fallback: string): string {
-  if (typeof value === 'string' && value.length > 0) return value;
-  return fallback;
-}
-
-// ── Event-specific seed templates ───────────────────────────────────────
-
-type SeedTemplate = (
-  payload: Record<string, unknown>,
-  signal: NotificationSignal,
-  verbosity: SurfaceVerbosity,
-) => string;
-
-const SEED_TEMPLATES: Record<string, SeedTemplate> = {
-  'reminder.fired': (payload, signal, verbosity) => {
-    const message = str(payload.message, str(payload.label, 'A reminder has fired.'));
-    if (verbosity === 'rich') {
-      const parts = [`Reminder: ${message}`];
-      if (signal.attentionHints.requiresAction) parts.push('This needs your attention.');
-      return parts.join(' ');
-    }
-    return signal.attentionHints.requiresAction
-      ? `Reminder: ${message} — action needed`
-      : `Reminder: ${message}`;
-  },
-
-  'schedule.complete': (payload, _signal, verbosity) => {
-    const name = str(payload.name, 'A schedule');
-    if (verbosity === 'rich') {
-      const summary = str(payload.summary, '');
-      return summary
-        ? `${name} has finished running. ${summary}`
-        : `${name} has finished running. Check the results when you have a moment.`;
-    }
-    return `${name} has finished running.`;
-  },
-
-  'guardian.question': (payload, _signal, verbosity) => {
-    const question = str(payload.questionText, 'A guardian question needs your attention.');
-    if (verbosity === 'rich') {
-      return `Guardian question: ${question} Reply in this thread to respond.`;
-    }
-    return `Guardian: ${question}`;
-  },
-
-  'ingress.escalation': (payload, signal, verbosity) => {
-    const sender = str(payload.senderIdentifier, 'Someone');
-    const preview = str(payload.preview, '');
-    if (verbosity === 'rich') {
-      const parts = [`${sender} sent a message that needs attention.`];
-      if (preview) parts.push(`Preview: "${preview}"`);
-      if (signal.attentionHints.requiresAction) parts.push('Please review and respond.');
-      return parts.join(' ');
-    }
-    return `${sender} needs attention${preview ? `: "${preview}"` : '.'}`;
-  },
-
-  'tool_confirmation.required_action': (payload, _signal, verbosity) => {
-    const toolName = str(payload.toolName, 'A tool');
-    if (verbosity === 'rich') {
-      return `${toolName} requires your confirmation before proceeding. Open this thread to review and approve the action.`;
-    }
-    return `${toolName} needs confirmation.`;
-  },
-
-  'activity.complete': (payload, _signal, verbosity) => {
-    const summary = str(payload.summary, 'An activity has completed.');
-    if (verbosity === 'rich') {
-      return `Activity complete. ${summary}`;
-    }
-    return summary;
-  },
-
-  'quick_chat.response_ready': (payload, _signal, verbosity) => {
-    const preview = str(payload.preview, 'Your response is ready.');
-    if (verbosity === 'rich') {
-      return `Your quick chat response is ready. ${preview}`;
-    }
-    return preview;
-  },
-
-  'watcher.notification': (payload, _signal, verbosity) => {
-    const title = str(payload.title, 'Watcher');
-    const body = str(payload.body, 'A watcher event occurred.');
-    if (verbosity === 'rich') {
-      return `${title}: ${body}`;
-    }
-    return body;
-  },
-
-  'watcher.escalation': (payload, signal, verbosity) => {
-    const title = str(payload.title, 'Watcher Escalation');
-    const body = str(payload.body, 'A watcher event requires your attention.');
-    if (verbosity === 'rich') {
-      const parts = [`${title}: ${body}`];
-      if (signal.attentionHints.requiresAction) parts.push('Please review promptly.');
-      return parts.join(' ');
-    }
-    return `${title}: ${body}`;
-  },
-
-  'voice.response_ready': (payload, _signal, verbosity) => {
-    const preview = str(payload.preview, 'A voice response is ready.');
-    if (verbosity === 'rich') {
-      return `Voice response ready. ${preview}`;
-    }
-    return preview;
-  },
-
-  'ride_shotgun.invitation': (payload, _signal, verbosity) => {
-    const message = str(payload.message, 'You have been invited to ride shotgun.');
-    if (verbosity === 'rich') {
-      return `Ride Shotgun invitation: ${message}`;
-    }
-    return message;
-  },
-};
-
 /**
  * Compose a thread seed message from signal context.
  *
- * Returns a readable, surface-aware seed that is richer than the concise
- * notification title/body. Used as the fallback when the decision engine
- * does not produce a usable threadSeedMessage.
+ * Builds from `copy.title` and `copy.body` so that LLM-localized content
+ * is preserved. Surface-aware formatting makes the seed richer on
+ * desktop (flowing prose) and compact on mobile (title + body separated).
  */
 export function composeThreadSeed(
   signal: NotificationSignal,
@@ -197,26 +83,17 @@ export function composeThreadSeed(
   copy: RenderedChannelCopy,
 ): string {
   const verbosity = resolveVerbosity(channel, signal.contextPayload);
-  const template = SEED_TEMPLATES[signal.sourceEventName];
 
-  if (template) {
-    return template(signal.contextPayload, signal, verbosity);
-  }
-
-  return composeGenericSeed(signal, copy, verbosity);
-}
-
-function composeGenericSeed(
-  signal: NotificationSignal,
-  copy: RenderedChannelCopy,
-  verbosity: SurfaceVerbosity,
-): string {
   if (verbosity === 'rich') {
     const parts: string[] = [];
     if (copy.title && copy.title !== 'Notification') parts.push(copy.title);
     if (copy.body) parts.push(copy.body);
-    if (signal.attentionHints.requiresAction) parts.push('Action required.');
-    return parts.filter(Boolean).join('. ').replace(/\.\./g, '.');
+    if (signal.attentionHints.requiresAction && parts.length > 0) {
+      parts.push('Action required.');
+    }
+    if (parts.length > 0) {
+      return parts.join('. ').replace(/\.\./g, '.');
+    }
   }
 
   return `${copy.title}\n\n${copy.body}`;


### PR DESCRIPTION
## Summary
- Replace English-only event templates in thread-seed-composer with copy-based composition that preserves LLM-localized `title/body` for non-English users
- Lower `isThreadSeedSane` min-length from 10 to 3 characters to support concise CJK text (e.g. `リマインダー`, `提醒您`)
- Update tests to verify localization preservation and new min-length boundary

Addresses review feedback from PR #9259: https://github.com/vellum-ai/vellum-assistant/pull/9259#pullrequestreview-3857658807

## Original prompt
address the PR feedback here https://github.com/vellum-ai/vellum-assistant/pull/9259#pullrequestreview-3857658807

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
