### PR TITLE
fix(macos): move pin button to leading overlay for independent click handling

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -851,31 +851,14 @@ struct MainWindowView: View {
             }
         }) {
             HStack(spacing: VSpacing.xs) {
-                // Leading icon: pin button (hovered) > spinner (busy) > pin indicator (pinned)
-                if isHovered {
-                    Button {
-                        if thread.isPinned {
-                            threadManager.unpinThread(id: thread.id)
-                        } else {
-                            threadManager.pinThread(id: thread.id)
-                        }
-                    } label: {
-                        Image(systemName: thread.isPinned ? "pin.fill" : "pin")
-                            .font(.system(size: 10, weight: .medium))
-                            .foregroundColor(thread.isPinned ? VColor.textMuted : VColor.textSecondary)
-                            .rotationEffect(.degrees(-45))
-                            .frame(width: 20, height: 20)
-                            .background(VColor.backgroundSubtle)
-                            .clipShape(Circle())
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(thread.isPinned ? "Unpin \(thread.title)" : "Pin \(thread.title)")
-                } else if isBusy {
+                // Leading icon: spinner (busy) > pin indicator (pinned) > spacer
+                // The interactive pin button is in .overlay(alignment: .leading) below
+                // to avoid nesting a Button inside this outer Button's label.
+                if isBusy {
                     ProgressView()
                         .controlSize(.small)
                         .frame(width: 20, height: 20)
-                } else if thread.isPinned {
+                } else if thread.isPinned && !isHovered {
                     Image(systemName: "pin.fill")
                         .font(.system(size: 10, weight: .medium))
                         .foregroundColor(VColor.textMuted)
@@ -918,6 +901,29 @@ struct MainWindowView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .overlay(alignment: .leading) {
+            if isHovered {
+                Button {
+                    if thread.isPinned {
+                        threadManager.unpinThread(id: thread.id)
+                    } else {
+                        threadManager.pinThread(id: thread.id)
+                    }
+                } label: {
+                    Image(systemName: thread.isPinned ? "pin.fill" : "pin")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(thread.isPinned ? VColor.textMuted : VColor.textSecondary)
+                        .rotationEffect(.degrees(-45))
+                        .frame(width: 20, height: 20)
+                        .background(VColor.backgroundSubtle)
+                        .clipShape(Circle())
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .padding(.leading, VSpacing.xs)
+                .accessibilityLabel(thread.isPinned ? "Unpin \(thread.title)" : "Pin \(thread.title)")
+            }
+        }
         .overlay(alignment: .trailing) {
             if sidebar.threadPendingDeletion == thread.id {
                 Button {


### PR DESCRIPTION
Moves the interactive pin button from inside the outer thread-selection Button's label to a .overlay(alignment: .leading) modifier, matching the pattern used by the archive button. This ensures the pin button receives independent click events in SwiftUI instead of being intercepted by the outer button. Non-interactive indicators (spinner, static pin icon) remain in the label.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
