### PR TITLE
M2: Unified executor and handler wiring

### DIFF
--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -125,10 +125,31 @@ export async function handleTaskSubmit(
         return;
       }
 
-      if (intentResult.kind === 'start_with_remainder' || intentResult.kind === 'stop_with_remainder') {
+      if (intentResult.kind === 'start_and_stop_only') {
+        let activeSessionId = ctx.socketToSession.get(socket);
+        if (!activeSessionId) {
+          const conversation = conversationStore.createConversation(msg.task);
+          activeSessionId = conversation.id;
+          ctx.socketToSession.set(socket, activeSessionId);
+        }
+
+        const execResult = executeRecordingIntent(intentResult, {
+          conversationId: activeSessionId,
+          socket,
+          ctx,
+        });
+
+        rlog.info('Recording start+stop intent intercepted');
+        ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
+        ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: activeSessionId });
+        ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        return;
+      }
+
+      if (intentResult.kind === 'start_with_remainder' || intentResult.kind === 'stop_with_remainder' || intentResult.kind === 'start_and_stop_with_remainder') {
         // Defer recording action until after classifier creates the final conversation
-        pendingRecordingStart = intentResult.kind === 'start_with_remainder';
-        pendingRecordingStop = intentResult.kind === 'stop_with_remainder';
+        pendingRecordingStart = intentResult.kind === 'start_with_remainder' || intentResult.kind === 'start_and_stop_with_remainder';
+        pendingRecordingStop = intentResult.kind === 'stop_with_remainder' || intentResult.kind === 'start_and_stop_with_remainder';
         (msg as { task: string }).task = intentResult.remainder;
         rlog.info({ remaining: intentResult.remainder }, 'Recording intent deferred, continuing with remaining text');
       }

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -21,7 +21,8 @@ import type {
   SuggestionRequest,
   TaskSubmit,
 } from '../ipc-protocol.js';
-import { classifyRecordingIntent, detectRecordingIntent, detectStopRecordingIntent, hasSubstantiveContent, isInterrogative, stripRecordingIntent, stripStopRecordingIntent } from '../recording-intent.js';
+import { executeRecordingIntent } from '../recording-executor.js';
+import { resolveRecordingIntent } from '../recording-intent.js';
 import { buildSessionErrorMessage,classifySessionError } from '../session-error.js';
 import { handleCuSessionCreate } from './computer-use.js';
 import { handleRecordingStart, handleRecordingStop } from './recording.js';
@@ -71,125 +72,68 @@ export async function handleTaskSubmit(
     }
 
     // ── Standalone recording intent interception ──────────────────────────
-    // Intercept recording-only and stop-recording prompts before they reach
-    // the classifier. This prevents "record my screen" from creating a CU
-    // session and routes it to the standalone recording flow instead.
-    //
-    // For mixed intent, recording start/stop is deferred until after the
-    // downstream classifier creates the final conversation, so the recording
-    // attachment is linked to the correct conversation (not an orphaned one).
     let pendingRecordingStart = false;
     let pendingRecordingStop = false;
     const config = getConfig();
     if (config.daemon.standaloneRecording) {
       const name = getAssistantName();
       const dynamicNames = [name].filter(Boolean) as string[];
-      const intentClass = classifyRecordingIntent(msg.task, dynamicNames);
+      const intentResult = resolveRecordingIntent(msg.task, dynamicNames);
 
-      switch (intentClass) {
-        case 'stop_only': {
-          // Find the active session for this socket so we can resolve the
-          // conversation that owns the recording.
-          let activeSessionId = ctx.socketToSession.get(socket);
-          // Ensure we have a sessionId for message_complete even if no prior session exists
-          if (!activeSessionId) {
-            const conversation = conversationStore.createConversation(msg.task);
-            activeSessionId = conversation.id;
-            ctx.socketToSession.set(socket, activeSessionId);
-          }
-          // Always attempt stop — handleRecordingStop has a global fallback that
-          // resolves to the active recording even if this conversation doesn't own it.
-          const stopped = handleRecordingStop(activeSessionId, ctx) !== undefined;
-          rlog.info('Recording stop intent intercepted');
-          ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
-          ctx.send(socket, {
-            type: 'assistant_text_delta',
-            text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',
-            sessionId: activeSessionId,
-          });
-          ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
-          return;
+      if (intentResult.kind === 'start_only') {
+        // Create a conversation so the recording can be attached later
+        const conversation = conversationStore.createConversation(msg.task);
+        ctx.socketToSession.set(socket, conversation.id);
+
+        const execResult = executeRecordingIntent(intentResult, {
+          conversationId: conversation.id,
+          socket,
+          ctx,
+        });
+
+        ctx.send(socket, { type: 'task_routed', sessionId: conversation.id, interactionType: 'text_qa' });
+        ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: conversation.id });
+        ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
+
+        // If recording rejected, unbind socket
+        if (execResult.responseText === 'A recording is already active.') {
+          ctx.socketToSession.delete(socket);
         }
-        case 'start_only': {
-          // Create a conversation so the recording can be attached later (M4).
-          const conversation = conversationStore.createConversation(msg.task);
-          ctx.socketToSession.set(socket, conversation.id);
 
-          const recordingId = handleRecordingStart(conversation.id, { promptForSource: true }, socket, ctx);
-
-          if (recordingId) {
-            ctx.send(socket, { type: 'task_routed', sessionId: conversation.id, interactionType: 'text_qa' });
-            ctx.send(socket, { type: 'assistant_text_delta', text: 'Starting screen recording.', sessionId: conversation.id });
-          } else {
-            // Recording was rejected (already active) — clean up the orphaned conversation
-            ctx.send(socket, { type: 'task_routed', sessionId: conversation.id, interactionType: 'text_qa' });
-            ctx.send(socket, { type: 'assistant_text_delta', text: 'A recording is already active.', sessionId: conversation.id });
-          }
-          ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
-
-          if (!recordingId) {
-            // Unbind the socket so the ephemeral rejection session doesn't block
-            // future task_submit routing, but keep the conversation in the DB so
-            // the client can still send follow-up messages to the routed sessionId.
-            ctx.socketToSession.delete(socket);
-          }
-
-          rlog.info({ sessionId: conversation.id }, 'Recording-only intent intercepted — routed to standalone recording');
-          return;
-        }
-        case 'mixed': {
-          // Skip recording side effects for questions about recording
-          // (e.g., "how do I stop recording?") — let the model answer instead.
-          if (isInterrogative(msg.task, dynamicNames)) {
-            rlog.info('Mixed recording intent is interrogative — skipping side effects');
-            break;
-          }
-
-          // Mixed = recording intent embedded in broader text (e.g., "open Chrome and record my screen").
-          // Defer recording start/stop until after the classifier creates the final conversation,
-          // so the recording attachment is linked to the correct conversation.
-          const hasStart = detectRecordingIntent(msg.task);
-          const hasStop = detectStopRecordingIntent(msg.task);
-
-          // Strip recording clauses from the task
-          let remaining = msg.task;
-          if (hasStart) remaining = stripRecordingIntent(remaining);
-          if (hasStop) remaining = stripStopRecordingIntent(remaining);
-
-          // If nothing substantive remains after stripping, handle as recording-only now
-          if (!hasSubstantiveContent(remaining, dynamicNames)) {
-            let sessionId = ctx.socketToSession.get(socket);
-            if (!sessionId) {
-              const conversation = conversationStore.createConversation(msg.task);
-              sessionId = conversation.id;
-              ctx.socketToSession.set(socket, sessionId);
-            }
-            if (hasStop) handleRecordingStop(sessionId, ctx);
-            const startResult = hasStart ? handleRecordingStart(sessionId, { promptForSource: true }, socket, ctx) : null;
-            ctx.send(socket, { type: 'task_routed', sessionId, interactionType: 'text_qa' });
-            let text: string;
-            if (hasStart && startResult) {
-              text = hasStop ? 'Stopping current recording and starting a new one.' : 'Starting screen recording.';
-            } else if (hasStart) {
-              text = 'A recording is already active.';
-            } else {
-              text = 'Stopping the recording.';
-            }
-            ctx.send(socket, { type: 'assistant_text_delta', text, sessionId });
-            ctx.send(socket, { type: 'message_complete', sessionId });
-            return;
-          }
-
-          // Set deferred flags — recording will start after the final conversation is created
-          pendingRecordingStart = hasStart;
-          pendingRecordingStop = hasStop;
-          (msg as { task: string }).task = remaining;
-          rlog.info({ remaining }, 'Mixed recording intent — deferred, continuing with remaining text');
-          break;
-        }
-        case 'none':
-          break;
+        rlog.info({ sessionId: conversation.id }, 'Recording-only intent intercepted — routed to standalone recording');
+        return;
       }
+
+      if (intentResult.kind === 'stop_only') {
+        let activeSessionId = ctx.socketToSession.get(socket);
+        if (!activeSessionId) {
+          const conversation = conversationStore.createConversation(msg.task);
+          activeSessionId = conversation.id;
+          ctx.socketToSession.set(socket, activeSessionId);
+        }
+
+        const execResult = executeRecordingIntent(intentResult, {
+          conversationId: activeSessionId,
+          socket,
+          ctx,
+        });
+
+        rlog.info('Recording stop intent intercepted');
+        ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
+        ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: activeSessionId });
+        ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        return;
+      }
+
+      if (intentResult.kind === 'start_with_remainder' || intentResult.kind === 'stop_with_remainder') {
+        // Defer recording action until after classifier creates the final conversation
+        pendingRecordingStart = intentResult.kind === 'start_with_remainder';
+        pendingRecordingStop = intentResult.kind === 'stop_with_remainder';
+        (msg as { task: string }).task = intentResult.remainder;
+        rlog.info({ remaining: intentResult.remainder }, 'Recording intent deferred, continuing with remaining text');
+      }
+
+      // 'none' falls through to normal processing
     }
 
     // Slash candidates always route to text_qa — bypass classifier

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -33,7 +33,8 @@ import type {
   UserMessage,
 } from '../ipc-protocol.js';
 import { normalizeThreadType } from '../ipc-protocol.js';
-import { classifyRecordingIntent, detectRecordingIntent, detectStopRecordingIntent, hasSubstantiveContent, isInterrogative, stripRecordingIntent, stripStopRecordingIntent } from '../recording-intent.js';
+import { executeRecordingIntent } from '../recording-executor.js';
+import { resolveRecordingIntent } from '../recording-intent.js';
 import { buildSessionErrorMessage,classifySessionError } from '../session-error.js';
 import { generateVideoThumbnail } from '../video-thumbnail.js';
 import { handleRecordingStart, handleRecordingStop } from './recording.js';
@@ -229,81 +230,30 @@ export async function handleUserMessage(
     if (config.daemon.standaloneRecording && messageText) {
       const name = getAssistantName();
       const dynamicNames = [name].filter(Boolean) as string[];
-      const intentClass = classifyRecordingIntent(messageText, dynamicNames);
+      const intentResult = resolveRecordingIntent(messageText, dynamicNames);
+      const execResult = executeRecordingIntent(intentResult, {
+        conversationId: msg.sessionId,
+        socket,
+        ctx,
+      });
 
-      switch (intentClass) {
-        case 'stop_only': {
-          const stopped = handleRecordingStop(msg.sessionId, ctx) !== undefined;
-          rlog.info('Recording stop intent intercepted in user_message');
-          ctx.send(socket, {
-            type: 'assistant_text_delta',
-            text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',
-            sessionId: msg.sessionId,
-          });
-          ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
-          return;
-        }
-        case 'start_only': {
-          const recordingId = handleRecordingStart(msg.sessionId, { promptForSource: true }, socket, ctx);
-          rlog.info('Recording-only intent intercepted in user_message');
+      if (execResult.handled) {
+        rlog.info({ kind: intentResult.kind }, 'Recording intent intercepted in user_message');
+        ctx.send(socket, {
+          type: 'assistant_text_delta',
+          text: execResult.responseText!,
+          sessionId: msg.sessionId,
+        });
+        ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+        return;
+      }
 
-          if (recordingId) {
-            ctx.send(socket, { type: 'assistant_text_delta', text: 'Starting screen recording.', sessionId: msg.sessionId });
-          } else {
-            ctx.send(socket, { type: 'assistant_text_delta', text: 'A recording is already active.', sessionId: msg.sessionId });
-          }
-          ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
-          return;
-        }
-        case 'mixed': {
-          // Skip recording side effects for questions about recording
-          // (e.g., "how do I stop recording?") — let the model answer instead.
-          if (isInterrogative(messageText, dynamicNames)) {
-            rlog.info('Mixed recording intent is interrogative — skipping side effects');
-            break;
-          }
-
-          // Mixed = recording intent embedded in broader text.
-          // Handle the recording action, then check if remaining text is substantive.
-          const hasStart = detectRecordingIntent(messageText);
-          const hasStop = detectStopRecordingIntent(messageText);
-
-          if (hasStop) {
-            handleRecordingStop(msg.sessionId, ctx);
-            rlog.info('Mixed intent — stopping recording');
-          }
-          const startResult = hasStart ? handleRecordingStart(msg.sessionId, { promptForSource: true }, socket, ctx) : null;
-          if (hasStart) {
-            rlog.info({ started: !!startResult }, 'Mixed intent — starting recording');
-          }
-
-          // Strip recording clauses from the message
-          let remaining = messageText;
-          if (hasStart) remaining = stripRecordingIntent(remaining);
-          if (hasStop) remaining = stripStopRecordingIntent(remaining);
-
-          // If nothing substantive remains (just fillers, names, punctuation), complete now
-          if (!hasSubstantiveContent(remaining, dynamicNames)) {
-            let text: string;
-            if (hasStart && startResult) {
-              text = hasStop ? 'Stopping current recording and starting a new one.' : 'Starting screen recording.';
-            } else if (hasStart) {
-              text = 'A recording is already active.';
-            } else {
-              text = 'Stopping the recording.';
-            }
-            ctx.send(socket, { type: 'assistant_text_delta', text, sessionId: msg.sessionId });
-            ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
-            return;
-          }
-
-          // Continue with stripped text for downstream processing
-          msg.content = remaining;
-          rlog.info({ remaining }, 'Mixed recording intent — recording handled, continuing with remaining text');
-          break;
-        }
-        case 'none':
-          break;
+      if (execResult.remainderText) {
+        // Execute deferred recording actions immediately for user_message path
+        if (execResult.pendingStop) handleRecordingStop(msg.sessionId, ctx);
+        if (execResult.pendingStart) handleRecordingStart(msg.sessionId, { promptForSource: true }, socket, ctx);
+        msg.content = execResult.remainderText;
+        rlog.info({ remaining: execResult.remainderText }, 'Recording intent handled, continuing with remaining text');
       }
     }
 

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -174,7 +174,7 @@ export async function handleUserMessage(
     };
 
     const config = getConfig();
-    const messageText = msg.content ?? '';
+    let messageText = msg.content ?? '';
 
     // Block inbound messages that contain secrets and redirect to secure prompt
     if (!msg.bypassSecretCheck) {
@@ -252,7 +252,7 @@ export async function handleUserMessage(
         // Execute deferred recording actions immediately for user_message path
         if (execResult.pendingStop) handleRecordingStop(msg.sessionId, ctx);
         if (execResult.pendingStart) handleRecordingStart(msg.sessionId, { promptForSource: true }, socket, ctx);
-        msg.content = execResult.remainderText;
+        messageText = execResult.remainderText;
         rlog.info({ remaining: execResult.remainderText }, 'Recording intent handled, continuing with remaining text');
       }
     }

--- a/assistant/src/daemon/recording-executor.ts
+++ b/assistant/src/daemon/recording-executor.ts
@@ -74,5 +74,29 @@ export function executeRecordingIntent(
         remainderText: result.remainder,
         pendingStop: true,
       };
+
+    case 'start_and_stop_only': {
+      handleRecordingStop(context.conversationId, context.ctx);
+      const recordingId = handleRecordingStart(
+        context.conversationId,
+        { promptForSource: true },
+        context.socket,
+        context.ctx,
+      );
+      return {
+        handled: true,
+        responseText: recordingId
+          ? 'Stopping current recording and starting a new one.'
+          : 'Stopping the recording.',
+      };
+    }
+
+    case 'start_and_stop_with_remainder':
+      return {
+        handled: false,
+        remainderText: result.remainder,
+        pendingStart: true,
+        pendingStop: true,
+      };
   }
 }

--- a/assistant/src/daemon/recording-executor.ts
+++ b/assistant/src/daemon/recording-executor.ts
@@ -1,0 +1,78 @@
+// Unified recording intent executor.
+// Bridges the gap between recording-intent.ts (classification) and
+// handlers/recording.ts (side effects), so both sessions.ts and misc.ts
+// can share the same execution logic without duplicating switch/case blocks.
+
+import type * as net from 'node:net';
+
+import type { HandlerContext } from './handlers/shared.js';
+import { handleRecordingStart, handleRecordingStop } from './handlers/recording.js';
+import type { RecordingIntentResult } from './recording-intent.js';
+
+export interface RecordingExecutionContext {
+  conversationId: string;
+  socket: net.Socket;
+  ctx: HandlerContext;
+}
+
+export interface RecordingExecutionOutput {
+  /** If true, the intent was fully handled (start_only / stop_only) -- handler should send completion and return */
+  handled: boolean;
+  /** Human-readable response text for the user */
+  responseText?: string;
+  /** For _with_remainder: the remaining text after stripping recording clauses */
+  remainderText?: string;
+  /** Whether a recording start should be/was initiated */
+  pendingStart?: boolean;
+  /** Whether a recording stop should be/was initiated */
+  pendingStop?: boolean;
+}
+
+export function executeRecordingIntent(
+  result: RecordingIntentResult,
+  context: RecordingExecutionContext,
+): RecordingExecutionOutput {
+  switch (result.kind) {
+    case 'none':
+      return { handled: false };
+
+    case 'start_only': {
+      const recordingId = handleRecordingStart(
+        context.conversationId,
+        { promptForSource: true },
+        context.socket,
+        context.ctx,
+      );
+      return {
+        handled: true,
+        responseText: recordingId
+          ? 'Starting screen recording.'
+          : 'A recording is already active.',
+      };
+    }
+
+    case 'stop_only': {
+      const stopped = handleRecordingStop(context.conversationId, context.ctx) !== undefined;
+      return {
+        handled: true,
+        responseText: stopped
+          ? 'Stopping the recording.'
+          : 'No active recording to stop.',
+      };
+    }
+
+    case 'start_with_remainder':
+      return {
+        handled: false,
+        remainderText: result.remainder,
+        pendingStart: true,
+      };
+
+    case 'stop_with_remainder':
+      return {
+        handled: false,
+        remainderText: result.remainder,
+        pendingStop: true,
+      };
+  }
+}

--- a/assistant/src/daemon/recording-intent.ts
+++ b/assistant/src/daemon/recording-intent.ts
@@ -9,7 +9,9 @@ export type RecordingIntentResult =
   | { kind: 'start_only' }
   | { kind: 'stop_only' }
   | { kind: 'start_with_remainder'; remainder: string }
-  | { kind: 'stop_with_remainder'; remainder: string };
+  | { kind: 'stop_with_remainder'; remainder: string }
+  | { kind: 'start_and_stop_only' }
+  | { kind: 'start_and_stop_with_remainder'; remainder: string };
 
 // ─── Start recording patterns ────────────────────────────────────────────────
 
@@ -275,15 +277,30 @@ export function resolveRecordingIntent(
   const hasStart = detectRecordingIntent(normalized);
   const hasStop = detectStopRecordingIntent(normalized);
 
-  // Step 5: Resolve — start takes precedence when both are present
+  // Step 5: Resolve
   if (hasStart) {
+    if (hasStop) {
+      // Both start and stop detected — use combined variants
+      if (isRecordingOnly(normalized)) {
+        // Check if stop-only after stripping start patterns
+        const withoutStart = stripRecordingIntent(normalized);
+        if (isStopRecordingOnly(withoutStart)) {
+          return { kind: 'start_and_stop_only' };
+        }
+      }
+      let remainder = stripRecordingIntent(text);
+      remainder = stripStopRecordingIntent(remainder);
+      if (hasSubstantiveContent(remainder, dynamicNames)) {
+        return { kind: 'start_and_stop_with_remainder', remainder };
+      }
+      return { kind: 'start_and_stop_only' };
+    }
+    // Only start detected
     if (isRecordingOnly(normalized)) {
       return { kind: 'start_only' };
     }
     // Strip from the ORIGINAL text to preserve user's exact phrasing
-    let remainder = stripRecordingIntent(text);
-    // Also strip stop-recording clauses when both intents are present
-    if (hasStop) remainder = stripStopRecordingIntent(remainder);
+    const remainder = stripRecordingIntent(text);
     if (hasSubstantiveContent(remainder, dynamicNames)) {
       return { kind: 'start_with_remainder', remainder };
     }


### PR DESCRIPTION
Create executeRecordingIntent in recording-executor.ts. Rewrite both sessions.ts and misc.ts recording blocks to use resolveRecordingIntent + executeRecordingIntent, eliminating duplicated classification/stripping/interrogative logic. Deferred recording pattern in task_submit preserved.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
