### PR TITLE
fix(macos): use macOS 14-compatible SF Symbol for refresh buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -144,7 +144,7 @@ struct SettingsConnectTab: View {
             if authManager.isLoading {
                 channelStatusRow(
                     label: "Account",
-                    icon: "arrow.trianglehead.2.counterclockwise",
+                    icon: "arrow.triangle.2.circlepath",
                     iconColor: VColor.textMuted,
                     value: "Checking..."
                 )
@@ -1849,7 +1849,7 @@ struct SettingsConnectTab: View {
                 Button {
                     if !isRefreshing { onRefresh() }
                 } label: {
-                    Image(systemName: "arrow.trianglehead.2.counterclockwise")
+                    Image(systemName: "arrow.triangle.2.circlepath")
                         .font(.system(size: 11, weight: .medium))
                         .foregroundColor(isRefreshing ? VColor.accent : VColor.textMuted)
                         .rotationEffect(.degrees(isRefreshing ? 360 : 0))


### PR DESCRIPTION
## Summary
- Replace `arrow.trianglehead.2.counterclockwise` (requires SF Symbols 6 / macOS 15) with `arrow.triangle.2.circlepath` (available since SF Symbols 1 / macOS 11)
- Fixes invisible refresh buttons on the Platform, Gateway, and Tunnel status rows for users on macOS 14 (Sonoma)
- Two occurrences: the `connectionStatusRow` helper and the "Checking..." account row spinner icon

## Original prompt
Replace the SF Symbol "arrow.trianglehead.2.counterclockwise" with "arrow.triangle.2.circlepath" in SettingsConnectTab.swift — the former requires macOS 15 / SF Symbols 6 and doesn't render on macOS 14 (Sonoma), making the refresh buttons invisible. There are two usages: one in the connectionStatusRow helper and one in the Vellum section "Checking..." account row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
