### PR TITLE
fix(macos): make VInfoTooltip non-actionable for assistive tech

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VInfoTooltip.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VInfoTooltip.swift
@@ -2,9 +2,11 @@ import SwiftUI
 
 /// A small info-circle icon that reliably shows a tooltip on hover.
 ///
-/// On macOS, plain `Image` views with `.help()` have inconsistent tooltip
-/// tracking. Wrapping the icon in a `Button` ensures the system registers
-/// the hover area and shows the tooltip every time.
+/// Uses a non-interactive view with `.help()` so the tooltip appears on
+/// hover without introducing a focusable button to VoiceOver or keyboard
+/// navigation. The `.accessibilityHidden(true)` keeps it out of the
+/// accessibility tree entirely — the adjacent label already conveys the
+/// context, and the tooltip text is supplementary.
 ///
 /// Usage:
 /// ```swift
@@ -21,16 +23,13 @@ public struct VInfoTooltip: View {
     }
 
     public var body: some View {
-        Button {} label: {
-            Image(systemName: "info.circle")
-                .font(.system(size: 12))
-                .foregroundColor(VColor.textMuted)
-                .frame(width: 16, height: 16)
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .help(tooltip)
-        .accessibilityLabel(tooltip)
+        Image(systemName: "info.circle")
+            .font(.system(size: 12))
+            .foregroundColor(VColor.textMuted)
+            .frame(width: 16, height: 16)
+            .contentShape(Rectangle())
+            .help(tooltip)
+            .accessibilityHidden(true)
     }
 }
 


### PR DESCRIPTION
Addresses feedback from PR #9243:\n- Replace Button wrapper in VInfoTooltip with non-interactive view\n- Removes dead-end focus targets and misleading button announcements for VoiceOver users\n- Tooltip still shows on hover via .help() modifier
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
