### PR TITLE
M3: macOS UX alignment for recording controls

### DIFF
--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -216,10 +216,23 @@ export function handleRecordingRestart(
   activeRestartToken = operationToken;
   pendingRestartByConversation.set(conversationId, operationToken);
 
+  // Resolve the actual owner conversation ID. When conversation B requests
+  // a restart but the recording is owned by conversation A, the stop above
+  // used the global fallback to find A's recording. We need to pass A's
+  // conversationId to cleanupMaps so it can delete the correct map entry.
+  let ownerConversationId = conversationId;
+  if (recordingOwnerByConversation.get(conversationId) !== stoppedRecordingId && recordingOwnerByConversation.size > 0) {
+    const [activeConv, activeRec] = [...recordingOwnerByConversation.entries()][0];
+    if (activeRec === stoppedRecordingId) {
+      ownerConversationId = activeConv;
+      log.info({ conversationId, ownerConversationId, stoppedRecordingId }, 'Resolved restart cleanup to actual owner conversation');
+    }
+  }
+
   // Immediately clean up the old recording maps so the start call
   // doesn't hit the "already active" guard. The stop command has already
   // been sent; we clean maps here to ensure atomic stop/start handoff.
-  cleanupMaps(stoppedRecordingId, conversationId);
+  cleanupMaps(stoppedRecordingId, ownerConversationId);
   cancelStopTimeout(stoppedRecordingId);
 
   // Start a new recording with the operation token

--- a/clients/macos/vellum-assistant/App/AppDelegate+Recording.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Recording.swift
@@ -23,7 +23,8 @@ extension AppDelegate {
                 type: "recording_status",
                 sessionId: msg.recordingId,
                 status: "failed",
-                error: "Screen recording permission is required. Please grant access in System Settings > Privacy & Security > Screen Recording, then try again."
+                error: "Screen recording permission is required. Please grant access in System Settings > Privacy & Security > Screen Recording, then try again.",
+                operationToken: msg.operationToken
             )
             try? daemonClient.send(statusMsg)
             return
@@ -35,7 +36,8 @@ extension AppDelegate {
         if options?.promptForSource == true {
             showRecordingSourcePicker(
                 recordingId: msg.recordingId,
-                attachToConversationId: msg.attachToConversationId
+                attachToConversationId: msg.attachToConversationId,
+                operationToken: msg.operationToken
             )
             return
         }
@@ -44,12 +46,36 @@ extension AppDelegate {
         startRecording(
             recordingId: msg.recordingId,
             options: options,
-            attachToConversationId: msg.attachToConversationId
+            attachToConversationId: msg.attachToConversationId,
+            operationToken: msg.operationToken
         )
     }
 
+    /// Handle a `recording_pause` message from the daemon.
+    func handleRecordingPause(_ msg: IPCRecordingPause) {
+        let paused = recordingManager.pause(sessionId: msg.recordingId)
+        if paused {
+            recordingHUDWindow?.setPaused(true)
+        }
+    }
+
+    /// Handle a `recording_resume` message from the daemon.
+    func handleRecordingResume(_ msg: IPCRecordingResume) {
+        let resumed = recordingManager.resume(sessionId: msg.recordingId)
+        if resumed {
+            recordingHUDWindow?.setPaused(false)
+        }
+    }
+
     /// Show the recording source picker, then start recording with the selected options.
-    private func showRecordingSourcePicker(recordingId: String, attachToConversationId: String?) {
+    ///
+    /// When `operationToken` is set (restart flow), dismissing the picker without
+    /// selecting a source sends a `restart_cancelled` status to the daemon.
+    private func showRecordingSourcePicker(
+        recordingId: String,
+        attachToConversationId: String?,
+        operationToken: String? = nil
+    ) {
         if recordingPickerWindow == nil {
             recordingPickerWindow = RecordingSourcePickerWindow()
         }
@@ -60,18 +86,32 @@ extension AppDelegate {
                     recordingId: recordingId,
                     options: selectedOptions,
                     attachToConversationId: attachToConversationId,
-                    promptForSource: true
+                    promptForSource: true,
+                    operationToken: operationToken
                 )
             },
             onCancel: { [weak self] in
-                // Notify daemon that recording was cancelled
-                let statusMsg = IPCRecordingStatus(
-                    type: "recording_status",
-                    sessionId: recordingId,
-                    status: "failed",
-                    error: "Recording cancelled by user"
-                )
-                try? self?.daemonClient.send(statusMsg)
+                if operationToken != nil {
+                    // Restart flow: picker dismissed without selection —
+                    // send restart_cancelled so the daemon knows to abort.
+                    let statusMsg = IPCRecordingStatus(
+                        type: "recording_status",
+                        sessionId: recordingId,
+                        status: "restart_cancelled",
+                        operationToken: operationToken
+                    )
+                    try? self?.daemonClient.send(statusMsg)
+                    log.info("Restart cancelled — source picker dismissed for session \(recordingId, privacy: .public)")
+                } else {
+                    // Normal start flow: picker cancelled
+                    let statusMsg = IPCRecordingStatus(
+                        type: "recording_status",
+                        sessionId: recordingId,
+                        status: "failed",
+                        error: "Recording cancelled by user"
+                    )
+                    try? self?.daemonClient.send(statusMsg)
+                }
             }
         )
     }
@@ -81,12 +121,17 @@ extension AppDelegate {
         recordingId: String,
         options: IPCRecordingOptions?,
         attachToConversationId: String?,
-        promptForSource: Bool = false
+        promptForSource: Bool = false,
+        operationToken: String? = nil
     ) {
         // Wire up re-prompt callback so RecordingManager can re-show the
         // source picker when the selected source is no longer available.
         recordingManager.onSourceValidationFailed = { [weak self] sessionId, conversationId in
-            self?.showRecordingSourcePicker(recordingId: sessionId, attachToConversationId: conversationId)
+            self?.showRecordingSourcePicker(
+                recordingId: sessionId,
+                attachToConversationId: conversationId,
+                operationToken: operationToken
+            )
         }
 
         Task {
@@ -120,7 +165,8 @@ extension AppDelegate {
                 sessionId: recordingId,
                 options: effectiveOptions,
                 attachToConversationId: attachToConversationId,
-                promptForSource: promptForSource
+                promptForSource: promptForSource,
+                operationToken: operationToken
             )
 
             guard started else { return }
@@ -130,13 +176,29 @@ extension AppDelegate {
                 recordingHUDWindow = RecordingHUDWindow()
             }
 
-            recordingHUDWindow?.show(onStop: { [weak self] in
-                guard let self else { return }
-                Task {
-                    _ = await self.recordingManager.stop(sessionId: recordingId)
-                    self.recordingHUDWindow?.dismiss()
+            recordingHUDWindow?.show(
+                onStop: { [weak self] in
+                    guard let self else { return }
+                    Task {
+                        _ = await self.recordingManager.stop(sessionId: recordingId)
+                        self.recordingHUDWindow?.dismiss()
+                    }
+                },
+                onPauseResume: { [weak self] requestPause in
+                    guard let self else { return }
+                    if requestPause {
+                        let paused = self.recordingManager.pause(sessionId: recordingId)
+                        if paused {
+                            self.recordingHUDWindow?.setPaused(true)
+                        }
+                    } else {
+                        let resumed = self.recordingManager.resume(sessionId: recordingId)
+                        if resumed {
+                            self.recordingHUDWindow?.setPaused(false)
+                        }
+                    }
                 }
-            })
+            )
         }
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1082,6 +1082,18 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             }
         }
 
+        // Handle recording_pause from daemon
+        daemonClient.onRecordingPause = { [weak self] msg in
+            guard let self else { return }
+            self.handleRecordingPause(msg)
+        }
+
+        // Handle recording_resume from daemon
+        daemonClient.onRecordingResume = { [weak self] msg in
+            guard let self else { return }
+            self.handleRecordingResume(msg)
+        }
+
         // Restart DaemonClient connection when the health monitor relaunches
         // the daemon process so we don't wait for the backoff timer to expire.
         assistantCli.onDaemonRestarted = { [weak self] in

--- a/clients/macos/vellum-assistant/Recording/RecordingHUDWindow.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingHUDWindow.swift
@@ -5,7 +5,8 @@ import VellumAssistantShared
 /// Recording indicator HUD that shows a red dot, elapsed time, and stop button.
 ///
 /// Floats as a small panel in the top-right corner of the screen during
-/// an active recording. Uses design system tokens for styling.
+/// an active recording. Supports pause/resume toggle. Uses design system
+/// tokens for styling.
 @MainActor
 final class RecordingHUDWindow {
     private var panel: NSPanel?
@@ -13,18 +14,21 @@ final class RecordingHUDWindow {
 
     /// Show the recording HUD.
     ///
-    /// - Parameter onStop: Called when the user clicks the stop button.
-    func show(onStop: @escaping () -> Void) {
+    /// - Parameters:
+    ///   - onStop: Called when the user clicks the stop button.
+    ///   - onPauseResume: Called when the user toggles pause/resume. The
+    ///     Bool parameter is `true` when requesting pause, `false` for resume.
+    func show(onStop: @escaping () -> Void, onPauseResume: ((Bool) -> Void)? = nil) {
         dismiss()
 
-        let vm = RecordingHUDViewModel(onStop: onStop)
+        let vm = RecordingHUDViewModel(onStop: onStop, onPauseResume: onPauseResume)
         self.viewModel = vm
 
         let hudView = RecordingHUDView(viewModel: vm)
         let hostingController = NSHostingController(rootView: hudView)
 
         let hudPanel = NSPanel(
-            contentRect: NSRect(x: 0, y: 0, width: 180, height: 44),
+            contentRect: NSRect(x: 0, y: 0, width: 220, height: 44),
             styleMask: [.nonactivatingPanel, .hudWindow, .utilityWindow],
             backing: .buffered,
             defer: false
@@ -42,13 +46,23 @@ final class RecordingHUDWindow {
         // Position in the top-right corner
         if let screen = NSScreen.main {
             let screenFrame = screen.visibleFrame
-            let x = screenFrame.maxX - 196
+            let x = screenFrame.maxX - 236
             let y = screenFrame.maxY - 60
             hudPanel.setFrameOrigin(NSPoint(x: x, y: y))
         }
 
         hudPanel.orderFront(nil)
         self.panel = hudPanel
+    }
+
+    /// Update the HUD to reflect paused state.
+    func setPaused(_ paused: Bool) {
+        viewModel?.isPaused = paused
+        if paused {
+            viewModel?.pauseTimer()
+        } else {
+            viewModel?.resumeTimer()
+        }
     }
 
     /// Update the HUD to show a failure message.
@@ -72,13 +86,16 @@ final class RecordingHUDWindow {
 final class RecordingHUDViewModel: ObservableObject {
     @Published var elapsedSeconds: Int = 0
     @Published var isRecording = true
+    @Published var isPaused = false
     @Published var failureMessage: String?
 
     private var timer: Timer?
     private let onStop: () -> Void
+    private let onPauseResume: ((Bool) -> Void)?
 
-    init(onStop: @escaping () -> Void) {
+    init(onStop: @escaping () -> Void, onPauseResume: ((Bool) -> Void)? = nil) {
         self.onStop = onStop
+        self.onPauseResume = onPauseResume
         startTimer()
     }
 
@@ -90,6 +107,18 @@ final class RecordingHUDViewModel: ObservableObject {
         }
     }
 
+    /// Pause the elapsed-time timer (called when recording is paused).
+    func pauseTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    /// Resume the elapsed-time timer (called when recording is resumed).
+    func resumeTimer() {
+        guard timer == nil else { return }
+        startTimer()
+    }
+
     func stopTimer() {
         timer?.invalidate()
         timer = nil
@@ -98,6 +127,11 @@ final class RecordingHUDViewModel: ObservableObject {
     func stop() {
         stopTimer()
         onStop()
+    }
+
+    func togglePauseResume() {
+        let requestPause = !isPaused
+        onPauseResume?(requestPause)
     }
 
     var formattedTime: String {
@@ -127,11 +161,11 @@ struct RecordingHUDView: View {
                     .foregroundColor(VColor.error)
                     .lineLimit(1)
             } else {
-                // Recording indicator dot with pulse animation
+                // Recording/paused indicator dot
                 Circle()
-                    .fill(VColor.error)
+                    .fill(viewModel.isPaused ? VColor.warning : VColor.error)
                     .frame(width: 10, height: 10)
-                    .opacity(dotOpacity)
+                    .opacity(viewModel.isPaused ? 1.0 : dotOpacity)
                     .onAppear {
                         withAnimation(
                             .easeInOut(duration: 0.8)
@@ -141,13 +175,33 @@ struct RecordingHUDView: View {
                         }
                     }
 
-                // Elapsed time
+                // Elapsed time (freezes when paused via timer pause)
                 Text(viewModel.formattedTime)
                     .font(VFont.monoSmall)
-                    .foregroundColor(VColor.textPrimary)
+                    .foregroundColor(viewModel.isPaused ? VColor.textSecondary : VColor.textPrimary)
                     .monospacedDigit()
 
+                if viewModel.isPaused {
+                    Text("Paused")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.warning)
+                }
+
                 Spacer()
+
+                // Pause/Resume toggle button
+                Button(action: { viewModel.togglePauseResume() }) {
+                    Image(systemName: viewModel.isPaused ? "play.fill" : "pause.fill")
+                        .font(.system(size: 10))
+                        .foregroundColor(.white)
+                        .frame(width: 24, height: 24)
+                        .background(
+                            RoundedRectangle(cornerRadius: VRadius.sm)
+                                .fill(VColor.accent)
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(viewModel.isPaused ? "Resume recording" : "Pause recording")
 
                 // Stop button
                 Button(action: { viewModel.stop() }) {
@@ -174,6 +228,6 @@ struct RecordingHUDView: View {
                         .stroke(VColor.surfaceBorder, lineWidth: 1)
                 )
         )
-        .frame(width: 180, height: 44)
+        .frame(width: 220, height: 44)
     }
 }

--- a/clients/macos/vellum-assistant/Recording/RecordingManager.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingManager.swift
@@ -15,12 +15,14 @@ enum RecordingState: Equatable, Sendable {
     case idle
     case starting
     case recording
+    case paused
     case stopping
+    case restarting
     case failed(String)
 
     var isActive: Bool {
         switch self {
-        case .starting, .recording, .stopping: return true
+        case .starting, .recording, .paused, .stopping, .restarting: return true
         case .idle, .failed: return false
         }
     }
@@ -38,6 +40,10 @@ final class RecordingManager: ObservableObject {
     @Published private(set) var state: RecordingState = .idle
     @Published private(set) var ownerSessionId: String?
     @Published private(set) var attachToConversationId: String?
+
+    /// Operation token for restart race hardening. When set, status messages
+    /// include this token so the daemon can reject stale completions.
+    private(set) var operationToken: String?
 
     // MARK: - Dependencies
 
@@ -67,7 +73,7 @@ final class RecordingManager: ObservableObject {
     ///   - attachToConversationId: Optional conversation ID to attach the recording to.
     /// - Returns: `true` if the recording started successfully, `false` otherwise.
     @discardableResult
-    func start(sessionId: String, options: IPCRecordingOptions? = nil, attachToConversationId: String? = nil, promptForSource: Bool = false) async -> Bool {
+    func start(sessionId: String, options: IPCRecordingOptions? = nil, attachToConversationId: String? = nil, promptForSource: Bool = false, operationToken: String? = nil) async -> Bool {
         guard !state.isActive else {
             log.warning("Cannot start recording — already active (state=\(String(describing: self.state)), owner=\(self.ownerSessionId ?? "nil"))")
             sendStatus(sessionId: sessionId, status: "failed", error: "Another recording is already active")
@@ -76,6 +82,7 @@ final class RecordingManager: ObservableObject {
 
         self.ownerSessionId = sessionId
         self.attachToConversationId = attachToConversationId
+        self.operationToken = operationToken
         self.state = .starting
 
         // Clear any stale stream error callback from a previous session.
@@ -180,6 +187,11 @@ final class RecordingManager: ObservableObject {
             return nil
         }
 
+        // If paused, unpause so the writer can finalize cleanly
+        if state == .paused {
+            recorder.isPaused = false
+        }
+
         state = .stopping
 
         do {
@@ -198,6 +210,7 @@ final class RecordingManager: ObservableObject {
             let savedConversationId = attachToConversationId
             ownerSessionId = nil
             attachToConversationId = nil
+            operationToken = nil
 
             _ = savedSessionId
             _ = savedConversationId
@@ -213,6 +226,53 @@ final class RecordingManager: ObservableObject {
         }
     }
 
+    // MARK: - Pause
+
+    /// Pause the active recording.
+    ///
+    /// Only valid when the state is `.recording`. The underlying ScreenRecorder
+    /// stream keeps running but frames are dropped, so the output file won't
+    /// contain the paused interval.
+    ///
+    /// - Parameter sessionId: The recording session ID. Must match the active recording.
+    /// - Returns: `true` if the recording was paused, `false` if not in a pausable state.
+    @discardableResult
+    func pause(sessionId: String) -> Bool {
+        guard state == .recording, ownerSessionId == sessionId else {
+            log.warning("Cannot pause recording — not recording (state=\(String(describing: self.state)), owner=\(self.ownerSessionId ?? "nil"), requested=\(sessionId, privacy: .public))")
+            return false
+        }
+
+        recorder.isPaused = true
+        state = .paused
+        sendStatus(sessionId: sessionId, status: "paused")
+        log.info("Recording paused for session \(sessionId, privacy: .public)")
+        return true
+    }
+
+    // MARK: - Resume
+
+    /// Resume a paused recording.
+    ///
+    /// Only valid when the state is `.paused`. Resumes writing frames from
+    /// the ScreenRecorder stream.
+    ///
+    /// - Parameter sessionId: The recording session ID. Must match the active recording.
+    /// - Returns: `true` if the recording was resumed, `false` if not in a resumable state.
+    @discardableResult
+    func resume(sessionId: String) -> Bool {
+        guard state == .paused, ownerSessionId == sessionId else {
+            log.warning("Cannot resume recording — not paused (state=\(String(describing: self.state)), owner=\(self.ownerSessionId ?? "nil"), requested=\(sessionId, privacy: .public))")
+            return false
+        }
+
+        recorder.isPaused = false
+        state = .recording
+        sendStatus(sessionId: sessionId, status: "resumed")
+        log.info("Recording resumed for session \(sessionId, privacy: .public)")
+        return true
+    }
+
     // MARK: - Force Stop
 
     /// Force-stop any active recording, regardless of owner. Used during app shutdown.
@@ -222,6 +282,11 @@ final class RecordingManager: ObservableObject {
     /// It discards the recording rather than trying to finalize the file.
     func forceStop() {
         guard state.isActive else { return }
+
+        // Unpause before cancelling so internal state is consistent
+        if state == .paused {
+            recorder.isPaused = false
+        }
 
         recorder.onStreamError = nil
         recorder.cancelRecording()
@@ -234,6 +299,7 @@ final class RecordingManager: ObservableObject {
         state = .idle
         ownerSessionId = nil
         attachToConversationId = nil
+        operationToken = nil
         log.info("Force-stopped recording (synchronous cancel)")
     }
 
@@ -258,7 +324,8 @@ final class RecordingManager: ObservableObject {
             filePath: filePath,
             durationMs: durationMs.flatMap { Double($0) },
             error: error,
-            attachToConversationId: attachToConversationId
+            attachToConversationId: attachToConversationId,
+            operationToken: operationToken
         )
 
         do {

--- a/clients/macos/vellum-assistant/Recording/RecordingManager.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingManager.swift
@@ -85,6 +85,10 @@ final class RecordingManager: ObservableObject {
         self.operationToken = operationToken
         self.state = .starting
 
+        // Reset pause flag so a stale isPaused from a previous session
+        // (e.g. error-during-pause) doesn't silently drop every frame.
+        recorder.isPaused = false
+
         // Clear any stale stream error callback from a previous session.
         // If the prior recording ended via stream error, the old callback
         // (capturing the old sessionId) is never cleared. Without this,

--- a/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
+++ b/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
@@ -416,6 +416,16 @@ final class ScreenRecorder: NSObject {
     /// RecordingManager sets this to react to stream failures (update state, send IPC, clean up).
     var onStreamError: ((RecorderError) -> Void)?
 
+    /// When true, incoming sample buffers are silently dropped instead of being
+    /// appended to the writer. The SCStream keeps running so resume is instant.
+    /// Thread-safe: read on the output queue, written from MainActor.
+    var isPaused: Bool {
+        get { pauseLock.withLock { _isPaused } }
+        set { pauseLock.withLock { _isPaused = newValue } }
+    }
+    private var _isPaused = false
+    private let pauseLock = NSLock()
+
     /// Background queue for processing sample buffers from ScreenCaptureKit.
     private let outputQueue = DispatchQueue(label: "com.vellum.screen-recorder.output", qos: .userInitiated)
 
@@ -1347,6 +1357,8 @@ private final class StreamOutputDelegate: NSObject, SCStreamOutput, SCStreamDele
     }
 
     func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
+        // Drop frames while paused — the stream keeps running so resume is instant
+        guard !recorder.isPaused else { return }
         writerContext.processSampleBuffer(sampleBuffer, ofType: type)
     }
 

--- a/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
+++ b/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
@@ -1123,7 +1123,7 @@ final class ScreenRecorder: NSObject {
         guard isRecordingActive else { return }
 
         // Reset pause flag so it doesn't leak into a future recording.
-        _isPaused = false
+        isPaused = false
 
         // Emit cancel telemetry before tearing down state
         let durationMs: Int
@@ -1199,7 +1199,7 @@ final class ScreenRecorder: NSObject {
             log.error("Stream error during active recording — cleaning up (error=\(recorderError.localizedDescription, privacy: .public))")
 
             // Reset pause flag so it doesn't leak into a future recording.
-            self._isPaused = false
+            self.isPaused = false
 
             // Store for attemptStartWithConfig to propagate typed errors
             // instead of collapsing them to .noFramesReceived.

--- a/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
+++ b/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
@@ -1122,6 +1122,9 @@ final class ScreenRecorder: NSObject {
     func cancelRecording() {
         guard isRecordingActive else { return }
 
+        // Reset pause flag so it doesn't leak into a future recording.
+        _isPaused = false
+
         // Emit cancel telemetry before tearing down state
         let durationMs: Int
         if let startDate = recordingStartDate {
@@ -1194,6 +1197,9 @@ final class ScreenRecorder: NSObject {
             guard isRecordingActive else { return }
 
             log.error("Stream error during active recording — cleaning up (error=\(recorderError.localizedDescription, privacy: .public))")
+
+            // Reset pause flag so it doesn't leak into a future recording.
+            self._isPaused = false
 
             // Store for attemptStartWithConfig to propagate typed errors
             // instead of collapsing them to .noFramesReceived.


### PR DESCRIPTION
Part of #9344. Wires macOS client to handle recording_pause, recording_resume IPC messages. Adds pause/resume/restart control support in RecordingManager. Handles restart-cancel when picker is dismissed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
