### PR TITLE
fix: split channel replies at tool boundaries

### DIFF
--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { RuntimeAttachmentMetadata } from '../runtime/http-types.js';
+
+type DeliveryCall = {
+  callbackUrl: string;
+  payload: Record<string, unknown>;
+  bearerToken?: string;
+};
+
+const deliveryCalls: DeliveryCall[] = [];
+const conversationMessages: Array<{ id: string; role: string; content: string }> = [];
+const attachmentsByMessageId = new Map<string, Array<{
+  id: string;
+  originalFilename?: string;
+  mimeType?: string;
+  sizeBytes?: number;
+  kind?: string;
+}>>();
+
+let renderedHistoryContent: {
+  text: string;
+  textSegments: string[];
+  toolCalls: unknown[];
+  toolCallsBeforeText: boolean;
+  contentOrder: string[];
+  surfaces: unknown[];
+} = {
+  text: '',
+  textSegments: [],
+  toolCalls: [],
+  toolCallsBeforeText: false,
+  contentOrder: [],
+  surfaces: [],
+};
+
+mock.module('../runtime/gateway-client.js', () => ({
+  deliverChannelReply: async (
+    callbackUrl: string,
+    payload: Record<string, unknown>,
+    bearerToken?: string,
+  ) => {
+    deliveryCalls.push({ callbackUrl, payload, bearerToken });
+  },
+}));
+
+mock.module('../memory/conversation-store.js', () => ({
+  getMessages: () => conversationMessages,
+}));
+
+mock.module('../memory/attachments-store.js', () => ({
+  getAttachmentMetadataForMessage: (messageId: string) => attachmentsByMessageId.get(messageId) ?? [],
+}));
+
+mock.module('../daemon/handlers.js', () => ({
+  renderHistoryContent: () => renderedHistoryContent,
+}));
+
+const { deliverRenderedReplyViaCallback, deliverReplyViaCallback } = await import('../runtime/channel-reply-delivery.js');
+
+describe('channel-reply-delivery', () => {
+  beforeEach(() => {
+    deliveryCalls.length = 0;
+    conversationMessages.length = 0;
+    attachmentsByMessageId.clear();
+    renderedHistoryContent = {
+      text: '',
+      textSegments: [],
+      toolCalls: [],
+      toolCallsBeforeText: false,
+      contentOrder: [],
+      surfaces: [],
+    };
+  });
+
+  it('sends non-empty text segments as separate messages and puts attachments on the last segment', async () => {
+    const attachments: RuntimeAttachmentMetadata[] = [
+      { id: 'att-1', filename: 'file.txt', mimeType: 'text/plain', sizeBytes: 5, kind: 'uploaded' },
+    ];
+
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: 'http://gateway/deliver/telegram',
+      chatId: 'chat-1',
+      textSegments: ['Before tool.', '   ', '', 'After tool.'],
+      fallbackText: 'Before tool.After tool.',
+      attachments,
+      assistantId: 'assistant-1',
+      bearerToken: 'token',
+      interSegmentDelayMs: 0,
+    });
+
+    expect(deliveryCalls).toHaveLength(2);
+    expect(deliveryCalls[0]).toEqual({
+      callbackUrl: 'http://gateway/deliver/telegram',
+      payload: {
+        chatId: 'chat-1',
+        text: 'Before tool.',
+        attachments: undefined,
+        assistantId: 'assistant-1',
+      },
+      bearerToken: 'token',
+    });
+    expect(deliveryCalls[1]).toEqual({
+      callbackUrl: 'http://gateway/deliver/telegram',
+      payload: {
+        chatId: 'chat-1',
+        text: 'After tool.',
+        attachments,
+        assistantId: 'assistant-1',
+      },
+      bearerToken: 'token',
+    });
+  });
+
+  it('falls back to rendered.text when no non-empty textSegments exist', async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: 'http://gateway/deliver/sms',
+      chatId: 'chat-2',
+      textSegments: [' ', ''],
+      fallbackText: 'Fallback text',
+      interSegmentDelayMs: 0,
+    });
+
+    expect(deliveryCalls).toHaveLength(1);
+    expect(deliveryCalls[0].payload.text).toBe('Fallback text');
+  });
+
+  it('uses rendered textSegments (tool boundaries) when delivering from conversation history', async () => {
+    conversationMessages.push(
+      { id: 'msg-user', role: 'user', content: 'hi' },
+      { id: 'msg-assistant', role: 'assistant', content: '[{"type":"text","text":"ignored"}]' },
+    );
+    attachmentsByMessageId.set('msg-assistant', [{
+      id: 'att-2',
+      originalFilename: 'log.txt',
+      mimeType: 'text/plain',
+      sizeBytes: 42,
+      kind: 'uploaded',
+    }]);
+    renderedHistoryContent = {
+      text: 'Before tool.After tool.',
+      textSegments: ['Before tool.', 'After tool.'],
+      toolCalls: [],
+      toolCallsBeforeText: false,
+      contentOrder: ['text:0', 'tool:0', 'text:1'],
+      surfaces: [],
+    };
+
+    await deliverReplyViaCallback(
+      'conv-1',
+      'chat-3',
+      'http://gateway/deliver/telegram',
+      'token',
+      'assistant-2',
+    );
+
+    expect(deliveryCalls).toHaveLength(2);
+    expect(deliveryCalls[0].payload).toEqual({
+      chatId: 'chat-3',
+      text: 'Before tool.',
+      attachments: undefined,
+      assistantId: 'assistant-2',
+    });
+    expect(deliveryCalls[1].payload).toEqual({
+      chatId: 'chat-3',
+      text: 'After tool.',
+      attachments: [{
+        id: 'att-2',
+        filename: 'log.txt',
+        mimeType: 'text/plain',
+        sizeBytes: 42,
+        kind: 'uploaded',
+      }],
+      assistantId: 'assistant-2',
+    });
+  });
+});

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -1,0 +1,124 @@
+import { renderHistoryContent } from '../daemon/handlers.js';
+import * as attachmentsStore from '../memory/attachments-store.js';
+import * as conversationStore from '../memory/conversation-store.js';
+import { deliverChannelReply } from './gateway-client.js';
+import type { RuntimeAttachmentMetadata } from './http-types.js';
+
+const INTER_SEGMENT_DELAY_MS = 150;
+
+type DeliverRenderedReplyParams = {
+  callbackUrl: string;
+  chatId: string;
+  textSegments: string[];
+  fallbackText?: string;
+  attachments?: RuntimeAttachmentMetadata[];
+  assistantId?: string;
+  bearerToken?: string;
+  interSegmentDelayMs?: number;
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function toDeliverableTextSegments(
+  textSegments: string[],
+  fallbackText?: string,
+): string[] {
+  const nonEmptySegments = textSegments.filter((segment) => segment.trim().length > 0);
+  if (nonEmptySegments.length > 0) return nonEmptySegments;
+  if (typeof fallbackText === 'string' && fallbackText.trim().length > 0) {
+    return [fallbackText];
+  }
+  return [];
+}
+
+export async function deliverRenderedReplyViaCallback(
+  params: DeliverRenderedReplyParams,
+): Promise<void> {
+  const {
+    callbackUrl,
+    chatId,
+    textSegments,
+    fallbackText,
+    attachments,
+    assistantId,
+    bearerToken,
+    interSegmentDelayMs = INTER_SEGMENT_DELAY_MS,
+  } = params;
+
+  const deliverableSegments = toDeliverableTextSegments(textSegments, fallbackText);
+  const replyAttachments = attachments && attachments.length > 0 ? attachments : undefined;
+
+  if (deliverableSegments.length === 0) {
+    if (replyAttachments) {
+      await deliverChannelReply(
+        callbackUrl,
+        {
+          chatId,
+          attachments: replyAttachments,
+          assistantId,
+        },
+        bearerToken,
+      );
+    }
+    return;
+  }
+
+  for (let i = 0; i < deliverableSegments.length; i++) {
+    const isLastSegment = i === deliverableSegments.length - 1;
+    await deliverChannelReply(
+      callbackUrl,
+      {
+        chatId,
+        text: deliverableSegments[i],
+        attachments: isLastSegment ? replyAttachments : undefined,
+        assistantId,
+      },
+      bearerToken,
+    );
+
+    // Send split messages in-order with a short gap so downstream channel
+    // providers preserve the original turn ordering around tool boundaries.
+    if (!isLastSegment && interSegmentDelayMs > 0) {
+      await sleep(interSegmentDelayMs);
+    }
+  }
+}
+
+export async function deliverReplyViaCallback(
+  conversationId: string,
+  externalChatId: string,
+  callbackUrl: string,
+  bearerToken?: string,
+  assistantId?: string,
+): Promise<void> {
+  const msgs = conversationStore.getMessages(conversationId);
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    if (msgs[i].role !== 'assistant') continue;
+
+    let parsed: unknown;
+    try { parsed = JSON.parse(msgs[i].content); } catch { parsed = msgs[i].content; }
+    const rendered = renderHistoryContent(parsed);
+
+    const linked = attachmentsStore.getAttachmentMetadataForMessage(msgs[i].id);
+    const replyAttachments: RuntimeAttachmentMetadata[] = linked.map((a) => ({
+      id: a.id,
+      filename: a.originalFilename,
+      mimeType: a.mimeType,
+      sizeBytes: a.sizeBytes,
+      kind: a.kind,
+    }));
+
+    await deliverRenderedReplyViaCallback({
+      callbackUrl,
+      chatId: externalChatId,
+      textSegments: rendered.textSegments,
+      fallbackText: rendered.text,
+      attachments: replyAttachments,
+      assistantId,
+      bearerToken,
+    });
+    break;
+  }
+}

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -2,14 +2,11 @@
  * Periodic retry sweep for failed channel inbound events.
  */
 
-import { isChannelId,parseChannelId, parseInterfaceId } from '../channels/types.js';
-import { renderHistoryContent } from '../daemon/handlers.js';
+import { isChannelId, parseChannelId, parseInterfaceId } from '../channels/types.js';
 import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
-import * as attachmentsStore from '../memory/attachments-store.js';
 import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
-import * as conversationStore from '../memory/conversation-store.js';
 import { getLogger } from '../util/logger.js';
-import { deliverChannelReply } from './gateway-client.js';
+import { deliverReplyViaCallback } from './channel-reply-delivery.js';
 import type { MessageProcessor } from './http-types.js';
 
 const log = getLogger('runtime-http');
@@ -148,42 +145,6 @@ export async function sweepFailedEvents(
     } catch (err) {
       log.error({ err, eventId: event.id }, 'Retry failed for channel event');
       channelDeliveryStore.recordProcessingFailure(event.id, err);
-    }
-  }
-}
-
-async function deliverReplyViaCallback(
-  conversationId: string,
-  externalChatId: string,
-  callbackUrl: string,
-  bearerToken: string | undefined,
-  assistantId?: string,
-): Promise<void> {
-  const msgs = conversationStore.getMessages(conversationId);
-  for (let i = msgs.length - 1; i >= 0; i--) {
-    if (msgs[i].role === 'assistant') {
-      let parsed: unknown;
-      try { parsed = JSON.parse(msgs[i].content); } catch { parsed = msgs[i].content; }
-      const rendered = renderHistoryContent(parsed);
-
-      const linked = attachmentsStore.getAttachmentMetadataForMessage(msgs[i].id);
-      const replyAttachments = linked.map((a) => ({
-        id: a.id,
-        filename: a.originalFilename,
-        mimeType: a.mimeType,
-        sizeBytes: a.sizeBytes,
-        kind: a.kind,
-      }));
-
-      if (rendered.text || replyAttachments.length > 0) {
-        await deliverChannelReply(callbackUrl, {
-          chatId: externalChatId,
-          text: rendered.text || undefined,
-          attachments: replyAttachments.length > 0 ? replyAttachments : undefined,
-          assistantId,
-        }, bearerToken);
-      }
-      break;
     }
   }
 }

--- a/assistant/src/runtime/routes/channel-delivery-routes.ts
+++ b/assistant/src/runtime/routes/channel-delivery-routes.ts
@@ -2,15 +2,8 @@
  * Channel delivery routes: delivery ack, dead letters, reply delivery,
  * and post-decision delivery scheduling.
  */
-import { renderHistoryContent } from '../../daemon/handlers.js';
-import * as attachmentsStore from '../../memory/attachments-store.js';
 import * as channelDeliveryStore from '../../memory/channel-delivery-store.js';
-import * as conversationStore from '../../memory/conversation-store.js';
-import { getLogger } from '../../util/logger.js';
-import { deliverChannelReply } from '../gateway-client.js';
-import type { RuntimeAttachmentMetadata } from '../http-types.js';
-
-const _log = getLogger('runtime-http');
+export { deliverReplyViaCallback } from '../channel-reply-delivery.js';
 
 // ---------------------------------------------------------------------------
 // Dead letter management
@@ -72,40 +65,3 @@ export async function handleChannelDeliveryAck(req: Request): Promise<Response> 
 // ---------------------------------------------------------------------------
 // Reply delivery via callback
 // ---------------------------------------------------------------------------
-
-export async function deliverReplyViaCallback(
-  conversationId: string,
-  externalChatId: string,
-  callbackUrl: string,
-  bearerToken?: string,
-  assistantId?: string,
-): Promise<void> {
-  const msgs = conversationStore.getMessages(conversationId);
-  for (let i = msgs.length - 1; i >= 0; i--) {
-    if (msgs[i].role === 'assistant') {
-      let parsed: unknown;
-      try { parsed = JSON.parse(msgs[i].content); } catch { parsed = msgs[i].content; }
-      const rendered = renderHistoryContent(parsed);
-
-      const linked = attachmentsStore.getAttachmentMetadataForMessage(msgs[i].id);
-      const replyAttachments: RuntimeAttachmentMetadata[] = linked.map((a) => ({
-        id: a.id,
-        filename: a.originalFilename,
-        mimeType: a.mimeType,
-        sizeBytes: a.sizeBytes,
-        kind: a.kind,
-      }));
-
-      if (rendered.text || replyAttachments.length > 0) {
-        await deliverChannelReply(callbackUrl, {
-          chatId: externalChatId,
-          text: rendered.text || undefined,
-          attachments: replyAttachments.length > 0 ? replyAttachments : undefined,
-          assistantId,
-        }, bearerToken);
-      }
-      break;
-    }
-  }
-}
-


### PR DESCRIPTION
## Summary
- centralize callback reply delivery into a shared runtime module
- split assistant text into separate outbound messages using `renderHistoryContent().textSegments`
- treat `tool_use` boundaries as message boundaries and skip empty segments
- add a short inter-message delay (150ms) to preserve ordering
- apply the same behavior to normal callback delivery and retry-sweep replay paths

## Why
Assistant turns shaped like `text -> tool_use -> text` were being flattened into one outbound message. This preserves pre-tool and post-tool text as separate channel messages.

## Validation
- `cd assistant && bun test src/__tests__/channel-reply-delivery.test.ts`
- `cd assistant && bun test src/__tests__/server-history-render.test.ts`
- `cd assistant && bunx tsc --noEmit`

## Notes
- `bun run lint` currently reports unrelated pre-existing lint errors in the repo; this change does not introduce new lint failures.
