### PR TITLE
fix: history truncation consistency + legacy tool result rehydrate

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -764,8 +764,8 @@ export function handleHistoryRequest(
       timestamp: m.timestamp,
       ...(truncatedToolCalls.length > 0 ? { toolCalls: truncatedToolCalls, toolCallsBeforeText: m.toolCallsBeforeText } : {}),
       ...(attachments ? { attachments } : {}),
-      ...(m.textSegments.length > 0 ? { textSegments: m.textSegments } : {}),
-      ...(m.contentOrder.length > 0 ? { contentOrder: m.contentOrder } : {}),
+      ...(!wasTruncated && m.textSegments.length > 0 ? { textSegments: m.textSegments } : {}),
+      ...(!wasTruncated && m.contentOrder.length > 0 ? { contentOrder: m.contentOrder } : {}),
       ...(filteredSurfaces.length > 0 ? { surfaces: filteredSurfaces } : {}),
       ...(m.subagentNotification ? { subagentNotification: m.subagentNotification } : {}),
       ...(wasTruncated ? { wasTruncated: true } : {}),
@@ -927,8 +927,35 @@ export function handleMessageContentRequest(
     const content = JSON.parse(dbMessage.content);
     const rendered = renderHistoryContent(content);
     text = rendered.text || undefined;
-    if (rendered.toolCalls.length > 0) {
-      toolCalls = rendered.toolCalls.map((tc) => ({
+    let mergedToolCalls = rendered.toolCalls;
+
+    // Handle legacy conversations where tool_result blocks are stored in the
+    // following user message rather than inline with the assistant message.
+    // This mirrors the mergeToolResults logic used by handleHistoryRequest.
+    if (dbMessage.role === 'assistant' && mergedToolCalls.some((tc) => tc.result === undefined)) {
+      const nextMsg = conversationStore.getNextMessage(msg.sessionId, dbMessage.createdAt);
+      if (nextMsg && nextMsg.role === 'user') {
+        try {
+          const nextContent = JSON.parse(nextMsg.content);
+          const nextRendered = renderHistoryContent(nextContent);
+          if (nextRendered.text.trim() === '' && nextRendered.toolCalls.length > 0) {
+            for (const resultEntry of nextRendered.toolCalls) {
+              const unresolved = mergedToolCalls.find((tc) => tc.result === undefined);
+              if (unresolved) {
+                unresolved.result = resultEntry.result;
+                unresolved.isError = resultEntry.isError;
+                if (resultEntry.imageData) unresolved.imageData = resultEntry.imageData;
+              }
+            }
+          }
+        } catch {
+          // Next message isn't valid JSON — skip merging
+        }
+      }
+    }
+
+    if (mergedToolCalls.length > 0) {
+      toolCalls = mergedToolCalls.map((tc) => ({
         name: tc.name,
         input: tc.input,
         ...(tc.result !== undefined ? { result: tc.result } : {}),

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, desc, eq, inArray, isNull, lt, lte, ne, sql } from 'drizzle-orm';
+import { and, asc, count, desc, eq, gt, inArray, isNull, lt, lte, ne, sql } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { z } from 'zod';
 
@@ -334,6 +334,25 @@ export function getMessageById(messageId: string, conversationId?: string): Mess
     .select()
     .from(messages)
     .where(and(...conditions))
+    .get();
+  return row ? parseMessage(row) : null;
+}
+
+/**
+ * Get the next message in a conversation after a given message (by timestamp).
+ * Used for legacy tool_result merging in the rehydrate endpoint.
+ */
+export function getNextMessage(conversationId: string, afterTimestamp: number): MessageRow | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(messages)
+    .where(and(
+      eq(messages.conversationId, conversationId),
+      gt(messages.createdAt, afterTimestamp),
+    ))
+    .orderBy(asc(messages.createdAt))
+    .limit(1)
     .get();
   return row ? parseMessage(row) : null;
 }


### PR DESCRIPTION
Address review feedback on #9295: (1) omit textSegments and contentOrder when text is truncated to prevent leaking full content, (2) handle legacy conversations where tool_result blocks are stored in the following user message during message_content_request rehydration.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
