### PR TITLE
M2: Picker UI upgrade with thumbnails and preview pane

### DIFF
--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -4,10 +4,17 @@ import VellumAssistantShared
 /// Source picker view for selecting what to record (display or window).
 ///
 /// Uses design system tokens (VColor, VFont, VSpacing, VRadius) for consistent styling.
+/// When `sourcePreviewEnabled` is true, displays per-row thumbnails and a
+/// larger preview pane above the source list.
 struct RecordingSourcePickerView: View {
     @ObservedObject var viewModel: RecordingSourcePickerViewModel
     var onStart: (IPCRecordingOptions) -> Void
     var onCancel: () -> Void
+
+    /// Row thumbnail size (80x50pt).
+    private let rowThumbnailSize = CGSize(width: 80, height: 50)
+    /// Preview pane height.
+    private static let previewPaneHeight: CGFloat = 160
 
     var body: some View {
         VStack(spacing: 0) {
@@ -28,6 +35,13 @@ struct RecordingSourcePickerView: View {
             .padding(.horizontal, VSpacing.xl)
             .padding(.bottom, VSpacing.lg)
 
+            // Preview pane (only when feature flag is on)
+            if viewModel.sourcePreviewEnabled {
+                previewPane
+                    .padding(.horizontal, VSpacing.lg)
+                    .padding(.bottom, VSpacing.md)
+            }
+
             // Source list
             if viewModel.isLoading {
                 Spacer()
@@ -45,7 +59,10 @@ struct RecordingSourcePickerView: View {
             // Audio toggle + buttons
             bottomBar
         }
-        .frame(width: 420, height: 440)
+        .frame(
+            width: 420,
+            height: viewModel.sourcePreviewEnabled ? 640 : 440
+        )
         .background(VColor.background)
         .task {
             await viewModel.loadSources()
@@ -54,6 +71,28 @@ struct RecordingSourcePickerView: View {
         .onChange(of: viewModel.captureScope) { _, _ in
             Task { await viewModel.loadPreviews() }
         }
+    }
+
+    // MARK: - Preview Pane
+
+    /// Shows the currently selected source's thumbnail at a larger size
+    /// above the source list.
+    @ViewBuilder
+    private var previewPane: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.backgroundSubtle)
+
+            ThumbnailView(
+                thumbnail: viewModel.selectedThumbnail,
+                previewStatus: viewModel.selectedPreviewStatus,
+                size: CGSize(
+                    width: 420 - VSpacing.lg * 2 - VSpacing.lg * 2,
+                    height: Self.previewPaneHeight - VSpacing.md * 2
+                )
+            )
+        }
+        .frame(height: Self.previewPaneHeight)
     }
 
     // MARK: - Source List
@@ -78,10 +117,8 @@ struct RecordingSourcePickerView: View {
 
                 case .window:
                     ForEach(viewModel.windows) { window in
-                        sourceRow(
-                            title: window.title,
-                            subtitle: window.appName,
-                            icon: "macwindow",
+                        windowRow(
+                            window: window,
                             isSelected: viewModel.selectedWindowId == window.id
                         ) {
                             viewModel.selectedWindowId = window.id
@@ -97,26 +134,34 @@ struct RecordingSourcePickerView: View {
         }
     }
 
-    private func sourceRow(
-        title: String,
-        subtitle: String,
-        icon: String,
+    /// Row for a window source. When preview is enabled, shows a thumbnail
+    /// to the left of the text content.
+    private func windowRow(
+        window: WindowSource,
         isSelected: Bool,
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
             HStack(spacing: VSpacing.md) {
-                Image(systemName: icon)
+                if viewModel.sourcePreviewEnabled {
+                    ThumbnailView(
+                        thumbnail: window.thumbnail,
+                        previewStatus: window.previewStatus,
+                        size: rowThumbnailSize
+                    )
+                }
+
+                Image(systemName: "macwindow")
                     .font(.system(size: 16))
                     .foregroundColor(isSelected ? VColor.accent : VColor.textSecondary)
                     .frame(width: 24)
 
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(title)
+                    Text(window.title)
                         .font(VFont.bodyMedium)
                         .foregroundColor(VColor.textPrimary)
                         .lineLimit(1)
-                    Text(subtitle)
+                    Text(window.appName)
                         .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
                         .lineLimit(1)
@@ -145,7 +190,8 @@ struct RecordingSourcePickerView: View {
     }
 
     /// Row for a display source showing name, resolution + scale, and a badge
-    /// when this is the display the picker window is on.
+    /// when this is the display the picker window is on. When preview is
+    /// enabled, shows a thumbnail to the left of the text content.
     private func displayRow(
         display: DisplaySource,
         isSelected: Bool,
@@ -153,6 +199,14 @@ struct RecordingSourcePickerView: View {
     ) -> some View {
         Button(action: action) {
             HStack(spacing: VSpacing.md) {
+                if viewModel.sourcePreviewEnabled {
+                    ThumbnailView(
+                        thumbnail: display.thumbnail,
+                        previewStatus: display.previewStatus,
+                        size: rowThumbnailSize
+                    )
+                }
+
                 Image(systemName: "display")
                     .font(.system(size: 16))
                     .foregroundColor(isSelected ? VColor.accent : VColor.textSecondary)

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
@@ -130,6 +130,35 @@ final class RecordingSourcePickerViewModel: ObservableObject {
         }
     }
 
+    /// Whether source preview UI should be shown.
+    var sourcePreviewEnabled: Bool {
+        FeatureFlagManager.shared.isEnabled(.sourcePreviewEnabled)
+    }
+
+    /// The currently selected source's thumbnail, if any.
+    var selectedThumbnail: NSImage? {
+        switch captureScope {
+        case .display:
+            guard let id = selectedDisplayId else { return nil }
+            return displays.first(where: { $0.id == id })?.thumbnail
+        case .window:
+            guard let id = selectedWindowId else { return nil }
+            return windows.first(where: { $0.id == id })?.thumbnail
+        }
+    }
+
+    /// The preview status of the currently selected source.
+    var selectedPreviewStatus: PreviewStatus {
+        switch captureScope {
+        case .display:
+            guard let id = selectedDisplayId else { return .idle }
+            return displays.first(where: { $0.id == id })?.previewStatus ?? .idle
+        case .window:
+            guard let id = selectedWindowId else { return .idle }
+            return windows.first(where: { $0.id == id })?.previewStatus ?? .idle
+        }
+    }
+
     // MARK: - Load Sources
 
     /// Enumerate available displays and windows.

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerWindow.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerWindow.swift
@@ -50,8 +50,9 @@ final class RecordingSourcePickerWindow: NSObject, NSWindowDelegate {
         )
 
         let hostingController = NSHostingController(rootView: pickerView)
+        let windowHeight: CGFloat = FeatureFlagManager.shared.isEnabled(.sourcePreviewEnabled) ? 640 : 440
         let newWindow = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 420, height: 440),
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: windowHeight),
             styleMask: [.titled, .closable, .fullSizeContentView],
             backing: .buffered,
             defer: false

--- a/clients/macos/vellum-assistant/Recording/ThumbnailView.swift
+++ b/clients/macos/vellum-assistant/Recording/ThumbnailView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import VellumAssistantShared
 
 /// Reusable thumbnail view that renders a source preview with proper
 /// fallback states for all `PreviewStatus` values.
@@ -41,6 +42,11 @@ struct ThumbnailView: View {
             }
         }
         .frame(width: size.width, height: size.height)
+        .onChange(of: previewStatus) { _, newValue in
+            if newValue != .loading {
+                isPulsing = false
+            }
+        }
     }
 
     // MARK: - Substates

--- a/clients/macos/vellum-assistant/Recording/ThumbnailView.swift
+++ b/clients/macos/vellum-assistant/Recording/ThumbnailView.swift
@@ -1,0 +1,86 @@
+import AppKit
+import SwiftUI
+
+/// Reusable thumbnail view that renders a source preview with proper
+/// fallback states for all `PreviewStatus` values.
+///
+/// Used in both the per-row thumbnails (80x50pt) and the larger preview
+/// pane (fills available width, ~160pt tall). Pass the desired `size`
+/// to control dimensions.
+struct ThumbnailView: View {
+    let thumbnail: NSImage?
+    let previewStatus: PreviewStatus
+    let size: CGSize
+
+    /// Drives the loading skeleton pulse animation.
+    @State private var isPulsing = false
+
+    var body: some View {
+        Group {
+            switch previewStatus {
+            case .idle:
+                placeholder
+
+            case .loading:
+                loadingSkeleton
+
+            case .loaded:
+                if let thumbnail {
+                    Image(nsImage: thumbnail)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: size.width, height: size.height)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                } else {
+                    // Loaded but no thumbnail (shouldn't happen, but handle gracefully)
+                    placeholder
+                }
+
+            case .failed:
+                failedState
+            }
+        }
+        .frame(width: size.width, height: size.height)
+    }
+
+    // MARK: - Substates
+
+    private var placeholder: some View {
+        RoundedRectangle(cornerRadius: VRadius.sm)
+            .fill(VColor.backgroundSubtle)
+            .frame(width: size.width, height: size.height)
+    }
+
+    private var loadingSkeleton: some View {
+        RoundedRectangle(cornerRadius: VRadius.sm)
+            .fill(VColor.backgroundSubtle)
+            .frame(width: size.width, height: size.height)
+            .opacity(isPulsing ? 0.4 : 1.0)
+            .onAppear {
+                withAnimation(
+                    VAnimation.standard.repeatForever(autoreverses: true)
+                ) {
+                    isPulsing = true
+                }
+            }
+    }
+
+    private var failedState: some View {
+        VStack(spacing: VSpacing.xs) {
+            Image(systemName: "rectangle.dashed")
+                .font(.system(size: min(size.width, size.height) * 0.3))
+                .foregroundColor(VColor.textMuted)
+            if size.height >= 50 {
+                Text("Preview unavailable")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .lineLimit(1)
+            }
+        }
+        .frame(width: size.width, height: size.height)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .fill(VColor.backgroundSubtle)
+        )
+    }
+}


### PR DESCRIPTION
Part of #9281. Adds per-row thumbnails (80×50pt) for displays and windows, a selected-source preview pane (160pt), fallback visuals (loading skeleton, 'Preview unavailable'), and feature-flag-gated window size adjustment. All preview UI gated behind sourcePreviewEnabled flag.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
