### PR TITLE
fix: make split channel reply delivery resumable across retries

### DIFF
--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -33,12 +33,17 @@ let renderedHistoryContent: {
   surfaces: [],
 };
 
+let deliveryFailAtIndex = -1;
+
 mock.module('../runtime/gateway-client.js', () => ({
   deliverChannelReply: async (
     callbackUrl: string,
     payload: Record<string, unknown>,
     bearerToken?: string,
   ) => {
+    if (deliveryFailAtIndex >= 0 && deliveryCalls.length === deliveryFailAtIndex) {
+      throw new Error('Simulated delivery failure (502)');
+    }
     deliveryCalls.push({ callbackUrl, payload, bearerToken });
   },
 }));
@@ -60,6 +65,7 @@ const { deliverRenderedReplyViaCallback, deliverReplyViaCallback } = await impor
 describe('channel-reply-delivery', () => {
   beforeEach(() => {
     deliveryCalls.length = 0;
+    deliveryFailAtIndex = -1;
     conversationMessages.length = 0;
     attachmentsByMessageId.clear();
     renderedHistoryContent = {
@@ -172,5 +178,144 @@ describe('channel-reply-delivery', () => {
       }],
       assistantId: 'assistant-2',
     });
+  });
+
+  it('skips already-delivered segments when startFromSegment is set', async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: 'http://gateway/deliver/telegram',
+      chatId: 'chat-resume',
+      textSegments: ['Segment A.', 'Segment B.', 'Segment C.'],
+      interSegmentDelayMs: 0,
+      startFromSegment: 1,
+    });
+
+    // Should only deliver segments B and C (indices 1 and 2)
+    expect(deliveryCalls).toHaveLength(2);
+    expect(deliveryCalls[0].payload.text).toBe('Segment B.');
+    expect(deliveryCalls[1].payload.text).toBe('Segment C.');
+  });
+
+  it('calls onSegmentDelivered after each successful segment', async () => {
+    const delivered: number[] = [];
+
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: 'http://gateway/deliver/telegram',
+      chatId: 'chat-progress',
+      textSegments: ['Part 1.', 'Part 2.', 'Part 3.'],
+      interSegmentDelayMs: 0,
+      onSegmentDelivered: (count) => delivered.push(count),
+    });
+
+    expect(delivered).toEqual([1, 2, 3]);
+    expect(deliveryCalls).toHaveLength(3);
+  });
+
+  it('does not call onSegmentDelivered for a failing segment', async () => {
+    const delivered: number[] = [];
+    deliveryFailAtIndex = 2;
+
+    try {
+      await deliverRenderedReplyViaCallback({
+        callbackUrl: 'http://gateway/deliver/telegram',
+        chatId: 'chat-fail',
+        textSegments: ['Part 1.', 'Part 2.', 'Part 3.'],
+        interSegmentDelayMs: 0,
+        onSegmentDelivered: (count) => delivered.push(count),
+      });
+    } catch {
+      // Expected failure on third segment
+    }
+
+    // Only segments 0 and 1 were delivered, callback was called twice
+    expect(delivered).toEqual([1, 2]);
+    expect(deliveryCalls).toHaveLength(2);
+  });
+
+  it('resumes delivery after partial failure using startFromSegment', async () => {
+    const delivered: number[] = [];
+
+    // First attempt: fails on third segment (index 2)
+    deliveryFailAtIndex = 2;
+    try {
+      await deliverRenderedReplyViaCallback({
+        callbackUrl: 'http://gateway/deliver/telegram',
+        chatId: 'chat-retry',
+        textSegments: ['Seg A.', 'Seg B.', 'Seg C.'],
+        interSegmentDelayMs: 0,
+        onSegmentDelivered: (count) => delivered.push(count),
+      });
+    } catch {
+      // Expected
+    }
+
+    expect(delivered).toEqual([1, 2]);
+    expect(deliveryCalls).toHaveLength(2);
+
+    // Reset for retry
+    deliveryCalls.length = 0;
+    delivered.length = 0;
+    deliveryFailAtIndex = -1;
+
+    // Retry: start from segment 2 (the last delivered count)
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: 'http://gateway/deliver/telegram',
+      chatId: 'chat-retry',
+      textSegments: ['Seg A.', 'Seg B.', 'Seg C.'],
+      interSegmentDelayMs: 0,
+      startFromSegment: 2,
+      onSegmentDelivered: (count) => delivered.push(count),
+    });
+
+    // Only segment C should be delivered
+    expect(deliveryCalls).toHaveLength(1);
+    expect(deliveryCalls[0].payload.text).toBe('Seg C.');
+    expect(delivered).toEqual([3]);
+  });
+
+  it('skips all segments when startFromSegment equals total count', async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: 'http://gateway/deliver/telegram',
+      chatId: 'chat-done',
+      textSegments: ['Done A.', 'Done B.'],
+      interSegmentDelayMs: 0,
+      startFromSegment: 2,
+    });
+
+    // All segments already delivered, nothing to send
+    expect(deliveryCalls).toHaveLength(0);
+  });
+
+  it('passes startFromSegment through deliverReplyViaCallback options', async () => {
+    conversationMessages.push(
+      { id: 'msg-u', role: 'user', content: 'hi' },
+      { id: 'msg-a', role: 'assistant', content: '"text"' },
+    );
+    renderedHistoryContent = {
+      text: 'Alpha.Beta.Gamma.',
+      textSegments: ['Alpha.', 'Beta.', 'Gamma.'],
+      toolCalls: [],
+      toolCallsBeforeText: false,
+      contentOrder: ['text:0', 'tool:0', 'text:1', 'tool:1', 'text:2'],
+      surfaces: [],
+    };
+
+    const delivered: number[] = [];
+    await deliverReplyViaCallback(
+      'conv-resume',
+      'chat-resume',
+      'http://gateway/deliver/telegram',
+      'token',
+      'assistant-3',
+      {
+        startFromSegment: 1,
+        onSegmentDelivered: (count) => delivered.push(count),
+      },
+    );
+
+    // Should skip 'Alpha.' and deliver 'Beta.' and 'Gamma.'
+    expect(deliveryCalls).toHaveLength(2);
+    expect(deliveryCalls[0].payload.text).toBe('Beta.');
+    expect(deliveryCalls[1].payload.text).toBe('Gamma.');
+    expect(delivered).toEqual([2, 3]);
   });
 });

--- a/assistant/src/memory/channel-delivery-store.ts
+++ b/assistant/src/memory/channel-delivery-store.ts
@@ -270,6 +270,37 @@ export function clearPendingVerificationReply(eventId: string): void {
     .run();
 }
 
+// ── Per-segment delivery progress ──────────────────────────────────
+//
+// When a split reply (multiple text segments from tool boundaries) fails
+// partway through delivery, we persist how many segments were sent so
+// the retry can resume from where it left off.
+
+/**
+ * Read the number of reply segments already delivered for an event.
+ */
+export function getDeliveredSegmentCount(eventId: string): number {
+  const db = getDb();
+  const row = db
+    .select({ count: channelInboundEvents.deliveredSegmentCount })
+    .from(channelInboundEvents)
+    .where(eq(channelInboundEvents.id, eventId))
+    .get();
+  return row?.count ?? 0;
+}
+
+/**
+ * Update the delivered segment count after successful delivery of one
+ * or more segments. Called incrementally as segments are sent.
+ */
+export function updateDeliveredSegmentCount(eventId: string, count: number): void {
+  const db = getDb();
+  db.update(channelInboundEvents)
+    .set({ deliveredSegmentCount: count, updatedAt: Date.now() })
+    .where(eq(channelInboundEvents.id, eventId))
+    .run();
+}
+
 // ── Dead-letter queue helpers ───────────────────────────────────────
 
 /**

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -16,6 +16,7 @@ import {
   createTasksAndWorkItemsTables,
   createWatchersAndLogsTables,
   migrateCallSessionMode,
+  migrateChannelInboundDeliveredSegments,
   migrateGuardianBootstrapToken,
   migrateGuardianVerificationSessions,
   migrateMessagesFtsBackfill,
@@ -77,6 +78,9 @@ export function initializeDb(): void {
 
   // 14. Late-stage migrations (guardian actions, FTS backfill, index migrations)
   runLateMigrations(database);
+
+  // 14b. Track per-segment delivery progress for split channel replies
+  migrateChannelInboundDeliveredSegments(database);
 
   // 15. Notification system
   createNotificationTables(database);

--- a/assistant/src/memory/migrations/029-channel-inbound-delivered-segments.ts
+++ b/assistant/src/memory/migrations/029-channel-inbound-delivered-segments.ts
@@ -1,0 +1,16 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Add delivered_segment_count column to channel_inbound_events.
+ *
+ * Tracks how many text segments of a split reply were successfully
+ * delivered, so retries can resume from where they left off rather
+ * than re-sending already-delivered segments.
+ */
+export function migrateChannelInboundDeliveredSegments(database: DrizzleDb): void {
+  try {
+    database.run(
+      /*sql*/ `ALTER TABLE channel_inbound_events ADD COLUMN delivered_segment_count INTEGER NOT NULL DEFAULT 0`,
+    );
+  } catch { /* Column already exists */ }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -28,6 +28,7 @@ export { migrateGuardianVerificationSessions } from './026-guardian-verification
 export { migrateGuardianBootstrapToken } from './027-guardian-bootstrap-token.js';
 export { migrateNotificationDeliveryPairingColumns } from './027-notification-delivery-pairing-columns.js';
 export { migrateCallSessionMode } from './028-call-session-mode.js';
+export { migrateChannelInboundDeliveredSegments } from './029-channel-inbound-delivered-segments.js';
 export { createCoreTables } from './100-core-tables.js';
 export { createWatchersAndLogsTables } from './101-watchers-and-logs.js';
 export { addCoreColumns } from './102-alter-table-columns.js';

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -220,6 +220,7 @@ export const channelInboundEvents = sqliteTable('channel_inbound_events', {
   lastProcessingError: text('last_processing_error'),
   retryAfter: integer('retry_after'),
   rawPayload: text('raw_payload'),
+  deliveredSegmentCount: integer('delivered_segment_count').notNull().default(0),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 });

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -15,6 +15,11 @@ type DeliverRenderedReplyParams = {
   assistantId?: string;
   bearerToken?: string;
   interSegmentDelayMs?: number;
+  /** Skip segments already delivered on a previous attempt. */
+  startFromSegment?: number;
+  /** Called after each segment is successfully delivered, with the
+   *  1-based count of segments delivered so far (including prior attempts). */
+  onSegmentDelivered?: (deliveredCount: number) => void;
 };
 
 function sleep(ms: number): Promise<void> {
@@ -45,6 +50,8 @@ export async function deliverRenderedReplyViaCallback(
     assistantId,
     bearerToken,
     interSegmentDelayMs = INTER_SEGMENT_DELAY_MS,
+    startFromSegment = 0,
+    onSegmentDelivered,
   } = params;
 
   const deliverableSegments = toDeliverableTextSegments(textSegments, fallbackText);
@@ -65,7 +72,7 @@ export async function deliverRenderedReplyViaCallback(
     return;
   }
 
-  for (let i = 0; i < deliverableSegments.length; i++) {
+  for (let i = startFromSegment; i < deliverableSegments.length; i++) {
     const isLastSegment = i === deliverableSegments.length - 1;
     await deliverChannelReply(
       callbackUrl,
@@ -78,6 +85,8 @@ export async function deliverRenderedReplyViaCallback(
       bearerToken,
     );
 
+    onSegmentDelivered?.(i + 1);
+
     // Send split messages in-order with a short gap so downstream channel
     // providers preserve the original turn ordering around tool boundaries.
     if (!isLastSegment && interSegmentDelayMs > 0) {
@@ -86,12 +95,18 @@ export async function deliverRenderedReplyViaCallback(
   }
 }
 
+export type DeliverReplyOptions = {
+  startFromSegment?: number;
+  onSegmentDelivered?: (deliveredCount: number) => void;
+};
+
 export async function deliverReplyViaCallback(
   conversationId: string,
   externalChatId: string,
   callbackUrl: string,
   bearerToken?: string,
   assistantId?: string,
+  options?: DeliverReplyOptions,
 ): Promise<void> {
   const msgs = conversationStore.getMessages(conversationId);
   for (let i = msgs.length - 1; i >= 0; i--) {
@@ -118,6 +133,8 @@ export async function deliverReplyViaCallback(
       attachments: replyAttachments,
       assistantId,
       bearerToken,
+      startFromSegment: options?.startFromSegment,
+      onSegmentDelivered: options?.onSegmentDelivered,
     });
     break;
   }

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -133,12 +133,18 @@ export async function sweepFailedEvents(
           ? payload.externalChatId
           : undefined;
         if (externalChatId) {
+          const startFromSegment = channelDeliveryStore.getDeliveredSegmentCount(event.id);
           await deliverReplyViaCallback(
             event.conversationId,
             externalChatId,
             replyCallbackUrl,
             bearerToken,
             assistantId,
+            {
+              startFromSegment,
+              onSegmentDelivered: (count) =>
+                channelDeliveryStore.updateDeliveredSegmentCount(event.id, count),
+            },
           );
         }
       }

--- a/assistant/src/runtime/routes/channel-delivery-routes.ts
+++ b/assistant/src/runtime/routes/channel-delivery-routes.ts
@@ -3,7 +3,7 @@
  * and post-decision delivery scheduling.
  */
 import * as channelDeliveryStore from '../../memory/channel-delivery-store.js';
-export { deliverReplyViaCallback } from '../channel-reply-delivery.js';
+export { deliverReplyViaCallback, type DeliverReplyOptions } from '../channel-reply-delivery.js';
 
 // ---------------------------------------------------------------------------
 // Dead letter management

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1051,6 +1051,10 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
           replyCallbackUrl,
           bearerToken,
           assistantId,
+          {
+            onSegmentDelivered: (count) =>
+              channelDeliveryStore.updateDeliveredSegmentCount(eventId, count),
+          },
         );
       }
     } catch (err) {


### PR DESCRIPTION
When multi-segment delivery fails partway through, the retry sweep would replay already-delivered segments, causing duplicates. This fix tracks delivered segment progress so retries resume from where they left off.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
