### PR TITLE
fix: rehydration correctness — positional matching, cache invalidation, contentOrder

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -317,6 +317,11 @@ private struct UsedToolsRow: View {
             }
         }
         .animation(VAnimation.fast, value: isExpanded)
+        .onChange(of: toolCall.inputFull) { _ in
+            // Invalidate the cached formatted input so the next render picks up
+            // the fresh (rehydrated) value instead of the stale truncated one.
+            cachedInputFull = nil
+        }
     }
 
     /// Open the image in Preview.app. Tries the original file path first; falls

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -501,22 +501,45 @@ public final class ChatViewModel: ObservableObject {
     public func handleMessageContentResponse(_ response: IPCMessageContentResponse) {
         guard let idx = messages.firstIndex(where: { $0.daemonMessageId == response.messageId }) else { return }
 
-        // Update text with full content
+        // Update text with full content. When collapsing multiple text segments
+        // into one, also update contentOrder so stale .text(N>0) references are
+        // removed — otherwise interleaved content orders become invalid.
         if let fullText = response.text {
             messages[idx].textSegments = fullText.isEmpty ? [] : [fullText]
+            if !messages[idx].contentOrder.isEmpty {
+                var seenText = false
+                messages[idx].contentOrder = messages[idx].contentOrder.compactMap { entry in
+                    if case .text = entry {
+                        if seenText { return nil }
+                        seenText = true
+                        return .text(0)
+                    }
+                    return entry
+                }
+            }
         }
 
-        // Update tool call results with full content
+        // Update tool call results with full content.
+        // Use positional matching first — when a message has multiple tool calls
+        // with the same name (e.g. two `bash` calls), name-based lookup always
+        // overwrites the first match. Fall back to name-based only when the
+        // positional index is out of bounds or the name doesn't match.
         if let fullToolCalls = response.toolCalls {
-            for fullTC in fullToolCalls {
-                if let tcIdx = messages[idx].toolCalls.firstIndex(where: { $0.toolName == fullTC.name }) {
-                    if let result = fullTC.result {
-                        messages[idx].toolCalls[tcIdx].result = result
-                    }
-                    if let input = fullTC.input {
-                        messages[idx].toolCalls[tcIdx].inputFull = ToolCallData.formatAllToolInput(input)
-                        messages[idx].toolCalls[tcIdx].inputRawDict = input
-                    }
+            for (i, fullTC) in fullToolCalls.enumerated() {
+                let tcIdx: Int
+                if i < messages[idx].toolCalls.count && messages[idx].toolCalls[i].toolName == fullTC.name {
+                    tcIdx = i
+                } else if let fallback = messages[idx].toolCalls.firstIndex(where: { $0.toolName == fullTC.name }) {
+                    tcIdx = fallback
+                } else {
+                    continue
+                }
+                if let result = fullTC.result {
+                    messages[idx].toolCalls[tcIdx].result = result
+                }
+                if let input = fullTC.input {
+                    messages[idx].toolCalls[tcIdx].inputFull = ToolCallData.formatAllToolInput(input)
+                    messages[idx].toolCalls[tcIdx].inputRawDict = input
                 }
             }
         }

--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -200,6 +200,11 @@ public struct ToolCallChip: View {
                     ? VColor.error.opacity(0.3)
                     : VColor.surfaceBorder.opacity(0.5), lineWidth: 0.5)
         )
+        .onChange(of: toolCall.inputFull) { _ in
+            // Invalidate the cached formatted input so the next render picks up
+            // the fresh (rehydrated) value instead of the stale truncated one.
+            cachedInputFull = nil
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Address review feedback on #9302: 

1. **Positional tool call matching**: Use index-based matching for tool call rehydration to handle duplicate tool names (e.g. two `bash` calls). Falls back to name-based lookup only when the positional index is out of bounds or name doesn't match.

2. **Cache invalidation**: Add `.onChange(of: toolCall.inputFull)` to both `UsedToolsRow` and `ToolCallChip` to clear `cachedInputFull` when rehydrated data arrives, so the UI displays the full content instead of the stale truncated value.

3. **contentOrder preservation**: After collapsing multiple text segments into one during rehydration, collapse all `.text(N)` entries in `contentOrder` to a single `.text(0)`, removing stale references that would otherwise point to non-existent segments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
