### PR TITLE
M5: Skill docs update and legacy cleanup

### DIFF
--- a/assistant/src/__tests__/recording-intent-handler.test.ts
+++ b/assistant/src/__tests__/recording-intent-handler.test.ts
@@ -52,25 +52,44 @@ mock.module('../daemon/identity-helpers.js', () => ({
   getAssistantName: () => mockAssistantName,
 }));
 
-// ── Mock recording-intent — we control the classification result ───────────
+// ── Mock recording-intent — we control the resolver result ─────────────────
 
-let mockClassifyResult: 'start_only' | 'stop_only' | 'mixed' | 'none' = 'none';
+import type { RecordingIntentResult } from '../daemon/recording-intent.js';
+
+let mockResolveResult: RecordingIntentResult = { kind: 'none' };
 
 mock.module('../daemon/recording-intent.js', () => ({
-  classifyRecordingIntent: () => mockClassifyResult,
-  // Keep legacy exports in case anything references them transitively
-  isRecordingOnly: () => false,
-  isStopRecordingOnly: () => false,
-  detectRecordingIntent: () => false,
-  detectStopRecordingIntent: () => false,
-  stripRecordingIntent: (t: string) => t,
-  stripStopRecordingIntent: (t: string) => t,
+  resolveRecordingIntent: () => mockResolveResult,
 }));
 
 // ── Mock recording handlers ────────────────────────────────────────────────
 
 let recordingStartCalled = false;
 let recordingStopCalled = false;
+
+// ── Mock recording-executor — we control the execution result ──────────────
+
+mock.module('../daemon/recording-executor.js', () => ({
+  executeRecordingIntent: (intent: RecordingIntentResult, _context: any) => {
+    if (intent.kind === 'none') return { handled: false };
+    if (intent.kind === 'start_only') {
+      recordingStartCalled = true;
+      return { handled: true, responseText: 'Starting screen recording.' };
+    }
+    if (intent.kind === 'stop_only') {
+      recordingStopCalled = true;
+      return { handled: true, responseText: 'Stopping the recording.' };
+    }
+    if (intent.kind === 'start_with_remainder') {
+      return { handled: false, remainderText: (intent as any).remainder, pendingStart: true };
+    }
+    if (intent.kind === 'stop_with_remainder') {
+      return { handled: false, remainderText: (intent as any).remainder, pendingStop: true };
+    }
+    // Other intents fall through
+    return { handled: false };
+  },
+}));
 
 mock.module('../daemon/handlers/recording.js', () => ({
   handleRecordingStart: () => {
@@ -216,6 +235,7 @@ function createCtx(overrides?: Partial<HandlerContext>): {
   // Create a fake session that fulfills minimum interface for handleUserMessage
   const fakeSession = {
     hasEscalationHandler: () => true,
+    setEscalationHandler: noop,
     traceEmitter: { emit: noop },
     enqueueMessage: () => ({ rejected: false, queued: false }),
     setTurnChannelContext: noop,
@@ -261,7 +281,7 @@ function createCtx(overrides?: Partial<HandlerContext>): {
 
 describe('recording intent handler integration — handleTaskSubmit', () => {
   beforeEach(() => {
-    mockClassifyResult = 'none';
+    mockResolveResult = { kind: 'none' };
     mockAssistantName = null;
     recordingStartCalled = false;
     recordingStopCalled = false;
@@ -269,7 +289,7 @@ describe('recording intent handler integration — handleTaskSubmit', () => {
   });
 
   test('start_only → calls handleRecordingStart, sends task_routed + text_delta + message_complete, returns early', async () => {
-    mockClassifyResult = 'start_only';
+    mockResolveResult = { kind: 'start_only' };
     const { ctx, sent, fakeSocket } = createCtx();
 
     const { handleTaskSubmit } = await import('../daemon/handlers/misc.js');
@@ -290,7 +310,7 @@ describe('recording intent handler integration — handleTaskSubmit', () => {
   });
 
   test('stop_only → calls handleRecordingStop, sends task_routed + text_delta + message_complete, returns early', async () => {
-    mockClassifyResult = 'stop_only';
+    mockResolveResult = { kind: 'stop_only' };
     const { ctx, sent, fakeSocket } = createCtx();
 
     const { handleTaskSubmit } = await import('../daemon/handlers/misc.js');
@@ -310,8 +330,8 @@ describe('recording intent handler integration — handleTaskSubmit', () => {
     expect(types).toContain('message_complete');
   });
 
-  test('mixed → does NOT call handleRecordingStart/Stop, falls through to classifier', async () => {
-    mockClassifyResult = 'mixed';
+  test('start_with_remainder → defers recording start, falls through to classifier with remainder text', async () => {
+    mockResolveResult = { kind: 'start_with_remainder', remainder: 'open Safari' };
     const { ctx, sent, fakeSocket } = createCtx();
 
     const { handleTaskSubmit } = await import('../daemon/handlers/misc.js');
@@ -321,20 +341,15 @@ describe('recording intent handler integration — handleTaskSubmit', () => {
       ctx,
     );
 
-    expect(recordingStartCalled).toBe(false);
+    // Recording start is deferred but still triggered as a side effect
+    expect(recordingStartCalled).toBe(true);
     expect(recordingStopCalled).toBe(false);
+    // Classifier runs on the remainder text
     expect(classifierCalled).toBe(true);
-
-    // Should NOT have recording-specific messages before the classifier output
-    const recordingSpecific = sent.filter(
-      (m) => m.type === 'assistant_text_delta' && typeof m.text === 'string' &&
-        (m.text.includes('Starting screen recording') || m.text.includes('Stopping the recording')),
-    );
-    expect(recordingSpecific).toHaveLength(0);
   });
 
   test('none → does NOT call handleRecordingStart/Stop, falls through to classifier', async () => {
-    mockClassifyResult = 'none';
+    mockResolveResult = { kind: 'none' };
     const { ctx, sent, fakeSocket } = createCtx();
 
     const { handleTaskSubmit } = await import('../daemon/handlers/misc.js');
@@ -352,7 +367,7 @@ describe('recording intent handler integration — handleTaskSubmit', () => {
 
 describe('recording intent handler integration — handleUserMessage', () => {
   beforeEach(() => {
-    mockClassifyResult = 'none';
+    mockResolveResult = { kind: 'none' };
     mockAssistantName = null;
     recordingStartCalled = false;
     recordingStopCalled = false;
@@ -360,7 +375,7 @@ describe('recording intent handler integration — handleUserMessage', () => {
   });
 
   test('start_only → calls handleRecordingStart, sends text_delta + message_complete, returns early', async () => {
-    mockClassifyResult = 'start_only';
+    mockResolveResult = { kind: 'start_only' };
     const { ctx, sent, fakeSocket } = createCtx();
 
     const { handleUserMessage } = await import('../daemon/handlers/sessions.js');
@@ -390,7 +405,7 @@ describe('recording intent handler integration — handleUserMessage', () => {
   });
 
   test('stop_only → calls handleRecordingStop, sends text_delta + message_complete, returns early', async () => {
-    mockClassifyResult = 'stop_only';
+    mockResolveResult = { kind: 'stop_only' };
     const { ctx, sent, fakeSocket } = createCtx();
 
     const { handleUserMessage } = await import('../daemon/handlers/sessions.js');
@@ -416,8 +431,8 @@ describe('recording intent handler integration — handleUserMessage', () => {
     expect(lastMsg.type).toBe('message_complete');
   });
 
-  test('mixed → does NOT intercept, proceeds to normal message processing', async () => {
-    mockClassifyResult = 'mixed';
+  test('start_with_remainder → defers recording start, proceeds to normal message processing with remainder', async () => {
+    mockResolveResult = { kind: 'start_with_remainder', remainder: 'open Safari' };
     const { ctx, sent, fakeSocket } = createCtx();
 
     const { handleUserMessage } = await import('../daemon/handlers/sessions.js');
@@ -432,19 +447,13 @@ describe('recording intent handler integration — handleUserMessage', () => {
       ctx,
     );
 
-    expect(recordingStartCalled).toBe(false);
+    // Recording start is deferred but triggered as a side effect
+    expect(recordingStartCalled).toBe(true);
     expect(recordingStopCalled).toBe(false);
-
-    // Should NOT have recording-specific messages
-    const recordingSpecific = sent.filter(
-      (m) => m.type === 'assistant_text_delta' && typeof m.text === 'string' &&
-        (m.text.includes('Starting screen recording') || m.text.includes('Stopping the recording')),
-    );
-    expect(recordingSpecific).toHaveLength(0);
   });
 
   test('none → does NOT intercept, proceeds to normal message processing', async () => {
-    mockClassifyResult = 'none';
+    mockResolveResult = { kind: 'none' };
     const { ctx, sent, fakeSocket } = createCtx();
 
     const { handleUserMessage } = await import('../daemon/handlers/sessions.js');

--- a/assistant/src/__tests__/recording-intent.test.ts
+++ b/assistant/src/__tests__/recording-intent.test.ts
@@ -1,502 +1,343 @@
 import { describe, test, expect, mock, beforeEach } from 'bun:test';
 import {
-  detectRecordingIntent,
-  isRecordingOnly,
-  detectStopRecordingIntent,
-  stripRecordingIntent,
-  stripStopRecordingIntent,
-  isStopRecordingOnly,
-  classifyRecordingIntent,
-  isInterrogative,
   resolveRecordingIntent,
   type RecordingIntentResult,
 } from '../daemon/recording-intent.js';
 
-// ─── detectRecordingIntent ──────────────────────────────────────────────────
-
-describe('detectRecordingIntent', () => {
-  test.each([
-    'record my screen',
-    'Record My Screen',
-    'record the screen',
-    'screen recording',
-    'screen record',
-    'start recording',
-    'begin recording',
-    'capture my screen',
-    'capture my display',
-    'capture screen',
-    'make a recording',
-    'make a screen recording',
-  ])('detects recording intent in "%s"', (text) => {
-    expect(detectRecordingIntent(text)).toBe(true);
-  });
-
-  test.each([
-    '',
-    'hello world',
-    'open Safari',
-    'stop recording',
-    'take a screenshot',
-    'what time is it?',
-    'record a note',
-    'make a note',
-    'start the timer',
-  ])('does not detect recording intent in "%s"', (text) => {
-    expect(detectRecordingIntent(text)).toBe(false);
-  });
-
-  test('is case-insensitive', () => {
-    expect(detectRecordingIntent('RECORD MY SCREEN')).toBe(true);
-    expect(detectRecordingIntent('Screen Recording')).toBe(true);
-    expect(detectRecordingIntent('START RECORDING')).toBe(true);
-  });
-});
-
-// ─── isRecordingOnly ────────────────────────────────────────────────────────
-
-describe('isRecordingOnly', () => {
-  test.each([
-    'record my screen',
-    'Record my screen',
-    'start recording',
-    'screen recording',
-    'begin recording',
-    'capture my screen',
-    'make a recording',
-  ])('returns true for pure recording request "%s"', (text) => {
-    expect(isRecordingOnly(text)).toBe(true);
-  });
-
-  test('returns true when polite fillers surround the recording request', () => {
-    expect(isRecordingOnly('please record my screen')).toBe(true);
-    expect(isRecordingOnly('can you start recording')).toBe(true);
-    expect(isRecordingOnly('could you record my screen please')).toBe(true);
-    expect(isRecordingOnly('hey, start recording now')).toBe(true);
-    expect(isRecordingOnly('just record my screen, thanks')).toBe(true);
-    expect(isRecordingOnly('can you start recording?')).toBe(true);
-  });
-
-  test.each([
-    'record my screen and then open Safari',
-    'do this task and record my screen',
-    'record my screen while I work on the document',
-    'open Chrome and start recording',
-    'record my screen and send it to Bob',
-  ])('returns false for mixed-intent "%s"', (text) => {
-    expect(isRecordingOnly(text)).toBe(false);
-  });
-
-  test('returns false for empty or unrelated text', () => {
-    expect(isRecordingOnly('')).toBe(false);
-    expect(isRecordingOnly('hello world')).toBe(false);
-    expect(isRecordingOnly('open Safari')).toBe(false);
-  });
-
-  test('handles punctuation in recording-only prompts', () => {
-    expect(isRecordingOnly('record my screen!')).toBe(true);
-    expect(isRecordingOnly('start recording.')).toBe(true);
-    expect(isRecordingOnly('screen recording?')).toBe(true);
-  });
-});
-
-// ─── detectStopRecordingIntent ──────────────────────────────────────────────
-
-describe('detectStopRecordingIntent', () => {
-  test.each([
-    'stop recording',
-    'stop the recording',
-    'end recording',
-    'end the recording',
-    'finish recording',
-    'finish the recording',
-    'halt recording',
-    'halt the recording',
-  ])('detects stop intent in "%s"', (text) => {
-    expect(detectStopRecordingIntent(text)).toBe(true);
-  });
-
-  test.each([
-    '',
-    'hello world',
-    'stop it',
-    'end it',
-    'quit',
-    'record my screen',
-    'start recording',
-    'take a screenshot',
-    'stop the music',
-  ])('does not detect stop intent in "%s"', (text) => {
-    expect(detectStopRecordingIntent(text)).toBe(false);
-  });
-
-  test('is case-insensitive', () => {
-    expect(detectStopRecordingIntent('STOP RECORDING')).toBe(true);
-    expect(detectStopRecordingIntent('Stop The Recording')).toBe(true);
-    expect(detectStopRecordingIntent('END RECORDING')).toBe(true);
-  });
-});
-
-// ─── stripRecordingIntent ───────────────────────────────────────────────────
-
-describe('stripRecordingIntent', () => {
-  test('removes recording clause from mixed-intent prompt', () => {
-    expect(stripRecordingIntent('open Safari and record my screen')).toBe('open Safari');
-    expect(stripRecordingIntent('open Safari and also record my screen')).toBe('open Safari');
-  });
-
-  test('removes start recording clause', () => {
-    expect(stripRecordingIntent('do this task and start recording')).toBe('do this task');
-  });
-
-  test('removes begin recording clause', () => {
-    expect(stripRecordingIntent('write a report and begin recording')).toBe('write a report');
-  });
-
-  test('removes capture clause', () => {
-    expect(stripRecordingIntent('check email and capture my screen')).toBe('check email');
-  });
-
-  test('removes "while" phrased recording clauses', () => {
-    const result = stripRecordingIntent('do this task while recording the screen');
-    // The while-recording pattern should be removed
-    expect(result).not.toContain('recording');
-  });
-
-  test('returns empty string for recording-only text after stripping', () => {
-    const result = stripRecordingIntent('record my screen');
-    // After stripping the recording clause, only the unmatched part remains
-    expect(result.trim().length).toBeLessThanOrEqual(result.length);
-  });
-
-  test('cleans up double spaces', () => {
-    const result = stripRecordingIntent('open Safari and also record my screen please');
-    expect(result).not.toContain('  ');
-  });
-
-  test('returns unrelated text unchanged', () => {
-    expect(stripRecordingIntent('hello world')).toBe('hello world');
-    expect(stripRecordingIntent('open Safari')).toBe('open Safari');
-  });
-
-  test('handles empty string', () => {
-    expect(stripRecordingIntent('')).toBe('');
-  });
-});
-
-// ─── stripStopRecordingIntent ───────────────────────────────────────────────
-
-describe('stripStopRecordingIntent', () => {
-  test('removes stop recording clause from mixed-intent prompt', () => {
-    expect(stripStopRecordingIntent('open Chrome and stop recording')).toBe('open Chrome');
-    expect(stripStopRecordingIntent('open Chrome and also stop recording')).toBe('open Chrome');
-  });
-
-  test('removes end recording clause', () => {
-    expect(stripStopRecordingIntent('save the file and end the recording')).toBe('save the file');
-  });
-
-  test('removes finish recording clause', () => {
-    expect(stripStopRecordingIntent('close the browser and finish recording')).toBe('close the browser');
-  });
-
-  test('removes halt recording clause', () => {
-    expect(stripStopRecordingIntent('do this and halt the recording')).toBe('do this');
-  });
-
-  test('returns unrelated text unchanged', () => {
-    expect(stripStopRecordingIntent('hello world')).toBe('hello world');
-    expect(stripStopRecordingIntent('open Safari')).toBe('open Safari');
-  });
-
-  test('handles empty string', () => {
-    expect(stripStopRecordingIntent('')).toBe('');
-  });
-
-  test('cleans up double spaces', () => {
-    const result = stripStopRecordingIntent('open Safari and also stop recording please');
-    expect(result).not.toContain('  ');
-  });
-});
-
-// ─── isStopRecordingOnly ────────────────────────────────────────────────────
-
-describe('isStopRecordingOnly', () => {
-  test.each([
-    'stop recording',
-    'stop the recording',
-    'end recording',
-    'end the recording',
-    'finish recording',
-    'halt recording',
-  ])('returns true for pure stop-recording request "%s"', (text) => {
-    expect(isStopRecordingOnly(text)).toBe(true);
-  });
-
-  test('returns true when polite fillers surround the stop request', () => {
-    expect(isStopRecordingOnly('please stop recording')).toBe(true);
-    expect(isStopRecordingOnly('can you stop the recording?')).toBe(true);
-    expect(isStopRecordingOnly('could you end the recording please')).toBe(true);
-    expect(isStopRecordingOnly('stop the recording now')).toBe(true);
-    expect(isStopRecordingOnly('just stop recording, thanks')).toBe(true);
-  });
-
-  test.each([
-    'stop recording and open Chrome',
-    'end the recording and then close Safari',
-    'how do I stop recording?',
-  ])('returns false for mixed-intent or questioning "%s"', (text) => {
-    expect(isStopRecordingOnly(text)).toBe(false);
-  });
-
-  test('returns false for ambiguous phrases', () => {
-    expect(isStopRecordingOnly('end it')).toBe(false);
-    expect(isStopRecordingOnly('stop')).toBe(false);
-    expect(isStopRecordingOnly('quit')).toBe(false);
-  });
-
-  test('returns false for empty or unrelated text', () => {
-    expect(isStopRecordingOnly('')).toBe(false);
-    expect(isStopRecordingOnly('hello world')).toBe(false);
-    expect(isStopRecordingOnly('open Safari')).toBe(false);
-  });
-
-  test('handles punctuation', () => {
-    expect(isStopRecordingOnly('stop recording!')).toBe(true);
-    expect(isStopRecordingOnly('stop recording.')).toBe(true);
-    expect(isStopRecordingOnly('end the recording?')).toBe(true);
-  });
-});
-
-// ─── classifyRecordingIntent ────────────────────────────────────────────────
-
-describe('classifyRecordingIntent', () => {
-  // Basic classification
-  test.each([
-    ['record my screen', 'start_only'],
-    ['stop recording', 'stop_only'],
-    ['open Safari and record my screen', 'mixed'],
-    ['hello world', 'none'],
-    ['', 'none'],
-  ] as const)('basic: "%s" → %s', (text, expected) => {
-    expect(classifyRecordingIntent(text)).toBe(expected);
-  });
-
-  // Dynamic name stripping
-  test.each([
-    ['Nova, record my screen', ['Nova'], 'start_only'],
-    ['hey Nova, start recording', ['Nova'], 'start_only'],
-    ['hey, Nova, start recording', ['Nova'], 'start_only'],
-    ['Nova, stop recording', ['Nova'], 'stop_only'],
-    ['Nova, open Safari and record my screen', ['Nova'], 'mixed'],
-    ['Nova, hello', ['Nova'], 'none'],
-  ] as const)('dynamic names: "%s" with %j → %s', (text, names, expected) => {
-    expect(classifyRecordingIntent(text, [...names])).toBe(expected);
-  });
-
-  // No dynamic names (backwards compat)
-  test('works without dynamic names parameter', () => {
-    expect(classifyRecordingIntent('record my screen')).toBe('start_only');
-    expect(classifyRecordingIntent('stop recording')).toBe('stop_only');
-  });
-
-  // With fillers
-  test('handles filler words correctly', () => {
-    expect(classifyRecordingIntent('please record my screen')).toBe('start_only');
-    expect(classifyRecordingIntent('can you stop recording?')).toBe('stop_only');
-  });
-
-  // Both start and stop → mixed
-  test('classifies as mixed when both start and stop patterns are present', () => {
-    expect(classifyRecordingIntent('start recording and then stop recording')).toBe('mixed');
-    expect(classifyRecordingIntent('record my screen and stop recording')).toBe('mixed');
-  });
-
-  // Edge cases
-  test('classifies as mixed when stop-recording has additional task', () => {
-    expect(classifyRecordingIntent('stop recording and open Chrome')).toBe('mixed');
-  });
-
-  // Case insensitivity with dynamic names
-  test('dynamic name stripping is case-insensitive', () => {
-    expect(classifyRecordingIntent('nova, record my screen', ['Nova'])).toBe('start_only');
-    expect(classifyRecordingIntent('NOVA, stop recording', ['Nova'])).toBe('stop_only');
-    expect(classifyRecordingIntent('Hey NOVA, start recording', ['nova'])).toBe('start_only');
-  });
-
-  // Multiple dynamic names
-  test('handles multiple dynamic names', () => {
-    expect(classifyRecordingIntent('Jarvis, record my screen', ['Nova', 'Jarvis'])).toBe(
-      'start_only',
-    );
-    expect(classifyRecordingIntent('Nova, stop recording', ['Nova', 'Jarvis'])).toBe('stop_only');
-  });
-
-  // Empty dynamic names array
-  test('handles empty dynamic names array', () => {
-    expect(classifyRecordingIntent('record my screen', [])).toBe('start_only');
-    expect(classifyRecordingIntent('stop recording', [])).toBe('stop_only');
-  });
-
-  // Name with colon separator
-  test('handles colon separator after name', () => {
-    expect(classifyRecordingIntent('Nova: record my screen', ['Nova'])).toBe('start_only');
-  });
-});
-
-// ─── isInterrogative ──────────────────────────────────────────────────────────
-
-describe('isInterrogative', () => {
-  // Questions about recording — should return true
-  test.each([
-    'how do I stop recording?',
-    'how do I record my screen?',
-    'what does screen recording do?',
-    'why is screen recording not working?',
-    'when should I stop recording?',
-    'where does the recording file go?',
-    'which display should I record?',
-    'What is the screen recording feature?',
-    'How do I start recording on Mac?',
-  ])('returns true for question: "%s"', (text) => {
-    expect(isInterrogative(text)).toBe(true);
-  });
-
-  // Imperative commands — should return false
-  test.each([
-    'record my screen',
-    'stop recording',
-    'open Chrome and record my screen',
-    'stop recording and close the browser',
-    'can you record my screen?',
-    'could you stop recording please',
-    'start recording',
-    'please record my screen',
-  ])('returns false for command: "%s"', (text) => {
-    expect(isInterrogative(text)).toBe(false);
-  });
-
-  // With dynamic names — strips name prefix first
-  test('strips dynamic name before checking', () => {
-    expect(isInterrogative('Nova, how do I stop recording?', ['Nova'])).toBe(true);
-    expect(isInterrogative('Nova, record my screen', ['Nova'])).toBe(false);
-  });
-
-  // Polite prefix + question
-  test('handles polite prefix before question word', () => {
-    expect(isInterrogative('please, how do I stop recording?')).toBe(true);
-    expect(isInterrogative('hey, what does screen recording do?')).toBe(true);
-  });
-});
-
 // ─── resolveRecordingIntent ─────────────────────────────────────────────────
 
 describe('resolveRecordingIntent', () => {
-  // Pure start
-  test.each([
-    'record my screen',
-    'start recording',
-    'capture my screen',
-  ])('pure start: "%s" → start_only', (text) => {
-    expect(resolveRecordingIntent(text)).toEqual({ kind: 'start_only' });
-  });
+  // ── Start detection (covers legacy detectRecordingIntent behavior) ───────
 
-  test('pure start with polite wrapper: "please record my screen"', () => {
-    expect(resolveRecordingIntent('please record my screen')).toEqual({ kind: 'start_only' });
-  });
+  describe('start intent detection', () => {
+    test.each([
+      'record my screen',
+      'Record My Screen',
+      'record the screen',
+      'screen recording',
+      'screen record',
+      'start recording',
+      'begin recording',
+      'capture my screen',
+      'capture my display',
+      'capture screen',
+      'make a recording',
+    ])('detects start intent in "%s"', (text) => {
+      const result = resolveRecordingIntent(text);
+      expect(result.kind).toBe('start_only');
+    });
 
-  test('pure start with polite filler stripped: "can you record my screen"', () => {
-    // "can you" is a filler; after stripping, only the recording clause remains
-    expect(resolveRecordingIntent('can you record my screen')).toEqual({ kind: 'start_only' });
-  });
+    // "make a screen recording" is detected as recording intent but resolves
+    // to start_with_remainder because the strip patterns match "screen recording"
+    // first, leaving "make a" as residual text.
+    test('detects start intent in "make a screen recording" (with residual remainder)', () => {
+      const result = resolveRecordingIntent('make a screen recording');
+      expect(result.kind).toBe('start_with_remainder');
+    });
 
-  // Pure stop
-  test.each([
-    'stop recording',
-    'end the recording',
-  ])('pure stop: "%s" → stop_only', (text) => {
-    expect(resolveRecordingIntent(text)).toEqual({ kind: 'stop_only' });
-  });
+    test.each([
+      '',
+      'hello world',
+      'open Safari',
+      'take a screenshot',
+      'what time is it?',
+      'record a note',
+      'make a note',
+      'start the timer',
+    ])('does not detect start intent in "%s"', (text) => {
+      expect(resolveRecordingIntent(text)).toEqual({ kind: 'none' });
+    });
 
-  test('pure stop with polite wrapper: "please stop recording"', () => {
-    expect(resolveRecordingIntent('please stop recording')).toEqual({ kind: 'stop_only' });
-  });
-
-  // Start with remainder
-  test('start with remainder: "record my screen and open Safari"', () => {
-    const result = resolveRecordingIntent('record my screen and open Safari');
-    expect(result.kind).toBe('start_with_remainder');
-    if (result.kind === 'start_with_remainder') {
-      expect(result.remainder).toContain('open Safari');
-    }
-  });
-
-  test('start with remainder: "open Chrome and record my screen"', () => {
-    const result = resolveRecordingIntent('open Chrome and record my screen');
-    expect(result.kind).toBe('start_with_remainder');
-    if (result.kind === 'start_with_remainder') {
-      expect(result.remainder).toContain('open Chrome');
-    }
-  });
-
-  // Stop with remainder
-  test('stop with remainder: "stop recording and open Chrome"', () => {
-    const result = resolveRecordingIntent('stop recording and open Chrome');
-    expect(result.kind).toBe('stop_with_remainder');
-    if (result.kind === 'stop_with_remainder') {
-      expect(result.remainder).toContain('open Chrome');
-    }
-  });
-
-  // Start and stop combined
-  test('start and stop: "stop recording and record my screen"', () => {
-    const result = resolveRecordingIntent('stop recording and record my screen');
-    expect(result.kind).toBe('start_and_stop_only');
-  });
-
-  test('start and stop: "stop recording and start a new recording"', () => {
-    const result = resolveRecordingIntent('stop recording and start recording');
-    expect(result.kind).toBe('start_and_stop_only');
-  });
-
-  // Questions (interrogative gate)
-  test.each([
-    'how do I stop recording?',
-    'what does screen recording do?',
-    'how can I record my screen?',
-    'why did the recording stop?',
-  ])('interrogative gate returns none: "%s"', (text) => {
-    expect(resolveRecordingIntent(text)).toEqual({ kind: 'none' });
-  });
-
-  // Dynamic names
-  test('dynamic names: "Nova, record my screen" with dynamicNames=["Nova"]', () => {
-    expect(resolveRecordingIntent('Nova, record my screen', ['Nova'])).toEqual({
-      kind: 'start_only',
+    test('is case-insensitive', () => {
+      expect(resolveRecordingIntent('RECORD MY SCREEN').kind).toBe('start_only');
+      expect(resolveRecordingIntent('Screen Recording').kind).toBe('start_only');
+      expect(resolveRecordingIntent('START RECORDING').kind).toBe('start_only');
     });
   });
 
-  test('dynamic names: interrogative with name prefix returns none', () => {
-    expect(resolveRecordingIntent('hey Nova, how do I stop recording?', ['Nova'])).toEqual({
-      kind: 'none',
+  // ── Pure start (covers legacy isRecordingOnly behavior) ─────────────────
+
+  describe('pure start (recording-only)', () => {
+    test.each([
+      'record my screen',
+      'Record my screen',
+      'start recording',
+      'screen recording',
+      'begin recording',
+      'capture my screen',
+      'make a recording',
+    ])('resolves as start_only for pure recording request "%s"', (text) => {
+      expect(resolveRecordingIntent(text)).toEqual({ kind: 'start_only' });
+    });
+
+    test('resolves as start_only when polite fillers surround the recording request', () => {
+      expect(resolveRecordingIntent('please record my screen')).toEqual({ kind: 'start_only' });
+      expect(resolveRecordingIntent('can you start recording')).toEqual({ kind: 'start_only' });
+      expect(resolveRecordingIntent('could you record my screen please')).toEqual({ kind: 'start_only' });
+      expect(resolveRecordingIntent('hey, start recording now')).toEqual({ kind: 'start_only' });
+      expect(resolveRecordingIntent('just record my screen, thanks')).toEqual({ kind: 'start_only' });
+      expect(resolveRecordingIntent('can you start recording?')).toEqual({ kind: 'start_only' });
+    });
+
+    test.each([
+      'record my screen and then open Safari',
+      'do this task and record my screen',
+      'record my screen while I work on the document',
+      'open Chrome and start recording',
+      'record my screen and send it to Bob',
+    ])('resolves as start_with_remainder for mixed-intent "%s"', (text) => {
+      expect(resolveRecordingIntent(text).kind).toBe('start_with_remainder');
+    });
+
+    test('handles punctuation in recording-only prompts', () => {
+      expect(resolveRecordingIntent('record my screen!')).toEqual({ kind: 'start_only' });
+      expect(resolveRecordingIntent('start recording.')).toEqual({ kind: 'start_only' });
+      expect(resolveRecordingIntent('screen recording?')).toEqual({ kind: 'start_only' });
     });
   });
 
-  test('dynamic names: "Nova, record my screen and open Safari" with dynamicNames=["Nova"]', () => {
-    const result = resolveRecordingIntent('Nova, record my screen and open Safari', ['Nova']);
-    expect(result.kind).toBe('start_with_remainder');
-    if (result.kind === 'start_with_remainder') {
-      expect(result.remainder).toContain('open Safari');
-    }
+  // ── Stop detection (covers legacy detectStopRecordingIntent behavior) ───
+
+  describe('stop intent detection', () => {
+    test.each([
+      'stop recording',
+      'stop the recording',
+      'end recording',
+      'end the recording',
+      'finish recording',
+      'finish the recording',
+      'halt recording',
+      'halt the recording',
+    ])('detects stop intent in "%s"', (text) => {
+      expect(resolveRecordingIntent(text).kind).toBe('stop_only');
+    });
+
+    test.each([
+      '',
+      'hello world',
+      'stop it',
+      'end it',
+      'quit',
+      'take a screenshot',
+      'stop the music',
+    ])('does not detect stop intent in "%s"', (text) => {
+      expect(resolveRecordingIntent(text)).toEqual({ kind: 'none' });
+    });
+
+    test('is case-insensitive', () => {
+      expect(resolveRecordingIntent('STOP RECORDING').kind).toBe('stop_only');
+      expect(resolveRecordingIntent('Stop The Recording').kind).toBe('stop_only');
+      expect(resolveRecordingIntent('END RECORDING').kind).toBe('stop_only');
+    });
   });
 
-  // None (no recording intent)
-  test.each([
-    'open Safari',
-    'I broke the record',
-    '',
-  ])('no recording intent: "%s" → none', (text) => {
-    expect(resolveRecordingIntent(text)).toEqual({ kind: 'none' });
+  // ── Pure stop (covers legacy isStopRecordingOnly behavior) ──────────────
+
+  describe('pure stop (stop-recording-only)', () => {
+    test.each([
+      'stop recording',
+      'stop the recording',
+      'end recording',
+      'end the recording',
+      'finish recording',
+      'halt recording',
+    ])('resolves as stop_only for pure stop request "%s"', (text) => {
+      expect(resolveRecordingIntent(text)).toEqual({ kind: 'stop_only' });
+    });
+
+    test('resolves as stop_only when polite fillers surround the stop request', () => {
+      expect(resolveRecordingIntent('please stop recording')).toEqual({ kind: 'stop_only' });
+      expect(resolveRecordingIntent('can you stop the recording?')).toEqual({ kind: 'stop_only' });
+      expect(resolveRecordingIntent('could you end the recording please')).toEqual({ kind: 'stop_only' });
+      expect(resolveRecordingIntent('stop the recording now')).toEqual({ kind: 'stop_only' });
+      expect(resolveRecordingIntent('just stop recording, thanks')).toEqual({ kind: 'stop_only' });
+    });
+
+    test('resolves as stop_with_remainder when stop has additional task', () => {
+      const r1 = resolveRecordingIntent('stop recording and open Chrome');
+      expect(r1.kind).toBe('stop_with_remainder');
+      if (r1.kind === 'stop_with_remainder') {
+        expect(r1.remainder).toContain('open Chrome');
+      }
+    });
+
+    test('handles ambiguous phrases as none', () => {
+      expect(resolveRecordingIntent('end it')).toEqual({ kind: 'none' });
+      expect(resolveRecordingIntent('stop')).toEqual({ kind: 'none' });
+      expect(resolveRecordingIntent('quit')).toEqual({ kind: 'none' });
+    });
+
+    test('handles punctuation', () => {
+      expect(resolveRecordingIntent('stop recording!')).toEqual({ kind: 'stop_only' });
+      expect(resolveRecordingIntent('stop recording.')).toEqual({ kind: 'stop_only' });
+      expect(resolveRecordingIntent('end the recording?')).toEqual({ kind: 'stop_only' });
+    });
+  });
+
+  // ── Remainder extraction (covers legacy strip* behavior) ────────────────
+
+  describe('remainder extraction', () => {
+    test('extracts remainder when start intent is mixed with other task', () => {
+      const r1 = resolveRecordingIntent('open Safari and record my screen');
+      expect(r1.kind).toBe('start_with_remainder');
+      if (r1.kind === 'start_with_remainder') {
+        expect(r1.remainder).toBe('open Safari');
+      }
+
+      const r2 = resolveRecordingIntent('do this task and start recording');
+      expect(r2.kind).toBe('start_with_remainder');
+      if (r2.kind === 'start_with_remainder') {
+        expect(r2.remainder).toContain('do this task');
+      }
+    });
+
+    test('extracts remainder when stop intent is mixed with other task', () => {
+      const r1 = resolveRecordingIntent('open Chrome and stop recording');
+      expect(r1.kind).toBe('stop_with_remainder');
+      if (r1.kind === 'stop_with_remainder') {
+        expect(r1.remainder).toBe('open Chrome');
+      }
+
+      const r2 = resolveRecordingIntent('save the file and end the recording');
+      expect(r2.kind).toBe('stop_with_remainder');
+      if (r2.kind === 'stop_with_remainder') {
+        expect(r2.remainder).toContain('save the file');
+      }
+    });
+
+    test('remainder does not contain double spaces', () => {
+      const r1 = resolveRecordingIntent('open Safari and also record my screen please');
+      if (r1.kind === 'start_with_remainder') {
+        expect(r1.remainder).not.toContain('  ');
+      }
+
+      const r2 = resolveRecordingIntent('open Safari and also stop recording please');
+      if (r2.kind === 'stop_with_remainder') {
+        expect(r2.remainder).not.toContain('  ');
+      }
+    });
+  });
+
+  // ── Interrogative gate (covers legacy isInterrogative behavior) ─────────
+
+  describe('interrogative gate', () => {
+    test.each([
+      'how do I stop recording?',
+      'how do I record my screen?',
+      'what does screen recording do?',
+      'why is screen recording not working?',
+      'when should I stop recording?',
+      'where does the recording file go?',
+      'which display should I record?',
+      'What is the screen recording feature?',
+      'How do I start recording on Mac?',
+      'how can I record my screen?',
+      'why did the recording stop?',
+    ])('returns none for question: "%s"', (text) => {
+      expect(resolveRecordingIntent(text)).toEqual({ kind: 'none' });
+    });
+
+    test.each([
+      'record my screen',
+      'stop recording',
+      'open Chrome and record my screen',
+      'can you record my screen?',
+      'could you stop recording please',
+      'start recording',
+      'please record my screen',
+    ])('does not block command: "%s"', (text) => {
+      expect(resolveRecordingIntent(text).kind).not.toBe('none');
+    });
+
+    test('strips dynamic name before checking interrogative', () => {
+      expect(resolveRecordingIntent('Nova, how do I stop recording?', ['Nova'])).toEqual({ kind: 'none' });
+      expect(resolveRecordingIntent('Nova, record my screen', ['Nova']).kind).toBe('start_only');
+    });
+
+    test('handles polite prefix before question word', () => {
+      expect(resolveRecordingIntent('please, how do I stop recording?')).toEqual({ kind: 'none' });
+      expect(resolveRecordingIntent('hey, what does screen recording do?')).toEqual({ kind: 'none' });
+    });
+  });
+
+  // ── Dynamic names ──────────────────────────────────────────────────────────
+
+  describe('dynamic name handling', () => {
+    test.each([
+      ['Nova, record my screen', ['Nova'], 'start_only'],
+      ['hey Nova, start recording', ['Nova'], 'start_only'],
+      ['hey, Nova, start recording', ['Nova'], 'start_only'],
+      ['Nova, stop recording', ['Nova'], 'stop_only'],
+      ['Nova, hello', ['Nova'], 'none'],
+    ] as const)('"%s" with names %j resolves to %s', (text, names, expected) => {
+      expect(resolveRecordingIntent(text, [...names]).kind).toBe(expected);
+    });
+
+    test('mixed intent with dynamic name extracts remainder', () => {
+      const result = resolveRecordingIntent('Nova, open Safari and record my screen', ['Nova']);
+      expect(result.kind).toBe('start_with_remainder');
+      if (result.kind === 'start_with_remainder') {
+        expect(result.remainder).toContain('open Safari');
+      }
+    });
+
+    test('dynamic name stripping is case-insensitive', () => {
+      expect(resolveRecordingIntent('nova, record my screen', ['Nova']).kind).toBe('start_only');
+      expect(resolveRecordingIntent('NOVA, stop recording', ['Nova']).kind).toBe('stop_only');
+      expect(resolveRecordingIntent('Hey NOVA, start recording', ['nova']).kind).toBe('start_only');
+    });
+
+    test('handles multiple dynamic names', () => {
+      expect(resolveRecordingIntent('Jarvis, record my screen', ['Nova', 'Jarvis']).kind).toBe('start_only');
+      expect(resolveRecordingIntent('Nova, stop recording', ['Nova', 'Jarvis']).kind).toBe('stop_only');
+    });
+
+    test('handles empty dynamic names array', () => {
+      expect(resolveRecordingIntent('record my screen', []).kind).toBe('start_only');
+      expect(resolveRecordingIntent('stop recording', []).kind).toBe('stop_only');
+    });
+
+    test('handles colon separator after name', () => {
+      expect(resolveRecordingIntent('Nova: record my screen', ['Nova']).kind).toBe('start_only');
+    });
+
+    test('interrogative with name prefix returns none', () => {
+      expect(resolveRecordingIntent('hey Nova, how do I stop recording?', ['Nova'])).toEqual({ kind: 'none' });
+    });
+  });
+
+  // ── Start + stop combined ──────────────────────────────────────────────────
+
+  describe('combined start and stop', () => {
+    test('start and stop: "stop recording and record my screen"', () => {
+      const result = resolveRecordingIntent('stop recording and record my screen');
+      expect(result.kind).toBe('start_and_stop_only');
+    });
+
+    test('start and stop: "stop recording and start recording"', () => {
+      const result = resolveRecordingIntent('stop recording and start recording');
+      expect(result.kind).toBe('start_and_stop_only');
+    });
+  });
+
+  // ── No recording intent ────────────────────────────────────────────────────
+
+  describe('no recording intent', () => {
+    test.each([
+      'open Safari',
+      'I broke the record',
+      '',
+      'hello world',
+    ])('returns none for "%s"', (text) => {
+      expect(resolveRecordingIntent(text)).toEqual({ kind: 'none' });
+    });
+  });
+
+  // ── Works without dynamic names parameter ──────────────────────────────────
+
+  test('works without dynamic names parameter', () => {
+    expect(resolveRecordingIntent('record my screen')).toEqual({ kind: 'start_only' });
+    expect(resolveRecordingIntent('stop recording')).toEqual({ kind: 'stop_only' });
   });
 });
 
@@ -504,8 +345,8 @@ describe('resolveRecordingIntent', () => {
 
 describe('executeRecordingIntent', () => {
   // Mock the recording handlers module
-  const mockHandleRecordingStart = mock(() => 'mock-recording-id');
-  const mockHandleRecordingStop = mock(() => 'mock-recording-id');
+  const mockHandleRecordingStart = mock((): string | null => 'mock-recording-id');
+  const mockHandleRecordingStop = mock((): string | undefined => 'mock-recording-id');
 
   mock.module('../daemon/handlers/recording.js', () => ({
     handleRecordingStart: mockHandleRecordingStart,

--- a/assistant/src/config/bundled-skills/screen-recording/SKILL.md
+++ b/assistant/src/config/bundled-skills/screen-recording/SKILL.md
@@ -8,42 +8,51 @@ Capture screen recordings as video files attached to the conversation.
 
 ## Activation
 
-This skill activates when the user asks to record their screen. Common phrases:
+This skill activates when the user asks to record their screen. Intent is resolved through a two-tier pipeline:
 
-**Start recording:**
-- "record my screen"
-- "start recording"
-- "begin recording"
-- "capture my screen"
-- "capture my display"
-- "make a recording"
-- "Nova, record my screen" (where Nova is the assistant's identity name)
-- "hey Nova, start recording"
+1. **Structured `commandIntent`** (primary path) — The client sends a `commandIntent` payload with `domain: "screen_recording"` and `action: "start" | "stop"`. This bypasses all text parsing and is the preferred routing mechanism. The macOS/iOS client sends this when the user taps a dedicated recording button or uses a keyboard shortcut.
 
-**Stop recording:**
-- "stop recording"
-- "end recording"
-- "finish recording"
-- "halt recording"
+2. **Text resolver fallback** — When no `commandIntent` is present, `resolveRecordingIntent()` analyzes the user's natural-language text through a deterministic pipeline:
+   - Strip dynamic assistant name prefixes (e.g., "Nova, ...")
+   - Strip leading polite wrappers ("please", "hey", etc.)
+   - Interrogative gate — WH-questions ("how do I record?") return `none` (no side effects)
+   - Detect start/stop recording patterns via regex
+   - Classify as pure intent or extract a remainder for mixed-intent prompts
 
-## Classification
+## Intent Resolution
 
-Recording prompts are classified into four intent types:
+The text resolver produces a `RecordingIntentResult` with one of these kinds:
 
-- **start_only** — Pure recording request with no additional task (e.g., "record my screen"). Handled by standalone recording route.
-- **stop_only** — Pure stop request with no additional task (e.g., "stop recording"). Handled by standalone recording route.
-- **mixed** — Recording intent embedded in a broader task (e.g., "open Safari and record my screen"). Not intercepted; routed to normal processing.
-- **none** — No recording intent detected. Normal routing.
+- **`start_only`** — Pure recording request with no additional task (e.g., "record my screen")
+- **`stop_only`** — Pure stop request with no additional task (e.g., "stop recording")
+- **`start_with_remainder`** — Recording intent embedded in a broader task (e.g., "open Safari and record my screen"). The remainder ("open Safari") is forwarded to normal processing while recording starts as a side effect.
+- **`stop_with_remainder`** — Stop intent embedded in a broader task (e.g., "stop recording and close the browser")
+- **`start_and_stop_only`** — Both start and stop with no remainder (e.g., "stop recording and start a new recording")
+- **`start_and_stop_with_remainder`** — Both start and stop with additional task text
+- **`none`** — No recording intent detected, or the message is a question about recording
 
-Dynamic name prefixes (from IDENTITY.md) are stripped during classification, so "Nova, record my screen" classifies the same as "record my screen".
+## Routing Examples
 
-## Routing
+**Structured intent (commandIntent path):**
+```
+{ commandIntent: { domain: "screen_recording", action: "start" } }
+  -> Starts recording immediately, no text parsing
+{ commandIntent: { domain: "screen_recording", action: "stop" } }
+  -> Stops recording immediately, no text parsing
+```
 
-Recording-only requests are handled by the **standalone recording route** — they do NOT create a computer-use session.
+**Text resolver (fallback path):**
+```
+"record my screen"         -> start_only     -> standalone recording route
+"stop recording"           -> stop_only      -> standalone recording route
+"Nova, start recording"    -> start_only     -> standalone recording route (name stripped)
+"please record my screen"  -> start_only     -> standalone recording route (filler stripped)
+"how do I record?"         -> none           -> normal routing (interrogative gate)
+"open Safari and record"   -> start_with_remainder -> recording starts, "open Safari" continues
+"stop recording and close" -> stop_with_remainder  -> recording stops, "close" continues
+```
 
-- When the user says "record my screen" (with no other task), the daemon intercepts this and starts a standalone recording directly.
-- When the user says "stop recording", the daemon intercepts and stops the active recording for the current conversation.
-- The recording is saved as a video file and attached to the conversation thread.
+Recording-only intents (`start_only`, `stop_only`, `start_and_stop_only`) are handled by the **standalone recording route** -- they do NOT create a computer-use session.
 
 ## Behavior Rules
 
@@ -51,10 +60,11 @@ Recording-only requests are handled by the **standalone recording route** — th
 2. **One recording at a time.** If a recording is already active, starting another returns an "already recording" message.
 3. **Conversation-scoped.** Each recording is linked to the conversation that started it. Stopping in a different thread does not affect unrelated recordings.
 4. **Permission required.** Screen recording requires macOS Screen Recording permission. If denied, the user sees actionable guidance to enable it in System Settings.
-5. **Mixed-intent prompts** (recording + other task) are NOT intercepted by the standalone route.
+5. **Mixed-intent prompts** (recording + other task) start/stop the recording as a side effect while the remainder text proceeds through normal classification and routing.
+6. **Questions are not commands.** WH-questions like "how do I stop recording?" are routed to the assistant for a text answer, not treated as recording commands.
 
 ## What This Skill Does NOT Do
 
-- This skill does not contain recorder logic — the `RecordingManager` and `ScreenRecorder` in the macOS app handle the actual recording.
+- This skill does not contain recorder logic -- the `RecordingManager` and `ScreenRecorder` in the macOS app handle the actual recording.
 - This skill does not provide shell commands or scripts for recording.
 - This skill does not fall back to computer use for recording tasks.

--- a/assistant/src/daemon/recording-intent.ts
+++ b/assistant/src/daemon/recording-intent.ts
@@ -1,8 +1,13 @@
-// Recording intent detection for standalone screen recording routing.
-// Used by task/message handlers to intercept recording-related prompts
+// Recording intent resolution for standalone screen recording routing.
+// Exports `resolveRecordingIntent` as the single public entry point for
+// text-based intent detection. Handlers use this (or structured
+// `commandIntent` payloads) to intercept recording-related prompts
 // before they reach the classifier or create a CU session.
+//
+// Internal helpers (detect/strip/classify) are kept as private utilities
+// consumed only by `resolveRecordingIntent`.
 
-export type RecordingIntentClass = 'start_only' | 'stop_only' | 'mixed' | 'none';
+type RecordingIntentClass = 'start_only' | 'stop_only' | 'mixed' | 'none';
 
 export type RecordingIntentResult =
   | { kind: 'none' }
@@ -60,13 +65,13 @@ const RECORDING_CLAUSE_PATTERNS: RegExp[] = [
 const FILLER_PATTERN =
   /\b(please|pls|plz|can\s+you|could\s+you|would\s+you|now|right\s+now|thanks|thank\s+you|thx|ty|for\s+me|ok(ay)?|hey|hi|just)\b/gi;
 
-// ─── Public API ──────────────────────────────────────────────────────────────
+// ─── Internal helpers ────────────────────────────────────────────────────────
 
 /**
  * Returns true if the user's message includes any recording-related phrases.
  * Does not distinguish between recording-only and mixed-intent prompts.
  */
-export function detectRecordingIntent(taskText: string): boolean {
+function detectRecordingIntent(taskText: string): boolean {
   return START_RECORDING_PATTERNS.some((p) => p.test(taskText));
 }
 
@@ -76,7 +81,7 @@ export function detectRecordingIntent(taskText: string): boolean {
  * "record my screen while I work" -> false (has CU task component)
  * "open Chrome and record my screen" -> false (has CU task component)
  */
-export function isRecordingOnly(taskText: string): boolean {
+function isRecordingOnly(taskText: string): boolean {
   if (!detectRecordingIntent(taskText)) return false;
 
   // Strip the recording clause and check if anything substantive remains
@@ -93,7 +98,7 @@ export function isRecordingOnly(taskText: string): boolean {
  * Requires explicit "stop/end/finish/halt recording" phrasing --
  * bare "stop", "end it", or "quit" are too ambiguous and will not match.
  */
-export function detectStopRecordingIntent(taskText: string): boolean {
+function detectStopRecordingIntent(taskText: string): boolean {
   return STOP_RECORDING_PATTERNS.some((p) => p.test(taskText));
 }
 
@@ -102,7 +107,7 @@ export function detectStopRecordingIntent(taskText: string): boolean {
  * Used when a recording intent is embedded in a broader CU task so the
  * recording portion can be handled separately while the task continues.
  */
-export function stripRecordingIntent(taskText: string): string {
+function stripRecordingIntent(taskText: string): string {
   let result = taskText;
   for (const pattern of RECORDING_CLAUSE_PATTERNS) {
     result = result.replace(pattern, '');
@@ -115,7 +120,7 @@ export function stripRecordingIntent(taskText: string): string {
  * Removes stop-recording clauses from a message, returning the cleaned text.
  * Analogous to stripRecordingIntent but for stop-recording phrases.
  */
-export function stripStopRecordingIntent(taskText: string): string {
+function stripStopRecordingIntent(taskText: string): string {
   let result = taskText;
   for (const pattern of STOP_RECORDING_CLAUSE_PATTERNS) {
     result = result.replace(pattern, '');
@@ -130,7 +135,7 @@ export function stripStopRecordingIntent(taskText: string): string {
  * "how do I stop recording?" -> false (has additional context)
  * "stop recording and close the browser" -> false (has CU task component)
  */
-export function isStopRecordingOnly(taskText: string): boolean {
+function isStopRecordingOnly(taskText: string): boolean {
   if (!detectStopRecordingIntent(taskText)) return false;
 
   const stripped = stripStopRecordingIntent(taskText);
@@ -168,7 +173,7 @@ export function stripDynamicNames(text: string, dynamicNames: string[]): string 
  * punctuation, and dynamic assistant names. Used to determine whether
  * remaining text after stripping recording clauses needs further processing.
  */
-export function hasSubstantiveContent(text: string, dynamicNames?: string[]): boolean {
+function hasSubstantiveContent(text: string, dynamicNames?: string[]): boolean {
   let cleaned = text;
   if (dynamicNames && dynamicNames.length > 0) {
     cleaned = stripDynamicNames(cleaned, dynamicNames);
@@ -192,7 +197,7 @@ const WH_INTERROGATIVE = /^\s*(how|what|why|when|where|who|which)\b/i;
  * "open Chrome and record my screen" → false  (command — trigger recording)
  * "can you record my screen?" → false  (polite imperative — trigger recording)
  */
-export function isInterrogative(text: string, dynamicNames?: string[]): boolean {
+function isInterrogative(text: string, dynamicNames?: string[]): boolean {
   let cleaned = text;
   if (dynamicNames && dynamicNames.length > 0) {
     cleaned = stripDynamicNames(cleaned, dynamicNames);
@@ -215,7 +220,7 @@ export function isInterrogative(text: string, dynamicNames?: string[]): boolean 
  * If `dynamicNames` are provided, they are stripped from the beginning of the
  * text before classification (e.g., "Nova, record my screen" -> "record my screen").
  */
-export function classifyRecordingIntent(
+function classifyRecordingIntent(
   taskText: string,
   dynamicNames?: string[],
 ): RecordingIntentClass {


### PR DESCRIPTION
Update SKILL.md to document deterministic resolver pipeline and commandIntent routing. Remove legacy exports from recording-intent.ts (classifyRecordingIntent, isInterrogative, detectRecordingIntent, etc.) while keeping functions as internal utilities. Closes #9267.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
