### PR TITLE
M3: Telegram inferred seen signals from inbound activity

### DIFF
--- a/assistant/src/notifications/README.md
+++ b/assistant/src/notifications/README.md
@@ -348,11 +348,23 @@ Each interaction carries a `source` string identifying where it originated:
 - `telegram_callback_query` -- user clicked an inline button on a Telegram notification
 - `vellum_thread_opened` -- user opened the notification thread in the vellum interface
 
+### Telegram Inferred Seen Signals
+
+When non-duplicate Telegram inbound activity arrives (user message or callback query), the system infers that the user has "seen" the most recent unseen notification delivered to that chat. The inbound message handler (`runtime/routes/inbound-message-handler.ts`) resolves the latest eligible unseen telegram delivery for the (assistantId, externalChatId) pair and records an inferred interaction:
+
+- **Inbound message** -- interaction type `replied`, confidence `inferred`, source `telegram_inbound_message`
+- **Callback query** -- interaction type `callback_clicked`, confidence `inferred`, source `telegram_callback_query`
+
+The interaction record automatically sets `seen_at` on the delivery summary (first-write-wins). `viewed_at` is NOT set for Telegram inferred signals -- that column is reserved for explicit vellum view sources.
+
+Evidence text is a truncated snippet of the message content or callback data. UUID-only payloads are excluded from evidence to keep it human-readable.
+
 ### Store API (`interactions-store.ts`)
 
 - `recordNotificationDeliveryInteraction(params)` -- insert interaction + update summaries transactionally
 - `markDeliverySeen(params)` -- helper to record a 'viewed' interaction (first-write-wins for `seen_at`)
 - `markDeliveryViewed(params)` -- helper for explicit vellum view (sets `viewed_at`)
+- `findLatestUnseenTelegramDelivery(assistantId, destination)` -- find the most recent sent telegram delivery that has not been marked as seen
 - `getNotificationDeliverySummaries(filters)` -- query delivery summaries with filters
 
 Query examples:

--- a/assistant/src/notifications/interactions-store.ts
+++ b/assistant/src/notifications/interactions-store.ts
@@ -296,7 +296,7 @@ export function findLatestUnseenTelegramDelivery(
         isNull(notificationDeliveries.seenAt),
       ),
     )
-    .orderBy(desc(notificationDeliveries.createdAt))
+    .orderBy(desc(sql`COALESCE(${notificationDeliveries.sentAt}, ${notificationDeliveries.createdAt})`))
     .limit(1)
     .get();
 

--- a/assistant/src/notifications/interactions-store.ts
+++ b/assistant/src/notifications/interactions-store.ts
@@ -9,7 +9,7 @@
  * - last_interaction_*: always reflects the most recent interaction by occurred_at
  */
 
-import { and, desc, eq, isNotNull, sql } from 'drizzle-orm';
+import { and, desc, eq, isNotNull, isNull, sql } from 'drizzle-orm';
 
 import { getDb } from '../memory/db.js';
 import { notificationDeliveries, notificationDeliveryInteractions } from '../memory/schema.js';
@@ -260,4 +260,45 @@ export function getNotificationDeliverySummaries(
     .all();
 
   return rows;
+}
+
+// -- Telegram inferred-seen helpers -------------------------------------------
+
+export interface UnseenTelegramDelivery {
+  id: string;
+  assistantId: string;
+  channel: string;
+}
+
+/**
+ * Find the most recent sent telegram delivery for (assistantId, destination)
+ * that has not yet been marked as seen. Returns undefined when there is no
+ * eligible delivery.
+ */
+export function findLatestUnseenTelegramDelivery(
+  assistantId: string,
+  destination: string,
+): UnseenTelegramDelivery | undefined {
+  const db = getDb();
+  const row = db
+    .select({
+      id: notificationDeliveries.id,
+      assistantId: notificationDeliveries.assistantId,
+      channel: notificationDeliveries.channel,
+    })
+    .from(notificationDeliveries)
+    .where(
+      and(
+        eq(notificationDeliveries.assistantId, assistantId),
+        eq(notificationDeliveries.channel, 'telegram'),
+        eq(notificationDeliveries.destination, destination),
+        eq(notificationDeliveries.status, 'sent'),
+        isNull(notificationDeliveries.seenAt),
+      ),
+    )
+    .orderBy(desc(notificationDeliveries.createdAt))
+    .limit(1)
+    .get();
+
+  return row ?? undefined;
 }

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -837,6 +837,27 @@ export async function handleChannelInbound(
       approvalConversationGenerator,
     });
 
+    // ── Telegram inferred seen for callback early returns ──
+    // Callback queries always return early from this approval interception
+    // block (either handled or stale_ignored), so inferTelegramSeen must
+    // run here before those returns. Callback data is system-generated
+    // (e.g. "apr:<requestId>:<action>"), not user-typed, so secret ingress
+    // concerns do not apply — safe to record as evidenceText without the
+    // secret gate that protects the normal message path below.
+    if (sourceChannel === 'telegram' && hasCallbackData) {
+      try {
+        inferTelegramSeen({
+          assistantId: canonicalAssistantId,
+          externalChatId,
+          hasCallbackData,
+          callbackData: body.callbackData,
+          content: trimmedContent,
+        });
+      } catch (err) {
+        log.warn({ err, externalChatId }, 'Failed to record inferred telegram seen signal (callback)');
+      }
+    }
+
     if (approvalResult.handled) {
       return Response.json({
         accepted: true,

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -21,6 +21,10 @@ import {
 } from '../../memory/guardian-action-store.js';
 import { findMember, updateLastSeen, upsertMember } from '../../memory/ingress-member-store.js';
 import { emitNotificationSignal } from '../../notifications/emit-signal.js';
+import {
+  findLatestUnseenTelegramDelivery,
+  recordNotificationDeliveryInteraction,
+} from '../../notifications/interactions-store.js';
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
 import { getGatewayInternalBaseUrl } from '../../config/env.js';
 import { IngressBlockedError } from '../../util/errors.js';
@@ -423,6 +427,23 @@ export async function handleChannelInbound(
       displayName: body.senderName ?? null,
       username: body.senderUsername ?? null,
     });
+  }
+
+  // ── Telegram inferred seen ──
+  // Any non-duplicate telegram inbound activity (message or callback) implies
+  // the user has seen previously delivered notifications in this chat.
+  if (!result.duplicate && sourceChannel === 'telegram') {
+    try {
+      inferTelegramSeen({
+        assistantId: canonicalAssistantId,
+        externalChatId,
+        hasCallbackData,
+        callbackData: body.callbackData,
+        content: trimmedContent,
+      });
+    } catch (err) {
+      log.warn({ err, externalChatId }, 'Failed to record inferred telegram seen signal');
+    }
   }
 
   // ── Ingress escalation ──
@@ -1124,4 +1145,69 @@ function deliverBootstrapVerificationTelegram(
       }
     }, 3000);
   })();
+}
+
+// ---------------------------------------------------------------------------
+// Telegram inferred-seen signal
+// ---------------------------------------------------------------------------
+
+/** Truncate a string to a reasonable evidence snippet length. */
+function truncateEvidence(text: string, maxLen: number = 120): string {
+  if (text.length <= maxLen) return text;
+  return text.slice(0, maxLen - 1) + '\u2026';
+}
+
+/**
+ * Returns true if the text looks like a bare UUID or structured ID payload
+ * that carries no meaningful evidence value for a human reader.
+ */
+function isUuidOnlyPayload(text: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(text.trim());
+}
+
+interface InferTelegramSeenParams {
+  assistantId: string;
+  externalChatId: string;
+  hasCallbackData: boolean;
+  callbackData?: string;
+  content: string;
+}
+
+/**
+ * When Telegram inbound activity arrives, infer that the user has "seen"
+ * the most recent unseen notification delivered to this chat. Records an
+ * inferred interaction (replied or callback_clicked) and sets seen_at
+ * via markDeliverySeen if not already set.
+ */
+function inferTelegramSeen(params: InferTelegramSeenParams): void {
+  const { assistantId, externalChatId, hasCallbackData, callbackData, content } = params;
+
+  const delivery = findLatestUnseenTelegramDelivery(assistantId, externalChatId);
+  if (!delivery) return;
+
+  const now = Date.now();
+  const isCallback = hasCallbackData && typeof callbackData === 'string' && callbackData.length > 0;
+
+  const interactionType = isCallback ? 'callback_clicked' as const : 'replied' as const;
+  const source = isCallback ? 'telegram_callback_query' as const : 'telegram_inbound_message' as const;
+
+  // Build a concise evidence snippet, skipping UUID-only payloads
+  const rawEvidence = isCallback ? callbackData! : content;
+  const evidenceText = rawEvidence.length > 0 && !isUuidOnlyPayload(rawEvidence)
+    ? truncateEvidence(rawEvidence)
+    : undefined;
+
+  // Record the interaction. recordNotificationDeliveryInteraction also sets
+  // seen_at on first write, so no separate markDeliverySeen call is needed.
+  recordNotificationDeliveryInteraction({
+    id: crypto.randomUUID(),
+    notificationDeliveryId: delivery.id,
+    assistantId: delivery.assistantId,
+    channel: delivery.channel,
+    interactionType,
+    confidence: 'inferred',
+    source,
+    evidenceText,
+    occurredAt: now,
+  });
 }

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -429,23 +429,6 @@ export async function handleChannelInbound(
     });
   }
 
-  // ── Telegram inferred seen ──
-  // Any non-duplicate telegram inbound activity (message or callback) implies
-  // the user has seen previously delivered notifications in this chat.
-  if (!result.duplicate && sourceChannel === 'telegram') {
-    try {
-      inferTelegramSeen({
-        assistantId: canonicalAssistantId,
-        externalChatId,
-        hasCallbackData,
-        callbackData: body.callbackData,
-        content: trimmedContent,
-      });
-    } catch (err) {
-      log.warn({ err, externalChatId }, 'Failed to record inferred telegram seen signal');
-    }
-  }
-
   // ── Ingress escalation ──
   // When the member's policy is 'escalate', create a pending guardian
   // approval request and halt the run. This check runs after recordInbound
@@ -906,6 +889,25 @@ export async function handleChannelInbound(
     if (ingressCheck.blocked) {
       channelDeliveryStore.clearPayload(result.eventId);
       throw new IngressBlockedError(ingressCheck.userNotice!, ingressCheck.detectedTypes);
+    }
+
+    // ── Telegram inferred seen ──
+    // Any non-duplicate telegram inbound activity (message or callback) implies
+    // the user has seen previously delivered notifications in this chat.
+    // Runs after secret ingress validation so rejected messages don't persist
+    // secret-bearing content as evidenceText in notification_delivery_interactions.
+    if (sourceChannel === 'telegram') {
+      try {
+        inferTelegramSeen({
+          assistantId: canonicalAssistantId,
+          externalChatId,
+          hasCallbackData,
+          callbackData: body.callbackData,
+          content: trimmedContent,
+        });
+      } catch (err) {
+        log.warn({ err, externalChatId }, 'Failed to record inferred telegram seen signal');
+      }
     }
 
     // Fire-and-forget: process the message and deliver the reply in the background.


### PR DESCRIPTION
On Telegram inbound message or callback query, resolve the latest eligible unseen delivery for the (assistantId, externalChatId) pair and record an inferred interaction (replied/callback_clicked). Sets seen_at if not already set. Attaches evidence_text snippet. Part of #9305.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
