### PR TITLE
M3: Extend stripHeavyContent() for large text + tool results

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1324,6 +1324,7 @@ public struct ChatMessage: Identifiable, Equatable {
         && lhs.inlineSurfaces.count == rhs.inlineSurfaces.count
         && lhs.confirmation?.state == rhs.confirmation?.state
         && lhs.isSubagentNotification == rhs.isSubagentNotification
+        && lhs.isContentStripped == rhs.isContentStripped
         && lhs.streamingCodePreview == rhs.streamingCodePreview
     }
     public let id: UUID
@@ -1357,6 +1358,10 @@ public struct ChatMessage: Identifiable, Equatable {
     /// reconstructed from history. It should be hidden from the chat UI since the
     /// corresponding subagent chip conveys the same information.
     public var isSubagentNotification: Bool = false
+    /// When true, heavyweight content (tool results, large text, inputFull/inputRawDict)
+    /// has been stripped from this message to reduce memory. The UI can use this flag
+    /// to show a "load full content" affordance in a future milestone.
+    public var isContentStripped: Bool = false
 
     /// Concatenated text from all segments. Backward-compatible computed property.
     public var text: String {
@@ -1379,13 +1384,22 @@ public struct ChatMessage: Identifiable, Equatable {
         self.isError = isError
     }
 
+    /// Maximum text segment length before truncation during stripping.
+    private static let stripTextLimit = 200
+
     /// Release heavyweight data (images, attachment binary data, completed surface
-    /// payloads) to reduce memory pressure on old messages that are no longer visible.
-    /// Metadata (tool names, summaries, surface refs) is preserved for display.
+    /// payloads, tool results, large text) to reduce memory pressure on old messages
+    /// that are no longer visible.
+    /// Metadata (tool names, inputSummary, inputRawValue, surface refs) is preserved for display.
     public mutating func stripHeavyContent() {
+        // Tool calls: clear images, results, full input, and raw dict.
+        // Keep toolName, inputSummary, and inputRawValue (short one-liner) intact for display.
         for i in toolCalls.indices {
             toolCalls[i].cachedImage = nil
             toolCalls[i].imageData = nil
+            toolCalls[i].result = nil
+            toolCalls[i].inputFull = ""
+            toolCalls[i].inputRawDict = nil
         }
         for i in attachments.indices {
             attachments[i].data = ""
@@ -1406,6 +1420,14 @@ public struct ChatMessage: Identifiable, Equatable {
                 )
             }
         }
+        // Truncate long text segments to reduce string memory.
+        let limit = Self.stripTextLimit
+        for i in textSegments.indices {
+            if textSegments[i].count > limit {
+                textSegments[i] = String(textSegments[i].prefix(limit)) + " \u{2026} [stripped]"
+            }
+        }
+        isContentStripped = true
     }
 
     /// Build a default content order from the legacy `arrivedBeforeText` flag.

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -483,9 +483,9 @@ public final class ChatViewModel: ObservableObject {
     // MARK: - Message Trimming
 
     /// Threshold above which old messages have their heavy content stripped.
-    private static let trimThreshold = 200
+    private static let trimThreshold = 150
     /// Number of recent messages to keep untrimmed (images, attachments, surfaces intact).
-    private static let trimKeepRecent = 100
+    private static let trimKeepRecent = 75
 
     /// Strip heavyweight binary data (images, attachments, completed surface payloads)
     /// from old messages when the total count exceeds `trimThreshold`. The most recent


### PR DESCRIPTION
Part of #9275. Extends `stripHeavyContent()` to also clear tool results, `inputFull`, `inputRawDict`, and truncate long text segments (>200 chars). Adds `isContentStripped` flag for future rehydrate UI.

## Summary
- Extended `stripHeavyContent()` in `ChatMessage.swift` to clear `toolCalls[i].result`, `toolCalls[i].inputFull`, and `toolCalls[i].inputRawDict` on old messages
- Text segments longer than 200 characters are truncated to 200 chars + " ... [stripped]"
- Added `public var isContentStripped: Bool = false` flag to `ChatMessage`, included in `Equatable`
- Lowered trim thresholds in `ChatViewModel.swift` from 200/100 to 150/75 so stripping kicks in earlier

## Key Technical Choices
- `toolName`, `inputSummary`, and `inputRawValue` (short one-liner) are preserved for display — only the heavyweight fields are cleared
- The `isContentStripped` flag enables a future "load full content" affordance without requiring changes to the stripping logic
- Existing image/attachment/surface stripping behavior is preserved — this extends, not replaces

## Files Changed
- `clients/shared/Features/Chat/ChatMessage.swift` — Extended `stripHeavyContent()`, added `isContentStripped` flag
- `clients/shared/Features/Chat/ChatViewModel.swift` — Updated trim thresholds to 150/75

## Testing
- Build verified: `cd clients/macos && swift build --product vellum-assistant`
- Existing `trimOldMessagesIfNeeded()` call sites unchanged — stripping is wired in automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
