### PR TITLE
fix(macos): simplify Platform connection error text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1573,7 +1573,7 @@ public final class SettingsStore: ObservableObject {
             }
         } catch {
             vellumPlatformReachable = false
-            vellumPlatformError = error.localizedDescription
+            vellumPlatformError = "Could not connect"
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace `error.localizedDescription` with `"Could not connect"` in the Platform URL health check catch block
- Keeps the status row concise and consistent with other status labels

## Original prompt
Simplify the Platform connection error text from "Could not connect to the server." to "Could not connect" in the SettingsConnectTab or wherever the platform URL status info is computed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
