### PR TITLE
fix: restore Button semantics for heartbeat run row expansion

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/HeartbeatSettingsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/HeartbeatSettingsTab.swift
@@ -199,29 +199,31 @@ struct HeartbeatSettingsTab: View {
             } else {
                 ForEach(runs, id: \.id) { run in
                     VStack(alignment: .leading, spacing: 0) {
-                        HStack(spacing: VSpacing.md) {
-                            resultBadge(run.result)
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(run.title)
-                                    .font(VFont.body)
-                                    .foregroundColor(VColor.textPrimary)
-                                    .lineLimit(1)
-                                Text(formatTimestamp(run.createdAt))
-                                    .font(VFont.caption)
-                                    .foregroundColor(VColor.textMuted)
-                            }
-                            Spacer()
-                            Image(systemName: expandedRunId == run.id ? "chevron.down" : "chevron.right")
-                                .font(.system(size: 10, weight: .semibold))
-                                .foregroundColor(VColor.textMuted)
-                        }
-                        .padding(VSpacing.sm)
-                        .contentShape(Rectangle())
-                        .onTapGesture {
+                        Button {
                             withAnimation(VAnimation.fast) {
                                 expandedRunId = expandedRunId == run.id ? nil : run.id
                             }
+                        } label: {
+                            HStack(spacing: VSpacing.md) {
+                                resultBadge(run.result)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(run.title)
+                                        .font(VFont.body)
+                                        .foregroundColor(VColor.textPrimary)
+                                        .lineLimit(1)
+                                    Text(formatTimestamp(run.createdAt))
+                                        .font(VFont.caption)
+                                        .foregroundColor(VColor.textMuted)
+                                }
+                                Spacer()
+                                Image(systemName: expandedRunId == run.id ? "chevron.down" : "chevron.right")
+                                    .font(.system(size: 10, weight: .semibold))
+                                    .foregroundColor(VColor.textMuted)
+                            }
+                            .padding(VSpacing.sm)
+                            .contentShape(Rectangle())
                         }
+                        .buttonStyle(.plain)
 
                         if expandedRunId == run.id {
                             Text(run.summary?.isEmpty == false ? run.summary! : "No summary available")


### PR DESCRIPTION
## Summary
- Replace `onTapGesture` with `Button` + `.contentShape(Rectangle())` on the label
- Preserves full-row tap target while restoring keyboard activation and VoiceOver accessibility
- `onTapGesture` lost built-in control semantics, making expand/collapse pointer-only

## Original prompt
Addresses review feedback from #9256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
