### PR TITLE
fix: prevent tool input flash on first expand

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -317,6 +317,19 @@ private struct UsedToolsRow: View {
             }
         }
         .animation(VAnimation.fast, value: isExpanded)
+        .onChange(of: isExpanded) { newValue in
+            // Populate the cache *before* the expanded body evaluates so that
+            // `resolvedInputFull` returns the formatted input on the very first
+            // render of the expanded section — avoiding a visible flash/pop-in
+            // for lazy-loaded history tool calls where `.onAppear` fires too late.
+            if newValue, cachedInputFull == nil {
+                if let dict = toolCall.inputRawDict {
+                    cachedInputFull = ToolCallData.formatAllToolInput(dict)
+                } else if !toolCall.inputFull.isEmpty {
+                    cachedInputFull = toolCall.inputFull
+                }
+            }
+        }
         .onChange(of: toolCall.inputFull) { _ in
             // Invalidate the cached formatted input so the next render picks up
             // the fresh (rehydrated) value instead of the stale truncated one.

--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -200,6 +200,19 @@ public struct ToolCallChip: View {
                     ? VColor.error.opacity(0.3)
                     : VColor.surfaceBorder.opacity(0.5), lineWidth: 0.5)
         )
+        .onChange(of: isExpanded) { newValue in
+            // Populate the cache *before* the expanded body evaluates so that
+            // `resolvedInputFull` returns the formatted input on the very first
+            // render of the expanded section — avoiding a visible flash/pop-in
+            // for lazy-loaded history tool calls where `.onAppear` fires too late.
+            if newValue, cachedInputFull == nil {
+                if let dict = toolCall.inputRawDict {
+                    cachedInputFull = ToolCallData.formatAllToolInput(dict)
+                } else if !toolCall.inputFull.isEmpty {
+                    cachedInputFull = toolCall.inputFull
+                }
+            }
+        }
         .onChange(of: toolCall.inputFull) { _ in
             // Invalidate the cached formatted input so the next render picks up
             // the fresh (rehydrated) value instead of the stale truncated one.


### PR DESCRIPTION
Address review feedback on #9245: add .onChange(of: isExpanded) to populate cachedInputFull before the expanded content renders, preventing the visible pop-in/flash for lazy-loaded tool call inputs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
