### PR TITLE
fix: fail local hatch if base data directory already exists

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -538,6 +538,16 @@ async function hatchLocal(species: Species, name: string | null, daemonOnly: boo
     }
   }
 
+  const baseDataDir = join(process.env.BASE_DATA_DIR?.trim() || (process.env.HOME ?? userInfo().homedir), ".vellum");
+
+  if (existsSync(baseDataDir)) {
+    throw new Error(
+      `Base data directory already exists: ${baseDataDir}\n` +
+        "  Another assistant may already be using this directory.\n" +
+        "  To use a different directory, set the BASE_DATA_DIR environment variable.",
+    );
+  }
+
   console.log(`🥚 Hatching local assistant: ${instanceName}`);
   console.log(`   Species: ${species}`);
   console.log("");
@@ -554,8 +564,6 @@ async function hatchLocal(species: Species, name: string | null, daemonOnly: boo
     await stopLocalProcesses();
     throw error;
   }
-
-  const baseDataDir = join(process.env.BASE_DATA_DIR?.trim() || (process.env.HOME ?? userInfo().homedir), ".vellum");
 
   // Read the bearer token written by the daemon so the client can authenticate
   // with the gateway (which requires auth by default).


### PR DESCRIPTION
## Summary
- Checks if the `.vellum` base data directory already exists before starting a local hatch
- Fails early with a clear error message if the directory is taken, preventing accidental data overwrites
- Suggests setting `BASE_DATA_DIR` to use a different directory
- Moved `baseDataDir` computation earlier in `hatchLocal()` to enable the check before starting the daemon/gateway

## Test plan
- [x] All 35 CLI tests pass
- [ ] `vellum hatch` fails with clear error when `~/.vellum` already exists
- [ ] `vellum hatch` succeeds on fresh machine with no `~/.vellum`
- [ ] `BASE_DATA_DIR=/tmp/alt vellum hatch` works when `~/.vellum` exists but `/tmp/alt/.vellum` doesn't

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
