### PR TITLE
M4: Cache guardrails for huge messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -394,6 +394,58 @@ struct ChatBubble: View {
     @MainActor static var inlineMarkdownCache = [String: (value: AttributedString, accessTime: Int)]()
     static let maxCacheSize = 100
 
+    // MARK: - Cache Guardrails
+    //
+    // Prevents a single huge message from consuming disproportionate cache
+    // space.  Text over `maxCacheableTextLength` is parsed but never stored.
+    // `estimatedCacheBytes` tracks a rough byte budget across all three
+    // caches; when it exceeds `maxCacheBytes` the oldest entries are evicted.
+
+    static let maxCacheableTextLength = 10_000
+    static let maxCacheBytes = 5_000_000
+    /// Rough byte estimate of all entries across segmentCache, markdownCache,
+    /// and inlineMarkdownCache.  Updated on insert/evict.
+    @MainActor static var estimatedCacheBytes: Int = 0
+
+    /// Estimate the in-memory cost of caching the given text's parsed result.
+    /// Uses `utf8.count * 3` as a rough AttributedString/segment overhead.
+    static func estimatedBytes(for text: String) -> Int {
+        text.utf8.count * 3
+    }
+
+    /// Evicts the oldest entries across all three caches until
+    /// `estimatedCacheBytes` drops below `maxCacheBytes`.
+    @MainActor static func evictIfOverBudget() {
+        while estimatedCacheBytes > maxCacheBytes {
+            // Find the LRU entry across all three caches.
+            var oldestKey: String?
+            var oldestTime = Int.max
+            var oldestCache: CacheKind?
+
+            for (key, entry) in markdownCache where entry.accessTime < oldestTime {
+                oldestKey = key; oldestTime = entry.accessTime; oldestCache = .markdown
+            }
+            for (key, entry) in segmentCache where entry.accessTime < oldestTime {
+                oldestKey = key; oldestTime = entry.accessTime; oldestCache = .segment
+            }
+            for (key, entry) in inlineMarkdownCache where entry.accessTime < oldestTime {
+                oldestKey = key; oldestTime = entry.accessTime; oldestCache = .inlineMarkdown
+            }
+
+            guard let key = oldestKey, let cache = oldestCache else { break }
+
+            let cost = estimatedBytes(for: key)
+            switch cache {
+            case .markdown:       markdownCache.removeValue(forKey: key)
+            case .segment:        segmentCache.removeValue(forKey: key)
+            case .inlineMarkdown: inlineMarkdownCache.removeValue(forKey: key)
+            }
+            estimatedCacheBytes -= cost
+        }
+    }
+
+    private enum CacheKind { case markdown, segment, inlineMarkdown }
+
     // MARK: - Streaming Dedup Caches
     //
     // During streaming, the LRU caches above skip storing results to avoid

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -59,14 +59,21 @@ extension ChatBubble {
             lastStreamingInlineMarkdown = (text, result)
             return result
         }
+        // Skip caching for very long text to avoid a single huge entry
+        // evicting many smaller, more frequently accessed entries.
+        if text.count > maxCacheableTextLength { return result }
         if inlineMarkdownCache.count >= maxCacheSize {
             // Evict the least-recently-used entry (lowest accessTime).
             if let lruKey = inlineMarkdownCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
+                estimatedCacheBytes -= estimatedBytes(for: lruKey)
                 inlineMarkdownCache.removeValue(forKey: lruKey)
             }
         }
         lruCounter += 1
+        let cost = estimatedBytes(for: text)
         inlineMarkdownCache[text] = (result, lruCounter)
+        estimatedCacheBytes += cost
+        evictIfOverBudget()
         return result
     }
 
@@ -90,14 +97,21 @@ extension ChatBubble {
             lastStreamingSegments = (text, result)
             return result
         }
+        // Skip caching for very long text to avoid a single huge entry
+        // evicting many smaller, more frequently accessed entries.
+        if text.count > maxCacheableTextLength { return result }
         if segmentCache.count >= maxCacheSize {
             // Evict the least-recently-used entry (lowest accessTime).
             if let lruKey = segmentCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
+                estimatedCacheBytes -= estimatedBytes(for: lruKey)
                 segmentCache.removeValue(forKey: lruKey)
             }
         }
         lruCounter += 1
+        let cost = estimatedBytes(for: text)
         segmentCache[text] = (result, lruCounter)
+        estimatedCacheBytes += cost
+        evictIfOverBudget()
         return result
     }
 
@@ -145,14 +159,22 @@ extension ChatBubble {
             return parsed
         }
 
+        // Skip caching for very long text to avoid a single huge entry
+        // evicting many smaller, more frequently accessed entries.
+        if trimmed.count > Self.maxCacheableTextLength { return parsed }
+
         // Store in cache with LRU eviction
         if Self.markdownCache.count >= Self.maxCacheSize {
             if let lruKey = Self.markdownCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
+                Self.estimatedCacheBytes -= Self.estimatedBytes(for: lruKey)
                 Self.markdownCache.removeValue(forKey: lruKey)
             }
         }
         Self.lruCounter += 1
+        let cost = Self.estimatedBytes(for: trimmed)
         Self.markdownCache[trimmed] = (parsed, Self.lruCounter)
+        Self.estimatedCacheBytes += cost
+        Self.evictIfOverBudget()
 
         return parsed
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -130,15 +130,47 @@ struct MarkdownSegmentView: View {
     /// Keyed by a hash of the segment descriptions so identical segment
     /// arrays return the cached value instead of re-parsing markdown and
     /// re-creating `AttributedString` on every SwiftUI body evaluation.
-    /// Each entry stores (value, accessTime) for LRU eviction.
-    @MainActor private static var attributedStringCache: [Int: (value: AttributedString, accessTime: Int)] = [:]
+    /// Each entry stores (value, accessTime, estimatedBytes) for LRU eviction
+    /// and byte-budget enforcement.
+    @MainActor private static var attributedStringCache: [Int: (value: AttributedString, accessTime: Int, estimatedBytes: Int)] = [:]
     @MainActor private static var lruCounter: Int = 0
     private static let attributedStringCacheLimit = 200
+
+    // MARK: - Cache Guardrails
+
+    private static let maxCacheableTextLength = 10_000
+    private static let maxCacheBytes = 5_000_000
+    @MainActor static var estimatedCacheBytes: Int = 0
 
     /// Clears the attributed string cache.  Called when switching threads
     /// or archiving a conversation to reclaim memory.
     static func clearAttributedStringCache() {
         attributedStringCache.removeAll()
+        estimatedCacheBytes = 0
+    }
+
+    /// Rough character count of the text content within a segment array.
+    private static func segmentTextLength(_ segments: [MarkdownSegment]) -> Int {
+        segments.reduce(0) { total, seg in
+            switch seg {
+            case .text(let t): return total + t.count
+            case .heading(_, let t): return total + t.count
+            case .codeBlock(_, let c): return total + c.count
+            case .list(let items): return total + items.reduce(0) { $0 + $1.text.count }
+            case .table(let h, let r): return total + h.joined().count + r.flatMap { $0 }.joined().count
+            case .image, .horizontalRule: return total
+            }
+        }
+    }
+
+    /// Evicts the oldest entries until `estimatedCacheBytes` drops below
+    /// `maxCacheBytes`.
+    @MainActor private static func evictIfOverBudget() {
+        while estimatedCacheBytes > maxCacheBytes {
+            guard let lruKey = attributedStringCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key else { break }
+            let entry = attributedStringCache.removeValue(forKey: lruKey)
+            estimatedCacheBytes -= entry?.estimatedBytes ?? 0
+        }
     }
 
     /// Builds (or retrieves from cache) a single AttributedString from
@@ -158,20 +190,29 @@ struct MarkdownSegmentView: View {
 
         if let cached = Self.attributedStringCache[cacheKey] {
             Self.lruCounter += 1
-            Self.attributedStringCache[cacheKey] = (cached.value, Self.lruCounter)
+            Self.attributedStringCache[cacheKey] = (cached.value, Self.lruCounter, cached.estimatedBytes)
             return cached.value
         }
 
         let result = Self.buildAttributedStringUncached(from: segments, secondaryTextColor: secondaryTextColor, zoomScale: zoomScale)
 
+        // Skip caching for very long segment groups to avoid a single huge
+        // entry evicting many smaller, more frequently accessed entries.
+        let textLen = Self.segmentTextLength(segments)
+        if textLen > Self.maxCacheableTextLength { return result }
+
         // Evict the least-recently-used entry when the cache is full.
         if Self.attributedStringCache.count >= Self.attributedStringCacheLimit {
             if let lruKey = Self.attributedStringCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
-                Self.attributedStringCache.removeValue(forKey: lruKey)
+                let evicted = Self.attributedStringCache.removeValue(forKey: lruKey)
+                Self.estimatedCacheBytes -= evicted?.estimatedBytes ?? 0
             }
         }
         Self.lruCounter += 1
-        Self.attributedStringCache[cacheKey] = (result, Self.lruCounter)
+        let cost = textLen * 3
+        Self.attributedStringCache[cacheKey] = (result, Self.lruCounter, cost)
+        Self.estimatedCacheBytes += cost
+        Self.evictIfOverBudget()
         return result
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -398,6 +398,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         ChatBubble.segmentCache.removeAll()
         ChatBubble.markdownCache.removeAll()
         ChatBubble.inlineMarkdownCache.removeAll()
+        ChatBubble.estimatedCacheBytes = 0
         ChatBubble.lastStreamingSegments = nil
         ChatBubble.lastStreamingInlineMarkdown = nil
         ChatBubble.lastStreamingMarkdown = nil


### PR DESCRIPTION
Part of #9272. Skips caching for text > 10k chars and adds byte-based eviction to prevent markdown caches from ballooning on long messages.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
