### PR TITLE
fix: address review feedback from PR #9334

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -3272,23 +3272,23 @@ describe('outbound Telegram verification', () => {
     expect(revoked).toBeNull();
   });
 
-  test('telegram template includes verification instruction without code', () => {
+  test('telegram template includes verification code in message', () => {
     const msg = composeVerificationTelegram(
       GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST,
       { code: 'abc123', expiresInMinutes: 10 },
     );
-    // Should ask user to reply with code but NOT include the actual code
-    expect(msg).toContain('code you were given');
-    expect(msg).not.toContain('abc123');
+    // Code must be visible in-channel for bootstrap flows where the app cannot display it
+    expect(msg).toContain('abc123');
+    expect(msg).toContain('/guardian_verify abc123');
   });
 
-  test('telegram resend template includes (resent) suffix', () => {
+  test('telegram resend template includes code and (resent) suffix', () => {
     const msg = composeVerificationTelegram(
       GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_RESEND,
       { code: 'xyz789', expiresInMinutes: 5 },
     );
-    expect(msg).toContain('code you were given');
-    expect(msg).not.toContain('xyz789');
+    expect(msg).toContain('xyz789');
+    expect(msg).toContain('/guardian_verify xyz789');
     expect(msg).toContain('(resent)');
   });
 
@@ -3298,8 +3298,7 @@ describe('outbound Telegram verification', () => {
       { code: '999999', expiresInMinutes: 10, assistantName: 'MyBot' },
     );
     expect(msg).toContain('Vellum assistant');
-    // Code should NOT appear in the message
-    expect(msg).not.toContain('999999');
+    expect(msg).toContain('999999');
   });
 
   test('start_outbound for telegram with missing destination fails', () => {

--- a/assistant/src/runtime/guardian-verification-templates.ts
+++ b/assistant/src/runtime/guardian-verification-templates.ts
@@ -80,23 +80,23 @@ export interface ChannelVerifyReplyVars {
 
 const templates: Record<TextVerifyTemplateKey, (vars: GuardianVerifyTemplateVars) => string> = {
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST]: (_vars) => {
-    return 'Vellum assistant guardian verification requested. Reply with the 6-digit code you were given.';
+    return 'Vellum assistant guardian verification requested. Reply with the 6-digit code you were given, or use /guardian_verify <code>.';
   },
 
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.RESEND]: (_vars) => {
-    return 'Vellum assistant guardian verification requested. Reply with the 6-digit code you were given. (resent)';
+    return 'Vellum assistant guardian verification requested. Reply with the 6-digit code you were given, or use /guardian_verify <code>. (resent)';
   },
 
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.ALREADY_VERIFIED]: (_vars) => {
     return 'This channel is already verified. No further action is needed.';
   },
 
-  [GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST]: (_vars) => {
-    return 'Vellum assistant guardian verification requested. Reply with the 6-digit code you were given.';
+  [GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST]: (vars) => {
+    return `Vellum assistant guardian verification requested. Your code is: ${vars.code}. Reply with this code or use /guardian_verify ${vars.code}`;
   },
 
-  [GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_RESEND]: (_vars) => {
-    return 'Vellum assistant guardian verification requested. Reply with the 6-digit code you were given. (resent)';
+  [GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_RESEND]: (vars) => {
+    return `Vellum assistant guardian verification requested. Your code is: ${vars.code}. Reply with this code or use /guardian_verify ${vars.code} (resent)`;
   },
 };
 


### PR DESCRIPTION
Address review comments from https://github.com/vellum-ai/vellum-assistant/pull/9334 (revert #9333 + rework guardian: show code in UI, reply in channel)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
