### PR TITLE
M1: Recording intent resolver contract and implementation

### DIFF
--- a/assistant/src/daemon/recording-intent.ts
+++ b/assistant/src/daemon/recording-intent.ts
@@ -4,6 +4,13 @@
 
 export type RecordingIntentClass = 'start_only' | 'stop_only' | 'mixed' | 'none';
 
+export type RecordingIntentResult =
+  | { kind: 'none' }
+  | { kind: 'start_only' }
+  | { kind: 'stop_only' }
+  | { kind: 'start_with_remainder'; remainder: string }
+  | { kind: 'stop_with_remainder'; remainder: string };
+
 // ─── Start recording patterns ────────────────────────────────────────────────
 
 const START_RECORDING_PATTERNS: RegExp[] = [
@@ -230,4 +237,68 @@ export function classifyRecordingIntent(
   }
 
   return 'none';
+}
+
+// ─── Structured intent resolver ─────────────────────────────────────────────
+
+/**
+ * Resolves recording intent from user text into a structured result that
+ * distinguishes pure recording commands from commands with remaining task text.
+ *
+ * Pipeline:
+ * 1. Strip dynamic assistant names (leading vocative)
+ * 2. Strip leading polite wrappers
+ * 3. Interrogative gate — questions return `none`
+ * 4. Detect start/stop patterns (start takes precedence when both present)
+ * 5. Determine if recording-only or has a remainder, stripping from the
+ *    ORIGINAL text to preserve the user's exact phrasing
+ */
+export function resolveRecordingIntent(
+  text: string,
+  dynamicNames?: string[],
+): RecordingIntentResult {
+  // Step 1: Strip dynamic assistant names for normalization
+  let normalized =
+    dynamicNames && dynamicNames.length > 0
+      ? stripDynamicNames(text, dynamicNames)
+      : text;
+
+  // Step 2: Strip leading polite wrappers for normalization
+  normalized = normalized.replace(/^\s*(hey|hi|hello|please|pls|plz)[,\s]+/i, '');
+
+  // Step 3: Interrogative gate — WH-questions are not commands
+  if (WH_INTERROGATIVE.test(normalized)) {
+    return { kind: 'none' };
+  }
+
+  // Step 4: Detect start and stop patterns on the normalized text
+  const hasStart = detectRecordingIntent(normalized);
+  const hasStop = detectStopRecordingIntent(normalized);
+
+  // Step 5: Resolve — start takes precedence when both are present
+  if (hasStart) {
+    if (isRecordingOnly(normalized)) {
+      return { kind: 'start_only' };
+    }
+    // Strip from the ORIGINAL text to preserve user's exact phrasing
+    const remainder = stripRecordingIntent(text);
+    if (hasSubstantiveContent(remainder, dynamicNames)) {
+      return { kind: 'start_with_remainder', remainder };
+    }
+    return { kind: 'start_only' };
+  }
+
+  if (hasStop) {
+    if (isStopRecordingOnly(normalized)) {
+      return { kind: 'stop_only' };
+    }
+    // Strip from the ORIGINAL text to preserve user's exact phrasing
+    const remainder = stripStopRecordingIntent(text);
+    if (hasSubstantiveContent(remainder, dynamicNames)) {
+      return { kind: 'stop_with_remainder', remainder };
+    }
+    return { kind: 'stop_only' };
+  }
+
+  return { kind: 'none' };
 }

--- a/assistant/src/daemon/recording-intent.ts
+++ b/assistant/src/daemon/recording-intent.ts
@@ -281,7 +281,9 @@ export function resolveRecordingIntent(
       return { kind: 'start_only' };
     }
     // Strip from the ORIGINAL text to preserve user's exact phrasing
-    const remainder = stripRecordingIntent(text);
+    let remainder = stripRecordingIntent(text);
+    // Also strip stop-recording clauses when both intents are present
+    if (hasStop) remainder = stripStopRecordingIntent(remainder);
     if (hasSubstantiveContent(remainder, dynamicNames)) {
       return { kind: 'start_with_remainder', remainder };
     }


### PR DESCRIPTION
Add RecordingIntentResult discriminated union and resolveRecordingIntent function that returns structured outcomes (none, start_only, stop_only, start_with_remainder, stop_with_remainder). Reuses existing internal functions. All existing exports preserved for backward compatibility.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
