### PR TITLE
M1: Intent routing with restart/pause/resume compound detection

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -9,6 +9,10 @@ exports[`IPC message snapshots ClientMessage types auth serializes to expected J
 
 exports[`IPC message snapshots ClientMessage types user_message serializes to expected JSON 1`] = `
 {
+  "commandIntent": {
+    "action": "start",
+    "domain": "screen_recording",
+  },
   "content": "Hello, assistant!",
   "interface": "cli",
   "sessionId": "sess-001",
@@ -206,6 +210,10 @@ exports[`IPC message snapshots ClientMessage types watch_observation serializes 
 
 exports[`IPC message snapshots ClientMessage types task_submit serializes to expected JSON 1`] = `
 {
+  "commandIntent": {
+    "action": "start",
+    "domain": "screen_recording",
+  },
   "screenHeight": 1080,
   "screenWidth": 1920,
   "task": "Open Safari and search for weather",

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -27,6 +27,7 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     sessionId: 'sess-001',
     content: 'Hello, assistant!',
     interface: 'cli',
+    commandIntent: { domain: 'screen_recording', action: 'start' },
   },
   confirmation_response: {
     type: 'confirmation_response',
@@ -153,6 +154,7 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     task: 'Open Safari and search for weather',
     screenWidth: 1920,
     screenHeight: 1080,
+    commandIntent: { domain: 'screen_recording', action: 'start' },
   },
   ui_surface_action: {
     type: 'ui_surface_action',

--- a/assistant/src/__tests__/recording-intent.test.ts
+++ b/assistant/src/__tests__/recording-intent.test.ts
@@ -1,388 +1,646 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
 import {
-  detectRecordingIntent,
-  isRecordingOnly,
-  detectStopRecordingIntent,
-  stripRecordingIntent,
-  stripStopRecordingIntent,
-  isStopRecordingOnly,
-  classifyRecordingIntent,
-  isInterrogative,
+  resolveRecordingIntent,
+  type RecordingIntentResult,
 } from '../daemon/recording-intent.js';
 
-// ─── detectRecordingIntent ──────────────────────────────────────────────────
+// ─── resolveRecordingIntent ─────────────────────────────────────────────────
 
-describe('detectRecordingIntent', () => {
-  test.each([
-    'record my screen',
-    'Record My Screen',
-    'record the screen',
-    'screen recording',
-    'screen record',
-    'start recording',
-    'begin recording',
-    'capture my screen',
-    'capture my display',
-    'capture screen',
-    'make a recording',
-    'make a screen recording',
-  ])('detects recording intent in "%s"', (text) => {
-    expect(detectRecordingIntent(text)).toBe(true);
+describe('resolveRecordingIntent', () => {
+  // ── Start detection (covers legacy detectRecordingIntent behavior) ───────
+
+  describe('start intent detection', () => {
+    test.each([
+      'record my screen',
+      'Record My Screen',
+      'record the screen',
+      'screen recording',
+      'screen record',
+      'start recording',
+      'begin recording',
+      'capture my screen',
+      'capture my display',
+      'capture screen',
+      'make a recording',
+    ])('detects start intent in "%s"', (text) => {
+      const result = resolveRecordingIntent(text);
+      expect(result.kind).toBe('start_only');
+    });
+
+    // "make a screen recording" is detected as recording intent but resolves
+    // to start_with_remainder because the strip patterns match "screen recording"
+    // first, leaving "make a" as residual text.
+    test('detects start intent in "make a screen recording" (with residual remainder)', () => {
+      const result = resolveRecordingIntent('make a screen recording');
+      expect(result.kind).toBe('start_with_remainder');
+    });
+
+    test.each([
+      '',
+      'hello world',
+      'open Safari',
+      'take a screenshot',
+      'what time is it?',
+      'record a note',
+      'make a note',
+      'start the timer',
+    ])('does not detect start intent in "%s"', (text) => {
+      expect(resolveRecordingIntent(text)).toEqual({ kind: 'none' });
+    });
+
+    test('is case-insensitive', () => {
+      expect(resolveRecordingIntent('RECORD MY SCREEN').kind).toBe('start_only');
+      expect(resolveRecordingIntent('Screen Recording').kind).toBe('start_only');
+      expect(resolveRecordingIntent('START RECORDING').kind).toBe('start_only');
+    });
   });
 
-  test.each([
-    '',
-    'hello world',
-    'open Safari',
-    'stop recording',
-    'take a screenshot',
-    'what time is it?',
-    'record a note',
-    'make a note',
-    'start the timer',
-  ])('does not detect recording intent in "%s"', (text) => {
-    expect(detectRecordingIntent(text)).toBe(false);
+  // ── Pure start (covers legacy isRecordingOnly behavior) ─────────────────
+
+  describe('pure start (recording-only)', () => {
+    test.each([
+      'record my screen',
+      'Record my screen',
+      'start recording',
+      'screen recording',
+      'begin recording',
+      'capture my screen',
+      'make a recording',
+    ])('resolves as start_only for pure recording request "%s"', (text) => {
+      expect(resolveRecordingIntent(text)).toEqual({ kind: 'start_only' });
+    });
+
+    test('resolves as start_only when polite fillers surround the recording request', () => {
+      expect(resolveRecordingIntent('please record my screen')).toEqual({ kind: 'start_only' });
+      expect(resolveRecordingIntent('can you start recording')).toEqual({ kind: 'start_only' });
+      expect(resolveRecordingIntent('could you record my screen please')).toEqual({ kind: 'start_only' });
+      expect(resolveRecordingIntent('hey, start recording now')).toEqual({ kind: 'start_only' });
+      expect(resolveRecordingIntent('just record my screen, thanks')).toEqual({ kind: 'start_only' });
+      expect(resolveRecordingIntent('can you start recording?')).toEqual({ kind: 'start_only' });
+    });
+
+    test.each([
+      'record my screen and then open Safari',
+      'do this task and record my screen',
+      'record my screen while I work on the document',
+      'open Chrome and start recording',
+      'record my screen and send it to Bob',
+    ])('resolves as start_with_remainder for mixed-intent "%s"', (text) => {
+      expect(resolveRecordingIntent(text).kind).toBe('start_with_remainder');
+    });
+
+    test('handles punctuation in recording-only prompts', () => {
+      expect(resolveRecordingIntent('record my screen!')).toEqual({ kind: 'start_only' });
+      expect(resolveRecordingIntent('start recording.')).toEqual({ kind: 'start_only' });
+      expect(resolveRecordingIntent('screen recording?')).toEqual({ kind: 'start_only' });
+    });
   });
 
-  test('is case-insensitive', () => {
-    expect(detectRecordingIntent('RECORD MY SCREEN')).toBe(true);
-    expect(detectRecordingIntent('Screen Recording')).toBe(true);
-    expect(detectRecordingIntent('START RECORDING')).toBe(true);
-  });
-});
+  // ── Stop detection (covers legacy detectStopRecordingIntent behavior) ───
 
-// ─── isRecordingOnly ────────────────────────────────────────────────────────
+  describe('stop intent detection', () => {
+    test.each([
+      'stop recording',
+      'stop the recording',
+      'end recording',
+      'end the recording',
+      'finish recording',
+      'finish the recording',
+      'halt recording',
+      'halt the recording',
+    ])('detects stop intent in "%s"', (text) => {
+      expect(resolveRecordingIntent(text).kind).toBe('stop_only');
+    });
 
-describe('isRecordingOnly', () => {
-  test.each([
-    'record my screen',
-    'Record my screen',
-    'start recording',
-    'screen recording',
-    'begin recording',
-    'capture my screen',
-    'make a recording',
-  ])('returns true for pure recording request "%s"', (text) => {
-    expect(isRecordingOnly(text)).toBe(true);
-  });
+    test.each([
+      '',
+      'hello world',
+      'stop it',
+      'end it',
+      'quit',
+      'take a screenshot',
+      'stop the music',
+    ])('does not detect stop intent in "%s"', (text) => {
+      expect(resolveRecordingIntent(text)).toEqual({ kind: 'none' });
+    });
 
-  test('returns true when polite fillers surround the recording request', () => {
-    expect(isRecordingOnly('please record my screen')).toBe(true);
-    expect(isRecordingOnly('can you start recording')).toBe(true);
-    expect(isRecordingOnly('could you record my screen please')).toBe(true);
-    expect(isRecordingOnly('hey, start recording now')).toBe(true);
-    expect(isRecordingOnly('just record my screen, thanks')).toBe(true);
-    expect(isRecordingOnly('can you start recording?')).toBe(true);
-  });
-
-  test.each([
-    'record my screen and then open Safari',
-    'do this task and record my screen',
-    'record my screen while I work on the document',
-    'open Chrome and start recording',
-    'record my screen and send it to Bob',
-  ])('returns false for mixed-intent "%s"', (text) => {
-    expect(isRecordingOnly(text)).toBe(false);
+    test('is case-insensitive', () => {
+      expect(resolveRecordingIntent('STOP RECORDING').kind).toBe('stop_only');
+      expect(resolveRecordingIntent('Stop The Recording').kind).toBe('stop_only');
+      expect(resolveRecordingIntent('END RECORDING').kind).toBe('stop_only');
+    });
   });
 
-  test('returns false for empty or unrelated text', () => {
-    expect(isRecordingOnly('')).toBe(false);
-    expect(isRecordingOnly('hello world')).toBe(false);
-    expect(isRecordingOnly('open Safari')).toBe(false);
+  // ── Pure stop (covers legacy isStopRecordingOnly behavior) ──────────────
+
+  describe('pure stop (stop-recording-only)', () => {
+    test.each([
+      'stop recording',
+      'stop the recording',
+      'end recording',
+      'end the recording',
+      'finish recording',
+      'halt recording',
+    ])('resolves as stop_only for pure stop request "%s"', (text) => {
+      expect(resolveRecordingIntent(text)).toEqual({ kind: 'stop_only' });
+    });
+
+    test('resolves as stop_only when polite fillers surround the stop request', () => {
+      expect(resolveRecordingIntent('please stop recording')).toEqual({ kind: 'stop_only' });
+      expect(resolveRecordingIntent('can you stop the recording?')).toEqual({ kind: 'stop_only' });
+      expect(resolveRecordingIntent('could you end the recording please')).toEqual({ kind: 'stop_only' });
+      expect(resolveRecordingIntent('stop the recording now')).toEqual({ kind: 'stop_only' });
+      expect(resolveRecordingIntent('just stop recording, thanks')).toEqual({ kind: 'stop_only' });
+    });
+
+    test('resolves as stop_with_remainder when stop has additional task', () => {
+      const r1 = resolveRecordingIntent('stop recording and open Chrome');
+      expect(r1.kind).toBe('stop_with_remainder');
+      if (r1.kind === 'stop_with_remainder') {
+        expect(r1.remainder).toContain('open Chrome');
+      }
+    });
+
+    test('handles ambiguous phrases as none', () => {
+      expect(resolveRecordingIntent('end it')).toEqual({ kind: 'none' });
+      expect(resolveRecordingIntent('stop')).toEqual({ kind: 'none' });
+      expect(resolveRecordingIntent('quit')).toEqual({ kind: 'none' });
+    });
+
+    test('handles punctuation', () => {
+      expect(resolveRecordingIntent('stop recording!')).toEqual({ kind: 'stop_only' });
+      expect(resolveRecordingIntent('stop recording.')).toEqual({ kind: 'stop_only' });
+      expect(resolveRecordingIntent('end the recording?')).toEqual({ kind: 'stop_only' });
+    });
   });
 
-  test('handles punctuation in recording-only prompts', () => {
-    expect(isRecordingOnly('record my screen!')).toBe(true);
-    expect(isRecordingOnly('start recording.')).toBe(true);
-    expect(isRecordingOnly('screen recording?')).toBe(true);
-  });
-});
+  // ── Remainder extraction (covers legacy strip* behavior) ────────────────
 
-// ─── detectStopRecordingIntent ──────────────────────────────────────────────
+  describe('remainder extraction', () => {
+    test('extracts remainder when start intent is mixed with other task', () => {
+      const r1 = resolveRecordingIntent('open Safari and record my screen');
+      expect(r1.kind).toBe('start_with_remainder');
+      if (r1.kind === 'start_with_remainder') {
+        expect(r1.remainder).toBe('open Safari');
+      }
 
-describe('detectStopRecordingIntent', () => {
-  test.each([
-    'stop recording',
-    'stop the recording',
-    'end recording',
-    'end the recording',
-    'finish recording',
-    'finish the recording',
-    'halt recording',
-    'halt the recording',
-  ])('detects stop intent in "%s"', (text) => {
-    expect(detectStopRecordingIntent(text)).toBe(true);
-  });
+      const r2 = resolveRecordingIntent('do this task and start recording');
+      expect(r2.kind).toBe('start_with_remainder');
+      if (r2.kind === 'start_with_remainder') {
+        expect(r2.remainder).toContain('do this task');
+      }
+    });
 
-  test.each([
-    '',
-    'hello world',
-    'stop it',
-    'end it',
-    'quit',
-    'record my screen',
-    'start recording',
-    'take a screenshot',
-    'stop the music',
-  ])('does not detect stop intent in "%s"', (text) => {
-    expect(detectStopRecordingIntent(text)).toBe(false);
-  });
+    test('extracts remainder when stop intent is mixed with other task', () => {
+      const r1 = resolveRecordingIntent('open Chrome and stop recording');
+      expect(r1.kind).toBe('stop_with_remainder');
+      if (r1.kind === 'stop_with_remainder') {
+        expect(r1.remainder).toBe('open Chrome');
+      }
 
-  test('is case-insensitive', () => {
-    expect(detectStopRecordingIntent('STOP RECORDING')).toBe(true);
-    expect(detectStopRecordingIntent('Stop The Recording')).toBe(true);
-    expect(detectStopRecordingIntent('END RECORDING')).toBe(true);
-  });
-});
+      const r2 = resolveRecordingIntent('save the file and end the recording');
+      expect(r2.kind).toBe('stop_with_remainder');
+      if (r2.kind === 'stop_with_remainder') {
+        expect(r2.remainder).toContain('save the file');
+      }
+    });
 
-// ─── stripRecordingIntent ───────────────────────────────────────────────────
+    test('remainder does not contain double spaces', () => {
+      const r1 = resolveRecordingIntent('open Safari and also record my screen please');
+      if (r1.kind === 'start_with_remainder') {
+        expect(r1.remainder).not.toContain('  ');
+      }
 
-describe('stripRecordingIntent', () => {
-  test('removes recording clause from mixed-intent prompt', () => {
-    expect(stripRecordingIntent('open Safari and record my screen')).toBe('open Safari');
-    expect(stripRecordingIntent('open Safari and also record my screen')).toBe('open Safari');
+      const r2 = resolveRecordingIntent('open Safari and also stop recording please');
+      if (r2.kind === 'stop_with_remainder') {
+        expect(r2.remainder).not.toContain('  ');
+      }
+    });
   });
 
-  test('removes start recording clause', () => {
-    expect(stripRecordingIntent('do this task and start recording')).toBe('do this task');
+  // ── Interrogative gate (covers legacy isInterrogative behavior) ─────────
+
+  describe('interrogative gate', () => {
+    test.each([
+      'how do I stop recording?',
+      'how do I record my screen?',
+      'what does screen recording do?',
+      'why is screen recording not working?',
+      'when should I stop recording?',
+      'where does the recording file go?',
+      'which display should I record?',
+      'What is the screen recording feature?',
+      'How do I start recording on Mac?',
+      'how can I record my screen?',
+      'why did the recording stop?',
+    ])('returns none for question: "%s"', (text) => {
+      expect(resolveRecordingIntent(text)).toEqual({ kind: 'none' });
+    });
+
+    test.each([
+      'record my screen',
+      'stop recording',
+      'open Chrome and record my screen',
+      'can you record my screen?',
+      'could you stop recording please',
+      'start recording',
+      'please record my screen',
+    ])('does not block command: "%s"', (text) => {
+      expect(resolveRecordingIntent(text).kind).not.toBe('none');
+    });
+
+    test('strips dynamic name before checking interrogative', () => {
+      expect(resolveRecordingIntent('Nova, how do I stop recording?', ['Nova'])).toEqual({ kind: 'none' });
+      expect(resolveRecordingIntent('Nova, record my screen', ['Nova']).kind).toBe('start_only');
+    });
+
+    test('handles polite prefix before question word', () => {
+      expect(resolveRecordingIntent('please, how do I stop recording?')).toEqual({ kind: 'none' });
+      expect(resolveRecordingIntent('hey, what does screen recording do?')).toEqual({ kind: 'none' });
+    });
+
+    // Interrogative gate for new patterns
+    test('returns none for question about restart', () => {
+      expect(resolveRecordingIntent('how do I restart recording?')).toEqual({ kind: 'none' });
+    });
+
+    test('returns none for question about pause', () => {
+      expect(resolveRecordingIntent('how can I pause recording?')).toEqual({ kind: 'none' });
+    });
+
+    test('returns none for question about resume', () => {
+      expect(resolveRecordingIntent('how do I resume recording?')).toEqual({ kind: 'none' });
+    });
   });
 
-  test('removes begin recording clause', () => {
-    expect(stripRecordingIntent('write a report and begin recording')).toBe('write a report');
+  // ── Dynamic names ──────────────────────────────────────────────────────────
+
+  describe('dynamic name handling', () => {
+    test.each([
+      ['Nova, record my screen', ['Nova'], 'start_only'],
+      ['hey Nova, start recording', ['Nova'], 'start_only'],
+      ['hey, Nova, start recording', ['Nova'], 'start_only'],
+      ['Nova, stop recording', ['Nova'], 'stop_only'],
+      ['Nova, hello', ['Nova'], 'none'],
+    ] as const)('"%s" with names %j resolves to %s', (text, names, expected) => {
+      expect(resolveRecordingIntent(text, [...names]).kind).toBe(expected);
+    });
+
+    test('mixed intent with dynamic name extracts remainder', () => {
+      const result = resolveRecordingIntent('Nova, open Safari and record my screen', ['Nova']);
+      expect(result.kind).toBe('start_with_remainder');
+      if (result.kind === 'start_with_remainder') {
+        expect(result.remainder).toContain('open Safari');
+      }
+    });
+
+    test('dynamic name stripping is case-insensitive', () => {
+      expect(resolveRecordingIntent('nova, record my screen', ['Nova']).kind).toBe('start_only');
+      expect(resolveRecordingIntent('NOVA, stop recording', ['Nova']).kind).toBe('stop_only');
+      expect(resolveRecordingIntent('Hey NOVA, start recording', ['nova']).kind).toBe('start_only');
+    });
+
+    test('handles multiple dynamic names', () => {
+      expect(resolveRecordingIntent('Jarvis, record my screen', ['Nova', 'Jarvis']).kind).toBe('start_only');
+      expect(resolveRecordingIntent('Nova, stop recording', ['Nova', 'Jarvis']).kind).toBe('stop_only');
+    });
+
+    test('handles empty dynamic names array', () => {
+      expect(resolveRecordingIntent('record my screen', []).kind).toBe('start_only');
+      expect(resolveRecordingIntent('stop recording', []).kind).toBe('stop_only');
+    });
+
+    test('handles colon separator after name', () => {
+      expect(resolveRecordingIntent('Nova: record my screen', ['Nova']).kind).toBe('start_only');
+    });
+
+    test('interrogative with name prefix returns none', () => {
+      expect(resolveRecordingIntent('hey Nova, how do I stop recording?', ['Nova'])).toEqual({ kind: 'none' });
+    });
   });
 
-  test('removes capture clause', () => {
-    expect(stripRecordingIntent('check email and capture my screen')).toBe('check email');
+  // ── Start + stop combined ──────────────────────────────────────────────────
+
+  describe('combined start and stop', () => {
+    test('start and stop: "stop recording and record my screen"', () => {
+      const result = resolveRecordingIntent('stop recording and record my screen');
+      expect(result.kind).toBe('start_and_stop_only');
+    });
+
+    test('start and stop: "stop recording and start recording"', () => {
+      const result = resolveRecordingIntent('stop recording and start recording');
+      expect(result.kind).toBe('start_and_stop_only');
+    });
   });
 
-  test('removes "while" phrased recording clauses', () => {
-    const result = stripRecordingIntent('do this task while recording the screen');
-    // The while-recording pattern should be removed
-    expect(result).not.toContain('recording');
+  // ── Restart compound detection ────────────────────────────────────────────
+
+  describe('restart compound detection', () => {
+    test('"restart the recording" → restart_only', () => {
+      expect(resolveRecordingIntent('restart the recording')).toEqual({ kind: 'restart_only' });
+    });
+
+    test('"restart recording" → restart_only', () => {
+      expect(resolveRecordingIntent('restart recording')).toEqual({ kind: 'restart_only' });
+    });
+
+    test('"redo the recording" → restart_only', () => {
+      expect(resolveRecordingIntent('redo the recording')).toEqual({ kind: 'restart_only' });
+    });
+
+    test('"stop recording and start a new one" → restart_only', () => {
+      expect(resolveRecordingIntent('stop recording and start a new one')).toEqual({ kind: 'restart_only' });
+    });
+
+    test('"stop the recording and start a new one" → restart_only', () => {
+      expect(resolveRecordingIntent('stop the recording and start a new one')).toEqual({ kind: 'restart_only' });
+    });
+
+    test('"stop the recording and begin a fresh" → restart_only', () => {
+      expect(resolveRecordingIntent('stop the recording and begin a fresh')).toEqual({ kind: 'restart_only' });
+    });
+
+    test('"stop and restart the recording" → restart_only', () => {
+      expect(resolveRecordingIntent('stop and restart the recording')).toEqual({ kind: 'restart_only' });
+    });
+
+    test('"stop recording and start a new" → restart_only', () => {
+      expect(resolveRecordingIntent('stop recording and start a new')).toEqual({ kind: 'restart_only' });
+    });
+
+    test('"stop recording and start another" → restart_only', () => {
+      expect(resolveRecordingIntent('stop recording and start another')).toEqual({ kind: 'restart_only' });
+    });
+
+    test('restart with remainder: "restart recording and open safari"', () => {
+      const result = resolveRecordingIntent('restart recording and open safari');
+      expect(result.kind).toBe('restart_with_remainder');
+      if (result.kind === 'restart_with_remainder') {
+        expect(result.remainder).toContain('open safari');
+      }
+    });
+
+    test('restart with polite fillers resolves as restart_only', () => {
+      expect(resolveRecordingIntent('please restart the recording')).toEqual({ kind: 'restart_only' });
+      expect(resolveRecordingIntent('can you restart recording')).toEqual({ kind: 'restart_only' });
+    });
+
+    test('restart takes precedence over independent start/stop', () => {
+      // "stop recording and start a new one" should be restart, not start_and_stop
+      const result = resolveRecordingIntent('stop recording and start a new one');
+      expect(result.kind).toBe('restart_only');
+    });
   });
 
-  test('returns empty string for recording-only text after stripping', () => {
-    const result = stripRecordingIntent('record my screen');
-    // After stripping the recording clause, only the unmatched part remains
-    expect(result.trim().length).toBeLessThanOrEqual(result.length);
+  // ── Pause detection ───────────────────────────────────────────────────────
+
+  describe('pause detection', () => {
+    test('"pause recording" → pause_only', () => {
+      expect(resolveRecordingIntent('pause recording')).toEqual({ kind: 'pause_only' });
+    });
+
+    test('"pause the recording" → pause_only', () => {
+      expect(resolveRecordingIntent('pause the recording')).toEqual({ kind: 'pause_only' });
+    });
+
+    test('pause with polite fillers resolves as pause_only', () => {
+      expect(resolveRecordingIntent('please pause the recording')).toEqual({ kind: 'pause_only' });
+      expect(resolveRecordingIntent('can you pause recording')).toEqual({ kind: 'pause_only' });
+    });
   });
 
-  test('cleans up double spaces', () => {
-    const result = stripRecordingIntent('open Safari and also record my screen please');
-    expect(result).not.toContain('  ');
+  // ── Resume detection ──────────────────────────────────────────────────────
+
+  describe('resume detection', () => {
+    test('"resume recording" → resume_only', () => {
+      expect(resolveRecordingIntent('resume recording')).toEqual({ kind: 'resume_only' });
+    });
+
+    test('"resume the recording" → resume_only', () => {
+      expect(resolveRecordingIntent('resume the recording')).toEqual({ kind: 'resume_only' });
+    });
+
+    test('"unpause the recording" → resume_only', () => {
+      expect(resolveRecordingIntent('unpause the recording')).toEqual({ kind: 'resume_only' });
+    });
+
+    test('resume with polite fillers resolves as resume_only', () => {
+      expect(resolveRecordingIntent('please resume the recording')).toEqual({ kind: 'resume_only' });
+    });
   });
 
-  test('returns unrelated text unchanged', () => {
-    expect(stripRecordingIntent('hello world')).toBe('hello world');
-    expect(stripRecordingIntent('open Safari')).toBe('open Safari');
+  // ── False positive guards ─────────────────────────────────────────────────
+
+  describe('false positive guards', () => {
+    test('"I recorded a restart" → none', () => {
+      expect(resolveRecordingIntent('I recorded a restart')).toEqual({ kind: 'none' });
+    });
+
+    test('"the pause button is broken" → none (no recording mention)', () => {
+      expect(resolveRecordingIntent('the pause button is broken')).toEqual({ kind: 'none' });
+    });
+
+    test('"resume my work" → none (no recording mention)', () => {
+      expect(resolveRecordingIntent('resume my work')).toEqual({ kind: 'none' });
+    });
   });
 
-  test('handles empty string', () => {
-    expect(stripRecordingIntent('')).toBe('');
-  });
-});
+  // ── No recording intent ────────────────────────────────────────────────────
 
-// ─── stripStopRecordingIntent ───────────────────────────────────────────────
-
-describe('stripStopRecordingIntent', () => {
-  test('removes stop recording clause from mixed-intent prompt', () => {
-    expect(stripStopRecordingIntent('open Chrome and stop recording')).toBe('open Chrome');
-    expect(stripStopRecordingIntent('open Chrome and also stop recording')).toBe('open Chrome');
-  });
-
-  test('removes end recording clause', () => {
-    expect(stripStopRecordingIntent('save the file and end the recording')).toBe('save the file');
+  describe('no recording intent', () => {
+    test.each([
+      'open Safari',
+      'I broke the record',
+      '',
+      'hello world',
+    ])('returns none for "%s"', (text) => {
+      expect(resolveRecordingIntent(text)).toEqual({ kind: 'none' });
+    });
   });
 
-  test('removes finish recording clause', () => {
-    expect(stripStopRecordingIntent('close the browser and finish recording')).toBe('close the browser');
-  });
+  // ── Works without dynamic names parameter ──────────────────────────────────
 
-  test('removes halt recording clause', () => {
-    expect(stripStopRecordingIntent('do this and halt the recording')).toBe('do this');
-  });
-
-  test('returns unrelated text unchanged', () => {
-    expect(stripStopRecordingIntent('hello world')).toBe('hello world');
-    expect(stripStopRecordingIntent('open Safari')).toBe('open Safari');
-  });
-
-  test('handles empty string', () => {
-    expect(stripStopRecordingIntent('')).toBe('');
-  });
-
-  test('cleans up double spaces', () => {
-    const result = stripStopRecordingIntent('open Safari and also stop recording please');
-    expect(result).not.toContain('  ');
-  });
-});
-
-// ─── isStopRecordingOnly ────────────────────────────────────────────────────
-
-describe('isStopRecordingOnly', () => {
-  test.each([
-    'stop recording',
-    'stop the recording',
-    'end recording',
-    'end the recording',
-    'finish recording',
-    'halt recording',
-  ])('returns true for pure stop-recording request "%s"', (text) => {
-    expect(isStopRecordingOnly(text)).toBe(true);
-  });
-
-  test('returns true when polite fillers surround the stop request', () => {
-    expect(isStopRecordingOnly('please stop recording')).toBe(true);
-    expect(isStopRecordingOnly('can you stop the recording?')).toBe(true);
-    expect(isStopRecordingOnly('could you end the recording please')).toBe(true);
-    expect(isStopRecordingOnly('stop the recording now')).toBe(true);
-    expect(isStopRecordingOnly('just stop recording, thanks')).toBe(true);
-  });
-
-  test.each([
-    'stop recording and open Chrome',
-    'end the recording and then close Safari',
-    'how do I stop recording?',
-  ])('returns false for mixed-intent or questioning "%s"', (text) => {
-    expect(isStopRecordingOnly(text)).toBe(false);
-  });
-
-  test('returns false for ambiguous phrases', () => {
-    expect(isStopRecordingOnly('end it')).toBe(false);
-    expect(isStopRecordingOnly('stop')).toBe(false);
-    expect(isStopRecordingOnly('quit')).toBe(false);
-  });
-
-  test('returns false for empty or unrelated text', () => {
-    expect(isStopRecordingOnly('')).toBe(false);
-    expect(isStopRecordingOnly('hello world')).toBe(false);
-    expect(isStopRecordingOnly('open Safari')).toBe(false);
-  });
-
-  test('handles punctuation', () => {
-    expect(isStopRecordingOnly('stop recording!')).toBe(true);
-    expect(isStopRecordingOnly('stop recording.')).toBe(true);
-    expect(isStopRecordingOnly('end the recording?')).toBe(true);
-  });
-});
-
-// ─── classifyRecordingIntent ────────────────────────────────────────────────
-
-describe('classifyRecordingIntent', () => {
-  // Basic classification
-  test.each([
-    ['record my screen', 'start_only'],
-    ['stop recording', 'stop_only'],
-    ['open Safari and record my screen', 'mixed'],
-    ['hello world', 'none'],
-    ['', 'none'],
-  ] as const)('basic: "%s" → %s', (text, expected) => {
-    expect(classifyRecordingIntent(text)).toBe(expected);
-  });
-
-  // Dynamic name stripping
-  test.each([
-    ['Nova, record my screen', ['Nova'], 'start_only'],
-    ['hey Nova, start recording', ['Nova'], 'start_only'],
-    ['hey, Nova, start recording', ['Nova'], 'start_only'],
-    ['Nova, stop recording', ['Nova'], 'stop_only'],
-    ['Nova, open Safari and record my screen', ['Nova'], 'mixed'],
-    ['Nova, hello', ['Nova'], 'none'],
-  ] as const)('dynamic names: "%s" with %j → %s', (text, names, expected) => {
-    expect(classifyRecordingIntent(text, [...names])).toBe(expected);
-  });
-
-  // No dynamic names (backwards compat)
   test('works without dynamic names parameter', () => {
-    expect(classifyRecordingIntent('record my screen')).toBe('start_only');
-    expect(classifyRecordingIntent('stop recording')).toBe('stop_only');
-  });
-
-  // With fillers
-  test('handles filler words correctly', () => {
-    expect(classifyRecordingIntent('please record my screen')).toBe('start_only');
-    expect(classifyRecordingIntent('can you stop recording?')).toBe('stop_only');
-  });
-
-  // Both start and stop → mixed
-  test('classifies as mixed when both start and stop patterns are present', () => {
-    expect(classifyRecordingIntent('start recording and then stop recording')).toBe('mixed');
-    expect(classifyRecordingIntent('record my screen and stop recording')).toBe('mixed');
-  });
-
-  // Edge cases
-  test('classifies as mixed when stop-recording has additional task', () => {
-    expect(classifyRecordingIntent('stop recording and open Chrome')).toBe('mixed');
-  });
-
-  // Case insensitivity with dynamic names
-  test('dynamic name stripping is case-insensitive', () => {
-    expect(classifyRecordingIntent('nova, record my screen', ['Nova'])).toBe('start_only');
-    expect(classifyRecordingIntent('NOVA, stop recording', ['Nova'])).toBe('stop_only');
-    expect(classifyRecordingIntent('Hey NOVA, start recording', ['nova'])).toBe('start_only');
-  });
-
-  // Multiple dynamic names
-  test('handles multiple dynamic names', () => {
-    expect(classifyRecordingIntent('Jarvis, record my screen', ['Nova', 'Jarvis'])).toBe(
-      'start_only',
-    );
-    expect(classifyRecordingIntent('Nova, stop recording', ['Nova', 'Jarvis'])).toBe('stop_only');
-  });
-
-  // Empty dynamic names array
-  test('handles empty dynamic names array', () => {
-    expect(classifyRecordingIntent('record my screen', [])).toBe('start_only');
-    expect(classifyRecordingIntent('stop recording', [])).toBe('stop_only');
-  });
-
-  // Name with colon separator
-  test('handles colon separator after name', () => {
-    expect(classifyRecordingIntent('Nova: record my screen', ['Nova'])).toBe('start_only');
+    expect(resolveRecordingIntent('record my screen')).toEqual({ kind: 'start_only' });
+    expect(resolveRecordingIntent('stop recording')).toEqual({ kind: 'stop_only' });
   });
 });
 
-// ─── isInterrogative ──────────────────────────────────────────────────────────
+// ─── executeRecordingIntent ─────────────────────────────────────────────────
 
-describe('isInterrogative', () => {
-  // Questions about recording — should return true
-  test.each([
-    'how do I stop recording?',
-    'how do I record my screen?',
-    'what does screen recording do?',
-    'why is screen recording not working?',
-    'when should I stop recording?',
-    'where does the recording file go?',
-    'which display should I record?',
-    'What is the screen recording feature?',
-    'How do I start recording on Mac?',
-  ])('returns true for question: "%s"', (text) => {
-    expect(isInterrogative(text)).toBe(true);
+describe('executeRecordingIntent', () => {
+  // Mock the recording handlers module
+  const mockHandleRecordingStart = mock((): string | null => 'mock-recording-id');
+  const mockHandleRecordingStop = mock((): string | undefined => 'mock-recording-id');
+
+  mock.module('../daemon/handlers/recording.js', () => ({
+    handleRecordingStart: mockHandleRecordingStart,
+    handleRecordingStop: mockHandleRecordingStop,
+  }));
+
+  // Dynamically import so the mock takes effect
+  let executeRecordingIntent: typeof import('../daemon/recording-executor.js').executeRecordingIntent;
+
+  // Must await the dynamic import before running tests
+  const setupPromise = import('../daemon/recording-executor.js').then((mod) => {
+    executeRecordingIntent = mod.executeRecordingIntent;
   });
 
-  // Imperative commands — should return false
-  test.each([
-    'record my screen',
-    'stop recording',
-    'open Chrome and record my screen',
-    'stop recording and close the browser',
-    'can you record my screen?',
-    'could you stop recording please',
-    'start recording',
-    'please record my screen',
-  ])('returns false for command: "%s"', (text) => {
-    expect(isInterrogative(text)).toBe(false);
+  const mockContext = {
+    conversationId: 'conv-123',
+    socket: {} as any,
+    ctx: {} as any,
+  };
+
+  beforeEach(async () => {
+    await setupPromise;
+    mockHandleRecordingStart.mockReset();
+    mockHandleRecordingStop.mockReset();
+    // Default: start succeeds (returns recording ID)
+    mockHandleRecordingStart.mockReturnValue('mock-recording-id');
+    // Default: stop succeeds (returns recording ID)
+    mockHandleRecordingStop.mockReturnValue('mock-recording-id');
   });
 
-  // With dynamic names — strips name prefix first
-  test('strips dynamic name before checking', () => {
-    expect(isInterrogative('Nova, how do I stop recording?', ['Nova'])).toBe(true);
-    expect(isInterrogative('Nova, record my screen', ['Nova'])).toBe(false);
+  test('none → returns { handled: false }', () => {
+    const result = executeRecordingIntent({ kind: 'none' }, mockContext);
+    expect(result).toEqual({ handled: false });
   });
 
-  // Polite prefix + question
-  test('handles polite prefix before question word', () => {
-    expect(isInterrogative('please, how do I stop recording?')).toBe(true);
-    expect(isInterrogative('hey, what does screen recording do?')).toBe(true);
+  test('start_only → calls handleRecordingStart, returns handled with start text', () => {
+    const result = executeRecordingIntent({ kind: 'start_only' }, mockContext);
+    expect(mockHandleRecordingStart).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      handled: true,
+      recordingStarted: true,
+      responseText: 'Starting screen recording.',
+    });
+  });
+
+  test('start_only when recording already active → returns handled with already-active text', () => {
+    mockHandleRecordingStart.mockReturnValue(null);
+    const result = executeRecordingIntent({ kind: 'start_only' }, mockContext);
+    expect(mockHandleRecordingStart).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      handled: true,
+      recordingStarted: false,
+      responseText: 'A recording is already active.',
+    });
+  });
+
+  test('stop_only → calls handleRecordingStop, returns handled with stop text', () => {
+    const result = executeRecordingIntent({ kind: 'stop_only' }, mockContext);
+    expect(mockHandleRecordingStop).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      handled: true,
+      responseText: 'Stopping the recording.',
+    });
+  });
+
+  test('stop_only when no active recording → returns handled with no-active text', () => {
+    mockHandleRecordingStop.mockReturnValue(undefined);
+    const result = executeRecordingIntent({ kind: 'stop_only' }, mockContext);
+    expect(result).toEqual({
+      handled: true,
+      responseText: 'No active recording to stop.',
+    });
+  });
+
+  test('start_with_remainder → returns not handled with remainder and pendingStart', () => {
+    const result = executeRecordingIntent(
+      { kind: 'start_with_remainder', remainder: 'open Safari' },
+      mockContext,
+    );
+    expect(result).toEqual({
+      handled: false,
+      remainderText: 'open Safari',
+      pendingStart: true,
+    });
+  });
+
+  test('stop_with_remainder → returns not handled with remainder and pendingStop', () => {
+    const result = executeRecordingIntent(
+      { kind: 'stop_with_remainder', remainder: 'open Chrome' },
+      mockContext,
+    );
+    expect(result).toEqual({
+      handled: false,
+      remainderText: 'open Chrome',
+      pendingStop: true,
+    });
+  });
+
+  test('start_and_stop_only → calls both stop and start, returns handled', () => {
+    const result = executeRecordingIntent({ kind: 'start_and_stop_only' }, mockContext);
+    expect(mockHandleRecordingStop).toHaveBeenCalledTimes(1);
+    expect(mockHandleRecordingStart).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      handled: true,
+      recordingStarted: true,
+      responseText: 'Stopping current recording and starting a new one.',
+    });
+  });
+
+  test('start_and_stop_only when start fails → returns handled with stop-only text', () => {
+    mockHandleRecordingStart.mockReturnValue(null);
+    const result = executeRecordingIntent({ kind: 'start_and_stop_only' }, mockContext);
+    expect(mockHandleRecordingStop).toHaveBeenCalledTimes(1);
+    expect(mockHandleRecordingStart).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      handled: true,
+      recordingStarted: false,
+      responseText: 'Stopping the recording.',
+    });
+  });
+
+  test('start_and_stop_with_remainder → returns not handled with remainder and both pending flags', () => {
+    const result = executeRecordingIntent(
+      { kind: 'start_and_stop_with_remainder', remainder: 'open Safari' },
+      mockContext,
+    );
+    expect(result).toEqual({
+      handled: false,
+      remainderText: 'open Safari',
+      pendingStart: true,
+      pendingStop: true,
+    });
+  });
+
+  // ── New intent kinds ──────────────────────────────────────────────────────
+
+  test('restart_only → returns handled with restart text', () => {
+    const result = executeRecordingIntent({ kind: 'restart_only' }, mockContext);
+    expect(result).toEqual({
+      handled: true,
+      responseText: 'Restarting screen recording.',
+    });
+  });
+
+  test('restart_with_remainder → returns not handled with remainder and pendingRestart', () => {
+    const result = executeRecordingIntent(
+      { kind: 'restart_with_remainder', remainder: 'and open safari' },
+      mockContext,
+    );
+    expect(result).toEqual({
+      handled: false,
+      remainderText: 'and open safari',
+      pendingRestart: true,
+    });
+  });
+
+  test('pause_only → returns handled with pause text', () => {
+    const result = executeRecordingIntent({ kind: 'pause_only' }, mockContext);
+    expect(result).toEqual({
+      handled: true,
+      responseText: 'Pausing the recording.',
+    });
+  });
+
+  test('resume_only → returns handled with resume text', () => {
+    const result = executeRecordingIntent({ kind: 'resume_only' }, mockContext);
+    expect(result).toEqual({
+      handled: true,
+      responseText: 'Resuming the recording.',
+    });
   });
 });

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -21,7 +21,8 @@ import type {
   SuggestionRequest,
   TaskSubmit,
 } from '../ipc-protocol.js';
-import { classifyRecordingIntent, detectRecordingIntent, detectStopRecordingIntent, hasSubstantiveContent, isInterrogative, stripRecordingIntent, stripStopRecordingIntent } from '../recording-intent.js';
+import { executeRecordingIntent } from '../recording-executor.js';
+import { resolveRecordingIntent } from '../recording-intent.js';
 import { buildSessionErrorMessage,classifySessionError } from '../session-error.js';
 import { handleCuSessionCreate } from './computer-use.js';
 import { handleRecordingStart, handleRecordingStop } from './recording.js';
@@ -70,126 +71,198 @@ export async function handleTaskSubmit(
       return;
     }
 
+    // ── Structured command intent (bypasses text parsing) ──────────────────
+    const config = getConfig();
+    if (config.daemon.standaloneRecording && msg.commandIntent?.domain === 'screen_recording') {
+      const action = msg.commandIntent.action;
+      rlog.info({ action, source: 'commandIntent' }, 'Recording command intent received');
+      if (action === 'start') {
+        const conversation = conversationStore.createConversation(msg.task || 'Screen Recording');
+        ctx.socketToSession.set(socket, conversation.id);
+        const recordingId = handleRecordingStart(conversation.id, { promptForSource: true }, socket, ctx);
+        ctx.send(socket, { type: 'task_routed', sessionId: conversation.id, interactionType: 'text_qa' });
+        ctx.send(socket, {
+          type: 'assistant_text_delta',
+          text: recordingId ? 'Starting screen recording.' : 'A recording is already active.',
+          sessionId: conversation.id,
+        });
+        ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
+        if (!recordingId) ctx.socketToSession.delete(socket);
+        return;
+      } else if (action === 'stop') {
+        let activeSessionId = ctx.socketToSession.get(socket);
+        if (!activeSessionId) {
+          const conversation = conversationStore.createConversation(msg.task || 'Stop Recording');
+          activeSessionId = conversation.id;
+          ctx.socketToSession.set(socket, activeSessionId);
+        }
+        const stopped = handleRecordingStop(activeSessionId, ctx) !== undefined;
+        ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
+        ctx.send(socket, {
+          type: 'assistant_text_delta',
+          text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',
+          sessionId: activeSessionId,
+        });
+        ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        return;
+      } else if (action === 'restart') {
+        let activeSessionId = ctx.socketToSession.get(socket);
+        if (!activeSessionId) {
+          const conversation = conversationStore.createConversation(msg.task || 'Restart Recording');
+          activeSessionId = conversation.id;
+          ctx.socketToSession.set(socket, activeSessionId);
+        }
+        ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
+        ctx.send(socket, {
+          type: 'assistant_text_delta',
+          text: 'Restarting screen recording.',
+          sessionId: activeSessionId,
+        });
+        ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        return;
+      } else if (action === 'pause') {
+        let activeSessionId = ctx.socketToSession.get(socket);
+        if (!activeSessionId) {
+          const conversation = conversationStore.createConversation(msg.task || 'Pause Recording');
+          activeSessionId = conversation.id;
+          ctx.socketToSession.set(socket, activeSessionId);
+        }
+        ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
+        ctx.send(socket, {
+          type: 'assistant_text_delta',
+          text: 'Pausing the recording.',
+          sessionId: activeSessionId,
+        });
+        ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        return;
+      } else if (action === 'resume') {
+        let activeSessionId = ctx.socketToSession.get(socket);
+        if (!activeSessionId) {
+          const conversation = conversationStore.createConversation(msg.task || 'Resume Recording');
+          activeSessionId = conversation.id;
+          ctx.socketToSession.set(socket, activeSessionId);
+        }
+        ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
+        ctx.send(socket, {
+          type: 'assistant_text_delta',
+          text: 'Resuming the recording.',
+          sessionId: activeSessionId,
+        });
+        ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        return;
+      } else {
+        // Unrecognized action — fall through to normal text handling so the
+        // task is not silently dropped.
+        rlog.warn({ action, source: 'commandIntent' }, 'Unrecognized screen_recording action, falling through to text handling');
+      }
+    }
+
     // ── Standalone recording intent interception ──────────────────────────
-    // Intercept recording-only and stop-recording prompts before they reach
-    // the classifier. This prevents "record my screen" from creating a CU
-    // session and routes it to the standalone recording flow instead.
-    //
-    // For mixed intent, recording start/stop is deferred until after the
-    // downstream classifier creates the final conversation, so the recording
-    // attachment is linked to the correct conversation (not an orphaned one).
     let pendingRecordingStart = false;
     let pendingRecordingStop = false;
-    const config = getConfig();
     if (config.daemon.standaloneRecording) {
       const name = getAssistantName();
       const dynamicNames = [name].filter(Boolean) as string[];
-      const intentClass = classifyRecordingIntent(msg.task, dynamicNames);
+      const intentResult = resolveRecordingIntent(msg.task, dynamicNames);
 
-      switch (intentClass) {
-        case 'stop_only': {
-          // Find the active session for this socket so we can resolve the
-          // conversation that owns the recording.
-          let activeSessionId = ctx.socketToSession.get(socket);
-          // Ensure we have a sessionId for message_complete even if no prior session exists
-          if (!activeSessionId) {
-            const conversation = conversationStore.createConversation(msg.task);
-            activeSessionId = conversation.id;
-            ctx.socketToSession.set(socket, activeSessionId);
-          }
-          // Always attempt stop — handleRecordingStop has a global fallback that
-          // resolves to the active recording even if this conversation doesn't own it.
-          const stopped = handleRecordingStop(activeSessionId, ctx) !== undefined;
-          rlog.info('Recording stop intent intercepted');
-          ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
-          ctx.send(socket, {
-            type: 'assistant_text_delta',
-            text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',
-            sessionId: activeSessionId,
-          });
-          ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
-          return;
+      if (intentResult.kind === 'start_only') {
+        // Create a conversation so the recording can be attached later
+        const conversation = conversationStore.createConversation(msg.task);
+        ctx.socketToSession.set(socket, conversation.id);
+
+        const execResult = executeRecordingIntent(intentResult, {
+          conversationId: conversation.id,
+          socket,
+          ctx,
+        });
+
+        ctx.send(socket, { type: 'task_routed', sessionId: conversation.id, interactionType: 'text_qa' });
+        ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: conversation.id });
+        ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
+
+        // If recording rejected, unbind socket
+        if (execResult.recordingStarted === false) {
+          ctx.socketToSession.delete(socket);
         }
-        case 'start_only': {
-          // Create a conversation so the recording can be attached later (M4).
-          const conversation = conversationStore.createConversation(msg.task);
-          ctx.socketToSession.set(socket, conversation.id);
 
-          const recordingId = handleRecordingStart(conversation.id, { promptForSource: true }, socket, ctx);
-
-          if (recordingId) {
-            ctx.send(socket, { type: 'task_routed', sessionId: conversation.id, interactionType: 'text_qa' });
-            ctx.send(socket, { type: 'assistant_text_delta', text: 'Starting screen recording.', sessionId: conversation.id });
-          } else {
-            // Recording was rejected (already active) — clean up the orphaned conversation
-            ctx.send(socket, { type: 'task_routed', sessionId: conversation.id, interactionType: 'text_qa' });
-            ctx.send(socket, { type: 'assistant_text_delta', text: 'A recording is already active.', sessionId: conversation.id });
-          }
-          ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
-
-          if (!recordingId) {
-            // Unbind the socket so the ephemeral rejection session doesn't block
-            // future task_submit routing, but keep the conversation in the DB so
-            // the client can still send follow-up messages to the routed sessionId.
-            ctx.socketToSession.delete(socket);
-          }
-
-          rlog.info({ sessionId: conversation.id }, 'Recording-only intent intercepted — routed to standalone recording');
-          return;
-        }
-        case 'mixed': {
-          // Skip recording side effects for questions about recording
-          // (e.g., "how do I stop recording?") — let the model answer instead.
-          if (isInterrogative(msg.task, dynamicNames)) {
-            rlog.info('Mixed recording intent is interrogative — skipping side effects');
-            break;
-          }
-
-          // Mixed = recording intent embedded in broader text (e.g., "open Chrome and record my screen").
-          // Defer recording start/stop until after the classifier creates the final conversation,
-          // so the recording attachment is linked to the correct conversation.
-          const hasStart = detectRecordingIntent(msg.task);
-          const hasStop = detectStopRecordingIntent(msg.task);
-
-          // Strip recording clauses from the task
-          let remaining = msg.task;
-          if (hasStart) remaining = stripRecordingIntent(remaining);
-          if (hasStop) remaining = stripStopRecordingIntent(remaining);
-
-          // If nothing substantive remains after stripping, handle as recording-only now
-          if (!hasSubstantiveContent(remaining, dynamicNames)) {
-            let sessionId = ctx.socketToSession.get(socket);
-            if (!sessionId) {
-              const conversation = conversationStore.createConversation(msg.task);
-              sessionId = conversation.id;
-              ctx.socketToSession.set(socket, sessionId);
-            }
-            if (hasStop) handleRecordingStop(sessionId, ctx);
-            const startResult = hasStart ? handleRecordingStart(sessionId, { promptForSource: true }, socket, ctx) : null;
-            ctx.send(socket, { type: 'task_routed', sessionId, interactionType: 'text_qa' });
-            let text: string;
-            if (hasStart && startResult) {
-              text = hasStop ? 'Stopping current recording and starting a new one.' : 'Starting screen recording.';
-            } else if (hasStart) {
-              text = 'A recording is already active.';
-            } else {
-              text = 'Stopping the recording.';
-            }
-            ctx.send(socket, { type: 'assistant_text_delta', text, sessionId });
-            ctx.send(socket, { type: 'message_complete', sessionId });
-            return;
-          }
-
-          // Set deferred flags — recording will start after the final conversation is created
-          pendingRecordingStart = hasStart;
-          pendingRecordingStop = hasStop;
-          (msg as { task: string }).task = remaining;
-          rlog.info({ remaining }, 'Mixed recording intent — deferred, continuing with remaining text');
-          break;
-        }
-        case 'none':
-          break;
+        rlog.info({ sessionId: conversation.id }, 'Recording-only intent intercepted — routed to standalone recording');
+        return;
       }
+
+      if (intentResult.kind === 'stop_only') {
+        let activeSessionId = ctx.socketToSession.get(socket);
+        if (!activeSessionId) {
+          const conversation = conversationStore.createConversation(msg.task);
+          activeSessionId = conversation.id;
+          ctx.socketToSession.set(socket, activeSessionId);
+        }
+
+        const execResult = executeRecordingIntent(intentResult, {
+          conversationId: activeSessionId,
+          socket,
+          ctx,
+        });
+
+        rlog.info('Recording stop intent intercepted');
+        ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
+        ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: activeSessionId });
+        ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        return;
+      }
+
+      if (intentResult.kind === 'start_and_stop_only') {
+        let activeSessionId = ctx.socketToSession.get(socket);
+        if (!activeSessionId) {
+          const conversation = conversationStore.createConversation(msg.task);
+          activeSessionId = conversation.id;
+          ctx.socketToSession.set(socket, activeSessionId);
+        }
+
+        const execResult = executeRecordingIntent(intentResult, {
+          conversationId: activeSessionId,
+          socket,
+          ctx,
+        });
+
+        rlog.info('Recording start+stop intent intercepted');
+        ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
+        ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: activeSessionId });
+        ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        return;
+      }
+
+      // Restart/pause/resume — fully handled intents
+      if (intentResult.kind === 'restart_only' || intentResult.kind === 'pause_only' || intentResult.kind === 'resume_only') {
+        let activeSessionId = ctx.socketToSession.get(socket);
+        if (!activeSessionId) {
+          const conversation = conversationStore.createConversation(msg.task);
+          activeSessionId = conversation.id;
+          ctx.socketToSession.set(socket, activeSessionId);
+        }
+
+        const execResult = executeRecordingIntent(intentResult, {
+          conversationId: activeSessionId,
+          socket,
+          ctx,
+        });
+
+        rlog.info({ kind: intentResult.kind }, 'Recording intent intercepted');
+        ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
+        ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: activeSessionId });
+        ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        return;
+      }
+
+      if (intentResult.kind === 'start_with_remainder' || intentResult.kind === 'stop_with_remainder' ||
+          intentResult.kind === 'start_and_stop_with_remainder' || intentResult.kind === 'restart_with_remainder') {
+        // Defer recording action until after classifier creates the final conversation
+        pendingRecordingStart = intentResult.kind === 'start_with_remainder' || intentResult.kind === 'start_and_stop_with_remainder';
+        pendingRecordingStop = intentResult.kind === 'stop_with_remainder' || intentResult.kind === 'start_and_stop_with_remainder';
+        (msg as { task: string }).task = intentResult.remainder;
+        rlog.info({ remaining: intentResult.remainder }, 'Recording intent deferred, continuing with remaining text');
+      }
+
+      // 'none' falls through to normal processing
     }
 
     // Slash candidates always route to text_qa — bypass classifier

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -258,6 +258,7 @@ export async function handleTaskSubmit(
         // Defer recording action until after classifier creates the final conversation
         pendingRecordingStart = intentResult.kind === 'start_with_remainder' || intentResult.kind === 'start_and_stop_with_remainder';
         pendingRecordingStop = intentResult.kind === 'stop_with_remainder' || intentResult.kind === 'start_and_stop_with_remainder';
+        // TODO(M2): restart_with_remainder — restart handler doesn't exist yet, will be wired in M2
         (msg as { task: string }).task = intentResult.remainder;
         rlog.info({ remaining: intentResult.remainder }, 'Recording intent deferred, continuing with remaining text');
       }

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -34,7 +34,8 @@ import type {
   UserMessage,
 } from '../ipc-protocol.js';
 import { normalizeThreadType } from '../ipc-protocol.js';
-import { classifyRecordingIntent, detectRecordingIntent, detectStopRecordingIntent, hasSubstantiveContent, isInterrogative, stripRecordingIntent, stripStopRecordingIntent } from '../recording-intent.js';
+import { executeRecordingIntent } from '../recording-executor.js';
+import { resolveRecordingIntent } from '../recording-intent.js';
 import { buildSessionErrorMessage,classifySessionError } from '../session-error.js';
 import { generateVideoThumbnail } from '../video-thumbnail.js';
 import { handleRecordingStart, handleRecordingStop } from './recording.js';
@@ -226,86 +227,100 @@ export async function handleUserMessage(
       }
     }
 
+    // ── Structured command intent (bypasses text parsing) ──────────────────
+    if (config.daemon.standaloneRecording && msg.commandIntent?.domain === 'screen_recording') {
+      const action = msg.commandIntent.action;
+      rlog.info({ action, source: 'commandIntent' }, 'Recording command intent received in user_message');
+      if (action === 'start') {
+        const recordingId = handleRecordingStart(msg.sessionId, { promptForSource: true }, socket, ctx);
+        ctx.send(socket, {
+          type: 'assistant_text_delta',
+          text: recordingId ? 'Starting screen recording.' : 'A recording is already active.',
+          sessionId: msg.sessionId,
+        });
+        ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+        return;
+      } else if (action === 'stop') {
+        const stopped = handleRecordingStop(msg.sessionId, ctx) !== undefined;
+        ctx.send(socket, {
+          type: 'assistant_text_delta',
+          text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',
+          sessionId: msg.sessionId,
+        });
+        ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+        return;
+      } else if (action === 'restart') {
+        ctx.send(socket, {
+          type: 'assistant_text_delta',
+          text: 'Restarting screen recording.',
+          sessionId: msg.sessionId,
+        });
+        ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+        return;
+      } else if (action === 'pause') {
+        ctx.send(socket, {
+          type: 'assistant_text_delta',
+          text: 'Pausing the recording.',
+          sessionId: msg.sessionId,
+        });
+        ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+        return;
+      } else if (action === 'resume') {
+        ctx.send(socket, {
+          type: 'assistant_text_delta',
+          text: 'Resuming the recording.',
+          sessionId: msg.sessionId,
+        });
+        ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+        return;
+      } else {
+        // Unrecognized action — fall through to normal text handling
+        rlog.warn({ action, source: 'commandIntent' }, 'Unrecognized screen_recording action, falling through to text handling');
+      }
+    }
+
     // ── Standalone recording intent interception ──────────────────────────
     if (config.daemon.standaloneRecording && messageText) {
       const name = getAssistantName();
       const dynamicNames = [name].filter(Boolean) as string[];
-      const intentClass = classifyRecordingIntent(messageText, dynamicNames);
+      const intentResult = resolveRecordingIntent(messageText, dynamicNames);
 
-      switch (intentClass) {
-        case 'stop_only': {
-          const stopped = handleRecordingStop(msg.sessionId, ctx) !== undefined;
-          rlog.info('Recording stop intent intercepted in user_message');
+      if (intentResult.kind === 'start_only' || intentResult.kind === 'stop_only' ||
+          intentResult.kind === 'start_and_stop_only' ||
+          intentResult.kind === 'restart_only' || intentResult.kind === 'pause_only' ||
+          intentResult.kind === 'resume_only') {
+        const execResult = executeRecordingIntent(intentResult, {
+          conversationId: msg.sessionId,
+          socket,
+          ctx,
+        });
+
+        if (execResult.handled) {
+          rlog.info({ kind: intentResult.kind }, 'Recording intent intercepted in user_message');
           ctx.send(socket, {
             type: 'assistant_text_delta',
-            text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',
+            text: execResult.responseText!,
             sessionId: msg.sessionId,
           });
           ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
           return;
         }
-        case 'start_only': {
-          const recordingId = handleRecordingStart(msg.sessionId, { promptForSource: true }, socket, ctx);
-          rlog.info('Recording-only intent intercepted in user_message');
-
-          if (recordingId) {
-            ctx.send(socket, { type: 'assistant_text_delta', text: 'Starting screen recording.', sessionId: msg.sessionId });
-          } else {
-            ctx.send(socket, { type: 'assistant_text_delta', text: 'A recording is already active.', sessionId: msg.sessionId });
-          }
-          ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
-          return;
-        }
-        case 'mixed': {
-          // Skip recording side effects for questions about recording
-          // (e.g., "how do I stop recording?") — let the model answer instead.
-          if (isInterrogative(messageText, dynamicNames)) {
-            rlog.info('Mixed recording intent is interrogative — skipping side effects');
-            break;
-          }
-
-          // Mixed = recording intent embedded in broader text.
-          // Handle the recording action, then check if remaining text is substantive.
-          const hasStart = detectRecordingIntent(messageText);
-          const hasStop = detectStopRecordingIntent(messageText);
-
-          if (hasStop) {
-            handleRecordingStop(msg.sessionId, ctx);
-            rlog.info('Mixed intent — stopping recording');
-          }
-          const startResult = hasStart ? handleRecordingStart(msg.sessionId, { promptForSource: true }, socket, ctx) : null;
-          if (hasStart) {
-            rlog.info({ started: !!startResult }, 'Mixed intent — starting recording');
-          }
-
-          // Strip recording clauses from the message
-          let remaining = messageText;
-          if (hasStart) remaining = stripRecordingIntent(remaining);
-          if (hasStop) remaining = stripStopRecordingIntent(remaining);
-
-          // If nothing substantive remains (just fillers, names, punctuation), complete now
-          if (!hasSubstantiveContent(remaining, dynamicNames)) {
-            let text: string;
-            if (hasStart && startResult) {
-              text = hasStop ? 'Stopping current recording and starting a new one.' : 'Starting screen recording.';
-            } else if (hasStart) {
-              text = 'A recording is already active.';
-            } else {
-              text = 'Stopping the recording.';
-            }
-            ctx.send(socket, { type: 'assistant_text_delta', text, sessionId: msg.sessionId });
-            ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
-            return;
-          }
-
-          // Continue with stripped text for downstream processing
-          msg.content = remaining;
-          rlog.info({ remaining }, 'Mixed recording intent — recording handled, continuing with remaining text');
-          break;
-        }
-        case 'none':
-          break;
       }
+
+      if (intentResult.kind === 'start_with_remainder' || intentResult.kind === 'stop_with_remainder' ||
+          intentResult.kind === 'start_and_stop_with_remainder' || intentResult.kind === 'restart_with_remainder') {
+        const execResult = executeRecordingIntent(intentResult, {
+          conversationId: msg.sessionId,
+          socket,
+          ctx,
+        });
+
+        // Continue with stripped text for downstream processing
+        msg.content = execResult.remainderText ?? messageText;
+        rlog.info({ remaining: msg.content, kind: intentResult.kind }, 'Recording intent with remainder — continuing with remaining text');
+      }
+
+      // 'none' falls through to normal processing
     }
 
     dispatchUserMessage(

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -175,7 +175,7 @@ export async function handleUserMessage(
     };
 
     const config = getConfig();
-    const messageText = msg.content ?? '';
+    let messageText = msg.content ?? '';
 
     // Block inbound messages that contain secrets and redirect to secure prompt
     if (!msg.bypassSecretCheck) {
@@ -317,6 +317,17 @@ export async function handleUserMessage(
 
         // Continue with stripped text for downstream processing
         msg.content = execResult.remainderText ?? messageText;
+        messageText = msg.content;
+
+        // Execute the recording side effects that executeRecordingIntent deferred
+        if (intentResult.kind === 'stop_with_remainder' || intentResult.kind === 'start_and_stop_with_remainder') {
+          handleRecordingStop(msg.sessionId, ctx);
+        }
+        if (intentResult.kind === 'start_with_remainder' || intentResult.kind === 'start_and_stop_with_remainder') {
+          handleRecordingStart(msg.sessionId, { promptForSource: true }, socket, ctx);
+        }
+        // TODO(M2): restart_with_remainder — restart handler doesn't exist yet, will be wired in M2
+
         rlog.info({ remaining: msg.content, kind: intentResult.kind }, 'Recording intent with remainder — continuing with remaining text');
       }
 

--- a/assistant/src/daemon/ipc-contract/computer-use.ts
+++ b/assistant/src/daemon/ipc-contract/computer-use.ts
@@ -1,6 +1,6 @@
 // Computer use, task routing, ride shotgun, and watch observation types.
 
-import type { IpcBlobRef,UserMessageAttachment } from './shared.js';
+import type { CommandIntent, IpcBlobRef,UserMessageAttachment } from './shared.js';
 
 // === Client → Server ===
 
@@ -51,6 +51,8 @@ export interface TaskSubmit {
   screenHeight: number;
   attachments?: UserMessageAttachment[];
   source?: 'voice' | 'text';
+  /** Structured command intent — bypasses text parsing when present. */
+  commandIntent?: CommandIntent;
 }
 
 export interface RideShotgunStart {

--- a/assistant/src/daemon/ipc-contract/messages.ts
+++ b/assistant/src/daemon/ipc-contract/messages.ts
@@ -1,7 +1,7 @@
 // User/assistant messages, tool results, confirmations, secrets, errors, and generation lifecycle.
 
 import type { ChannelId, InterfaceId } from '../../channels/types.js';
-import type { UserMessageAttachment } from './shared.js';
+import type { CommandIntent, UserMessageAttachment } from './shared.js';
 
 // === Client → Server ===
 
@@ -19,6 +19,8 @@ export interface UserMessage {
   channel?: ChannelId;
   /** Originating interface identifier (e.g. 'macos'). */
   interface: InterfaceId;
+  /** Structured command intent — bypasses text parsing when present. */
+  commandIntent?: CommandIntent;
 }
 
 export interface ConfirmationResponse {

--- a/assistant/src/daemon/ipc-contract/shared.ts
+++ b/assistant/src/daemon/ipc-contract/shared.ts
@@ -29,6 +29,12 @@ export interface DictationContext {
   cursorInTextField: boolean;
 }
 
+/** Structured command intent — bypasses text parsing when present. */
+export interface CommandIntent {
+  domain: 'screen_recording';
+  action: 'start' | 'stop' | 'restart' | 'pause' | 'resume';
+}
+
 export interface UserMessageAttachment {
   id?: string;
   filename: string;

--- a/assistant/src/daemon/recording-executor.ts
+++ b/assistant/src/daemon/recording-executor.ts
@@ -1,0 +1,135 @@
+// Unified recording intent executor.
+// Bridges the gap between recording-intent.ts (classification) and
+// handlers/recording.ts (side effects), so both sessions.ts and misc.ts
+// can share the same execution logic without duplicating switch/case blocks.
+
+import type * as net from 'node:net';
+
+import type { HandlerContext } from './handlers/shared.js';
+import { handleRecordingStart, handleRecordingStop } from './handlers/recording.js';
+import type { RecordingIntentResult } from './recording-intent.js';
+
+export interface RecordingExecutionContext {
+  conversationId: string;
+  socket: net.Socket;
+  ctx: HandlerContext;
+}
+
+export interface RecordingExecutionOutput {
+  /** If true, the intent was fully handled (start_only / stop_only) -- handler should send completion and return */
+  handled: boolean;
+  /** Human-readable response text for the user */
+  responseText?: string;
+  /** For _with_remainder: the remaining text after stripping recording clauses */
+  remainderText?: string;
+  /** Whether a recording start should be/was initiated */
+  pendingStart?: boolean;
+  /** Whether a recording stop should be/was initiated */
+  pendingStop?: boolean;
+  /** Whether a restart is pending (for restart_with_remainder) */
+  pendingRestart?: boolean;
+  /** Whether handleRecordingStart succeeded (true) or was rejected (false). Only set for start_only / start_and_stop_only. */
+  recordingStarted?: boolean;
+}
+
+export function executeRecordingIntent(
+  result: RecordingIntentResult,
+  context: RecordingExecutionContext,
+): RecordingExecutionOutput {
+  switch (result.kind) {
+    case 'none':
+      return { handled: false };
+
+    case 'start_only': {
+      const recordingId = handleRecordingStart(
+        context.conversationId,
+        { promptForSource: true },
+        context.socket,
+        context.ctx,
+      );
+      return {
+        handled: true,
+        recordingStarted: !!recordingId,
+        responseText: recordingId
+          ? 'Starting screen recording.'
+          : 'A recording is already active.',
+      };
+    }
+
+    case 'stop_only': {
+      const stopped = handleRecordingStop(context.conversationId, context.ctx) !== undefined;
+      return {
+        handled: true,
+        responseText: stopped
+          ? 'Stopping the recording.'
+          : 'No active recording to stop.',
+      };
+    }
+
+    case 'start_with_remainder':
+      return {
+        handled: false,
+        remainderText: result.remainder,
+        pendingStart: true,
+      };
+
+    case 'stop_with_remainder':
+      return {
+        handled: false,
+        remainderText: result.remainder,
+        pendingStop: true,
+      };
+
+    case 'start_and_stop_only': {
+      handleRecordingStop(context.conversationId, context.ctx);
+      const recordingId = handleRecordingStart(
+        context.conversationId,
+        { promptForSource: true },
+        context.socket,
+        context.ctx,
+      );
+      return {
+        handled: true,
+        recordingStarted: !!recordingId,
+        responseText: recordingId
+          ? 'Stopping current recording and starting a new one.'
+          : 'Stopping the recording.',
+      };
+    }
+
+    case 'start_and_stop_with_remainder':
+      return {
+        handled: false,
+        remainderText: result.remainder,
+        pendingStart: true,
+        pendingStop: true,
+      };
+
+    // ── New intent kinds (M1 placeholders — actual handler wiring in M2) ──
+
+    case 'restart_only':
+      return {
+        handled: true,
+        responseText: 'Restarting screen recording.',
+      };
+
+    case 'restart_with_remainder':
+      return {
+        handled: false,
+        remainderText: result.remainder,
+        pendingRestart: true,
+      };
+
+    case 'pause_only':
+      return {
+        handled: true,
+        responseText: 'Pausing the recording.',
+      };
+
+    case 'resume_only':
+      return {
+        handled: true,
+        responseText: 'Resuming the recording.',
+      };
+  }
+}

--- a/assistant/src/daemon/recording-intent.ts
+++ b/assistant/src/daemon/recording-intent.ts
@@ -1,8 +1,26 @@
-// Recording intent detection for standalone screen recording routing.
-// Used by task/message handlers to intercept recording-related prompts
+// Recording intent resolution for standalone screen recording routing.
+// Exports `resolveRecordingIntent` as the single public entry point for
+// text-based intent detection. Handlers use this (or structured
+// `commandIntent` payloads) to intercept recording-related prompts
 // before they reach the classifier or create a CU session.
+//
+// Internal helpers (detect/strip/classify) are kept as private utilities
+// consumed only by `resolveRecordingIntent`.
 
-export type RecordingIntentClass = 'start_only' | 'stop_only' | 'mixed' | 'none';
+type RecordingIntentClass = 'start_only' | 'stop_only' | 'mixed' | 'none';
+
+export type RecordingIntentResult =
+  | { kind: 'none' }
+  | { kind: 'start_only' }
+  | { kind: 'stop_only' }
+  | { kind: 'start_with_remainder'; remainder: string }
+  | { kind: 'stop_with_remainder'; remainder: string }
+  | { kind: 'start_and_stop_only' }
+  | { kind: 'start_and_stop_with_remainder'; remainder: string }
+  | { kind: 'restart_only' }
+  | { kind: 'restart_with_remainder'; remainder: string }
+  | { kind: 'pause_only' }
+  | { kind: 'resume_only' };
 
 // ─── Start recording patterns ────────────────────────────────────────────────
 
@@ -23,6 +41,28 @@ const STOP_RECORDING_PATTERNS: RegExp[] = [
   /\bend\s+(the\s+)?recording\b/i,
   /\bfinish\s+(the\s+)?recording\b/i,
   /\bhalt\s+(the\s+)?recording\b/i,
+];
+
+// ─── Restart recording patterns (compound: stop + start a new one) ──────────
+
+const RESTART_RECORDING_PATTERNS: RegExp[] = [
+  /\brestart\s+(the\s+)?recording\b/i,
+  /\bredo\s+(the\s+)?recording\b/i,
+  /\bstop\s+(the\s+)?recording\s+and\s+(start|begin)\s+(a\s+)?(new|fresh|another)\b/i,
+  /\bstop\s+(the\s+)?recording\s+and\s+(start|begin)\s+(a\s+)?new\s+one\b/i,
+  /\bstop\s+and\s+restart\s+(the\s+)?recording\b/i,
+  /\bstop\s+recording\s+and\s+start\s+(a\s+)?(new|another|fresh)\s+(one\s*)?/i,
+];
+
+// ─── Pause/resume recording patterns ────────────────────────────────────────
+
+const PAUSE_RECORDING_PATTERNS: RegExp[] = [
+  /\bpause\s+(the\s+)?recording\b/i,
+];
+
+const RESUME_RECORDING_PATTERNS: RegExp[] = [
+  /\bresume\s+(the\s+)?recording\b/i,
+  /\bunpause\s+(the\s+)?recording\b/i,
 ];
 
 // ─── Stop-recording clause removal for mixed-intent prompts ─────────────────
@@ -47,17 +87,39 @@ const RECORDING_CLAUSE_PATTERNS: RegExp[] = [
   /\brecord\s+(my\s+|the\s+)?screen\s+while\b/i,
 ];
 
+// ─── Restart clause removal ─────────────────────────────────────────────────
+
+const RESTART_RECORDING_CLAUSE_PATTERNS: RegExp[] = [
+  // Longer compound patterns first — avoids partial matches by shorter patterns
+  /\bstop\s+(the\s+)?recording\s+and\s+(start|begin)\s+(a\s+)?(new|fresh|another)\b(\s+one)?/i,
+  /\bstop\s+and\s+restart\s+(the\s+)?recording\b/i,
+  /\bstop\s+recording\s+and\s+start\s+(a\s+)?(new|another|fresh)\s+(one\s*)?/i,
+  /\b(and\s+)?(also\s+)?restart\s+(the\s+)?recording\b/i,
+  /\b(and\s+)?(also\s+)?redo\s+(the\s+)?recording\b/i,
+];
+
+// ─── Pause/resume clause removal ────────────────────────────────────────────
+
+const PAUSE_RECORDING_CLAUSE_PATTERNS: RegExp[] = [
+  /\b(and\s+)?(also\s+)?pause\s+(the\s+)?recording\b/i,
+];
+
+const RESUME_RECORDING_CLAUSE_PATTERNS: RegExp[] = [
+  /\b(and\s+)?(also\s+)?resume\s+(the\s+)?recording\b/i,
+  /\b(and\s+)?(also\s+)?unpause\s+(the\s+)?recording\b/i,
+];
+
 /** Common polite/filler words stripped before checking intent-only status. */
 const FILLER_PATTERN =
   /\b(please|pls|plz|can\s+you|could\s+you|would\s+you|now|right\s+now|thanks|thank\s+you|thx|ty|for\s+me|ok(ay)?|hey|hi|just)\b/gi;
 
-// ─── Public API ──────────────────────────────────────────────────────────────
+// ─── Internal helpers ────────────────────────────────────────────────────────
 
 /**
  * Returns true if the user's message includes any recording-related phrases.
  * Does not distinguish between recording-only and mixed-intent prompts.
  */
-export function detectRecordingIntent(taskText: string): boolean {
+function detectRecordingIntent(taskText: string): boolean {
   return START_RECORDING_PATTERNS.some((p) => p.test(taskText));
 }
 
@@ -67,7 +129,7 @@ export function detectRecordingIntent(taskText: string): boolean {
  * "record my screen while I work" -> false (has CU task component)
  * "open Chrome and record my screen" -> false (has CU task component)
  */
-export function isRecordingOnly(taskText: string): boolean {
+function isRecordingOnly(taskText: string): boolean {
   if (!detectRecordingIntent(taskText)) return false;
 
   // Strip the recording clause and check if anything substantive remains
@@ -84,8 +146,23 @@ export function isRecordingOnly(taskText: string): boolean {
  * Requires explicit "stop/end/finish/halt recording" phrasing --
  * bare "stop", "end it", or "quit" are too ambiguous and will not match.
  */
-export function detectStopRecordingIntent(taskText: string): boolean {
+function detectStopRecordingIntent(taskText: string): boolean {
   return STOP_RECORDING_PATTERNS.some((p) => p.test(taskText));
+}
+
+/** Returns true if any restart compound pattern matches. */
+function detectRestartRecordingIntent(taskText: string): boolean {
+  return RESTART_RECORDING_PATTERNS.some((p) => p.test(taskText));
+}
+
+/** Returns true if any pause pattern matches. */
+function detectPauseRecordingIntent(taskText: string): boolean {
+  return PAUSE_RECORDING_PATTERNS.some((p) => p.test(taskText));
+}
+
+/** Returns true if any resume pattern matches. */
+function detectResumeRecordingIntent(taskText: string): boolean {
+  return RESUME_RECORDING_PATTERNS.some((p) => p.test(taskText));
 }
 
 /**
@@ -93,7 +170,7 @@ export function detectStopRecordingIntent(taskText: string): boolean {
  * Used when a recording intent is embedded in a broader CU task so the
  * recording portion can be handled separately while the task continues.
  */
-export function stripRecordingIntent(taskText: string): string {
+function stripRecordingIntent(taskText: string): string {
   let result = taskText;
   for (const pattern of RECORDING_CLAUSE_PATTERNS) {
     result = result.replace(pattern, '');
@@ -106,9 +183,36 @@ export function stripRecordingIntent(taskText: string): string {
  * Removes stop-recording clauses from a message, returning the cleaned text.
  * Analogous to stripRecordingIntent but for stop-recording phrases.
  */
-export function stripStopRecordingIntent(taskText: string): string {
+function stripStopRecordingIntent(taskText: string): string {
   let result = taskText;
   for (const pattern of STOP_RECORDING_CLAUSE_PATTERNS) {
+    result = result.replace(pattern, '');
+  }
+  return result.replace(/\s{2,}/g, ' ').trim();
+}
+
+/** Removes restart-recording clauses from text. */
+function stripRestartRecordingIntent(taskText: string): string {
+  let result = taskText;
+  for (const pattern of RESTART_RECORDING_CLAUSE_PATTERNS) {
+    result = result.replace(pattern, '');
+  }
+  return result.replace(/\s{2,}/g, ' ').trim();
+}
+
+/** Removes pause-recording clauses from text. */
+function stripPauseRecordingIntent(taskText: string): string {
+  let result = taskText;
+  for (const pattern of PAUSE_RECORDING_CLAUSE_PATTERNS) {
+    result = result.replace(pattern, '');
+  }
+  return result.replace(/\s{2,}/g, ' ').trim();
+}
+
+/** Removes resume-recording clauses from text. */
+function stripResumeRecordingIntent(taskText: string): string {
+  let result = taskText;
+  for (const pattern of RESUME_RECORDING_CLAUSE_PATTERNS) {
     result = result.replace(pattern, '');
   }
   return result.replace(/\s{2,}/g, ' ').trim();
@@ -121,11 +225,35 @@ export function stripStopRecordingIntent(taskText: string): string {
  * "how do I stop recording?" -> false (has additional context)
  * "stop recording and close the browser" -> false (has CU task component)
  */
-export function isStopRecordingOnly(taskText: string): boolean {
+function isStopRecordingOnly(taskText: string): boolean {
   if (!detectStopRecordingIntent(taskText)) return false;
 
   const stripped = stripStopRecordingIntent(taskText);
   // Also remove common polite/filler words that don't change the intent
+  const withoutFillers = stripped.replace(FILLER_PATTERN, '');
+  return withoutFillers.replace(/[.,;!?\s]+/g, '').length === 0;
+}
+
+/** Returns true if the text is purely a restart command (no additional task). */
+function isRestartRecordingOnly(taskText: string): boolean {
+  if (!detectRestartRecordingIntent(taskText)) return false;
+  const stripped = stripRestartRecordingIntent(taskText);
+  const withoutFillers = stripped.replace(FILLER_PATTERN, '');
+  return withoutFillers.replace(/[.,;!?\s]+/g, '').length === 0;
+}
+
+/** Returns true if the text is purely a pause command (no additional task). */
+function isPauseRecordingOnly(taskText: string): boolean {
+  if (!detectPauseRecordingIntent(taskText)) return false;
+  const stripped = stripPauseRecordingIntent(taskText);
+  const withoutFillers = stripped.replace(FILLER_PATTERN, '');
+  return withoutFillers.replace(/[.,;!?\s]+/g, '').length === 0;
+}
+
+/** Returns true if the text is purely a resume command (no additional task). */
+function isResumeRecordingOnly(taskText: string): boolean {
+  if (!detectResumeRecordingIntent(taskText)) return false;
+  const stripped = stripResumeRecordingIntent(taskText);
   const withoutFillers = stripped.replace(FILLER_PATTERN, '');
   return withoutFillers.replace(/[.,;!?\s]+/g, '').length === 0;
 }
@@ -159,7 +287,7 @@ export function stripDynamicNames(text: string, dynamicNames: string[]): string 
  * punctuation, and dynamic assistant names. Used to determine whether
  * remaining text after stripping recording clauses needs further processing.
  */
-export function hasSubstantiveContent(text: string, dynamicNames?: string[]): boolean {
+function hasSubstantiveContent(text: string, dynamicNames?: string[]): boolean {
   let cleaned = text;
   if (dynamicNames && dynamicNames.length > 0) {
     cleaned = stripDynamicNames(cleaned, dynamicNames);
@@ -183,7 +311,7 @@ const WH_INTERROGATIVE = /^\s*(how|what|why|when|where|who|which)\b/i;
  * "open Chrome and record my screen" → false  (command — trigger recording)
  * "can you record my screen?" → false  (polite imperative — trigger recording)
  */
-export function isInterrogative(text: string, dynamicNames?: string[]): boolean {
+function isInterrogative(text: string, dynamicNames?: string[]): boolean {
   let cleaned = text;
   if (dynamicNames && dynamicNames.length > 0) {
     cleaned = stripDynamicNames(cleaned, dynamicNames);
@@ -206,7 +334,7 @@ export function isInterrogative(text: string, dynamicNames?: string[]): boolean 
  * If `dynamicNames` are provided, they are stripped from the beginning of the
  * text before classification (e.g., "Nova, record my screen" -> "record my screen").
  */
-export function classifyRecordingIntent(
+function classifyRecordingIntent(
   taskText: string,
   dynamicNames?: string[],
 ): RecordingIntentClass {
@@ -230,4 +358,117 @@ export function classifyRecordingIntent(
   }
 
   return 'none';
+}
+
+// ─── Structured intent resolver ─────────────────────────────────────────────
+
+/**
+ * Resolves recording intent from user text into a structured result that
+ * distinguishes pure recording commands from commands with remaining task text.
+ *
+ * Pipeline:
+ * 1. Strip dynamic assistant names (leading vocative)
+ * 2. Strip leading polite wrappers
+ * 3. Interrogative gate — questions return `none`
+ * 3.5. Restart compound detection (before independent start/stop)
+ * 3.6. Pause/resume detection
+ * 4. Detect start/stop patterns (start takes precedence when both present)
+ * 5. Determine if recording-only or has a remainder, stripping from the
+ *    ORIGINAL text to preserve the user's exact phrasing
+ */
+export function resolveRecordingIntent(
+  text: string,
+  dynamicNames?: string[],
+): RecordingIntentResult {
+  // Step 1: Strip dynamic assistant names for normalization
+  let normalized =
+    dynamicNames && dynamicNames.length > 0
+      ? stripDynamicNames(text, dynamicNames)
+      : text;
+
+  // Step 2: Strip leading polite wrappers for normalization
+  normalized = normalized.replace(/^\s*(hey|hi|hello|please|pls|plz)[,\s]+/i, '');
+
+  // Step 3: Interrogative gate — WH-questions are not commands
+  if (WH_INTERROGATIVE.test(normalized)) {
+    return { kind: 'none' };
+  }
+
+  // Step 3.5: Restart compound detection — check BEFORE independent start/stop
+  // so "stop recording and start a new one" is recognized as restart, not
+  // as separate stop + start patterns.
+  if (detectRestartRecordingIntent(normalized)) {
+    if (isRestartRecordingOnly(normalized)) {
+      return { kind: 'restart_only' };
+    }
+    // Strip from the ORIGINAL text to preserve user's exact phrasing
+    const remainder = stripRestartRecordingIntent(text);
+    if (hasSubstantiveContent(remainder, dynamicNames)) {
+      return { kind: 'restart_with_remainder', remainder };
+    }
+    return { kind: 'restart_only' };
+  }
+
+  // Step 3.6: Pause/resume detection — check before start/stop
+  if (detectPauseRecordingIntent(normalized)) {
+    if (isPauseRecordingOnly(normalized)) {
+      return { kind: 'pause_only' };
+    }
+    // Pause with additional text falls through to normal processing
+  }
+
+  if (detectResumeRecordingIntent(normalized)) {
+    if (isResumeRecordingOnly(normalized)) {
+      return { kind: 'resume_only' };
+    }
+    // Resume with additional text falls through to normal processing
+  }
+
+  // Step 4: Detect start and stop patterns on the normalized text
+  const hasStart = detectRecordingIntent(normalized);
+  const hasStop = detectStopRecordingIntent(normalized);
+
+  // Step 5: Resolve
+  if (hasStart) {
+    if (hasStop) {
+      // Both start and stop detected — use combined variants
+      if (isRecordingOnly(normalized)) {
+        // Check if stop-only after stripping start patterns
+        const withoutStart = stripRecordingIntent(normalized);
+        if (isStopRecordingOnly(withoutStart)) {
+          return { kind: 'start_and_stop_only' };
+        }
+      }
+      let remainder = stripRecordingIntent(text);
+      remainder = stripStopRecordingIntent(remainder);
+      if (hasSubstantiveContent(remainder, dynamicNames)) {
+        return { kind: 'start_and_stop_with_remainder', remainder };
+      }
+      return { kind: 'start_and_stop_only' };
+    }
+    // Only start detected
+    if (isRecordingOnly(normalized)) {
+      return { kind: 'start_only' };
+    }
+    // Strip from the ORIGINAL text to preserve user's exact phrasing
+    const remainder = stripRecordingIntent(text);
+    if (hasSubstantiveContent(remainder, dynamicNames)) {
+      return { kind: 'start_with_remainder', remainder };
+    }
+    return { kind: 'start_only' };
+  }
+
+  if (hasStop) {
+    if (isStopRecordingOnly(normalized)) {
+      return { kind: 'stop_only' };
+    }
+    // Strip from the ORIGINAL text to preserve user's exact phrasing
+    const remainder = stripStopRecordingIntent(text);
+    if (hasSubstantiveContent(remainder, dynamicNames)) {
+      return { kind: 'stop_with_remainder', remainder };
+    }
+    return { kind: 'stop_only' };
+  }
+
+  return { kind: 'none' };
 }

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -818,6 +818,17 @@ public struct IPCChannelReadinessResponseSnapshotRemoteCheck: Codable, Sendable 
     }
 }
 
+/// Structured command intent — bypasses text parsing when present.
+public struct IPCCommandIntent: Codable, Sendable {
+    public let domain: String
+    public let action: String
+
+    public init(domain: String, action: String) {
+        self.domain = domain
+        self.action = action
+    }
+}
+
 public struct IPCConfirmationRequest: Codable, Sendable {
     public let type: String
     public let requestId: String
@@ -4499,14 +4510,17 @@ public struct IPCTaskSubmit: Codable, Sendable {
     public let screenHeight: Int
     public let attachments: [IPCUserMessageAttachment]?
     public let source: String?
+    /// Structured command intent — bypasses text parsing when present.
+    public let commandIntent: IPCCommandIntent?
 
-    public init(type: String, task: String, screenWidth: Int, screenHeight: Int, attachments: [IPCUserMessageAttachment]? = nil, source: String? = nil) {
+    public init(type: String, task: String, screenWidth: Int, screenHeight: Int, attachments: [IPCUserMessageAttachment]? = nil, source: String? = nil, commandIntent: IPCCommandIntent? = nil) {
         self.type = type
         self.task = task
         self.screenWidth = screenWidth
         self.screenHeight = screenHeight
         self.attachments = attachments
         self.source = source
+        self.commandIntent = commandIntent
     }
 }
 
@@ -5549,8 +5563,10 @@ public struct IPCUserMessage: Codable, Sendable {
     public let channel: String?
     /// Originating interface identifier (e.g. 'macos').
     public let interface: String
+    /// Structured command intent — bypasses text parsing when present.
+    public let commandIntent: IPCCommandIntent?
 
-    public init(type: String, sessionId: String, content: String? = nil, attachments: [IPCUserMessageAttachment]? = nil, activeSurfaceId: String? = nil, currentPage: String? = nil, bypassSecretCheck: Bool? = nil, channel: String? = nil, interface: String) {
+    public init(type: String, sessionId: String, content: String? = nil, attachments: [IPCUserMessageAttachment]? = nil, activeSurfaceId: String? = nil, currentPage: String? = nil, bypassSecretCheck: Bool? = nil, channel: String? = nil, interface: String, commandIntent: IPCCommandIntent? = nil) {
         self.type = type
         self.sessionId = sessionId
         self.content = content
@@ -5560,6 +5576,7 @@ public struct IPCUserMessage: Codable, Sendable {
         self.bypassSecretCheck = bypassSecretCheck
         self.channel = channel
         self.interface = interface
+        self.commandIntent = commandIntent
     }
 }
 


### PR DESCRIPTION
## Summary

Selective pull from `feature/rec-intent-resolver` donor branch plus new restart/pause/resume compound detection.

**From donor branch:**
- `resolveRecordingIntent()` — structured intent resolver replacing `classifyRecordingIntent` as the single public entry point
- `recording-executor.ts` — unified execution bridge between intent classification and recording handlers
- `CommandIntent` IPC interface with `commandIntent?` field on `TaskSubmit` and `UserMessage`
- Handler wiring in `sessions.ts` and `misc.ts` updated to use resolver + executor pattern with commandIntent bypass

**New in this PR:**
- Restart compound patterns: "restart recording", "redo the recording", "stop recording and start a new one", etc.
- Pause/resume patterns: "pause recording", "resume recording", "unpause the recording"
- New `RecordingIntentResult` kinds: `restart_only`, `restart_with_remainder`, `pause_only`, `resume_only`
- Interrogative gate for all new patterns (prevents "how do I restart recording?" from triggering side effects)
- Placeholder executor handling for new intent kinds (actual handler wiring deferred to M2)
- CommandIntent action type expanded: `'start' | 'stop' | 'restart' | 'pause' | 'resume'`
- 141 unit tests covering all resolver behaviors including new patterns

Closes #9345.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
