### PR TITLE
feat: 6-digit codes for all channels, update verification copy

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -389,7 +389,7 @@ describe('guardian service challenge validation', () => {
 
     expect(result.challengeId).toBeDefined();
     expect(result.secret).toBeDefined();
-    expect(result.secret.length).toBe(64); // 32 bytes hex-encoded
+    expect(result.secret.length).toBe(6); // 6-digit numeric code
     expect(result.verifyCommand).toBe(result.secret);
     expect(result.ttlSeconds).toBe(600);
     expect(result.instruction).toBeDefined();
@@ -1556,11 +1556,11 @@ describe('voice guardian challenge generation', () => {
     expect(result.secret.length).toBe(6);
   });
 
-  test('createVerificationChallenge for non-voice returns 64-char hex secret', () => {
+  test('createVerificationChallenge for non-voice returns 6-digit numeric secret', () => {
     const result = createVerificationChallenge('asst-1', 'telegram');
 
-    expect(result.secret.length).toBe(64);
-    expect(result.secret).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.secret.length).toBe(6);
+    expect(result.secret).toMatch(/^\d{6}$/);
   });
 
   test('voice challenge verifyCommand contains the six-digit secret', () => {
@@ -2867,12 +2867,12 @@ describe('outbound SMS verification', () => {
     expect(lastSms.to).toBe('+15551234567');
   });
 
-  test('template composer includes assistantName when provided', () => {
+  test('template composer includes Vellum assistant prefix', () => {
     const sms = composeVerificationSms(
       GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST,
       { code: '999999', expiresInMinutes: 10, assistantName: 'MyBot' },
     );
-    expect(sms).toContain('[MyBot]');
+    expect(sms).toContain('Vellum assistant');
     // Code should NOT appear in the message
     expect(sms).not.toContain('999999');
   });
@@ -3291,12 +3291,12 @@ describe('outbound Telegram verification', () => {
     expect(msg).toContain('(resent)');
   });
 
-  test('telegram template includes assistantName when provided', () => {
+  test('telegram template includes Vellum assistant prefix', () => {
     const msg = composeVerificationTelegram(
       GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST,
       { code: '999999', expiresInMinutes: 10, assistantName: 'MyBot' },
     );
-    expect(msg).toContain('[MyBot]');
+    expect(msg).toContain('Vellum assistant');
     // Code should NOT appear in the message
     expect(msg).not.toContain('999999');
   });

--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -78,12 +78,12 @@ function hashSecret(secret: string): string {
 // ---------------------------------------------------------------------------
 
 /**
- * Generate a numeric secret for voice channel challenges.
+ * Generate a 6-digit numeric secret for verification challenges.
  * Uses cryptographic randomness to pick a number with the specified
  * number of digits (defaults to 6). The result is always zero-padded
  * to exactly `digits` characters.
  */
-function generateVoiceSecret(digits: number = 6): string {
+function generateNumericSecret(digits: number = 6): string {
   const buf = randomBytes(4);
   const num = buf.readUInt32BE(0);
   const max = 10 ** digits;
@@ -93,8 +93,7 @@ function generateVoiceSecret(digits: number = 6): string {
 /**
  * Create a new verification challenge for a guardian candidate.
  *
- * For voice channels, generates a six-digit numeric secret that can be
- * spoken aloud. For all other channels, generates a 32-byte hex secret.
+ * Generates a six-digit numeric secret for all channels.
  *
  * Hashes the secret (SHA-256) and stores the challenge record with a
  * 10-minute TTL. The raw secret is returned so it can be displayed to
@@ -105,7 +104,7 @@ export function createVerificationChallenge(
   channel: string,
   sessionId?: string,
 ): CreateChallengeResult {
-  const secret = channel === 'voice' ? generateVoiceSecret() : randomBytes(32).toString('hex');
+  const secret = generateNumericSecret();
   const challengeHash = hashSecret(secret);
   const challengeId = uuid();
   const expiresAt = Date.now() + CHALLENGE_TTL_MS;
@@ -395,7 +394,7 @@ export function createOutboundSession(params: {
   const isUnbound = params.identityBindingStatus === 'pending_bootstrap';
   const secret = isUnbound
     ? randomBytes(32).toString('hex')
-    : generateVoiceSecret(params.codeDigits ?? 6);
+    : generateNumericSecret(params.codeDigits ?? 6);
   const challengeHash = hashSecret(secret);
   const sessionId = params.sessionId ?? uuid();
   const expiresAt = Date.now() + CHALLENGE_TTL_MS;

--- a/assistant/src/runtime/guardian-verification-templates.ts
+++ b/assistant/src/runtime/guardian-verification-templates.ts
@@ -79,29 +79,24 @@ export interface ChannelVerifyReplyVars {
 // ---------------------------------------------------------------------------
 
 const templates: Record<TextVerifyTemplateKey, (vars: GuardianVerifyTemplateVars) => string> = {
-  [GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST]: (vars) => {
-    const prefix = vars.assistantName ? `[${vars.assistantName}] ` : '';
-    return `${prefix}Guardian verification requested. Reply with the code you were given.`;
+  [GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST]: (_vars) => {
+    return 'Vellum assistant guardian verification requested. Reply with the 6-digit code you were given.';
   },
 
-  [GUARDIAN_VERIFY_TEMPLATE_KEYS.RESEND]: (vars) => {
-    const prefix = vars.assistantName ? `[${vars.assistantName}] ` : '';
-    return `${prefix}Guardian verification requested. Reply with the code you were given. (resent)`;
+  [GUARDIAN_VERIFY_TEMPLATE_KEYS.RESEND]: (_vars) => {
+    return 'Vellum assistant guardian verification requested. Reply with the 6-digit code you were given. (resent)';
   },
 
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.ALREADY_VERIFIED]: (_vars) => {
-    const prefix = _vars.assistantName ? `[${_vars.assistantName}] ` : '';
-    return `${prefix}This channel is already verified. No further action is needed.`;
+    return 'This channel is already verified. No further action is needed.';
   },
 
-  [GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST]: (vars) => {
-    const prefix = vars.assistantName ? `[${vars.assistantName}] ` : '';
-    return `${prefix}Guardian verification requested. Reply with the code you were given.`;
+  [GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST]: (_vars) => {
+    return 'Vellum assistant guardian verification requested. Reply with the 6-digit code you were given.';
   },
 
-  [GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_RESEND]: (vars) => {
-    const prefix = vars.assistantName ? `[${vars.assistantName}] ` : '';
-    return `${prefix}Guardian verification requested. Reply with the code you were given. (resent)`;
+  [GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_RESEND]: (_vars) => {
+    return 'Vellum assistant guardian verification requested. Reply with the 6-digit code you were given. (resent)';
   },
 };
 
@@ -141,7 +136,7 @@ type VoiceTemplateKey =
 
 const voiceTemplates: Record<VoiceTemplateKey, (vars: GuardianVerifyVoiceTemplateVars) => string> = {
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_CALL_INTRO]: (vars) =>
-    `You are receiving a verification call. Please enter your ${vars.codeDigits}-digit verification code using your keypad.`,
+    `You are receiving a guardian verification call for your Vellum assistant. Please enter your ${vars.codeDigits}-digit verification code using your keypad.`,
 
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_RETRY]: (_vars) =>
     'That code was incorrect. Please try again.',

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -71,7 +71,7 @@ const log = getLogger('runtime-http');
  * Accepts three formats:
  *   1. `/guardian_verify <code>` (legacy command format)
  *   2. `/guardian_verify@BotName <code>` (Telegram group format)
- *   3. A bare code (hex string or 6-digit numeric) as the entire message
+ *   3. A bare 6-digit numeric code as the entire message
  * Returns the verification code if recognized, or undefined otherwise.
  */
 function parseGuardianVerifyCommand(content: string): string | undefined {
@@ -79,9 +79,9 @@ function parseGuardianVerifyCommand(content: string): string | undefined {
   const commandMatch = content.match(/^\/guardian_verify(?:@\S+)?\s+(\S+)/);
   if (commandMatch) return commandMatch[1];
 
-  // Bare code: 64-char hex (standard channels) or 6-digit numeric (voice)
-  const bareMatch = content.match(/^([0-9a-fA-F]{64}|\d{6})$/);
-  return bareMatch?.[1];
+  // Bare 6-digit numeric code
+  const bareMatch = content.match(/^\d{6}$/);
+  return bareMatch?.[0];
 }
 
 export async function handleChannelInbound(


### PR DESCRIPTION
## Summary
- All channels now generate 6-digit numeric verification codes (SMS/Telegram previously used 64-char hex)
- Updated SMS/Telegram message to: "Vellum assistant guardian verification requested. Reply with the 6-digit code you were given."
- Updated voice call intro to: "You are receiving a guardian verification call for your Vellum assistant. Please enter your 6-digit verification code using your keypad."
- Simplified bare code parser to match 6-digit numeric only

## Test plan
- [x] All 175 channel-guardian tests pass
- [x] SMS/Telegram challenge secrets are 6-digit numeric
- [x] Voice challenge secrets remain 6-digit numeric
- [x] Bare code parser accepts 6-digit codes from all channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
