### PR TITLE
Conversation attention: expose seen/unseen state in conversation lists and render macOS sidebar indicator

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -832,7 +832,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     type: 'session_list_response',
     sessions: [
       { id: 'sess-001', title: 'First session', updatedAt: 1700000000, threadType: 'standard' },
-      { id: 'sess-002', title: 'Second session', updatedAt: 1700001000, threadType: 'standard' },
+      { id: 'sess-002', title: 'Second session', updatedAt: 1700001000, threadType: 'standard', assistantAttention: { hasUnseenLatestAssistantMessage: true, latestAssistantMessageAt: 1700001000, lastSeenConfidence: 'explicit', lastSeenSignalType: 'macos_notification_view' } },
     ],
   },
   sessions_clear_response: {

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -5,6 +5,7 @@ import { v4 as uuid } from 'uuid';
 import { type InterfaceId,isChannelId, parseChannelId, parseInterfaceId } from '../../channels/types.js';
 import { getConfig } from '../../config/loader.js';
 import { getAttachmentsForMessage, setAttachmentThumbnail } from '../../memory/attachments-store.js';
+import { getAttentionStateByConversationIds } from '../../memory/conversation-attention-store.js';
 import * as conversationStore from '../../memory/conversation-store.js';
 import { GENERATING_TITLE, queueGenerateConversationTitle, UNTITLED_FALLBACK } from '../../memory/conversation-title-service.js';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
@@ -393,15 +394,24 @@ export function handleSecretResponse(
 export function handleSessionList(socket: net.Socket, ctx: HandlerContext, offset = 0, limit = 50): void {
   const conversations = conversationStore.listConversations(limit, false, offset);
   const totalCount = conversationStore.countConversations();
-  const bindings = externalConversationStore.getBindingsForConversations(
-    conversations.map((c) => c.id),
-  );
+  const conversationIds = conversations.map((c) => c.id);
+  const bindings = externalConversationStore.getBindingsForConversations(conversationIds);
+  const attentionStates = getAttentionStateByConversationIds(conversationIds);
   ctx.send(socket, {
     type: 'session_list_response',
     sessions: conversations.map((c) => {
       const binding = bindings.get(c.id);
       const originChannel = parseChannelId(c.originChannel);
       const originInterface = parseInterfaceId(c.originInterface);
+      const attn = attentionStates.get(c.id);
+      const assistantAttention = attn ? {
+        hasUnseenLatestAssistantMessage: attn.latestAssistantMessageAt !== null &&
+          (attn.lastSeenAssistantMessageAt === null || attn.lastSeenAssistantMessageAt < attn.latestAssistantMessageAt),
+        ...(attn.latestAssistantMessageAt !== null ? { latestAssistantMessageAt: attn.latestAssistantMessageAt } : {}),
+        ...(attn.lastSeenAssistantMessageAt !== null ? { lastSeenAssistantMessageAt: attn.lastSeenAssistantMessageAt } : {}),
+        ...(attn.lastSeenConfidence !== null ? { lastSeenConfidence: attn.lastSeenConfidence } : {}),
+        ...(attn.lastSeenSignalType !== null ? { lastSeenSignalType: attn.lastSeenSignalType } : {}),
+      } : undefined;
       return {
         id: c.id,
         title: c.title ?? 'Untitled',
@@ -419,6 +429,7 @@ export function handleSessionList(socket: net.Socket, ctx: HandlerContext, offse
         } : {}),
         ...(originChannel ? { conversationOriginChannel: originChannel } : {}),
         ...(originInterface ? { conversationOriginInterface: originInterface } : {}),
+        ...(assistantAttention ? { assistantAttention } : {}),
       };
     }),
     hasMore: offset + conversations.length < totalCount,

--- a/assistant/src/daemon/ipc-contract/sessions.ts
+++ b/assistant/src/daemon/ipc-contract/sessions.ts
@@ -202,9 +202,18 @@ export interface ChannelBinding {
   username?: string | null;
 }
 
+/** Attention state metadata for a conversation's latest assistant message. */
+export interface AssistantAttention {
+  hasUnseenLatestAssistantMessage: boolean;
+  latestAssistantMessageAt?: number;
+  lastSeenAssistantMessageAt?: number;
+  lastSeenConfidence?: string;
+  lastSeenSignalType?: string;
+}
+
 export interface SessionListResponse {
   type: 'session_list_response';
-  sessions: Array<{ id: string; title: string; updatedAt: number; threadType?: ThreadType; source?: string; channelBinding?: ChannelBinding; conversationOriginChannel?: ChannelId; conversationOriginInterface?: InterfaceId }>;
+  sessions: Array<{ id: string; title: string; updatedAt: number; threadType?: ThreadType; source?: string; channelBinding?: ChannelBinding; conversationOriginChannel?: ChannelId; conversationOriginInterface?: InterfaceId; assistantAttention?: AssistantAttention }>;
   /** Whether more sessions exist beyond the returned page. */
   hasMore?: boolean;
 }

--- a/assistant/src/memory/conversation-attention-store.ts
+++ b/assistant/src/memory/conversation-attention-store.ts
@@ -11,7 +11,7 @@ import { v4 as uuid } from 'uuid';
 
 import { getLogger } from '../util/logger.js';
 import { getDb } from './db.js';
-import { conversationAssistantAttentionState, conversationAttentionEvents, messages } from './schema.js';
+import { conversationAssistantAttentionState, conversationAttentionEvents, conversations, messages } from './schema.js';
 
 const log = getLogger('conversation-attention-store');
 
@@ -322,6 +322,7 @@ export interface ListConversationAttentionParams {
   assistantId: string;
   state?: AttentionFilterState;
   sourceChannel?: string;
+  source?: string;
   limit?: number;
   before?: number;
 }
@@ -337,6 +338,7 @@ export function listConversationAttention(
     assistantId,
     state: filterState = 'all',
     sourceChannel,
+    source,
     limit = 50,
     before,
   } = params;
@@ -346,6 +348,10 @@ export function listConversationAttention(
 
   if (sourceChannel) {
     conditions.push(eq(conversationAssistantAttentionState.lastSeenSourceChannel, sourceChannel));
+  }
+
+  if (source) {
+    conditions.push(eq(conversations.source, source));
   }
 
   if (before !== undefined) {
@@ -375,9 +381,34 @@ export function listConversationAttention(
     );
   }
 
-  const rows = db
-    .select()
-    .from(conversationAssistantAttentionState)
+  let query = db
+    .select({
+      conversationId: conversationAssistantAttentionState.conversationId,
+      assistantId: conversationAssistantAttentionState.assistantId,
+      latestAssistantMessageId: conversationAssistantAttentionState.latestAssistantMessageId,
+      latestAssistantMessageAt: conversationAssistantAttentionState.latestAssistantMessageAt,
+      lastSeenAssistantMessageId: conversationAssistantAttentionState.lastSeenAssistantMessageId,
+      lastSeenAssistantMessageAt: conversationAssistantAttentionState.lastSeenAssistantMessageAt,
+      lastSeenEventAt: conversationAssistantAttentionState.lastSeenEventAt,
+      lastSeenConfidence: conversationAssistantAttentionState.lastSeenConfidence,
+      lastSeenSignalType: conversationAssistantAttentionState.lastSeenSignalType,
+      lastSeenSourceChannel: conversationAssistantAttentionState.lastSeenSourceChannel,
+      lastSeenSource: conversationAssistantAttentionState.lastSeenSource,
+      lastSeenEvidenceText: conversationAssistantAttentionState.lastSeenEvidenceText,
+      createdAt: conversationAssistantAttentionState.createdAt,
+      updatedAt: conversationAssistantAttentionState.updatedAt,
+    })
+    .from(conversationAssistantAttentionState);
+
+  // Join with conversations table when filtering by source
+  if (source) {
+    query = query.innerJoin(
+      conversations,
+      eq(conversationAssistantAttentionState.conversationId, conversations.id),
+    ) as typeof query;
+  }
+
+  const rows = query
     .where(and(...conditions))
     .orderBy(desc(conversationAssistantAttentionState.latestAssistantMessageAt))
     .limit(limit)

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -29,6 +29,7 @@ import {
 } from '../config/env.js';
 import type { ServerMessage } from '../daemon/ipc-contract.js';
 import { PairingStore } from '../daemon/pairing-store.js';
+import { getAttentionStateByConversationIds } from '../memory/conversation-attention-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import * as externalConversationStore from '../memory/external-conversation-store.js';
 import { consumeCallback, consumeCallbackError } from '../security/oauth-callback-registry.js';
@@ -94,6 +95,7 @@ import {
   handleListContacts,
   handleMergeContacts,
 } from './routes/contact-routes.js';
+import { handleListConversationAttention } from './routes/conversation-attention-routes.js';
 // Route handlers — grouped by domain
 import {
   handleGetSuggestion,
@@ -535,13 +537,22 @@ export class RuntimeHttpServer {
         const offset = Number(url.searchParams.get('offset') ?? 0);
         const conversations = conversationStore.listConversations(limit, false, offset);
         const totalCount = conversationStore.countConversations();
-        const bindings = externalConversationStore.getBindingsForConversations(
-          conversations.map((c) => c.id),
-        );
+        const conversationIds = conversations.map((c) => c.id);
+        const bindings = externalConversationStore.getBindingsForConversations(conversationIds);
+        const attentionStates = getAttentionStateByConversationIds(conversationIds);
         return Response.json({
           sessions: conversations.map((c) => {
             const binding = bindings.get(c.id);
             const originChannel = parseChannelId(c.originChannel);
+            const attn = attentionStates.get(c.id);
+            const assistantAttention = attn ? {
+              hasUnseenLatestAssistantMessage: attn.latestAssistantMessageAt !== null &&
+                (attn.lastSeenAssistantMessageAt === null || attn.lastSeenAssistantMessageAt < attn.latestAssistantMessageAt),
+              ...(attn.latestAssistantMessageAt !== null ? { latestAssistantMessageAt: attn.latestAssistantMessageAt } : {}),
+              ...(attn.lastSeenAssistantMessageAt !== null ? { lastSeenAssistantMessageAt: attn.lastSeenAssistantMessageAt } : {}),
+              ...(attn.lastSeenConfidence !== null ? { lastSeenConfidence: attn.lastSeenConfidence } : {}),
+              ...(attn.lastSeenSignalType !== null ? { lastSeenSignalType: attn.lastSeenSignalType } : {}),
+            } : undefined;
             return {
               id: c.id,
               title: c.title ?? 'Untitled',
@@ -557,11 +568,14 @@ export class RuntimeHttpServer {
                 },
               } : {}),
               ...(originChannel ? { conversationOriginChannel: originChannel } : {}),
+              ...(assistantAttention ? { assistantAttention } : {}),
             };
           }),
           hasMore: offset + conversations.length < totalCount,
         });
       }
+
+      if (endpoint === 'conversations/attention' && req.method === 'GET') return handleListConversationAttention(url);
 
       if (endpoint === 'messages' && req.method === 'GET') return handleListMessages(url, this.interfacesDir);
       if (endpoint === 'search' && req.method === 'GET') return handleSearchConversations(url);

--- a/assistant/src/runtime/routes/conversation-attention-routes.ts
+++ b/assistant/src/runtime/routes/conversation-attention-routes.ts
@@ -1,0 +1,81 @@
+/**
+ * Route handler for the conversation attention API.
+ * Exposes attention state (seen/unseen) for conversations,
+ * useful for assistant/LLM reporting and UI indicators.
+ */
+
+import {
+  type AttentionFilterState,
+  listConversationAttention,
+} from '../../memory/conversation-attention-store.js';
+import * as conversationStore from '../../memory/conversation-store.js';
+import { truncate } from '../../util/truncate.js';
+
+export function handleListConversationAttention(url: URL): Response {
+  const stateParam = url.searchParams.get('state') ?? 'all';
+  const sourceParam = url.searchParams.get('source') ?? 'all';
+  const channel = url.searchParams.get('channel') ?? undefined;
+  const limit = Math.min(Math.max(Number(url.searchParams.get('limit') ?? 20), 1), 100);
+  const beforeParam = url.searchParams.get('before');
+  const before = beforeParam ? Number(beforeParam) : undefined;
+
+  if (!['seen', 'unseen', 'all'].includes(stateParam)) {
+    return Response.json({ error: 'Invalid state parameter. Must be seen, unseen, or all.' }, { status: 400 });
+  }
+
+  const attentionStates = listConversationAttention({
+    assistantId: 'self',
+    state: stateParam as AttentionFilterState,
+    sourceChannel: channel,
+    limit: limit + 1, // fetch one extra to determine hasMore
+    before,
+  });
+
+  const hasMore = attentionStates.length > limit;
+  const pageStates = hasMore ? attentionStates.slice(0, limit) : attentionStates;
+
+  // Batch-fetch conversation metadata for title and source filtering
+  const conversationIds = pageStates.map((s) => s.conversationId);
+  const conversationMap = new Map<string, { title: string | null; source: string }>();
+  for (const id of conversationIds) {
+    const conv = conversationStore.getConversation(id);
+    if (conv) {
+      conversationMap.set(id, { title: conv.title, source: conv.source ?? 'user' });
+    }
+  }
+
+  let results = pageStates.map((attn) => {
+    const conv = conversationMap.get(attn.conversationId);
+    const convSource = conv?.source ?? 'user';
+    const hasUnseen = attn.latestAssistantMessageAt !== null &&
+      (attn.lastSeenAssistantMessageAt === null || attn.lastSeenAssistantMessageAt < attn.latestAssistantMessageAt);
+    const state: 'seen' | 'unseen' | 'no_assistant_message' = attn.latestAssistantMessageAt === null
+      ? 'no_assistant_message'
+      : hasUnseen ? 'unseen' : 'seen';
+
+    return {
+      conversationId: attn.conversationId,
+      title: conv?.title ?? null,
+      source: convSource,
+      state,
+      latestAssistantMessageAt: attn.latestAssistantMessageAt,
+      latestAssistantSnippet: null as string | null,
+      lastSeenAssistantMessageAt: attn.lastSeenAssistantMessageAt,
+      lastSeenConfidence: attn.lastSeenConfidence,
+      lastSeenSignalType: attn.lastSeenSignalType,
+      lastSeenSourceChannel: attn.lastSeenSourceChannel,
+      lastSeenSource: attn.lastSeenSource,
+      lastSeenEvidenceText: attn.lastSeenEvidenceText ? truncate(attn.lastSeenEvidenceText, 200, '') : null,
+    };
+  });
+
+  // Apply source filter client-side (attention store doesn't know about conversation source)
+  if (sourceParam !== 'all') {
+    results = results.filter((r) => r.source === sourceParam);
+  }
+
+  return Response.json({
+    conversations: results,
+    hasMore,
+  });
+}

--- a/assistant/src/runtime/routes/conversation-attention-routes.ts
+++ b/assistant/src/runtime/routes/conversation-attention-routes.ts
@@ -27,6 +27,7 @@ export function handleListConversationAttention(url: URL): Response {
     assistantId: 'self',
     state: stateParam as AttentionFilterState,
     sourceChannel: channel,
+    source: sourceParam !== 'all' ? sourceParam : undefined,
     limit: limit + 1, // fetch one extra to determine hasMore
     before,
   });
@@ -34,7 +35,7 @@ export function handleListConversationAttention(url: URL): Response {
   const hasMore = attentionStates.length > limit;
   const pageStates = hasMore ? attentionStates.slice(0, limit) : attentionStates;
 
-  // Batch-fetch conversation metadata for title and source filtering
+  // Batch-fetch conversation metadata for title enrichment
   const conversationIds = pageStates.map((s) => s.conversationId);
   const conversationMap = new Map<string, { title: string | null; source: string }>();
   for (const id of conversationIds) {
@@ -44,7 +45,7 @@ export function handleListConversationAttention(url: URL): Response {
     }
   }
 
-  let results = pageStates.map((attn) => {
+  const results = pageStates.map((attn) => {
     const conv = conversationMap.get(attn.conversationId);
     const convSource = conv?.source ?? 'user';
     const hasUnseen = attn.latestAssistantMessageAt !== null &&
@@ -68,11 +69,6 @@ export function handleListConversationAttention(url: URL): Response {
       lastSeenEvidenceText: attn.lastSeenEvidenceText ? truncate(attn.lastSeenEvidenceText, 200, '') : null,
     };
   });
-
-  // Apply source filter client-side (attention store doesn't know about conversation source)
-  if (sourceParam !== 'all') {
-    results = results.filter((r) => r.source === sourceParam);
-  }
 
   return Response.json({
     conversations: results,

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -847,6 +847,11 @@ struct MainWindowView: View {
             }
         }) {
             HStack(spacing: VSpacing.xs) {
+                if thread.source == "notification" && thread.hasUnseenLatestAssistantMessage {
+                    Circle()
+                        .fill(VColor.accent)
+                        .frame(width: 8, height: 8)
+                }
                 if thread.kind == .private {
                     Image(systemName: "lock.fill")
                         .font(.system(size: 10, weight: .medium))

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -398,6 +398,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         // SwiftUI's onChange cycle calls selectThread with the same id).
         if id != previousActiveId, let sessionId = thread.sessionId {
             emitConversationSeenSignal(conversationId: sessionId)
+            if let idx = threads.firstIndex(where: { $0.id == id }) {
+                threads[idx].hasUnseenLatestAssistantMessage = false
+            }
         }
     }
 
@@ -653,6 +656,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
            let thread = threads.first(where: { $0.id == id }),
            let sessionId = thread.sessionId {
             emitConversationSeenSignal(conversationId: sessionId)
+            if let idx = threads.firstIndex(where: { $0.id == id }) {
+                threads[idx].hasUnseenLatestAssistantMessage = false
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -351,7 +351,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 sessionId: session.id,
                 isArchived: isSessionArchived(session.id),
                 kind: session.threadType == "private" ? .private : .standard,
-                source: session.source
+                source: session.source,
+                hasUnseenLatestAssistantMessage: session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false
             )
             // VM creation is lazy — getOrCreateViewModel() will instantiate
             // when the thread is first accessed (e.g. selected by the user).

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
@@ -18,8 +18,9 @@ struct ThreadModel: Identifiable, Hashable {
     var lastInteractedAt: Date
     var kind: ThreadKind
     var source: String?
+    var hasUnseenLatestAssistantMessage: Bool = false
 
-    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), sessionId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, pinnedOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ThreadKind = .standard, source: String? = nil) {
+    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), sessionId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, pinnedOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ThreadKind = .standard, source: String? = nil, hasUnseenLatestAssistantMessage: Bool = false) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -30,6 +31,7 @@ struct ThreadModel: Identifiable, Hashable {
         self.lastInteractedAt = lastInteractedAt ?? createdAt
         self.kind = kind
         self.source = source
+        self.hasUnseenLatestAssistantMessage = hasUnseenLatestAssistantMessage
     }
 
     /// Whether this thread was created by a schedule or reminder trigger.

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -199,7 +199,8 @@ final class ThreadSessionRestorer {
                 sessionId: session.id,
                 isArchived: delegate.isSessionArchived(session.id),
                 kind: kind,
-                source: session.source
+                source: session.source,
+                hasUnseenLatestAssistantMessage: session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false
             )
             // VM creation is lazy — only the active thread will get a VM via
             // getOrCreateViewModel() when it's first accessed.

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -373,6 +373,23 @@ public struct IPCAppUpdatePreviewResponse: Codable, Sendable {
     }
 }
 
+/// Attention state metadata for a conversation's latest assistant message.
+public struct IPCAssistantAttention: Codable, Sendable {
+    public let hasUnseenLatestAssistantMessage: Bool
+    public let latestAssistantMessageAt: Int?
+    public let lastSeenAssistantMessageAt: Int?
+    public let lastSeenConfidence: String?
+    public let lastSeenSignalType: String?
+
+    public init(hasUnseenLatestAssistantMessage: Bool, latestAssistantMessageAt: Int? = nil, lastSeenAssistantMessageAt: Int? = nil, lastSeenConfidence: String? = nil, lastSeenSignalType: String? = nil) {
+        self.hasUnseenLatestAssistantMessage = hasUnseenLatestAssistantMessage
+        self.latestAssistantMessageAt = latestAssistantMessageAt
+        self.lastSeenAssistantMessageAt = lastSeenAssistantMessageAt
+        self.lastSeenConfidence = lastSeenConfidence
+        self.lastSeenSignalType = lastSeenSignalType
+    }
+}
+
 public struct IPCAssistantInboxEscalationRequest: Codable, Sendable {
     public let type: String
     public let action: String
@@ -3721,8 +3738,10 @@ public struct IPCSessionListResponseSession: Codable, Sendable {
     public let channelBinding: IPCChannelBinding?
     public let conversationOriginChannel: String?
     public let conversationOriginInterface: String?
+    /// Attention state metadata for a conversation's latest assistant message.
+    public let assistantAttention: IPCAssistantAttention?
 
-    public init(id: String, title: String, updatedAt: Int, threadType: String? = nil, source: String? = nil, channelBinding: IPCChannelBinding? = nil, conversationOriginChannel: String? = nil, conversationOriginInterface: String? = nil) {
+    public init(id: String, title: String, updatedAt: Int, threadType: String? = nil, source: String? = nil, channelBinding: IPCChannelBinding? = nil, conversationOriginChannel: String? = nil, conversationOriginInterface: String? = nil, assistantAttention: IPCAssistantAttention? = nil) {
         self.id = id
         self.title = title
         self.updatedAt = updatedAt
@@ -3731,6 +3750,7 @@ public struct IPCSessionListResponseSession: Codable, Sendable {
         self.channelBinding = channelBinding
         self.conversationOriginChannel = conversationOriginChannel
         self.conversationOriginInterface = conversationOriginInterface
+        self.assistantAttention = assistantAttention
     }
 }
 

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -27,6 +27,7 @@ struct ConversationsListResponse: Decodable {
         let channelBinding: IPCChannelBinding?
         let conversationOriginChannel: String?
         let conversationOriginInterface: String?
+        let assistantAttention: IPCAssistantAttention?
     }
     let sessions: [Session]
     let hasMore: Bool?
@@ -423,7 +424,7 @@ final class HTTPTransport {
             do {
                 let decoded = try decoder.decode(ConversationsListResponse.self, from: data)
                 let sessions = decoded.sessions.map {
-                    IPCSessionListResponseSession(id: $0.id, title: $0.title, updatedAt: $0.updatedAt, threadType: $0.threadType, source: $0.source, channelBinding: $0.channelBinding, conversationOriginChannel: $0.conversationOriginChannel, conversationOriginInterface: $0.conversationOriginInterface)
+                    IPCSessionListResponseSession(id: $0.id, title: $0.title, updatedAt: $0.updatedAt, threadType: $0.threadType, source: $0.source, channelBinding: $0.channelBinding, conversationOriginChannel: $0.conversationOriginChannel, conversationOriginInterface: $0.conversationOriginInterface, assistantAttention: $0.assistantAttention)
                 }
                 onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: sessions, hasMore: decoded.hasMore)))
             } catch {

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1234,6 +1234,10 @@ extension IPCSkillsInspectResponseData {
 /// Backed by generated `IPCSkillsInspectResponse`.
 public typealias SkillsInspectResponseMessage = IPCSkillsInspectResponse
 
+/// Attention state metadata for a conversation's latest assistant message.
+/// Backed by generated `IPCAssistantAttention`.
+public typealias AssistantAttention = IPCAssistantAttention
+
 /// Response containing the list of past sessions.
 /// Backed by generated `IPCSessionListResponse`.
 public typealias SessionListResponseMessage = IPCSessionListResponse


### PR DESCRIPTION
Add assistantAttention fields to session/conversation list responses. Add /v1/conversations/attention endpoint for assistant/LLM reporting. Extend ThreadModel with attention state. Render sidebar dot for notification-origin unseen conversations. Closes #9376
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
