### PR TITLE
perf(macos): fix SwiftUI layout hangs in message list

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -182,10 +182,11 @@ struct ChatBubble: View {
                             .animation(VAnimation.fast, value: showOverflowMenu)
                     }
                 }
-                // Prevent LazyVStack from compressing the bubble height, which causes the
-                // trailing tool-chip to overlap long text content.
-                .fixedSize(horizontal: false, vertical: true)
-                .contextMenu {}
+                // Give this content priority so LazyVStack doesn't compress it,
+                // which caused trailing tool chips to overlap long text content.
+                // Uses layoutPriority instead of fixedSize to avoid forcing
+                // full height measurement during lazy placement.
+                .layoutPriority(1)
                 .overlay(alignment: .topLeading) {
                     if !isUser && showAvatar {
                         Image(nsImage: appearance.chatAvatarImage)

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -65,15 +65,21 @@ struct MessageListView: View {
         return textLen + (last?.toolCalls.count ?? 0) + (last?.inlineSurfaces.count ?? 0)
     }
 
-    private func shouldShowTimestamp(at index: Int, in list: [ChatMessage]) -> Bool {
-        if index == 0 { return true }
-        let current = list[index].timestamp
-        let previous = list[index - 1].timestamp
+    /// Pre-compute which message indices should show a timestamp divider.
+    /// Avoids creating a Calendar instance per-message inside the ForEach body.
+    private func timestampIndices(for list: [ChatMessage]) -> Set<Int> {
+        guard !list.isEmpty else { return [] }
+        var result: Set<Int> = [0]
         var calendar = Calendar.current
         calendar.timeZone = ChatTimestampTimeZone.resolve()
-        if !calendar.isDate(current, inSameDayAs: previous) { return true }
-        let gap = current.timeIntervalSince(previous)
-        return gap > 300
+        for i in 1..<list.count {
+            let current = list[i].timestamp
+            let previous = list[i - 1].timestamp
+            if !calendar.isDate(current, inSameDayAs: previous) || current.timeIntervalSince(previous) > 300 {
+                result.insert(i)
+            }
+        }
+        return result
     }
 
     private func modelPickerView(for message: ChatMessage) -> some View {
@@ -126,8 +132,13 @@ struct MessageListView: View {
 
                     let displayMessages = visibleMessages
                     let activePendingRequestId = PendingConfirmationFocusSelector.activeRequestId(from: displayMessages)
-                    ForEach(Array(displayMessages.enumerated()), id: \.element.id) { index, message in
-                        if shouldShowTimestamp(at: index, in: displayMessages) {
+                    let latestAssistantId = displayMessages.last(where: { $0.role == .assistant })?.id
+                    // Pre-compute subagent lookup to avoid O(n*m) filtering inside ForEach
+                    let subagentsByParent: [UUID: [SubagentInfo]] = Dictionary(grouping: activeSubagents.filter { $0.parentMessageId != nil }, by: { $0.parentMessageId! })
+                    let orphanSubagents = activeSubagents.filter { $0.parentMessageId == nil }
+                    let showTimestamp = timestampIndices(for: displayMessages)
+                    ForEach(Array(zip(displayMessages.indices, displayMessages)), id: \.1.id) { index, message in
+                        if showTimestamp.contains(index) {
                             TimestampDivider(date: message.timestamp)
                         }
 
@@ -141,7 +152,7 @@ struct MessageListView: View {
                                     onAlwaysAllow: onAlwaysAllow
                                 )
                                 .id(message.id)
-                                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                                .transition(.opacity)
                             } else {
                                 let hasPrecedingAssistant: Bool = {
                                     guard index > 0 else { return false }
@@ -156,21 +167,21 @@ struct MessageListView: View {
                                         onAlwaysAllow: onAlwaysAllow
                                     )
                                     .id(message.id)
-                                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+                                    .transition(.opacity)
                                 }
                             }
                         } else if message.modelPicker != nil {
                             modelPickerView(for: message)
                                 .id(message.id)
-                                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                                .transition(.opacity)
                         } else if message.modelList != nil {
                             modelListView(for: message)
                                 .id(message.id)
-                                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                                .transition(.opacity)
                         } else if message.commandList != nil {
                             CommandListBubble()
                                 .id(message.id)
-                                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                                .transition(.opacity)
                         } else {
                             let nextIsPendingConfirmation = index + 1 < displayMessages.count
                                 && displayMessages[index + 1].confirmation?.state == .pending
@@ -197,14 +208,14 @@ struct MessageListView: View {
                                 mediaEmbedSettings: mediaEmbedSettings,
                                 daemonHttpPort: daemonHttpPort,
                                 showAvatar: !previousIsAssistant,
-                                isLatestAssistantMessage: message.role == .assistant && displayMessages.last(where: { $0.role == .assistant })?.id == message.id,
+                                isLatestAssistantMessage: message.role == .assistant && message.id == latestAssistantId,
                                 activeSurfaceId: activeSurfaceId
                             )
                                 .id(message.id)
-                                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                                .transition(.opacity)
                         }
 
-                        ForEach(activeSubagents.filter { $0.parentMessageId == message.id }) { subagent in
+                        ForEach(subagentsByParent[message.id] ?? []) { subagent in
                             SubagentThreadView(
                                 subagent: subagent,
                                 events: subagentDetailStore.eventsBySubagent[subagent.id] ?? [],
@@ -214,11 +225,11 @@ struct MessageListView: View {
                                 .frame(maxWidth: 520, alignment: .leading)
                                 .padding(.leading, 36)
                                 .id("subagent-\(subagent.id)")
-                                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                                .transition(.opacity)
                         }
                     }
 
-                    ForEach(activeSubagents.filter { $0.parentMessageId == nil }) { subagent in
+                    ForEach(orphanSubagents) { subagent in
                         SubagentThreadView(
                             subagent: subagent,
                             events: subagentDetailStore.eventsBySubagent[subagent.id] ?? [],

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1308,7 +1308,24 @@ public enum ContentBlockRef: Equatable {
     case surface(Int)
 }
 
-public struct ChatMessage: Identifiable {
+public struct ChatMessage: Identifiable, Equatable {
+    // Explicit Equatable: compare only fields that affect rendering.
+    // Avoids expensive byte-by-byte comparison of attachment data,
+    // image payloads, and surface HTML that don't change the UI.
+    public static func == (lhs: ChatMessage, rhs: ChatMessage) -> Bool {
+        lhs.id == rhs.id
+        && lhs.role == rhs.role
+        && lhs.textSegments == rhs.textSegments
+        && lhs.isStreaming == rhs.isStreaming
+        && lhs.status == rhs.status
+        && lhs.isError == rhs.isError
+        && lhs.toolCalls.count == rhs.toolCalls.count
+        && lhs.attachments.count == rhs.attachments.count
+        && lhs.inlineSurfaces.count == rhs.inlineSurfaces.count
+        && lhs.confirmation?.state == rhs.confirmation?.state
+        && lhs.isSubagentNotification == rhs.isSubagentNotification
+        && lhs.streamingCodePreview == rhs.streamingCodePreview
+    }
     public let id: UUID
     public let role: ChatRole
     public var textSegments: [String]


### PR DESCRIPTION
## Summary
Fix main-thread hangs in the chat message list caused by expensive SwiftUI layout operations. A hang report showed 1.07s blocks in `LazySubviewPlacements.placeSubviews` during normal chat use.

## Changes

**ChatMessage Equatable** (`ChatMessage.swift`)
- Add explicit `Equatable` conformance comparing only render-relevant fields (id, role, textSegments, isStreaming, status, counts)
- Avoids synthetic byte-by-byte comparison of attachment data, image payloads, tool call internals, and surface HTML

**MessageListView pre-computation** (`MessageListView.swift`)
- Pre-compute `latestAssistantId` once before ForEach (was O(n) per message = O(n²))
- Pre-compute `subagentsByParent` dictionary (was filtering full array per message)
- Pre-compute `timestampIndices` set (was creating Calendar per message per render)

**ChatBubble layout** (`ChatBubble.swift`)
- Replace `.fixedSize(horizontal: false, vertical: true)` with `.layoutPriority(1)` — `.fixedSize` forces full height measurement during lazy placement, defeating LazyVStack's deferred layout
- Remove empty `.contextMenu {}` — forces NSMenu infrastructure per bubble even with no items

**Transitions** (`MessageListView.swift`)
- Simplify `.transition(.opacity.combined(with: .move(edge: .bottom)))` to `.transition(.opacity)` — combined transitions force SwiftUI to track extra animation state for items entering/leaving the visible region

## Testing
- Open a long conversation with many messages, tool calls, and subagents
- Scroll through — should be smooth, no hangs
- Streaming responses should not cause layout stalls
- Tool chips should not overlap long text (regression check for .fixedSize removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
