### PR TITLE
Fix notification fallback to always notify desktop

### DIFF
--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -165,31 +165,43 @@ function buildFallbackDecision(
   const isHighUrgencyAction =
     signal.attentionHints.urgency === 'high' && signal.attentionHints.requiresAction;
 
-  if (isHighUrgencyAction) {
-    const copy: Partial<Record<NotificationChannel, RenderedChannelCopy>> = {};
-    for (const ch of availableChannels) {
-      copy[ch] = {
-        title: signal.sourceEventName,
-        body: `Action required: ${signal.sourceEventName}`,
-      };
-    }
+  // Always include the vellum channel in the fallback — it's a local IPC
+  // broadcast with no cost, so desktop notifications should never be lost
+  // when the LLM is unavailable. External channels (e.g. Telegram) are
+  // only included for high-urgency actionable signals.
+  const selectedChannels: NotificationChannel[] = isHighUrgencyAction
+    ? [...availableChannels]
+    : availableChannels.filter((ch) => ch === 'vellum');
 
+  if (selectedChannels.length === 0) {
     return {
-      shouldNotify: true,
-      selectedChannels: [...availableChannels],
-      reasoningSummary: 'Fallback: high urgency + requires action',
-      renderedCopy: copy,
+      shouldNotify: false,
+      selectedChannels: [],
+      reasoningSummary: 'Fallback: suppressed (vellum channel not available)',
+      renderedCopy: {},
       dedupeKey: `fallback:${signal.sourceEventName}:${signal.sourceSessionId}:${signal.createdAt}`,
       confidence: 0.3,
       fallbackUsed: true,
     };
   }
 
+  const copy: Partial<Record<NotificationChannel, RenderedChannelCopy>> = {};
+  for (const ch of selectedChannels) {
+    copy[ch] = {
+      title: signal.sourceEventName,
+      body: isHighUrgencyAction
+        ? `Action required: ${signal.sourceEventName}`
+        : signal.sourceEventName,
+    };
+  }
+
   return {
-    shouldNotify: false,
-    selectedChannels: [],
-    reasoningSummary: 'Fallback: suppressed (not high urgency + requires action)',
-    renderedCopy: {},
+    shouldNotify: true,
+    selectedChannels,
+    reasoningSummary: isHighUrgencyAction
+      ? 'Fallback: high urgency + requires action — all channels'
+      : 'Fallback: vellum-only (local IPC, always delivered)',
+    renderedCopy: copy,
     dedupeKey: `fallback:${signal.sourceEventName}:${signal.sourceSessionId}:${signal.createdAt}`,
     confidence: 0.3,
     fallbackUsed: true,


### PR DESCRIPTION
## Summary
- Make buildFallbackDecision always select the vellum channel (local IPC, no cost)
- Only gate external channels (Telegram) on high urgency in fallback mode
- Prevents schedule.complete and other medium-urgency events from being suppressed when LLM fails
- Addresses feedback on #9151

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
