### PR TITLE
fix: clean up telegram notification copy inconsistencies

### DIFF
--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -126,8 +126,9 @@ describe('notification decision strategy', () => {
       // Both channels get the same copy
       expect(copy.vellum!.title).toBe(copy.telegram!.title);
       expect(copy.vellum!.body).toBe(copy.telegram!.body);
-      // Telegram gets a dedicated chat message field.
+      // Telegram gets a dedicated chat message field; vellum does not.
       expect(copy.telegram!.deliveryText).toBe(copy.telegram!.body);
+      expect(copy.vellum!.deliveryText).toBeUndefined();
     });
 
     test('empty payload falls back to default text in template', () => {

--- a/assistant/src/__tests__/notification-telegram-adapter.test.ts
+++ b/assistant/src/__tests__/notification-telegram-adapter.test.ts
@@ -126,6 +126,6 @@ describe('TelegramAdapter', () => {
       }),
       makeDestination(),
     );
-    expect(deliveryCalls[2]?.payload.text).toBe('watcher.escalation');
+    expect(deliveryCalls[2]?.payload.text).toBe('watcher escalation');
   });
 });

--- a/assistant/src/notifications/adapters/telegram.ts
+++ b/assistant/src/notifications/adapters/telegram.ts
@@ -11,6 +11,7 @@ import { getGatewayInternalBaseUrl } from '../../config/env.js';
 import { deliverChannelReply } from '../../runtime/gateway-client.js';
 import { getLogger } from '../../util/logger.js';
 import { readHttpToken } from '../../util/platform.js';
+import { nonEmpty } from '../copy-composer.js';
 import { isThreadSeedSane } from '../thread-seed-composer.js';
 import type {
   ChannelAdapter,
@@ -21,12 +22,6 @@ import type {
 } from '../types.js';
 
 const log = getLogger('notif-adapter-telegram');
-
-function nonEmpty(value: string | undefined): string | undefined {
-  if (typeof value !== 'string') return undefined;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
-}
 
 function resolveTelegramMessageText(payload: ChannelDeliveryPayload): string {
   const deliveryText = nonEmpty(payload.copy.deliveryText);
@@ -42,7 +37,7 @@ function resolveTelegramMessageText(payload: ChannelDeliveryPayload): string {
   const title = nonEmpty(payload.copy.title);
   if (title) return title;
 
-  return payload.sourceEventName;
+  return payload.sourceEventName.replace(/[._]/g, ' ');
 }
 
 export class TelegramAdapter implements ChannelAdapter {

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -19,7 +19,7 @@ function str(value: unknown, fallback: string): string {
   return fallback;
 }
 
-function nonEmpty(value: string | undefined): string | undefined {
+export function nonEmpty(value: string | undefined): string | undefined {
   if (typeof value !== 'string') return undefined;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -197,7 +197,7 @@ function buildFallbackDecision(
     copy[ch] = {
       title: signal.sourceEventName,
       body: fallbackBody,
-      deliveryText: fallbackBody,
+      ...(ch === 'telegram' ? { deliveryText: fallbackBody } : {}),
     };
   }
 


### PR DESCRIPTION
## Summary
- Deduplicate `nonEmpty` helper by exporting from `copy-composer.ts` and importing in `telegram.ts`
- Humanize the `sourceEventName` fallback in the telegram adapter to match the copy-composer (e.g. `watcher escalation` instead of `watcher.escalation`)
- Only set `deliveryText` on telegram channel in `buildFallbackDecision`, not on vellum which doesn't use it
- Add negative test assertion that vellum does NOT receive `deliveryText` from `composeFallbackCopy`

## Original prompt
Address feedback in https://github.com/vellum-ai/vellum-assistant/pull/9396

🤖 Generated with [Claude Code](https://claude.com/claude-code)