### PR TITLE
M5: Inactive thread memory eviction

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -374,6 +374,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     func selectThread(id: UUID) {
         guard let thread = threads.first(where: { $0.id == id }) else { return }
 
+        trimPreviousThreadIfNeeded(nextThreadId: id)
+
         // Re-create the ViewModel if it was LRU-evicted.
         if chatViewModels[id] == nil {
             let viewModel = makeViewModel()
@@ -629,10 +631,22 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     func activateThread(_ id: UUID) {
+        trimPreviousThreadIfNeeded(nextThreadId: id)
         activeThreadId = id
     }
 
     // MARK: - Private
+
+    /// Trim the previously active thread's view model to shed memory before
+    /// switching to a different thread. Skipped when the VM hasn't loaded
+    /// history yet or when it has an active generation in progress.
+    private func trimPreviousThreadIfNeeded(nextThreadId: UUID) {
+        guard let previousId = activeThreadId, previousId != nextThreadId,
+              let vm = chatViewModels[previousId],
+              vm.isHistoryLoaded,
+              !vm.isSending, !vm.isThinking else { return }
+        vm.trimForBackground()
+    }
 
     /// Backfill ThreadModel.sessionId when the daemon assigns a session to a new thread.
     private func backfillSessionId(_ sessionId: String, for viewModel: ChatViewModel) {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -500,6 +500,21 @@ public final class ChatViewModel: ObservableObject {
         }
     }
 
+    /// Aggressively trim this view model for background retention. Keeps only
+    /// the latest page of messages with heavy content stripped, and resets
+    /// pagination so re-activation fetches fresh history from the daemon.
+    public func trimForBackground() {
+        let pageSize = Self.messagePageSize
+        if messages.count > pageSize {
+            messages = Array(messages.suffix(pageSize))
+        }
+        for i in messages.indices {
+            messages[i].stripHeavyContent()
+        }
+        displayedMessageCount = Self.messagePageSize
+        isHistoryLoaded = false
+    }
+
     /// Surface the user is currently viewing in workspace mode.
     /// Set by MainWindowView when the dynamic workspace is expanded.
     public var activeSurfaceId: String? {


### PR DESCRIPTION
Part of #9272. Adds trimForBackground() to ChatViewModel that shrinks messages to the latest page and strips heavy content. Called from ThreadManager on thread switch to shed memory from inactive threads.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
