### PR TITLE
fix: restore hasNoClient after interactive HTTP agent loop completes

### DIFF
--- a/assistant/src/__tests__/daemon-server-session-init.test.ts
+++ b/assistant/src/__tests__/daemon-server-session-init.test.ts
@@ -37,6 +37,9 @@ class MockSession {
   public lastUpdateClientHasNoClient: boolean | undefined;
   public lastUpdateClientSender: ((msg: Record<string, unknown>) => void) | undefined;
   public lastRunAgentLoopOptions: { skipPreMessageRollback?: boolean; isInteractive?: boolean } | undefined;
+  public updateClientHistory: Array<{ hasNoClient: boolean }> = [];
+  /** When set, runAgentLoop will invoke onEvent with this message during execution. */
+  public confirmationToEmitDuringLoop: Record<string, unknown> | undefined;
   public setSandboxOverrideCalls = 0;
   private stale = false;
   private processing = false;
@@ -64,6 +67,7 @@ class MockSession {
     this.updateClientCalls += 1;
     this.lastUpdateClientSender = sender;
     this.lastUpdateClientHasNoClient = hasNoClient;
+    this.updateClientHistory.push({ hasNoClient });
   }
 
   setSandboxOverride(): void {
@@ -126,10 +130,13 @@ class MockSession {
   async runAgentLoop(
     _content: string,
     _messageId: string,
-    _onEvent: (msg: Record<string, unknown>) => void,
+    onEvent: (msg: Record<string, unknown>) => void,
     options?: { skipPreMessageRollback?: boolean; isInteractive?: boolean },
   ): Promise<void> {
     this.lastRunAgentLoopOptions = options;
+    if (this.confirmationToEmitDuringLoop) {
+      onEvent(this.confirmationToEmitDuringLoop);
+    }
     this.processing = false;
   }
 
@@ -584,6 +591,19 @@ describe('DaemonServer initial session hydration', () => {
     const server = new DaemonServer();
     const internal = asDaemonServerTestAccess(server);
 
+    // Pre-configure the mock to emit a confirmation_request during runAgentLoop,
+    // simulating a tool requesting approval while the session is interactive.
+    MockSession.prototype.confirmationToEmitDuringLoop = {
+      type: 'confirmation_request',
+      requestId: 'req-interactive-1',
+      toolName: 'notify_desktop',
+      input: { title: 'Weather' },
+      riskLevel: 'high',
+      allowlistOptions: [{ label: 'notify_desktop:*', description: 'notify_desktop:*', pattern: 'notify_desktop:*' }],
+      scopeOptions: [{ label: 'everywhere', scope: 'everywhere' }],
+      persistentDecisionsAllowed: true,
+    };
+
     await server.processMessage(
       conversation.id,
       'send me a notification',
@@ -593,24 +613,24 @@ describe('DaemonServer initial session hydration', () => {
       'telegram',
     );
 
+    MockSession.prototype.confirmationToEmitDuringLoop = undefined;
+
     const session = internal.sessions.get(conversation.id);
     expect(session).toBeDefined();
     expect(session!.lastRunAgentLoopOptions?.isInteractive).toBe(true);
-    expect(session!.lastUpdateClientHasNoClient).toBe(false);
 
-    const sender = session!.lastUpdateClientSender;
-    expect(typeof sender).toBe('function');
-    sender!({
-      type: 'confirmation_request',
-      requestId: 'req-interactive-1',
-      toolName: 'notify_desktop',
-      input: { title: 'Weather' },
-      riskLevel: 'high',
-      allowlistOptions: [{ label: 'notify_desktop:*', description: 'notify_desktop:*', pattern: 'notify_desktop:*' }],
-      scopeOptions: [{ label: 'everywhere', scope: 'everywhere' }],
-      persistentDecisionsAllowed: true,
-    });
+    // Verify the session was marked interactive during the loop, then restored.
+    // updateClientHistory: [0] = initial no-socket creation (hasNoClient: true),
+    //                      [1] = interactive override (hasNoClient: false),
+    //                      [2] = reset after loop (hasNoClient: true)
+    expect(session!.updateClientHistory.length).toBeGreaterThanOrEqual(3);
+    expect(session!.updateClientHistory[1].hasNoClient).toBe(false);
+    expect(session!.updateClientHistory[2].hasNoClient).toBe(true);
 
+    // After the loop completes, the session is restored to no-client state.
+    expect(session!.lastUpdateClientHasNoClient).toBe(true);
+
+    // The pending interaction was registered during the loop.
     const interaction = pendingInteractions.get('req-interactive-1');
     expect(interaction).toBeDefined();
     expect(interaction?.kind).toBe('confirmation');

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -822,9 +822,15 @@ export class DaemonServer {
       session.updateClient(onEvent, false);
     }
 
-    session.runAgentLoop(content, messageId, onEvent, { isInteractive: options?.isInteractive ?? false }).catch((err) => {
-      log.error({ err, conversationId }, 'Background agent loop failed');
-    });
+    session.runAgentLoop(content, messageId, onEvent, { isInteractive: options?.isInteractive ?? false })
+      .finally(() => {
+        if (options?.isInteractive === true) {
+          session.updateClient(() => {}, true);
+        }
+      })
+      .catch((err) => {
+        log.error({ err, conversationId }, 'Background agent loop failed');
+      });
 
     return { messageId };
   }
@@ -917,12 +923,18 @@ export class DaemonServer {
       session.updateClient(onEvent, false);
     }
 
-    await session.runAgentLoop(
-      resolvedContent,
-      messageId,
-      onEvent,
-      { isInteractive: options?.isInteractive ?? false },
-    );
+    try {
+      await session.runAgentLoop(
+        resolvedContent,
+        messageId,
+        onEvent,
+        { isInteractive: options?.isInteractive ?? false },
+      );
+    } finally {
+      if (options?.isInteractive === true) {
+        session.updateClient(() => {}, true);
+      }
+    }
 
     return { messageId };
   }


### PR DESCRIPTION
## Summary
- After an interactive HTTP request (e.g. Telegram channel ingress) marks a session as having a client (`hasNoClient = false`), the flag was never reset when the agent loop finished
- Subsequent non-interactive requests on the same session incorrectly behaved as interactive, waiting for permission timeouts instead of auto-denying
- Added `finally` blocks to both `persistAndProcessMessage` (fire-and-forget) and `processMessage` (awaited) to restore `hasNoClient = true` after the agent loop completes

## Original prompt
Address feedback in https://github.com/vellum-ai/vellum-assistant/pull/9398

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
