### PR TITLE
Use friendlier language in token regeneration warning

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -120,7 +120,7 @@ struct SettingsConnectTab: View {
                 regenerateHttpToken()
             }
         } message: {
-            Text("This will replace the current bearer token and restart the daemon. Any paired devices will need to reconnect.")
+            Text("This will generate a new security token and restart your assistant. Any paired devices will need to reconnect.")
         }
         .sheet(isPresented: $showingPairingQR) {
             PairingQRCodeSheet(


### PR DESCRIPTION
## Summary
- Changed "replace the current bearer token and restart the daemon" to "generate a new security token and restart your assistant"

## Original prompt
lets make this warning message less technical "This will replace the current bearer token and restart the daemon. Any paired devices will need to reconnect." We should not use the word daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
