### PR TITLE
fix(macos): remove file name from heartbeat checklist label

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/HeartbeatSettingsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/HeartbeatSettingsTab.swift
@@ -126,7 +126,7 @@ struct HeartbeatSettingsTab: View {
                 }
             }
 
-            Text("Items the heartbeat checks on each run (HEARTBEAT.md)")
+            Text("Items the heartbeat checks on each run")
                 .font(VFont.caption)
                 .foregroundColor(VColor.textMuted)
 


### PR DESCRIPTION
## Summary
- Remove "(HEARTBEAT.md)" from the checklist description label — implementation detail users don't need to see

## Test plan
- [ ] Settings → Heartbeat → checklist card shows "Items the heartbeat checks on each run" without the file name

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
