### PR TITLE
fix: surface context-too-large error when agent loop made progress

### DIFF
--- a/assistant/src/__tests__/session-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/session-provider-retry-repair.test.ts
@@ -136,13 +136,39 @@ mock.module('../context/window-manager.js', () => ({
 
 // Track how many times agentLoop.run was called
 let agentLoopRunCount = 0;
-let firstRunErrorMode: 'none' | 'ordering' | 'context_too_large' | 'context_too_large_phrase' | 'context_too_large_413' = 'ordering';
+let firstRunErrorMode: 'none' | 'ordering' | 'context_too_large' | 'context_too_large_phrase' | 'context_too_large_413' | 'context_too_large_413_with_progress' = 'ordering';
 
 mock.module('../agent/loop.js', () => ({
   AgentLoop: class {
     constructor() {}
     async run(messages: Message[], onEvent: (event: AgentEvent) => void, _signal?: AbortSignal): Promise<Message[]> {
       agentLoopRunCount++;
+
+      if (agentLoopRunCount === 1 && firstRunErrorMode === 'context_too_large_413_with_progress') {
+        // Simulate a run that made progress (tool-use + tool-result) before
+        // hitting a 413 context-too-large error on the second LLM call.
+        onEvent({ type: 'usage', inputTokens: 10, outputTokens: 20, model: 'mock', providerDurationMs: 50 });
+        const assistantMsg: Message = {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'tu-1', name: 'bash', input: { command: 'echo hi' } }],
+        };
+        onEvent({ type: 'message_complete', message: assistantMsg });
+        onEvent({
+          type: 'tool_result',
+          toolUseId: 'tu-1',
+          content: 'hi',
+          isError: false,
+        });
+        // Now the second LLM call fails with 413
+        onEvent({ type: 'error', error: new ProviderError('request entity too large', 'mock-provider', 413) });
+        const history = [...messages];
+        history.push(assistantMsg);
+        history.push({
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'tu-1', content: 'hi' }],
+        } as Message);
+        return history; // Progress was made — history grew
+      }
 
       if (agentLoopRunCount === 1 && firstRunErrorMode !== 'none') {
         onEvent({ type: 'usage', inputTokens: 0, outputTokens: 0, model: 'mock', providerDurationMs: 0 });
@@ -370,5 +396,28 @@ describe('provider ordering error retry', () => {
     ]);
     expect(events.some((e) => e.type === 'message_complete')).toBe(true);
     expect(events.some((e) => e.type === 'session_error')).toBe(false);
+  });
+
+  test('context-too-large after progress surfaces error instead of silent failure', async () => {
+    firstRunErrorMode = 'context_too_large_413_with_progress';
+    forceCompactionEnabled = false;
+
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const events: Array<Record<string, unknown>> = [];
+    await session.processMessage(
+      'Run some tools then hit the limit.',
+      [],
+      (msg) => events.push(msg as unknown as Record<string, unknown>),
+    );
+
+    // Only one agent loop run — the retry path is skipped because progress was made.
+    expect(agentLoopRunCount).toBe(1);
+
+    // The error must be surfaced to clients via session_error, not silently swallowed.
+    const sessionError = events.find((e) => e.type === 'session_error') as { code?: string } | undefined;
+    expect(sessionError).toBeDefined();
+    expect(sessionError?.code).toBe('CONTEXT_TOO_LARGE');
   });
 });

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -534,6 +534,16 @@ export async function runAgentLoopImpl(
         );
         onEvent(buildSessionErrorMessage(ctx.conversationId, classified));
       }
+    } else if (state.contextTooLargeDetected) {
+      // Progress was made (updatedHistory grew), so the retry path above was
+      // skipped. Surface the error so clients are not left with a silent failure.
+      rlog.warn({ phase: 'post_run' }, 'Context too large after progress — surfacing error without retry');
+      const classified = classifySessionError(
+        new Error('context_length_exceeded'),
+        { phase: 'agent_loop' },
+      );
+      onEvent(buildSessionErrorMessage(ctx.conversationId, classified));
+      state.providerErrorUserMessage = classified.userMessage;
     }
 
     if (state.deferredOrderingError) {


### PR DESCRIPTION
When a context-too-large error (including 413 ProviderError) occurs after the agent loop has already made progress, the error was being silently swallowed. This fix ensures session_error is still emitted when forced-compaction retry won't be attempted.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
