### PR TITLE
fix: skip thread trim during in-flight pagination

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -645,7 +645,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         guard let previousId = activeThreadId, previousId != nextThreadId,
               let vm = chatViewModels[previousId],
               vm.isHistoryLoaded,
-              !vm.isSending, !vm.isThinking else { return }
+              !vm.isSending, !vm.isThinking, !vm.isLoadingMoreMessages else { return }
         vm.trimForBackground()
     }
 


### PR DESCRIPTION
## Summary

Address review feedback on #9287: add `!vm.isLoadingMoreMessages` to `trimPreviousThreadIfNeeded` guard to prevent `trimForBackground()` from corrupting pagination state when user switches threads during a load-more request.

## Problem

If a user triggers "load more" pagination then quickly switches threads, `trimForBackground()` runs while the pagination request is still in-flight, setting `isHistoryLoaded = false`. When the pagination response arrives, it's misclassified as an initial load instead of a pagination append, corrupting message state.

## Fix

One-line change: add `!vm.isLoadingMoreMessages` to the guard in `trimPreviousThreadIfNeeded(nextThreadId:)` so that thread trimming is skipped while a pagination request is in flight.

## Files Changed

- `clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift` — Added `!vm.isLoadingMoreMessages` guard condition
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
