### PR TITLE
M4: In-chat playback reliability

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -16,7 +16,9 @@ struct ChatBubble: View {
     /// Called when expanding a tool call with truncated content to fetch the full text.
     var onRehydrate: (() -> Void)?
     var mediaEmbedSettings: MediaEmbedResolverSettings?
-    var daemonHttpPort: Int?
+    /// Resolves the daemon HTTP port at call time so lazy-loaded video
+    /// attachments always use the latest port after daemon restarts.
+    var resolveHttpPort: (() -> Int?) = { nil }
     var showAvatar: Bool = true
     var isLatestAssistantMessage: Bool = false
 
@@ -330,7 +332,7 @@ struct ChatBubble: View {
                 if !partitioned.videos.isEmpty {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
                         ForEach(partitioned.videos) { attachment in
-                            InlineVideoAttachmentView(attachment: attachment, daemonHttpPort: daemonHttpPort)
+                            InlineVideoAttachmentView(attachment: attachment, resolveHttpPort: resolveHttpPort)
                         }
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -79,7 +79,7 @@ extension ChatBubble {
         if !partitioned.videos.isEmpty {
             VStack(alignment: .leading, spacing: VSpacing.sm) {
                 ForEach(partitioned.videos) { attachment in
-                    InlineVideoAttachmentView(attachment: attachment, daemonHttpPort: daemonHttpPort)
+                    InlineVideoAttachmentView(attachment: attachment, resolveHttpPort: resolveHttpPort)
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -56,7 +56,9 @@ struct ChatView: View {
     /// Called to rehydrate truncated message content on demand.
     var onRehydrateMessage: ((UUID) -> Void)?
     @ObservedObject var subagentDetailStore: SubagentDetailStore
-    var daemonHttpPort: Int?
+    /// Resolves the daemon HTTP port at call time so lazy-loaded video
+    /// attachments always use the latest port after daemon restarts.
+    var resolveHttpPort: (() -> Int?) = { nil }
     var isHistoryLoaded: Bool = true
     var dismissedDocumentSurfaceIds: Set<String> = []
     var onDismissDocumentWidget: ((String) -> Void)?
@@ -186,7 +188,7 @@ struct ChatView: View {
                             onDismissDocumentWidget: onDismissDocumentWidget,
                             onReportMessage: onReportMessage,
                             mediaEmbedSettings: mediaEmbedSettings,
-                            daemonHttpPort: daemonHttpPort,
+                            resolveHttpPort: resolveHttpPort,
                             onModelPickerSelect: onModelPickerSelect,
                             onAbortSubagent: onAbortSubagent,
                             onSubagentTap: onSubagentTap,

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -5,30 +5,101 @@ import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "InlineVideoAttachment")
 
+// MARK: - Failure State Buckets
+
+/// Deterministic failure categories for video playback.
+/// Each bucket has a clear UI treatment and recovery path.
+enum VideoPlaybackFailure: Equatable {
+    /// Daemon not connected or HTTP port not available.
+    /// Recovery: retry when daemon reconnects (auto) or on user tap (manual).
+    case port_missing
+
+    /// HTTP request to daemon failed (network error, 4xx/5xx).
+    /// Recovery: retry on user tap.
+    case fetch_failed(String)
+
+    /// Content fetched but not playable (corrupt file, wrong format, bad base64).
+    /// Recovery: open in external player as fallback.
+    case invalid_media
+
+    var userMessage: String {
+        switch self {
+        case .port_missing:
+            return "Reconnecting to daemon..."
+        case .fetch_failed(let detail):
+            return detail.isEmpty ? "Could not fetch video" : detail
+        case .invalid_media:
+            return "Could not play video"
+        }
+    }
+
+    /// Whether this failure is eligible for automatic retry on daemon reconnect.
+    var isRetryableOnReconnect: Bool {
+        if case .port_missing = self { return true }
+        return false
+    }
+}
+
+// MARK: - View
+
 /// Inline video player for file-based video attachments (e.g. video/mp4).
 ///
 /// Decodes base64 attachment data to a temp file and plays it with native
 /// AVPlayerView. Uses a click-to-play pattern to avoid auto-playing videos
 /// on scroll. Supports lazy-loading large attachments via the daemon HTTP API.
+///
+/// Resolves the daemon HTTP port at fetch time (not at view init) to avoid
+/// stale port snapshots after daemon restarts. On `port_missing` failures,
+/// retries up to 3 times with 1s delays before showing the error state.
+/// Listens for `daemonDidReconnect` to auto-retry `port_missing` failures.
 struct InlineVideoAttachmentView: View {
     let attachment: ChatAttachment
-    let daemonHttpPort: Int?
+    /// Resolves the current daemon HTTP port at call time.
+    /// Returns nil when the daemon is not connected or the port is unavailable.
+    let resolveHttpPort: () -> Int?
 
     @State private var player: AVPlayer?
     @State private var isPlaying = false
     @State private var isLoading = false
-    @State private var failed = false
+    @State private var failure: VideoPlaybackFailure?
     @State private var videoAspectRatio: CGFloat
     @State private var isHovering = false
     @State private var isSaving = false
     @State private var thumbnailImage: NSImage?
+    /// Tracks whether a user-initiated retry has already failed, so the next
+    /// tap on the failed tile opens the external player instead of retrying again.
+    @State private var hasRetriedOnce = false
 
+    // Backward-compatible initializer that accepts a static port snapshot.
+    // Used by callers that haven't migrated to the closure-based API yet.
     init(attachment: ChatAttachment, daemonHttpPort: Int?) {
         self.attachment = attachment
-        self.daemonHttpPort = daemonHttpPort
+        let port = daemonHttpPort
+        self.resolveHttpPort = { port }
 
         if let img = attachment.thumbnailImage {
-            // Use pixel dimensions for accurate aspect ratio (immune to DPI metadata).
+            var w: CGFloat = 0
+            var h: CGFloat = 0
+            if let rep = img.representations.first {
+                w = CGFloat(rep.pixelsWide)
+                h = CGFloat(rep.pixelsHigh)
+            }
+            if w <= 0 || h <= 0 {
+                w = img.size.width
+                h = img.size.height
+            }
+            _videoAspectRatio = State(initialValue: w > 0 && h > 0 ? w / h : 3.0 / 4.0)
+            _thumbnailImage = State(initialValue: img)
+        } else {
+            _videoAspectRatio = State(initialValue: 3.0 / 4.0)
+        }
+    }
+
+    init(attachment: ChatAttachment, resolveHttpPort: @escaping () -> Int?) {
+        self.attachment = attachment
+        self.resolveHttpPort = resolveHttpPort
+
+        if let img = attachment.thumbnailImage {
             var w: CGFloat = 0
             var h: CGFloat = 0
             if let rep = img.representations.first {
@@ -55,8 +126,8 @@ struct InlineVideoAttachmentView: View {
                         .stroke(VColor.surfaceBorder.opacity(0.4), lineWidth: 0.5)
                 )
 
-            if failed {
-                failedView
+            if let failure {
+                failedView(failure)
             } else if isLoading {
                 loadingView
             } else if let player, isPlaying {
@@ -66,7 +137,7 @@ struct InlineVideoAttachmentView: View {
                 placeholderView
             }
 
-            if !failed && !isLoading && isHovering {
+            if failure == nil && !isLoading && isHovering {
                 Button(action: saveVideo) {
                     if isSaving {
                         ProgressView()
@@ -91,6 +162,14 @@ struct InlineVideoAttachmentView: View {
             player?.pause()
             player = nil
             isPlaying = false
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .daemonDidReconnect)) { _ in
+            // Auto-retry playback when daemon reconnects and the current failure
+            // is port_missing (the most common transient failure).
+            guard let failure, failure.isRetryableOnReconnect else { return }
+            self.failure = nil
+            hasRetriedOnce = false
+            prepareAndPlay()
         }
     }
 
@@ -138,19 +217,68 @@ struct InlineVideoAttachmentView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    private var failedView: some View {
+    private func failedView(_ failure: VideoPlaybackFailure) -> some View {
         VStack(spacing: VSpacing.xs) {
-            Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 20))
-                .foregroundStyle(VColor.textSecondary)
+            if case .port_missing = failure {
+                Image(systemName: "arrow.triangle.2.circlepath")
+                    .font(.system(size: 20))
+                    .foregroundStyle(VColor.textSecondary)
+            } else {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.system(size: 20))
+                    .foregroundStyle(VColor.textSecondary)
+            }
 
-            Text("Could not play video")
+            Text(failure.userMessage)
                 .font(VFont.caption)
                 .foregroundStyle(VColor.textSecondary)
+
+            if case .port_missing = failure {
+                Text("Tap to retry")
+                    .font(VFont.small)
+                    .foregroundStyle(VColor.textMuted)
+            } else if case .invalid_media = failure {
+                Text("Tap to open externally")
+                    .font(VFont.small)
+                    .foregroundStyle(VColor.textMuted)
+            } else {
+                Text(hasRetriedOnce ? "Tap to open externally" : "Tap to retry")
+                    .font(VFont.small)
+                    .foregroundStyle(VColor.textMuted)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .contentShape(Rectangle())
         .onTapGesture {
+            handleFailedTileTap(failure)
+        }
+    }
+
+    // MARK: - Failure Tap Handling
+
+    /// Failed tile tap retries playback first; external-open is a fallback
+    /// only after retry fails or for non-retryable failures.
+    private func handleFailedTileTap(_ failure: VideoPlaybackFailure) {
+        switch failure {
+        case .port_missing:
+            // Always retry for port_missing — daemon may have reconnected.
+            self.failure = nil
+            hasRetriedOnce = false
+            prepareAndPlay()
+
+        case .fetch_failed:
+            if hasRetriedOnce {
+                // Second tap: fall back to external player.
+                openInExternalPlayer()
+            } else {
+                // First tap: retry playback.
+                self.failure = nil
+                hasRetriedOnce = true
+                prepareAndPlay()
+            }
+
+        case .invalid_media:
+            // Media is fundamentally broken; skip retry, open externally.
             openInExternalPlayer()
         }
     }
@@ -239,6 +367,13 @@ struct InlineVideoAttachmentView: View {
             }
         }
 
+        // Verify the file is actually playable before handing it to AVPlayer.
+        let isPlayable = (try? await asset.load(.isPlayable)) ?? false
+        guard isPlayable else {
+            await MainActor.run { failure = .invalid_media }
+            return
+        }
+
         let avPlayer = AVPlayer(url: fileURL)
         await MainActor.run {
             self.player = avPlayer
@@ -249,7 +384,7 @@ struct InlineVideoAttachmentView: View {
 
     private func playFromBase64(_ base64: String) async {
         guard let data = Data(base64Encoded: base64) else {
-            await MainActor.run { failed = true }
+            await MainActor.run { failure = .invalid_media }
             return
         }
 
@@ -257,33 +392,59 @@ struct InlineVideoAttachmentView: View {
         do {
             try data.write(to: fileURL)
         } catch {
-            await MainActor.run { failed = true }
+            await MainActor.run { failure = .invalid_media }
             return
         }
 
         await playFromFile(fileURL)
     }
 
+    /// Fetch attachment content from the daemon HTTP API with retry logic.
+    ///
+    /// For `port_missing` failures, retries up to 3 times with 1s delays
+    /// because the daemon may be mid-restart and the port will appear shortly.
     private func fetchAndPlay() {
-        guard let port = daemonHttpPort, let attachmentId = attachment.id.isEmpty ? nil : attachment.id else {
-            failed = true
+        guard let attachmentId = attachment.id.isEmpty ? nil : attachment.id else {
+            failure = .invalid_media
             return
         }
 
         isLoading = true
         Task {
-            do {
-                let data = try await fetchAttachmentContent(port: port, attachmentId: attachmentId)
-                let fileURL = safeTempURL()
-                try data.write(to: fileURL)
-                await MainActor.run { isLoading = false }
-                await playFromFile(fileURL)
-            } catch {
-                log.error("Failed to fetch attachment \(attachmentId): \(error.localizedDescription)")
-                await MainActor.run {
-                    isLoading = false
-                    failed = true
+            // Retry loop: resolve port at each attempt to pick up daemon restarts.
+            let maxRetries = 3
+            var lastError: VideoPlaybackFailure?
+
+            for attempt in 0..<maxRetries {
+                if attempt > 0 {
+                    try? await Task.sleep(nanoseconds: 1_000_000_000) // 1s between retries
                 }
+
+                guard let port = resolveHttpPort() else {
+                    lastError = .port_missing
+                    log.info("Port missing on attempt \(attempt + 1)/\(maxRetries) for attachment \(attachmentId)")
+                    continue
+                }
+
+                do {
+                    let data = try await fetchAttachmentContent(port: port, attachmentId: attachmentId)
+                    let fileURL = safeTempURL()
+                    try data.write(to: fileURL)
+                    await MainActor.run { isLoading = false }
+                    await playFromFile(fileURL)
+                    return
+                } catch {
+                    log.error("Fetch attempt \(attempt + 1)/\(maxRetries) failed for \(attachmentId): \(error.localizedDescription)")
+                    lastError = .fetch_failed(error.localizedDescription)
+                    // Only retry on port_missing; fetch_failed errors are typically
+                    // not transient (4xx/5xx, auth issues) so retrying wastes time.
+                    break
+                }
+            }
+
+            await MainActor.run {
+                isLoading = false
+                failure = lastError ?? .port_missing
             }
         }
     }
@@ -315,7 +476,7 @@ struct InlineVideoAttachmentView: View {
                 await MainActor.run { isSaving = false }
             }
         } else if attachment.isLazyLoad {
-            guard let port = daemonHttpPort, let attachmentId = attachment.id.isEmpty ? nil : attachment.id else {
+            guard let port = resolveHttpPort(), let attachmentId = attachment.id.isEmpty ? nil : attachment.id else {
                 isSaving = false
                 return
             }
@@ -345,7 +506,7 @@ struct InlineVideoAttachmentView: View {
         if let fileURL = cachedFileURL {
             NSWorkspace.shared.open(fileURL)
         } else if attachment.isLazyLoad {
-            guard let port = daemonHttpPort, let attachmentId = attachment.id.isEmpty ? nil : attachment.id else { return }
+            guard let port = resolveHttpPort(), let attachmentId = attachment.id.isEmpty ? nil : attachment.id else { return }
             isLoading = true
             Task {
                 do {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -16,7 +16,9 @@ struct MessageListView: View {
     let onDismissDocumentWidget: ((String) -> Void)?
     let onReportMessage: ((String?) -> Void)?
     let mediaEmbedSettings: MediaEmbedResolverSettings?
-    let daemonHttpPort: Int?
+    /// Resolves the daemon HTTP port at call time so lazy-loaded video
+    /// attachments always use the latest port after daemon restarts.
+    var resolveHttpPort: (() -> Int?) = { nil }
     var onModelPickerSelect: ((UUID, String) -> Void)?
     var onAbortSubagent: ((String) -> Void)?
     var onSubagentTap: ((String) -> Void)?
@@ -209,7 +211,7 @@ struct MessageListView: View {
                                 onReportMessage: onReportMessage,
                                 onRehydrate: message.wasTruncated ? { onRehydrateMessage?(message.id) } : nil,
                                 mediaEmbedSettings: mediaEmbedSettings,
-                                daemonHttpPort: daemonHttpPort,
+                                resolveHttpPort: resolveHttpPort,
                                 showAvatar: !previousIsAssistant,
                                 isLatestAssistantMessage: message.role == .assistant && message.id == latestAssistantId,
                                 activeSurfaceId: activeSurfaceId

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -758,7 +758,7 @@ struct ActiveChatViewWrapper: View {
                 viewModel.rehydrateMessage(id: messageId)
             },
             subagentDetailStore: viewModel.subagentDetailStore,
-            daemonHttpPort: daemonClient.httpPort,
+            resolveHttpPort: daemonClient.httpPortResolver,
             isHistoryLoaded: viewModel.isHistoryLoaded,
             dismissedDocumentSurfaceIds: viewModel.dismissedDocumentSurfaceIds,
             onDismissDocumentWidget: { viewModel.dismissDocumentSurface(id: $0) },

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -149,6 +149,14 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// `nil` means the HTTP server is not running.
     @Published public var httpPort: Int?
 
+    /// Returns a closure that resolves the current HTTP port at call time.
+    /// Use this instead of reading `httpPort` directly when the value must
+    /// reflect the latest daemon state (e.g. after a daemon restart). The
+    /// closure captures `self` weakly to avoid retain cycles.
+    public var httpPortResolver: () -> Int? {
+        { [weak self] in self?.httpPort }
+    }
+
     /// The daemon version string, populated via `daemon_status` on connect.
     @Published public internal(set) var daemonVersion: String?
 


### PR DESCRIPTION
Part of #9344. Resolves daemon HTTP port at fetch time, adds retry with reconnect awareness, implements deterministic failure state buckets (port_missing, fetch_failed, invalid_media).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
