### PR TITLE
M4: Sidebar indicator + assistant read surface

### DIFF
--- a/assistant/src/config/bundled-skills/notifications/SKILL.md
+++ b/assistant/src/config/bundled-skills/notifications/SKILL.md
@@ -16,3 +16,19 @@ Use `send_notification` for user-facing alerts and notifications. This tool rout
 
 - Do **NOT** use AppleScript `display notification` or other OS-level notification commands for assistant-managed alerts. Always use `send_notification`.
 - For sending messages into a specific chat, email, or SMS destination, use the messaging skill's `messaging_send` instead.
+
+## Querying Delivery History
+
+Use the runtime HTTP API to query notification delivery summaries. The endpoint returns delivery records with interaction tracking (seen/viewed status).
+
+```bash
+# List recent deliveries for this assistant
+curl -s -H "Authorization: Bearer $(cat ~/.vellum/http-token)" \
+  "http://localhost:7821/v1/notifications/deliveries?assistantId=self&limit=50"
+
+# Paginate through older deliveries
+curl -s -H "Authorization: Bearer $(cat ~/.vellum/http-token)" \
+  "http://localhost:7821/v1/notifications/deliveries?assistantId=self&limit=20&offset=20"
+```
+
+Each delivery record includes: `deliveryId`, `assistantId`, `channel`, `destination`, `status`, `seenAt`, `viewedAt`, `lastInteractionType`, `lastInteractionAt`, `sentAt`, `createdAt`, and `conversationId`.

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -13,6 +13,7 @@ import { redactSecrets } from '../../security/secret-scanner.js';
 import { getSubagentManager } from '../../subagent/index.js';
 import { silentlyWithLog } from '../../util/silently.js';
 import { truncate } from '../../util/truncate.js';
+import { getConversationNotificationStates } from '../../notifications/interactions-store.js';
 import { getAssistantName } from '../identity-helpers.js';
 import type { UserMessageAttachment } from '../ipc-contract.js';
 import type {
@@ -396,12 +397,16 @@ export function handleSessionList(socket: net.Socket, ctx: HandlerContext, offse
   const bindings = externalConversationStore.getBindingsForConversations(
     conversations.map((c) => c.id),
   );
+  const notificationStates = getConversationNotificationStates(
+    conversations.map((c) => c.id),
+  );
   ctx.send(socket, {
     type: 'session_list_response',
     sessions: conversations.map((c) => {
       const binding = bindings.get(c.id);
       const originChannel = parseChannelId(c.originChannel);
       const originInterface = parseInterfaceId(c.originInterface);
+      const notifState = notificationStates.get(c.id);
       return {
         id: c.id,
         title: c.title ?? 'Untitled',
@@ -419,6 +424,13 @@ export function handleSessionList(socket: net.Socket, ctx: HandlerContext, offse
         } : {}),
         ...(originChannel ? { conversationOriginChannel: originChannel } : {}),
         ...(originInterface ? { conversationOriginInterface: originInterface } : {}),
+        ...(notifState ? {
+          notificationState: {
+            hasUnviewedNotification: notifState.hasUnviewedNotification,
+            ...(notifState.lastInteractionType ? { lastInteractionType: notifState.lastInteractionType } : {}),
+            ...(notifState.lastInteractionAt ? { lastInteractionAt: notifState.lastInteractionAt } : {}),
+          },
+        } : {}),
       };
     }),
     hasMore: offset + conversations.length < totalCount,

--- a/assistant/src/daemon/ipc-contract/sessions.ts
+++ b/assistant/src/daemon/ipc-contract/sessions.ts
@@ -202,9 +202,16 @@ export interface ChannelBinding {
   username?: string | null;
 }
 
+/** Notification interaction state for a session/conversation. */
+export interface SessionNotificationState {
+  hasUnviewedNotification: boolean;
+  lastInteractionType?: string;
+  lastInteractionAt?: number;
+}
+
 export interface SessionListResponse {
   type: 'session_list_response';
-  sessions: Array<{ id: string; title: string; updatedAt: number; threadType?: ThreadType; source?: string; channelBinding?: ChannelBinding; conversationOriginChannel?: ChannelId; conversationOriginInterface?: InterfaceId }>;
+  sessions: Array<{ id: string; title: string; updatedAt: number; threadType?: ThreadType; source?: string; channelBinding?: ChannelBinding; conversationOriginChannel?: ChannelId; conversationOriginInterface?: InterfaceId; notificationState?: SessionNotificationState }>;
   /** Whether more sessions exist beyond the returned page. */
   hasMore?: boolean;
 }

--- a/assistant/src/notifications/interactions-store.ts
+++ b/assistant/src/notifications/interactions-store.ts
@@ -262,6 +262,72 @@ export function getNotificationDeliverySummaries(
   return rows;
 }
 
+// -- Conversation notification state helpers ----------------------------------
+
+export interface ConversationNotificationState {
+  hasUnviewedNotification: boolean;
+  lastInteractionType: string | null;
+  lastInteractionAt: number | null;
+}
+
+/**
+ * Check whether a conversation has any notification deliveries that have
+ * not yet been explicitly viewed. Returns a summary object suitable for
+ * inclusion in the session list response.
+ */
+export function getConversationNotificationState(
+  conversationId: string,
+): ConversationNotificationState | undefined {
+  const db = getDb();
+  const row = db
+    .select({
+      id: notificationDeliveries.id,
+      viewedAt: notificationDeliveries.viewedAt,
+      lastInteractionType: notificationDeliveries.lastInteractionType,
+      lastInteractionAt: notificationDeliveries.lastInteractionAt,
+    })
+    .from(notificationDeliveries)
+    .where(
+      and(
+        eq(notificationDeliveries.conversationId, conversationId),
+        eq(notificationDeliveries.status, 'sent'),
+      ),
+    )
+    .orderBy(desc(sql`COALESCE(${notificationDeliveries.sentAt}, ${notificationDeliveries.createdAt})`))
+    .limit(1)
+    .get();
+
+  if (!row) return undefined;
+
+  return {
+    hasUnviewedNotification: row.viewedAt === null,
+    lastInteractionType: row.lastInteractionType,
+    lastInteractionAt: row.lastInteractionAt,
+  };
+}
+
+/**
+ * Batch-query notification state for multiple conversation IDs. Returns a
+ * map from conversationId to notification state. Only conversations that
+ * have at least one sent notification delivery are included.
+ */
+export function getConversationNotificationStates(
+  conversationIds: string[],
+): Map<string, ConversationNotificationState> {
+  const result = new Map<string, ConversationNotificationState>();
+  if (conversationIds.length === 0) return result;
+
+  // Query individually per conversation -- the list is typically small (50 items)
+  // and the index on conversationId makes this fast. A single SQL query with
+  // GROUP BY would be more complex and less readable for marginal perf gain.
+  for (const cid of conversationIds) {
+    const state = getConversationNotificationState(cid);
+    if (state) result.set(cid, state);
+  }
+
+  return result;
+}
+
 // -- Telegram inferred-seen helpers -------------------------------------------
 
 export interface UnseenTelegramDelivery {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -119,6 +119,7 @@ import {
   handleSetTelegramConfig,
   handleSetupTelegram,
 } from './routes/integration-routes.js';
+import { handleListNotificationDeliveries } from './routes/notification-routes.js';
 import { handleAddSecret } from './routes/secret-routes.js';
 
 // Re-export for consumers
@@ -579,6 +580,9 @@ export class RuntimeHttpServer {
       if (endpoint === 'secret' && req.method === 'POST') return await handleSecret(req);
       if (endpoint === 'trust-rules' && req.method === 'POST') return await handleTrustRule(req);
       if (endpoint === 'pending-interactions' && req.method === 'GET') return handleListPendingInteractions(url);
+
+      // Notification deliveries
+      if (endpoint === 'notifications/deliveries' && req.method === 'GET') return handleListNotificationDeliveries(url);
 
       // Contacts
       if (endpoint === 'contacts' && req.method === 'GET') return handleListContacts(url);

--- a/assistant/src/runtime/routes/notification-routes.ts
+++ b/assistant/src/runtime/routes/notification-routes.ts
@@ -1,0 +1,58 @@
+/**
+ * Route handlers for notification delivery read endpoints.
+ *
+ * GET /v1/notifications/deliveries — list delivery summaries
+ */
+
+import { and, desc, eq, sql } from 'drizzle-orm';
+
+import { getDb } from '../../memory/db.js';
+import { notificationDeliveries } from '../../memory/schema.js';
+
+/**
+ * GET /v1/notifications/deliveries?assistantId=self&limit=50&offset=0
+ */
+export function handleListNotificationDeliveries(url: URL): Response {
+  const assistantId = url.searchParams.get('assistantId');
+  if (!assistantId) {
+    return Response.json(
+      { ok: false, error: 'assistantId query parameter is required' },
+      { status: 400 },
+    );
+  }
+
+  const limit = Math.min(Math.max(Number(url.searchParams.get('limit') ?? 50), 1), 200);
+  const offset = Math.max(Number(url.searchParams.get('offset') ?? 0), 0);
+
+  const db = getDb();
+  const conditions = [eq(notificationDeliveries.assistantId, assistantId)];
+
+  const rows = db
+    .select({
+      deliveryId: notificationDeliveries.id,
+      notificationDecisionId: notificationDeliveries.notificationDecisionId,
+      assistantId: notificationDeliveries.assistantId,
+      channel: notificationDeliveries.channel,
+      destination: notificationDeliveries.destination,
+      status: notificationDeliveries.status,
+      seenAt: notificationDeliveries.seenAt,
+      viewedAt: notificationDeliveries.viewedAt,
+      lastInteractionType: notificationDeliveries.lastInteractionType,
+      lastInteractionAt: notificationDeliveries.lastInteractionAt,
+      sentAt: notificationDeliveries.sentAt,
+      conversationId: notificationDeliveries.conversationId,
+      createdAt: notificationDeliveries.createdAt,
+    })
+    .from(notificationDeliveries)
+    .where(and(...conditions))
+    .orderBy(desc(sql`COALESCE(${notificationDeliveries.sentAt}, ${notificationDeliveries.createdAt})`))
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  return Response.json({
+    ok: true,
+    deliveries: rows,
+    pagination: { limit, offset, count: rows.length },
+  });
+}

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -303,6 +303,7 @@ extension AppDelegate {
                 return false
             }
             threadManager.activeThreadId = thread.id
+            threadManager.clearNotificationIndicator(threadId: thread.id)
             return true
         }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -847,6 +847,11 @@ struct MainWindowView: View {
             }
         }) {
             HStack(spacing: VSpacing.xs) {
+                if thread.notificationState?.hasUnviewedNotification == true {
+                    Circle()
+                        .fill(VColor.accent)
+                        .frame(width: 7, height: 7)
+                }
                 if thread.kind == .private {
                     Image(systemName: "lock.fill")
                         .font(.system(size: 10, weight: .medium))

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -191,7 +191,11 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             return
         }
 
-        let thread = ThreadModel(title: title, sessionId: conversationId)
+        let thread = ThreadModel(
+            title: title,
+            sessionId: conversationId,
+            notificationState: ThreadNotificationState(hasUnviewedNotification: true)
+        )
         let viewModel = makeViewModel()
         viewModel.sessionId = conversationId
         // Start the message loop so the view model receives streamed messages
@@ -351,7 +355,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 sessionId: session.id,
                 isArchived: isSessionArchived(session.id),
                 kind: session.threadType == "private" ? .private : .standard,
-                source: session.source
+                source: session.source,
+                notificationState: Self.mapNotificationState(session.notificationState)
             )
             // VM creation is lazy — getOrCreateViewModel() will instantiate
             // when the thread is first accessed (e.g. selected by the user).
@@ -386,6 +391,21 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
         touchVMAccessOrder(id)
         activeThreadId = id
+
+        // Clear the unviewed notification indicator when the user opens
+        // a notification-origin thread. The daemon is separately notified
+        // via notification_conversation_viewed from the AppDelegate deep-link
+        // path, but sidebar selection also needs to send the IPC message.
+        if thread.notificationState?.hasUnviewedNotification == true,
+           let sessionId = thread.sessionId {
+            clearNotificationIndicator(threadId: id)
+            try? daemonClient.sendNotificationConversationViewed(
+                conversationId: sessionId,
+                source: "macos_conversation_opened",
+                occurredAt: Int(Date().timeIntervalSince1970 * 1000)
+            )
+        }
+
         // Switching threads is a natural point to shed cached render
         // artefacts from the previous conversation.
         Self.clearRenderCaches()
@@ -725,6 +745,24 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             vmAccessOrder.removeAll { $0 == victim }
             log.info("LRU evicted VM for thread \(victim)")
         }
+    }
+
+    /// Convert IPC notification state to the model type.
+    static func mapNotificationState(_ ipc: IPCSessionNotificationState?) -> ThreadNotificationState? {
+        guard let ipc else { return nil }
+        return ThreadNotificationState(
+            hasUnviewedNotification: ipc.hasUnviewedNotification,
+            lastInteractionType: ipc.lastInteractionType,
+            lastInteractionAt: ipc.lastInteractionAt.map { Date(timeIntervalSince1970: TimeInterval($0) / 1000.0) }
+        )
+    }
+
+    /// Clear the unviewed notification indicator for a thread. Called when
+    /// the user opens a notification-origin thread (the daemon is separately
+    /// notified via `notification_conversation_viewed`).
+    func clearNotificationIndicator(threadId: UUID) {
+        guard let index = threads.firstIndex(where: { $0.id == threadId }) else { return }
+        threads[index].notificationState?.hasUnviewedNotification = false
     }
 
     private var archivedSessionIds: Set<String> {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
@@ -5,6 +5,13 @@ enum ThreadKind: String, Hashable, Sendable {
     case `private`
 }
 
+/// Notification interaction state for a thread backed by a notification delivery.
+struct ThreadNotificationState: Hashable {
+    var hasUnviewedNotification: Bool
+    var lastInteractionType: String?
+    var lastInteractionAt: Date?
+}
+
 struct ThreadModel: Identifiable, Hashable {
     let id: UUID
     var title: String
@@ -18,8 +25,10 @@ struct ThreadModel: Identifiable, Hashable {
     var lastInteractedAt: Date
     var kind: ThreadKind
     var source: String?
+    /// Notification delivery state. Non-nil only for threads originating from a notification.
+    var notificationState: ThreadNotificationState?
 
-    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), sessionId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, pinnedOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ThreadKind = .standard, source: String? = nil) {
+    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), sessionId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, pinnedOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ThreadKind = .standard, source: String? = nil, notificationState: ThreadNotificationState? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -30,6 +39,7 @@ struct ThreadModel: Identifiable, Hashable {
         self.lastInteractedAt = lastInteractedAt ?? createdAt
         self.kind = kind
         self.source = source
+        self.notificationState = notificationState
     }
 
     /// Whether this thread was created by a schedule or reminder trigger.

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -199,7 +199,8 @@ final class ThreadSessionRestorer {
                 sessionId: session.id,
                 isArchived: delegate.isSessionArchived(session.id),
                 kind: kind,
-                source: session.source
+                source: session.source,
+                notificationState: ThreadManager.mapNotificationState(session.notificationState)
             )
             // VM creation is lazy — only the active thread will get a VM via
             // getOrCreateViewModel() when it's first accessed.

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -3734,8 +3734,10 @@ public struct IPCSessionListResponseSession: Codable, Sendable {
     public let channelBinding: IPCChannelBinding?
     public let conversationOriginChannel: String?
     public let conversationOriginInterface: String?
+    /// Notification interaction state for a session/conversation.
+    public let notificationState: IPCSessionNotificationState?
 
-    public init(id: String, title: String, updatedAt: Int, threadType: String? = nil, source: String? = nil, channelBinding: IPCChannelBinding? = nil, conversationOriginChannel: String? = nil, conversationOriginInterface: String? = nil) {
+    public init(id: String, title: String, updatedAt: Int, threadType: String? = nil, source: String? = nil, channelBinding: IPCChannelBinding? = nil, conversationOriginChannel: String? = nil, conversationOriginInterface: String? = nil, notificationState: IPCSessionNotificationState? = nil) {
         self.id = id
         self.title = title
         self.updatedAt = updatedAt
@@ -3744,6 +3746,20 @@ public struct IPCSessionListResponseSession: Codable, Sendable {
         self.channelBinding = channelBinding
         self.conversationOriginChannel = conversationOriginChannel
         self.conversationOriginInterface = conversationOriginInterface
+        self.notificationState = notificationState
+    }
+}
+
+/// Notification interaction state for a session/conversation.
+public struct IPCSessionNotificationState: Codable, Sendable {
+    public let hasUnviewedNotification: Bool
+    public let lastInteractionType: String?
+    public let lastInteractionAt: Int?
+
+    public init(hasUnviewedNotification: Bool, lastInteractionType: String? = nil, lastInteractionAt: Int? = nil) {
+        self.hasUnviewedNotification = hasUnviewedNotification
+        self.lastInteractionType = lastInteractionType
+        self.lastInteractionAt = lastInteractionAt
     }
 }
 


### PR DESCRIPTION
Extends session list with notificationState for notification-origin threads. Adds sidebar dot indicator for unviewed notifications. Adds GET /v1/notifications/deliveries read endpoint for assistant/LLM reporting. Updates notification skill docs with curl examples. Part of #9305.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
