### PR TITLE
fix: address review feedback from PR #9244

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -1660,6 +1660,13 @@ struct SettingsConnectTab: View {
                         }
                     )
                 }
+
+                Button("Clear All") {
+                    store.clearAllApprovedDevices()
+                }
+                .font(VFont.caption)
+                .foregroundColor(VColor.error)
+                .buttonStyle(.borderless)
             }
 
             Divider().background(VColor.surfaceBorder)


### PR DESCRIPTION
Address review comments from https://github.com/vellum-ai/vellum-assistant/pull/9244 (fix(macos): clean up Mobile section on Connect page)

Restores the "Clear All" button for bulk revocation of approved devices in the Mobile pairing card. The original PR removed this control, which was flagged by Codex as a functional regression in a security-sensitive flow — users could no longer quickly invalidate all previously approved devices after a compromise or shared-device incident.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
