### PR TITLE
feat: write full default config on first startup, sync platform URL to lockfile

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync, statSync,writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
 
 import { deleteSecureKey,getSecureKey, setSecureKey } from '../security/secure-keys.js';
 import { ConfigError } from '../util/errors.js';
@@ -113,6 +114,7 @@ export function loadConfig(): AssistantConfig {
     const configPath = getConfigPath();
 
     let fileConfig: Record<string, unknown> = {};
+    let configFileExisted = true;
     if (existsSync(configPath)) {
       const mode = statSync(configPath).mode;
       if (mode & 0o077) {
@@ -127,6 +129,8 @@ export function loadConfig(): AssistantConfig {
       } catch (err) {
         throw new ConfigError(`Failed to parse config at ${configPath}: ${err}`);
       }
+    } else {
+      configFileExisted = false;
     }
 
     // Pre-validate apiKeys shape before migration (must be a plain object)
@@ -181,6 +185,23 @@ export function loadConfig(): AssistantConfig {
 
     // Validate and apply defaults via Zod schema
     const config = validateWithSchema(fileConfig);
+
+    // If the config file didn't exist, write the full defaults to disk so
+    // users can discover and edit all available options.
+    if (!configFileExisted) {
+      try {
+        const dir = dirname(configPath);
+        if (!existsSync(dir)) {
+          mkdirSync(dir, { recursive: true });
+        }
+        // Strip apiKeys (managed in secure storage) and dataDir (runtime-derived)
+        const { apiKeys: _, dataDir: _d, ...persistable } = config;
+        writeFileSync(configPath, JSON.stringify(persistable, null, 2) + '\n');
+        log.info('Wrote default config to %s', configPath);
+      } catch (err) {
+        log.warn({ err }, 'Failed to write default config file');
+      }
+    }
 
     // Set cached before secure-key/env overrides so re-entrant calls
     // return the in-flight config instead of bare defaults.

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -2,6 +2,8 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
+import { syncConfigToLockfile } from "../lib/assistant-config";
+
 interface AllowlistConfig {
   values?: string[];
   prefixes?: string[];
@@ -176,6 +178,7 @@ export function config(): void {
       }
       setNestedValue(raw, key, parsed);
       saveRawConfig(raw);
+      syncConfigToLockfile();
       console.log(`Set ${key} = ${JSON.stringify(parsed)}`);
       break;
     }

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -6,7 +6,7 @@ import { join } from "path";
 import cliPkg from "../../package.json";
 
 import { buildOpenclawStartupScript } from "../adapters/openclaw";
-import { loadAllAssistants, saveAssistantEntry } from "../lib/assistant-config";
+import { loadAllAssistants, saveAssistantEntry, syncConfigToLockfile } from "../lib/assistant-config";
 import type { AssistantEntry } from "../lib/assistant-config";
 import { hatchAws } from "../lib/aws";
 import {
@@ -536,6 +536,7 @@ async function hatchLocal(species: Species, name: string | null, daemonOnly: boo
   };
   if (!daemonOnly) {
     saveAssistantEntry(localEntry);
+    syncConfigToLockfile();
 
     if (process.env.VELLUM_DESKTOP_APP) {
       installCLISymlink();

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -20,6 +20,7 @@ export interface AssistantEntry {
 
 interface LockfileData {
   assistants?: AssistantEntry[];
+  platformBaseUrl?: string;
   [key: string]: unknown;
 }
 
@@ -101,4 +102,24 @@ export function saveAssistantEntry(entry: AssistantEntry): void {
   const entries = readAssistants();
   entries.unshift(entry);
   writeAssistants(entries);
+}
+
+/**
+ * Read the assistant config file and sync client-relevant values to the
+ * lockfile. This lets external tools (e.g. vel) discover the platform URL
+ * without importing the assistant config schema.
+ */
+export function syncConfigToLockfile(): void {
+  const configPath = join(getBaseDir(), ".vellum", "workspace", "config.json");
+  if (!existsSync(configPath)) return;
+
+  try {
+    const raw = JSON.parse(readFileSync(configPath, "utf-8")) as Record<string, unknown>;
+    const platform = raw.platform as Record<string, unknown> | undefined;
+    const data = readLockfile();
+    data.platformBaseUrl = (platform?.baseUrl as string) || undefined;
+    writeLockfile(data);
+  } catch {
+    // Config file unreadable — skip sync
+  }
 }


### PR DESCRIPTION
On first daemon startup, `loadConfig()` now writes the complete default config to `~/.vellum/workspace/config.json` so users can discover and edit all available config options without needing to know the schema. Also adds `platformBaseUrl` as a top-level field in the lockfile (`~/.vellum.lock.json`), so external tools like `vel` can discover the platform URL without importing the assistant config schema.

`syncConfigToLockfile()` is called from `vellum hatch` (local path) and `vellum config set` to keep the lockfile in sync.

### Lockfile structure
```json
{
  "assistants": [...],
  "platformBaseUrl": "https://dev-platform.vellum.ai"
}
```

## Review & Testing Checklist for Human
- [ ] Delete `~/.vellum/workspace/config.json`, restart daemon — verify the file is created with full defaults and does **not** include `apiKeys` or `dataDir`
- [ ] `vellum config set platform.baseUrl https://dev-platform.vellum.ai` — verify both `config.json` and lockfile are updated (lockfile should have top-level `platformBaseUrl`)
- [ ] `vellum hatch` (local) — verify default config is written and `platformBaseUrl` is synced to lockfile
- [ ] Confirm GCP/AWS hatch paths don't need `syncConfigToLockfile()` (custom hatch was removed from main; GCP/AWS delegate to their own modules)

### Notes
- The original branch's `hatchCustom` function was removed from `main` during the time this PR was open, so the merge conflict resolution simply dropped that code path. Only the local hatch path retains the `syncConfigToLockfile()` call.
- `syncConfigToLockfile` coerces empty-string `baseUrl` to `undefined` (i.e., the key is omitted from the lockfile when unset).
- Requested by: @dvargas92495
- Session: https://app.devin.ai/sessions/c03b7e869b14484ca63027ca5168e1f9