### PR TITLE
macOS: emit explicit conversation seen signals from notification view and conversation open

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -686,6 +686,17 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     deliveryId: 'delivery-001',
     success: true,
   },
+  conversation_seen_signal: {
+    type: 'conversation_seen_signal',
+    conversationId: 'conv-001',
+    sourceChannel: 'vellum',
+    signalType: 'macos_notification_view',
+    confidence: 'explicit',
+    source: 'notification-action',
+    evidenceText: 'User clicked View on notification',
+    observedAt: 1700000000000,
+    metadata: { notificationCategory: 'NOTIFICATION_INTENT' },
+  },
   recording_status: {
     type: 'recording_status',
     sessionId: 'rec-001',

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -1,5 +1,6 @@
 import * as net from 'node:net';
 
+import { recordConversationSeenSignal, type Confidence, type SignalType } from '../../memory/conversation-attention-store.js';
 import { updateDeliveryClientOutcome } from '../../notifications/deliveries-store.js';
 import type { ClientMessage } from '../ipc-protocol.js';
 import { handleRideShotgunStart, handleRideShotgunStop } from '../ride-shotgun-handler.js';
@@ -95,6 +96,25 @@ const inlineHandlers = defineHandlers({
     });
   },
   integration_disconnect: () => { /* no-op — integration registry removed */ },
+
+  // Client signal: user has seen a conversation (notification click, conversation open, etc.)
+  conversation_seen_signal: (msg) => {
+    try {
+      recordConversationSeenSignal({
+        conversationId: msg.conversationId,
+        assistantId: 'self',
+        sourceChannel: msg.sourceChannel,
+        signalType: msg.signalType as SignalType,
+        confidence: msg.confidence as Confidence,
+        source: msg.source,
+        evidenceText: msg.evidenceText,
+        metadata: msg.metadata,
+        observedAt: msg.observedAt,
+      });
+    } catch (err) {
+      log.error({ err, conversationId: msg.conversationId }, 'conversation_seen_signal: failed to record seen signal');
+    }
+  },
 
   // Client ack for notification delivery outcome (UNUserNotificationCenter.add result).
   notification_intent_result: (msg) => {

--- a/assistant/src/daemon/ipc-contract/notifications.ts
+++ b/assistant/src/daemon/ipc-contract/notifications.ts
@@ -27,8 +27,21 @@ export interface NotificationIntentResult {
   errorCode?: string;
 }
 
+/** Client signal indicating the user has seen a conversation (e.g. opened it or clicked a notification). */
+export interface ConversationSeenSignal {
+  type: 'conversation_seen_signal';
+  conversationId: string;
+  sourceChannel: string;
+  signalType: string;
+  confidence: string;
+  source: string;
+  evidenceText?: string;
+  observedAt?: number;
+  metadata?: Record<string, unknown>;
+}
+
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
-export type _NotificationsClientMessages = NotificationIntentResult;
+export type _NotificationsClientMessages = NotificationIntentResult | ConversationSeenSignal;
 
 export type _NotificationsServerMessages = NotificationIntent | NotificationThreadCreated;

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -394,6 +394,28 @@ extension AppDelegate {
         }
     }
 
+    /// Send a `conversation_seen_signal` IPC message to the daemon.
+    func sendConversationSeenSignal(
+        conversationId: String,
+        signalType: String,
+        source: String,
+        evidenceText: String? = nil
+    ) {
+        let signal = IPCConversationSeenSignal(
+            conversationId: conversationId,
+            sourceChannel: "vellum",
+            signalType: signalType,
+            confidence: "explicit",
+            source: source,
+            evidenceText: evidenceText
+        )
+        do {
+            try daemonClient.send(signal)
+        } catch {
+            log.warning("Failed to send conversation_seen_signal for \(conversationId): \(error.localizedDescription)")
+        }
+    }
+
     func registerBundledFonts() {
         for name in ["Silkscreen-Regular", "Silkscreen-Bold", "DMMono-Regular", "DMMono-Medium", "Inter-Regular", "Inter-Medium", "Inter-SemiBold", "CrimsonPro-Variable", "Fraunces-Variable"] {
             guard let url = ResourceBundle.bundle.url(forResource: name, withExtension: "ttf") else {
@@ -475,6 +497,12 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                 guard !self.isBootstrapping else { return }
                 if let conversationId {
                     self.openConversationThread(conversationId: conversationId)
+                    self.sendConversationSeenSignal(
+                        conversationId: conversationId,
+                        signalType: "macos_notification_view",
+                        source: "notification-action",
+                        evidenceText: "User clicked View on notification"
+                    )
                 } else {
                     self.showMainWindow()
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -646,7 +646,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         activeThreadId = id
 
         // Emit explicit seen signal for user-initiated thread activation.
-        if id != previousActiveId,
+        // Skip during session restoration to avoid false "seen" signals on bootstrap.
+        if !isRestoringThreads,
+           id != previousActiveId,
            let thread = threads.first(where: { $0.id == id }),
            let sessionId = thread.sessionId {
             emitConversationSeenSignal(conversationId: sessionId)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -374,6 +374,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     func selectThread(id: UUID) {
         guard let thread = threads.first(where: { $0.id == id }) else { return }
 
+        let previousActiveId = activeThreadId
         trimPreviousThreadIfNeeded(nextThreadId: id)
 
         // Re-create the ViewModel if it was LRU-evicted.
@@ -389,6 +390,14 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         // Switching threads is a natural point to shed cached render
         // artefacts from the previous conversation.
         Self.clearRenderCaches()
+
+        // Emit explicit seen signal for user-initiated thread selection.
+        // Skip if this thread was already active to avoid duplicate signals
+        // (e.g. when openConversationThread sets activeThreadId directly and
+        // SwiftUI's onChange cycle calls selectThread with the same id).
+        if id != previousActiveId, let sessionId = thread.sessionId {
+            emitConversationSeenSignal(conversationId: sessionId)
+        }
     }
 
     // MARK: - Render Cache Management
@@ -632,11 +641,36 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     func activateThread(_ id: UUID) {
+        let previousActiveId = activeThreadId
         trimPreviousThreadIfNeeded(nextThreadId: id)
         activeThreadId = id
+
+        // Emit explicit seen signal for user-initiated thread activation.
+        if id != previousActiveId,
+           let thread = threads.first(where: { $0.id == id }),
+           let sessionId = thread.sessionId {
+            emitConversationSeenSignal(conversationId: sessionId)
+        }
     }
 
     // MARK: - Private
+
+    /// Send a `conversation_seen_signal` IPC message to the daemon.
+    private func emitConversationSeenSignal(conversationId: String) {
+        let signal = IPCConversationSeenSignal(
+            conversationId: conversationId,
+            sourceChannel: "vellum",
+            signalType: "macos_conversation_opened",
+            confidence: "explicit",
+            source: "ui-navigation",
+            evidenceText: "User opened conversation in app"
+        )
+        do {
+            try daemonClient.send(signal)
+        } catch {
+            log.warning("Failed to send conversation_seen_signal for \(conversationId): \(error.localizedDescription)")
+        }
+    }
 
     /// Trim the previously active thread's view model to shed memory before
     /// switching to a different thread. Skipped when the VM hasn't loaded

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1082,6 +1082,31 @@ public struct IPCConversationSearchResultItem: Codable, Sendable {
     }
 }
 
+/// Client signal indicating the user has seen a conversation (e.g. opened it or clicked a notification).
+public struct IPCConversationSeenSignal: Codable, Sendable {
+    public let type: String
+    public let conversationId: String
+    public let sourceChannel: String
+    public let signalType: String
+    public let confidence: String
+    public let source: String
+    public let evidenceText: String?
+    public let observedAt: Int?
+    public let metadata: [String: AnyCodable]?
+
+    public init(type: String, conversationId: String, sourceChannel: String, signalType: String, confidence: String, source: String, evidenceText: String? = nil, observedAt: Int? = nil, metadata: [String: AnyCodable]? = nil) {
+        self.type = type
+        self.conversationId = conversationId
+        self.sourceChannel = sourceChannel
+        self.signalType = signalType
+        self.confidence = confidence
+        self.source = source
+        self.evidenceText = evidenceText
+        self.observedAt = observedAt
+        self.metadata = metadata
+    }
+}
+
 public struct IPCCuAction: Codable, Sendable {
     public let type: String
     public let sessionId: String

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2132,6 +2132,31 @@ extension IPCSessionSwitchRequest {
     }
 }
 
+extension IPCConversationSeenSignal {
+    public init(
+        conversationId: String,
+        sourceChannel: String,
+        signalType: String,
+        confidence: String,
+        source: String,
+        evidenceText: String? = nil,
+        observedAt: Int? = nil,
+        metadata: [String: AnyCodable]? = nil
+    ) {
+        self.init(
+            type: "conversation_seen_signal",
+            conversationId: conversationId,
+            sourceChannel: sourceChannel,
+            signalType: signalType,
+            confidence: confidence,
+            source: source,
+            evidenceText: evidenceText,
+            observedAt: observedAt,
+            metadata: metadata
+        )
+    }
+}
+
 /// Sent by the client to request subagent detail (events) for a completed subagent.
 public struct SubagentDetailRequestMessage: Encodable, Sendable {
     public let type: String = "subagent_detail_request"


### PR DESCRIPTION
Add conversation_seen_signal IPC message. Wire macOS to emit explicit seen signals when user clicks View on a notification or opens a conversation in the app UI. Does not emit on dismiss or on restore/bootstrap selections. Part of #9372.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
