### PR TITLE
fix: preserve text in stripHeavyContent + early-return guard

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1388,14 +1388,16 @@ public struct ChatMessage: Identifiable, Equatable {
         self.isError = isError
     }
 
-    /// Maximum text segment length before truncation during stripping.
-    private static let stripTextLimit = 200
-
     /// Release heavyweight data (images, attachment binary data, completed surface
-    /// payloads, tool results, large text) to reduce memory pressure on old messages
+    /// payloads, tool results) to reduce memory pressure on old messages
     /// that are no longer visible.
+    /// Text segments are preserved in full — they are lightweight compared to binary
+    /// data and are needed for transcript export. Full content can be rehydrated from
+    /// the daemon via message_content_request if needed.
     /// Metadata (tool names, inputSummary, inputRawValue, surface refs) is preserved for display.
     public mutating func stripHeavyContent() {
+        guard !isContentStripped else { return }
+
         // Tool calls: clear images, results, full input, and raw dict.
         // Keep toolName, inputSummary, and inputRawValue (short one-liner) intact for display.
         for i in toolCalls.indices {
@@ -1422,13 +1424,6 @@ public struct ChatMessage: Identifiable, Equatable {
                     surfaceRef: inlineSurfaces[i].surfaceRef,
                     completionState: inlineSurfaces[i].completionState
                 )
-            }
-        }
-        // Truncate long text segments to reduce string memory.
-        let limit = Self.stripTextLimit
-        for i in textSegments.indices {
-            if textSegments[i].count > limit {
-                textSegments[i] = String(textSegments[i].prefix(limit)) + " \u{2026} [stripped]"
             }
         }
         isContentStripped = true


### PR DESCRIPTION
Address review feedback on #9286: remove text segment truncation from stripHeavyContent() (text is lightweight and can be rehydrated from daemon if needed), and add early-return when isContentStripped is already true to avoid redundant processing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
