### PR TITLE
docs: update skills and architecture for 6-digit verification codes

### DIFF
--- a/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
@@ -73,7 +73,7 @@ Now link the user's Telegram account as the trusted guardian for this bot. Tell 
 }
 ```
 
-2. The daemon returns a `guardian_verification_response` with `success: true`, `secret`, and `instruction`. Display the `secret` code to the user. Tell them: "You'll receive a message from your Telegram bot asking for a verification code. Reply to that message with the code shown here."
+2. The daemon returns a `guardian_verification_response` with `success: true`, `secret`, and `instruction`. Display the 6-digit `secret` code to the user. Tell them: "You'll receive a message from your Telegram bot asking for a verification code. Reply to that message with this 6-digit code."
 
 3. Wait for the user to confirm they have replied with the code. The verification happens automatically when the bot receives the code — the channel inbound handler validates it and creates the guardian binding.
 

--- a/assistant/src/config/vellum-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/twilio-setup/SKILL.md
@@ -214,7 +214,7 @@ Now link the user's phone number as the trusted SMS guardian for this assistant.
 }
 ```
 
-2. The daemon returns a `guardian_verification_response` with `success: true`, `secret`, and `instruction`. Display the `secret` code to the user. Tell them: "You'll receive an SMS asking for a verification code. Reply to that SMS with the code shown here."
+2. The daemon returns a `guardian_verification_response` with `success: true`, `secret`, and `instruction`. Display the 6-digit `secret` code to the user. Tell them: "You'll receive an SMS asking for a verification code. Reply to that SMS with this 6-digit code."
 
 3. Wait for the user to confirm they have replied with the verification code via SMS to the assistant's phone number.
 

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -176,7 +176,7 @@ All channel ingress paths canonicalize the `assistantId` via `normalizeAssistant
 
 The inbound message handler (`inbound-message-handler.ts`) accepts verification codes in two formats:
 
-- **Bare code**: A 64-character hex string (SMS/Telegram) or 6-digit numeric code (voice) sent as the entire message body. This is the primary flow — the user receives a channel message asking them to reply with the code they were given, and simply replies with the code.
+- **Bare code**: A 6-digit numeric code sent as the entire message body. This is the primary flow — the user receives a channel message asking them to reply with the code they were given, and simply replies with the code.
 - **Legacy command**: `/guardian_verify <code>` (or `/guardian_verify@BotName <code>` for Telegram group chats). This format is still accepted for backward compatibility but is no longer the recommended flow.
 
 #### Explicit Rebind Policy

--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -72,7 +72,7 @@ curl -sf -X POST http://localhost:7821/v1/integrations/guardian/challenge \
   -d '{"channel":"telegram"}'
 ```
 
-2. The response includes `secret` and `instruction`. Display the `secret` code to the user. Tell them: "You'll receive a message from your Telegram bot asking for a verification code. Reply to that message with the code shown here."
+2. The response includes a 6-digit `secret` code and `instruction`. Display the 6-digit code to the user. Tell them: "You'll receive a message from your Telegram bot asking for a verification code. Reply to that message with this 6-digit code."
 
 3. Wait for the user to confirm they have replied with the code. The verification happens automatically when the bot receives the code — the channel inbound handler validates it and creates the guardian binding.
 


### PR DESCRIPTION
## Summary
- Update gateway ARCHITECTURE.md to reflect all channels use 6-digit numeric codes (was "64-char hex or 6-digit")
- Update telegram-setup and twilio-setup skills to mention 6-digit code in verification instructions

## Test plan
- Documentation-only changes, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
