### PR TITLE
fix: sort imports/exports to pass lint

### DIFF
--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
 import type { RuntimeAttachmentMetadata } from '../runtime/http-types.js';
 
 type DeliveryCall = {

--- a/assistant/src/__tests__/daemon-server-session-init.test.ts
+++ b/assistant/src/__tests__/daemon-server-session-init.test.ts
@@ -1,6 +1,7 @@
 import type * as net from 'node:net';
 
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
 import * as pendingInteractions from '../runtime/pending-interactions.js';
 
 interface MockMemoryPolicy {

--- a/assistant/src/runtime/routes/channel-delivery-routes.ts
+++ b/assistant/src/runtime/routes/channel-delivery-routes.ts
@@ -3,7 +3,7 @@
  * and post-decision delivery scheduling.
  */
 import * as channelDeliveryStore from '../../memory/channel-delivery-store.js';
-export { deliverReplyViaCallback, type DeliverReplyOptions } from '../channel-reply-delivery.js';
+export { type DeliverReplyOptions,deliverReplyViaCallback } from '../channel-reply-delivery.js';
 
 // ---------------------------------------------------------------------------
 // Dead letter management


### PR DESCRIPTION
## Summary
- Auto-fix import sorting in `channel-reply-delivery.test.ts` and `daemon-server-session-init.test.ts`
- Auto-fix export sorting in `channel-delivery-routes.ts`

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22426775616

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
