### PR TITLE
macOS notifications: report viewed/dismissed interactions and conversation-open views

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1104,6 +1104,24 @@ exports[`IPC message snapshots ClientMessage types notification_intent_result se
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types notification_delivery_interaction serializes to expected JSON 1`] = `
+{
+  "confidence": "explicit",
+  "deliveryId": "delivery-001",
+  "interactionType": "viewed",
+  "source": "macos_notification_view_action",
+  "type": "notification_delivery_interaction",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types notification_conversation_viewed serializes to expected JSON 1`] = `
+{
+  "conversationId": "conv-notif-001",
+  "source": "macos_conversation_opened",
+  "type": "notification_conversation_viewed",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types recording_status serializes to expected JSON 1`] = `
 {
   "sessionId": "rec-001",

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -686,6 +686,18 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     deliveryId: 'delivery-001',
     success: true,
   },
+  notification_delivery_interaction: {
+    type: 'notification_delivery_interaction',
+    deliveryId: 'delivery-001',
+    interactionType: 'viewed',
+    confidence: 'explicit',
+    source: 'macos_notification_view_action',
+  },
+  notification_conversation_viewed: {
+    type: 'notification_conversation_viewed',
+    conversationId: 'conv-notif-001',
+    source: 'macos_conversation_opened',
+  },
   recording_status: {
     type: 'recording_status',
     sessionId: 'rec-001',

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -1,7 +1,12 @@
 import * as net from 'node:net';
 
+import { desc, eq } from 'drizzle-orm';
+
 import type { ClientMessage } from '../ipc-protocol.js';
+import { getDb } from '../../memory/db.js';
+import { notificationDeliveries } from '../../memory/schema.js';
 import { updateDeliveryClientOutcome } from '../../notifications/deliveries-store.js';
+import { recordNotificationDeliveryInteraction, markDeliveryViewed } from '../../notifications/interactions-store.js';
 import { handleRideShotgunStart, handleRideShotgunStop } from '../ride-shotgun-handler.js';
 import { handleWatchObservation } from '../watch-handler.js';
 import { appHandlers } from './apps.js';
@@ -112,6 +117,55 @@ const inlineHandlers = defineHandlers({
       }
     } catch (err) {
       log.error({ err, deliveryId: msg.deliveryId }, 'notification_intent_result: failed to persist client delivery outcome');
+    }
+  },
+
+  // Client reports a direct delivery interaction (view, dismiss, etc).
+  notification_delivery_interaction: (msg) => {
+    try {
+      recordNotificationDeliveryInteraction({
+        id: crypto.randomUUID(),
+        notificationDeliveryId: msg.deliveryId,
+        assistantId: 'self',
+        channel: 'vellum',
+        interactionType: msg.interactionType as 'viewed' | 'dismissed' | 'replied' | 'callback_clicked' | 'conversation_opened',
+        confidence: msg.confidence as 'explicit' | 'inferred',
+        source: msg.source,
+        evidenceText: msg.evidenceText,
+        occurredAt: msg.occurredAt ?? Date.now(),
+      });
+    } catch (err) {
+      log.error({ err, deliveryId: msg.deliveryId }, 'notification_delivery_interaction: failed to persist interaction');
+    }
+  },
+
+  // Client reports explicit conversation view (sidebar selection or deep-link).
+  notification_conversation_viewed: (msg) => {
+    try {
+      const db = getDb();
+      const delivery = db
+        .select({ id: notificationDeliveries.id })
+        .from(notificationDeliveries)
+        .where(eq(notificationDeliveries.conversationId, msg.conversationId))
+        .orderBy(desc(notificationDeliveries.createdAt))
+        .limit(1)
+        .get();
+
+      if (!delivery) {
+        log.debug({ conversationId: msg.conversationId }, 'notification_conversation_viewed: no delivery found for conversationId');
+        return;
+      }
+
+      markDeliveryViewed({
+        notificationDeliveryId: delivery.id,
+        assistantId: 'self',
+        channel: 'vellum',
+        source: msg.source as 'macos_conversation_opened' | 'vellum_thread_opened',
+        evidenceText: msg.evidenceText,
+        occurredAt: msg.occurredAt ?? Date.now(),
+      });
+    } catch (err) {
+      log.error({ err, conversationId: msg.conversationId }, 'notification_conversation_viewed: failed to persist view');
     }
   },
 

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -104,6 +104,8 @@
     "message_content_request",
     "model_get",
     "model_set",
+    "notification_conversation_viewed",
+    "notification_delivery_interaction",
     "notification_intent_result",
     "oauth_connect_start",
     "open_bundle",

--- a/assistant/src/daemon/ipc-contract/notifications.ts
+++ b/assistant/src/daemon/ipc-contract/notifications.ts
@@ -27,8 +27,31 @@ export interface NotificationIntentResult {
   errorCode?: string;
 }
 
+/** Client reports a direct delivery interaction (view, dismiss, etc). */
+export interface NotificationDeliveryInteraction {
+  type: 'notification_delivery_interaction';
+  deliveryId: string;
+  interactionType: string;
+  confidence: string;
+  source: string;
+  evidenceText?: string;
+  occurredAt?: number;
+}
+
+/** Client reports explicit conversation view (sidebar selection or deep-link). */
+export interface NotificationConversationViewed {
+  type: 'notification_conversation_viewed';
+  conversationId: string;
+  source: string;
+  evidenceText?: string;
+  occurredAt?: number;
+}
+
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
-export type _NotificationsClientMessages = NotificationIntentResult;
+export type _NotificationsClientMessages =
+  | NotificationIntentResult
+  | NotificationDeliveryInteraction
+  | NotificationConversationViewed;
 
 export type _NotificationsServerMessages = NotificationIntent | NotificationThreadCreated;

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -81,7 +81,7 @@ extension AppDelegate {
             identifier: "NOTIFICATION_INTENT",
             actions: [viewNotificationIntentAction],
             intentIdentifiers: [],
-            options: []
+            options: [.customDismissAction]
         )
 
         center.setNotificationCategories([
@@ -252,6 +252,9 @@ extension AppDelegate {
         var userInfo: [String: Any] = [
             "sourceEventName": sourceEventName,
         ]
+        if let deliveryId {
+            userInfo["deliveryId"] = deliveryId
+        }
         if let metadata = deepLinkMetadata {
             for (key, wrapped) in metadata {
                 // Keep sourceEventName authoritative from the envelope.
@@ -468,15 +471,47 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         }
 
         if categoryId == "NOTIFICATION_INTENT" {
+            let userInfo = response.notification.request.content.userInfo
             let conversationId =
-                response.notification.request.content.userInfo["conversationId"] as? String ??
-                response.notification.request.content.userInfo["conversation_id"] as? String
-            await MainActor.run {
-                guard !self.isBootstrapping else { return }
-                if let conversationId {
-                    self.openConversationThread(conversationId: conversationId)
-                } else {
-                    self.showMainWindow()
+                userInfo["conversationId"] as? String ??
+                userInfo["conversation_id"] as? String
+            let deliveryId = userInfo["deliveryId"] as? String
+            let nowMs = Int(Date().timeIntervalSince1970 * 1000)
+
+            switch response.actionIdentifier {
+            case UNNotificationDismissActionIdentifier:
+                // User swiped away / dismissed the notification
+                if let deliveryId {
+                    await MainActor.run {
+                        try? self.daemonClient.sendNotificationDeliveryInteraction(
+                            deliveryId: deliveryId,
+                            interactionType: "dismissed",
+                            confidence: "explicit",
+                            source: "macos_notification_dismiss_action",
+                            occurredAt: nowMs
+                        )
+                    }
+                }
+            default:
+                // Default action (clicked banner) or VIEW_NOTIFICATION_INTENT
+                if let deliveryId {
+                    await MainActor.run {
+                        try? self.daemonClient.sendNotificationDeliveryInteraction(
+                            deliveryId: deliveryId,
+                            interactionType: "viewed",
+                            confidence: "explicit",
+                            source: "macos_notification_view_action",
+                            occurredAt: nowMs
+                        )
+                    }
+                }
+                await MainActor.run {
+                    guard !self.isBootstrapping else { return }
+                    if let conversationId {
+                        self.openConversationThread(conversationId: conversationId)
+                    } else {
+                        self.showMainWindow()
+                    }
                 }
             }
             return

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -306,13 +306,28 @@ extension AppDelegate {
             return true
         }
 
-        if trySelect() { return }
+        if trySelect() {
+            // Report explicit conversation view for notification deep-links.
+            try? daemonClient.sendNotificationConversationViewed(
+                conversationId: conversationId,
+                source: "macos_conversation_opened",
+                occurredAt: Int(Date().timeIntervalSince1970 * 1000)
+            )
+            return
+        }
 
         // Thread may not be loaded yet — retry up to 5 times with 500ms delay
         Task { @MainActor in
             for _ in 0..<5 {
                 try? await Task.sleep(nanoseconds: 500_000_000)
-                if trySelect() { return }
+                if trySelect() {
+                    try? self.daemonClient.sendNotificationConversationViewed(
+                        conversationId: conversationId,
+                        source: "macos_conversation_opened",
+                        occurredAt: Int(Date().timeIntervalSince1970 * 1000)
+                    )
+                    return
+                }
             }
             log.warning("Could not find thread for conversation \(conversationId) after retries")
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -389,17 +389,6 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         // Switching threads is a natural point to shed cached render
         // artefacts from the previous conversation.
         Self.clearRenderCaches()
-
-        // Report explicit conversation view for notification threads.
-        // selectThread is only called from user-initiated actions (sidebar
-        // click, search result), never during restore-time synthetic selections.
-        if let sessionId = thread.sessionId {
-            try? daemonClient.sendNotificationConversationViewed(
-                conversationId: sessionId,
-                source: "macos_conversation_opened",
-                occurredAt: Int(Date().timeIntervalSince1970 * 1000)
-            )
-        }
     }
 
     // MARK: - Render Cache Management

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -389,6 +389,17 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         // Switching threads is a natural point to shed cached render
         // artefacts from the previous conversation.
         Self.clearRenderCaches()
+
+        // Report explicit conversation view for notification threads.
+        // selectThread is only called from user-initiated actions (sidebar
+        // click, search result), never during restore-time synthetic selections.
+        if let sessionId = thread.sessionId {
+            try? daemonClient.sendNotificationConversationViewed(
+                conversationId: sessionId,
+                source: "macos_conversation_opened",
+                occurredAt: Int(Date().timeIntervalSince1970 * 1000)
+            )
+        }
     }
 
     // MARK: - Render Cache Management

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1462,4 +1462,42 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(ApprovedDevicesClearMessage())
     }
 
+    // MARK: - Notification Interactions
+
+    /// Report a direct delivery interaction (view, dismiss, etc).
+    public func sendNotificationDeliveryInteraction(
+        deliveryId: String,
+        interactionType: String,
+        confidence: String,
+        source: String,
+        evidenceText: String? = nil,
+        occurredAt: Int? = nil
+    ) throws {
+        try send(IPCNotificationDeliveryInteraction(
+            type: "notification_delivery_interaction",
+            deliveryId: deliveryId,
+            interactionType: interactionType,
+            confidence: confidence,
+            source: source,
+            evidenceText: evidenceText,
+            occurredAt: occurredAt
+        ))
+    }
+
+    /// Report that a notification conversation was explicitly opened.
+    public func sendNotificationConversationViewed(
+        conversationId: String,
+        source: String,
+        evidenceText: String? = nil,
+        occurredAt: Int? = nil
+    ) throws {
+        try send(IPCNotificationConversationViewed(
+            type: "notification_conversation_viewed",
+            conversationId: conversationId,
+            source: source,
+            evidenceText: evidenceText,
+            occurredAt: occurredAt
+        ))
+    }
+
 }

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -2780,6 +2780,44 @@ public struct IPCModelSetRequest: Codable, Sendable {
     }
 }
 
+/// Client reports explicit conversation view (sidebar selection or deep-link).
+public struct IPCNotificationConversationViewed: Codable, Sendable {
+    public let type: String
+    public let conversationId: String
+    public let source: String
+    public let evidenceText: String?
+    public let occurredAt: Int?
+
+    public init(type: String, conversationId: String, source: String, evidenceText: String? = nil, occurredAt: Int? = nil) {
+        self.type = type
+        self.conversationId = conversationId
+        self.source = source
+        self.evidenceText = evidenceText
+        self.occurredAt = occurredAt
+    }
+}
+
+/// Client reports a direct delivery interaction (view, dismiss, etc).
+public struct IPCNotificationDeliveryInteraction: Codable, Sendable {
+    public let type: String
+    public let deliveryId: String
+    public let interactionType: String
+    public let confidence: String
+    public let source: String
+    public let evidenceText: String?
+    public let occurredAt: Int?
+
+    public init(type: String, deliveryId: String, interactionType: String, confidence: String, source: String, evidenceText: String? = nil, occurredAt: Int? = nil) {
+        self.type = type
+        self.deliveryId = deliveryId
+        self.interactionType = interactionType
+        self.confidence = confidence
+        self.source = source
+        self.evidenceText = evidenceText
+        self.occurredAt = occurredAt
+    }
+}
+
 /// Broadcast to connected macOS clients when a notification should be displayed.
 public struct IPCNotificationIntent: Codable, Sendable {
     public let type: String


### PR DESCRIPTION
Part of #9305. Adds IPC messages for notification_delivery_interaction and notification_conversation_viewed, daemon handlers to persist interactions via the M1 store, macOS notification response handler for View/Dismiss actions, and conversation-open tracking in ThreadManager. Includes deliveryId in notification userInfo and customDismissAction for NOTIFICATION_INTENT category.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
