### PR TITLE
feat: add busy spinner and hover-aware pin/archive to sidebar thread rows

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -835,6 +835,11 @@ struct MainWindowView: View {
             return false
         }()
         let isHovered = sidebar.isHoveredThread == thread.id
+        let isBusy = threadManager.isThreadBusy(thread.id)
+        // Reserve trailing space for overlay icons so text doesn't jitter on state changes.
+        // Hovered: pin(20) + xs(4) + archive(20) + xs(4) padding on each side = 52
+        // Busy or pinned (not hovered): same as hovered to keep layout stable
+        let hasTrailingIcons = isHovered || isBusy || thread.isPinned
         Button(action: {
             if case .appEditing(let appId, _) = windowState.selection {
                 // Stay in editing mode, just switch the thread
@@ -861,7 +866,7 @@ struct MainWindowView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, VSpacing.md)
-            .padding(.trailing, isHovered ? (VSpacing.xs + 20 + VSpacing.xs + 20 + VSpacing.xs) : VSpacing.sm)
+            .padding(.trailing, hasTrailingIcons ? (VSpacing.xs + 20 + VSpacing.xs + 20 + VSpacing.xs) : VSpacing.sm)
             .padding(.vertical, VSpacing.sm)
             .background {
                 if isSelected {
@@ -933,6 +938,11 @@ struct MainWindowView: View {
                     }
                 }
                 .padding(.trailing, VSpacing.xs)
+            } else if isBusy {
+                ProgressView()
+                    .controlSize(.small)
+                    .frame(width: 20, height: 20)
+                    .padding(.trailing, VSpacing.xs + 20 + VSpacing.xs)
             } else if thread.isPinned {
                 Image(systemName: "pin.fill")
                     .font(.system(size: 10, weight: .medium))

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -62,6 +62,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// Subscription to activeViewModel's messages count changes.
     /// Forwards only message count changes to ThreadManager's objectWillChange.
     private var activeViewModelCancellable: AnyCancellable?
+    /// Subscriptions to per-thread busy-state changes (isSending, isThinking, pendingQueuedCount).
+    private var busyStateCancellables: [UUID: Set<AnyCancellable>] = [:]
+    /// Cached set of thread IDs whose ChatViewModel indicates active processing.
+    @Published private(set) var busyThreadIds: Set<UUID> = []
 
     /// Threads that are not archived — used by the UI to populate the sidebar.
     /// Sorted: pinned first (by pinnedOrder ascending), then unpinned by lastInteractedAt descending.
@@ -130,6 +134,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
         threads.insert(thread, at: 0)
         chatViewModels[thread.id] = viewModel
+        subscribeToBusyState(for: thread.id, viewModel: viewModel)
         touchVMAccessOrder(thread.id)
         evictStaleCachedViewModels()
         activeThreadId = thread.id
@@ -148,6 +153,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
         threads.insert(thread, at: 0)
         chatViewModels[thread.id] = viewModel
+        subscribeToBusyState(for: thread.id, viewModel: viewModel)
         touchVMAccessOrder(thread.id)
         evictStaleCachedViewModels()
         activeThreadId = thread.id
@@ -176,6 +182,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
         threads.insert(thread, at: 0)
         chatViewModels[thread.id] = viewModel
+        subscribeToBusyState(for: thread.id, viewModel: viewModel)
         touchVMAccessOrder(thread.id)
         evictStaleCachedViewModels()
 
@@ -199,6 +206,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
         threads.insert(thread, at: 0)
         chatViewModels[thread.id] = viewModel
+        subscribeToBusyState(for: thread.id, viewModel: viewModel)
         touchVMAccessOrder(thread.id)
         evictStaleCachedViewModels()
 
@@ -217,6 +225,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
         threads.remove(at: index)
         chatViewModels.removeValue(forKey: id)
+        unsubscribeFromBusyState(for: id)
         vmAccessOrder.removeAll { $0 == id }
 
         // Reclaim memory held by static caches that may reference
@@ -248,6 +257,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             archivedSessionIds = archived
             // Session ID already known — safe to release the view model.
             chatViewModels.removeValue(forKey: id)
+            unsubscribeFromBusyState(for: id)
             vmAccessOrder.removeAll { $0 == id }
         } else if chatViewModels[id]?.messages.contains(where: { $0.role == .user }) != true
                     && chatViewModels[id]?.isBootstrapping != true {
@@ -256,6 +266,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             // a session will never be created, so there is nothing to backfill.
             // Clean up immediately.
             chatViewModels.removeValue(forKey: id)
+            unsubscribeFromBusyState(for: id)
             vmAccessOrder.removeAll { $0 == id }
         } else {
             // Session ID is nil but a session is expected (user messages exist
@@ -526,6 +537,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
     func setChatViewModel(_ vm: ChatViewModel, for threadId: UUID) {
         chatViewModels[threadId] = vm
+        subscribeToBusyState(for: threadId, viewModel: vm)
         touchVMAccessOrder(threadId)
         evictStaleCachedViewModels()
         // Re-subscribe if this is the active view model
@@ -536,6 +548,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
     func removeChatViewModel(for threadId: UUID) {
         chatViewModels.removeValue(forKey: threadId)
+        unsubscribeFromBusyState(for: threadId)
         vmAccessOrder.removeAll { $0 == threadId }
     }
 
@@ -663,6 +676,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             archived.insert(sessionId)
             archivedSessionIds = archived
             chatViewModels.removeValue(forKey: threadId)
+            unsubscribeFromBusyState(for: threadId)
             vmAccessOrder.removeAll { $0 == threadId }
         }
     }
@@ -686,6 +700,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             viewModel.isHistoryLoaded = true
         }
         chatViewModels[threadId] = viewModel
+        subscribeToBusyState(for: threadId, viewModel: viewModel)
         touchVMAccessOrder(threadId)
         evictStaleCachedViewModels()
         return viewModel
@@ -709,6 +724,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             }
             chatViewModels[victim]?.stopGenerating()
             chatViewModels.removeValue(forKey: victim)
+            unsubscribeFromBusyState(for: victim)
             vmAccessOrder.removeAll { $0 == victim }
             log.info("LRU evicted VM for thread \(victim)")
         }
@@ -750,6 +766,49 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
         // Clear the flag so future activeThreadId changes persist normally
         isRestoringThreads = false
+    }
+
+    // MARK: - Busy State
+
+    /// Whether the given thread's ChatViewModel indicates active processing.
+    func isThreadBusy(_ threadId: UUID) -> Bool {
+        busyThreadIds.contains(threadId)
+    }
+
+    /// Subscribe to busy-state publishers on a ChatViewModel so `busyThreadIds` stays current.
+    func subscribeToBusyState(for threadId: UUID, viewModel: ChatViewModel) {
+        // Tear down any previous subscriptions for this thread.
+        busyStateCancellables.removeValue(forKey: threadId)
+        var subs = Set<AnyCancellable>()
+
+        let mgr = viewModel.messageManager
+        // Combine the three relevant publishers into a single derived boolean.
+        Publishers.CombineLatest3(
+            mgr.$isSending,
+            mgr.$isThinking,
+            mgr.$pendingQueuedCount
+        )
+        .map { isSending, isThinking, pendingQueuedCount in
+            isSending || isThinking || pendingQueuedCount > 0
+        }
+        .removeDuplicates()
+        .sink { [weak self] isBusy in
+            guard let self else { return }
+            if isBusy {
+                self.busyThreadIds.insert(threadId)
+            } else {
+                self.busyThreadIds.remove(threadId)
+            }
+        }
+        .store(in: &subs)
+
+        busyStateCancellables[threadId] = subs
+    }
+
+    /// Remove busy-state subscriptions for a thread (e.g. on archive/close).
+    private func unsubscribeFromBusyState(for threadId: UUID) {
+        busyStateCancellables.removeValue(forKey: threadId)
+        busyThreadIds.remove(threadId)
     }
 
     /// Subscribe to the active ChatViewModel's messages publisher.

--- a/clients/macos/vellum-assistantTests/ThreadManagerBusyStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerBusyStateTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class ThreadManagerBusyStateTests: XCTestCase {
+
+    private var daemonClient: DaemonClient!
+    private var threadManager: ThreadManager!
+
+    override func setUp() {
+        super.setUp()
+        daemonClient = DaemonClient()
+        daemonClient.isConnected = true
+        daemonClient.sendOverride = { _ in }
+        threadManager = ThreadManager(daemonClient: daemonClient)
+    }
+
+    override func tearDown() {
+        daemonClient?.sendOverride = nil
+        threadManager = nil
+        daemonClient = nil
+        super.tearDown()
+    }
+
+    // MARK: - Busy state derivation
+
+    func testBusyFalseByDefault() {
+        // init creates a default thread
+        let threadId = threadManager.activeThreadId!
+        XCTAssertFalse(threadManager.isThreadBusy(threadId), "Thread should not be busy by default")
+        XCTAssertTrue(threadManager.busyThreadIds.isEmpty)
+    }
+
+    func testBusyTrueWhenIsSending() {
+        let threadId = threadManager.activeThreadId!
+        let vm = threadManager.activeViewModel!
+        vm.isSending = true
+
+        // Allow Combine pipeline to deliver
+        let exp = expectation(description: "busy state propagates")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { exp.fulfill() }
+        wait(for: [exp], timeout: 1.0)
+
+        XCTAssertTrue(threadManager.isThreadBusy(threadId), "Thread should be busy when isSending is true")
+    }
+
+    func testBusyTrueWhenIsThinking() {
+        let threadId = threadManager.activeThreadId!
+        let vm = threadManager.activeViewModel!
+        vm.isThinking = true
+
+        let exp = expectation(description: "busy state propagates")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { exp.fulfill() }
+        wait(for: [exp], timeout: 1.0)
+
+        XCTAssertTrue(threadManager.isThreadBusy(threadId), "Thread should be busy when isThinking is true")
+    }
+
+    func testBusyTrueWhenPendingQueuedCountPositive() {
+        let threadId = threadManager.activeThreadId!
+        let vm = threadManager.activeViewModel!
+        vm.pendingQueuedCount = 3
+
+        let exp = expectation(description: "busy state propagates")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { exp.fulfill() }
+        wait(for: [exp], timeout: 1.0)
+
+        XCTAssertTrue(threadManager.isThreadBusy(threadId), "Thread should be busy when pendingQueuedCount > 0")
+    }
+
+    func testBusyFalseAfterAllReturnToIdle() {
+        let threadId = threadManager.activeThreadId!
+        let vm = threadManager.activeViewModel!
+
+        // Set busy
+        vm.isSending = true
+        vm.isThinking = true
+        vm.pendingQueuedCount = 1
+
+        let expBusy = expectation(description: "busy state set")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { expBusy.fulfill() }
+        wait(for: [expBusy], timeout: 1.0)
+        XCTAssertTrue(threadManager.isThreadBusy(threadId))
+
+        // Return to idle
+        vm.isSending = false
+        vm.isThinking = false
+        vm.pendingQueuedCount = 0
+
+        let expIdle = expectation(description: "idle state propagates")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { expIdle.fulfill() }
+        wait(for: [expIdle], timeout: 1.0)
+
+        XCTAssertFalse(threadManager.isThreadBusy(threadId), "Thread should not be busy after all states return to idle")
+        XCTAssertTrue(threadManager.busyThreadIds.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- Add thread busy-state derivation in `ThreadManager` via Combine subscriptions on `isSending`, `isThinking`, and `pendingQueuedCount` for each thread's `ChatViewModel`
- Update `MainWindowView.threadItem(_:)` overlay to show a spinner in the left pin slot when a thread is busy and not hovered, replacing it with the pin button on hover
- Stabilize trailing padding across all overlay states (hovered, busy, pinned, idle) to prevent text jitter
- Add 5 unit tests for busy-state derivation (default false, true for each trigger, false after idle)

## Changed files
| File | Why |
|------|-----|
| `ThreadManager.swift` | Add `busyThreadIds` set, `subscribeToBusyState`/`unsubscribeFromBusyState` methods, wire up subscriptions in all VM creation/teardown paths |
| `MainWindowView.swift` | Add `isBusy` check in `threadItem`, show `ProgressView` spinner in busy-not-hovered state, stabilize trailing padding |
| `ThreadManagerBusyStateTests.swift` | New test file with 5 tests covering busy-state derivation |

## Acceptance checklist
- [x] Hover: pin button (left) + archive button (right)
- [x] Non-hover busy: spinner in pin slot
- [x] Hover while busy: pin shown, spinner hidden
- [x] Non-hover idle pinned: passive pin icon shown
- [x] Confirm-archive flow still works (highest priority overlay)
- [x] Tests pass (`./build.sh test`)
- [x] Lint passes (`./build.sh lint`)

## Residual risk
- The pre-existing `indicatorAutoDismisses` test is flaky (timing-based) and fails intermittently — unrelated to this PR
- Busy-state subscriptions are per-thread Combine pipelines; for repos with many active threads, this adds a small memory/CPU overhead (bounded by `maxCachedViewModels = 10`)

## Original prompt
Replicate Codex-style sidebar thread actions in macOS thread rows with busy spinner, hover-aware pin/archive, and stable layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
