### PR TITLE
fix: clear isContentStripped after rehydration

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -522,6 +522,7 @@ public final class ChatViewModel: ObservableObject {
         }
 
         messages[idx].wasTruncated = false
+        messages[idx].isContentStripped = false
     }
 
     // MARK: - Message Trimming


### PR DESCRIPTION
Address review feedback on #9313: set isContentStripped = false after handleMessageContentResponse updates a message with full content from the daemon, ensuring future trim passes can re-strip the message if it falls outside the keep-recent window.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
