### PR TITLE
fix: add .sh module type declaration for CLI typecheck

### DIFF
--- a/cli/src/types/sh.d.ts
+++ b/cli/src/types/sh.d.ts
@@ -1,0 +1,4 @@
+declare module "*.sh" {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Summary
- Add `cli/src/types/sh.d.ts` type declaration so TypeScript recognizes `import ... from "*.sh" with { type: "text" }` (Bun text import)
- Fixes CI Main CLI Checks which have been failing since `b38c898f4` introduced `.sh` text imports in `hatch.ts` and `gcp.ts`

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22425346341

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
