### PR TITLE
fix: add assistant_inbox_escalation_response to Swift decoder omit allowlist

### DIFF
--- a/assistant/scripts/ipc/check-swift-decoder-drift.ts
+++ b/assistant/scripts/ipc/check-swift-decoder-drift.ts
@@ -54,6 +54,8 @@ const SWIFT_OMIT_ALLOWLIST = new Set<string>([
   // Ingress invite/member management — not yet consumed by the macOS client
   'ingress_invite_response',
   'ingress_member_response',
+  // Inbox escalation — not yet consumed by the macOS client
+  'assistant_inbox_escalation_response',
   // Work item messages — not yet consumed by the macOS client
   'work_item_get_response',
   'work_item_run_task_response',


### PR DESCRIPTION
## Summary
- Add `assistant_inbox_escalation_response` to the Swift decoder omit allowlist in `check-swift-decoder-drift.ts`
- This message type was added to the IPC contract but is not consumed by the macOS client, causing the Swift decoder drift CI check to fail

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22425716865

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
