### PR TITLE
M4: Preview telemetry and QA test matrix expansion

### DIFF
--- a/clients/macos/vellum-assistant/Recording/RECORDING_TEST_MATRIX.md
+++ b/clients/macos/vellum-assistant/Recording/RECORDING_TEST_MATRIX.md
@@ -127,6 +127,24 @@ These scenarios verify that the encoder fallback chain (primary -> halved -> HEV
 
 ---
 
+## Source Preview
+
+These scenarios verify that thumbnail previews in the source picker work
+correctly across configurations.
+
+- [ ] **Mixed-DPI displays** — Connect 1x + 2x displays, open picker → Thumbnails render correctly for both
+- [ ] **Multi-monitor previews** — Multiple displays connected → Previews load for all displays
+- [ ] **Disappearing window** — Open picker, close a listed window → Preview clears gracefully, no crash
+- [ ] **Protected content (DRM)** — Have a DRM-protected window visible → Shows "Preview unavailable"
+- [ ] **Large window list (20+)** — Open many windows, open picker → Picker remains responsive, previews load progressively
+- [ ] **Scope switching** — Switch display ↔ window tabs → Previous previews cancelled, new ones load
+- [ ] **Feature flag off** — Disable `sourcePreviewEnabled` → No thumbnails, original picker behavior
+- [ ] **Preview failure + recording** — Let preview fail, click Start Recording → Recording starts normally
+- [ ] **Selected source preview** — Click different sources → Large preview pane updates to show selected source
+- [ ] **Cache behavior** — Switch away and back quickly → Cached thumbnails appear instantly
+
+---
+
 ## Validation Checklist (For Each Test Above)
 
 For each checked scenario, verify:

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
@@ -380,6 +380,7 @@ final class RecordingSourcePickerViewModel: ObservableObject {
                 for i in self.displays.indices {
                     self.displays[i].previewStatus = .loading
                 }
+                let totalDisplaySources = self.displays.count
                 await withTaskGroup(of: (UInt32, NSImage?, PreviewStatus, Int, Bool).self) { group in
                     for display in self.displays {
                         group.addTask { [thumbnailProvider] in
@@ -390,22 +391,32 @@ final class RecordingSourcePickerViewModel: ObservableObject {
                             let start = Date()
                             let result = await thumbnailProvider.captureThumbnail(for: display)
                             let latencyMs = Int(Date().timeIntervalSince(start) * 1000)
-                            // Cache hits return almost instantly (< 1ms)
-                            let fromCache = latencyMs < 2 && result.status == .loaded
-                            return (display.id, result.image, result.status, latencyMs, fromCache)
+                            return (display.id, result.image, result.status, latencyMs, result.fromCache)
                         }
                     }
+                    var processedCount = 0
                     for await (displayId, image, status, latencyMs, fromCache) in group {
                         // Discard stale results from a previous generation;
                         // cancel remaining children so they release semaphore slots promptly
                         guard self.previewGeneration == generation else {
+                            let remaining = totalDisplaySources - processedCount
+                            if remaining > 0 {
+                                self.previewCancelCount += remaining
+                                RecordingTelemetry.logPreviewCancelled(sourceType: "display", sourceId: "batch", reason: "generation_mismatch_\(remaining)_sources")
+                            }
                             group.cancelAll()
                             return
                         }
                         guard !Task.isCancelled else {
+                            let remaining = totalDisplaySources - processedCount
+                            if remaining > 0 {
+                                self.previewCancelCount += remaining
+                                RecordingTelemetry.logPreviewCancelled(sourceType: "display", sourceId: "batch", reason: "task_cancelled_\(remaining)_sources")
+                            }
                             group.cancelAll()
                             return
                         }
+                        processedCount += 1
                         if let idx = self.displays.firstIndex(where: { $0.id == displayId }) {
                             self.displays[idx].thumbnail = image
                             self.displays[idx].previewStatus = status
@@ -438,6 +449,7 @@ final class RecordingSourcePickerViewModel: ObservableObject {
                 for i in self.windows.indices {
                     self.windows[i].previewStatus = .loading
                 }
+                let totalWindowSources = self.windows.count
                 await withTaskGroup(of: (Int, NSImage?, PreviewStatus, Int, Bool).self) { group in
                     for window in self.windows {
                         group.addTask { [thumbnailProvider] in
@@ -447,19 +459,30 @@ final class RecordingSourcePickerViewModel: ObservableObject {
                             let start = Date()
                             let result = await thumbnailProvider.captureThumbnail(for: window)
                             let latencyMs = Int(Date().timeIntervalSince(start) * 1000)
-                            let fromCache = latencyMs < 2 && result.status == .loaded
-                            return (window.id, result.image, result.status, latencyMs, fromCache)
+                            return (window.id, result.image, result.status, latencyMs, result.fromCache)
                         }
                     }
+                    var processedCount = 0
                     for await (windowId, image, status, latencyMs, fromCache) in group {
                         guard self.previewGeneration == generation else {
+                            let remaining = totalWindowSources - processedCount
+                            if remaining > 0 {
+                                self.previewCancelCount += remaining
+                                RecordingTelemetry.logPreviewCancelled(sourceType: "window", sourceId: "batch", reason: "generation_mismatch_\(remaining)_sources")
+                            }
                             group.cancelAll()
                             return
                         }
                         guard !Task.isCancelled else {
+                            let remaining = totalWindowSources - processedCount
+                            if remaining > 0 {
+                                self.previewCancelCount += remaining
+                                RecordingTelemetry.logPreviewCancelled(sourceType: "window", sourceId: "batch", reason: "task_cancelled_\(remaining)_sources")
+                            }
                             group.cancelAll()
                             return
                         }
+                        processedCount += 1
                         if let idx = self.windows.firstIndex(where: { $0.id == windowId }) {
                             self.windows[idx].thumbnail = image
                             self.windows[idx].previewStatus = status

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
@@ -399,8 +399,9 @@ final class RecordingSourcePickerViewModel: ObservableObject {
                         // Discard stale results from a previous generation;
                         // cancel remaining children so they release semaphore slots promptly
                         guard self.previewGeneration == generation else {
-                            let remaining = totalDisplaySources - processedCount
+                            let remaining = totalDisplaySources - processedCount - 1
                             if remaining > 0 {
+                                self.previewAttemptCount += remaining
                                 self.previewCancelCount += remaining
                                 RecordingTelemetry.logPreviewCancelled(sourceType: "display", sourceId: "batch", reason: "generation_mismatch_\(remaining)_sources")
                             }
@@ -408,8 +409,9 @@ final class RecordingSourcePickerViewModel: ObservableObject {
                             return
                         }
                         guard !Task.isCancelled else {
-                            let remaining = totalDisplaySources - processedCount
+                            let remaining = totalDisplaySources - processedCount - 1
                             if remaining > 0 {
+                                self.previewAttemptCount += remaining
                                 self.previewCancelCount += remaining
                                 RecordingTelemetry.logPreviewCancelled(sourceType: "display", sourceId: "batch", reason: "task_cancelled_\(remaining)_sources")
                             }
@@ -465,8 +467,9 @@ final class RecordingSourcePickerViewModel: ObservableObject {
                     var processedCount = 0
                     for await (windowId, image, status, latencyMs, fromCache) in group {
                         guard self.previewGeneration == generation else {
-                            let remaining = totalWindowSources - processedCount
+                            let remaining = totalWindowSources - processedCount - 1
                             if remaining > 0 {
+                                self.previewAttemptCount += remaining
                                 self.previewCancelCount += remaining
                                 RecordingTelemetry.logPreviewCancelled(sourceType: "window", sourceId: "batch", reason: "generation_mismatch_\(remaining)_sources")
                             }
@@ -474,8 +477,9 @@ final class RecordingSourcePickerViewModel: ObservableObject {
                             return
                         }
                         guard !Task.isCancelled else {
-                            let remaining = totalWindowSources - processedCount
+                            let remaining = totalWindowSources - processedCount - 1
                             if remaining > 0 {
+                                self.previewAttemptCount += remaining
                                 self.previewCancelCount += remaining
                                 RecordingTelemetry.logPreviewCancelled(sourceType: "window", sourceId: "batch", reason: "task_cancelled_\(remaining)_sources")
                             }

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
@@ -399,7 +399,7 @@ final class RecordingSourcePickerViewModel: ObservableObject {
                         // Discard stale results from a previous generation;
                         // cancel remaining children so they release semaphore slots promptly
                         guard self.previewGeneration == generation else {
-                            let remaining = totalDisplaySources - processedCount - 1
+                            let remaining = totalDisplaySources - processedCount
                             if remaining > 0 {
                                 self.previewAttemptCount += remaining
                                 self.previewCancelCount += remaining
@@ -409,7 +409,7 @@ final class RecordingSourcePickerViewModel: ObservableObject {
                             return
                         }
                         guard !Task.isCancelled else {
-                            let remaining = totalDisplaySources - processedCount - 1
+                            let remaining = totalDisplaySources - processedCount
                             if remaining > 0 {
                                 self.previewAttemptCount += remaining
                                 self.previewCancelCount += remaining
@@ -467,7 +467,7 @@ final class RecordingSourcePickerViewModel: ObservableObject {
                     var processedCount = 0
                     for await (windowId, image, status, latencyMs, fromCache) in group {
                         guard self.previewGeneration == generation else {
-                            let remaining = totalWindowSources - processedCount - 1
+                            let remaining = totalWindowSources - processedCount
                             if remaining > 0 {
                                 self.previewAttemptCount += remaining
                                 self.previewCancelCount += remaining
@@ -477,7 +477,7 @@ final class RecordingSourcePickerViewModel: ObservableObject {
                             return
                         }
                         guard !Task.isCancelled else {
-                            let remaining = totalWindowSources - processedCount - 1
+                            let remaining = totalWindowSources - processedCount
                             if remaining > 0 {
                                 self.previewAttemptCount += remaining
                                 self.previewCancelCount += remaining
@@ -522,8 +522,9 @@ final class RecordingSourcePickerViewModel: ObservableObject {
     }
 
     /// Clear thumbnail caches and cancel in-flight tasks when the picker is dismissed.
-    func clearPreviews() {
+    func clearPreviews() async {
         previewTask?.cancel()
+        await previewTask?.value  // Wait for task to finish cleanup so cancel counts are finalized
         previewTask = nil
 
         // Log session summary if any previews were attempted

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
@@ -341,6 +341,25 @@ final class RecordingSourcePickerViewModel: ObservableObject {
     /// Used to discard stale capture results from a previous scope/refresh cycle.
     private var previewGeneration: Int = 0
 
+    // MARK: - Preview Telemetry Counters
+
+    private var previewAttemptCount = 0
+    private var previewSuccessCount = 0
+    private var previewFailureCount = 0
+    private var previewCancelCount = 0
+    private var previewTotalLatencyMs = 0
+    private var previewCacheHitCount = 0
+
+    /// Map a `PreviewFailureReason` to the telemetry `PreviewErrorCategory`.
+    private static func errorCategory(from reason: PreviewFailureReason) -> RecordingTelemetry.PreviewErrorCategory {
+        switch reason {
+        case .captureFailed: return .captureFailed
+        case .blankFrame: return .blankFrame
+        case .sourceGone: return .sourceGone
+        case .cancelled: return .cancelled
+        }
+    }
+
     /// Load preview thumbnails for all currently visible sources.
     /// Must be called after `loadSources()` completes. Does not block
     /// source loading — previews arrive asynchronously and update the UI.
@@ -361,18 +380,22 @@ final class RecordingSourcePickerViewModel: ObservableObject {
                 for i in self.displays.indices {
                     self.displays[i].previewStatus = .loading
                 }
-                await withTaskGroup(of: (UInt32, NSImage?, PreviewStatus).self) { group in
+                await withTaskGroup(of: (UInt32, NSImage?, PreviewStatus, Int, Bool).self) { group in
                     for display in self.displays {
                         group.addTask { [thumbnailProvider] in
                             // Check cancellation before starting each capture
                             guard !Task.isCancelled else {
-                                return (display.id, nil, PreviewStatus.failed(.cancelled))
+                                return (display.id, nil, PreviewStatus.failed(.cancelled), 0, false)
                             }
+                            let start = Date()
                             let result = await thumbnailProvider.captureThumbnail(for: display)
-                            return (display.id, result.image, result.status)
+                            let latencyMs = Int(Date().timeIntervalSince(start) * 1000)
+                            // Cache hits return almost instantly (< 1ms)
+                            let fromCache = latencyMs < 2 && result.status == .loaded
+                            return (display.id, result.image, result.status, latencyMs, fromCache)
                         }
                     }
-                    for await (displayId, image, status) in group {
+                    for await (displayId, image, status, latencyMs, fromCache) in group {
                         // Discard stale results from a previous generation;
                         // cancel remaining children so they release semaphore slots promptly
                         guard self.previewGeneration == generation else {
@@ -387,6 +410,27 @@ final class RecordingSourcePickerViewModel: ObservableObject {
                             self.displays[idx].thumbnail = image
                             self.displays[idx].previewStatus = status
                         }
+
+                        // Telemetry
+                        let sourceId = String(displayId)
+                        self.previewAttemptCount += 1
+                        self.previewTotalLatencyMs += latencyMs
+                        switch status {
+                        case .loaded:
+                            self.previewSuccessCount += 1
+                            if fromCache { self.previewCacheHitCount += 1 }
+                            RecordingTelemetry.logPreviewGenerated(sourceType: "display", sourceId: sourceId, latencyMs: latencyMs, fromCache: fromCache)
+                        case .failed(let reason):
+                            if reason == .cancelled {
+                                self.previewCancelCount += 1
+                                RecordingTelemetry.logPreviewCancelled(sourceType: "display", sourceId: sourceId, reason: "task_cancelled")
+                            } else {
+                                self.previewFailureCount += 1
+                                RecordingTelemetry.logPreviewFailed(sourceType: "display", sourceId: sourceId, category: Self.errorCategory(from: reason), latencyMs: latencyMs)
+                            }
+                        case .idle, .loading:
+                            break
+                        }
                     }
                 }
 
@@ -394,17 +438,20 @@ final class RecordingSourcePickerViewModel: ObservableObject {
                 for i in self.windows.indices {
                     self.windows[i].previewStatus = .loading
                 }
-                await withTaskGroup(of: (Int, NSImage?, PreviewStatus).self) { group in
+                await withTaskGroup(of: (Int, NSImage?, PreviewStatus, Int, Bool).self) { group in
                     for window in self.windows {
                         group.addTask { [thumbnailProvider] in
                             guard !Task.isCancelled else {
-                                return (window.id, nil, PreviewStatus.failed(.cancelled))
+                                return (window.id, nil, PreviewStatus.failed(.cancelled), 0, false)
                             }
+                            let start = Date()
                             let result = await thumbnailProvider.captureThumbnail(for: window)
-                            return (window.id, result.image, result.status)
+                            let latencyMs = Int(Date().timeIntervalSince(start) * 1000)
+                            let fromCache = latencyMs < 2 && result.status == .loaded
+                            return (window.id, result.image, result.status, latencyMs, fromCache)
                         }
                     }
-                    for await (windowId, image, status) in group {
+                    for await (windowId, image, status, latencyMs, fromCache) in group {
                         guard self.previewGeneration == generation else {
                             group.cancelAll()
                             return
@@ -416,6 +463,27 @@ final class RecordingSourcePickerViewModel: ObservableObject {
                         if let idx = self.windows.firstIndex(where: { $0.id == windowId }) {
                             self.windows[idx].thumbnail = image
                             self.windows[idx].previewStatus = status
+                        }
+
+                        // Telemetry
+                        let sourceId = String(windowId)
+                        self.previewAttemptCount += 1
+                        self.previewTotalLatencyMs += latencyMs
+                        switch status {
+                        case .loaded:
+                            self.previewSuccessCount += 1
+                            if fromCache { self.previewCacheHitCount += 1 }
+                            RecordingTelemetry.logPreviewGenerated(sourceType: "window", sourceId: sourceId, latencyMs: latencyMs, fromCache: fromCache)
+                        case .failed(let reason):
+                            if reason == .cancelled {
+                                self.previewCancelCount += 1
+                                RecordingTelemetry.logPreviewCancelled(sourceType: "window", sourceId: sourceId, reason: "task_cancelled")
+                            } else {
+                                self.previewFailureCount += 1
+                                RecordingTelemetry.logPreviewFailed(sourceType: "window", sourceId: sourceId, category: Self.errorCategory(from: reason), latencyMs: latencyMs)
+                            }
+                        case .idle, .loading:
+                            break
                         }
                     }
                 }
@@ -430,6 +498,32 @@ final class RecordingSourcePickerViewModel: ObservableObject {
     func clearPreviews() {
         previewTask?.cancel()
         previewTask = nil
+
+        // Log session summary if any previews were attempted
+        if previewAttemptCount > 0 {
+            let completedCount = previewSuccessCount + previewFailureCount
+            let avgLatency = completedCount > 0 ? previewTotalLatencyMs / completedCount : 0
+            let cacheHitRate = previewSuccessCount > 0
+                ? Double(previewCacheHitCount) / Double(previewSuccessCount)
+                : 0.0
+
+            RecordingTelemetry.logPreviewSessionSummary(
+                totalAttempted: previewAttemptCount,
+                succeeded: previewSuccessCount,
+                failed: previewFailureCount,
+                cancelled: previewCancelCount,
+                avgLatencyMs: avgLatency,
+                cacheHitRate: cacheHitRate
+            )
+        }
+
+        // Reset telemetry counters
+        previewAttemptCount = 0
+        previewSuccessCount = 0
+        previewFailureCount = 0
+        previewCancelCount = 0
+        previewTotalLatencyMs = 0
+        previewCacheHitCount = 0
 
         // Reset all sources' preview states
         for i in displays.indices {

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerWindow.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerWindow.swift
@@ -90,7 +90,8 @@ final class RecordingSourcePickerWindow: NSObject, NSWindowDelegate {
             NotificationCenter.default.removeObserver(observer)
             moveObserver = nil
         }
-        viewModel?.clearPreviews()
+        let vm = viewModel
+        Task { await vm?.clearPreviews() }
         window?.delegate = nil
         window?.close()
         window = nil

--- a/clients/macos/vellum-assistant/Recording/RecordingTelemetry.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingTelemetry.swift
@@ -15,6 +15,14 @@ enum RecordingTelemetry {
 
     // MARK: - Error Categories
 
+    /// Coarse error category for preview capture telemetry.
+    enum PreviewErrorCategory: String {
+        case captureFailed = "capture_failed"
+        case blankFrame = "blank_frame"
+        case sourceGone = "source_gone"
+        case cancelled = "cancelled"
+    }
+
     /// Coarse error category for telemetry grouping.
     enum ErrorCategory: String {
         case dimension
@@ -161,6 +169,100 @@ enum RecordingTelemetry {
             from=\(fromConfig, privacy: .public), \
             to=\(toConfig, privacy: .public), \
             reason=\(reason, privacy: .public)
+            """)
+    }
+
+    // MARK: - Preview Telemetry
+
+    /// Log when a source preview thumbnail is successfully generated.
+    ///
+    /// - Parameters:
+    ///   - sourceType: The type of source ("display" or "window").
+    ///   - sourceId: The identifier of the source (display ID or window ID).
+    ///   - latencyMs: Time taken to generate the preview in milliseconds.
+    ///   - fromCache: Whether the thumbnail was served from cache.
+    static func logPreviewGenerated(
+        sourceType: String,
+        sourceId: String,
+        latencyMs: Int,
+        fromCache: Bool
+    ) {
+        log.info("""
+            preview.generated: \
+            sourceType=\(sourceType, privacy: .public), \
+            sourceId=\(sourceId, privacy: .public), \
+            latencyMs=\(latencyMs), \
+            fromCache=\(fromCache)
+            """)
+    }
+
+    /// Log when a source preview thumbnail capture fails.
+    ///
+    /// - Parameters:
+    ///   - sourceType: The type of source ("display" or "window").
+    ///   - sourceId: The identifier of the source.
+    ///   - category: The category of failure.
+    ///   - latencyMs: Time elapsed before the failure in milliseconds.
+    static func logPreviewFailed(
+        sourceType: String,
+        sourceId: String,
+        category: PreviewErrorCategory,
+        latencyMs: Int
+    ) {
+        log.error("""
+            preview.failed: \
+            sourceType=\(sourceType, privacy: .public), \
+            sourceId=\(sourceId, privacy: .public), \
+            category=\(category.rawValue, privacy: .public), \
+            latencyMs=\(latencyMs)
+            """)
+    }
+
+    /// Log when a source preview capture is cancelled.
+    ///
+    /// - Parameters:
+    ///   - sourceType: The type of source ("display" or "window").
+    ///   - sourceId: The identifier of the source.
+    ///   - reason: Why the preview was cancelled (e.g. "scope_switch").
+    static func logPreviewCancelled(
+        sourceType: String,
+        sourceId: String,
+        reason: String
+    ) {
+        log.info("""
+            preview.cancelled: \
+            sourceType=\(sourceType, privacy: .public), \
+            sourceId=\(sourceId, privacy: .public), \
+            reason=\(reason, privacy: .public)
+            """)
+    }
+
+    /// Log an aggregate summary of preview activity for the picker session.
+    /// Called when the picker is dismissed.
+    ///
+    /// - Parameters:
+    ///   - totalAttempted: Total number of preview captures attempted.
+    ///   - succeeded: Number of successful captures.
+    ///   - failed: Number of failed captures.
+    ///   - cancelled: Number of cancelled captures.
+    ///   - avgLatencyMs: Average latency across all completed (success + fail) captures.
+    ///   - cacheHitRate: Fraction of successful captures served from cache (0.0–1.0).
+    static func logPreviewSessionSummary(
+        totalAttempted: Int,
+        succeeded: Int,
+        failed: Int,
+        cancelled: Int,
+        avgLatencyMs: Int,
+        cacheHitRate: Double
+    ) {
+        log.info("""
+            preview.session_summary: \
+            attempted=\(totalAttempted), \
+            succeeded=\(succeeded), \
+            failed=\(failed), \
+            cancelled=\(cancelled), \
+            avgLatencyMs=\(avgLatencyMs), \
+            cacheHitRate=\(String(format: "%.2f", cacheHitRate), privacy: .public)
             """)
     }
 }

--- a/clients/macos/vellum-assistant/Recording/ThumbnailProvider.swift
+++ b/clients/macos/vellum-assistant/Recording/ThumbnailProvider.swift
@@ -8,6 +8,8 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 struct ThumbnailResult {
     let image: NSImage?
     let status: PreviewStatus
+    /// Whether the result was served from the in-memory cache (no fresh capture).
+    let fromCache: Bool
 }
 
 /// Captures, normalizes, and caches source preview thumbnails.
@@ -95,16 +97,16 @@ actor ThumbnailProvider {
         let cacheKey = "display-\(display.id)"
 
         if let cached = cachedThumbnail(for: cacheKey) {
-            return ThumbnailResult(image: cached, status: .loaded)
+            return ThumbnailResult(image: cached, status: .loaded, fromCache: true)
         }
 
         guard let scDisplay = display.scDisplay else {
             log.warning("No SCDisplay reference for display \(display.id)")
-            return ThumbnailResult(image: nil, status: .failed(.sourceGone))
+            return ThumbnailResult(image: nil, status: .failed(.sourceGone), fromCache: false)
         }
 
         guard #available(macOS 14, *) else {
-            return ThumbnailResult(image: nil, status: .failed(.captureFailed))
+            return ThumbnailResult(image: nil, status: .failed(.captureFailed), fromCache: false)
         }
 
         await acquireSlot()
@@ -138,19 +140,19 @@ actor ThumbnailProvider {
             // Check for blank frame (all pixels the same or empty)
             if isBlankImage(cgImage) {
                 log.debug("Blank frame captured for display \(display.id)")
-                result = ThumbnailResult(image: nil, status: .failed(.blankFrame))
+                result = ThumbnailResult(image: nil, status: .failed(.blankFrame), fromCache: false)
             } else {
                 let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
                 if let normalized = normalizeToThumbnail(nsImage) {
                     cache(normalized, for: cacheKey)
-                    result = ThumbnailResult(image: normalized, status: .loaded)
+                    result = ThumbnailResult(image: normalized, status: .loaded, fromCache: false)
                 } else {
-                    result = ThumbnailResult(image: nil, status: .failed(.captureFailed))
+                    result = ThumbnailResult(image: nil, status: .failed(.captureFailed), fromCache: false)
                 }
             }
         } catch {
             log.error("Failed to capture display \(display.id) thumbnail: \(error.localizedDescription)")
-            result = ThumbnailResult(image: nil, status: .failed(.captureFailed))
+            result = ThumbnailResult(image: nil, status: .failed(.captureFailed), fromCache: false)
         }
         releaseSlot()
         return result
@@ -163,16 +165,16 @@ actor ThumbnailProvider {
         let cacheKey = "window-\(window.id)"
 
         if let cached = cachedThumbnail(for: cacheKey) {
-            return ThumbnailResult(image: cached, status: .loaded)
+            return ThumbnailResult(image: cached, status: .loaded, fromCache: true)
         }
 
         guard let scWindow = window.scWindow else {
             log.warning("No SCWindow reference for window \(window.id)")
-            return ThumbnailResult(image: nil, status: .failed(.sourceGone))
+            return ThumbnailResult(image: nil, status: .failed(.sourceGone), fromCache: false)
         }
 
         guard #available(macOS 14, *) else {
-            return ThumbnailResult(image: nil, status: .failed(.captureFailed))
+            return ThumbnailResult(image: nil, status: .failed(.captureFailed), fromCache: false)
         }
 
         await acquireSlot()
@@ -197,19 +199,19 @@ actor ThumbnailProvider {
 
             if isBlankImage(cgImage) {
                 log.debug("Blank frame captured for window \(window.id)")
-                result = ThumbnailResult(image: nil, status: .failed(.blankFrame))
+                result = ThumbnailResult(image: nil, status: .failed(.blankFrame), fromCache: false)
             } else {
                 let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
                 if let normalized = normalizeToThumbnail(nsImage) {
                     cache(normalized, for: cacheKey)
-                    result = ThumbnailResult(image: normalized, status: .loaded)
+                    result = ThumbnailResult(image: normalized, status: .loaded, fromCache: false)
                 } else {
-                    result = ThumbnailResult(image: nil, status: .failed(.captureFailed))
+                    result = ThumbnailResult(image: nil, status: .failed(.captureFailed), fromCache: false)
                 }
             }
         } catch {
             log.error("Failed to capture window \(window.id) thumbnail: \(error.localizedDescription)")
-            result = ThumbnailResult(image: nil, status: .failed(.captureFailed))
+            result = ThumbnailResult(image: nil, status: .failed(.captureFailed), fromCache: false)
         }
         releaseSlot()
         return result


### PR DESCRIPTION
Part of #9281. Adds preview telemetry (success/failure/cancellation/session summary logging), integrates telemetry into ViewModel preview pipeline, and expands RECORDING_TEST_MATRIX.md with source preview test scenarios.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
