### PR TITLE
fix(macos): resolve two build errors on main

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -35,19 +35,19 @@ struct VellumAssistantApp: App {
                     appDelegate.handleConversationZoomIn()
                 }
                 .keyboardShortcut("+", modifiers: .command)
-                .disabled(!(appDelegate.mainWindow?.windowState.isConversationVisible ?? false))
+                .disabled(!appDelegate.isConversationZoomEnabled)
 
                 Button("Conversation Zoom Out") {
                     appDelegate.handleConversationZoomOut()
                 }
                 .keyboardShortcut("-", modifiers: .command)
-                .disabled(!(appDelegate.mainWindow?.windowState.isConversationVisible ?? false))
+                .disabled(!appDelegate.isConversationZoomEnabled)
 
                 Button("Conversation Actual Size") {
                     appDelegate.handleConversationZoomReset()
                 }
                 .keyboardShortcut("0", modifiers: .command)
-                .disabled(!(appDelegate.mainWindow?.windowState.isConversationVisible ?? false))
+                .disabled(!appDelegate.isConversationZoomEnabled)
 
                 Divider()
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -187,6 +187,11 @@ extension AppDelegate {
         }
     }
 
+    /// Whether conversation zoom commands should be enabled (public for the SwiftUI command group).
+    public var isConversationZoomEnabled: Bool {
+        mainWindow?.windowState.isConversationVisible ?? false
+    }
+
     @objc public func handleConversationZoomIn() { routeZoomIntent(.conversationZoomIn) }
     @objc public func handleConversationZoomOut() { routeZoomIntent(.conversationZoomOut) }
     @objc public func handleConversationZoomReset() { routeZoomIntent(.conversationZoomReset) }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -1862,7 +1862,7 @@ struct SettingsConnectTab: View {
                         .font(.system(size: 11, weight: .medium))
                         .foregroundColor(spinning ? VColor.accent : VColor.textMuted)
                         .rotationEffect(.degrees(spinning ? 360 : 0))
-                        .animation(spinning ? .linear(duration: 1).repeatForever(autoreverses: false) : .identity, value: spinning)
+                        .animation(spinning ? .linear(duration: 1).repeatForever(autoreverses: false) : .default, value: spinning)
                         .frame(width: 24, height: 24)
                         .contentShape(Rectangle())
                 }


### PR DESCRIPTION
## Summary
- Replace `.identity` animation value with `.default` in `SettingsConnectTab.swift` (`.identity` doesn't exist in this Swift version)
- Add `public var isConversationZoomEnabled` to `AppDelegate+MenuBar.swift` to expose conversation-visible state across module boundaries
- Use the new public accessor in `VellumAssistantApp.swift` instead of directly accessing `internal` properties `mainWindow` and `windowState`

## Original prompt
Fix two build errors on main: 1) In SettingsConnectTab.swift, the `.identity` animation value doesn't exist in this Swift version — change it to `.default`. 2) In VellumAssistantApp.swift, the `.disabled()` guard on conversation zoom commands accesses `mainWindow` and `windowState` which are `internal` to `VellumAssistantLib` but inaccessible from the executable target. Fix by adding a `public var isConversationZoomEnabled: Bool` computed property to AppDelegate+MenuBar.swift that wraps `mainWindow?.windowState.isConversationVisible ?? false`, then use `appDelegate.isConversationZoomEnabled` in VellumAssistantApp.swift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
