### PR TITLE
Notifications: add interaction event log and seen/viewed delivery summary fields

### DIFF
--- a/assistant/src/memory/migrations/029-notification-delivery-interactions.ts
+++ b/assistant/src/memory/migrations/029-notification-delivery-interactions.ts
@@ -1,0 +1,52 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Add the notification_delivery_interactions table (append-only interaction log)
+ * and summary columns on notification_deliveries for seen/viewed/last-interaction
+ * tracking.
+ *
+ * All DDL statements are idempotent (CREATE TABLE IF NOT EXISTS, ALTER TABLE
+ * ADD COLUMN try/catch).
+ */
+export function migrateNotificationDeliveryInteractions(database: DrizzleDb): void {
+  // -- Interaction log table --------------------------------------------------
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS notification_delivery_interactions (
+      id TEXT PRIMARY KEY,
+      notification_delivery_id TEXT NOT NULL REFERENCES notification_deliveries(id) ON DELETE CASCADE,
+      assistant_id TEXT NOT NULL,
+      channel TEXT NOT NULL,
+      interaction_type TEXT NOT NULL,
+      confidence TEXT NOT NULL,
+      source TEXT NOT NULL,
+      evidence_text TEXT,
+      metadata_json TEXT NOT NULL DEFAULT '{}',
+      occurred_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_ndi_delivery_occurred ON notification_delivery_interactions(notification_delivery_id, occurred_at DESC)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_ndi_assistant_occurred ON notification_delivery_interactions(assistant_id, occurred_at DESC)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_ndi_channel_occurred ON notification_delivery_interactions(channel, occurred_at DESC)`);
+
+  // -- Summary columns on notification_deliveries -----------------------------
+  const summaryColumns = [
+    'seen_at INTEGER',
+    'seen_confidence TEXT',
+    'seen_source TEXT',
+    'seen_evidence_text TEXT',
+    'viewed_at INTEGER',
+    'last_interaction_at INTEGER',
+    'last_interaction_type TEXT',
+    'last_interaction_confidence TEXT',
+    'last_interaction_source TEXT',
+    'last_interaction_evidence_text TEXT',
+  ];
+
+  for (const col of summaryColumns) {
+    try {
+      database.run(/*sql*/ `ALTER TABLE notification_deliveries ADD COLUMN ${col}`);
+    } catch { /* Column already exists */ }
+  }
+}

--- a/assistant/src/memory/migrations/114-notifications.ts
+++ b/assistant/src/memory/migrations/114-notifications.ts
@@ -2,6 +2,7 @@ import type { DrizzleDb } from '../db-connection.js';
 import { migrateNotificationTablesSchema } from './019-notification-tables-schema-migration.js';
 import { migrateNotificationDeliveryPairingColumns } from './027-notification-delivery-pairing-columns.js';
 import { migrateNotificationDeliveryClientAck } from './028-notification-delivery-client-ack.js';
+import { migrateNotificationDeliveryInteractions } from './029-notification-delivery-interactions.js';
 
 /**
  * Notification system tables: preferences, events, decisions, and deliveries.
@@ -90,4 +91,7 @@ export function createNotificationTables(database: DrizzleDb): void {
 
   // Add client delivery ack columns (idempotent ALTER TABLE)
   migrateNotificationDeliveryClientAck(database);
+
+  // Add interaction log table + delivery summary columns (idempotent)
+  migrateNotificationDeliveryInteractions(database);
 }

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -45,6 +45,7 @@ export { createMessagesFts } from './116-messages-fts.js';
 export { migrateGuardianVerificationSessions } from './026-guardian-verification-sessions.js';
 export { migrateGuardianBootstrapToken } from './027-guardian-bootstrap-token.js';
 export { migrateCallSessionMode } from './028-call-session-mode.js';
+export { migrateNotificationDeliveryInteractions } from './029-notification-delivery-interactions.js';
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -1002,6 +1002,37 @@ export const notificationDeliveries = sqliteTable('notification_deliveries', {
   clientDeliveryStatus: text('client_delivery_status'),
   clientDeliveryError: text('client_delivery_error'),
   clientDeliveryAt: integer('client_delivery_at'),
+  // Interaction summary columns (populated transactionally by interactions-store)
+  seenAt: integer('seen_at'),
+  seenConfidence: text('seen_confidence'),
+  seenSource: text('seen_source'),
+  seenEvidenceText: text('seen_evidence_text'),
+  viewedAt: integer('viewed_at'),
+  lastInteractionAt: integer('last_interaction_at'),
+  lastInteractionType: text('last_interaction_type'),
+  lastInteractionConfidence: text('last_interaction_confidence'),
+  lastInteractionSource: text('last_interaction_source'),
+  lastInteractionEvidenceText: text('last_interaction_evidence_text'),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 });
+
+export const notificationDeliveryInteractions = sqliteTable('notification_delivery_interactions', {
+  id: text('id').primaryKey(),
+  notificationDeliveryId: text('notification_delivery_id')
+    .notNull()
+    .references(() => notificationDeliveries.id, { onDelete: 'cascade' }),
+  assistantId: text('assistant_id').notNull(),
+  channel: text('channel').notNull(),
+  interactionType: text('interaction_type').notNull(),
+  confidence: text('confidence').notNull(),
+  source: text('source').notNull(),
+  evidenceText: text('evidence_text'),
+  metadataJson: text('metadata_json').notNull().default('{}'),
+  occurredAt: integer('occurred_at').notNull(),
+  createdAt: integer('created_at').notNull(),
+}, (table) => [
+  index('idx_ndi_delivery_occurred').on(table.notificationDeliveryId, table.occurredAt),
+  index('idx_ndi_assistant_occurred').on(table.assistantId, table.occurredAt),
+  index('idx_ndi_channel_occurred').on(table.channel, table.occurredAt),
+]);

--- a/assistant/src/notifications/README.md
+++ b/assistant/src/notifications/README.md
@@ -214,6 +214,7 @@ For notification flows that create conversations, the conversation must be creat
 | `events-store.ts` | CRUD for `notification_events` table |
 | `decisions-store.ts` | CRUD for `notification_decisions` table |
 | `deliveries-store.ts` | CRUD for `notification_deliveries` table |
+| `interactions-store.ts` | Append-only interaction log + delivery summary updates |
 
 ## How to Add a New Notification Producer
 
@@ -252,11 +253,12 @@ The call is fire-and-forget safe by default -- errors are caught and logged inte
 
 ## Audit Trail
 
-Three SQLite tables form the audit chain:
+Four SQLite tables form the audit chain:
 
 - **`notification_events`** -- every signal that entered the pipeline, with attention hints and context payload
 - **`notification_decisions`** -- the routing decision for each event (shouldNotify, selectedChannels, reasoning, confidence, whether fallback was used)
-- **`notification_deliveries`** -- per-channel delivery attempts with status (pending/sent/failed/skipped), rendered copy, error details, conversation pairing data (`conversation_id`, `message_id`, `conversation_strategy`), and client delivery outcome (`client_delivery_status`, `client_delivery_error`, `client_delivery_at`)
+- **`notification_deliveries`** -- per-channel delivery attempts with status (pending/sent/failed/skipped), rendered copy, error details, conversation pairing data (`conversation_id`, `message_id`, `conversation_strategy`), client delivery outcome, and interaction summary columns
+- **`notification_delivery_interactions`** -- append-only log of user interactions with delivered notifications (viewed, dismissed, replied, callback_clicked, conversation_opened)
 
 ### Client Delivery Ack
 
@@ -304,6 +306,75 @@ SELECT d.rendered_title, d.client_delivery_status, d.client_delivery_error, d.cl
 FROM notification_deliveries d
 WHERE d.channel = 'vellum' AND d.client_delivery_status = 'client_failed'
 ORDER BY d.created_at DESC;
+```
+
+## Delivery Interaction Tracking
+
+After a notification is delivered, the system tracks how the user interacts with it. Each interaction is recorded as an append-only row in `notification_delivery_interactions`, and summary columns on `notification_deliveries` are updated transactionally.
+
+### Interaction Types
+
+| Type | Description |
+|------|-------------|
+| `viewed` | The user saw the notification (explicit vellum view or inferred from channel signals) |
+| `dismissed` | The user dismissed/cleared the notification without engaging |
+| `replied` | The user replied to the notification thread |
+| `callback_clicked` | The user clicked a callback button (e.g. Telegram inline keyboard) |
+| `conversation_opened` | The user opened the notification's conversation thread |
+
+### Confidence Levels
+
+| Level | Meaning |
+|-------|---------|
+| `explicit` | Directly observed action (e.g. user clicked "View" on a macOS notification, opened the thread in vellum) |
+| `inferred` | Derived from indirect signals (e.g. a Telegram inbound message in the same chat implies the user saw the notification) |
+
+### Summary Columns on `notification_deliveries`
+
+| Column | Invariant |
+|--------|-----------|
+| `seen_at`, `seen_confidence`, `seen_source`, `seen_evidence_text` | First-write-wins: once set, never overwritten or cleared |
+| `viewed_at` | Set only by explicit vellum view interactions |
+| `last_interaction_at`, `last_interaction_type`, `last_interaction_confidence`, `last_interaction_source`, `last_interaction_evidence_text` | Always reflects the most recent interaction by `occurred_at` |
+
+### Interaction Sources
+
+Each interaction carries a `source` string identifying where it originated:
+
+- `macos_notification_view_action` -- user tapped "View" on a macOS notification
+- `macos_notification_dismiss_action` -- user dismissed a macOS notification
+- `macos_conversation_opened` -- user opened the notification thread in the macOS app
+- `telegram_inbound_message` -- user sent a message in the Telegram chat where the notification was delivered
+- `telegram_callback_query` -- user clicked an inline button on a Telegram notification
+- `vellum_thread_opened` -- user opened the notification thread in the vellum interface
+
+### Store API (`interactions-store.ts`)
+
+- `recordNotificationDeliveryInteraction(params)` -- insert interaction + update summaries transactionally
+- `markDeliverySeen(params)` -- helper to record a 'viewed' interaction (first-write-wins for `seen_at`)
+- `markDeliveryViewed(params)` -- helper for explicit vellum view (sets `viewed_at`)
+- `getNotificationDeliverySummaries(filters)` -- query delivery summaries with filters
+
+Query examples:
+
+```sql
+-- Deliveries the user has seen
+SELECT id, channel, seen_at, seen_source, seen_confidence
+FROM notification_deliveries
+WHERE seen_at IS NOT NULL
+ORDER BY seen_at DESC;
+
+-- Interaction history for a specific delivery
+SELECT interaction_type, confidence, source, evidence_text, occurred_at
+FROM notification_delivery_interactions
+WHERE notification_delivery_id = ?
+ORDER BY occurred_at DESC;
+
+-- Deliveries with no interaction (potentially missed notifications)
+SELECT id, channel, rendered_title, created_at
+FROM notification_deliveries
+WHERE status = 'sent' AND last_interaction_at IS NULL
+ORDER BY created_at DESC;
 ```
 
 ## Conversational Preferences

--- a/assistant/src/notifications/deliveries-store.ts
+++ b/assistant/src/notifications/deliveries-store.ts
@@ -31,6 +31,16 @@ export interface NotificationDeliveryRow {
   clientDeliveryStatus: string | null;
   clientDeliveryError: string | null;
   clientDeliveryAt: number | null;
+  seenAt: number | null;
+  seenConfidence: string | null;
+  seenSource: string | null;
+  seenEvidenceText: string | null;
+  viewedAt: number | null;
+  lastInteractionAt: number | null;
+  lastInteractionType: string | null;
+  lastInteractionConfidence: string | null;
+  lastInteractionSource: string | null;
+  lastInteractionEvidenceText: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -55,6 +65,16 @@ function rowToDelivery(row: typeof notificationDeliveries.$inferSelect): Notific
     clientDeliveryStatus: row.clientDeliveryStatus,
     clientDeliveryError: row.clientDeliveryError,
     clientDeliveryAt: row.clientDeliveryAt,
+    seenAt: row.seenAt,
+    seenConfidence: row.seenConfidence,
+    seenSource: row.seenSource,
+    seenEvidenceText: row.seenEvidenceText,
+    viewedAt: row.viewedAt,
+    lastInteractionAt: row.lastInteractionAt,
+    lastInteractionType: row.lastInteractionType,
+    lastInteractionConfidence: row.lastInteractionConfidence,
+    lastInteractionSource: row.lastInteractionSource,
+    lastInteractionEvidenceText: row.lastInteractionEvidenceText,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };

--- a/assistant/src/notifications/interactions-store.ts
+++ b/assistant/src/notifications/interactions-store.ts
@@ -1,0 +1,242 @@
+/**
+ * Notification delivery interaction persistence.
+ *
+ * Append-only interaction log plus transactional summary updates on
+ * notification_deliveries. Summary invariants:
+ *
+ * - seen_at: first-write-wins (monotonic, never cleared once set)
+ * - viewed_at: set only by explicit vellum view interactions
+ * - last_interaction_*: always reflects the most recent interaction by occurred_at
+ */
+
+import { and, desc, eq, isNotNull, sql } from 'drizzle-orm';
+
+import { getDb } from '../memory/db.js';
+import { notificationDeliveries, notificationDeliveryInteractions } from '../memory/schema.js';
+import type {
+  InteractionConfidence,
+  InteractionSource,
+  InteractionType,
+  NotificationDeliverySummary,
+} from './types.js';
+
+// -- Row type -----------------------------------------------------------------
+
+export interface NotificationDeliveryInteractionRow {
+  id: string;
+  notificationDeliveryId: string;
+  assistantId: string;
+  channel: string;
+  interactionType: string;
+  confidence: string;
+  source: string;
+  evidenceText: string | null;
+  metadataJson: string;
+  occurredAt: number;
+  createdAt: number;
+}
+
+// -- Params -------------------------------------------------------------------
+
+export interface RecordInteractionParams {
+  id: string;
+  notificationDeliveryId: string;
+  assistantId: string;
+  channel: string;
+  interactionType: InteractionType;
+  confidence: InteractionConfidence;
+  source: InteractionSource;
+  evidenceText?: string;
+  metadata?: Record<string, unknown>;
+  occurredAt: number;
+}
+
+export interface MarkDeliverySeenParams {
+  notificationDeliveryId: string;
+  assistantId: string;
+  channel: string;
+  confidence: InteractionConfidence;
+  source: InteractionSource;
+  evidenceText?: string;
+  occurredAt: number;
+}
+
+export interface MarkDeliveryViewedParams {
+  notificationDeliveryId: string;
+  assistantId: string;
+  channel: string;
+  source: InteractionSource;
+  evidenceText?: string;
+  occurredAt: number;
+}
+
+export interface GetDeliverySummariesFilters {
+  assistantId: string;
+  channel?: string;
+  /** Only return deliveries that have at least one interaction. */
+  hasInteraction?: boolean;
+  limit?: number;
+}
+
+// -- Core functions -----------------------------------------------------------
+
+/**
+ * Record a delivery interaction and transactionally update the delivery
+ * summary columns. Returns the persisted interaction row.
+ */
+export function recordNotificationDeliveryInteraction(
+  params: RecordInteractionParams,
+): NotificationDeliveryInteractionRow {
+  const db = getDb();
+  const now = Date.now();
+
+  const row: NotificationDeliveryInteractionRow = {
+    id: params.id,
+    notificationDeliveryId: params.notificationDeliveryId,
+    assistantId: params.assistantId,
+    channel: params.channel,
+    interactionType: params.interactionType,
+    confidence: params.confidence,
+    source: params.source,
+    evidenceText: params.evidenceText ?? null,
+    metadataJson: JSON.stringify(params.metadata ?? {}),
+    occurredAt: params.occurredAt,
+    createdAt: now,
+  };
+
+  db.transaction((tx) => {
+    // 1. Insert the interaction row
+    tx.insert(notificationDeliveryInteractions).values(row).run();
+
+    // 2. Build summary updates
+    const summaryUpdates: Record<string, unknown> = {
+      updatedAt: now,
+    };
+
+    // seen_at: first-write-wins -- only set if not already set
+    const delivery = tx
+      .select({
+        seenAt: notificationDeliveries.seenAt,
+        lastInteractionAt: notificationDeliveries.lastInteractionAt,
+      })
+      .from(notificationDeliveries)
+      .where(eq(notificationDeliveries.id, params.notificationDeliveryId))
+      .get();
+
+    if (delivery && delivery.seenAt === null) {
+      summaryUpdates.seenAt = params.occurredAt;
+      summaryUpdates.seenConfidence = params.confidence;
+      summaryUpdates.seenSource = params.source;
+      summaryUpdates.seenEvidenceText = params.evidenceText ?? null;
+    }
+
+    // viewed_at: only set for explicit vellum view interactions
+    if (params.interactionType === 'viewed' && params.confidence === 'explicit') {
+      summaryUpdates.viewedAt = params.occurredAt;
+    }
+
+    // last_interaction_*: update if this interaction is more recent
+    if (!delivery?.lastInteractionAt || params.occurredAt >= delivery.lastInteractionAt) {
+      summaryUpdates.lastInteractionAt = params.occurredAt;
+      summaryUpdates.lastInteractionType = params.interactionType;
+      summaryUpdates.lastInteractionConfidence = params.confidence;
+      summaryUpdates.lastInteractionSource = params.source;
+      summaryUpdates.lastInteractionEvidenceText = params.evidenceText ?? null;
+    }
+
+    // 3. Apply summary updates
+    tx.update(notificationDeliveries)
+      .set(summaryUpdates)
+      .where(eq(notificationDeliveries.id, params.notificationDeliveryId))
+      .run();
+  });
+
+  return row;
+}
+
+/**
+ * Mark a delivery as "seen" (first-write-wins). Records a 'viewed'
+ * interaction with the given confidence and source. If seen_at is
+ * already set, the interaction is still logged but seen_at is not
+ * overwritten.
+ */
+export function markDeliverySeen(params: MarkDeliverySeenParams): NotificationDeliveryInteractionRow {
+  const id = crypto.randomUUID();
+  return recordNotificationDeliveryInteraction({
+    id,
+    notificationDeliveryId: params.notificationDeliveryId,
+    assistantId: params.assistantId,
+    channel: params.channel,
+    interactionType: 'viewed',
+    confidence: params.confidence,
+    source: params.source,
+    evidenceText: params.evidenceText,
+    occurredAt: params.occurredAt,
+  });
+}
+
+/**
+ * Mark a delivery as explicitly viewed in the vellum interface.
+ * Sets viewed_at (explicit vellum view only) and records a 'viewed'
+ * interaction with 'explicit' confidence.
+ */
+export function markDeliveryViewed(params: MarkDeliveryViewedParams): NotificationDeliveryInteractionRow {
+  const id = crypto.randomUUID();
+  return recordNotificationDeliveryInteraction({
+    id,
+    notificationDeliveryId: params.notificationDeliveryId,
+    assistantId: params.assistantId,
+    channel: params.channel,
+    interactionType: 'viewed',
+    confidence: 'explicit',
+    source: params.source,
+    evidenceText: params.evidenceText,
+    occurredAt: params.occurredAt,
+  });
+}
+
+/**
+ * Query delivery summaries with optional filters. Returns the summary
+ * projection from notification_deliveries ordered by most recent
+ * interaction first, falling back to created_at.
+ */
+export function getNotificationDeliverySummaries(
+  filters: GetDeliverySummariesFilters,
+): NotificationDeliverySummary[] {
+  const db = getDb();
+  const conditions = [eq(notificationDeliveries.assistantId, filters.assistantId)];
+
+  if (filters.channel) {
+    conditions.push(eq(notificationDeliveries.channel, filters.channel));
+  }
+
+  if (filters.hasInteraction) {
+    conditions.push(isNotNull(notificationDeliveries.lastInteractionAt));
+  }
+
+  const limit = filters.limit ?? 50;
+
+  const rows = db
+    .select({
+      id: notificationDeliveries.id,
+      assistantId: notificationDeliveries.assistantId,
+      channel: notificationDeliveries.channel,
+      seenAt: notificationDeliveries.seenAt,
+      seenConfidence: notificationDeliveries.seenConfidence,
+      seenSource: notificationDeliveries.seenSource,
+      seenEvidenceText: notificationDeliveries.seenEvidenceText,
+      viewedAt: notificationDeliveries.viewedAt,
+      lastInteractionAt: notificationDeliveries.lastInteractionAt,
+      lastInteractionType: notificationDeliveries.lastInteractionType,
+      lastInteractionConfidence: notificationDeliveries.lastInteractionConfidence,
+      lastInteractionSource: notificationDeliveries.lastInteractionSource,
+      lastInteractionEvidenceText: notificationDeliveries.lastInteractionEvidenceText,
+    })
+    .from(notificationDeliveries)
+    .where(and(...conditions))
+    .orderBy(desc(sql`COALESCE(${notificationDeliveries.lastInteractionAt}, ${notificationDeliveries.createdAt})`))
+    .limit(limit)
+    .all();
+
+  return rows;
+}

--- a/assistant/src/notifications/interactions-store.ts
+++ b/assistant/src/notifications/interactions-store.ts
@@ -20,6 +20,20 @@ import type {
   NotificationDeliverySummary,
 } from './types.js';
 
+// -- Vellum view sources ------------------------------------------------------
+
+/**
+ * Sources that represent the user actually opening or viewing the notification
+ * in a vellum-controlled interface. Only interactions from these sources are
+ * eligible to set `viewed_at` on the delivery summary — other explicit signals
+ * (e.g. future non-vellum integrations) should only set `seen_at`.
+ */
+export const VELLUM_VIEW_SOURCES: ReadonlySet<InteractionSource> = new Set<InteractionSource>([
+  'macos_notification_view_action',
+  'macos_conversation_opened',
+  'vellum_thread_opened',
+]);
+
 // -- Row type -----------------------------------------------------------------
 
 export interface NotificationDeliveryInteractionRow {
@@ -130,8 +144,12 @@ export function recordNotificationDeliveryInteraction(
       summaryUpdates.seenEvidenceText = params.evidenceText ?? null;
     }
 
-    // viewed_at: only set for explicit vellum view interactions
-    if (params.interactionType === 'viewed' && params.confidence === 'explicit') {
+    // viewed_at: only set for explicit vellum view interactions from known sources
+    if (
+      params.interactionType === 'viewed' &&
+      params.confidence === 'explicit' &&
+      VELLUM_VIEW_SOURCES.has(params.source)
+    ) {
       summaryUpdates.viewedAt = params.occurredAt;
     }
 

--- a/assistant/src/notifications/interactions-store.ts
+++ b/assistant/src/notifications/interactions-store.ts
@@ -131,6 +131,7 @@ export function recordNotificationDeliveryInteraction(
     const delivery = tx
       .select({
         seenAt: notificationDeliveries.seenAt,
+        viewedAt: notificationDeliveries.viewedAt,
         lastInteractionAt: notificationDeliveries.lastInteractionAt,
       })
       .from(notificationDeliveries)
@@ -144,11 +145,13 @@ export function recordNotificationDeliveryInteraction(
       summaryUpdates.seenEvidenceText = params.evidenceText ?? null;
     }
 
-    // viewed_at: only set for explicit vellum view interactions from known sources
+    // viewed_at: only set for explicit vellum view interactions from known sources,
+    // with monotonicity guard to prevent regression on out-of-order events
     if (
       params.interactionType === 'viewed' &&
       params.confidence === 'explicit' &&
-      VELLUM_VIEW_SOURCES.has(params.source)
+      VELLUM_VIEW_SOURCES.has(params.source) &&
+      (!delivery?.viewedAt || params.occurredAt >= delivery.viewedAt)
     ) {
       summaryUpdates.viewedAt = params.occurredAt;
     }

--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -87,3 +87,47 @@ export interface NotificationDecision {
   /** UUID of the persisted decision row (set after persistence in the decision engine). */
   persistedDecisionId?: string;
 }
+
+// -- Delivery interaction tracking --------------------------------------------
+
+/** How the user interacted with a notification delivery. */
+export type InteractionType =
+  | 'viewed'
+  | 'dismissed'
+  | 'replied'
+  | 'callback_clicked'
+  | 'conversation_opened';
+
+/** Whether the interaction was directly observed or inferred from signals. */
+export type InteractionConfidence = 'explicit' | 'inferred';
+
+/**
+ * Sources that produce interaction events. Each value identifies the
+ * originating subsystem or client action so callers can filter and
+ * audit by provenance.
+ */
+export type InteractionSource =
+  | 'macos_notification_view_action'
+  | 'macos_notification_dismiss_action'
+  | 'macos_conversation_opened'
+  | 'telegram_inbound_message'
+  | 'telegram_callback_query'
+  | 'vellum_thread_opened'
+  | (string & {});
+
+/** Summary of interaction state materialized on notification_deliveries. */
+export interface NotificationDeliverySummary {
+  id: string;
+  assistantId: string;
+  channel: string;
+  seenAt: number | null;
+  seenConfidence: string | null;
+  seenSource: string | null;
+  seenEvidenceText: string | null;
+  viewedAt: number | null;
+  lastInteractionAt: number | null;
+  lastInteractionType: string | null;
+  lastInteractionConfidence: string | null;
+  lastInteractionSource: string | null;
+  lastInteractionEvidenceText: string | null;
+}


### PR DESCRIPTION
Part of #9305. Adds notification_delivery_interactions table for append-only interaction tracking, summary columns on notification_deliveries (seen_at, viewed_at, last_interaction_*), interactions-store with transactional summary updates, and types.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
