### PR TITLE
fix(macos): disable conversation zoom commands when no conversation visible

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -35,16 +35,19 @@ struct VellumAssistantApp: App {
                     appDelegate.handleConversationZoomIn()
                 }
                 .keyboardShortcut("+", modifiers: .command)
+                .disabled(!(appDelegate.mainWindow?.windowState.isConversationVisible ?? false))
 
                 Button("Conversation Zoom Out") {
                     appDelegate.handleConversationZoomOut()
                 }
                 .keyboardShortcut("-", modifiers: .command)
+                .disabled(!(appDelegate.mainWindow?.windowState.isConversationVisible ?? false))
 
                 Button("Conversation Actual Size") {
                     appDelegate.handleConversationZoomReset()
                 }
                 .keyboardShortcut("0", modifiers: .command)
+                .disabled(!(appDelegate.mainWindow?.windowState.isConversationVisible ?? false))
 
                 Divider()
 


### PR DESCRIPTION
## Summary
- Add `.disabled()` modifiers to the three conversation zoom SwiftUI command buttons
- Mirrors the existing `validateMenuItem` guard in `AppDelegate+MenuBar.swift` that checks `mainWindow?.windowState.isConversationVisible`
- Prevents accidental zoom-level mutations when the user is on a non-chat panel (e.g. Settings)

## Original prompt
address the pr feedback in https://github.com/vellum-ai/vellum-assistant/pull/9300

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
