### PR TITLE
M2: Conversational Routing + Guardian Setup Skill

### DIFF
--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -225,3 +225,69 @@ describe('cross-tool routing consistency', () => {
     expect(reminderCreateDef.description).toContain('add to my queue');
   });
 });
+
+// =====================================================================
+// 4. Guardian verification routing section in system prompt
+// =====================================================================
+
+describe('Guardian verification routing section in system prompt', () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  test('system prompt includes the guardian verification routing heading', () => {
+    const prompt = buildSystemPrompt();
+    expect(prompt).toContain('## Routing: Guardian Verification');
+  });
+
+  test('routing section includes trigger phrase "verify guardian"', () => {
+    const prompt = buildSystemPrompt();
+    expect(prompt).toContain('verify guardian');
+  });
+
+  test('routing section includes trigger phrase "set guardian for SMS"', () => {
+    const prompt = buildSystemPrompt();
+    expect(prompt).toContain('set guardian for SMS');
+  });
+
+  test('routing section includes trigger phrase "verify my Telegram account"', () => {
+    const prompt = buildSystemPrompt();
+    expect(prompt).toContain('verify my Telegram account');
+  });
+
+  test('routing section includes trigger phrase "verify voice channel"', () => {
+    const prompt = buildSystemPrompt();
+    expect(prompt).toContain('verify voice channel');
+  });
+
+  test('routing section includes trigger phrase "verify my phone number"', () => {
+    const prompt = buildSystemPrompt();
+    expect(prompt).toContain('verify my phone number');
+  });
+
+  test('routing section includes trigger phrase "set up guardian verification"', () => {
+    const prompt = buildSystemPrompt();
+    expect(prompt).toContain('set up guardian verification');
+  });
+
+  test('routing section references the guardian-verify-setup skill', () => {
+    const prompt = buildSystemPrompt();
+    expect(prompt).toContain('guardian-verify-setup');
+  });
+
+  test('routing section mentions all three channels', () => {
+    const prompt = buildSystemPrompt();
+    // The section should mention sms, voice, and telegram as supported channels
+    const routingStart = prompt.indexOf('## Routing: Guardian Verification');
+    const routingSection = prompt.substring(routingStart, routingStart + 1000);
+    expect(routingSection).toContain('sms');
+    expect(routingSection).toContain('voice');
+    expect(routingSection).toContain('telegram');
+  });
+});

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -124,6 +124,7 @@ export function buildSystemPrompt(tier: ResponseTier = 'high'): string {
   if (tier !== 'low') {
     parts.push(buildToolPermissionSection());
     parts.push(buildTaskScheduleReminderRoutingSection());
+    parts.push(buildGuardianVerificationRoutingSection());
     parts.push(buildAttachmentSection());
     parts.push(buildInChatConfigurationSection());
     parts.push(buildChannelCommandIntentSection());
@@ -183,6 +184,31 @@ function buildTaskScheduleReminderRoutingSection(): string {
     '',
     '### task_list_show UI note',
     'When you call `task_list_show`, the Tasks window opens automatically. Present a brief summary in chat — do NOT also create a separate surface/UI (`ui_show` or `app_create`) to display the task queue.',
+  ].join('\n');
+}
+
+export function buildGuardianVerificationRoutingSection(): string {
+  return [
+    '## Routing: Guardian Verification',
+    '',
+    'When the user wants to verify their identity as the trusted guardian for a messaging channel, load the **Guardian Verify Setup** skill.',
+    '',
+    '### Trigger phrases',
+    '- "verify guardian"',
+    '- "set guardian for SMS"',
+    '- "verify my Telegram account"',
+    '- "verify voice channel"',
+    '- "verify my phone number"',
+    '- "set up guardian verification"',
+    '',
+    '### What it does',
+    'The skill walks through outbound guardian verification for SMS, voice, or Telegram:',
+    '1. Confirm channel (sms, voice, telegram)',
+    '2. Collect destination (phone number or Telegram handle/chat ID)',
+    '3. Start outbound verification via runtime HTTP API',
+    '4. Guide the user through code entry, resend, or cancel',
+    '',
+    'Load with: `skill_load` using `skill: "guardian-verify-setup"`',
   ].join('\n');
 }
 

--- a/assistant/src/config/vellum-skills/catalog.json
+++ b/assistant/src/config/vellum-skills/catalog.json
@@ -46,6 +46,12 @@
       "name": "SMS Setup",
       "description": "Set up and troubleshoot SMS messaging with guided Twilio configuration, compliance, and verification",
       "emoji": "\ud83d\udce8"
+    },
+    {
+      "id": "guardian-verify-setup",
+      "name": "Guardian Verify Setup",
+      "description": "Set up guardian verification for SMS, voice, or Telegram channels via outbound verification flow",
+      "emoji": "\ud83d\udd10"
     }
   ]
 }

--- a/assistant/src/config/vellum-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/guardian-verify-setup/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: "Guardian Verify Setup"
+description: "Set up guardian verification for SMS, voice, or Telegram channels via outbound verification flow"
+user-invocable: true
+metadata: {"vellum": {"emoji": "\ud83d\udd10"}}
+---
+
+You are helping your user set up guardian verification for a messaging channel (SMS, voice, or Telegram). This links their identity as the trusted guardian for the chosen channel. All API calls go through the runtime HTTP API using `curl` with bearer auth.
+
+## Prerequisites
+
+- The runtime HTTP API is available at `http://localhost:7821` (or the configured `RUNTIME_HTTP_PORT`).
+- The bearer token is stored at `~/.vellum/http-token`. Read it with: `TOKEN=$(cat ~/.vellum/http-token)`.
+
+## Step 1: Confirm Channel
+
+Ask the user which channel they want to verify:
+
+- **sms** -- verify a phone number for SMS messaging
+- **voice** -- verify a phone number for voice calls
+- **telegram** -- verify a Telegram account
+
+If the user's intent already specifies a channel (e.g. "verify my phone number for SMS"), skip the prompt and proceed.
+
+## Step 2: Collect Destination
+
+Based on the chosen channel, ask for the required destination:
+
+- **SMS or voice**: Ask for their phone number. Accept any common format (e.g. +15551234567, (555) 123-4567, 555-123-4567). The API normalizes it to E.164.
+- **Telegram**: Ask for their Telegram chat ID (numeric) or @handle. Explain:
+  - If they know their numeric chat ID, provide it directly. The bot will send the code to that chat.
+  - If they only know their @handle, the flow uses a bootstrap deep-link that they must click first.
+
+## Step 3: Start Outbound Verification
+
+Execute the outbound start request:
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+curl -s -X POST http://localhost:7821/v1/integrations/guardian/outbound/start \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"channel": "<channel>", "destination": "<destination>"}'
+```
+
+Replace `<channel>` with `sms`, `voice`, or `telegram`, and `<destination>` with the phone number or Telegram destination.
+
+### On success (`success: true`)
+
+Report the exact next action based on the channel:
+
+- **SMS**: "I've sent a 6-digit verification code to [number]. Reply with the code here or text it back to the number."
+- **Voice**: "I'm calling [number] now with a 6-digit verification code. Enter the code here once you receive it."
+- **Telegram with chat ID** (no `telegramBootstrapUrl` in response): "I've sent a verification code to your Telegram. Reply with the code here."
+- **Telegram with handle** (`telegramBootstrapUrl` present in response): "Tap this deep-link first: [telegramBootstrapUrl]. After Telegram binds your identity, I'll send your verification code."
+
+After reporting the bootstrap URL for Telegram handle flows, wait for the user to confirm they clicked the link. Then check guardian status (Step 6) to see if the bootstrap completed and a code was sent.
+
+### On error (`success: false`)
+
+Handle each error code:
+
+| Error code | Action |
+|---|---|
+| `missing_destination` | Ask the user to provide their phone number or Telegram destination. |
+| `invalid_destination` | Tell the user the format is invalid. For phone: suggest E.164 format (+15551234567). For Telegram: explain that group chat IDs (negative numbers) are not supported. |
+| `already_bound` | Tell the user a guardian is already bound for this channel. Ask if they want to replace it. If yes, re-run the start request with `"rebind": true` added to the JSON body. |
+| `pending_bootstrap` | Tell the user there is a pending Telegram bootstrap. They need to click the deep-link first, or cancel and start over. |
+| `rate_limited` | Tell the user they have sent too many verification attempts. Ask them to wait and try again later. |
+| `no_active_session` | No session is active. Start a new one from Step 3. |
+| `unsupported_channel` | Tell the user the channel is not supported. Only sms, voice, and telegram are valid. |
+| `no_bot_username` | Telegram bot is not configured. Load and run the `telegram-setup` skill first. |
+
+## Step 4: Handle Resend
+
+If the user says they did not receive the code or asks to resend:
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+curl -s -X POST http://localhost:7821/v1/integrations/guardian/outbound/resend \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"channel": "<channel>"}'
+```
+
+On success, tell the user a new code has been sent. On `rate_limited` error, tell them to wait before trying again (the response includes `nextResendAt` as a Unix timestamp). On `pending_bootstrap`, remind them to click the deep-link. On `no_active_session`, start a new session from Step 3.
+
+## Step 5: Handle Cancel
+
+If the user wants to cancel the verification:
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+curl -s -X POST http://localhost:7821/v1/integrations/guardian/outbound/cancel \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"channel": "<channel>"}'
+```
+
+Confirm cancellation to the user. On `no_active_session`, tell them there is nothing to cancel.
+
+## Step 6: Check Guardian Status
+
+After the user reports entering the code, verify the binding was created:
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+curl -s http://localhost:7821/v1/integrations/guardian/status?channel=<channel> \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+If the response shows the guardian is bound, confirm success: "Guardian verified! Your [channel] identity is now the trusted guardian."
+
+If not yet bound, offer to resend (Step 4) or generate a new session (Step 3).
+
+## Important Notes
+
+- Verification codes expire after 10 minutes. If the session expires, start a new one.
+- The resend cooldown is 15 seconds between sends, with a maximum of 5 sends per session.
+- Per-destination rate limiting allows up to 10 sends within a 1-hour rolling window.
+- Guardian verification is identity-bound: the code can only be consumed by the identity matching the destination provided at start time.

--- a/assistant/src/config/vellum-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/guardian-verify-setup/SKILL.md
@@ -49,7 +49,7 @@ Replace `<channel>` with `sms`, `voice`, or `telegram`, and `<destination>` with
 
 Report the exact next action based on the channel:
 
-- **SMS**: "I've sent a 6-digit verification code to [number]. Reply with the code here or text it back to the number."
+- **SMS**: "I've sent a 6-digit verification code to [number]. Reply with the code from that SMS conversation (not here) to complete verification — the code can only be consumed through the SMS channel."
 - **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad."
 - **Telegram with chat ID** (no `telegramBootstrapUrl` in response): "I've sent a verification code to your Telegram. Send the code back to me in the Telegram bot chat to complete verification."
 - **Telegram with handle** (`telegramBootstrapUrl` present in response): "Tap this deep-link first: [telegramBootstrapUrl]. After Telegram binds your identity, I'll send your verification code."

--- a/assistant/src/config/vellum-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/guardian-verify-setup/SKILL.md
@@ -50,8 +50,8 @@ Replace `<channel>` with `sms`, `voice`, or `telegram`, and `<destination>` with
 Report the exact next action based on the channel:
 
 - **SMS**: "I've sent a 6-digit verification code to [number]. Reply with the code here or text it back to the number."
-- **Voice**: "I'm calling [number] now with a 6-digit verification code. Enter the code here once you receive it."
-- **Telegram with chat ID** (no `telegramBootstrapUrl` in response): "I've sent a verification code to your Telegram. Reply with the code here."
+- **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad."
+- **Telegram with chat ID** (no `telegramBootstrapUrl` in response): "I've sent a verification code to your Telegram. Send the code back to me in the Telegram bot chat to complete verification."
 - **Telegram with handle** (`telegramBootstrapUrl` present in response): "Tap this deep-link first: [telegramBootstrapUrl]. After Telegram binds your identity, I'll send your verification code."
 
 After reporting the bootstrap URL for Telegram handle flows, wait for the user to confirm they clicked the link. Then check guardian status (Step 6) to see if the bootstrap completed and a code was sent.


### PR DESCRIPTION
Add system prompt routing guidance for guardian verification intent. Create reusable guardian-verify-setup skill with conversational flow for SMS/voice/Telegram. Add catalog entry and intent routing tests. Part of #9364.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
