### PR TITLE
fix(macos): simplify Telegram guardian verification help text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -1298,26 +1298,24 @@ struct SettingsConnectTab: View {
             }
 
             if channel == "telegram" {
-                Text("Enter a Telegram @username (e.g. @janedoe) or numeric chat ID for the guardian.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
+                HStack(spacing: 0) {
+                    Text("Enter a @username or chat ID. ")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
 
-                Button {
-                    if let url = URL(string: "https://web.telegram.org/k/#@userinfobot") {
-                        NSWorkspace.shared.open(url)
-                    }
-                } label: {
-                    HStack(spacing: VSpacing.xs) {
-                        Image(systemName: "questionmark.circle")
-                            .font(.system(size: 11))
-                        Text("Find your Telegram username or chat ID")
+                    Button {
+                        if let url = URL(string: "https://web.telegram.org/k/#@userinfobot") {
+                            NSWorkspace.shared.open(url)
+                        }
+                    } label: {
+                        Text("Find yours →")
                             .font(VFont.caption)
+                            .foregroundColor(VColor.accent)
                     }
-                    .foregroundColor(VColor.accent)
-                }
-                .buttonStyle(.plain)
-                .onHover { hovering in
-                    if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                    .buttonStyle(.plain)
+                    .onHover { hovering in
+                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Condensed two lines of Telegram help text into a single inline line: "Enter a @username or chat ID. Find yours →"
- Removed redundant "Telegram" mention (already clear from channel context)
- Removed the questionmark.circle icon for a cleaner look

## Original prompt
Simplify the two lines of Telegram help text into one line with a hyperlink to the Telegram UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
