### PR TITLE
M4: Drift Guard + Docs + Final E2E

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -22,6 +22,41 @@ This document owns assistant-runtime architecture details. The repo-level archit
 - Voice calls mirror the same prompt contract: `CallController` receives guardian context on setup and refreshes it immediately after successful voice challenge verification, so the first post-verification turn is grounded as `actor_role: guardian`.
 - Voice-specific behavior (DTMF/speech verification flow, relay state machine) remains voice-local; only actor-role resolution is shared.
 
+### Outbound Guardian Verification (HTTP Endpoints)
+
+Guardian verification can be initiated through the runtime HTTP API as an alternative to the legacy IPC-only flow. This enables chat-first verification where the assistant guides the user through guardian setup via normal conversation.
+
+**HTTP Endpoints:**
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/v1/integrations/guardian/outbound/start` | POST | Start a new outbound verification session. Body: `{ channel, destination?, assistantId?, rebind? }` |
+| `/v1/integrations/guardian/outbound/resend` | POST | Resend the verification code for an active session. Body: `{ channel, assistantId? }` |
+| `/v1/integrations/guardian/outbound/cancel` | POST | Cancel an active outbound verification session. Body: `{ channel, assistantId? }` |
+
+All endpoints are bearer-authenticated via the runtime HTTP token (`~/.vellum/http-token`).
+
+**Shared Business Logic:**
+
+The HTTP route handlers (`integration-routes.ts`) and the legacy IPC handlers (`config-channels.ts`) both delegate to the same action functions in `guardian-outbound-actions.ts`. This module contains transport-agnostic business logic for starting, resending, and cancelling outbound verification flows across SMS, Telegram, and voice channels. It returns `OutboundActionResult` objects that the transport layer (HTTP or IPC) maps to its respective response format.
+
+**Chat-First Orchestration Flow:**
+
+1. The user asks the assistant (via desktop chat) to set up guardian verification for a channel.
+2. The conversational routing layer detects the guardian-setup intent and loads the `guardian-verify-setup` skill via `skill_load`.
+3. The skill guides the assistant through collecting the channel and destination, then calls the outbound HTTP endpoints using `curl`.
+4. The assistant relays verification status (code sent, resend available, expiry) back to the user conversationally.
+5. On the channel side, the verification code arrives (SMS text, Telegram message, or voice call) and the recipient enters it to complete the binding.
+
+**Key Source Files:**
+
+| File | Purpose |
+|------|---------|
+| `src/runtime/guardian-outbound-actions.ts` | Shared business logic for start/resend/cancel outbound verification |
+| `src/runtime/routes/integration-routes.ts` | HTTP route handlers for `/v1/integrations/guardian/outbound/*` |
+| `src/daemon/handlers/config-channels.ts` | IPC handler that delegates to the same shared actions |
+| `src/config/vellum-skills/guardian-verify-setup/SKILL.md` | Skill that teaches the assistant how to orchestrate guardian verification via chat |
+
 ### SMS Channel (Twilio)
 
 The SMS channel provides text-only messaging via Twilio, sharing the same telephony provider as voice calls. It follows the same ingress/egress pattern as Telegram but uses Twilio's HMAC-SHA1 signature validation instead of a secret header.

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -321,6 +321,27 @@ Guardian verification and ingress membership are complementary but independent s
 | `src/memory/ingress-member-store.ts` | Member CRUD: `findMember`, `upsertMember`, `revokeMember`, `blockMember` |
 | `src/memory/ingress-invite-store.ts` | Invite lifecycle: `createInvite`, `redeemInvite` (atomically creates member record) |
 | `src/memory/channel-guardian-store.ts` | Persistence for guardian bindings, verification challenges, and approval requests |
+| `src/runtime/guardian-outbound-actions.ts` | Shared business logic for outbound verification (start/resend/cancel) |
+| `src/runtime/routes/integration-routes.ts` | HTTP route handlers for outbound guardian verification endpoints |
+
+### Chat-Initiated Guardian Verification
+
+Guardian verification can also be initiated through normal desktop chat. When the user asks the assistant to set up guardian verification, the conversational routing layer loads the `guardian-verify-setup` skill, which guides the flow:
+
+1. Confirm which channel to verify (SMS, voice, or Telegram).
+2. Collect the destination (phone number or Telegram handle/chat ID).
+3. Call the outbound HTTP endpoints to start, resend, or cancel verification.
+4. Guide the user through the verification lifecycle conversationally.
+
+**Outbound HTTP Endpoints** (available when the runtime HTTP server is running):
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/v1/integrations/guardian/outbound/start` | POST | Start outbound verification. Body: `{ channel, destination?, assistantId?, rebind? }` |
+| `/v1/integrations/guardian/outbound/resend` | POST | Resend verification code. Body: `{ channel, assistantId? }` |
+| `/v1/integrations/guardian/outbound/cancel` | POST | Cancel active session. Body: `{ channel, assistantId? }` |
+
+These endpoints share the same business logic as the IPC-based verification flow via `guardian-outbound-actions.ts`.
 
 ## Channel Readiness
 

--- a/assistant/src/__tests__/skill-mirror-parity.test.ts
+++ b/assistant/src/__tests__/skill-mirror-parity.test.ts
@@ -74,6 +74,17 @@ describe('Skill mirror parity — embedded ↔ top-level', () => {
     expect(sharedSkills.length).toBeGreaterThan(0);
   });
 
+  // ── Every top-level skill must have an embedded source ──────────────────
+
+  test('every top-level skill directory has a corresponding embedded directory', () => {
+    const embedded = new Set(listSkillDirs(EMBEDDED_SKILLS_DIR));
+    const toplevel = listSkillDirs(TOPLEVEL_SKILLS_DIR);
+
+    const missingFromEmbedded = toplevel.filter((id) => !embedded.has(id));
+
+    expect(missingFromEmbedded).toEqual([]);
+  });
+
   // ── SKILL.md content parity ─────────────────────────────────────────────
 
   for (const skillId of sharedSkills) {
@@ -102,6 +113,23 @@ describe('Skill mirror parity — embedded ↔ top-level', () => {
       expect(embeddedContent).toBe(toplevelContent);
     });
   }
+
+  // ── Every top-level catalog entry must have an embedded source ──────────
+
+  test('every top-level catalog entry exists in the embedded catalog', () => {
+    expect(existsSync(EMBEDDED_CATALOG)).toBe(true);
+    expect(existsSync(TOPLEVEL_CATALOG)).toBe(true);
+
+    const embeddedCatalog: Catalog = JSON.parse(readFileSync(EMBEDDED_CATALOG, 'utf-8'));
+    const toplevelCatalog: Catalog = JSON.parse(readFileSync(TOPLEVEL_CATALOG, 'utf-8'));
+
+    const embeddedIds = new Set(embeddedCatalog.skills.map((s) => s.id));
+    const toplevelIds = toplevelCatalog.skills.map((s) => s.id);
+
+    const missingFromEmbedded = toplevelIds.filter((id) => !embeddedIds.has(id));
+
+    expect(missingFromEmbedded).toEqual([]);
+  });
 
   // ── Catalog entry parity for shared skills ──────────────────────────────
 

--- a/assistant/src/__tests__/skill-mirror-parity.test.ts
+++ b/assistant/src/__tests__/skill-mirror-parity.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Drift guard: asserts parity between mirrored first-party skill directories.
+ *
+ * Skills that exist in both `assistant/src/config/vellum-skills/` (embedded in
+ * the runtime) and `skills/` (top-level repo, fetched from GitHub at runtime)
+ * must have identical SKILL.md content. The catalog.json entries for shared
+ * skills must also match.
+ *
+ * This test prevents silent drift between the two copies. When a skill is
+ * updated in one location but not the other, this test fails with a clear
+ * message indicating which skill and file diverged.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { describe, expect, test } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+const ASSISTANT_DIR = resolve(__dirname, '..', '..');
+const REPO_ROOT = resolve(ASSISTANT_DIR, '..');
+
+const EMBEDDED_SKILLS_DIR = join(ASSISTANT_DIR, 'src', 'config', 'vellum-skills');
+const TOPLEVEL_SKILLS_DIR = join(REPO_ROOT, 'skills');
+
+const EMBEDDED_CATALOG = join(EMBEDDED_SKILLS_DIR, 'catalog.json');
+const TOPLEVEL_CATALOG = join(TOPLEVEL_SKILLS_DIR, 'catalog.json');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface CatalogEntry {
+  id: string;
+  name: string;
+  description: string;
+  emoji: string;
+  includes?: string[];
+}
+
+interface Catalog {
+  description: string;
+  version: number;
+  skills: CatalogEntry[];
+}
+
+/** List subdirectories (skill directories) in a given parent. */
+function listSkillDirs(parent: string): string[] {
+  if (!existsSync(parent)) return [];
+  return readdirSync(parent).filter((entry) => {
+    const full = join(parent, entry);
+    return statSync(full).isDirectory();
+  });
+}
+
+/** Find skill IDs that exist as directories in both locations. */
+function findSharedSkills(): string[] {
+  const embedded = new Set(listSkillDirs(EMBEDDED_SKILLS_DIR));
+  const toplevel = new Set(listSkillDirs(TOPLEVEL_SKILLS_DIR));
+  return [...embedded].filter((id) => toplevel.has(id)).sort();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Skill mirror parity — embedded ↔ top-level', () => {
+  const sharedSkills = findSharedSkills();
+
+  test('at least one shared skill exists (sanity check)', () => {
+    expect(sharedSkills.length).toBeGreaterThan(0);
+  });
+
+  // ── SKILL.md content parity ─────────────────────────────────────────────
+
+  for (const skillId of sharedSkills) {
+    test(`${skillId}/SKILL.md content matches between embedded and top-level`, () => {
+      const embeddedPath = join(EMBEDDED_SKILLS_DIR, skillId, 'SKILL.md');
+      const toplevelPath = join(TOPLEVEL_SKILLS_DIR, skillId, 'SKILL.md');
+
+      const embeddedExists = existsSync(embeddedPath);
+      const toplevelExists = existsSync(toplevelPath);
+
+      if (!embeddedExists && !toplevelExists) {
+        // Neither has a SKILL.md — acceptable, no parity violation
+        return;
+      }
+
+      // If one exists but not the other, that is a drift violation
+      expect(embeddedExists).toBe(
+        toplevelExists,
+      );
+
+      if (!embeddedExists || !toplevelExists) return;
+
+      const embeddedContent = readFileSync(embeddedPath, 'utf-8');
+      const toplevelContent = readFileSync(toplevelPath, 'utf-8');
+
+      expect(embeddedContent).toBe(toplevelContent);
+    });
+  }
+
+  // ── Catalog entry parity for shared skills ──────────────────────────────
+
+  test('catalog.json entries match for all shared skills', () => {
+    expect(existsSync(EMBEDDED_CATALOG)).toBe(true);
+    expect(existsSync(TOPLEVEL_CATALOG)).toBe(true);
+
+    const embeddedCatalog: Catalog = JSON.parse(readFileSync(EMBEDDED_CATALOG, 'utf-8'));
+    const toplevelCatalog: Catalog = JSON.parse(readFileSync(TOPLEVEL_CATALOG, 'utf-8'));
+
+    const embeddedMap = new Map(embeddedCatalog.skills.map((s) => [s.id, s]));
+    const toplevelMap = new Map(toplevelCatalog.skills.map((s) => [s.id, s]));
+
+    // Only compare entries that exist in both catalogs
+    const sharedIds = [...embeddedMap.keys()].filter((id) => toplevelMap.has(id));
+
+    expect(sharedIds.length).toBeGreaterThan(0);
+
+    for (const id of sharedIds) {
+      const embedded = embeddedMap.get(id)!;
+      const toplevel = toplevelMap.get(id)!;
+
+      expect(embedded).toEqual(toplevel);
+    }
+  });
+});

--- a/assistant/src/__tests__/skill-mirror-parity.test.ts
+++ b/assistant/src/__tests__/skill-mirror-parity.test.ts
@@ -30,6 +30,19 @@ const EMBEDDED_CATALOG = join(EMBEDDED_SKILLS_DIR, 'catalog.json');
 const TOPLEVEL_CATALOG = join(TOPLEVEL_SKILLS_DIR, 'catalog.json');
 
 // ---------------------------------------------------------------------------
+// Skills that exist only in the top-level `skills/` directory and have no
+// embedded source in `assistant/src/config/vellum-skills/`. These are
+// community/third-party skills maintained outside the assistant runtime.
+// ---------------------------------------------------------------------------
+
+const TOPLEVEL_ONLY_SKILLS = new Set([
+  'google-oauth-setup',
+  'notion',
+  'notion-oauth-setup',
+  'oauth-setup',
+]);
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -80,7 +93,9 @@ describe('Skill mirror parity — embedded ↔ top-level', () => {
     const embedded = new Set(listSkillDirs(EMBEDDED_SKILLS_DIR));
     const toplevel = listSkillDirs(TOPLEVEL_SKILLS_DIR);
 
-    const missingFromEmbedded = toplevel.filter((id) => !embedded.has(id));
+    const missingFromEmbedded = toplevel.filter(
+      (id) => !embedded.has(id) && !TOPLEVEL_ONLY_SKILLS.has(id),
+    );
 
     expect(missingFromEmbedded).toEqual([]);
   });
@@ -126,7 +141,9 @@ describe('Skill mirror parity — embedded ↔ top-level', () => {
     const embeddedIds = new Set(embeddedCatalog.skills.map((s) => s.id));
     const toplevelIds = toplevelCatalog.skills.map((s) => s.id);
 
-    const missingFromEmbedded = toplevelIds.filter((id) => !embeddedIds.has(id));
+    const missingFromEmbedded = toplevelIds.filter(
+      (id) => !embeddedIds.has(id) && !TOPLEVEL_ONLY_SKILLS.has(id),
+    );
 
     expect(missingFromEmbedded).toEqual([]);
   });

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -32,7 +32,7 @@
       "name": "Slack OAuth Setup",
       "description": "Create Slack App and OAuth credentials for Slack integration using browser automation",
       "emoji": "\ud83d\udd11",
-      "includes": ["browser"]
+      "includes": ["browser", "public-ingress"]
     },
     {
       "id": "telegram-setup",

--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -8,17 +8,10 @@ metadata: {"vellum": {"emoji": "\ud83e\udd16"}}
 
 You are helping your user connect a Telegram bot to the Vellum Assistant gateway. Telegram webhooks are received exclusively by the gateway (the public ingress boundary) — they never hit the assistant runtime directly. When this skill is invoked, walk through each step below using only existing tools.
 
-## Prerequisites — Check Before Starting
-
-Before beginning setup, verify these conditions are met:
-
-1. **Daemon is running:** Run `curl -sf http://localhost:7821/healthz` — it should return OK. If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
-2. **Public ingress URL is configured.** The gateway webhook URL is derived from `${ingress.publicBaseUrl}/webhooks/telegram`. If the ingress URL is not configured, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the URL before continuing.
-
 ## What You Need
 
 1. **Bot token** from Telegram's @BotFather (the user provides this)
-2. **Gateway webhook URL** — derived from the canonical ingress setting: `${ingress.publicBaseUrl}/webhooks/telegram`. The gateway is the only publicly reachable endpoint; Telegram sends webhooks to the gateway, which validates and forwards them to the assistant runtime internally.
+2. **Gateway webhook URL** — derived from the canonical ingress setting: `${ingress.publicBaseUrl}/webhooks/telegram`. The gateway is the only publicly reachable endpoint; Telegram sends webhooks to the gateway, which validates and forwards them to the assistant runtime internally. If `ingress.publicBaseUrl` is not configured, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the URL before continuing.
 
 **IMPORTANT — Secure credential collection only:** Never use a bot token that was pasted in plaintext chat. Always collect the bot token through the secure credential prompt flow using `credential_store` with `action: "prompt"` and `service: "telegram"`, `field: "bot_token"`. If the user has already pasted a token in the conversation, inform them that for security reasons you cannot use tokens shared in chat and must collect it through the secure prompt instead.
 
@@ -31,27 +24,19 @@ Collect the bot token through the secure credential prompt:
 
 The token is collected securely via a system-level prompt and is never exposed in plaintext chat.
 
-### Step 2: Configure Bot and Register Commands
+### Step 2: Configure via Daemon
 
-After the token is collected, call the composite setup endpoint which validates the token, stores credentials, and registers bot commands in a single request:
+After the token is collected, send it to the daemon's `telegram_config` handler which validates, stores, and configures everything in one step:
 
-```bash
-curl -sf -X POST http://localhost:7821/v1/integrations/telegram/setup \
-  -H "Authorization: Bearer $(cat ~/.vellum/http-token)" \
-  -H "Content-Type: application/json"
-```
+- Send the `telegram_config` IPC message with `action: "set"`. The daemon retrieves the token from secure storage internally when `botToken` is not provided in the message — you do not need to retrieve it yourself.
 
-This endpoint automatically:
-- Retrieves the bot token from secure storage
+The daemon's `telegram_config set` handler automatically:
 - Validates the token by calling the Telegram `getMe` API
-- Stores the bot token with bot username metadata
+- Stores the bot token in secure storage with bot username metadata
 - Generates a webhook secret if one does not already exist
 - Triggers an immediate gateway webhook reconcile
-- Registers bot commands (`/new`)
 
-If the request fails, check the response body for an error message. If the token is invalid, tell the user and ask them to re-enter the token via the secure prompt (repeat Step 1).
-
-On success, check the `commandsRegistered` field in the response. Confirm to the user which commands were registered (e.g., "Registered bot commands: /new").
+If the token is invalid, the daemon returns an error. Tell the user and ask them to re-enter the token via the secure prompt.
 
 ### Step 3: Webhook Registration (Automatic)
 
@@ -59,7 +44,23 @@ Manual webhook registration is no longer required. The gateway automatically rec
 
 If the webhook secret changes (e.g., secret rotation), the gateway's credential watcher detects the change and re-registers the webhook automatically. If the ingress URL changes (e.g., tunnel restart), the assistant daemon triggers an immediate internal reconcile so the webhook re-registers automatically without a gateway restart.
 
-### Step 4: Verify Guardian Identity
+### Step 4: Register Bot Commands
+
+Send the `telegram_config` IPC message with `action: "set_commands"` to register the `/new` command:
+
+```json
+{
+  "type": "telegram_config",
+  "action": "set_commands",
+  "commands": [
+    { "command": "new", "description": "Start a new conversation" }
+  ]
+}
+```
+
+The daemon handles token retrieval from secure storage internally — you do not need to retrieve it yourself.
+
+### Step 5: Verify Guardian Identity
 
 Now link the user's Telegram account as the trusted guardian for this bot. Tell the user: "Now let's verify your guardian identity. This links your Telegram account as the trusted guardian for this bot."
 
@@ -78,11 +79,11 @@ The guardian-verify-setup skill manages the full outbound verification flow for 
 
 Tell the user: *"I've loaded the guardian verification guide. It will walk you through linking your Telegram account as the trusted guardian."*
 
-After the guardian-verify-setup skill completes (or the user skips), continue to Step 5.
+After the guardian-verify-setup skill completes (or the user skips), continue to Step 6.
 
-**Note:** Guardian verification is optional but recommended. If the user declines or wants to skip, proceed to Step 5 without blocking.
+**Note:** Guardian verification is optional but recommended. If the user declines or wants to skip, proceed to Step 6 without blocking.
 
-### Step 5: Validate Routing Configuration
+### Step 6: Validate Routing Configuration
 
 Verify that the gateway routing is configured to deliver inbound messages to the assistant:
 
@@ -91,25 +92,29 @@ Verify that the gateway routing is configured to deliver inbound messages to the
 
 If routing is misconfigured, inbound Telegram messages will be rejected and the gateway will send a visible notice to the chat explaining the issue (rate-limited to once per 5 minutes per chat).
 
-### Step 6: Verify Binding State
+### Step 7: Verify Binding State
 
 Before reporting success, confirm the guardian binding was actually created. Check the guardian binding status:
 
 ```bash
-curl -sf http://localhost:7821/v1/integrations/guardian/status?channel=telegram \
-  -H "Authorization: Bearer $(cat ~/.vellum/http-token)"
+TOKEN=$(cat ~/.vellum/http-token)
+curl -s http://localhost:7821/v1/integrations/guardian/status?channel=telegram \
+  -H "Authorization: Bearer $TOKEN"
 ```
 
 If the binding is absent and the user said they completed the verification:
 
 1. Tell the user the verification does not appear to have succeeded.
-2. Offer to re-run the guardian-verify-setup skill (repeat Step 4).
-3. Only proceed to Step 7 once binding state is confirmed or the user explicitly skips guardian verification.
+2. Offer to re-run the guardian-verify-setup skill (repeat Step 5).
+3. Only proceed to Step 8 once binding state is confirmed or the user explicitly skips guardian verification.
 
-### Step 7: Report Success
+### Step 8: Report Success
+
+First, retrieve the bot identity by sending a `telegram_config` IPC message with `action: "get"` and reading the `botUsername` field from the response.
 
 Summarize what was done:
-- Bot verified and credentials stored securely
+- Bot identity: @{botUsername}
+- Bot verified and credentials stored securely via daemon
 - Webhook registration: handled automatically by the gateway
 - Bot commands registered: /new
 - Guardian identity: {verified | not configured}
@@ -145,6 +150,6 @@ The following steps still require **manual** action:
 | Step | Details |
 |------|---------|
 | Bot token from @BotFather | User must create a bot and provide the token via secure prompt |
-| Bot configuration and command registration | Configured via the setup skill (Step 2 above) using the `/v1/integrations/telegram/setup` endpoint |
-| Guardian verification | Handled via the guardian-verify-setup skill using the outbound verification flow (Step 4 above) |
+| Bot command registration | Registered via the setup skill (Step 4 above) |
+| Guardian verification | Handled via the guardian-verify-setup skill using the outbound verification flow (Step 5 above) |
 | Multi-assistant routing | Requires manual `GATEWAY_ASSISTANT_ROUTING_JSON` configuration |

--- a/skills/twilio-setup/SKILL.md
+++ b/skills/twilio-setup/SKILL.md
@@ -18,6 +18,27 @@ This skill manages the full Twilio lifecycle:
 
 All operations go through the `twilio_config` IPC handler on the daemon, which validates inputs, stores credentials securely, and manages phone number state.
 
+### Multi-Assistant Setups
+
+In a multi-assistant environment (multiple assistants sharing the same daemon), some `twilio_config` actions are **assistant-scoped** while others are **global** (shared across all assistants):
+
+**Global actions** (ignore `assistantId` — credentials are shared across all assistants):
+- `set_credentials` — Stores Account SID and Auth Token in global secure storage (`credential:twilio:*` keys). All assistants share the same Twilio account credentials.
+- `clear_credentials` — Removes the globally stored Account SID and Auth Token. This affects all assistants.
+
+**Assistant-scoped actions** (use `assistantId` to scope phone number configuration per assistant):
+- `get` — Returns the phone number assigned to the specified assistant (falls back to the legacy global number if no per-assistant mapping exists).
+- `assign_number` — Assigns a phone number to a specific assistant via the per-assistant mapping.
+- `provision_number` — Provisions a new number and assigns it to the specified assistant.
+- `list_numbers` — Lists all phone numbers on the shared Twilio account (uses global credentials).
+
+Include `assistantId` in assistant-scoped actions whenever:
+- Multiple assistants share the same Twilio account but use different phone numbers
+- You want to ensure configuration changes only affect a specific assistant
+- The user has explicitly selected or referenced a particular assistant
+
+All IPC examples below include the optional `assistantId` field in assistant-scoped actions. Omit it in single-assistant setups. For global actions (`set_credentials`, `clear_credentials`), the `assistantId` field is accepted but ignored.
+
 ## Step 1: Check Current Configuration
 
 First, check whether Twilio is already configured by sending the `twilio_config` IPC message with `action: "get"`:
@@ -25,7 +46,8 @@ First, check whether Twilio is already configured by sending the `twilio_config`
 ```json
 {
   "type": "twilio_config",
-  "action": "get"
+  "action": "get",
+  "assistantId": "<optional — omit for single-assistant setups>"
 }
 ```
 
@@ -62,6 +84,8 @@ After both credentials are collected, retrieve them from secure storage and pass
 
 Both `accountSid` and `authToken` are required — the daemon validates the credentials against the Twilio API before storing them. If credentials are invalid, the daemon returns an error. Tell the user and ask them to re-enter via the secure prompt.
 
+**Note:** `set_credentials` is a global operation — credentials are stored once and shared across all assistants. The `assistantId` field is accepted but ignored.
+
 ## Step 3: Get a Phone Number
 
 The assistant needs a phone number to make calls and send SMS. There are two paths:
@@ -75,7 +99,8 @@ If the user wants to buy a new number through Twilio, send:
   "type": "twilio_config",
   "action": "provision_number",
   "areaCode": "415",
-  "country": "US"
+  "country": "US",
+  "assistantId": "<optional — omit for single-assistant setups>"
 }
 ```
 
@@ -100,7 +125,8 @@ If the user already has a Twilio phone number, first list available numbers:
 ```json
 {
   "type": "twilio_config",
-  "action": "list_numbers"
+  "action": "list_numbers",
+  "assistantId": "<optional — omit for single-assistant setups>"
 }
 ```
 
@@ -112,7 +138,8 @@ Then assign the chosen number:
 {
   "type": "twilio_config",
   "action": "assign_number",
-  "phoneNumber": "+14155551234"
+  "phoneNumber": "+14155551234",
+  "assistantId": "<optional — omit for single-assistant setups>"
 }
 ```
 
@@ -132,7 +159,8 @@ Then assign it through the IPC:
 {
   "type": "twilio_config",
   "action": "assign_number",
-  "phoneNumber": "+14155551234"
+  "phoneNumber": "+14155551234",
+  "assistantId": "<optional — omit for single-assistant setups>"
 }
 ```
 
@@ -231,7 +259,9 @@ If the user wants to disconnect Twilio, send:
 }
 ```
 
-This removes the stored Account SID and Auth Token. Your phone number assignment will be preserved. Voice calls and SMS will stop working until credentials are reconfigured.
+This removes the stored Account SID and Auth Token. Phone number assignments are preserved. Voice calls and SMS will stop working until credentials are reconfigured.
+
+**Note:** `clear_credentials` is a global operation — it removes credentials for all assistants, not just the current one. The `assistantId` field is accepted but ignored. In multi-assistant setups, warn the user that clearing credentials will affect all assistants sharing this Twilio account.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Add mirror parity test for vellum-skills ↔ skills/, update ARCHITECTURE.md with outbound guardian HTTP endpoints and chat-first orchestration flow, update README.md with guardian verification via chat references. Closes #9368.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
