### PR TITLE
fix: replace explicit any with NodeJS.ErrnoException in CLI hatch command

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -555,8 +555,8 @@ function installCLISymlink(): void {
       if (dest === cliBinary) return;
       // Stale or dangling symlink — remove before creating new one
       unlinkSync(symlinkPath);
-    } catch (e: any) {
-      if (e?.code !== "ENOENT") throw e;
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException)?.code !== "ENOENT") throw e;
       // Path doesn't exist — proceed to create symlink
     }
 


### PR DESCRIPTION
## Summary

- Replace `catch (e: any)` with `catch (e)` + `NodeJS.ErrnoException` type assertion in `cli/src/commands/hatch.ts` to fix `@typescript-eslint/no-explicit-any` lint error

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22425213571

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
