### PR TITLE
M5: Recording completion truthfulness

### DIFF
--- a/assistant/src/__tests__/recording-handler.test.ts
+++ b/assistant/src/__tests__/recording-handler.test.ts
@@ -406,14 +406,130 @@ describe('recordingHandlers.recording_status', () => {
     // No attachment should have been created
     expect(mockAttachments.length).toBe(0);
 
-    // Client should be notified that the file is unavailable
+    // Client should be notified that the recording failed to save
     const textDeltas = sent.filter((m) => m.type === 'assistant_text_delta');
     expect(textDeltas.length).toBeGreaterThanOrEqual(1);
-    expect(textDeltas[0].text).toContain('unavailable');
+    expect(textDeltas[0].text).toContain('Recording failed to save');
 
     const completes = sent.filter((m) => m.type === 'message_complete');
     expect(completes.length).toBeGreaterThanOrEqual(1);
     expect(completes[0].sessionId).toBe(conversationId);
+  });
+
+  test('handles stopped status with zero-length file — treated as failure', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-status-zero-file';
+
+    ctx.socketToSession.set(fakeSocket, conversationId);
+    mockFileExists = true;
+    mockFileSize = 0;
+
+    const recordingId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    expect(recordingId).not.toBeNull();
+    sent.length = 0;
+
+    const statusMsg: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: recordingId!,
+      status: 'stopped',
+      filePath: '/tmp/recording-empty.mov',
+      durationMs: 2000,
+    };
+
+    expect(() => {
+      recordingHandlers.recording_status(statusMsg, fakeSocket, ctx);
+    }).not.toThrow();
+
+    // No attachment should have been created for a zero-length file
+    expect(mockAttachments.length).toBe(0);
+
+    // Client should be told the recording failed to save
+    const textDeltas = sent.filter((m) => m.type === 'assistant_text_delta');
+    expect(textDeltas.length).toBeGreaterThanOrEqual(1);
+    expect(textDeltas[0].text).toContain('Recording failed to save');
+
+    // Should NOT contain the success message
+    const hasSuccessMessage = textDeltas.some(
+      (m) => typeof m.text === 'string' && m.text.includes('recording complete')
+    );
+    expect(hasSuccessMessage).toBe(false);
+
+    const completes = sent.filter((m) => m.type === 'message_complete');
+    expect(completes.length).toBeGreaterThanOrEqual(1);
+    expect(completes[0].sessionId).toBe(conversationId);
+  });
+
+  test('successful finalization — attachment created and success message sent', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-status-success';
+
+    ctx.socketToSession.set(fakeSocket, conversationId);
+    mockFileExists = true;
+    mockFileSize = 4096;
+
+    const recordingId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    expect(recordingId).not.toBeNull();
+    sent.length = 0;
+
+    const statusMsg: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: recordingId!,
+      status: 'stopped',
+      filePath: '/tmp/recording-good.mov',
+      durationMs: 5000,
+    };
+
+    recordingHandlers.recording_status(statusMsg, fakeSocket, ctx);
+
+    // Attachment should have been created
+    expect(mockAttachments.length).toBe(1);
+    expect(mockAttachments[0].sizeBytes).toBe(4096);
+
+    // Success message should be present
+    const textDeltas = sent.filter((m) => m.type === 'assistant_text_delta');
+    expect(textDeltas.length).toBeGreaterThanOrEqual(1);
+    expect(textDeltas[0].text).toContain('Screen recording complete');
+
+    // Should NOT contain failure message
+    const hasFailureMessage = textDeltas.some(
+      (m) => typeof m.text === 'string' && m.text.includes('Recording failed')
+    );
+    expect(hasFailureMessage).toBe(false);
+  });
+
+  test('failed finalization — failure status sent and no success message', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-status-fail-final';
+
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    const recordingId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    expect(recordingId).not.toBeNull();
+    sent.length = 0;
+
+    // Client reports failure (writer finalization error)
+    const statusMsg: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: recordingId!,
+      status: 'failed',
+      error: 'Video writer finished with non-completed status 3',
+    };
+
+    recordingHandlers.recording_status(statusMsg, fakeSocket, ctx);
+
+    // No attachment should have been created
+    expect(mockAttachments.length).toBe(0);
+
+    // Should send failure message, not success
+    const textDeltas = sent.filter((m) => m.type === 'assistant_text_delta');
+    expect(textDeltas.length).toBeGreaterThanOrEqual(1);
+    expect(textDeltas[0].text).toContain('Recording failed');
+
+    // Should NOT contain the success message
+    const hasSuccessMessage = textDeltas.some(
+      (m) => typeof m.text === 'string' && m.text.includes('recording complete')
+    );
+    expect(hasSuccessMessage).toBe(false);
   });
 
   test('handles failed status and notifies client', () => {

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -526,7 +526,7 @@ async function handleRecordingStatus(
             if (notifySocket) {
               ctx.send(notifySocket, {
                 type: 'assistant_text_delta',
-                text: 'Recording file is unavailable or expired.',
+                text: 'Recording failed to save.',
                 sessionId: conversationId,
               });
               ctx.send(notifySocket, { type: 'message_complete', sessionId: conversationId });
@@ -534,6 +534,19 @@ async function handleRecordingStatus(
           } else {
             const stat = statSync(resolvedPath);
             const sizeBytes = stat.size;
+
+            if (sizeBytes === 0) {
+              log.error({ recordingId, filePath: msg.filePath }, 'Recording file is zero-length — treating as failed');
+              if (notifySocket) {
+                ctx.send(notifySocket, {
+                  type: 'assistant_text_delta',
+                  text: 'Recording failed to save.',
+                  sessionId: conversationId,
+                });
+                ctx.send(notifySocket, { type: 'message_complete', sessionId: conversationId });
+              }
+              break;
+            }
             const filename = path.basename(resolvedPath);
 
             // Infer MIME type from extension

--- a/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
+++ b/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
@@ -1104,7 +1104,25 @@ final class ScreenRecorder: NSObject {
             durationMs = 0
         }
 
+        // Verify the output file exists and has non-zero size before
+        // reporting success. A zero-length file indicates a silent write
+        // failure that the writer status check above may not catch.
+        guard FileManager.default.fileExists(atPath: finalURL.path) else {
+            log.error("Stop: output file missing after finalization — \(finalURL.path, privacy: .public)")
+            cleanUpWriter()
+            clearTelemetryState()
+            throw RecorderError.invalidOutputFile
+        }
+
         let fileSize = (try? FileManager.default.attributesOfItem(atPath: finalURL.path)[.size] as? Int) ?? 0
+
+        guard fileSize > 0 else {
+            log.error("Stop: output file is zero-length — discarding as invalid")
+            try? FileManager.default.removeItem(at: finalURL)
+            cleanUpWriter()
+            clearTelemetryState()
+            throw RecorderError.invalidOutputFile
+        }
 
         RecordingTelemetry.logStop(durationMs: durationMs, fileSize: fileSize, status: .success)
 


### PR DESCRIPTION
Part of #9344. Validates output file before reporting success. Failed finalization sends failure status to daemon. Daemon never emits 'recording complete' for failed recordings.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
