### PR TITLE
fix: add non-null assertion for Drizzle or() return type in conversation-store

### DIFF
--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -391,7 +391,7 @@ export function getMessagesPaginated(
       conditions.push(or(
         lt(messages.createdAt, beforeTimestamp),
         and(eq(messages.createdAt, beforeTimestamp), lt(messages.id, beforeMessageId)),
-      ));
+      )!);
     } else {
       // Legacy callers without a message ID tie-breaker: use strict lt.
       // This may skip same-millisecond messages at boundaries, but avoids


### PR DESCRIPTION
## Summary
- Fix TypeScript error in `conversation-store.ts` where `or()` returns `SQL<unknown> | undefined` but was passed to `conditions.push()` expecting `SQL<unknown>`
- Added non-null assertion (`!`) since `or()` with defined arguments always returns a defined value

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22423964416

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
