### PR TITLE
feat(cu): overlay UX — wider panel, full text, steering input, auto-approve

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -688,6 +688,12 @@ export class ComputerUseSession {
   private buildObservationResultContent(obs: CuObservation, hadPreviousAXTree: boolean): string {
     const parts: string[] = [];
 
+    // Surface user guidance prominently so the model sees it first
+    if (obs.userGuidance) {
+      parts.push(`USER GUIDANCE: ${obs.userGuidance}`);
+      parts.push('');
+    }
+
     if (obs.executionResult) {
       parts.push(obs.executionResult);
       parts.push('');
@@ -852,6 +858,12 @@ export class ComputerUseSession {
           `WARNING: You have repeated the exact same action (${recent[0].toolName}) ${LOOP_DETECTION_WINDOW} times in a row. You MUST try a completely different approach or call computer_use_done with an explanation of why you are stuck.`,
         );
       }
+    }
+
+    // Surface user guidance prominently
+    if (obs.userGuidance) {
+      textParts.push('');
+      textParts.push(`USER GUIDANCE: ${obs.userGuidance}`);
     }
 
     // Prompt for next action

--- a/assistant/src/daemon/ipc-contract/computer-use.ts
+++ b/assistant/src/daemon/ipc-contract/computer-use.ts
@@ -42,6 +42,8 @@ export interface CuObservation {
   executionError?: string;
   axTreeBlob?: IpcBlobRef;
   screenshotBlob?: IpcBlobRef;
+  /** Free-form guidance from the user, injected mid-turn to steer the agent. */
+  userGuidance?: string;
 }
 
 export interface TaskSubmit {

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -23,6 +23,8 @@ final class ComputerUseSession: ObservableObject {
     @Published var state: SessionState = .idle
     @Published var undoCount = 0
     @Published var autoApproveTools = false
+    /// Free-form guidance from the user, consumed on the next observation.
+    @Published var pendingUserGuidance: String?
 
     let task: String
     let id: String
@@ -584,6 +586,10 @@ final class ComputerUseSession: ObservableObject {
             }
         }
 
+        // Drain any pending user guidance so it's included in this observation
+        let guidance = pendingUserGuidance
+        pendingUserGuidance = nil
+
         let observation = CuObservationMessage(
             sessionId: id,
             axTree: axTreeInline,
@@ -599,7 +605,8 @@ final class ComputerUseSession: ObservableObject {
             executionResult: executionResult,
             executionError: executionError,
             axTreeBlob: axTreeBlobRef,
-            screenshotBlob: screenshotBlobRef
+            screenshotBlob: screenshotBlobRef,
+            userGuidance: guidance
         )
 
         let screenshotRawBytes = screenshotData?.count ?? 0

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -300,6 +300,14 @@ final class ComputerUseSession: ObservableObject {
             verifier.resetBlockCount()
 
         case .needsConfirmation(let reason):
+            // Skip confirmation when auto-approve is on
+            if autoApproveTools {
+                log.info("[\(action.stepNumber)] Auto-approved: \(reason)")
+                verifier.recordConfirmedAction(agentAction)
+                verifier.resetBlockCount()
+                break
+            }
+
             // Capture the PID before showing confirmation UI
             if let result = enumerator.enumerateCurrentWindow() {
                 primaryPID = result.pid

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -300,8 +300,10 @@ final class ComputerUseSession: ObservableObject {
             verifier.resetBlockCount()
 
         case .needsConfirmation(let reason):
-            // Skip confirmation when auto-approve is on
-            if autoApproveTools {
+            // Auto-approve only low-risk confirmations (AppleScript).
+            // Destructive keys and form submissions (Enter) always prompt.
+            let isLowRisk = agentAction.type == .runAppleScript
+            if autoApproveTools && isLowRisk {
                 log.info("[\(action.stepNumber)] Auto-approved: \(reason)")
                 verifier.recordConfirmedAction(agentAction)
                 verifier.resetBlockCount()

--- a/clients/macos/vellum-assistant/Features/Session/SessionOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/SessionOverlayWindow.swift
@@ -12,11 +12,13 @@ final class SessionOverlayWindow {
     private var headerLabel: NSTextField?
     private var taskLabel: NSTextField?
     private var stateContainer: NSView?
+    private var guidanceContainer: NSView?
     private var controlsContainer: NSView?
     private var spinner: NSProgressIndicator?
+    private var guidanceField: NSTextField?
 
-    private let panelWidth: CGFloat = 340
-    private let padding: CGFloat = 14
+    private let panelWidth: CGFloat = 440
+    private let padding: CGFloat = 16
     private let sectionSpacing: CGFloat = 14 // VSpacing.md + VSpacing.xxs
 
     init(session: ComputerUseSession) {
@@ -107,10 +109,38 @@ final class SessionOverlayWindow {
         stack.addArrangedSubview(divider)
         divider.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
 
-        // State content
+        // State content (wrapped in scroll view)
         let stateView = buildStateContent(session.state)
         self.stateContainer = stateView
-        stack.addArrangedSubview(stateView)
+
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.borderType = .noBorder
+        scrollView.drawsBackground = false
+
+        let clipView = NSClipView()
+        clipView.drawsBackground = false
+        scrollView.contentView = clipView
+        scrollView.documentView = stateView
+        stateView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stateView.topAnchor.constraint(equalTo: clipView.topAnchor),
+            stateView.leadingAnchor.constraint(equalTo: clipView.leadingAnchor),
+            stateView.trailingAnchor.constraint(equalTo: clipView.trailingAnchor),
+        ])
+        scrollView.heightAnchor.constraint(lessThanOrEqualToConstant: 400).isActive = true
+
+        stack.addArrangedSubview(scrollView)
+        scrollView.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+
+        // Guidance input
+        let guidance = buildGuidanceInput()
+        self.guidanceContainer = guidance
+        stack.addArrangedSubview(guidance)
+        guidance.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+        updateGuidanceVisibility()
 
         // Controls
         let controls = buildControls()
@@ -231,7 +261,7 @@ final class SessionOverlayWindow {
             bar.translatesAutoresizingMaskIntoConstraints = false
             bar.widthAnchor.constraint(equalToConstant: 3).isActive = true
 
-            let reasoningLabel = makeLabel(reasoning, font: .systemFont(ofSize: 11), color: .labelColor, maxLines: 3)
+            let reasoningLabel = makeLabel(reasoning, font: .systemFont(ofSize: 13), color: .labelColor)
             reasoningLabel.translatesAutoresizingMaskIntoConstraints = false
 
             let wrapper = NSView()
@@ -256,7 +286,7 @@ final class SessionOverlayWindow {
             wrapper.widthAnchor.constraint(equalTo: vstack.widthAnchor).isActive = true
         }
 
-        let actionLabel = makeLabel(lastAction, font: .systemFont(ofSize: 11), color: .secondaryLabelColor, maxLines: 2)
+        let actionLabel = makeLabel(lastAction, font: .systemFont(ofSize: 13), color: .secondaryLabelColor)
         vstack.addArrangedSubview(actionLabel)
 
         return vstack
@@ -508,25 +538,98 @@ final class SessionOverlayWindow {
         }
     }
 
+    // MARK: - Guidance Input
+
+    private func buildGuidanceInput() -> NSView {
+        let container = NSView()
+
+        let hstack = NSStackView()
+        hstack.orientation = .horizontal
+        hstack.spacing = 8
+        hstack.translatesAutoresizingMaskIntoConstraints = false
+
+        let field = NSTextField()
+        field.placeholderString = "Steer the agent..."
+        field.font = NSFont.systemFont(ofSize: 13)
+        field.textColor = .labelColor
+        field.backgroundColor = NSColor(white: 0.2, alpha: 1.0)
+        field.isBordered = false
+        field.isBezeled = true
+        field.bezelStyle = .roundedBezel
+        field.cell?.wraps = false
+        field.cell?.isScrollable = true
+        field.target = buttonTarget
+        field.action = #selector(SessionOverlayButtonTarget.sendGuidanceClicked)
+        self.guidanceField = field
+
+        let sendBtn = NSButton()
+        if let img = NSImage(systemSymbolName: "arrow.up.circle.fill", accessibilityDescription: "Send guidance") {
+            sendBtn.image = img
+        }
+        sendBtn.isBordered = false
+        sendBtn.target = buttonTarget
+        sendBtn.action = #selector(SessionOverlayButtonTarget.sendGuidanceClicked)
+        sendBtn.widthAnchor.constraint(equalToConstant: 20).isActive = true
+        sendBtn.heightAnchor.constraint(equalToConstant: 20).isActive = true
+
+        hstack.addArrangedSubview(field)
+        hstack.addArrangedSubview(sendBtn)
+
+        container.addSubview(hstack)
+        NSLayoutConstraint.activate([
+            hstack.topAnchor.constraint(equalTo: container.topAnchor),
+            hstack.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            hstack.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            hstack.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+
+        return container
+    }
+
+    func sendGuidance() {
+        guard let field = guidanceField else { return }
+        let text = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        session.pendingUserGuidance = text
+        field.stringValue = ""
+    }
+
+    private func updateGuidanceVisibility() {
+        let showGuidance: Bool
+        switch session.state {
+        case .running, .thinking, .paused:
+            showGuidance = true
+        default:
+            showGuidance = false
+        }
+        guidanceContainer?.isHidden = !showGuidance
+    }
+
     // MARK: - Update
 
     private func updateState(_ state: SessionState) {
-        guard let stateContainer, let controlsContainer else { return }
+        guard let stateContainer else { return }
 
         // Stop any running spinner
         spinner?.stopAnimation(nil)
         spinner = nil
 
-        // Replace state content
-        if let parent = stateContainer.superview as? NSStackView,
-           let index = parent.arrangedSubviews.firstIndex(of: stateContainer) {
-            parent.removeArrangedSubview(stateContainer)
+        // Replace state content inside the scroll view's clip view
+        let newState = buildStateContent(state)
+        if let scrollDocView = stateContainer.superview {
             stateContainer.removeFromSuperview()
-
-            let newState = buildStateContent(state)
-            parent.insertArrangedSubview(newState, at: index)
+            scrollDocView.addSubview(newState)
+            newState.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                newState.topAnchor.constraint(equalTo: scrollDocView.topAnchor),
+                newState.leadingAnchor.constraint(equalTo: scrollDocView.leadingAnchor),
+                newState.trailingAnchor.constraint(equalTo: scrollDocView.trailingAnchor),
+            ])
             self.stateContainer = newState
         }
+
+        // Update guidance visibility
+        updateGuidanceVisibility()
 
         // Replace controls
         updateControls()
@@ -640,7 +743,9 @@ final class SessionOverlayWindow {
     // MARK: - Button Target
 
     private lazy var buttonTarget: SessionOverlayButtonTarget = {
-        SessionOverlayButtonTarget(session: session)
+        let target = SessionOverlayButtonTarget(session: session)
+        target.overlayWindow = self
+        return target
     }()
 }
 
@@ -648,6 +753,7 @@ final class SessionOverlayWindow {
 
 private class SessionOverlayButtonTarget: NSObject {
     private let session: ComputerUseSession
+    weak var overlayWindow: SessionOverlayWindow?
 
     init(session: ComputerUseSession) {
         self.session = session
@@ -660,6 +766,7 @@ private class SessionOverlayButtonTarget: NSObject {
     @MainActor @objc func resumeClicked() { session.resume() }
     @MainActor @objc func undoClicked() { session.undo() }
     @MainActor @objc func autoApproveClicked() { session.autoApproveTools.toggle() }
+    @MainActor @objc func sendGuidanceClicked() { overlayWindow?.sendGuidance() }
 }
 
 // MARK: - Background View

--- a/clients/macos/vellum-assistant/Features/Session/SessionOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/SessionOverlayWindow.swift
@@ -14,7 +14,6 @@ final class SessionOverlayWindow {
     private var stateContainer: NSView?
     private var guidanceContainer: NSView?
     private var controlsContainer: NSView?
-    private var stateScrollView: NSScrollView?
     private var spinner: NSProgressIndicator?
     private var guidanceField: NSTextField?
 
@@ -110,32 +109,10 @@ final class SessionOverlayWindow {
         stack.addArrangedSubview(divider)
         divider.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
 
-        // State content (wrapped in scroll view)
+        // State content
         let stateView = buildStateContent(session.state)
         self.stateContainer = stateView
-
-        let scrollView = NSScrollView()
-        scrollView.hasVerticalScroller = true
-        scrollView.hasHorizontalScroller = false
-        scrollView.autohidesScrollers = true
-        scrollView.borderType = .noBorder
-        scrollView.drawsBackground = false
-
-        let clipView = NSClipView()
-        clipView.drawsBackground = false
-        scrollView.contentView = clipView
-        scrollView.documentView = stateView
-        stateView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            stateView.topAnchor.constraint(equalTo: clipView.topAnchor),
-            stateView.leadingAnchor.constraint(equalTo: clipView.leadingAnchor),
-            stateView.trailingAnchor.constraint(equalTo: clipView.trailingAnchor),
-        ])
-        scrollView.heightAnchor.constraint(lessThanOrEqualToConstant: 400).isActive = true
-        self.stateScrollView = scrollView
-
-        stack.addArrangedSubview(scrollView)
-        scrollView.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+        stack.addArrangedSubview(stateView)
 
         // Guidance input
         let guidance = buildGuidanceInput()
@@ -610,26 +587,22 @@ final class SessionOverlayWindow {
     // MARK: - Update
 
     private func updateState(_ state: SessionState) {
-        guard let stateScrollView else { return }
+        guard let stateContainer else { return }
 
         // Stop any running spinner
         spinner?.stopAnimation(nil)
         spinner = nil
 
-        // Replace state content as the scroll view's document view
-        let newState = buildStateContent(state)
-        newState.translatesAutoresizingMaskIntoConstraints = false
-        stateScrollView.documentView = newState
+        // Replace state content in parent stack
+        if let parent = stateContainer.superview as? NSStackView,
+           let index = parent.arrangedSubviews.firstIndex(of: stateContainer) {
+            parent.removeArrangedSubview(stateContainer)
+            stateContainer.removeFromSuperview()
 
-        if let clipView = stateScrollView.contentView as? NSClipView {
-            NSLayoutConstraint.activate([
-                newState.topAnchor.constraint(equalTo: clipView.topAnchor),
-                newState.leadingAnchor.constraint(equalTo: clipView.leadingAnchor),
-                newState.trailingAnchor.constraint(equalTo: clipView.trailingAnchor),
-            ])
+            let newState = buildStateContent(state)
+            parent.insertArrangedSubview(newState, at: index)
+            self.stateContainer = newState
         }
-
-        self.stateContainer = newState
 
         // Update guidance visibility
         updateGuidanceVisibility()

--- a/clients/macos/vellum-assistant/Features/Session/SessionOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/SessionOverlayWindow.swift
@@ -14,6 +14,7 @@ final class SessionOverlayWindow {
     private var stateContainer: NSView?
     private var guidanceContainer: NSView?
     private var controlsContainer: NSView?
+    private var stateScrollView: NSScrollView?
     private var spinner: NSProgressIndicator?
     private var guidanceField: NSTextField?
 
@@ -131,6 +132,7 @@ final class SessionOverlayWindow {
             stateView.trailingAnchor.constraint(equalTo: clipView.trailingAnchor),
         ])
         scrollView.heightAnchor.constraint(lessThanOrEqualToConstant: 400).isActive = true
+        self.stateScrollView = scrollView
 
         stack.addArrangedSubview(scrollView)
         scrollView.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
@@ -608,25 +610,26 @@ final class SessionOverlayWindow {
     // MARK: - Update
 
     private func updateState(_ state: SessionState) {
-        guard let stateContainer else { return }
+        guard let stateScrollView else { return }
 
         // Stop any running spinner
         spinner?.stopAnimation(nil)
         spinner = nil
 
-        // Replace state content inside the scroll view's clip view
+        // Replace state content as the scroll view's document view
         let newState = buildStateContent(state)
-        if let scrollDocView = stateContainer.superview {
-            stateContainer.removeFromSuperview()
-            scrollDocView.addSubview(newState)
-            newState.translatesAutoresizingMaskIntoConstraints = false
+        newState.translatesAutoresizingMaskIntoConstraints = false
+        stateScrollView.documentView = newState
+
+        if let clipView = stateScrollView.contentView as? NSClipView {
             NSLayoutConstraint.activate([
-                newState.topAnchor.constraint(equalTo: scrollDocView.topAnchor),
-                newState.leadingAnchor.constraint(equalTo: scrollDocView.leadingAnchor),
-                newState.trailingAnchor.constraint(equalTo: scrollDocView.trailingAnchor),
+                newState.topAnchor.constraint(equalTo: clipView.topAnchor),
+                newState.leadingAnchor.constraint(equalTo: clipView.leadingAnchor),
+                newState.trailingAnchor.constraint(equalTo: clipView.trailingAnchor),
             ])
-            self.stateContainer = newState
         }
+
+        self.stateContainer = newState
 
         // Update guidance visibility
         updateGuidanceVisibility()

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1072,8 +1072,10 @@ public struct IPCCuObservation: Codable, Sendable {
     public let executionError: String?
     public let axTreeBlob: IPCIpcBlobRef?
     public let screenshotBlob: IPCIpcBlobRef?
+    /// Free-form guidance from the user, injected mid-turn to steer the agent.
+    public let userGuidance: String?
 
-    public init(type: String, sessionId: String, axTree: String? = nil, axDiff: String? = nil, secondaryWindows: String? = nil, screenshot: String? = nil, screenshotWidthPx: Double? = nil, screenshotHeightPx: Double? = nil, screenWidthPt: Double? = nil, screenHeightPt: Double? = nil, coordinateOrigin: String? = nil, captureDisplayId: Double? = nil, executionResult: String? = nil, executionError: String? = nil, axTreeBlob: IPCIpcBlobRef? = nil, screenshotBlob: IPCIpcBlobRef? = nil) {
+    public init(type: String, sessionId: String, axTree: String? = nil, axDiff: String? = nil, secondaryWindows: String? = nil, screenshot: String? = nil, screenshotWidthPx: Double? = nil, screenshotHeightPx: Double? = nil, screenWidthPt: Double? = nil, screenHeightPt: Double? = nil, coordinateOrigin: String? = nil, captureDisplayId: Double? = nil, executionResult: String? = nil, executionError: String? = nil, axTreeBlob: IPCIpcBlobRef? = nil, screenshotBlob: IPCIpcBlobRef? = nil, userGuidance: String? = nil) {
         self.type = type
         self.sessionId = sessionId
         self.axTree = axTree
@@ -1090,6 +1092,7 @@ public struct IPCCuObservation: Codable, Sendable {
         self.executionError = executionError
         self.axTreeBlob = axTreeBlob
         self.screenshotBlob = screenshotBlob
+        self.userGuidance = userGuidance
     }
 }
 

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -173,7 +173,8 @@ extension IPCCuObservation {
         executionResult: String?,
         executionError: String?,
         axTreeBlob: IPCIpcBlobRef? = nil,
-        screenshotBlob: IPCIpcBlobRef? = nil
+        screenshotBlob: IPCIpcBlobRef? = nil,
+        userGuidance: String? = nil
     ) {
         self.init(
             type: "cu_observation",
@@ -191,7 +192,8 @@ extension IPCCuObservation {
             executionResult: executionResult,
             executionError: executionError,
             axTreeBlob: axTreeBlob,
-            screenshotBlob: screenshotBlob
+            screenshotBlob: screenshotBlob,
+            userGuidance: userGuidance
         )
     }
 }


### PR DESCRIPTION
## Summary
- **Wider overlay panel** (340→440pt, 14→16pt padding) with full reasoning/action text (line limits removed, bumped from 11pt to 13pt)
- **Mid-turn steering**: text field in the overlay lets the user send guidance to the agent mid-session — injected as `USER GUIDANCE:` block in the next observation so Claude sees it prominently
- **Auto-approve wired up**: the toggle now actually skips AppleScript confirmations; destructive keys and form submissions (Enter after typing) always prompt regardless

## Changes
- `SessionOverlayWindow.swift` — wider panel, guidance input field, guidance visibility toggle
- `Session.swift` — `pendingUserGuidance` property, drained into observations; auto-approve check in verification flow
- `computer-use.ts` — `userGuidance?: string` added to `CuObservation`
- `computer-use-session.ts` — prepends `USER GUIDANCE:` block in both `buildObservationResultContent` and `buildMessages`
- `IPCContractGenerated.swift` / `IPCMessages.swift` — regenerated with `userGuidance` field

## Test plan
- [ ] Launch app, trigger CU task — verify wider panel with full reasoning/action text
- [ ] Type guidance in input field during a running task and hit Enter — verify it appears in daemon logs as `USER GUIDANCE:`
- [ ] Toggle Auto-approve on — verify AppleScript confirmations are skipped
- [ ] With Auto-approve on, verify Enter-after-typing still prompts for confirmation
- [ ] Toggle Auto-approve off — verify all confirmations prompt as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
