### PR TITLE
M2: Deterministic recording state machine with restart/pause/resume handlers

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -3013,6 +3013,20 @@ exports[`IPC message snapshots ServerMessage types approved_device_remove_respon
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types recording_pause serializes to expected JSON 1`] = `
+{
+  "recordingId": "rec-001",
+  "type": "recording_pause",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types recording_resume serializes to expected JSON 1`] = `
+{
+  "recordingId": "rec-001",
+  "type": "recording_resume",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types recording_start serializes to expected JSON 1`] = `
 {
   "recordingId": "rec-001",

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -1922,6 +1922,14 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     type: 'approved_device_remove_response',
     success: true,
   },
+  recording_pause: {
+    type: 'recording_pause',
+    recordingId: 'rec-001',
+  },
+  recording_resume: {
+    type: 'recording_resume',
+    recordingId: 'rec-001',
+  },
   recording_start: {
     type: 'recording_start',
     recordingId: 'rec-001',

--- a/assistant/src/__tests__/recording-state-machine.test.ts
+++ b/assistant/src/__tests__/recording-state-machine.test.ts
@@ -1,0 +1,691 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import * as net from 'node:net';
+
+// ─── Mocks (must be before any imports that depend on them) ─────────────────
+
+const noop = () => {};
+const noopLogger = {
+  info: noop, warn: noop, error: noop, debug: noop, trace: noop, fatal: noop,
+  child: () => noopLogger,
+};
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => noopLogger,
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    daemon: { standaloneRecording: true },
+    provider: 'mock-provider',
+    permissions: { mode: 'legacy' },
+    apiKeys: {},
+    sandbox: { enabled: false },
+    timeouts: { toolExecutionTimeoutSec: 30, permissionTimeoutSec: 5 },
+    skills: { load: { extraDirs: [] } },
+    secretDetection: { enabled: false, allowOneTimeSend: false },
+    contextWindow: {
+      enabled: true,
+      maxInputTokens: 180000,
+      targetInputTokens: 110000,
+      compactThreshold: 0.8,
+      preserveRecentUserTurns: 8,
+      summaryMaxTokens: 1200,
+      chunkTokens: 12000,
+    },
+  }),
+  invalidateConfigCache: noop,
+  loadConfig: noop,
+  saveConfig: noop,
+  loadRawConfig: () => ({}),
+  saveRawConfig: noop,
+  getNestedValue: () => undefined,
+  setNestedValue: noop,
+}));
+
+// Conversation store mock
+const mockMessages: Array<{ id: string; role: string; content: string }> = [];
+let mockMessageIdCounter = 0;
+
+mock.module('../memory/conversation-store.js', () => ({
+  getMessages: () => mockMessages,
+  addMessage: (_convId: string, role: string, content: string) => {
+    const msg = { id: `msg-${++mockMessageIdCounter}`, role, content };
+    mockMessages.push(msg);
+    return msg;
+  },
+  createConversation: () => ({ id: 'conv-mock' }),
+  getConversation: () => ({ id: 'conv-mock' }),
+}));
+
+// Attachments store mock
+mock.module('../memory/attachments-store.js', () => ({
+  uploadFileBackedAttachment: () => ({ id: 'att-mock', originalFilename: 'test.mov', mimeType: 'video/quicktime', sizeBytes: 1024 }),
+  linkAttachmentToMessage: noop,
+  setAttachmentThumbnail: noop,
+}));
+
+// Mock node:fs
+mock.module('node:fs', () => {
+  const realFs = require('fs');
+  return {
+    ...realFs,
+    existsSync: (p: string) => {
+      if (p.includes('recording') || p.includes('/tmp/')) return true;
+      return realFs.existsSync(p);
+    },
+    statSync: (p: string, opts?: any) => {
+      if (p.includes('recording') || p.includes('/tmp/')) return { size: 1024 };
+      return realFs.statSync(p, opts);
+    },
+  };
+});
+
+// Mock video thumbnail
+mock.module('../daemon/video-thumbnail.js', () => ({
+  generateVideoThumbnailFromPath: async () => null,
+}));
+
+// ─── Imports (after mocks) ──────────────────────────────────────────────────
+
+import {
+  handleRecordingStart,
+  handleRecordingStop,
+  handleRecordingRestart,
+  handleRecordingPause,
+  handleRecordingResume,
+  isRecordingIdle,
+  getActiveRestartToken,
+  recordingHandlers,
+  __resetRecordingState,
+} from '../daemon/handlers/recording.js';
+import { executeRecordingIntent } from '../daemon/recording-executor.js';
+import type { HandlerContext } from '../daemon/handlers/shared.js';
+import type { RecordingStatus } from '../daemon/ipc-contract/computer-use.js';
+import { DebouncerMap } from '../util/debounce.js';
+
+// ─── Test helpers ───────────────────────────────────────────────────────────
+
+function createCtx(): { ctx: HandlerContext; sent: Array<{ type: string; [k: string]: unknown }>; fakeSocket: net.Socket } {
+  const sent: Array<{ type: string; [k: string]: unknown }> = [];
+  const fakeSocket = {} as net.Socket;
+  const socketToSession = new Map<net.Socket, string>();
+
+  const ctx: HandlerContext = {
+    sessions: new Map(),
+    socketToSession,
+    cuSessions: new Map(),
+    socketToCuSession: new Map(),
+    cuObservationParseSequence: new Map(),
+    socketSandboxOverride: new Map(),
+    sharedRequestTimestamps: [],
+    debounceTimers: new DebouncerMap({ defaultDelayMs: 200 }),
+    suppressConfigReload: false,
+    setSuppressConfigReload: noop,
+    updateConfigFingerprint: noop,
+    send: (_socket, msg) => { sent.push(msg as { type: string; [k: string]: unknown }); },
+    broadcast: noop,
+    clearAllSessions: () => 0,
+    getOrCreateSession: () => { throw new Error('not implemented'); },
+    touchSession: noop,
+  };
+
+  return { ctx, sent, fakeSocket };
+}
+
+// ─── Restart state machine tests ────────────────────────────────────────────
+
+describe('handleRecordingRestart', () => {
+  beforeEach(() => {
+    __resetRecordingState();
+    mockMessages.length = 0;
+    mockMessageIdCounter = 0;
+  });
+
+  test('stops current recording and starts a new one with operation token', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-restart-1';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    // Start a recording first
+    const originalId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    expect(originalId).not.toBeNull();
+    sent.length = 0;
+
+    const result = handleRecordingRestart(conversationId, fakeSocket, ctx);
+
+    expect(result.initiated).toBe(true);
+    expect(result.operationToken).toBeTruthy();
+    expect(result.responseText).toBe('Restarting screen recording.');
+
+    // Should have sent: recording_stop, recording_start
+    const stopMsgs = sent.filter((m) => m.type === 'recording_stop');
+    const startMsgs = sent.filter((m) => m.type === 'recording_start');
+    expect(stopMsgs).toHaveLength(1);
+    expect(startMsgs).toHaveLength(1);
+
+    // The new recording_start should have the operation token
+    expect(startMsgs[0].operationToken).toBe(result.operationToken);
+  });
+
+  test('returns "no active recording" when nothing is recording', () => {
+    const { ctx, fakeSocket } = createCtx();
+
+    const result = handleRecordingRestart('conv-no-rec', fakeSocket, ctx);
+
+    expect(result.initiated).toBe(false);
+    expect(result.responseText).toBe('No active recording to restart.');
+  });
+
+  test('generates unique operation token for each restart', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-restart-unique';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    // First restart cycle
+    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    const result1 = handleRecordingRestart(conversationId, fakeSocket, ctx);
+
+    // Simulate the first restart completing (started status)
+    const startMsg1 = sent.filter((m) => m.type === 'recording_start').pop();
+    const status1: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: startMsg1!.recordingId as string,
+      status: 'started',
+      operationToken: result1.operationToken,
+    };
+    recordingHandlers.recording_status(status1, fakeSocket, ctx);
+
+    // Second restart cycle
+    sent.length = 0;
+    const result2 = handleRecordingRestart(conversationId, fakeSocket, ctx);
+
+    expect(result1.operationToken).not.toBe(result2.operationToken);
+  });
+});
+
+// ─── Restart cancel tests ───────────────────────────────────────────────────
+
+describe('restart_cancelled status', () => {
+  beforeEach(() => {
+    __resetRecordingState();
+    mockMessages.length = 0;
+    mockMessageIdCounter = 0;
+  });
+
+  test('emits restart_cancelled response, never "new recording started"', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-cancel-1';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    // Start -> restart
+    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    const restartResult = handleRecordingRestart(conversationId, fakeSocket, ctx);
+    expect(restartResult.initiated).toBe(true);
+
+    // Get the new recording ID from the recording_start message
+    const startMsg = sent.filter((m) => m.type === 'recording_start').pop();
+    sent.length = 0;
+
+    // Client sends restart_cancelled (picker was closed)
+    const cancelStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: startMsg!.recordingId as string,
+      status: 'restart_cancelled',
+      attachToConversationId: conversationId,
+    };
+    recordingHandlers.recording_status(cancelStatus, fakeSocket, ctx);
+
+    // Should have emitted the cancellation message
+    const textDeltas = sent.filter((m) => m.type === 'assistant_text_delta');
+    expect(textDeltas).toHaveLength(1);
+    expect(textDeltas[0].text).toBe('Recording restart cancelled.');
+
+    // Should NOT have "new recording started" anywhere
+    const startedMsgs = sent.filter(
+      (m) => m.type === 'assistant_text_delta' && typeof m.text === 'string' &&
+        m.text.includes('new recording started'),
+    );
+    expect(startedMsgs).toHaveLength(0);
+
+    // Recording should be truly idle after cancel
+    expect(isRecordingIdle()).toBe(true);
+  });
+
+  test('cleans up restart state on cancel', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-cancel-cleanup';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    handleRecordingRestart(conversationId, fakeSocket, ctx);
+
+    // Before cancel: not idle (mid-restart)
+    expect(isRecordingIdle()).toBe(false);
+
+    const startMsg = sent.filter((m) => m.type === 'recording_start').pop();
+    const cancelStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: startMsg!.recordingId as string,
+      status: 'restart_cancelled',
+      attachToConversationId: conversationId,
+    };
+    recordingHandlers.recording_status(cancelStatus, fakeSocket, ctx);
+
+    // After cancel: truly idle
+    expect(isRecordingIdle()).toBe(true);
+    expect(getActiveRestartToken()).toBeNull();
+  });
+});
+
+// ─── Stale completion guard tests ───────────────────────────────────────────
+
+describe('stale completion guard (operation token)', () => {
+  beforeEach(() => {
+    __resetRecordingState();
+    mockMessages.length = 0;
+    mockMessageIdCounter = 0;
+  });
+
+  test('rejects recording_status with stale operation token', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-stale-1';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    // Start recording -> restart (creates operation token)
+    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    const restartResult = handleRecordingRestart(conversationId, fakeSocket, ctx);
+    expect(restartResult.initiated).toBe(true);
+
+    const startMsg = sent.filter((m) => m.type === 'recording_start').pop();
+    sent.length = 0;
+
+    // Simulate a stale "started" status from a PREVIOUS restart cycle
+    const staleStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: startMsg!.recordingId as string,
+      status: 'started',
+      operationToken: 'old-stale-token-from-previous-cycle',
+    };
+    recordingHandlers.recording_status(staleStatus, fakeSocket, ctx);
+
+    // Should have been rejected — no "started" confirmation messages
+    const textDeltas = sent.filter((m) => m.type === 'assistant_text_delta');
+    expect(textDeltas).toHaveLength(0);
+
+    // Active restart token should still be set (not cleared by stale completion)
+    expect(getActiveRestartToken()).toBe(restartResult.operationToken);
+  });
+
+  test('accepts recording_status with matching operation token', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-matching-1';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    const restartResult = handleRecordingRestart(conversationId, fakeSocket, ctx);
+
+    const startMsg = sent.filter((m) => m.type === 'recording_start').pop();
+
+    // Send status with the CORRECT token
+    const validStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: startMsg!.recordingId as string,
+      status: 'started',
+      operationToken: restartResult.operationToken,
+    };
+    recordingHandlers.recording_status(validStatus, fakeSocket, ctx);
+
+    // Should have been accepted — restart token cleared
+    expect(getActiveRestartToken()).toBeNull();
+  });
+
+  test('no ghost state after restart stop/start handoff', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-ghost-1';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+
+    // Restart cleans up old state atomically before starting new
+    const restartResult = handleRecordingRestart(conversationId, fakeSocket, ctx);
+    expect(restartResult.initiated).toBe(true);
+
+    // The new recording should be active (not the old one)
+    const startMsgs = sent.filter((m) => m.type === 'recording_start');
+    expect(startMsgs.length).toBeGreaterThanOrEqual(2); // original + restart
+
+    // The last recording_start should have the operation token
+    const lastStart = startMsgs[startMsgs.length - 1];
+    expect(lastStart.operationToken).toBe(restartResult.operationToken);
+  });
+});
+
+// ─── Pause/resume state transition tests ────────────────────────────────────
+
+describe('handleRecordingPause', () => {
+  beforeEach(() => {
+    __resetRecordingState();
+  });
+
+  test('sends recording_pause for active recording', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-pause-1';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    const recordingId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    expect(recordingId).not.toBeNull();
+    sent.length = 0;
+
+    const result = handleRecordingPause(conversationId, ctx);
+
+    expect(result).toBe(recordingId);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].type).toBe('recording_pause');
+    expect(sent[0].recordingId).toBe(recordingId);
+  });
+
+  test('returns undefined when no active recording', () => {
+    const { ctx } = createCtx();
+
+    const result = handleRecordingPause('conv-no-rec', ctx);
+    expect(result).toBeUndefined();
+  });
+
+  test('resolves to globally active recording from different conversation', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const convA = 'conv-owner-pause';
+    ctx.socketToSession.set(fakeSocket, convA);
+
+    const recordingId = handleRecordingStart(convA, undefined, fakeSocket, ctx);
+    sent.length = 0;
+
+    const result = handleRecordingPause('conv-other-pause', ctx);
+    expect(result).toBe(recordingId);
+  });
+});
+
+describe('handleRecordingResume', () => {
+  beforeEach(() => {
+    __resetRecordingState();
+  });
+
+  test('sends recording_resume for active recording', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-resume-1';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    const recordingId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    expect(recordingId).not.toBeNull();
+    sent.length = 0;
+
+    const result = handleRecordingResume(conversationId, ctx);
+
+    expect(result).toBe(recordingId);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].type).toBe('recording_resume');
+    expect(sent[0].recordingId).toBe(recordingId);
+  });
+
+  test('returns undefined when no active recording', () => {
+    const { ctx } = createCtx();
+
+    const result = handleRecordingResume('conv-no-rec', ctx);
+    expect(result).toBeUndefined();
+  });
+});
+
+// ─── isRecordingIdle tests ──────────────────────────────────────────────────
+
+describe('isRecordingIdle', () => {
+  beforeEach(() => {
+    __resetRecordingState();
+  });
+
+  test('returns true when no recording and no pending restart', () => {
+    expect(isRecordingIdle()).toBe(true);
+  });
+
+  test('returns false when recording is active', () => {
+    const { ctx, fakeSocket } = createCtx();
+    handleRecordingStart('conv-idle-1', undefined, fakeSocket, ctx);
+    expect(isRecordingIdle()).toBe(false);
+  });
+
+  test('returns false when mid-restart (between stop and start confirmation)', () => {
+    const { ctx, fakeSocket } = createCtx();
+    const conversationId = 'conv-idle-restart';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    handleRecordingRestart(conversationId, fakeSocket, ctx);
+
+    // Mid-restart: there IS an active recording (the new one) AND a pending restart
+    expect(isRecordingIdle()).toBe(false);
+  });
+
+  test('returns true after restart completes', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-idle-complete';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    const restartResult = handleRecordingRestart(conversationId, fakeSocket, ctx);
+
+    // Simulate the new recording starting
+    const startMsg = sent.filter((m) => m.type === 'recording_start').pop();
+    const startedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: startMsg!.recordingId as string,
+      status: 'started',
+      operationToken: restartResult.operationToken,
+    };
+    recordingHandlers.recording_status(startedStatus, fakeSocket, ctx);
+
+    // Restart is complete, but recording is still active
+    expect(getActiveRestartToken()).toBeNull();
+    // Not idle because the new recording is still running
+    expect(isRecordingIdle()).toBe(false);
+  });
+});
+
+// ─── Recording executor integration tests ───────────────────────────────────
+
+describe('executeRecordingIntent — restart/pause/resume', () => {
+  beforeEach(() => {
+    __resetRecordingState();
+  });
+
+  test('restart_only executes actual restart', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-exec-restart';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    // Start a recording first
+    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    sent.length = 0;
+
+    const result = executeRecordingIntent(
+      { kind: 'restart_only' },
+      { conversationId, socket: fakeSocket, ctx },
+    );
+
+    expect(result.handled).toBe(true);
+    expect(result.responseText).toBe('Restarting screen recording.');
+
+    // Should have sent stop + start
+    const stopMsgs = sent.filter((m) => m.type === 'recording_stop');
+    const startMsgs = sent.filter((m) => m.type === 'recording_start');
+    expect(stopMsgs).toHaveLength(1);
+    expect(startMsgs).toHaveLength(1);
+  });
+
+  test('restart_only returns "no active recording" when idle', () => {
+    const { ctx, fakeSocket } = createCtx();
+
+    const result = executeRecordingIntent(
+      { kind: 'restart_only' },
+      { conversationId: 'conv-no-rec', socket: fakeSocket, ctx },
+    );
+
+    expect(result.handled).toBe(true);
+    expect(result.responseText).toBe('No active recording to restart.');
+  });
+
+  test('restart_with_remainder returns deferred restart', () => {
+    const { ctx, fakeSocket } = createCtx();
+
+    const result = executeRecordingIntent(
+      { kind: 'restart_with_remainder', remainder: 'do something else' },
+      { conversationId: 'conv-rem', socket: fakeSocket, ctx },
+    );
+
+    expect(result.handled).toBe(false);
+    expect(result.pendingRestart).toBe(true);
+    expect(result.remainderText).toBe('do something else');
+  });
+
+  test('pause_only executes actual pause', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-exec-pause';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    sent.length = 0;
+
+    const result = executeRecordingIntent(
+      { kind: 'pause_only' },
+      { conversationId, socket: fakeSocket, ctx },
+    );
+
+    expect(result.handled).toBe(true);
+    expect(result.responseText).toBe('Pausing the recording.');
+
+    const pauseMsgs = sent.filter((m) => m.type === 'recording_pause');
+    expect(pauseMsgs).toHaveLength(1);
+  });
+
+  test('pause_only returns "no active recording" when idle', () => {
+    const { ctx, fakeSocket } = createCtx();
+
+    const result = executeRecordingIntent(
+      { kind: 'pause_only' },
+      { conversationId: 'conv-no-rec', socket: fakeSocket, ctx },
+    );
+
+    expect(result.handled).toBe(true);
+    expect(result.responseText).toBe('No active recording to pause.');
+  });
+
+  test('resume_only executes actual resume', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-exec-resume';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    sent.length = 0;
+
+    const result = executeRecordingIntent(
+      { kind: 'resume_only' },
+      { conversationId, socket: fakeSocket, ctx },
+    );
+
+    expect(result.handled).toBe(true);
+    expect(result.responseText).toBe('Resuming the recording.');
+
+    const resumeMsgs = sent.filter((m) => m.type === 'recording_resume');
+    expect(resumeMsgs).toHaveLength(1);
+  });
+
+  test('resume_only returns "no active recording" when idle', () => {
+    const { ctx, fakeSocket } = createCtx();
+
+    const result = executeRecordingIntent(
+      { kind: 'resume_only' },
+      { conversationId: 'conv-no-rec', socket: fakeSocket, ctx },
+    );
+
+    expect(result.handled).toBe(true);
+    expect(result.responseText).toBe('No active recording to resume.');
+  });
+});
+
+// ─── Recording status paused/resumed acknowledgement tests ──────────────────
+
+describe('recording_status paused/resumed', () => {
+  beforeEach(() => {
+    __resetRecordingState();
+  });
+
+  test('handles paused status without error', () => {
+    const { ctx, fakeSocket } = createCtx();
+    const conversationId = 'conv-status-paused';
+
+    const recordingId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    expect(recordingId).not.toBeNull();
+
+    const statusMsg: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: recordingId!,
+      status: 'paused',
+    };
+
+    expect(() => {
+      recordingHandlers.recording_status(statusMsg, fakeSocket, ctx);
+    }).not.toThrow();
+  });
+
+  test('handles resumed status without error', () => {
+    const { ctx, fakeSocket } = createCtx();
+    const conversationId = 'conv-status-resumed';
+
+    const recordingId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    expect(recordingId).not.toBeNull();
+
+    const statusMsg: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: recordingId!,
+      status: 'resumed',
+    };
+
+    expect(() => {
+      recordingHandlers.recording_status(statusMsg, fakeSocket, ctx);
+    }).not.toThrow();
+  });
+});
+
+// ─── Failed during restart cleans up restart state ──────────────────────────
+
+describe('failure during restart', () => {
+  beforeEach(() => {
+    __resetRecordingState();
+    mockMessages.length = 0;
+    mockMessageIdCounter = 0;
+  });
+
+  test('failed status during restart clears pending restart state', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-fail-restart';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    handleRecordingRestart(conversationId, fakeSocket, ctx);
+
+    const startMsg = sent.filter((m) => m.type === 'recording_start').pop();
+    sent.length = 0;
+
+    // Simulate new recording failing
+    const failedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: startMsg!.recordingId as string,
+      status: 'failed',
+      error: 'Permission denied',
+      attachToConversationId: conversationId,
+    };
+    recordingHandlers.recording_status(failedStatus, fakeSocket, ctx);
+
+    // Restart state should be cleaned up
+    expect(getActiveRestartToken()).toBeNull();
+    expect(isRecordingIdle()).toBe(true);
+  });
+});

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -163,6 +163,7 @@ export async function handleTaskSubmit(
     // ── Standalone recording intent interception ──────────────────────────
     let pendingRecordingStart = false;
     let pendingRecordingStop = false;
+    let pendingRecordingRestart = false;
     if (config.daemon.standaloneRecording) {
       const name = getAssistantName();
       const dynamicNames = [name].filter(Boolean) as string[];
@@ -261,10 +262,7 @@ export async function handleTaskSubmit(
         // Defer recording action until after classifier creates the final conversation
         pendingRecordingStart = intentResult.kind === 'start_with_remainder' || intentResult.kind === 'start_and_stop_with_remainder';
         pendingRecordingStop = intentResult.kind === 'stop_with_remainder' || intentResult.kind === 'start_and_stop_with_remainder';
-        const pendingRecordingRestart = intentResult.kind === 'restart_with_remainder';
-        if (pendingRecordingRestart) {
-          handleRecordingRestart(ctx.socketToSession.get(socket) ?? 'unknown', socket, ctx);
-        }
+        pendingRecordingRestart = intentResult.kind === 'restart_with_remainder';
         (msg as { task: string }).task = intentResult.remainder;
         rlog.info({ remaining: intentResult.remainder }, 'Recording intent deferred, continuing with remaining text');
       }
@@ -295,10 +293,11 @@ export async function handleTaskSubmit(
 
       // Start deferred recording from mixed intent (create a DB conversation
       // for the recording attachment since CU sessions don't have one).
-      if (pendingRecordingStart || pendingRecordingStop) {
+      if (pendingRecordingStart || pendingRecordingStop || pendingRecordingRestart) {
         const recConversation = conversationStore.createConversation('Screen Recording');
         if (pendingRecordingStop) handleRecordingStop(recConversation.id, ctx);
         if (pendingRecordingStart) handleRecordingStart(recConversation.id, { promptForSource: true }, socket, ctx);
+        if (pendingRecordingRestart) handleRecordingRestart(recConversation.id, socket, ctx);
       }
 
       ctx.send(socket, {
@@ -323,6 +322,7 @@ export async function handleTaskSubmit(
       // Start deferred recording from mixed intent, now using the real conversation
       if (pendingRecordingStop) handleRecordingStop(conversation.id, ctx);
       if (pendingRecordingStart) handleRecordingStart(conversation.id, { promptForSource: true }, socket, ctx);
+      if (pendingRecordingRestart) handleRecordingRestart(conversation.id, socket, ctx);
 
       ctx.send(socket, {
         type: 'task_routed',

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -25,7 +25,7 @@ import { executeRecordingIntent } from '../recording-executor.js';
 import { resolveRecordingIntent } from '../recording-intent.js';
 import { buildSessionErrorMessage,classifySessionError } from '../session-error.js';
 import { handleCuSessionCreate } from './computer-use.js';
-import { handleRecordingStart, handleRecordingStop } from './recording.js';
+import { handleRecordingPause, handleRecordingRestart, handleRecordingResume, handleRecordingStart, handleRecordingStop } from './recording.js';
 import { defineHandlers, type HandlerContext,log, renderHistoryContent, wireEscalationHandler } from './shared.js';
 
 // ─── Task submit handler ────────────────────────────────────────────────────
@@ -112,10 +112,11 @@ export async function handleTaskSubmit(
           activeSessionId = conversation.id;
           ctx.socketToSession.set(socket, activeSessionId);
         }
+        const restartResult = handleRecordingRestart(activeSessionId, socket, ctx);
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: 'Restarting screen recording.',
+          text: restartResult.responseText,
           sessionId: activeSessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
@@ -127,10 +128,11 @@ export async function handleTaskSubmit(
           activeSessionId = conversation.id;
           ctx.socketToSession.set(socket, activeSessionId);
         }
+        const paused = handleRecordingPause(activeSessionId, ctx) !== undefined;
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: 'Pausing the recording.',
+          text: paused ? 'Pausing the recording.' : 'No active recording to pause.',
           sessionId: activeSessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
@@ -142,10 +144,11 @@ export async function handleTaskSubmit(
           activeSessionId = conversation.id;
           ctx.socketToSession.set(socket, activeSessionId);
         }
+        const resumed = handleRecordingResume(activeSessionId, ctx) !== undefined;
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: 'Resuming the recording.',
+          text: resumed ? 'Resuming the recording.' : 'No active recording to resume.',
           sessionId: activeSessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
@@ -258,7 +261,10 @@ export async function handleTaskSubmit(
         // Defer recording action until after classifier creates the final conversation
         pendingRecordingStart = intentResult.kind === 'start_with_remainder' || intentResult.kind === 'start_and_stop_with_remainder';
         pendingRecordingStop = intentResult.kind === 'stop_with_remainder' || intentResult.kind === 'start_and_stop_with_remainder';
-        // TODO(M2): restart_with_remainder — restart handler doesn't exist yet, will be wired in M2
+        const pendingRecordingRestart = intentResult.kind === 'restart_with_remainder';
+        if (pendingRecordingRestart) {
+          handleRecordingRestart(ctx.socketToSession.get(socket) ?? 'unknown', socket, ctx);
+        }
         (msg as { task: string }).task = intentResult.remainder;
         rlog.info({ remaining: intentResult.remainder }, 'Recording intent deferred, continuing with remaining text');
       }

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -37,18 +37,31 @@ const recordingOwnerByConversation = new Map<string, string>();
 /** Pending stop-acknowledgement timeouts keyed by recordingId. */
 const pendingStopTimeouts = new Map<string, NodeJS.Timeout>();
 
+/** Current restart operation token. When non-null, the recording system is
+ *  mid-restart and any async completions (started/failed) from a previous
+ *  cycle with a mismatched token are rejected. */
+let activeRestartToken: string | null = null;
+
+/** Tracks which conversationId has a pending restart so "no active recording"
+ *  is only returned when the state is truly idle (not mid-restart). */
+const pendingRestartByConversation = new Map<string, string>();
+
 // ─── Start ───────────────────────────────────────────────────────────────────
 
 /**
  * Initiate a standalone recording for a conversation.
  * Generates a unique recording ID, stores deterministic mappings, and sends
  * a `recording_start` message to the client.
+ *
+ * When `operationToken` is provided (restart flow), it is threaded through
+ * to the client so that status callbacks can be validated against the token.
  */
 export function handleRecordingStart(
   conversationId: string,
   options: RecordingOptions | undefined,
   socket: net.Socket,
   ctx: HandlerContext,
+  operationToken?: string,
 ): string | null {
   const existingRecordingId = recordingOwnerByConversation.get(conversationId);
   if (existingRecordingId) {
@@ -73,9 +86,10 @@ export function handleRecordingStart(
     recordingId,
     attachToConversationId: conversationId,
     options,
+    ...(operationToken ? { operationToken } : {}),
   });
 
-  log.info({ recordingId, conversationId }, 'Standalone recording started');
+  log.info({ recordingId, conversationId, operationToken }, 'Standalone recording started');
   return recordingId;
 }
 
@@ -143,6 +157,202 @@ export function handleRecordingStop(
   return recordingId;
 }
 
+// ─── Restart ─────────────────────────────────────────────────────────────────
+
+export interface RecordingRestartResult {
+  /** Whether the restart was initiated. false if no recording was active to stop. */
+  initiated: boolean;
+  /** The operation token threaded through the stop+start cycle. */
+  operationToken?: string;
+  /** Response text for the user. */
+  responseText: string;
+}
+
+/**
+ * Restart the active recording: stop the current one, then start a new one
+ * with `promptForSource: true` (client reopens source picker).
+ *
+ * Uses an operation token to guard against stale async completions from
+ * a previous restart cycle. The token is:
+ * 1. Generated here and stored as `activeRestartToken`
+ * 2. Threaded through to the new `recording_start` message
+ * 3. Validated when `recording_status` callbacks arrive
+ *
+ * If the picker is closed/canceled during restart, the client sends a
+ * `restart_cancelled` status and the daemon emits a deterministic response
+ * (never "new recording started").
+ */
+export function handleRecordingRestart(
+  conversationId: string,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): RecordingRestartResult {
+  // Generate a restart operation token for race hardening
+  const operationToken = uuid();
+
+  // Stop current recording (if any)
+  const stoppedRecordingId = handleRecordingStop(conversationId, ctx);
+
+  if (!stoppedRecordingId) {
+    // No active recording — check if mid-restart (state is not truly idle)
+    if (pendingRestartByConversation.has(conversationId)) {
+      log.info({ conversationId }, 'Restart requested while another restart is pending');
+      return {
+        initiated: false,
+        responseText: 'A restart is already in progress.',
+      };
+    }
+
+    log.info({ conversationId }, 'Restart requested but no active recording to stop');
+    return {
+      initiated: false,
+      responseText: 'No active recording to restart.',
+    };
+  }
+
+  // Atomically set the restart token and pending state so that:
+  // 1. Stale completions from a previous cycle are rejected
+  // 2. "no active recording" checks know we're mid-restart
+  activeRestartToken = operationToken;
+  pendingRestartByConversation.set(conversationId, operationToken);
+
+  // Immediately clean up the old recording maps so the start call
+  // doesn't hit the "already active" guard. The stop command has already
+  // been sent; we clean maps here to ensure atomic stop/start handoff.
+  cleanupMaps(stoppedRecordingId, conversationId);
+  cancelStopTimeout(stoppedRecordingId);
+
+  // Start a new recording with the operation token
+  const newRecordingId = handleRecordingStart(
+    conversationId,
+    { promptForSource: true },
+    socket,
+    ctx,
+    operationToken,
+  );
+
+  if (!newRecordingId) {
+    // Start failed (shouldn't happen after cleanup, but defensive)
+    activeRestartToken = null;
+    pendingRestartByConversation.delete(conversationId);
+    return {
+      initiated: false,
+      responseText: 'Failed to restart recording.',
+    };
+  }
+
+  log.info({ conversationId, operationToken, oldRecordingId: stoppedRecordingId, newRecordingId }, 'Recording restart initiated');
+
+  return {
+    initiated: true,
+    operationToken,
+    responseText: 'Restarting screen recording.',
+  };
+}
+
+// ─── Pause ───────────────────────────────────────────────────────────────────
+
+/**
+ * Pause the active recording for a conversation.
+ * Sends a `recording_pause` IPC message to the client.
+ *
+ * Returns the recording ID if pause was sent, or `undefined` if no active
+ * recording exists.
+ */
+export function handleRecordingPause(
+  conversationId: string,
+  ctx: HandlerContext,
+): string | undefined {
+  let recordingId = recordingOwnerByConversation.get(conversationId);
+  let ownerConversationId = conversationId;
+
+  // Global fallback
+  if (!recordingId && recordingOwnerByConversation.size > 0) {
+    const [activeConv, activeRec] = [...recordingOwnerByConversation.entries()][0];
+    recordingId = activeRec;
+    ownerConversationId = activeConv;
+  }
+
+  if (!recordingId) {
+    log.debug({ conversationId }, 'No active recording to pause');
+    return undefined;
+  }
+
+  const socket = findSocketForSession(ownerConversationId, ctx)
+    ?? findSocketForSession(conversationId, ctx);
+  if (!socket) {
+    log.warn({ conversationId, recordingId }, 'Cannot send recording_pause: no socket bound');
+    return undefined;
+  }
+
+  ctx.send(socket, {
+    type: 'recording_pause',
+    recordingId,
+  });
+
+  log.info({ recordingId, conversationId }, 'Recording pause sent');
+  return recordingId;
+}
+
+// ─── Resume ──────────────────────────────────────────────────────────────────
+
+/**
+ * Resume a paused recording for a conversation.
+ * Sends a `recording_resume` IPC message to the client.
+ *
+ * Returns the recording ID if resume was sent, or `undefined` if no active
+ * recording exists.
+ */
+export function handleRecordingResume(
+  conversationId: string,
+  ctx: HandlerContext,
+): string | undefined {
+  let recordingId = recordingOwnerByConversation.get(conversationId);
+  let ownerConversationId = conversationId;
+
+  // Global fallback
+  if (!recordingId && recordingOwnerByConversation.size > 0) {
+    const [activeConv, activeRec] = [...recordingOwnerByConversation.entries()][0];
+    recordingId = activeRec;
+    ownerConversationId = activeConv;
+  }
+
+  if (!recordingId) {
+    log.debug({ conversationId }, 'No active recording to resume');
+    return undefined;
+  }
+
+  const socket = findSocketForSession(ownerConversationId, ctx)
+    ?? findSocketForSession(conversationId, ctx);
+  if (!socket) {
+    log.warn({ conversationId, recordingId }, 'Cannot send recording_resume: no socket bound');
+    return undefined;
+  }
+
+  ctx.send(socket, {
+    type: 'recording_resume',
+    recordingId,
+  });
+
+  log.info({ recordingId, conversationId }, 'Recording resume sent');
+  return recordingId;
+}
+
+// ─── State queries ───────────────────────────────────────────────────────────
+
+/** Returns true if recording state is truly idle — no active recording and
+ *  no pending restart. Callers should use this instead of checking maps
+ *  directly to avoid returning "no active recording" during the stop/start
+ *  window of a restart cycle. */
+export function isRecordingIdle(): boolean {
+  return recordingOwnerByConversation.size === 0 && pendingRestartByConversation.size === 0;
+}
+
+/** Returns the current active restart operation token, or null if no restart is in progress. */
+export function getActiveRestartToken(): string | null {
+  return activeRestartToken;
+}
+
 // ─── Internal helpers ─────────────────────────────────────────────────────────
 
 /** Cancel a pending stop-acknowledgement timeout for a recording, if any. */
@@ -189,6 +399,17 @@ async function handleRecordingStatus(
     return;
   }
 
+  // ── Operation token validation for restart race hardening ──
+  // If a restart is in progress and the status callback carries a token,
+  // reject it if the token doesn't match the active restart token.
+  if (msg.operationToken && activeRestartToken && msg.operationToken !== activeRestartToken) {
+    log.warn(
+      { recordingId, expectedToken: activeRestartToken, receivedToken: msg.operationToken },
+      'Rejecting stale recording_status — operation token mismatch (previous restart cycle)',
+    );
+    return;
+  }
+
   // The client acknowledged this recording — cancel any pending stop timeout.
   cancelStopTimeout(recordingId);
 
@@ -197,8 +418,48 @@ async function handleRecordingStatus(
   const notifySocket = reportingSocket ?? findSocketForSession(conversationId, ctx);
 
   switch (msg.status) {
-    case 'started':
+    case 'started': {
       log.info({ recordingId, conversationId }, 'Standalone recording confirmed started by client');
+
+      // If this was part of a restart cycle, clear the pending restart state
+      // now that the new recording has successfully started.
+      if (activeRestartToken && pendingRestartByConversation.get(conversationId) === activeRestartToken) {
+        pendingRestartByConversation.delete(conversationId);
+        activeRestartToken = null;
+        log.info({ recordingId, conversationId }, 'Restart cycle complete — new recording started');
+      }
+      break;
+    }
+
+    case 'restart_cancelled': {
+      // The user closed/canceled the source picker during a restart.
+      // Emit a deterministic response — never "new recording started".
+      log.info({ recordingId, conversationId }, 'Restart cancelled — source picker closed');
+
+      // Clean up restart state
+      cleanupMaps(recordingId, conversationId);
+      pendingRestartByConversation.delete(conversationId);
+      if (activeRestartToken && pendingRestartByConversation.size === 0) {
+        activeRestartToken = null;
+      }
+
+      if (notifySocket) {
+        ctx.send(notifySocket, {
+          type: 'assistant_text_delta',
+          text: 'Recording restart cancelled.',
+          sessionId: conversationId,
+        });
+        ctx.send(notifySocket, { type: 'message_complete', sessionId: conversationId });
+      }
+      break;
+    }
+
+    case 'paused':
+      log.info({ recordingId, conversationId }, 'Recording paused by client');
+      break;
+
+    case 'resumed':
+      log.info({ recordingId, conversationId }, 'Recording resumed by client');
       break;
 
     case 'stopped': {
@@ -365,6 +626,15 @@ async function handleRecordingStatus(
       }
 
       cleanupMaps(recordingId, conversationId);
+
+      // If this failure was part of a restart cycle, clear restart state
+      if (pendingRestartByConversation.has(conversationId)) {
+        pendingRestartByConversation.delete(conversationId);
+        if (pendingRestartByConversation.size === 0) {
+          activeRestartToken = null;
+        }
+      }
+
       break;
     }
   }
@@ -392,7 +662,12 @@ export function cleanupRecordingsOnDisconnect(
       cancelStopTimeout(recId);
       standaloneRecordingConversationId.delete(recId);
       recordingOwnerByConversation.delete(convId);
+      pendingRestartByConversation.delete(convId);
     }
+  }
+  // Clear restart token if all pending restarts were cleaned up
+  if (pendingRestartByConversation.size === 0) {
+    activeRestartToken = null;
   }
 }
 
@@ -406,6 +681,8 @@ export function __resetRecordingState(): void {
   pendingStopTimeouts.clear();
   standaloneRecordingConversationId.clear();
   recordingOwnerByConversation.clear();
+  pendingRestartByConversation.clear();
+  activeRestartToken = null;
 }
 
 // ─── Export handler group ────────────────────────────────────────────────────

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -38,7 +38,7 @@ import { executeRecordingIntent } from '../recording-executor.js';
 import { resolveRecordingIntent } from '../recording-intent.js';
 import { buildSessionErrorMessage,classifySessionError } from '../session-error.js';
 import { generateVideoThumbnail } from '../video-thumbnail.js';
-import { handleRecordingStart, handleRecordingStop } from './recording.js';
+import { handleRecordingPause, handleRecordingRestart, handleRecordingResume, handleRecordingStart, handleRecordingStop } from './recording.js';
 import {
   defineHandlers,
   type HandlerContext,
@@ -250,25 +250,28 @@ export async function handleUserMessage(
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
         return;
       } else if (action === 'restart') {
+        const restartResult = handleRecordingRestart(msg.sessionId, socket, ctx);
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: 'Restarting screen recording.',
+          text: restartResult.responseText,
           sessionId: msg.sessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
         return;
       } else if (action === 'pause') {
+        const paused = handleRecordingPause(msg.sessionId, ctx) !== undefined;
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: 'Pausing the recording.',
+          text: paused ? 'Pausing the recording.' : 'No active recording to pause.',
           sessionId: msg.sessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
         return;
       } else if (action === 'resume') {
+        const resumed = handleRecordingResume(msg.sessionId, ctx) !== undefined;
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: 'Resuming the recording.',
+          text: resumed ? 'Resuming the recording.' : 'No active recording to resume.',
           sessionId: msg.sessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
@@ -326,7 +329,9 @@ export async function handleUserMessage(
         if (intentResult.kind === 'start_with_remainder' || intentResult.kind === 'start_and_stop_with_remainder') {
           handleRecordingStart(msg.sessionId, { promptForSource: true }, socket, ctx);
         }
-        // TODO(M2): restart_with_remainder — restart handler doesn't exist yet, will be wired in M2
+        if (intentResult.kind === 'restart_with_remainder') {
+          handleRecordingRestart(msg.sessionId, socket, ctx);
+        }
 
         rlog.info({ remaining: msg.content, kind: intentResult.kind }, 'Recording intent with remainder — continuing with remaining text');
       }

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -272,6 +272,8 @@
     "platform_config_response",
     "pong",
     "publish_page_response",
+    "recording_pause",
+    "recording_resume",
     "recording_start",
     "recording_stop",
     "reminders_list_response",

--- a/assistant/src/daemon/ipc-contract/computer-use.ts
+++ b/assistant/src/daemon/ipc-contract/computer-use.ts
@@ -100,11 +100,13 @@ export interface RecordingOptions {
 export interface RecordingStatus {
   type: 'recording_status';
   sessionId: string;          // matches recordingId from RecordingStart
-  status: 'started' | 'stopped' | 'failed';
+  status: 'started' | 'stopped' | 'failed' | 'restart_cancelled' | 'paused' | 'resumed';
   filePath?: string;          // on stop
   durationMs?: number;        // on stop
   error?: string;             // on failure
   attachToConversationId?: string;
+  /** Operation token for restart race hardening — matches the token from RecordingStart. */
+  operationToken?: string;
 }
 
 // === Server → Client ===
@@ -115,12 +117,26 @@ export interface RecordingStart {
   recordingId: string;        // daemon-assigned UUID
   attachToConversationId?: string;
   options?: RecordingOptions;
+  /** Operation token for restart race hardening — stale completions with mismatched tokens are rejected. */
+  operationToken?: string;
 }
 
 /** Server → Client: stop a recording. */
 export interface RecordingStop {
   type: 'recording_stop';
   recordingId: string;        // matches RecordingStart.recordingId
+}
+
+/** Server → Client: pause the active recording. */
+export interface RecordingPause {
+  type: 'recording_pause';
+  recordingId: string;
+}
+
+/** Server → Client: resume a paused recording. */
+export interface RecordingResume {
+  type: 'recording_resume';
+  recordingId: string;
 }
 
 export interface CuAction {
@@ -211,4 +227,6 @@ export type _ComputerUseServerMessages =
   | WatchStarted
   | WatchCompleteRequest
   | RecordingStart
-  | RecordingStop;
+  | RecordingStop
+  | RecordingPause
+  | RecordingResume;

--- a/assistant/src/daemon/recording-executor.ts
+++ b/assistant/src/daemon/recording-executor.ts
@@ -6,7 +6,13 @@
 import type * as net from 'node:net';
 
 import type { HandlerContext } from './handlers/shared.js';
-import { handleRecordingStart, handleRecordingStop } from './handlers/recording.js';
+import {
+  handleRecordingPause,
+  handleRecordingRestart,
+  handleRecordingResume,
+  handleRecordingStart,
+  handleRecordingStop,
+} from './handlers/recording.js';
 import type { RecordingIntentResult } from './recording-intent.js';
 
 export interface RecordingExecutionContext {
@@ -105,13 +111,17 @@ export function executeRecordingIntent(
         pendingStop: true,
       };
 
-    // ── New intent kinds (M1 placeholders — actual handler wiring in M2) ──
-
-    case 'restart_only':
+    case 'restart_only': {
+      const restartResult = handleRecordingRestart(
+        context.conversationId,
+        context.socket,
+        context.ctx,
+      );
       return {
         handled: true,
-        responseText: 'Restarting screen recording.',
+        responseText: restartResult.responseText,
       };
+    }
 
     case 'restart_with_remainder':
       return {
@@ -120,16 +130,24 @@ export function executeRecordingIntent(
         pendingRestart: true,
       };
 
-    case 'pause_only':
+    case 'pause_only': {
+      const paused = handleRecordingPause(context.conversationId, context.ctx) !== undefined;
       return {
         handled: true,
-        responseText: 'Pausing the recording.',
+        responseText: paused
+          ? 'Pausing the recording.'
+          : 'No active recording to pause.',
       };
+    }
 
-    case 'resume_only':
+    case 'resume_only': {
+      const resumed = handleRecordingResume(context.conversationId, context.ctx) !== undefined;
       return {
         handled: true,
-        responseText: 'Resuming the recording.',
+        responseText: resumed
+          ? 'Resuming the recording.'
+          : 'No active recording to resume.',
       };
+    }
   }
 }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -453,6 +453,12 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `subagent_detail_response` with lazy-loaded events.
     public var onSubagentDetailResponse: ((IPCSubagentDetailResponse) -> Void)?
 
+    /// Called when the daemon sends a `recording_pause` message.
+    public var onRecordingPause: ((IPCRecordingPause) -> Void)?
+
+    /// Called when the daemon sends a `recording_resume` message.
+    public var onRecordingResume: ((IPCRecordingResume) -> Void)?
+
     /// Called when the daemon sends a `recording_start` message.
     public var onRecordingStart: ((IPCRecordingStart) -> Void)?
 

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -268,6 +268,10 @@ extension DaemonClient {
             onApprovedDevicesListResponse?(msg)
         case .approvedDeviceRemoveResponse(let msg):
             onApprovedDeviceRemoveResponse?(msg)
+        case .recordingPause(let msg):
+            onRecordingPause?(msg)
+        case .recordingResume(let msg):
+            onRecordingResume?(msg)
         case .recordingStart(let msg):
             onRecordingStart?(msg)
         case .recordingStop(let msg):

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -3277,6 +3277,28 @@ public struct IPCRecordingOptions: Codable, Sendable {
     }
 }
 
+/// Server → Client: pause the active recording.
+public struct IPCRecordingPause: Codable, Sendable {
+    public let type: String
+    public let recordingId: String
+
+    public init(type: String, recordingId: String) {
+        self.type = type
+        self.recordingId = recordingId
+    }
+}
+
+/// Server → Client: resume a paused recording.
+public struct IPCRecordingResume: Codable, Sendable {
+    public let type: String
+    public let recordingId: String
+
+    public init(type: String, recordingId: String) {
+        self.type = type
+        self.recordingId = recordingId
+    }
+}
+
 /// Server → Client: start a recording.
 public struct IPCRecordingStart: Codable, Sendable {
     public let type: String
@@ -3284,12 +3306,15 @@ public struct IPCRecordingStart: Codable, Sendable {
     public let attachToConversationId: String?
     /// Recording options shared across standalone and CU recording flows.
     public let options: IPCRecordingOptions?
+    /// Operation token for restart race hardening — stale completions with mismatched tokens are rejected.
+    public let operationToken: String?
 
-    public init(type: String, recordingId: String, attachToConversationId: String? = nil, options: IPCRecordingOptions? = nil) {
+    public init(type: String, recordingId: String, attachToConversationId: String? = nil, options: IPCRecordingOptions? = nil, operationToken: String? = nil) {
         self.type = type
         self.recordingId = recordingId
         self.attachToConversationId = attachToConversationId
         self.options = options
+        self.operationToken = operationToken
     }
 }
 
@@ -3302,8 +3327,10 @@ public struct IPCRecordingStatus: Codable, Sendable {
     public let durationMs: Double?
     public let error: String?
     public let attachToConversationId: String?
+    /// Operation token for restart race hardening — matches the token from RecordingStart.
+    public let operationToken: String?
 
-    public init(type: String, sessionId: String, status: String, filePath: String? = nil, durationMs: Double? = nil, error: String? = nil, attachToConversationId: String? = nil) {
+    public init(type: String, sessionId: String, status: String, filePath: String? = nil, durationMs: Double? = nil, error: String? = nil, attachToConversationId: String? = nil, operationToken: String? = nil) {
         self.type = type
         self.sessionId = sessionId
         self.status = status
@@ -3311,6 +3338,7 @@ public struct IPCRecordingStatus: Codable, Sendable {
         self.durationMs = durationMs
         self.error = error
         self.attachToConversationId = attachToConversationId
+        self.operationToken = operationToken
     }
 }
 

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2295,6 +2295,8 @@ public enum ServerMessage: Decodable, Sendable {
     case pairingApprovalRequest(PairingApprovalRequestMessage)
     case approvedDevicesListResponse(ApprovedDevicesListResponseMessage)
     case approvedDeviceRemoveResponse(ApprovedDeviceRemoveResponseMessage)
+    case recordingPause(IPCRecordingPause)
+    case recordingResume(IPCRecordingResume)
     case recordingStart(IPCRecordingStart)
     case recordingStop(IPCRecordingStop)
     case heartbeatConfigResponse(IPCHeartbeatConfigResponse)
@@ -2705,6 +2707,12 @@ public enum ServerMessage: Decodable, Sendable {
         case "approved_device_remove_response":
             let message = try ApprovedDeviceRemoveResponseMessage(from: decoder)
             self = .approvedDeviceRemoveResponse(message)
+        case "recording_pause":
+            let message = try IPCRecordingPause(from: decoder)
+            self = .recordingPause(message)
+        case "recording_resume":
+            let message = try IPCRecordingResume(from: decoder)
+            self = .recordingResume(message)
         case "recording_start":
             let message = try IPCRecordingStart(from: decoder)
             self = .recordingStart(message)


### PR DESCRIPTION
Part of #9344. Implements restart/pause/resume handlers, restart-cancel semantics, and operation token race hardening. Wires up all new intent kinds in sessions.ts and misc.ts handlers.

Replaces #9377 (accidentally closed).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
