### PR TITLE
Fix redundant Telegram notification copy formatting

### DIFF
--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -62,6 +62,7 @@ describe('notification decision strategy', () => {
       expect(copy.vellum).toBeDefined();
       expect(copy.vellum!.body).toBe('Take out the trash');
       expect(copy.vellum!.title).toBe('Reminder');
+      expect(copy.telegram!.deliveryText).toBe('Take out the trash');
     });
 
     test('schedule.complete template uses name from payload', () => {
@@ -91,6 +92,7 @@ describe('notification decision strategy', () => {
       expect(copy.vellum!.title).toBe('Notification');
       expect(copy.vellum!.body).toContain('Urgent:');
       expect(copy.vellum!.body).toContain('action required');
+      expect(copy.telegram!.deliveryText).toBe(copy.telegram!.body);
     });
 
     test('unknown event name without urgency produces clean generic copy', () => {
@@ -124,6 +126,8 @@ describe('notification decision strategy', () => {
       // Both channels get the same copy
       expect(copy.vellum!.title).toBe(copy.telegram!.title);
       expect(copy.vellum!.body).toBe(copy.telegram!.body);
+      // Telegram gets a dedicated chat message field.
+      expect(copy.telegram!.deliveryText).toBe(copy.telegram!.body);
     });
 
     test('empty payload falls back to default text in template', () => {

--- a/assistant/src/__tests__/notification-telegram-adapter.test.ts
+++ b/assistant/src/__tests__/notification-telegram-adapter.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const deliveryCalls: Array<{ url: string; payload: Record<string, unknown>; bearerToken?: string }> = [];
+
+mock.module('../config/env.js', () => ({
+  getGatewayInternalBaseUrl: () => 'http://gateway.internal',
+}));
+
+mock.module('../runtime/gateway-client.js', () => ({
+  deliverChannelReply: async (
+    url: string,
+    payload: Record<string, unknown>,
+    bearerToken?: string,
+  ) => {
+    deliveryCalls.push({ url, payload, bearerToken });
+  },
+}));
+
+mock.module('../util/platform.js', () => ({
+  readHttpToken: () => 'test-http-token',
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { TelegramAdapter } from '../notifications/adapters/telegram.js';
+import type { ChannelDeliveryPayload, ChannelDestination } from '../notifications/types.js';
+
+function makePayload(overrides?: Partial<ChannelDeliveryPayload>): ChannelDeliveryPayload {
+  return {
+    sourceEventName: 'reminder.fired',
+    copy: {
+      title: 'Reminder',
+      body: 'Check the oven now!',
+    },
+    ...overrides,
+  };
+}
+
+function makeDestination(overrides?: Partial<ChannelDestination>): ChannelDestination {
+  return {
+    channel: 'telegram',
+    endpoint: 'chat-123',
+    ...overrides,
+  };
+}
+
+describe('TelegramAdapter', () => {
+  beforeEach(() => {
+    deliveryCalls.length = 0;
+  });
+
+  test('prefers deliveryText and does not append deterministic Thread label', async () => {
+    const adapter = new TelegramAdapter();
+    const payload = makePayload({
+      copy: {
+        title: 'Check the oven',
+        body: 'Reminder: Check the oven now!',
+        deliveryText: 'Check the oven now!',
+        threadTitle: 'Oven Reminder',
+      },
+    });
+
+    const result = await adapter.send(payload, makeDestination());
+
+    expect(result.success).toBe(true);
+    expect(deliveryCalls).toHaveLength(1);
+    expect(deliveryCalls[0]?.url).toBe('http://gateway.internal/deliver/telegram');
+    expect(deliveryCalls[0]?.payload.text).toBe('Check the oven now!');
+    expect((deliveryCalls[0]?.payload.text as string)).not.toContain('Thread:');
+  });
+
+  test('falls back to threadSeedMessage when deliveryText is absent', async () => {
+    const adapter = new TelegramAdapter();
+    const payload = makePayload({
+      copy: {
+        title: 'Reminder',
+        body: 'Check the oven now!',
+        threadSeedMessage: 'Please check the oven now.',
+      },
+    });
+
+    await adapter.send(payload, makeDestination());
+
+    expect(deliveryCalls).toHaveLength(1);
+    expect(deliveryCalls[0]?.payload.text).toBe('Please check the oven now.');
+  });
+
+  test('falls back to body/title/sourceEventName when richer text is unavailable', async () => {
+    const adapter = new TelegramAdapter();
+
+    await adapter.send(
+      makePayload({
+        copy: {
+          title: 'Reminder',
+          body: 'Check the oven now!',
+          threadSeedMessage: '{"raw":"json"}',
+        },
+      }),
+      makeDestination(),
+    );
+    expect(deliveryCalls[0]?.payload.text).toBe('Check the oven now!');
+
+    await adapter.send(
+      makePayload({
+        copy: {
+          title: 'Reminder',
+          body: '   ',
+        },
+      }),
+      makeDestination(),
+    );
+    expect(deliveryCalls[1]?.payload.text).toBe('Reminder');
+
+    await adapter.send(
+      makePayload({
+        sourceEventName: 'watcher.escalation',
+        copy: {
+          title: ' ',
+          body: '',
+        },
+      }),
+      makeDestination(),
+    );
+    expect(deliveryCalls[2]?.payload.text).toBe('watcher.escalation');
+  });
+});

--- a/assistant/src/notifications/README.md
+++ b/assistant/src/notifications/README.md
@@ -81,19 +81,22 @@ Each policy defines:
 
 The pairing function is resilient -- errors are caught and logged. A pairing failure never breaks the delivery pipeline.
 
-## Dual-Copy Architecture: Notification vs Thread Seed
+## Multi-Surface Copy Architecture
 
-The system produces **two distinct copy outputs** per notification:
+The system produces **three distinct copy outputs** per notification:
 
 | Output | Purpose | Verbosity |
 |--------|---------|-----------|
-| `title` + `body` | Native notification popup (macOS banner, Telegram message) | Short and glanceable |
+| `title` + `body` | Native notification popup (macOS/iOS banner) | Short and glanceable |
+| `deliveryText` | Channel-native chat message text (Telegram) | Natural chat phrasing |
 | Thread seed message | Opening message in the notification thread | Richer and context-aware |
 
 ### How It Works
 
-1. The **decision engine** can produce both `title`/`body` (concise popup copy) and `threadSeedMessage` (richer thread content) per channel.
-2. **Adapters** only use `copy.title` and `copy.body` for the native notification display. The `threadSeedMessage` field passes through the adapter payload but is not used for the popup.
+1. The **decision engine** can produce `title`/`body` (popup copy), `deliveryText` (chat copy), and `threadSeedMessage` (richer thread content) per channel.
+2. **Adapters** use the surface-appropriate field:
+   - Vellum/macOS notifications use `title` + `body`.
+   - Telegram delivery prefers `deliveryText` and falls back to `threadSeedMessage`, then `body`, then `title`.
 3. **Conversation pairing** uses the thread seed as the conversation's opening message:
    - If the LLM produced a valid `threadSeedMessage`, it is used directly (after a sanity check rejects empty, too-short, JSON dumps, or excessively long values).
    - Otherwise, the **runtime thread seed composer** (`thread-seed-composer.ts`) generates a deterministic, surface-aware seed.
@@ -114,20 +117,20 @@ Interface inference strategy:
 
 ### Example: Reminder Notification
 
-**Notification popup (both surfaces):**
+**Native popup (vellum/macos):**
 ```
 Title: Reminder
 Body:  Take out the trash
 ```
 
-**Thread seed on vellum/macos (rich):**
+**Telegram chat delivery (`deliveryText`):**
 ```
-Reminder: Take out the trash. This needs your attention.
+Take out the trash
 ```
 
-**Thread seed on telegram (compact):**
+**Thread seed on vellum/macos (rich):**
 ```
-Reminder: Take out the trash — action needed
+Reminder. Take out the trash. Action required.
 ```
 
 ## Thread Surfacing via `notification_thread_created` IPC
@@ -167,7 +170,7 @@ The macOS/iOS client posts a native `UNUserNotificationCenter` notification from
 
 ### Telegram (when guardian binding exists)
 
-HTTP POST to the gateway's `/deliver/telegram` endpoint. The `TelegramAdapter` formats the notification copy as plain text and sends it to the guardian's chat ID (resolved from the active guardian binding).
+HTTP POST to the gateway's `/deliver/telegram` endpoint. The `TelegramAdapter` sends channel-native text (`deliveryText` when present) to the guardian's chat ID (resolved from the active guardian binding), with deterministic fallbacks when model copy is unavailable.
 
 ### Channel Connectivity
 

--- a/assistant/src/notifications/adapters/telegram.ts
+++ b/assistant/src/notifications/adapters/telegram.ts
@@ -11,6 +11,7 @@ import { getGatewayInternalBaseUrl } from '../../config/env.js';
 import { deliverChannelReply } from '../../runtime/gateway-client.js';
 import { getLogger } from '../../util/logger.js';
 import { readHttpToken } from '../../util/platform.js';
+import { isThreadSeedSane } from '../thread-seed-composer.js';
 import type {
   ChannelAdapter,
   ChannelDeliveryPayload,
@@ -20,6 +21,29 @@ import type {
 } from '../types.js';
 
 const log = getLogger('notif-adapter-telegram');
+
+function nonEmpty(value: string | undefined): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function resolveTelegramMessageText(payload: ChannelDeliveryPayload): string {
+  const deliveryText = nonEmpty(payload.copy.deliveryText);
+  if (deliveryText) return deliveryText;
+
+  if (isThreadSeedSane(payload.copy.threadSeedMessage)) {
+    return payload.copy.threadSeedMessage.trim();
+  }
+
+  const body = nonEmpty(payload.copy.body);
+  if (body) return body;
+
+  const title = nonEmpty(payload.copy.title);
+  if (title) return title;
+
+  return payload.sourceEventName;
+}
 
 export class TelegramAdapter implements ChannelAdapter {
   readonly channel: NotificationChannel = 'telegram';
@@ -34,11 +58,9 @@ export class TelegramAdapter implements ChannelAdapter {
     const gatewayBase = getGatewayInternalBaseUrl();
     const deliverUrl = `${gatewayBase}/deliver/telegram`;
 
-    // Format copy for Telegram as plain text (no parse_mode set on gateway side)
-    let messageText = payload.copy.title + '\n\n' + payload.copy.body;
-    if (payload.copy.threadTitle) {
-      messageText += '\n\nThread: ' + payload.copy.threadTitle;
-    }
+    // Telegram is a chat surface, not a native popup. Use channel-native
+    // delivery copy when available and avoid deterministic label prefixes.
+    const messageText = resolveTelegramMessageText(payload);
 
     try {
       await deliverChannelReply(

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -19,6 +19,12 @@ function str(value: unknown, fallback: string): string {
   return fallback;
 }
 
+function nonEmpty(value: string | undefined): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 // Templates keyed by dot-separated sourceEventName strings matching producers.
 const TEMPLATES: Record<string, CopyTemplate> = {
   'reminder.fired': (payload) => ({
@@ -82,8 +88,8 @@ const TEMPLATES: Record<string, CopyTemplate> = {
  * engine's LLM path is unavailable.
  *
  * Returns a map of channel -> RenderedChannelCopy for the requested channels.
- * All channels currently receive the same template output; per-channel
- * customisation can be layered on later.
+ * Base title/body content comes from templates, then channel-specific
+ * defaults are applied (for example Telegram deliveryText).
  */
 export function composeFallbackCopy(
   signal: NotificationSignal,
@@ -97,9 +103,39 @@ export function composeFallbackCopy(
 
   const result: Partial<Record<NotificationChannel, RenderedChannelCopy>> = {};
   for (const ch of channels) {
-    result[ch] = { ...baseCopy };
+    result[ch] = applyChannelDefaults(ch, baseCopy, signal);
   }
   return result;
+}
+
+function applyChannelDefaults(
+  channel: NotificationChannel,
+  baseCopy: RenderedChannelCopy,
+  signal: NotificationSignal,
+): RenderedChannelCopy {
+  const copy: RenderedChannelCopy = { ...baseCopy };
+
+  if (channel === 'telegram') {
+    copy.deliveryText = buildTelegramFallbackDeliveryText(baseCopy, signal);
+  }
+
+  return copy;
+}
+
+function buildTelegramFallbackDeliveryText(
+  baseCopy: RenderedChannelCopy,
+  signal: NotificationSignal,
+): string {
+  const explicit = nonEmpty(baseCopy.deliveryText);
+  if (explicit) return explicit;
+
+  const body = nonEmpty(baseCopy.body);
+  if (body) return body;
+
+  const title = nonEmpty(baseCopy.title);
+  if (title) return title;
+
+  return signal.sourceEventName.replace(/[._]/g, ' ');
 }
 
 /**

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -24,7 +24,7 @@ import type { NotificationChannel, NotificationDecision, RenderedChannelCopy } f
 const log = getLogger('notification-decision-engine');
 
 const DECISION_TIMEOUT_MS = 15_000;
-const PROMPT_VERSION = 'v1';
+const PROMPT_VERSION = 'v2';
 
 // ── System prompt ──────────────────────────────────────────────────────
 
@@ -56,11 +56,14 @@ function buildSystemPrompt(
     `- For low-urgency background events, suppress unless they match user preferences.`,
     `- Generate a stable dedupeKey derived from the signal context so duplicate signals can be suppressed.`,
     ``,
-    `Copy guidelines (two distinct outputs):`,
-    `- \`title\` and \`body\` are for native notification popups — keep them short and glanceable (title ≤ 8 words, body ≤ 2 sentences).`,
-    `- \`threadSeedMessage\` is the opening message in the notification thread — it can be richer and more contextual.`,
-    `  - For vellum (desktop): 2-4 short sentences with useful context and clear next step if action is required.`,
+    `Copy guidelines (three distinct outputs):`,
+    `- \`title\` and \`body\` are for native notification popups (e.g. vellum desktop/mobile) — keep them short and glanceable (title ≤ 8 words, body ≤ 2 sentences).`,
+    `- \`deliveryText\` is the channel-native message for chat channels (e.g. telegram). It must read naturally as a standalone message.`,
+    `  - Do not prepend mechanical labels like "Thread:".`,
+    `  - Do not repeat title/body verbatim unless that repetition is truly necessary.`,
     `  - For telegram: 1-2 concise sentences.`,
+    `- \`threadSeedMessage\` is the opening message in the internal notification thread — it can be richer and more contextual.`,
+    `  - For vellum (desktop): 2-4 short sentences with useful context and clear next step if action is required.`,
     `  - Never dump raw JSON. Include only human-readable context.`,
     ``,
     `You MUST respond using the \`record_notification_decision\` tool. Do not respond with text.`,
@@ -130,6 +133,7 @@ function buildDecisionTool(availableChannels: NotificationChannel[]) {
                 properties: {
                   title: { type: 'string', description: 'Short notification popup title (≤ 8 words)' },
                   body: { type: 'string', description: 'Concise notification popup body (≤ 2 sentences)' },
+                  deliveryText: { type: 'string', description: 'Channel-native chat message text (for example Telegram). Must stand alone naturally.' },
                   threadTitle: { type: 'string', description: 'Optional thread title for grouped notifications' },
                   threadSeedMessage: { type: 'string', description: 'Richer opening message for the notification thread. More contextual than title/body. For vellum: 2-4 sentences. For telegram: 1-2 sentences. Never raw JSON.' },
                 },
@@ -187,11 +191,13 @@ function buildFallbackDecision(
 
   const copy: Partial<Record<NotificationChannel, RenderedChannelCopy>> = {};
   for (const ch of selectedChannels) {
+    const fallbackBody = isHighUrgencyAction
+      ? `Action required: ${signal.sourceEventName}`
+      : signal.sourceEventName;
     copy[ch] = {
       title: signal.sourceEventName,
-      body: isHighUrgencyAction
-        ? `Action required: ${signal.sourceEventName}`
-        : signal.sourceEventName,
+      body: fallbackBody,
+      deliveryText: fallbackBody,
     };
   }
 
@@ -243,6 +249,7 @@ function validateDecisionOutput(
           renderedCopy[ch] = {
             title: c.title,
             body: c.body,
+            deliveryText: typeof c.deliveryText === 'string' ? c.deliveryText : undefined,
             threadTitle: typeof c.threadTitle === 'string' ? c.threadTitle : undefined,
             threadSeedMessage: typeof c.threadSeedMessage === 'string' ? c.threadSeedMessage : undefined,
           };

--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -70,6 +70,8 @@ export interface ChannelAdapter {
 export interface RenderedChannelCopy {
   title: string;
   body: string;
+  /** Channel-native delivery text (e.g. Telegram chat message body). */
+  deliveryText?: string;
   threadTitle?: string;
   threadSeedMessage?: string;
 }


### PR DESCRIPTION
## Summary
- add channel-native `deliveryText` to notification copy so chat channels are not forced to reuse popup-oriented title/body
- update decision-engine prompt + tool schema to generate separate popup copy (`title/body`), chat copy (`deliveryText`), and thread seed copy (`threadSeedMessage`)
- remove deterministic Telegram formatting (`title + body + Thread:`) and use prioritized text resolution (`deliveryText` -> sane `threadSeedMessage` -> `body` -> `title`)
- make fallback copy channel-aware by populating Telegram `deliveryText` defaults
- update notification docs to reflect the multi-surface copy model
- add regression tests for Telegram adapter rendering behavior and fallback composer output

## Validation
- `cd assistant && export PATH="$HOME/.bun/bin:$PATH" && bun test src/__tests__/notification-decision-strategy.test.ts src/__tests__/notification-telegram-adapter.test.ts`
- `cd assistant && export PATH="$HOME/.bun/bin:$PATH" && bun test src/__tests__/notification-broadcaster.test.ts src/__tests__/conversation-pairing.test.ts`
- `cd assistant && export PATH="$HOME/.bun/bin:$PATH" && bun run lint src/notifications/adapters/telegram.ts src/notifications/copy-composer.ts src/notifications/decision-engine.ts src/notifications/types.ts src/__tests__/notification-decision-strategy.test.ts src/__tests__/notification-telegram-adapter.test.ts`

## Notes
- `bunx tsc --noEmit` currently fails on existing IPC snapshot drift in `src/__tests__/ipc-snapshot.test.ts` (missing `assistant_inbox_escalation` message variants), unrelated to this PR.