### PR TITLE
feat: install CLI symlink during desktop hatch and add --version flag

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "crypto";
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from "fs";
+import { existsSync, lstatSync, mkdirSync, readFileSync, readlinkSync, symlinkSync, unlinkSync, writeFileSync } from "fs";
 import { homedir, tmpdir, userInfo } from "os";
 import { join } from "path";
 
@@ -535,6 +535,39 @@ async function hatchCustom(
   }
 }
 
+function installCLISymlink(): void {
+  const cliBinary = process.execPath;
+  if (!cliBinary || !existsSync(cliBinary)) return;
+
+  const symlinkPath = "/usr/local/bin/vellum";
+
+  try {
+    // If path exists, check whether it's our symlink or something else
+    if (existsSync(symlinkPath)) {
+      const stats = lstatSync(symlinkPath);
+      if (!stats.isSymbolicLink()) {
+        // Real file — don't overwrite (developer's local install)
+        return;
+      }
+      // Already a symlink — skip if it already points to our binary
+      const dest = readlinkSync(symlinkPath);
+      if (dest === cliBinary) return;
+      // Stale symlink — remove before creating new one
+      unlinkSync(symlinkPath);
+    }
+
+    const dir = "/usr/local/bin";
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    symlinkSync(cliBinary, symlinkPath);
+    console.log(`   Symlinked ${symlinkPath} → ${cliBinary}`);
+  } catch {
+    // Permission denied or other error — not critical
+    console.log(`   ⚠ Could not create symlink at ${symlinkPath} (run with sudo or create manually)`);
+  }
+}
+
 async function hatchLocal(species: Species, name: string | null, daemonOnly: boolean = false): Promise<void> {
   const instanceName =
     name ?? process.env.VELLUM_ASSISTANT_NAME ?? `${species}-${generateRandomSuffix()}`;
@@ -601,6 +634,10 @@ async function hatchLocal(species: Species, name: string | null, daemonOnly: boo
   };
   if (!daemonOnly) {
     saveAssistantEntry(localEntry);
+
+    if (process.env.VELLUM_DESKTOP_APP) {
+      installCLISymlink();
+    }
 
     console.log("");
     console.log(`✅ Local assistant hatched!`);

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -542,8 +542,9 @@ function installCLISymlink(): void {
   const symlinkPath = "/usr/local/bin/vellum";
 
   try {
-    // If path exists, check whether it's our symlink or something else
-    if (existsSync(symlinkPath)) {
+    // Use lstatSync (not existsSync) to detect dangling symlinks —
+    // existsSync follows symlinks and returns false for broken links.
+    try {
       const stats = lstatSync(symlinkPath);
       if (!stats.isSymbolicLink()) {
         // Real file — don't overwrite (developer's local install)
@@ -552,8 +553,11 @@ function installCLISymlink(): void {
       // Already a symlink — skip if it already points to our binary
       const dest = readlinkSync(symlinkPath);
       if (dest === cliBinary) return;
-      // Stale symlink — remove before creating new one
+      // Stale or dangling symlink — remove before creating new one
       unlinkSync(symlinkPath);
+    } catch (e: any) {
+      if (e?.code !== "ENOENT") throw e;
+      // Path doesn't exist — proceed to create symlink
     }
 
     const dir = "/usr/local/bin";

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -5,6 +5,8 @@ import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
+
+import cliPkg from "../package.json";
 import { autonomy } from "./commands/autonomy";
 import { client } from "./commands/client";
 import { config } from "./commands/config";
@@ -70,6 +72,11 @@ function resolveAssistantEntry(): string | undefined {
 async function main() {
   const args = process.argv.slice(2);
   const commandName = args[0];
+
+  if (commandName === "--version" || commandName === "-v") {
+    console.log(`@vellumai/cli v${cliPkg.version}`);
+    process.exit(0);
+  }
 
   if (!commandName || commandName === "--help" || commandName === "-h") {
     console.log("Usage: vellum <command> [options]");


### PR DESCRIPTION
## Summary
- Installs `/usr/local/bin/vellum` symlink during `hatchLocal()` when `VELLUM_DESKTOP_APP` is set, using `process.execPath` to resolve the running CLI binary
- Works for both dev mode (DerivedData builds) and production (`/Applications`) — complements `AppDelegate.installCLISymlinkIfNeeded()` which skips dev mode
- Respects existing non-symlink binaries (developer's local `bun`/`npm` installs)
- Updates stale symlinks pointing to old binary paths
- Adds `--version` / `-v` flag to the CLI entry point (`vellum --version` → `@vellumai/cli v0.3.11`)

## Test plan
- [x] All 35 CLI tests pass
- [ ] Hatch from desktop app in dev mode → `which vellum` resolves to DerivedData `vellum-cli`
- [ ] Hatch from production desktop app → `which vellum` resolves to `/Applications/Vellum.app/Contents/MacOS/vellum-cli`
- [ ] `vellum --version` prints version
- [ ] Existing real file at `/usr/local/bin/vellum` is not overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
