### PR TITLE
fix: add missing assistant_inbox_escalation IPC snapshot entries

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1069,6 +1069,15 @@ exports[`IPC message snapshots ClientMessage types ingress_member serializes to 
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types assistant_inbox_escalation serializes to expected JSON 1`] = `
+{
+  "action": "list",
+  "assistantId": "asst-001",
+  "status": "pending",
+  "type": "assistant_inbox_escalation",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types pairing_approval_response serializes to expected JSON 1`] = `
 {
   "decision": "approve_once",
@@ -2973,6 +2982,26 @@ exports[`IPC message snapshots ServerMessage types ingress_member_response seria
   },
   "success": true,
   "type": "ingress_member_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types assistant_inbox_escalation_response serializes to expected JSON 1`] = `
+{
+  "escalations": [
+    {
+      "channel": "telegram",
+      "conversationId": "conv-001",
+      "createdAt": 1700000000,
+      "id": "esc-001",
+      "requestSummary": "Access request from new user",
+      "requesterChatId": "chat-456",
+      "requesterExternalUserId": "user-123",
+      "runId": "run-001",
+      "status": "pending",
+    },
+  ],
+  "success": true,
+  "type": "assistant_inbox_escalation_response",
 }
 `;
 

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -666,6 +666,12 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     policy: 'allow',
     status: 'active',
   },
+  assistant_inbox_escalation: {
+    type: 'assistant_inbox_escalation',
+    action: 'list',
+    assistantId: 'asst-001',
+    status: 'pending',
+  },
   pairing_approval_response: {
     type: 'pairing_approval_response',
     pairingRequestId: 'pair-001',
@@ -1901,6 +1907,21 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
       lastSeenAt: 1700000000,
       createdAt: 1700000000,
     },
+  },
+  assistant_inbox_escalation_response: {
+    type: 'assistant_inbox_escalation_response',
+    success: true,
+    escalations: [{
+      id: 'esc-001',
+      runId: 'run-001',
+      conversationId: 'conv-001',
+      channel: 'telegram',
+      requesterExternalUserId: 'user-123',
+      requesterChatId: 'chat-456',
+      status: 'pending',
+      requestSummary: 'Access request from new user',
+      createdAt: 1700000000,
+    }],
   },
   pairing_approval_request: {
     type: 'pairing_approval_request',


### PR DESCRIPTION
## Summary
- Add `assistant_inbox_escalation` client message and `assistant_inbox_escalation_response` server message examples to the IPC snapshot test
- These types were added in the inbox contract but the snapshot test wasn't updated, causing `tsc` to fail in CI

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22426164773

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
