### PR TITLE
fix: address review feedback from PR #9242

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VInfoTooltip.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VInfoTooltip.swift
@@ -4,9 +4,8 @@ import SwiftUI
 ///
 /// Uses a non-interactive view with `.help()` so the tooltip appears on
 /// hover without introducing a focusable button to VoiceOver or keyboard
-/// navigation. The `.accessibilityHidden(true)` keeps it out of the
-/// accessibility tree entirely — the adjacent label already conveys the
-/// context, and the tooltip text is supplementary.
+/// navigation. The tooltip text is exposed as an accessibility label so
+/// VoiceOver users can hear the supplementary information.
 ///
 /// Usage:
 /// ```swift
@@ -29,7 +28,7 @@ public struct VInfoTooltip: View {
             .frame(width: 16, height: 16)
             .contentShape(Rectangle())
             .help(tooltip)
-            .accessibilityHidden(true)
+            .accessibilityLabel(tooltip)
     }
 }
 


### PR DESCRIPTION
Address review comments from https://github.com/vellum-ai/vellum-assistant/pull/9242 (fix(macos): improve guardian tooltip reliability and remove redundant shield icons)

## Changes

Replace `.accessibilityHidden(true)` with `.accessibilityLabel(tooltip)` on the `VInfoTooltip` component so VoiceOver users can hear the tooltip text when navigating to the info icon. The Codex reviewer on PR #9242 flagged that the interactive info button lacked an accessibility label; this was subsequently refactored into the `VInfoTooltip` reusable component (PR #9243), but the accessibility concern still applied since the icon was hidden from the accessibility tree entirely.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
