### PR TITLE
fix: remove unused OAuthProviderProfile import

### DIFF
--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -23,7 +23,7 @@
 import type { TokenEndpointAuthMethod } from '../security/oauth2.js';
 import { prepareOAuth2Flow, startOAuth2Flow } from '../security/oauth2.js';
 import { getLogger } from '../util/logger.js';
-import type { OAuthConnectResult, OAuthProviderProfile } from './connect-types.js';
+import type { OAuthConnectResult } from './connect-types.js';
 import { getProviderProfile, resolveService } from './provider-profiles.js';
 import { resolveScopes } from './scope-policy.js';
 import { storeOAuth2Tokens } from './token-persistence.js';


### PR DESCRIPTION
## Summary
- Remove unused `OAuthProviderProfile` type import from `connect-orchestrator.ts`
- Follow-up to #9369 — this file was excluded due to a false-positive secret detection hook flagging existing `clientSecret: options.clientSecret` property assignments

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22421540987

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
