### PR TITLE
fix: address review feedback from PR #9329

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -1860,7 +1860,7 @@ struct SettingsConnectTab: View {
                         .font(.system(size: 11, weight: .medium))
                         .foregroundColor(spinning ? VColor.accent : VColor.textMuted)
                         .rotationEffect(.degrees(spinning ? 360 : 0))
-                        .animation(spinning ? .linear(duration: 1).repeatForever(autoreverses: false) : .default, value: spinning)
+                        .animation(spinning ? .linear(duration: 1).repeatForever(autoreverses: false) : nil, value: spinning)
                         .frame(width: 24, height: 24)
                         .contentShape(Rectangle())
                 }


### PR DESCRIPTION
Address review comments from https://github.com/vellum-ai/vellum-assistant/pull/9329 (fix(macos): resolve two build errors on main)

## Summary

- Replace `.default` with `nil` for the spinner stop animation in `SettingsConnectTab.swift`

The original PR replaced `.identity` (which no longer compiles) with `.default`, but `.default` is an easeInOut animation that causes a visible reverse-spin when the spinner stops. Using `nil` instead correctly means "no animation" -- an instant snap back to 0 degrees rotation, matching the original design intent.

## Files changed

- `clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
