### PR TITLE
fix: resolve eslint lint errors and pre-commit hook false positive

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -65,6 +65,13 @@ declare -a SAFE_LINE_PATTERNS=(
     "[Pp]rivate[_-]?[Kk]ey['\"]?:[[:space:]]*(String|string|Data|data)[?]?[[:space:]]*($|[,){;]|=[[:space:]]*nil|=[[:space:]]*['\"]['\"])"
     "(secret|Secret)['\"]?[[:space:]]*[:=][[:space:]]*['\"]<(optional|required|placeholder|none|empty|unset|redacted|your-[a-z-]+-here|[a-zA-Z][a-zA-Z_/ '-]*[A-Z_/][a-zA-Z_/ '.-]*)>['\"]"
     "[a-zA-Z_-]*[[:space:]]*[:=][[:space:]]*\\\$\\{\\{[[:space:]]*secrets\\.[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*\\}\\}([[:space:]]+#.*)?[[:space:]]*$"
+    # TS/JS: secret/key property assigned from a variable or dotted property (no string literal).
+    # E.g. `body.client_secret = clientSecret;`, `oauth2ClientSecret: clientSecret ?? undefined`,
+    # or `clientSecret: options.clientSecret,`.
+    # IMPORTANT: must come BEFORE the dotted-ref pattern below, so it strips
+    # the full `key: obj.prop,` expression before the dotted-ref strips only
+    # the RHS (which would leave `key: obj` still looking suspicious).
+    "[Cc]lient[_-]?[Ss]ecret[[:space:]]*[:=][[:space:]]*[a-zA-Z_][a-zA-Z0-9_.?]*[[:space:]]*((\?\?|\|\|)[[:space:]]*(undefined))?[[:space:]]*[;,]"
     # TS/JS: camelCase property names containing clientSecret used as identifiers
     # (typeof checks, null/undefined comparisons, variable/property references).
     # Avoids false positives like `oauth2ClientSecret: typeof record.oauth2ClientSecret`.
@@ -84,9 +91,6 @@ declare -a SAFE_LINE_PATTERNS=(
     # E.g. `requiresClientSecret: boolean;` or `client_secret: {`.
     "[Cc]lient[_-]?[Ss]ecret['\"]?:[[:space:]]*(boolean|number)[[:space:]]*[;,]?"
     "[Cc]lient[_-]?[Ss]ecret['\"]?:[[:space:]]*\{[[:space:]]*$"
-    # TS/JS: secret/key property assigned from a variable (no string literal).
-    # E.g. `body.client_secret = clientSecret;` or `oauth2ClientSecret: clientSecret ?? undefined`.
-    "[Cc]lient[_-]?[Ss]ecret[[:space:]]*[:=][[:space:]]*[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*((\?\?|\|\|)[[:space:]]*(undefined))?[[:space:]]*[;,]"
     # TS: optional property type annotation (e.g. `clientSecret?: string;`)
     # Must end with type + optional semicolon/comma — no `=` assignment.
     "[Cc]lient[_-]?[Ss]ecret[?]?:[[:space:]]*(string|String)[?]?[[:space:]]*[;,][[:space:]]*$"
@@ -200,6 +204,8 @@ if [ "${1:-}" = "--self-test" ]; then
     # Variable-to-variable assignment (false positive to whitelist)
     SAFE_VAR_ASSIGN_SECRET='body.client_secret = clientSecret;'
     SAFE_VAR_NULLISH_SECRET='oauth2ClientSecret: clientSecret ?? undefined,'
+    # Dotted property access as value (false positive to whitelist)
+    SAFE_DOTTED_PROP_SECRET='    clientSecret: options.clientSecret,'
     # AWS well-known example key (false positive to whitelist)
     SAFE_AWS_EXAMPLE_KEY='const EXAMPLE_KEY = "AKIAIOSFODNN7EXAMPLE";'
 
@@ -417,6 +423,10 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$SAFE_VAR_NULLISH_SECRET" && ! matches_safe_line_pattern "$SAFE_VAR_NULLISH_SECRET"; then
         echo -e "${RED}Self-test failed:${NC} clientSecret nullish coalescing undefined assignment false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_DOTTED_PROP_SECRET" && ! matches_safe_line_pattern "$SAFE_DOTTED_PROP_SECRET"; then
+        echo -e "${RED}Self-test failed:${NC} dotted property clientSecret assignment false positive"
         exit 1
     fi
     if matches_secret_pattern "$SAFE_AWS_EXAMPLE_KEY" && ! matches_safe_line_pattern "$SAFE_AWS_EXAMPLE_KEY"; then


### PR DESCRIPTION
## Summary
- Auto-fixed 44 import sorting and prefer-const issues via `eslint --fix`
- Removed unused imports/variables in production files (conversation-store, channel-approvals, inbound-message-handler, voice-session-bridge, connect-orchestrator, channel-delivery-routes, lifecycle)
- Fixed unused vars in test files by prefixing with `_` or removing unused imports
- Converted `require()` calls to `await import()` in test files (channel-guardian, deterministic-verification-control-plane)
- Added eslint-disable for `require()` in `mock.module` callbacks where sync execution is required
- Fixed pre-commit hook false positive for `clientSecret: options.clientSecret,` by widening the var-assign safe pattern to allow dotted property access and reordering it before the dotted-ref pattern

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22425310406

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
