### PR TITLE
fix(macos): use observable state for conversation zoom command enablement

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -187,11 +187,6 @@ extension AppDelegate {
         }
     }
 
-    /// Whether conversation zoom commands should be enabled (public for the SwiftUI command group).
-    public var isConversationZoomEnabled: Bool {
-        mainWindow?.windowState.isConversationVisible ?? false
-    }
-
     @objc public func handleConversationZoomIn() { routeZoomIntent(.conversationZoomIn) }
     @objc public func handleConversationZoomOut() { routeZoomIntent(.conversationZoomOut) }
     @objc public func handleConversationZoomReset() { routeZoomIntent(.conversationZoomReset) }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -95,7 +95,7 @@ private func quickInputHotKeyHandler(
 }
 
 @MainActor
-public final class AppDelegate: NSObject, NSApplicationDelegate {
+public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     /// Shared reference — `NSApp.delegate as? AppDelegate` fails under
     /// SwiftUI's `@NSApplicationDelegateAdaptor` because SwiftUI wraps
     /// the delegate.  Use `AppDelegate.shared` instead.
@@ -167,6 +167,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var statusIconCancellable: AnyCancellable?
     var connectionStatusCancellable: AnyCancellable?
     private var quickInputAttachmentCancellable: AnyCancellable?
+    private var conversationZoomEnabledCancellable: AnyCancellable?
+    /// Observable state for SwiftUI command group `.disabled()` modifiers.
+    /// Updated via Combine subscription to `MainWindowState.objectWillChange`.
+    @Published public var isConversationZoomEnabled: Bool = false
     var pulseTimer: Timer?
     var pulsePhase: CGFloat = 1.0
     var pulseDirection: CGFloat = -1.0
@@ -679,6 +683,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
             mainWindow?.close()
             mainWindow = nil
+            conversationZoomEnabledCancellable = nil
+            isConversationZoomEnabled = false
 
             if let hotKeyMonitor {
                 NSEvent.removeMonitor(hotKeyMonitor)
@@ -790,6 +796,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
         mainWindow?.close()
         mainWindow = nil
+        conversationZoomEnabledCancellable = nil
+        isConversationZoomEnabled = false
 
         if let hotKeyMonitor {
             NSEvent.removeMonitor(hotKeyMonitor)
@@ -2014,8 +2022,29 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             )
         }
         mainWindow = main
+        observeConversationZoomEnabled(main.windowState)
         observeAssistantStatus()
         return main
+    }
+
+    /// Subscribe to `MainWindowState` changes and keep `isConversationZoomEnabled`
+    /// in sync so SwiftUI command groups can observe it via `@Published`.
+    private func observeConversationZoomEnabled(_ windowState: MainWindowState) {
+        conversationZoomEnabledCancellable = windowState.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self, weak windowState] _ in
+                guard let self, let windowState else { return }
+                // objectWillChange fires before the new value is set,
+                // so defer the read to the next run-loop tick.
+                DispatchQueue.main.async {
+                    let enabled = windowState.isConversationVisible
+                    if self.isConversationZoomEnabled != enabled {
+                        self.isConversationZoomEnabled = enabled
+                    }
+                }
+            }
+        // Set initial value.
+        isConversationZoomEnabled = windowState.isConversationVisible
     }
 
     func showMainWindow(initialMessage: String? = nil, isFirstLaunch: Bool = false) {


### PR DESCRIPTION
Addresses feedback from PRs #9300 and #9310:\n- Add .disabled() modifiers to conversation zoom SwiftUI command buttons\n- Derive enabled state from observable data so SwiftUI properly tracks changes\n- Replaces non-observable AppDelegate property reads that could become stale
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
