### PR TITLE
Refine Telegram notification copy guidance

### DIFF
--- a/assistant/src/__tests__/notification-telegram-adapter.test.ts
+++ b/assistant/src/__tests__/notification-telegram-adapter.test.ts
@@ -90,6 +90,24 @@ describe('TelegramAdapter', () => {
     expect(deliveryCalls[0]?.payload.text).toBe('Please check the oven now.');
   });
 
+  test('uses recipient-facing fallback text without channel or meta-send phrasing', async () => {
+    const adapter = new TelegramAdapter();
+    const payload = makePayload({
+      copy: {
+        title: 'Reminder',
+        body: 'Check the oven now!',
+      },
+    });
+
+    await adapter.send(payload, makeDestination());
+
+    const text = deliveryCalls[0]?.payload.text as string;
+    expect(text).toBe('Check the oven now!');
+    expect(text).not.toMatch(/via telegram/i);
+    expect(text).not.toMatch(/may i go ahead/i);
+    expect(text).not.toMatch(/i'd like to send/i);
+  });
+
   test('falls back to body/title/sourceEventName when richer text is unavailable', async () => {
     const adapter = new TelegramAdapter();
 

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -24,7 +24,7 @@ import type { NotificationChannel, NotificationDecision, RenderedChannelCopy } f
 const log = getLogger('notification-decision-engine');
 
 const DECISION_TIMEOUT_MS = 15_000;
-const PROMPT_VERSION = 'v2';
+const PROMPT_VERSION = 'v3';
 
 // ── System prompt ──────────────────────────────────────────────────────
 
@@ -60,7 +60,9 @@ function buildSystemPrompt(
     `- \`title\` and \`body\` are for native notification popups (e.g. vellum desktop/mobile) — keep them short and glanceable (title ≤ 8 words, body ≤ 2 sentences).`,
     `- \`deliveryText\` is the channel-native message for chat channels (e.g. telegram). It must read naturally as a standalone message.`,
     `  - Do not prepend mechanical labels like "Thread:".`,
+    `  - Do not mention channel or transport names (e.g. Telegram, SMS, email) unless the event context explicitly requires it.`,
     `  - Do not repeat title/body verbatim unless that repetition is truly necessary.`,
+    `  - Avoid meta-send phrasing (e.g. "I'd like to send a notification", "May I go ahead with that?"). Write the recipient-facing message directly.`,
     `  - For telegram: 1-2 concise sentences.`,
     `- \`threadSeedMessage\` is the opening message in the internal notification thread — it can be richer and more contextual.`,
     `  - For vellum (desktop): 2-4 short sentences with useful context and clear next step if action is required.`,


### PR DESCRIPTION
## Summary
- update notification decision prompt guidance for `deliveryText` to avoid unnecessary channel mention (e.g. "via Telegram") unless context requires it
- add prompt guidance to avoid meta-send phrasing (e.g. "I'd like to send a notification", "May I go ahead with that?") and write recipient-facing text directly
- bump prompt version to `v3`
- add Telegram adapter regression test asserting fallback outgoing text does not include channel or meta-send phrasing when unnecessary

## Validation
- `cd assistant && export PATH="$HOME/.bun/bin:$PATH" && bun test src/__tests__/notification-telegram-adapter.test.ts src/__tests__/notification-decision-strategy.test.ts`
- `cd assistant && export PATH="$HOME/.bun/bin:$PATH" && bun run lint src/notifications/decision-engine.ts src/__tests__/notification-telegram-adapter.test.ts`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
