### PR TITLE
feat: client history truncation + lazy rehydrate

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -137,6 +137,9 @@ class IOSThreadStore: ObservableObject {
         daemon.onSubagentDetailResponse = { [weak self] response in
             self?.handleSubagentDetailResponse(response)
         }
+        daemon.onMessageContentResponse = { [weak self] response in
+            self?.handleMessageContentResponse(response)
+        }
 
         // Fetch session list once connected. Try immediately if already connected,
         // otherwise wait for the daemonDidReconnect notification.
@@ -213,6 +216,7 @@ class IOSThreadStore: ObservableObject {
             oldDaemon.onSessionListResponse = nil
             oldDaemon.onHistoryResponse = nil
             oldDaemon.onSubagentDetailResponse = nil
+            oldDaemon.onMessageContentResponse = nil
         }
 
         daemonClient = newClient
@@ -449,6 +453,15 @@ class IOSThreadStore: ObservableObject {
         }
     }
 
+    private func handleMessageContentResponse(_ response: IPCMessageContentResponse) {
+        for (_, vm) in viewModels {
+            if vm.messages.contains(where: { $0.daemonMessageId == response.messageId }) {
+                vm.handleMessageContentResponse(response)
+                return
+            }
+        }
+    }
+
     /// Load history for a daemon-backed thread when first selected.
     func loadHistoryIfNeeded(for threadId: UUID) {
         guard let thread = threads.first(where: { $0.id == threadId }),
@@ -464,7 +477,7 @@ class IOSThreadStore: ObservableObject {
             self?.requestPaginatedHistory(sessionId: sessionId, beforeTimestamp: beforeTimestamp)
         }
 
-        try? daemon.sendHistoryRequest(sessionId: sessionId, limit: 50, mode: "light")
+        try? daemon.sendHistoryRequest(sessionId: sessionId, limit: 50, mode: "light", maxTextChars: 2000, maxToolResultChars: 1000)
     }
 
     /// Request an older page of history for pagination.
@@ -481,7 +494,7 @@ class IOSThreadStore: ObservableObject {
         }
         pendingHistoryBySessionId[sessionId] = thread.id
         do {
-            try daemon.sendHistoryRequest(sessionId: sessionId, limit: 50, beforeTimestamp: beforeTimestamp, mode: "light")
+            try daemon.sendHistoryRequest(sessionId: sessionId, limit: 50, beforeTimestamp: beforeTimestamp, mode: "light", maxTextChars: 2000, maxToolResultChars: 1000)
         } catch {
             pendingHistoryBySessionId.removeValue(forKey: sessionId)
             if let vm = viewModels[thread.id] {
@@ -524,7 +537,7 @@ class IOSThreadStore: ObservableObject {
         vm.onReconnectHistoryNeeded = { [weak self, weak vm] sessionId in
             guard let self, let _ = vm, let daemon = self.daemonClient as? DaemonClient else { return }
             self.pendingHistoryBySessionId[sessionId] = threadId
-            try? daemon.sendHistoryRequest(sessionId: sessionId, limit: 50, mode: "light")
+            try? daemon.sendHistoryRequest(sessionId: sessionId, limit: 50, mode: "light", maxTextChars: 2000, maxToolResultChars: 1000)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -13,6 +13,8 @@ struct ChatBubble: View {
     let onDismissDocumentWidget: (String) -> Void
     let dismissedDocumentSurfaceIds: Set<String>
     var onReportMessage: ((String?) -> Void)?
+    /// Called when expanding a tool call with truncated content to fetch the full text.
+    var onRehydrate: (() -> Void)?
     var mediaEmbedSettings: MediaEmbedResolverSettings?
     var daemonHttpPort: Int?
     var showAvatar: Bool = true

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -70,7 +70,7 @@ extension ChatBubble {
                 }
 
                 if stepsExpanded && hasCompletedTools {
-                    StepsSection(toolCalls: message.toolCalls)
+                    StepsSection(toolCalls: message.toolCalls, onRehydrate: message.wasTruncated ? onRehydrate : nil)
                         .transition(.opacity.combined(with: .move(edge: .top)))
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -53,6 +53,8 @@ struct ChatView: View {
     var activeSubagents: [SubagentInfo] = []
     var onAbortSubagent: ((String) -> Void)?
     var onSubagentTap: ((String) -> Void)?
+    /// Called to rehydrate truncated message content on demand.
+    var onRehydrateMessage: ((UUID) -> Void)?
     @ObservedObject var subagentDetailStore: SubagentDetailStore
     var daemonHttpPort: Int?
     var isHistoryLoaded: Bool = true
@@ -188,6 +190,7 @@ struct ChatView: View {
                             onModelPickerSelect: onModelPickerSelect,
                             onAbortSubagent: onAbortSubagent,
                             onSubagentTap: onSubagentTap,
+                            onRehydrateMessage: onRehydrateMessage,
                             subagentDetailStore: subagentDetailStore,
                             displayedMessageCount: displayedMessageCount,
                             hasMoreMessages: hasMoreMessages,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -20,6 +20,8 @@ struct MessageListView: View {
     var onModelPickerSelect: ((UUID, String) -> Void)?
     var onAbortSubagent: ((String) -> Void)?
     var onSubagentTap: ((String) -> Void)?
+    /// Called to rehydrate truncated message content on demand.
+    var onRehydrateMessage: ((UUID) -> Void)?
     @ObservedObject var subagentDetailStore: SubagentDetailStore
 
     // MARK: - Pagination
@@ -205,6 +207,7 @@ struct MessageListView: View {
                                 },
                                 dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
                                 onReportMessage: onReportMessage,
+                                onRehydrate: message.wasTruncated ? { onRehydrateMessage?(message.id) } : nil,
                                 mediaEmbedSettings: mediaEmbedSettings,
                                 daemonHttpPort: daemonHttpPort,
                                 showAvatar: !previousIsAssistant,

--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -58,11 +58,13 @@ struct UsedToolsList: View {
 
 struct StepsSection: View {
     let toolCalls: [ToolCallData]
+    /// Optional callback invoked when a tool row with truncated content is expanded.
+    var onRehydrate: (() -> Void)?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             ForEach(Array(toolCalls.enumerated()), id: \.element.id) { index, toolCall in
-                UsedToolsRow(toolCall: toolCall)
+                UsedToolsRow(toolCall: toolCall, onRehydrate: onRehydrate)
 
                 if index < toolCalls.count - 1 {
                     Divider()
@@ -78,6 +80,8 @@ struct StepsSection: View {
 
 private struct UsedToolsRow: View {
     let toolCall: ToolCallData
+    /// Optional callback invoked when expanding a row with truncated content.
+    var onRehydrate: (() -> Void)?
 
     @State private var isExpanded = false
     @State private var isHovered = false
@@ -92,6 +96,12 @@ private struct UsedToolsRow: View {
         if let cached = cachedInputFull { return cached }
         if !toolCall.inputFull.isEmpty { return toolCall.inputFull }
         return ""
+    }
+
+    /// Whether the tool result or input appears to contain truncated content.
+    private var isTruncated: Bool {
+        (toolCall.result?.hasSuffix("[truncated]") ?? false)
+            || toolCall.inputFull.hasSuffix("[truncated]")
     }
 
     private var hasDetails: Bool {
@@ -159,10 +169,22 @@ private struct UsedToolsRow: View {
 
                     // Technical details
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        Text("Technical details")
-                            .font(VFont.small)
-                            .foregroundColor(VColor.textMuted)
-                            .textCase(.uppercase)
+                        HStack {
+                            Text("Technical details")
+                                .font(VFont.small)
+                                .foregroundColor(VColor.textMuted)
+                                .textCase(.uppercase)
+                            if isTruncated {
+                                Text("truncated")
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.warning)
+                                    .padding(.horizontal, VSpacing.xs)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: VRadius.xs)
+                                            .fill(VColor.warning.opacity(0.12))
+                                    )
+                            }
+                        }
 
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
                             Text(toolCall.friendlyName)
@@ -286,6 +308,10 @@ private struct UsedToolsRow: View {
                         } else if let dict = toolCall.inputRawDict {
                             cachedInputFull = ToolCallData.formatAllToolInput(dict)
                         }
+                    }
+                    // Trigger on-demand rehydration when expanding truncated content.
+                    if isTruncated {
+                        onRehydrate?()
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -754,6 +754,9 @@ struct ActiveChatViewWrapper: View {
             onSubagentTap: { subagentId in
                 windowState.selectedSubagentId = subagentId
             },
+            onRehydrateMessage: { messageId in
+                viewModel.rehydrateMessage(id: messageId)
+            },
             subagentDetailStore: viewModel.subagentDetailStore,
             daemonHttpPort: daemonClient.httpPort,
             isHistoryLoaded: viewModel.isHistoryLoaded,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -62,6 +62,9 @@ final class ThreadSessionRestorer {
         daemonClient.onSubagentDetailResponse = { [weak self] response in
             self?.handleSubagentDetailResponse(response)
         }
+        daemonClient.onMessageContentResponse = { [weak self] response in
+            self?.handleMessageContentResponse(response)
+        }
 
         // On first launch after onboarding, skip the initial session list fetch
         // so the session restorer doesn't override the wake-up conversation thread.
@@ -102,7 +105,7 @@ final class ThreadSessionRestorer {
         }
 
         do {
-            try daemonClient.sendHistoryRequest(sessionId: sessionId, limit: 50, mode: "light")
+            try daemonClient.sendHistoryRequest(sessionId: sessionId, limit: 50, mode: "light", maxTextChars: 2000, maxToolResultChars: 1000)
         } catch {
             log.error("Failed to send history_request: \(error.localizedDescription)")
             pendingHistoryBySessionId.removeValue(forKey: sessionId)
@@ -117,7 +120,7 @@ final class ThreadSessionRestorer {
         guard let thread = delegate.threads.first(where: { $0.sessionId == sessionId }) else { return }
         pendingHistoryBySessionId[sessionId] = thread.id
         do {
-            try daemonClient.sendHistoryRequest(sessionId: sessionId, limit: 50, mode: "light")
+            try daemonClient.sendHistoryRequest(sessionId: sessionId, limit: 50, mode: "light", maxTextChars: 2000, maxToolResultChars: 1000)
         } catch {
             log.error("Failed to send reconnect history_request: \(error.localizedDescription)")
             pendingHistoryBySessionId.removeValue(forKey: sessionId)
@@ -136,7 +139,7 @@ final class ThreadSessionRestorer {
         }
         pendingHistoryBySessionId[sessionId] = thread.id
         do {
-            try daemonClient.sendHistoryRequest(sessionId: sessionId, limit: 50, beforeTimestamp: beforeTimestamp, mode: "light")
+            try daemonClient.sendHistoryRequest(sessionId: sessionId, limit: 50, beforeTimestamp: beforeTimestamp, mode: "light", maxTextChars: 2000, maxToolResultChars: 1000)
         } catch {
             log.error("Failed to send paginated history_request: \(error.localizedDescription)")
             pendingHistoryBySessionId.removeValue(forKey: sessionId)
@@ -259,6 +262,19 @@ final class ThreadSessionRestorer {
         guard let delegate else { return }
         guard let index = delegate.threads.firstIndex(where: { $0.sessionId == response.sessionId }) else { return }
         delegate.threads[index].title = response.title
+    }
+
+    func handleMessageContentResponse(_ response: IPCMessageContentResponse) {
+        guard let delegate else { return }
+        // Route the full content back to the ChatViewModel that owns this message.
+        // We check all threads with existing VMs for a matching daemonMessageId.
+        for thread in delegate.threads {
+            guard let viewModel = delegate.existingChatViewModel(for: thread.id) else { continue }
+            if viewModel.messages.contains(where: { $0.daemonMessageId == response.messageId }) {
+                viewModel.handleMessageContentResponse(response)
+                return
+            }
+        }
     }
 
     func handleSubagentDetailResponse(_ response: IPCSubagentDetailResponse) {

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1362,6 +1362,10 @@ public struct ChatMessage: Identifiable, Equatable {
     /// has been stripped from this message to reduce memory. The UI can use this flag
     /// to show a "load full content" affordance in a future milestone.
     public var isContentStripped: Bool = false
+    /// When true, the message text and/or tool results were truncated by the daemon
+    /// during history loading (via maxTextChars/maxToolResultChars). Full content
+    /// can be fetched on demand via message_content_request.
+    public var wasTruncated: Bool = false
 
     /// Concatenated text from all segments. Backward-compatible computed property.
     public var text: String {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -480,6 +480,50 @@ public final class ChatViewModel: ObservableObject {
         hasMoreHistory = false
     }
 
+    // MARK: - On-Demand Content Rehydration
+
+    /// Fetch full (untruncated) content for a message that was loaded with truncated
+    /// text/tool results. No-ops if the message is not found or wasn't truncated.
+    public func rehydrateMessage(id: UUID) {
+        guard let idx = messages.firstIndex(where: { $0.id == id }),
+              messages[idx].wasTruncated,
+              let sessionId = sessionId,
+              let daemonMessageId = messages[idx].daemonMessageId else { return }
+        do {
+            try daemonClient.send(IPCMessageContentRequest(type: "message_content_request", sessionId: sessionId, messageId: daemonMessageId))
+        } catch {
+            log.error("Failed to send message_content_request: \(error)")
+        }
+    }
+
+    /// Handle a `message_content_response` from the daemon, updating the matching
+    /// message with full (untruncated) text and tool call results.
+    public func handleMessageContentResponse(_ response: IPCMessageContentResponse) {
+        guard let idx = messages.firstIndex(where: { $0.daemonMessageId == response.messageId }) else { return }
+
+        // Update text with full content
+        if let fullText = response.text {
+            messages[idx].textSegments = fullText.isEmpty ? [] : [fullText]
+        }
+
+        // Update tool call results with full content
+        if let fullToolCalls = response.toolCalls {
+            for fullTC in fullToolCalls {
+                if let tcIdx = messages[idx].toolCalls.firstIndex(where: { $0.toolName == fullTC.name }) {
+                    if let result = fullTC.result {
+                        messages[idx].toolCalls[tcIdx].result = result
+                    }
+                    if let input = fullTC.input {
+                        messages[idx].toolCalls[tcIdx].inputFull = ToolCallData.formatAllToolInput(input)
+                        messages[idx].toolCalls[tcIdx].inputRawDict = input
+                    }
+                }
+            }
+        }
+
+        messages[idx].wasTruncated = false
+    }
+
     // MARK: - Message Trimming
 
     /// Threshold above which old messages have their heavy content stripped.
@@ -1906,6 +1950,9 @@ public final class ChatViewModel: ObservableObject {
             // anchor to it. This is the database ID from the daemon, not the
             // client-side UUID.
             chatMsg.daemonMessageId = item.id
+
+            // Preserve truncation flag so the UI can offer on-demand rehydration.
+            chatMsg.wasTruncated = item.wasTruncated ?? false
 
             // Drop base64 data from history attachments — the daemon already
             // persisted them, so we only need thumbnails for display.

--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -5,14 +5,24 @@ import AppKit
 
 public struct ToolCallChip: View {
     public let toolCall: ToolCallData
+    /// Optional callback invoked when expanding a tool call whose content was truncated.
+    /// The parent view can use this to trigger on-demand rehydration of the full content.
+    public var onRehydrate: (() -> Void)?
 
-    public init(toolCall: ToolCallData) {
+    public init(toolCall: ToolCallData, onRehydrate: (() -> Void)? = nil) {
         self.toolCall = toolCall
+        self.onRehydrate = onRehydrate
     }
     @State private var isExpanded = false
     /// Cached formatted input — computed once on first expand to avoid re-running
     /// `formatAllToolInput` on every SwiftUI render pass.
     @State private var cachedInputFull: String?
+
+    /// Whether the tool result or input appears to contain truncated content.
+    private var isTruncated: Bool {
+        (toolCall.result?.hasSuffix("[truncated]") ?? false)
+            || toolCall.inputFull.hasSuffix("[truncated]")
+    }
 
     private var hasExpandableContent: Bool {
         toolCall.result != nil || toolCall.cachedImage != nil
@@ -72,10 +82,22 @@ public struct ToolCallChip: View {
 
                     // Technical details section
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        Text("Technical details")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-                            .textCase(.uppercase)
+                        HStack {
+                            Text("Technical details")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                                .textCase(.uppercase)
+                            if isTruncated {
+                                Text("truncated")
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.warning)
+                                    .padding(.horizontal, VSpacing.xs)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: VRadius.xs)
+                                            .fill(VColor.warning.opacity(0.12))
+                                    )
+                            }
+                        }
 
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
                             Text(toolCall.friendlyName)
@@ -158,6 +180,10 @@ public struct ToolCallChip: View {
                         } else if let dict = toolCall.inputRawDict {
                             cachedInputFull = ToolCallData.formatAllToolInput(dict)
                         }
+                    }
+                    // Trigger on-demand rehydration when expanding truncated content.
+                    if isTruncated {
+                        onRehydrate?()
                     }
                 }
             }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -297,6 +297,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `history_response` message.
     public var onHistoryResponse: ((HistoryResponseMessage) -> Void)?
 
+    /// Called when the daemon sends a `message_content_response` with full (untruncated) content.
+    public var onMessageContentResponse: ((IPCMessageContentResponse) -> Void)?
+
     /// Called when the daemon sends a `share_to_slack_response` message.
     public var onShareToSlackResponse: ((ShareToSlackResponseMessage) -> Void)?
 
@@ -966,8 +969,16 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     ///   - limit: Max messages to return per page.
     ///   - beforeTimestamp: Pagination cursor — only return messages before this timestamp (ms since epoch).
     ///   - mode: `"light"` omits heavy payloads (attachments, tool images, surface data); `"full"` includes everything.
-    public func sendHistoryRequest(sessionId: String, limit: Int? = nil, beforeTimestamp: Double? = nil, mode: String? = nil) throws {
-        try send(HistoryRequestMessage(sessionId: sessionId, limit: limit, beforeTimestamp: beforeTimestamp, mode: mode))
+    ///   - maxTextChars: When set, truncates assistant text content to this many characters.
+    ///   - maxToolResultChars: When set, truncates tool result content to this many characters.
+    public func sendHistoryRequest(sessionId: String, limit: Int? = nil, beforeTimestamp: Double? = nil, mode: String? = nil, maxTextChars: Int? = nil, maxToolResultChars: Int? = nil) throws {
+        try send(HistoryRequestMessage(sessionId: sessionId, limit: limit, beforeTimestamp: beforeTimestamp, mode: mode, maxTextChars: maxTextChars, maxToolResultChars: maxToolResultChars))
+    }
+
+    /// Request full (untruncated) content for a specific message.
+    /// Used to rehydrate messages that were loaded with truncated text/tool results.
+    public func sendMessageContentRequest(sessionId: String, messageId: String) throws {
+        try send(IPCMessageContentRequest(type: "message_content_request", sessionId: sessionId, messageId: messageId))
     }
 
     // MARK: - Apps

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -131,6 +131,8 @@ extension DaemonClient {
             onSessionTitleUpdated?(msg)
         case .historyResponse(let msg):
             onHistoryResponse?(msg)
+        case .messageContentResponse(let msg):
+            onMessageContentResponse?(msg)
         case .shareToSlackResponse(let msg):
             onShareToSlackResponse?(msg)
         case .slackWebhookConfigResponse(let msg):

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -553,13 +553,15 @@ extension IPCRegenerateRequest {
 public typealias HistoryRequestMessage = IPCHistoryRequest
 
 extension IPCHistoryRequest {
-    public init(sessionId: String, limit: Int? = nil, beforeTimestamp: Double? = nil, mode: String? = nil) {
+    public init(sessionId: String, limit: Int? = nil, beforeTimestamp: Double? = nil, mode: String? = nil, maxTextChars: Int? = nil, maxToolResultChars: Int? = nil) {
         self.init(
             type: "history_request",
             sessionId: sessionId,
             limit: limit.map { Double($0) },
             beforeTimestamp: beforeTimestamp,
-            mode: mode
+            mode: mode,
+            maxTextChars: maxTextChars.map { Double($0) },
+            maxToolResultChars: maxToolResultChars.map { Double($0) }
         )
     }
 }
@@ -2300,6 +2302,7 @@ public enum ServerMessage: Decodable, Sendable {
     case heartbeatRunNowResponse(IPCHeartbeatRunNowResponse)
     case heartbeatChecklistResponse(IPCHeartbeatChecklistResponse)
     case heartbeatChecklistWriteResponse(IPCHeartbeatChecklistWriteResponse)
+    case messageContentResponse(IPCMessageContentResponse)
     case pong
     case unknown(String)
 
@@ -2723,6 +2726,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "heartbeat_checklist_write_response":
             let message = try IPCHeartbeatChecklistWriteResponse(from: decoder)
             self = .heartbeatChecklistWriteResponse(message)
+        case "message_content_response":
+            let message = try IPCMessageContentResponse(from: decoder)
+            self = .messageContentResponse(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
Wire maxTextChars/maxToolResultChars in history requests and add message_content_request flow for on-demand full content retrieval. Part of text-retention-fix blitz (epic #9272). Closes #9274

## Implementation

### History request truncation
- Updated `IPCHistoryRequest` convenience init and `DaemonClient.sendHistoryRequest` to accept `maxTextChars` and `maxToolResultChars` parameters
- All history request call sites (ThreadSessionRestorer, IOSThreadStore) now pass `maxTextChars: 2000, maxToolResultChars: 1000`

### Message content request/response
- Added `sendMessageContentRequest(sessionId:messageId:)` to DaemonClient
- Added `onMessageContentResponse` callback to DaemonClient
- Added `messageContentResponse` case to ServerMessage enum with decoder
- Added routing in DaemonMessageRouter

### Truncation tracking
- Added `wasTruncated: Bool` to ChatMessage (not included in Equatable — it's metadata)
- Set from `IPCHistoryResponseMessage.wasTruncated` during history population

### On-demand rehydration
- Added `rehydrateMessage(id:)` and `handleMessageContentResponse(_:)` to ChatViewModel
- Response handler updates text segments, tool call results/inputs, and clears wasTruncated flag
- Wired response routing through ThreadSessionRestorer (macOS) and IOSThreadStore (iOS)

### UI truncation indicators
- ToolCallChip and UsedToolsRow detect truncated content via `[truncated]` suffix
- Show amber "truncated" badge in Technical Details header when content is truncated
- Trigger `onRehydrate` callback on expand to fetch full content
- Plumbed `onRehydrate` through ChatBubble → MessageListView → ChatView → PanelCoordinator

## Files Changed
- `clients/shared/IPC/IPCMessages.swift` — truncation params + ServerMessage case
- `clients/shared/IPC/DaemonClient.swift` — send method + callback + updated signature
- `clients/shared/IPC/DaemonMessageRouter.swift` — route new message type
- `clients/shared/Features/Chat/ChatMessage.swift` — wasTruncated flag
- `clients/shared/Features/Chat/ChatViewModel.swift` — rehydrate + response handler + history population
- `clients/shared/Features/Chat/ToolCallChip.swift` — truncation indicator + rehydrate trigger
- `clients/macos/.../UsedToolsList.swift` — truncation indicator + rehydrate trigger
- `clients/macos/.../ChatBubble.swift` — onRehydrate prop
- `clients/macos/.../ChatBubbleToolStatusView.swift` — pass onRehydrate to StepsSection
- `clients/macos/.../MessageListView.swift` — onRehydrateMessage prop
- `clients/macos/.../ChatView.swift` — onRehydrateMessage prop
- `clients/macos/.../PanelCoordinator.swift` — wire rehydrate to viewModel
- `clients/macos/.../ThreadSessionRestorer.swift` — truncation params + content response handler
- `clients/ios/App/IOSThreadStore.swift` — truncation params + content response handler

## Testing
1. Start daemon and client
2. Open a thread with history — messages should load with truncated content
3. Expand a tool call with truncated output — should show amber "truncated" badge
4. Badge triggers rehydrate request; full content replaces truncated text
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
