### PR TITLE
M3: Structured commandIntent IPC extension

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -9,6 +9,10 @@ exports[`IPC message snapshots ClientMessage types auth serializes to expected J
 
 exports[`IPC message snapshots ClientMessage types user_message serializes to expected JSON 1`] = `
 {
+  "commandIntent": {
+    "action": "start",
+    "domain": "screen_recording",
+  },
   "content": "Hello, assistant!",
   "interface": "cli",
   "sessionId": "sess-001",
@@ -206,6 +210,10 @@ exports[`IPC message snapshots ClientMessage types watch_observation serializes 
 
 exports[`IPC message snapshots ClientMessage types task_submit serializes to expected JSON 1`] = `
 {
+  "commandIntent": {
+    "action": "stop",
+    "domain": "screen_recording",
+  },
   "screenHeight": 1080,
   "screenWidth": 1920,
   "task": "Open Safari and search for weather",
@@ -1096,6 +1104,49 @@ exports[`IPC message snapshots ClientMessage types notification_intent_result se
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types recording_status serializes to expected JSON 1`] = `
+{
+  "sessionId": "rec-001",
+  "status": "started",
+  "type": "recording_status",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types heartbeat_config serializes to expected JSON 1`] = `
+{
+  "action": "get",
+  "type": "heartbeat_config",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types heartbeat_runs_list serializes to expected JSON 1`] = `
+{
+  "type": "heartbeat_runs_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types heartbeat_run_now serializes to expected JSON 1`] = `
+{
+  "type": "heartbeat_run_now",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types heartbeat_checklist_read serializes to expected JSON 1`] = `
+{
+  "type": "heartbeat_checklist_read",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types heartbeat_checklist_write serializes to expected JSON 1`] = `
+{
+  "content": 
+"- [ ] Check email
+- [ ] Review PRs"
+,
+  "type": "heartbeat_checklist_write",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types auth_result serializes to expected JSON 1`] = `
 {
   "success": true,
@@ -1360,6 +1411,7 @@ exports[`IPC message snapshots ServerMessage types model_info serializes to expe
 
 exports[`IPC message snapshots ServerMessage types history_response serializes to expected JSON 1`] = `
 {
+  "hasMore": false,
   "messages": [
     {
       "role": "user",
@@ -2932,5 +2984,70 @@ exports[`IPC message snapshots ServerMessage types approved_device_remove_respon
 {
   "success": true,
   "type": "approved_device_remove_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types recording_start serializes to expected JSON 1`] = `
+{
+  "recordingId": "rec-001",
+  "type": "recording_start",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types recording_stop serializes to expected JSON 1`] = `
+{
+  "recordingId": "rec-001",
+  "type": "recording_stop",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types heartbeat_config_response serializes to expected JSON 1`] = `
+{
+  "activeHoursEnd": 17,
+  "activeHoursStart": 9,
+  "enabled": true,
+  "intervalMs": 3600000,
+  "nextRunAt": 1700003600000,
+  "success": true,
+  "type": "heartbeat_config_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types heartbeat_runs_list_response serializes to expected JSON 1`] = `
+{
+  "runs": [
+    {
+      "createdAt": 1700000000000,
+      "id": "hb-run-001",
+      "result": "All systems nominal",
+      "title": "Morning heartbeat",
+    },
+  ],
+  "type": "heartbeat_runs_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types heartbeat_run_now_response serializes to expected JSON 1`] = `
+{
+  "success": true,
+  "type": "heartbeat_run_now_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types heartbeat_checklist_response serializes to expected JSON 1`] = `
+{
+  "content": 
+"- [ ] Check email
+- [ ] Review PRs"
+,
+  "isDefault": false,
+  "type": "heartbeat_checklist_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types heartbeat_checklist_write_response serializes to expected JSON 1`] = `
+{
+  "success": true,
+  "type": "heartbeat_checklist_write_response",
 }
 `;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -27,6 +27,7 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     sessionId: 'sess-001',
     content: 'Hello, assistant!',
     interface: 'cli',
+    commandIntent: { domain: 'screen_recording', action: 'start' },
   },
   confirmation_response: {
     type: 'confirmation_response',
@@ -153,6 +154,7 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     task: 'Open Safari and search for weather',
     screenWidth: 1920,
     screenHeight: 1080,
+    commandIntent: { domain: 'screen_recording', action: 'stop' },
   },
   ui_surface_action: {
     type: 'ui_surface_action',

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -71,6 +71,42 @@ export async function handleTaskSubmit(
       return;
     }
 
+    // ── Structured command intent (bypasses text parsing) ──────────────────
+    if (msg.commandIntent?.domain === 'screen_recording') {
+      const action = msg.commandIntent.action;
+      rlog.info({ action, source: 'commandIntent' }, 'Recording command intent received');
+      if (action === 'start') {
+        const conversation = conversationStore.createConversation(msg.task || 'Screen Recording');
+        ctx.socketToSession.set(socket, conversation.id);
+        const recordingId = handleRecordingStart(conversation.id, { promptForSource: true }, socket, ctx);
+        ctx.send(socket, { type: 'task_routed', sessionId: conversation.id, interactionType: 'text_qa' });
+        ctx.send(socket, {
+          type: 'assistant_text_delta',
+          text: recordingId ? 'Starting screen recording.' : 'A recording is already active.',
+          sessionId: conversation.id,
+        });
+        ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
+        if (!recordingId) ctx.socketToSession.delete(socket);
+        return;
+      } else if (action === 'stop') {
+        let activeSessionId = ctx.socketToSession.get(socket);
+        if (!activeSessionId) {
+          const conversation = conversationStore.createConversation(msg.task || 'Stop Recording');
+          activeSessionId = conversation.id;
+          ctx.socketToSession.set(socket, activeSessionId);
+        }
+        const stopped = handleRecordingStop(activeSessionId, ctx) !== undefined;
+        ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
+        ctx.send(socket, {
+          type: 'assistant_text_delta',
+          text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',
+          sessionId: activeSessionId,
+        });
+        ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        return;
+      }
+    }
+
     // ── Standalone recording intent interception ──────────────────────────
     let pendingRecordingStart = false;
     let pendingRecordingStop = false;

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -72,7 +72,8 @@ export async function handleTaskSubmit(
     }
 
     // ── Structured command intent (bypasses text parsing) ──────────────────
-    if (msg.commandIntent?.domain === 'screen_recording') {
+    const config = getConfig();
+    if (config.daemon.standaloneRecording && msg.commandIntent?.domain === 'screen_recording') {
       const action = msg.commandIntent.action;
       rlog.info({ action, source: 'commandIntent' }, 'Recording command intent received');
       if (action === 'start') {
@@ -110,7 +111,6 @@ export async function handleTaskSubmit(
     // ── Standalone recording intent interception ──────────────────────────
     let pendingRecordingStart = false;
     let pendingRecordingStop = false;
-    const config = getConfig();
     if (config.daemon.standaloneRecording) {
       const name = getAssistantName();
       const dynamicNames = [name].filter(Boolean) as string[];

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -227,7 +227,7 @@ export async function handleUserMessage(
     }
 
     // ── Structured command intent (bypasses text parsing) ──────────────────
-    if (msg.commandIntent?.domain === 'screen_recording') {
+    if (config.daemon.standaloneRecording && msg.commandIntent?.domain === 'screen_recording') {
       const action = msg.commandIntent.action;
       rlog.info({ action, source: 'commandIntent' }, 'Recording command intent received');
       if (action === 'start') {

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -226,6 +226,29 @@ export async function handleUserMessage(
       }
     }
 
+    // ── Structured command intent (bypasses text parsing) ──────────────────
+    if (msg.commandIntent?.domain === 'screen_recording') {
+      const action = msg.commandIntent.action;
+      rlog.info({ action, source: 'commandIntent' }, 'Recording command intent received');
+      if (action === 'start') {
+        const recordingId = handleRecordingStart(msg.sessionId, { promptForSource: true }, socket, ctx);
+        ctx.send(socket, {
+          type: 'assistant_text_delta',
+          text: recordingId ? 'Starting screen recording.' : 'A recording is already active.',
+          sessionId: msg.sessionId,
+        });
+      } else if (action === 'stop') {
+        const stopped = handleRecordingStop(msg.sessionId, ctx) !== undefined;
+        ctx.send(socket, {
+          type: 'assistant_text_delta',
+          text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',
+          sessionId: msg.sessionId,
+        });
+      }
+      ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+      return;
+    }
+
     // ── Standalone recording intent interception ──────────────────────────
     if (config.daemon.standaloneRecording && messageText) {
       const name = getAssistantName();

--- a/assistant/src/daemon/ipc-contract/computer-use.ts
+++ b/assistant/src/daemon/ipc-contract/computer-use.ts
@@ -1,6 +1,6 @@
 // Computer use, task routing, ride shotgun, and watch observation types.
 
-import type { IpcBlobRef,UserMessageAttachment } from './shared.js';
+import type { CommandIntent, IpcBlobRef,UserMessageAttachment } from './shared.js';
 
 // === Client → Server ===
 
@@ -51,6 +51,8 @@ export interface TaskSubmit {
   screenHeight: number;
   attachments?: UserMessageAttachment[];
   source?: 'voice' | 'text';
+  /** Structured command intent — bypasses text parsing when present. */
+  commandIntent?: CommandIntent;
 }
 
 export interface RideShotgunStart {

--- a/assistant/src/daemon/ipc-contract/messages.ts
+++ b/assistant/src/daemon/ipc-contract/messages.ts
@@ -1,7 +1,7 @@
 // User/assistant messages, tool results, confirmations, secrets, errors, and generation lifecycle.
 
 import type { ChannelId, InterfaceId } from '../../channels/types.js';
-import type { UserMessageAttachment } from './shared.js';
+import type { CommandIntent, UserMessageAttachment } from './shared.js';
 
 // === Client → Server ===
 
@@ -19,6 +19,8 @@ export interface UserMessage {
   channel?: ChannelId;
   /** Originating interface identifier (e.g. 'macos'). */
   interface: InterfaceId;
+  /** Structured command intent — bypasses text parsing when present. */
+  commandIntent?: CommandIntent;
 }
 
 export interface ConfirmationResponse {

--- a/assistant/src/daemon/ipc-contract/shared.ts
+++ b/assistant/src/daemon/ipc-contract/shared.ts
@@ -29,6 +29,12 @@ export interface DictationContext {
   cursorInTextField: boolean;
 }
 
+/** Structured command intent — bypasses text parsing when present. */
+export interface CommandIntent {
+  domain: 'screen_recording';
+  action: 'start' | 'stop';
+}
+
 export interface UserMessageAttachment {
   id?: string;
   filename: string;


### PR DESCRIPTION
Add CommandIntent interface (domain: screen_recording, action: start|stop) to TaskSubmit and UserMessage IPC interfaces. Add commandIntent handling in both handlers that bypasses text parsing entirely. Update IPC snapshot tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
