### PR TITLE
Fix layout decode for removed panel IDs

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
@@ -23,19 +23,22 @@ extension SlotContent: Codable {
         let type = try container.decode(String.self, forKey: .type)
         switch type {
         case "native":
-            let panel = try container.decode(NativePanelId.self, forKey: .panel)
-            self = .native(panel)
+            // Decode the raw string and try to match it to a known panel ID.
+            // If the value is stale (e.g. a removed panel like "assistantInbox"),
+            // degrade to .empty instead of failing the entire layout decode.
+            let rawPanel = try container.decode(String.self, forKey: .panel)
+            if let panel = NativePanelId(rawValue: rawPanel) {
+                self = .native(panel)
+            } else {
+                self = .empty
+            }
         case "surface":
             let surfaceId = try container.decode(String.self, forKey: .surfaceId)
             self = .surface(surfaceId: surfaceId)
         case "empty":
             self = .empty
         default:
-            throw DecodingError.dataCorruptedError(
-                forKey: .type,
-                in: container,
-                debugDescription: "Unknown SlotContent type: \(type)"
-            )
+            self = .empty
         }
     }
 


### PR DESCRIPTION
## Summary
- Make NativePanelId decoding handle unknown/stale values gracefully
- Prevents full layout reset when persisted JSON contains removed panel IDs like assistantInbox
- Addresses feedback on #9149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
