### PR TITLE
M5: Test/Docs Sweep for Outbound Guardian Hardening

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -2928,7 +2928,8 @@ describe('outbound Telegram verification', () => {
     const session = serviceFindActiveSession('self', 'telegram');
     expect(session).not.toBeNull();
     expect(session!.identityBindingStatus).toBe('pending_bootstrap');
-    expect(session!.destinationAddress).toBe('@someuser');
+    // destinationAddress is normalized: '@' stripped and lowercased
+    expect(session!.destinationAddress).toBe('someuser');
     expect(session!.bootstrapTokenHash).toBeDefined();
     expect(session!.bootstrapTokenHash).not.toBeNull();
   });
@@ -3601,5 +3602,161 @@ describe('outbound voice verification', () => {
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
     expect(resp!.error).toBe('missing_destination');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 22. M1–M4 Hardening: constant values, secret presence, and entropy
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('M1–M4 hardening coverage', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  // ── M2: RESEND_COOLDOWN_MS is 15 000 ms (was 60 000) ──
+
+  test('RESEND_COOLDOWN_MS is 15 000 ms', () => {
+    expect(RESEND_COOLDOWN_MS).toBe(15_000);
+  });
+
+  // ── M2: start_outbound for SMS returns secret in response ──
+
+  test('start_outbound for SMS response includes secret', () => {
+    const { ctx, lastResponse } = createMockCtx();
+    handleGuardianVerification({
+      type: 'guardian_verification',
+      action: 'start_outbound',
+      channel: 'sms',
+      assistantId: 'self',
+      destination: '+15551234567',
+    }, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(true);
+    expect(resp!.secret).toBeDefined();
+    expect(typeof resp!.secret).toBe('string');
+    expect(resp!.secret!.length).toBeGreaterThan(0);
+  });
+
+  // ── M2: resend_outbound for SMS returns secret in response ──
+
+  test('resend_outbound for SMS response includes secret', () => {
+    // Start a session first
+    const { ctx: startCtx } = createMockCtx();
+    handleGuardianVerification({
+      type: 'guardian_verification',
+      action: 'start_outbound',
+      channel: 'sms',
+      assistantId: 'self',
+      destination: '+15551234567',
+    }, mockSocket, startCtx);
+
+    // Move past cooldown
+    const session = serviceFindActiveSession('self', 'sms');
+    expect(session).not.toBeNull();
+    storeUpdateSessionDelivery(session!.id, Date.now() - RESEND_COOLDOWN_MS - 1000, 1, Date.now() - 1000);
+
+    // Resend
+    const { ctx, lastResponse } = createMockCtx();
+    handleGuardianVerification({
+      type: 'guardian_verification',
+      action: 'resend_outbound',
+      channel: 'sms',
+      assistantId: 'self',
+    }, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(true);
+    expect(resp!.secret).toBeDefined();
+    expect(typeof resp!.secret).toBe('string');
+    expect(resp!.secret!.length).toBeGreaterThan(0);
+  });
+
+  // ── M2: start_outbound for Telegram bootstrap does NOT return secret ──
+
+  test('start_outbound for Telegram bootstrap (handle) does NOT return secret', () => {
+    const { ctx, lastResponse } = createMockCtx();
+    handleGuardianVerification({
+      type: 'guardian_verification',
+      action: 'start_outbound',
+      channel: 'telegram',
+      assistantId: 'self',
+      destination: '@someuser',
+    }, mockSocket, ctx);
+
+    const resp = lastResponse();
+    expect(resp).not.toBeNull();
+    expect(resp!.success).toBe(true);
+    // Security: secret must NOT be revealed for pending_bootstrap sessions
+    expect(resp!.secret).toBeUndefined();
+    // Bootstrap URL should be present instead
+    expect(resp!.telegramBootstrapUrl).toBeDefined();
+  });
+
+  // ── M2: bootstrap sessions use high-entropy hex secrets ──
+
+  test('bootstrap (pending_bootstrap) sessions use high-entropy hex secrets, identity-bound use 6-digit numeric', () => {
+    // Pending bootstrap: high-entropy hex (32 bytes = 64 hex chars)
+    const bootstrapResult = createOutboundSession({
+      assistantId: 'asst-entropy',
+      channel: 'telegram',
+      identityBindingStatus: 'pending_bootstrap',
+      destinationAddress: '@testuser',
+    });
+    expect(bootstrapResult.secret.length).toBe(64);
+    expect(bootstrapResult.secret).toMatch(/^[a-f0-9]{64}$/);
+
+    resetTables();
+
+    // Identity-bound: 6-digit numeric code
+    const boundResult = createOutboundSession({
+      assistantId: 'asst-entropy',
+      channel: 'sms',
+      expectedPhoneE164: '+15551234567',
+      destinationAddress: '+15551234567',
+      identityBindingStatus: 'bound',
+    });
+    expect(boundResult.secret.length).toBe(6);
+    expect(boundResult.secret).toMatch(/^\d{6}$/);
+  });
+
+  // ── M2: all identity-bound channels use 6-digit numeric codes ──
+
+  test('all identity-bound channels (SMS, Telegram chat ID, voice) use 6-digit numeric codes', () => {
+    // SMS
+    const smsResult = createOutboundSession({
+      assistantId: 'asst-codes',
+      channel: 'sms',
+      expectedPhoneE164: '+15551234567',
+      destinationAddress: '+15551234567',
+    });
+    expect(smsResult.secret).toMatch(/^\d{6}$/);
+
+    resetTables();
+
+    // Telegram (bound via chat ID)
+    const tgResult = createOutboundSession({
+      assistantId: 'asst-codes',
+      channel: 'telegram',
+      expectedChatId: '123456789',
+      identityBindingStatus: 'bound',
+      destinationAddress: '123456789',
+    });
+    expect(tgResult.secret).toMatch(/^\d{6}$/);
+
+    resetTables();
+
+    // Voice
+    const voiceResult = createOutboundSession({
+      assistantId: 'asst-codes',
+      channel: 'voice',
+      expectedPhoneE164: '+15551234567',
+      destinationAddress: '+15551234567',
+      codeDigits: 6,
+    });
+    expect(voiceResult.secret).toMatch(/^\d{6}$/);
   });
 });

--- a/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
+++ b/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
@@ -282,4 +282,78 @@ describe('Verification commands are deterministic (guard)', () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  test('handleChannelInbound does not call processMessage for /start gv_<token> bootstrap commands', async () => {
+    const { createHash, randomBytes } = await import('node:crypto');
+    const { handleChannelInbound } = await import('../runtime/routes/inbound-message-handler.js');
+    const { createOutboundSession } = await import('../runtime/channel-guardian-service.js');
+
+    // Generate a bootstrap token and create a pending_bootstrap session
+    const bootstrapToken = randomBytes(16).toString('hex');
+    const bootstrapTokenHash = createHash('sha256').update(bootstrapToken).digest('hex');
+
+    createOutboundSession({
+      assistantId: 'self',
+      channel: 'telegram',
+      identityBindingStatus: 'pending_bootstrap',
+      destinationAddress: 'test_user',
+      bootstrapTokenHash,
+    });
+
+    // Track whether processMessage was called
+    let processMessageCalled = false;
+    const processMessage = async () => {
+      processMessageCalled = true;
+      return { messageId: 'msg-1' };
+    };
+
+    // Track channel replies (the handler delivers the verification code via fetch)
+    const deliveredReplies: Array<{ chatId: string; text: string }> = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (init?.method === 'POST' && init.body) {
+        try {
+          const body = JSON.parse(init.body as string);
+          if (body.chatId && body.text) {
+            deliveredReplies.push({ chatId: body.chatId, text: body.text });
+          }
+        } catch { /* not JSON */ }
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return originalFetch(input, init as never);
+    }) as typeof fetch;
+
+    try {
+      const req = new Request('http://localhost/channels/inbound', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sourceChannel: 'telegram',
+          interface: 'telegram',
+          externalChatId: 'chat-bootstrap-123',
+          externalMessageId: `msg-bootstrap-${Date.now()}`,
+          content: `/start gv_${bootstrapToken}`,
+          senderExternalUserId: 'user-bootstrap-123',
+          senderName: 'Bootstrap User',
+          replyCallbackUrl: 'http://localhost/callback',
+          sourceMetadata: {
+            commandIntent: { type: 'start', payload: `gv_${bootstrapToken}` },
+          },
+        }),
+      });
+
+      const response = await handleChannelInbound(req, processMessage);
+      const body = await response.json() as Record<string, unknown>;
+
+      // Bootstrap should have been handled deterministically
+      expect(body.guardianVerification).toBe('bootstrap_bound');
+      expect(body.accepted).toBe(true);
+
+      // processMessage must NOT have been called — deterministic handling
+      expect(processMessageCalled).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });


### PR DESCRIPTION
Add test coverage for all M1-M4 changes: RESEND_COOLDOWN_MS=15s, secret presence in start/resend responses, bootstrap secret exclusion, high-entropy bootstrap secrets, phone normalization integration. All tests passing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
