### PR TITLE
Conversation attention: add event log and latest-assistant seen cursor projection

### DIFF
--- a/assistant/src/__tests__/conversation-attention-store.test.ts
+++ b/assistant/src/__tests__/conversation-attention-store.test.ts
@@ -1,0 +1,594 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'conv-attn-store-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  isDebug: () => false,
+  truncateForLog: (value: string) => value,
+}));
+
+import { eq } from 'drizzle-orm';
+
+import {
+  getAttentionStateByConversationIds,
+  listConversationAttention,
+  projectAssistantMessage,
+  recordConversationSeenSignal,
+} from '../memory/conversation-attention-store.js';
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import {
+  conversationAssistantAttentionState,
+  conversationAttentionEvents,
+  conversations,
+} from '../memory/schema.js';
+
+initializeDb();
+
+function ensureConversation(id: string): void {
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations)
+    .values({
+      id,
+      title: `Conversation ${id}`,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function clearTables(): void {
+  const db = getDb();
+  db.delete(conversationAttentionEvents).run();
+  db.delete(conversationAssistantAttentionState).run();
+  db.delete(conversations).run();
+}
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe('conversation-attention-store', () => {
+  beforeEach(() => {
+    clearTables();
+  });
+
+  // ── projectAssistantMessage ─────────────────────────────────────
+
+  describe('projectAssistantMessage', () => {
+    test('creates a new state row when none exists', () => {
+      ensureConversation('conv-1');
+      projectAssistantMessage({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        messageId: 'msg-1',
+        messageAt: 1000,
+      });
+
+      const states = getAttentionStateByConversationIds(['conv-1']);
+      expect(states.size).toBe(1);
+      const state = states.get('conv-1')!;
+      expect(state.latestAssistantMessageId).toBe('msg-1');
+      expect(state.latestAssistantMessageAt).toBe(1000);
+      expect(state.lastSeenAssistantMessageId).toBeNull();
+      expect(state.lastSeenAssistantMessageAt).toBeNull();
+    });
+
+    test('advances cursor when new message is later', () => {
+      ensureConversation('conv-1');
+      projectAssistantMessage({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        messageId: 'msg-1',
+        messageAt: 1000,
+      });
+      projectAssistantMessage({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        messageId: 'msg-2',
+        messageAt: 2000,
+      });
+
+      const states = getAttentionStateByConversationIds(['conv-1']);
+      const state = states.get('conv-1')!;
+      expect(state.latestAssistantMessageId).toBe('msg-2');
+      expect(state.latestAssistantMessageAt).toBe(2000);
+    });
+
+    test('does not move cursor backward (monotonic invariant)', () => {
+      ensureConversation('conv-1');
+      projectAssistantMessage({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        messageId: 'msg-2',
+        messageAt: 2000,
+      });
+      projectAssistantMessage({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        messageId: 'msg-1',
+        messageAt: 1000,
+      });
+
+      const states = getAttentionStateByConversationIds(['conv-1']);
+      const state = states.get('conv-1')!;
+      expect(state.latestAssistantMessageId).toBe('msg-2');
+      expect(state.latestAssistantMessageAt).toBe(2000);
+    });
+
+    test('does not advance cursor when timestamp is equal', () => {
+      ensureConversation('conv-1');
+      projectAssistantMessage({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        messageId: 'msg-1',
+        messageAt: 1000,
+      });
+      projectAssistantMessage({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        messageId: 'msg-1-dup',
+        messageAt: 1000,
+      });
+
+      const states = getAttentionStateByConversationIds(['conv-1']);
+      const state = states.get('conv-1')!;
+      expect(state.latestAssistantMessageId).toBe('msg-1');
+    });
+  });
+
+  // ── recordConversationSeenSignal ────────────────────────────────
+
+  describe('recordConversationSeenSignal', () => {
+    test('appends an immutable event row', () => {
+      ensureConversation('conv-1');
+      const event = recordConversationSeenSignal({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        sourceChannel: 'vellum',
+        signalType: 'macos_conversation_opened',
+        confidence: 'explicit',
+        source: 'desktop-client',
+      });
+
+      expect(event.id).toBeTruthy();
+      expect(event.conversationId).toBe('conv-1');
+      expect(event.signalType).toBe('macos_conversation_opened');
+      expect(event.confidence).toBe('explicit');
+    });
+
+    test('advances seen cursor to current latest assistant message', () => {
+      ensureConversation('conv-1');
+
+      // Project an assistant message first
+      projectAssistantMessage({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        messageId: 'msg-1',
+        messageAt: 1000,
+      });
+
+      // Now record a seen signal
+      recordConversationSeenSignal({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        sourceChannel: 'vellum',
+        signalType: 'macos_conversation_opened',
+        confidence: 'explicit',
+        source: 'desktop-client',
+      });
+
+      const states = getAttentionStateByConversationIds(['conv-1']);
+      const state = states.get('conv-1')!;
+      expect(state.lastSeenAssistantMessageId).toBe('msg-1');
+      expect(state.lastSeenAssistantMessageAt).toBe(1000);
+    });
+
+    test('creates state row if none exists when recording seen signal', () => {
+      ensureConversation('conv-1');
+
+      recordConversationSeenSignal({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        sourceChannel: 'telegram',
+        signalType: 'telegram_inbound_message',
+        confidence: 'inferred',
+        source: 'telegram-gateway',
+      });
+
+      const states = getAttentionStateByConversationIds(['conv-1']);
+      expect(states.size).toBe(1);
+      const state = states.get('conv-1')!;
+      // No latest assistant message to mark as seen
+      expect(state.lastSeenAssistantMessageId).toBeNull();
+      expect(state.lastSeenSignalType).toBe('telegram_inbound_message');
+    });
+
+    test('does not regress seen cursor (monotonic invariant)', () => {
+      ensureConversation('conv-1');
+
+      // Project two assistant messages
+      projectAssistantMessage({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        messageId: 'msg-1',
+        messageAt: 1000,
+      });
+
+      // Mark as seen at msg-1
+      recordConversationSeenSignal({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        sourceChannel: 'vellum',
+        signalType: 'macos_conversation_opened',
+        confidence: 'explicit',
+        source: 'desktop-client',
+      });
+
+      // Project a second message
+      projectAssistantMessage({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        messageId: 'msg-2',
+        messageAt: 2000,
+      });
+
+      // Mark as seen at msg-2
+      recordConversationSeenSignal({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        sourceChannel: 'vellum',
+        signalType: 'macos_conversation_opened',
+        confidence: 'explicit',
+        source: 'desktop-client',
+      });
+
+      const states = getAttentionStateByConversationIds(['conv-1']);
+      const state = states.get('conv-1')!;
+      expect(state.lastSeenAssistantMessageId).toBe('msg-2');
+      expect(state.lastSeenAssistantMessageAt).toBe(2000);
+    });
+
+    test('records evidence text and metadata in event', () => {
+      ensureConversation('conv-1');
+
+      const event = recordConversationSeenSignal({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        sourceChannel: 'telegram',
+        signalType: 'telegram_callback',
+        confidence: 'explicit',
+        source: 'telegram-gateway',
+        evidenceText: 'User pressed inline button',
+        metadata: { callbackData: 'ack:123' },
+      });
+
+      expect(event.evidenceText).toBe('User pressed inline button');
+      expect(JSON.parse(event.metadataJson)).toEqual({ callbackData: 'ack:123' });
+    });
+
+    test('seen signal with no latest assistant message does not set seen cursor', () => {
+      ensureConversation('conv-1');
+
+      // Record seen signal without any assistant message
+      recordConversationSeenSignal({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        sourceChannel: 'vellum',
+        signalType: 'macos_notification_view',
+        confidence: 'inferred',
+        source: 'desktop-client',
+      });
+
+      const states = getAttentionStateByConversationIds(['conv-1']);
+      const state = states.get('conv-1')!;
+      expect(state.lastSeenAssistantMessageId).toBeNull();
+      expect(state.lastSeenAssistantMessageAt).toBeNull();
+      expect(state.lastSeenSignalType).toBe('macos_notification_view');
+    });
+
+    test('already-seen conversation does not regress on additional seen signal', () => {
+      ensureConversation('conv-1');
+
+      projectAssistantMessage({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        messageId: 'msg-1',
+        messageAt: 1000,
+      });
+
+      // Mark as seen
+      recordConversationSeenSignal({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        sourceChannel: 'vellum',
+        signalType: 'macos_conversation_opened',
+        confidence: 'explicit',
+        source: 'desktop-client',
+      });
+
+      // Record another seen signal (should not regress)
+      recordConversationSeenSignal({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        sourceChannel: 'telegram',
+        signalType: 'telegram_inbound_message',
+        confidence: 'inferred',
+        source: 'telegram-gateway',
+      });
+
+      const states = getAttentionStateByConversationIds(['conv-1']);
+      const state = states.get('conv-1')!;
+      // Seen cursor should still point to msg-1
+      expect(state.lastSeenAssistantMessageId).toBe('msg-1');
+      expect(state.lastSeenAssistantMessageAt).toBe(1000);
+      // Signal metadata should reflect the latest signal
+      expect(state.lastSeenSignalType).toBe('telegram_inbound_message');
+    });
+  });
+
+  // ── getAttentionStateByConversationIds ──────────────────────────
+
+  describe('getAttentionStateByConversationIds', () => {
+    test('returns empty map for empty input', () => {
+      const result = getAttentionStateByConversationIds([]);
+      expect(result.size).toBe(0);
+    });
+
+    test('returns states for multiple conversations', () => {
+      ensureConversation('conv-1');
+      ensureConversation('conv-2');
+
+      projectAssistantMessage({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        messageId: 'msg-1',
+        messageAt: 1000,
+      });
+      projectAssistantMessage({
+        conversationId: 'conv-2',
+        assistantId: 'self',
+        messageId: 'msg-2',
+        messageAt: 2000,
+      });
+
+      const result = getAttentionStateByConversationIds(['conv-1', 'conv-2']);
+      expect(result.size).toBe(2);
+      expect(result.get('conv-1')!.latestAssistantMessageId).toBe('msg-1');
+      expect(result.get('conv-2')!.latestAssistantMessageId).toBe('msg-2');
+    });
+
+    test('omits conversations without state', () => {
+      ensureConversation('conv-1');
+      ensureConversation('conv-2');
+
+      projectAssistantMessage({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        messageId: 'msg-1',
+        messageAt: 1000,
+      });
+
+      const result = getAttentionStateByConversationIds(['conv-1', 'conv-2']);
+      expect(result.size).toBe(1);
+      expect(result.has('conv-1')).toBe(true);
+      expect(result.has('conv-2')).toBe(false);
+    });
+  });
+
+  // ── listConversationAttention ───────────────────────────────────
+
+  describe('listConversationAttention', () => {
+    test('returns all states for an assistant', () => {
+      ensureConversation('conv-1');
+      ensureConversation('conv-2');
+
+      projectAssistantMessage({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        messageId: 'msg-1',
+        messageAt: 1000,
+      });
+      projectAssistantMessage({
+        conversationId: 'conv-2',
+        assistantId: 'self',
+        messageId: 'msg-2',
+        messageAt: 2000,
+      });
+
+      const result = listConversationAttention({ assistantId: 'self' });
+      expect(result).toHaveLength(2);
+    });
+
+    test('filters by unseen state', () => {
+      ensureConversation('conv-1');
+      ensureConversation('conv-2');
+
+      // conv-1: has assistant message, not seen
+      projectAssistantMessage({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        messageId: 'msg-1',
+        messageAt: 1000,
+      });
+
+      // conv-2: has assistant message, seen
+      projectAssistantMessage({
+        conversationId: 'conv-2',
+        assistantId: 'self',
+        messageId: 'msg-2',
+        messageAt: 2000,
+      });
+      recordConversationSeenSignal({
+        conversationId: 'conv-2',
+        assistantId: 'self',
+        sourceChannel: 'vellum',
+        signalType: 'macos_conversation_opened',
+        confidence: 'explicit',
+        source: 'desktop-client',
+      });
+
+      const unseen = listConversationAttention({ assistantId: 'self', state: 'unseen' });
+      expect(unseen).toHaveLength(1);
+      expect(unseen[0].conversationId).toBe('conv-1');
+    });
+
+    test('filters by seen state', () => {
+      ensureConversation('conv-1');
+      ensureConversation('conv-2');
+
+      projectAssistantMessage({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        messageId: 'msg-1',
+        messageAt: 1000,
+      });
+
+      projectAssistantMessage({
+        conversationId: 'conv-2',
+        assistantId: 'self',
+        messageId: 'msg-2',
+        messageAt: 2000,
+      });
+      recordConversationSeenSignal({
+        conversationId: 'conv-2',
+        assistantId: 'self',
+        sourceChannel: 'vellum',
+        signalType: 'macos_conversation_opened',
+        confidence: 'explicit',
+        source: 'desktop-client',
+      });
+
+      const seen = listConversationAttention({ assistantId: 'self', state: 'seen' });
+      expect(seen).toHaveLength(1);
+      expect(seen[0].conversationId).toBe('conv-2');
+    });
+
+    test('respects limit parameter', () => {
+      ensureConversation('conv-1');
+      ensureConversation('conv-2');
+      ensureConversation('conv-3');
+
+      projectAssistantMessage({ conversationId: 'conv-1', assistantId: 'self', messageId: 'msg-1', messageAt: 1000 });
+      projectAssistantMessage({ conversationId: 'conv-2', assistantId: 'self', messageId: 'msg-2', messageAt: 2000 });
+      projectAssistantMessage({ conversationId: 'conv-3', assistantId: 'self', messageId: 'msg-3', messageAt: 3000 });
+
+      const result = listConversationAttention({ assistantId: 'self', limit: 2 });
+      expect(result).toHaveLength(2);
+    });
+
+    test('orders by latest assistant message descending', () => {
+      ensureConversation('conv-1');
+      ensureConversation('conv-2');
+      ensureConversation('conv-3');
+
+      projectAssistantMessage({ conversationId: 'conv-1', assistantId: 'self', messageId: 'msg-1', messageAt: 1000 });
+      projectAssistantMessage({ conversationId: 'conv-2', assistantId: 'self', messageId: 'msg-2', messageAt: 3000 });
+      projectAssistantMessage({ conversationId: 'conv-3', assistantId: 'self', messageId: 'msg-3', messageAt: 2000 });
+
+      const result = listConversationAttention({ assistantId: 'self' });
+      expect(result[0].conversationId).toBe('conv-2');
+      expect(result[1].conversationId).toBe('conv-3');
+      expect(result[2].conversationId).toBe('conv-1');
+    });
+
+    test('before cursor filters out newer conversations', () => {
+      ensureConversation('conv-1');
+      ensureConversation('conv-2');
+      ensureConversation('conv-3');
+
+      projectAssistantMessage({ conversationId: 'conv-1', assistantId: 'self', messageId: 'msg-1', messageAt: 1000 });
+      projectAssistantMessage({ conversationId: 'conv-2', assistantId: 'self', messageId: 'msg-2', messageAt: 2000 });
+      projectAssistantMessage({ conversationId: 'conv-3', assistantId: 'self', messageId: 'msg-3', messageAt: 3000 });
+
+      const result = listConversationAttention({ assistantId: 'self', before: 2500 });
+      expect(result).toHaveLength(2);
+      expect(result[0].conversationId).toBe('conv-2');
+      expect(result[1].conversationId).toBe('conv-1');
+    });
+
+    test('filters by different assistant ID', () => {
+      ensureConversation('conv-1');
+
+      projectAssistantMessage({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        messageId: 'msg-1',
+        messageAt: 1000,
+      });
+
+      const result = listConversationAttention({ assistantId: 'other-assistant' });
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  // ── Evidence immutability ───────────────────────────────────────
+
+  describe('evidence immutability', () => {
+    test('multiple seen signals append separate event rows', () => {
+      ensureConversation('conv-1');
+
+      projectAssistantMessage({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        messageId: 'msg-1',
+        messageAt: 1000,
+      });
+
+      recordConversationSeenSignal({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        sourceChannel: 'vellum',
+        signalType: 'macos_notification_view',
+        confidence: 'inferred',
+        source: 'desktop-client',
+      });
+
+      recordConversationSeenSignal({
+        conversationId: 'conv-1',
+        assistantId: 'self',
+        sourceChannel: 'vellum',
+        signalType: 'macos_conversation_opened',
+        confidence: 'explicit',
+        source: 'desktop-client',
+      });
+
+      const db = getDb();
+      const events = db
+        .select()
+        .from(conversationAttentionEvents)
+        .where(eq(conversationAttentionEvents.conversationId, 'conv-1'))
+        .all();
+
+      expect(events).toHaveLength(2);
+      expect(events[0].signalType).not.toBe(events[1].signalType);
+    });
+  });
+});

--- a/assistant/src/memory/conversation-attention-store.ts
+++ b/assistant/src/memory/conversation-attention-store.ts
@@ -1,0 +1,364 @@
+/**
+ * Store operations for conversation-level attention tracking.
+ *
+ * Tracks whether the user has seen the latest assistant message using two
+ * tables: an append-only evidence log (conversation_attention_events) and a
+ * single-row projection per conversation (conversation_assistant_attention_state).
+ */
+
+import { and, desc, eq, inArray, isNull, lt, or, sql } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+
+import { getLogger } from '../util/logger.js';
+import { getDb } from './db.js';
+import { conversationAssistantAttentionState, conversationAttentionEvents } from './schema.js';
+
+const log = getLogger('conversation-attention-store');
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export type SignalType =
+  | 'macos_notification_view'
+  | 'macos_conversation_opened'
+  | 'telegram_inbound_message'
+  | 'telegram_callback';
+
+export type Confidence = 'explicit' | 'inferred';
+
+export interface AttentionEvent {
+  id: string;
+  conversationId: string;
+  assistantId: string;
+  sourceChannel: string;
+  signalType: SignalType;
+  confidence: Confidence;
+  source: string;
+  evidenceText: string | null;
+  metadataJson: string;
+  observedAt: number;
+  createdAt: number;
+}
+
+export interface AttentionState {
+  conversationId: string;
+  assistantId: string;
+  latestAssistantMessageId: string | null;
+  latestAssistantMessageAt: number | null;
+  lastSeenAssistantMessageId: string | null;
+  lastSeenAssistantMessageAt: number | null;
+  lastSeenEventAt: number | null;
+  lastSeenConfidence: Confidence | null;
+  lastSeenSignalType: SignalType | null;
+  lastSeenSourceChannel: string | null;
+  lastSeenSource: string | null;
+  lastSeenEvidenceText: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+// ── Row mappers ──────────────────────────────────────────────────────
+
+function rowToEvent(row: typeof conversationAttentionEvents.$inferSelect): AttentionEvent {
+  return {
+    id: row.id,
+    conversationId: row.conversationId,
+    assistantId: row.assistantId,
+    sourceChannel: row.sourceChannel,
+    signalType: row.signalType as SignalType,
+    confidence: row.confidence as Confidence,
+    source: row.source,
+    evidenceText: row.evidenceText,
+    metadataJson: row.metadataJson,
+    observedAt: row.observedAt,
+    createdAt: row.createdAt,
+  };
+}
+
+function rowToState(row: typeof conversationAssistantAttentionState.$inferSelect): AttentionState {
+  return {
+    conversationId: row.conversationId,
+    assistantId: row.assistantId,
+    latestAssistantMessageId: row.latestAssistantMessageId,
+    latestAssistantMessageAt: row.latestAssistantMessageAt,
+    lastSeenAssistantMessageId: row.lastSeenAssistantMessageId,
+    lastSeenAssistantMessageAt: row.lastSeenAssistantMessageAt,
+    lastSeenEventAt: row.lastSeenEventAt,
+    lastSeenConfidence: row.lastSeenConfidence as Confidence | null,
+    lastSeenSignalType: row.lastSeenSignalType as SignalType | null,
+    lastSeenSourceChannel: row.lastSeenSourceChannel,
+    lastSeenSource: row.lastSeenSource,
+    lastSeenEvidenceText: row.lastSeenEvidenceText,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+// ── projectAssistantMessage ──────────────────────────────────────────
+
+/**
+ * Update the latest-assistant cursor when a new assistant message is persisted.
+ * Monotonic: the cursor never moves backward.
+ */
+export function projectAssistantMessage(params: {
+  conversationId: string;
+  assistantId: string;
+  messageId: string;
+  messageAt: number;
+}): void {
+  const { conversationId, assistantId, messageId, messageAt } = params;
+  const db = getDb();
+  const now = Date.now();
+
+  const existing = db
+    .select()
+    .from(conversationAssistantAttentionState)
+    .where(eq(conversationAssistantAttentionState.conversationId, conversationId))
+    .get();
+
+  if (!existing) {
+    db.insert(conversationAssistantAttentionState)
+      .values({
+        conversationId,
+        assistantId,
+        latestAssistantMessageId: messageId,
+        latestAssistantMessageAt: messageAt,
+        lastSeenAssistantMessageId: null,
+        lastSeenAssistantMessageAt: null,
+        lastSeenEventAt: null,
+        lastSeenConfidence: null,
+        lastSeenSignalType: null,
+        lastSeenSourceChannel: null,
+        lastSeenSource: null,
+        lastSeenEvidenceText: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return;
+  }
+
+  // Monotonic: only advance if the new message is strictly later
+  if (existing.latestAssistantMessageAt !== null && messageAt <= existing.latestAssistantMessageAt) {
+    return;
+  }
+
+  db.update(conversationAssistantAttentionState)
+    .set({
+      latestAssistantMessageId: messageId,
+      latestAssistantMessageAt: messageAt,
+      updatedAt: now,
+    })
+    .where(eq(conversationAssistantAttentionState.conversationId, conversationId))
+    .run();
+}
+
+// ── recordConversationSeenSignal ─────────────────────────────────────
+
+/**
+ * Record a "seen" signal: appends an immutable event row and advances the
+ * seen cursor in the state projection to the current latest assistant message.
+ */
+export function recordConversationSeenSignal(params: {
+  conversationId: string;
+  assistantId: string;
+  sourceChannel: string;
+  signalType: SignalType;
+  confidence: Confidence;
+  source: string;
+  evidenceText?: string;
+  metadata?: Record<string, unknown>;
+  observedAt?: number;
+}): AttentionEvent {
+  const {
+    conversationId,
+    assistantId,
+    sourceChannel,
+    signalType,
+    confidence,
+    source,
+    evidenceText,
+    metadata,
+    observedAt,
+  } = params;
+
+  const db = getDb();
+  const now = Date.now();
+  const eventId = uuid();
+  const eventObservedAt = observedAt ?? now;
+  const metadataJson = metadata ? JSON.stringify(metadata) : '{}';
+
+  const event: typeof conversationAttentionEvents.$inferInsert = {
+    id: eventId,
+    conversationId,
+    assistantId,
+    sourceChannel,
+    signalType,
+    confidence,
+    source,
+    evidenceText: evidenceText ?? null,
+    metadataJson,
+    observedAt: eventObservedAt,
+    createdAt: now,
+  };
+
+  db.transaction((tx) => {
+    // 1. Append immutable evidence row
+    tx.insert(conversationAttentionEvents).values(event).run();
+
+    // 2. Advance the seen cursor to the current latest assistant message
+    const state = tx
+      .select()
+      .from(conversationAssistantAttentionState)
+      .where(eq(conversationAssistantAttentionState.conversationId, conversationId))
+      .get();
+
+    if (!state) {
+      // No state row yet — create one with seen cursor only (no latest assistant message yet)
+      tx.insert(conversationAssistantAttentionState)
+        .values({
+          conversationId,
+          assistantId,
+          latestAssistantMessageId: null,
+          latestAssistantMessageAt: null,
+          lastSeenAssistantMessageId: null,
+          lastSeenAssistantMessageAt: null,
+          lastSeenEventAt: eventObservedAt,
+          lastSeenConfidence: confidence,
+          lastSeenSignalType: signalType,
+          lastSeenSourceChannel: sourceChannel,
+          lastSeenSource: source,
+          lastSeenEvidenceText: evidenceText ?? null,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+      return;
+    }
+
+    // Only advance the seen cursor if there is a latest assistant message to mark as seen,
+    // and the seen cursor hasn't already reached or passed it (monotonic invariant).
+    const shouldAdvanceSeen =
+      state.latestAssistantMessageAt !== null &&
+      (state.lastSeenAssistantMessageAt === null ||
+        state.latestAssistantMessageAt > state.lastSeenAssistantMessageAt);
+
+    const updates: Record<string, unknown> = {
+      lastSeenEventAt: eventObservedAt,
+      lastSeenConfidence: confidence,
+      lastSeenSignalType: signalType,
+      lastSeenSourceChannel: sourceChannel,
+      lastSeenSource: source,
+      lastSeenEvidenceText: evidenceText ?? null,
+      updatedAt: now,
+    };
+
+    if (shouldAdvanceSeen) {
+      updates.lastSeenAssistantMessageId = state.latestAssistantMessageId;
+      updates.lastSeenAssistantMessageAt = state.latestAssistantMessageAt;
+    }
+
+    tx.update(conversationAssistantAttentionState)
+      .set(updates)
+      .where(eq(conversationAssistantAttentionState.conversationId, conversationId))
+      .run();
+  });
+
+  return rowToEvent(event as typeof conversationAttentionEvents.$inferSelect);
+}
+
+// ── getAttentionStateByConversationIds ───────────────────────────────
+
+/**
+ * Batch read for conversation list enrichment.
+ * Returns a map of conversationId -> AttentionState.
+ */
+export function getAttentionStateByConversationIds(
+  conversationIds: string[],
+): Map<string, AttentionState> {
+  if (conversationIds.length === 0) return new Map();
+
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(conversationAssistantAttentionState)
+    .where(inArray(conversationAssistantAttentionState.conversationId, conversationIds))
+    .all();
+
+  const result = new Map<string, AttentionState>();
+  for (const row of rows) {
+    result.set(row.conversationId, rowToState(row));
+  }
+  return result;
+}
+
+// ── listConversationAttention ────────────────────────────────────────
+
+export type AttentionFilterState = 'seen' | 'unseen' | 'all';
+
+export interface ListConversationAttentionParams {
+  assistantId: string;
+  state?: AttentionFilterState;
+  sourceChannel?: string;
+  limit?: number;
+  before?: number;
+}
+
+/**
+ * Filtered list for assistant/LLM reporting API.
+ * Supports filters: state (seen/unseen/all), source channel, limit, before cursor.
+ */
+export function listConversationAttention(
+  params: ListConversationAttentionParams,
+): AttentionState[] {
+  const {
+    assistantId,
+    state: filterState = 'all',
+    sourceChannel,
+    limit = 50,
+    before,
+  } = params;
+
+  const db = getDb();
+  const conditions = [eq(conversationAssistantAttentionState.assistantId, assistantId)];
+
+  if (sourceChannel) {
+    conditions.push(eq(conversationAssistantAttentionState.lastSeenSourceChannel, sourceChannel));
+  }
+
+  if (before !== undefined) {
+    conditions.push(
+      lt(conversationAssistantAttentionState.latestAssistantMessageAt, before),
+    );
+  }
+
+  if (filterState === 'unseen') {
+    // Unseen: latest assistant message exists but no seen cursor, or seen cursor is behind latest
+    conditions.push(
+      sql`${conversationAssistantAttentionState.latestAssistantMessageAt} IS NOT NULL`,
+    );
+    conditions.push(
+      or(
+        isNull(conversationAssistantAttentionState.lastSeenAssistantMessageAt),
+        sql`${conversationAssistantAttentionState.lastSeenAssistantMessageAt} < ${conversationAssistantAttentionState.latestAssistantMessageAt}`,
+      )!,
+    );
+  } else if (filterState === 'seen') {
+    // Seen: seen cursor equals latest assistant message
+    conditions.push(
+      sql`${conversationAssistantAttentionState.latestAssistantMessageAt} IS NOT NULL`,
+    );
+    conditions.push(
+      sql`${conversationAssistantAttentionState.lastSeenAssistantMessageAt} = ${conversationAssistantAttentionState.latestAssistantMessageAt}`,
+    );
+  }
+
+  const rows = db
+    .select()
+    .from(conversationAssistantAttentionState)
+    .where(and(...conditions))
+    .orderBy(desc(conversationAssistantAttentionState.latestAssistantMessageAt))
+    .limit(limit)
+    .all();
+
+  return rows.map(rowToState);
+}

--- a/assistant/src/memory/conversation-attention-store.ts
+++ b/assistant/src/memory/conversation-attention-store.ts
@@ -11,7 +11,7 @@ import { v4 as uuid } from 'uuid';
 
 import { getLogger } from '../util/logger.js';
 import { getDb } from './db.js';
-import { conversationAssistantAttentionState, conversationAttentionEvents } from './schema.js';
+import { conversationAssistantAttentionState, conversationAttentionEvents, messages } from './schema.js';
 
 const log = getLogger('conversation-attention-store');
 
@@ -213,15 +213,28 @@ export function recordConversationSeenSignal(params: {
       .get();
 
     if (!state) {
-      // No state row yet — create one with seen cursor only (no latest assistant message yet)
+      // No state row yet — look up the conversation's latest assistant message so
+      // upgraded databases (with existing messages but no attention row) correctly
+      // initialize the full state on the first seen signal.
+      const latestMsg = tx
+        .select({ id: messages.id, createdAt: messages.createdAt })
+        .from(messages)
+        .where(and(eq(messages.conversationId, conversationId), eq(messages.role, 'assistant')))
+        .orderBy(desc(messages.createdAt))
+        .limit(1)
+        .get();
+
+      const latestMsgId = latestMsg?.id ?? null;
+      const latestMsgAt = latestMsg?.createdAt ?? null;
+
       tx.insert(conversationAssistantAttentionState)
         .values({
           conversationId,
           assistantId,
-          latestAssistantMessageId: null,
-          latestAssistantMessageAt: null,
-          lastSeenAssistantMessageId: null,
-          lastSeenAssistantMessageAt: null,
+          latestAssistantMessageId: latestMsgId,
+          latestAssistantMessageAt: latestMsgAt,
+          lastSeenAssistantMessageId: latestMsgId,
+          lastSeenAssistantMessageAt: latestMsgAt,
           lastSeenEventAt: eventObservedAt,
           lastSeenConfidence: confidence,
           lastSeenSignalType: signalType,
@@ -242,15 +255,25 @@ export function recordConversationSeenSignal(params: {
       (state.lastSeenAssistantMessageAt === null ||
         state.latestAssistantMessageAt > state.lastSeenAssistantMessageAt);
 
+    // Guard seen metadata monotonicity: only update lastSeen* metadata when the
+    // new signal's observedAt is at least as recent as the existing projection.
+    // Out-of-order delivery (e.g. delayed channel callbacks) must not regress
+    // the projected channel/source/confidence metadata.
+    const isNewerSignal =
+      state.lastSeenEventAt === null || eventObservedAt >= state.lastSeenEventAt;
+
     const updates: Record<string, unknown> = {
-      lastSeenEventAt: eventObservedAt,
-      lastSeenConfidence: confidence,
-      lastSeenSignalType: signalType,
-      lastSeenSourceChannel: sourceChannel,
-      lastSeenSource: source,
-      lastSeenEvidenceText: evidenceText ?? null,
       updatedAt: now,
     };
+
+    if (isNewerSignal) {
+      updates.lastSeenEventAt = eventObservedAt;
+      updates.lastSeenConfidence = confidence;
+      updates.lastSeenSignalType = signalType;
+      updates.lastSeenSourceChannel = sourceChannel;
+      updates.lastSeenSource = source;
+      updates.lastSeenEvidenceText = evidenceText ?? null;
+    }
 
     if (shouldAdvanceSeen) {
       updates.lastSeenAssistantMessageId = state.latestAssistantMessageId;

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -10,6 +10,7 @@ import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.
 import { getLogger } from '../util/logger.js';
 import { createRowMapper } from '../util/row-mapper.js';
 import { deleteOrphanAttachments } from './attachments-store.js';
+import { projectAssistantMessage } from './conversation-attention-store.js';
 import { getDb, rawAll, rawExec,rawGet } from './db.js';
 import { indexMessageNow } from './indexer.js';
 import { channelInboundEvents, conversations, llmRequestLogs,memoryEmbeddings, memoryItemEntities, memoryItems, memoryItemSources, memorySegments, messageAttachments, messages, toolInvocations } from './schema.js';
@@ -306,6 +307,19 @@ export function addMessage(conversationId: string, role: string, content: string
       }, config.memory);
     } catch (err) {
       log.warn({ err, conversationId, messageId: message.id }, 'Failed to index message for memory');
+    }
+  }
+
+  if (role === 'assistant') {
+    try {
+      projectAssistantMessage({
+        conversationId,
+        assistantId: 'self',
+        messageId: message.id,
+        messageAt: message.createdAt,
+      });
+    } catch (err) {
+      log.warn({ err, conversationId, messageId: message.id }, 'Failed to project assistant message for attention tracking');
     }
   }
 

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -5,6 +5,7 @@ import {
   createCallSessionsTables,
   createChannelGuardianTables,
   createContactsAndTriageTables,
+  createConversationAttentionTables,
   createCoreIndexes,
   createCoreTables,
   createExternalConversationBindingsTables,
@@ -91,6 +92,9 @@ export function initializeDb(): void {
   // 17. Messages FTS (full-text search over message content)
   createMessagesFts(database);
   migrateMessagesFtsBackfill(database);
+
+  // 18. Conversation attention (seen-state tracking)
+  createConversationAttentionTables(database);
 
   validateMigrationState(database);
 }

--- a/assistant/src/memory/migrations/117-conversation-attention.ts
+++ b/assistant/src/memory/migrations/117-conversation-attention.ts
@@ -1,0 +1,49 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Conversation attention tables: append-only evidence log and single-row
+ * projection for tracking whether users have seen the latest assistant message.
+ */
+export function createConversationAttentionTables(database: DrizzleDb): void {
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS conversation_attention_events (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      assistant_id TEXT NOT NULL,
+      source_channel TEXT NOT NULL,
+      signal_type TEXT NOT NULL,
+      confidence TEXT NOT NULL,
+      source TEXT NOT NULL,
+      evidence_text TEXT,
+      metadata_json TEXT NOT NULL DEFAULT '{}',
+      observed_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_conv_attn_events_conv_observed ON conversation_attention_events(conversation_id, observed_at DESC)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_conv_attn_events_assistant_observed ON conversation_attention_events(assistant_id, observed_at DESC)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_conv_attn_events_channel_observed ON conversation_attention_events(source_channel, observed_at DESC)`);
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS conversation_assistant_attention_state (
+      conversation_id TEXT PRIMARY KEY REFERENCES conversations(id) ON DELETE CASCADE,
+      assistant_id TEXT NOT NULL,
+      latest_assistant_message_id TEXT,
+      latest_assistant_message_at INTEGER,
+      last_seen_assistant_message_id TEXT,
+      last_seen_assistant_message_at INTEGER,
+      last_seen_event_at INTEGER,
+      last_seen_confidence TEXT,
+      last_seen_signal_type TEXT,
+      last_seen_source_channel TEXT,
+      last_seen_source TEXT,
+      last_seen_evidence_text TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_conv_attn_state_assistant_latest_msg ON conversation_assistant_attention_state(assistant_id, latest_assistant_message_at DESC)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_conv_attn_state_assistant_last_seen ON conversation_assistant_attention_state(assistant_id, last_seen_assistant_message_at DESC)`);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -46,6 +46,7 @@ export { runLateMigrations } from './113-late-migrations.js';
 export { createNotificationTables } from './114-notifications.js';
 export { createSequenceTables } from './115-sequences.js';
 export { createMessagesFts } from './116-messages-fts.js';
+export { createConversationAttentionTables } from './117-conversation-attention.js';
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -1006,3 +1006,47 @@ export const notificationDeliveries = sqliteTable('notification_deliveries', {
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 });
+
+// ── Conversation Attention ───────────────────────────────────────────
+
+export const conversationAttentionEvents = sqliteTable('conversation_attention_events', {
+  id: text('id').primaryKey(),
+  conversationId: text('conversation_id')
+    .notNull()
+    .references(() => conversations.id, { onDelete: 'cascade' }),
+  assistantId: text('assistant_id').notNull(),
+  sourceChannel: text('source_channel').notNull(),
+  signalType: text('signal_type').notNull(),
+  confidence: text('confidence').notNull(),
+  source: text('source').notNull(),
+  evidenceText: text('evidence_text'),
+  metadataJson: text('metadata_json').notNull().default('{}'),
+  observedAt: integer('observed_at').notNull(),
+  createdAt: integer('created_at').notNull(),
+}, (table) => [
+  index('idx_conv_attn_events_conv_observed').on(table.conversationId, table.observedAt),
+  index('idx_conv_attn_events_assistant_observed').on(table.assistantId, table.observedAt),
+  index('idx_conv_attn_events_channel_observed').on(table.sourceChannel, table.observedAt),
+]);
+
+export const conversationAssistantAttentionState = sqliteTable('conversation_assistant_attention_state', {
+  conversationId: text('conversation_id')
+    .primaryKey()
+    .references(() => conversations.id, { onDelete: 'cascade' }),
+  assistantId: text('assistant_id').notNull(),
+  latestAssistantMessageId: text('latest_assistant_message_id'),
+  latestAssistantMessageAt: integer('latest_assistant_message_at'),
+  lastSeenAssistantMessageId: text('last_seen_assistant_message_id'),
+  lastSeenAssistantMessageAt: integer('last_seen_assistant_message_at'),
+  lastSeenEventAt: integer('last_seen_event_at'),
+  lastSeenConfidence: text('last_seen_confidence'),
+  lastSeenSignalType: text('last_seen_signal_type'),
+  lastSeenSourceChannel: text('last_seen_source_channel'),
+  lastSeenSource: text('last_seen_source'),
+  lastSeenEvidenceText: text('last_seen_evidence_text'),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+}, (table) => [
+  index('idx_conv_attn_state_assistant_latest_msg').on(table.assistantId, table.latestAssistantMessageAt),
+  index('idx_conv_attn_state_assistant_last_seen').on(table.assistantId, table.lastSeenAssistantMessageAt),
+]);


### PR DESCRIPTION
Add conversation_attention_events (append-only evidence log) and conversation_assistant_attention_state (single-row projection) tables with store operations for tracking whether users have seen the latest assistant message. Implements projectAssistantMessage, recordConversationSeenSignal, getAttentionStateByConversationIds, and listConversationAttention. Part of #9372.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
