### PR TITLE
fix(macos): fix build errors from cross-module access and invalid Animation member

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -147,7 +147,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private var onboardingWindow: OnboardingWindow?
     private var authWindow: NSWindow?
     var authManager: AuthManager { services.authManager }
-    var mainWindow: MainWindow?
+    public var mainWindow: MainWindow?
     var bundleConfirmationWindow: BundleConfirmationWindow?
     private var tasksWindow: TasksWindow?
     private var pairingApprovalWindow: PairingApprovalWindow?

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -129,13 +129,13 @@ private class NonDraggableContainerView: NSView {
 }
 
 @MainActor
-final class MainWindow {
+public final class MainWindow {
     private let services: AppServices
     private var window: NSWindow?
     let threadManager: ThreadManager
     let appListManager = AppListManager()
     let traceStore = TraceStore()
-    let windowState = MainWindowState()
+    public let windowState = MainWindowState()
     let documentManager = DocumentManager()
     let avatarEvolutionState: AvatarEvolutionState?
     var onMicrophoneToggle: (() -> Void)?

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -12,7 +12,7 @@ enum ViewSelection: Equatable {
 /// Cross-view UI state for the main window, extracted from `MainWindowView`
 /// to make it explicit, injectable, and easier to preview.
 @MainActor
-final class MainWindowState: ObservableObject {
+public final class MainWindowState: ObservableObject {
     @AppStorage("lastActivePanel") private var lastActivePanelString: String?
     @AppStorage("homeBaseDashboardDefaultEnabled") private var homeBaseDashboardDefaultEnabled: Bool = false
     @AppStorage("chatDockOpen") private var chatDockOpen = false
@@ -87,7 +87,7 @@ final class MainWindowState: ObservableObject {
     /// a live conversation alongside the panel).
     /// Used by zoom intent routing to decide whether Cmd+/- should
     /// target conversation text zoom or fall through to window zoom.
-    var isConversationVisible: Bool {
+    public var isConversationVisible: Bool {
         switch selection {
         case .thread, .none, .appEditing: return true
         case .panel(let panelType):

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -1862,7 +1862,7 @@ struct SettingsConnectTab: View {
                         .font(.system(size: 11, weight: .medium))
                         .foregroundColor(spinning ? VColor.accent : VColor.textMuted)
                         .rotationEffect(.degrees(spinning ? 360 : 0))
-                        .animation(spinning ? .linear(duration: 1).repeatForever(autoreverses: false) : .identity, value: spinning)
+                        .animation(spinning ? .linear(duration: 1).repeatForever(autoreverses: false) : .default, value: spinning)
                         .frame(width: 24, height: 24)
                         .contentShape(Rectangle())
                 }


### PR DESCRIPTION
## Summary

Fixes two pre-existing build errors on the macOS client:

1. **Cross-module access control**: `MainWindow`, `MainWindowState`, `mainWindow`, `windowState`, and `isConversationVisible` need `public` access since they're accessed from the `vellum-assistant-app` executable target (which imports `VellumAssistantLib`).

2. **Invalid Animation member**: `.identity` is not a valid member of `Animation`. Changed to `.default` in the Connect tab's refresh button spinner.

## Files Changed

- `AppDelegate.swift` — `var mainWindow` → `public var mainWindow`
- `MainWindow.swift` — `final class MainWindow` → `public final class MainWindow`, `let windowState` → `public let windowState`
- `MainWindowState.swift` — `final class MainWindowState` → `public final class MainWindowState`, `var isConversationVisible` → `public var isConversationVisible`
- `SettingsConnectTab.swift` — `.identity` → `.default` animation value

## Testing

`./build.sh` passes successfully after these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
