### PR TITLE
M1: State model extension, feature flag, and thumbnail capture pipeline

### DIFF
--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -51,6 +51,9 @@ struct RecordingSourcePickerView: View {
             await viewModel.loadSources()
             await viewModel.loadPreviews()
         }
+        .onChange(of: viewModel.captureScope) { _, _ in
+            Task { await viewModel.loadPreviews() }
+        }
     }
 
     // MARK: - Source List

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -49,6 +49,7 @@ struct RecordingSourcePickerView: View {
         .background(VColor.background)
         .task {
             await viewModel.loadSources()
+            await viewModel.loadPreviews()
         }
     }
 

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
@@ -5,6 +5,26 @@ import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "RecordingSourcePicker")
 
+// MARK: - Preview Types
+
+/// Reason a source preview capture failed.
+enum PreviewFailureReason: String, Equatable, Hashable, Sendable {
+    case captureFailed = "capture_failed"
+    case blankFrame = "blank_frame"
+    case sourceGone = "source_gone"
+    case cancelled = "cancelled"
+}
+
+/// Status of thumbnail preview capture for a source.
+enum PreviewStatus: Equatable, Hashable, Sendable {
+    case idle
+    case loading
+    case loaded
+    case failed(PreviewFailureReason)
+}
+
+// MARK: - Source Types
+
 /// Represents an available display for recording.
 struct DisplaySource: Identifiable, Hashable {
     let id: UInt32       // CGDirectDisplayID
@@ -14,11 +34,27 @@ struct DisplaySource: Identifiable, Hashable {
     let scaleFactor: CGFloat
     /// Whether the picker window is currently on this display.
     var isCurrentDisplay: Bool
+    /// Preview thumbnail image (not included in hash/equality).
+    var thumbnail: NSImage?
+    /// Current preview capture status.
+    var previewStatus: PreviewStatus = .idle
+    /// Reference to SCDisplay for content filter creation (not included in hash/equality).
+    var scDisplay: SCDisplay?
 
     /// Human-readable resolution and scale, e.g. "2560 × 1440 @ 2x".
     var subtitle: String {
         let scaleLabel = scaleFactor >= 2 ? "@ \(Int(scaleFactor))x" : "@ 1x"
         return "\(width) × \(height) \(scaleLabel)"
+    }
+
+    // Identity is based solely on the display ID so SwiftUI diffing
+    // doesn't trigger spurious rebuilds when thumbnails arrive.
+    static func == (lhs: DisplaySource, rhs: DisplaySource) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
     }
 }
 
@@ -28,6 +64,21 @@ struct WindowSource: Identifiable, Hashable {
     let title: String
     let appName: String
     let bundleIdentifier: String?
+    /// Preview thumbnail image (not included in hash/equality).
+    var thumbnail: NSImage?
+    /// Current preview capture status.
+    var previewStatus: PreviewStatus = .idle
+    /// Reference to SCWindow for content filter creation (not included in hash/equality).
+    var scWindow: SCWindow?
+
+    // Identity is based solely on the window ID.
+    static func == (lhs: WindowSource, rhs: WindowSource) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
 }
 
 /// Whether to capture a full display or a single window.
@@ -125,7 +176,8 @@ final class RecordingSourcePickerViewModel: ObservableObject {
                     width: display.width,
                     height: display.height,
                     scaleFactor: scale,
-                    isCurrentDisplay: display.displayID == pickerDisplayId
+                    isCurrentDisplay: display.displayID == pickerDisplayId,
+                    scDisplay: display
                 )
             }
 
@@ -158,7 +210,8 @@ final class RecordingSourcePickerViewModel: ObservableObject {
                         id: Int(window.windowID),
                         title: window.title ?? "Untitled",
                         appName: window.owningApplication?.applicationName ?? "Unknown",
-                        bundleIdentifier: window.owningApplication?.bundleIdentifier
+                        bundleIdentifier: window.owningApplication?.bundleIdentifier,
+                        scWindow: window
                     )
                 }
 
@@ -243,6 +296,65 @@ final class RecordingSourcePickerViewModel: ObservableObject {
             if sourceUnavailableNotice == message {
                 sourceUnavailableNotice = nil
             }
+        }
+    }
+
+    // MARK: - Preview Loading
+
+    private let thumbnailProvider = ThumbnailProvider()
+
+    /// Load preview thumbnails for all currently visible sources.
+    /// Must be called after `loadSources()` completes. Does not block
+    /// source loading — previews arrive asynchronously and update the UI.
+    func loadPreviews() async {
+        guard FeatureFlagManager.shared.isEnabled(.sourcePreviewEnabled) else { return }
+
+        switch captureScope {
+        case .display:
+            for i in displays.indices {
+                displays[i].previewStatus = .loading
+            }
+            // Capture in parallel with concurrency limited by the provider
+            await withTaskGroup(of: (UInt32, NSImage?, PreviewStatus).self) { group in
+                for display in displays {
+                    group.addTask { [thumbnailProvider] in
+                        let result = await thumbnailProvider.captureThumbnail(for: display)
+                        return (display.id, result.image, result.status)
+                    }
+                }
+                for await (displayId, image, status) in group {
+                    if let idx = displays.firstIndex(where: { $0.id == displayId }) {
+                        displays[idx].thumbnail = image
+                        displays[idx].previewStatus = status
+                    }
+                }
+            }
+
+        case .window:
+            for i in windows.indices {
+                windows[i].previewStatus = .loading
+            }
+            await withTaskGroup(of: (Int, NSImage?, PreviewStatus).self) { group in
+                for window in windows {
+                    group.addTask { [thumbnailProvider] in
+                        let result = await thumbnailProvider.captureThumbnail(for: window)
+                        return (window.id, result.image, result.status)
+                    }
+                }
+                for await (windowId, image, status) in group {
+                    if let idx = windows.firstIndex(where: { $0.id == windowId }) {
+                        windows[idx].thumbnail = image
+                        windows[idx].previewStatus = status
+                    }
+                }
+            }
+        }
+    }
+
+    /// Clear thumbnail caches when the picker is dismissed.
+    func clearPreviews() {
+        Task {
+            await thumbnailProvider.clearCache()
         }
     }
 }

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerWindow.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerWindow.swift
@@ -89,6 +89,7 @@ final class RecordingSourcePickerWindow: NSObject, NSWindowDelegate {
             NotificationCenter.default.removeObserver(observer)
             moveObserver = nil
         }
+        viewModel?.clearPreviews()
         window?.delegate = nil
         window?.close()
         window = nil

--- a/clients/macos/vellum-assistant/Recording/ThumbnailProvider.swift
+++ b/clients/macos/vellum-assistant/Recording/ThumbnailProvider.swift
@@ -1,0 +1,291 @@
+import AppKit
+import ScreenCaptureKit
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ThumbnailProvider")
+
+/// Result of a thumbnail capture attempt.
+struct ThumbnailResult {
+    let image: NSImage?
+    let status: PreviewStatus
+}
+
+/// Captures, normalizes, and caches source preview thumbnails.
+///
+/// Uses `SCScreenshotManager` (macOS 14+) to capture display and window
+/// screenshots, scales them to a max of 320x200pt for picker row thumbnails,
+/// and maintains an in-memory cache with a 30-second TTL.
+///
+/// Concurrency is limited to 3 simultaneous captures via a semaphore.
+actor ThumbnailProvider {
+
+    // MARK: - Configuration
+
+    /// Maximum capture resolution (before normalization).
+    private static let maxCaptureWidth = 640
+    /// Maximum thumbnail dimensions for row display.
+    private static let maxThumbnailWidth: CGFloat = 320
+    private static let maxThumbnailHeight: CGFloat = 200
+    /// Cache entry TTL in seconds.
+    private static let cacheTTLSeconds: TimeInterval = 30
+    /// Maximum number of concurrent captures.
+    private static let maxConcurrentCaptures = 3
+
+    // MARK: - Cache
+
+    private struct CacheEntry {
+        let image: NSImage
+        let timestamp: Date
+    }
+
+    private var cache: [String: CacheEntry] = [:]
+
+    /// Returns a cached thumbnail if it exists and is within the TTL window.
+    func cachedThumbnail(for key: String) -> NSImage? {
+        guard let entry = cache[key] else { return nil }
+        if Date().timeIntervalSince(entry.timestamp) > Self.cacheTTLSeconds {
+            cache.removeValue(forKey: key)
+            return nil
+        }
+        return entry.image
+    }
+
+    /// Stores a thumbnail in the cache with the current timestamp.
+    func cache(_ image: NSImage, for key: String) {
+        cache[key] = CacheEntry(image: image, timestamp: Date())
+    }
+
+    /// Removes all cached thumbnails. Called when the picker is dismissed.
+    func clearCache() {
+        cache.removeAll()
+    }
+
+    // MARK: - Concurrency Limiting
+
+    private var activeCaptureCount = 0
+    private var waitingContinuations: [CheckedContinuation<Void, Never>] = []
+
+    /// Acquire a capture slot, waiting if the maximum is already in use.
+    private func acquireSlot() async {
+        if activeCaptureCount < Self.maxConcurrentCaptures {
+            activeCaptureCount += 1
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waitingContinuations.append(continuation)
+        }
+        activeCaptureCount += 1
+    }
+
+    /// Release a capture slot, resuming the next waiter if any.
+    private func releaseSlot() {
+        activeCaptureCount -= 1
+        if !waitingContinuations.isEmpty {
+            let next = waitingContinuations.removeFirst()
+            next.resume()
+        }
+    }
+
+    // MARK: - Display Capture
+
+    /// Capture a thumbnail for a display source.
+    func captureThumbnail(for display: DisplaySource) async -> ThumbnailResult {
+        let cacheKey = "display-\(display.id)"
+
+        if let cached = cachedThumbnail(for: cacheKey) {
+            return ThumbnailResult(image: cached, status: .loaded)
+        }
+
+        guard let scDisplay = display.scDisplay else {
+            log.warning("No SCDisplay reference for display \(display.id)")
+            return ThumbnailResult(image: nil, status: .failed(.sourceGone))
+        }
+
+        guard #available(macOS 14, *) else {
+            return ThumbnailResult(image: nil, status: .failed(.captureFailed))
+        }
+
+        await acquireSlot()
+        let result: ThumbnailResult
+        do {
+            let selfBundleId = Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant"
+
+            // Get current shareable content to find Vellum app windows to exclude
+            let shareable = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+            let vellumApps = shareable.applications.filter { $0.bundleIdentifier == selfBundleId }
+
+            let filter = SCContentFilter(
+                display: scDisplay,
+                excludingApplications: vellumApps,
+                exceptingWindows: []
+            )
+
+            let config = SCStreamConfiguration()
+            // Cap capture resolution for performance
+            let aspectRatio = CGFloat(display.height) / CGFloat(display.width)
+            config.width = Self.maxCaptureWidth
+            config.height = Int(CGFloat(Self.maxCaptureWidth) * aspectRatio)
+            config.pixelFormat = kCVPixelFormatType_32BGRA
+            config.showsCursor = false
+
+            let cgImage = try await SCScreenshotManager.captureImage(
+                contentFilter: filter,
+                configuration: config
+            )
+
+            // Check for blank frame (all pixels the same or empty)
+            if isBlankImage(cgImage) {
+                log.debug("Blank frame captured for display \(display.id)")
+                result = ThumbnailResult(image: nil, status: .failed(.blankFrame))
+            } else {
+                let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+                let normalized = normalizeToThumbnail(nsImage)
+                cache(normalized, for: cacheKey)
+                result = ThumbnailResult(image: normalized, status: .loaded)
+            }
+        } catch {
+            log.error("Failed to capture display \(display.id) thumbnail: \(error.localizedDescription)")
+            result = ThumbnailResult(image: nil, status: .failed(.captureFailed))
+        }
+        releaseSlot()
+        return result
+    }
+
+    // MARK: - Window Capture
+
+    /// Capture a thumbnail for a window source.
+    func captureThumbnail(for window: WindowSource) async -> ThumbnailResult {
+        let cacheKey = "window-\(window.id)"
+
+        if let cached = cachedThumbnail(for: cacheKey) {
+            return ThumbnailResult(image: cached, status: .loaded)
+        }
+
+        guard let scWindow = window.scWindow else {
+            log.warning("No SCWindow reference for window \(window.id)")
+            return ThumbnailResult(image: nil, status: .failed(.sourceGone))
+        }
+
+        guard #available(macOS 14, *) else {
+            return ThumbnailResult(image: nil, status: .failed(.captureFailed))
+        }
+
+        await acquireSlot()
+        let result: ThumbnailResult
+        do {
+            let filter = SCContentFilter(desktopIndependentWindow: scWindow)
+
+            let config = SCStreamConfiguration()
+            // Use the window's actual aspect ratio for proportional sizing
+            let windowWidth = max(scWindow.frame.width, 1)
+            let windowHeight = max(scWindow.frame.height, 1)
+            let aspectRatio = windowHeight / windowWidth
+            config.width = Self.maxCaptureWidth
+            config.height = Int(CGFloat(Self.maxCaptureWidth) * aspectRatio)
+            config.pixelFormat = kCVPixelFormatType_32BGRA
+            config.showsCursor = false
+
+            let cgImage = try await SCScreenshotManager.captureImage(
+                contentFilter: filter,
+                configuration: config
+            )
+
+            if isBlankImage(cgImage) {
+                log.debug("Blank frame captured for window \(window.id)")
+                result = ThumbnailResult(image: nil, status: .failed(.blankFrame))
+            } else {
+                let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+                let normalized = normalizeToThumbnail(nsImage)
+                cache(normalized, for: cacheKey)
+                result = ThumbnailResult(image: normalized, status: .loaded)
+            }
+        } catch {
+            log.error("Failed to capture window \(window.id) thumbnail: \(error.localizedDescription)")
+            result = ThumbnailResult(image: nil, status: .failed(.captureFailed))
+        }
+        releaseSlot()
+        return result
+    }
+
+    // MARK: - Image Processing
+
+    /// Scale image to fit within max thumbnail dimensions, preserving aspect ratio.
+    private func normalizeToThumbnail(_ image: NSImage) -> NSImage {
+        let originalSize = image.size
+        guard originalSize.width > 0, originalSize.height > 0 else { return image }
+
+        let widthScale = Self.maxThumbnailWidth / originalSize.width
+        let heightScale = Self.maxThumbnailHeight / originalSize.height
+        let scale = min(widthScale, heightScale, 1.0) // Don't upscale
+
+        if scale >= 1.0 { return image }
+
+        let newSize = NSSize(
+            width: round(originalSize.width * scale),
+            height: round(originalSize.height * scale)
+        )
+
+        let resized = NSImage(size: newSize)
+        resized.lockFocus()
+        NSGraphicsContext.current?.imageInterpolation = .high
+        image.draw(
+            in: NSRect(origin: .zero, size: newSize),
+            from: NSRect(origin: .zero, size: originalSize),
+            operation: .copy,
+            fraction: 1.0
+        )
+        resized.unlockFocus()
+        return resized
+    }
+
+    /// Heuristic check for blank/empty captures by sampling corner pixels.
+    /// Returns true if all sampled pixels are identical (likely a blank frame).
+    private func isBlankImage(_ image: CGImage) -> Bool {
+        guard image.width > 0, image.height > 0 else { return true }
+
+        // Quick check: sample a few pixels from different regions
+        guard let dataProvider = image.dataProvider,
+              let data = dataProvider.data,
+              let bytes = CFDataGetBytePtr(data) else {
+            return true
+        }
+
+        let bytesPerPixel = image.bitsPerPixel / 8
+        let bytesPerRow = image.bytesPerRow
+        guard bytesPerPixel >= 3, bytesPerRow > 0 else { return true }
+
+        // Sample points: top-left, center, bottom-right, top-right
+        let points: [(Int, Int)] = [
+            (0, 0),
+            (image.width / 2, image.height / 2),
+            (max(image.width - 1, 0), max(image.height - 1, 0)),
+            (max(image.width - 1, 0), 0)
+        ]
+
+        var firstR: UInt8 = 0, firstG: UInt8 = 0, firstB: UInt8 = 0
+        var isFirst = true
+
+        for (x, y) in points {
+            guard x < image.width, y < image.height else { continue }
+            let offset = y * bytesPerRow + x * bytesPerPixel
+            let totalBytes = CFDataGetLength(data)
+            guard offset + 2 < totalBytes else { continue }
+
+            let r = bytes[offset]
+            let g = bytes[offset + 1]
+            let b = bytes[offset + 2]
+
+            if isFirst {
+                firstR = r; firstG = g; firstB = b
+                isFirst = false
+                continue
+            }
+
+            if r != firstR || g != firstG || b != firstB {
+                return false
+            }
+        }
+
+        return true
+    }
+}

--- a/clients/macos/vellum-assistant/Recording/ThumbnailProvider.swift
+++ b/clients/macos/vellum-assistant/Recording/ThumbnailProvider.swift
@@ -74,15 +74,17 @@ actor ThumbnailProvider {
         await withCheckedContinuation { continuation in
             waitingContinuations.append(continuation)
         }
-        activeCaptureCount += 1
+        // Slot was transferred by releaseSlot — no increment needed
     }
 
     /// Release a capture slot, resuming the next waiter if any.
     private func releaseSlot() {
-        activeCaptureCount -= 1
         if !waitingContinuations.isEmpty {
             let next = waitingContinuations.removeFirst()
+            // Transfer the slot directly — don't decrement
             next.resume()
+        } else {
+            activeCaptureCount -= 1
         }
     }
 
@@ -139,9 +141,12 @@ actor ThumbnailProvider {
                 result = ThumbnailResult(image: nil, status: .failed(.blankFrame))
             } else {
                 let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
-                let normalized = normalizeToThumbnail(nsImage)
-                cache(normalized, for: cacheKey)
-                result = ThumbnailResult(image: normalized, status: .loaded)
+                if let normalized = normalizeToThumbnail(nsImage) {
+                    cache(normalized, for: cacheKey)
+                    result = ThumbnailResult(image: normalized, status: .loaded)
+                } else {
+                    result = ThumbnailResult(image: nil, status: .failed(.captureFailed))
+                }
             }
         } catch {
             log.error("Failed to capture display \(display.id) thumbnail: \(error.localizedDescription)")
@@ -195,9 +200,12 @@ actor ThumbnailProvider {
                 result = ThumbnailResult(image: nil, status: .failed(.blankFrame))
             } else {
                 let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
-                let normalized = normalizeToThumbnail(nsImage)
-                cache(normalized, for: cacheKey)
-                result = ThumbnailResult(image: normalized, status: .loaded)
+                if let normalized = normalizeToThumbnail(nsImage) {
+                    cache(normalized, for: cacheKey)
+                    result = ThumbnailResult(image: normalized, status: .loaded)
+                } else {
+                    result = ThumbnailResult(image: nil, status: .failed(.captureFailed))
+                }
             }
         } catch {
             log.error("Failed to capture window \(window.id) thumbnail: \(error.localizedDescription)")
@@ -210,32 +218,48 @@ actor ThumbnailProvider {
     // MARK: - Image Processing
 
     /// Scale image to fit within max thumbnail dimensions, preserving aspect ratio.
-    private func normalizeToThumbnail(_ image: NSImage) -> NSImage {
+    /// Uses NSBitmapImageRep + NSGraphicsContext instead of lockFocus/unlockFocus
+    /// so it is safe to call off the main thread.
+    private func normalizeToThumbnail(_ image: NSImage) -> NSImage? {
         let originalSize = image.size
-        guard originalSize.width > 0, originalSize.height > 0 else { return image }
+        guard originalSize.width > 0, originalSize.height > 0 else { return nil }
 
-        let widthScale = Self.maxThumbnailWidth / originalSize.width
-        let heightScale = Self.maxThumbnailHeight / originalSize.height
-        let scale = min(widthScale, heightScale, 1.0) // Don't upscale
-
-        if scale >= 1.0 { return image }
-
-        let newSize = NSSize(
+        let scale = min(
+            Self.maxThumbnailWidth / originalSize.width,
+            Self.maxThumbnailHeight / originalSize.height,
+            1.0
+        )
+        let targetSize = NSSize(
             width: round(originalSize.width * scale),
             height: round(originalSize.height * scale)
         )
 
-        let resized = NSImage(size: newSize)
-        resized.lockFocus()
-        NSGraphicsContext.current?.imageInterpolation = .high
+        guard let bitmapRep = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: Int(targetSize.width),
+            pixelsHigh: Int(targetSize.height),
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ) else { return nil }
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: bitmapRep)
         image.draw(
-            in: NSRect(origin: .zero, size: newSize),
+            in: NSRect(origin: .zero, size: targetSize),
             from: NSRect(origin: .zero, size: originalSize),
             operation: .copy,
             fraction: 1.0
         )
-        resized.unlockFocus()
-        return resized
+        NSGraphicsContext.restoreGraphicsState()
+
+        let thumbnail = NSImage(size: targetSize)
+        thumbnail.addRepresentation(bitmapRep)
+        return thumbnail
     }
 
     /// Heuristic check for blank/empty captures by sampling corner pixels.

--- a/clients/shared/Utilities/FeatureFlagManager.swift
+++ b/clients/shared/Utilities/FeatureFlagManager.swift
@@ -8,6 +8,7 @@ public enum FeatureFlag: String, CaseIterable {
     case featureFlagEditorEnabled = "feature_flag_editor_enabled"
     case hatchNewAssistantEnabled = "hatch_new_assistant_enabled"
     case localHttpEnabled = "local_http_enabled"
+    case sourcePreviewEnabled = "source_preview_enabled"
 
     public var displayName: String {
         switch self {
@@ -16,6 +17,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .featureFlagEditorEnabled: return "Feature Flag Editor Enabled"
         case .hatchNewAssistantEnabled: return "Hatch New Assistant Enabled"
         case .localHttpEnabled: return "Local HTTP Enabled"
+        case .sourcePreviewEnabled: return "Source Preview Enabled"
         }
     }
 }


### PR DESCRIPTION
Part of #9281. Adds sourcePreviewEnabled feature flag, extends DisplaySource/WindowSource with thumbnail + previewStatus, and builds async ThumbnailProvider with SCScreenshotManager capture, normalization, in-memory caching, and concurrency limiting.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
