### PR TITLE
docs: make guardian verification copy match create_challenge behavior

### DIFF
--- a/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
@@ -73,7 +73,7 @@ Now link the user's Telegram account as the trusted guardian for this bot. Tell 
 }
 ```
 
-2. The daemon returns a `guardian_verification_response` with `success: true`, `secret`, and `instruction`. Display the 6-digit `secret` code to the user. Tell them: "You'll receive a message from your Telegram bot asking for a verification code. Reply to that message with this 6-digit code."
+2. The daemon returns a `guardian_verification_response` with `success: true`, `secret`, and `instruction`. Display the 6-digit `secret` code to the user. Tell them: "Open your chat with the Telegram bot and send this 6-digit code as a message."
 
 3. Wait for the user to confirm they have replied with the code. The verification happens automatically when the bot receives the code — the channel inbound handler validates it and creates the guardian binding.
 

--- a/assistant/src/config/vellum-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/twilio-setup/SKILL.md
@@ -214,7 +214,7 @@ Now link the user's phone number as the trusted SMS guardian for this assistant.
 }
 ```
 
-2. The daemon returns a `guardian_verification_response` with `success: true`, `secret`, and `instruction`. Display the 6-digit `secret` code to the user. Tell them: "You'll receive an SMS asking for a verification code. Reply to that SMS with this 6-digit code."
+2. The daemon returns a `guardian_verification_response` with `success: true`, `secret`, and `instruction`. Display the 6-digit `secret` code to the user. Tell them: "Send this 6-digit code by SMS to your assistant's phone number."
 
 3. Wait for the user to confirm they have replied with the verification code via SMS to the assistant's phone number.
 

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -176,7 +176,7 @@ All channel ingress paths canonicalize the `assistantId` via `normalizeAssistant
 
 The inbound message handler (`inbound-message-handler.ts`) accepts verification codes in two formats:
 
-- **Bare code**: A 6-digit numeric code sent as the entire message body. This is the primary flow — the user receives a channel message asking them to reply with the code they were given, and simply replies with the code.
+- **Bare code**: A 6-digit numeric code sent as the entire message body. This is the primary flow — the user is shown a verification code in setup UI and sends that code in-channel as a plain message.
 - **Legacy command**: `/guardian_verify <code>` (or `/guardian_verify@BotName <code>` for Telegram group chats). This format is still accepted for backward compatibility but is no longer the recommended flow.
 
 #### Explicit Rebind Policy
@@ -216,7 +216,7 @@ sequenceDiagram
     GW->>TG: sendMessage: "You are now the guardian"
 ```
 
-The raw secret is shown only once in the desktop UI and delivered to the channel in an outbound message prompting the user to reply with it. Only the SHA-256 hash is persisted. Challenges expire after 10 minutes. Consumed challenges cannot be reused. Rate limiting (5 invalid attempts per 15-minute window, 30-minute lockout) protects against brute-force attacks.
+The raw secret is shown only once in the desktop UI and must be sent by the user in-channel to complete verification. (Outbound `start_outbound` verification flows separately send template messages/calls with the code.) Only the SHA-256 hash is persisted. Challenges expire after 10 minutes. Consumed challenges cannot be reused. Rate limiting (5 invalid attempts per 15-minute window, 30-minute lockout) protects against brute-force attacks.
 
 #### Inbound Message Decision Chain
 

--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -72,7 +72,7 @@ curl -sf -X POST http://localhost:7821/v1/integrations/guardian/challenge \
   -d '{"channel":"telegram"}'
 ```
 
-2. The response includes a 6-digit `secret` code and `instruction`. Display the 6-digit code to the user. Tell them: "You'll receive a message from your Telegram bot asking for a verification code. Reply to that message with this 6-digit code."
+2. The response includes a 6-digit `secret` code and `instruction`. Display the 6-digit code to the user. Tell them: "Open your chat with the Telegram bot and send this 6-digit code as a message."
 
 3. Wait for the user to confirm they have replied with the code. The verification happens automatically when the bot receives the code — the channel inbound handler validates it and creates the guardian binding.
 


### PR DESCRIPTION
## Summary
- update guardian verification setup copy to describe the actual `create_challenge` flow
- remove wording that implied Telegram/SMS prompt delivery happens automatically for `create_challenge`
- keep the 6-digit code guidance and clarify that outbound `start_outbound` is the flow that sends channel prompts

## Why
The current docs/skills correctly describe 6-digit codes, but still imply automatic outbound prompt delivery in places where the implementation only returns `secret` + `instruction` and expects the user to send the code in-channel.
