### PR TITLE
fix(macos): address review feedback on sidebar thread row spinner

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -392,6 +392,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             let viewModel = makeViewModel()
             viewModel.sessionId = thread.sessionId
             chatViewModels[id] = viewModel
+            subscribeToBusyState(for: id, viewModel: viewModel)
             evictStaleCachedViewModels()
         }
 


### PR DESCRIPTION
Addresses review feedback from PR #9382 on busy spinner and hover-aware pin/archive in sidebar thread rows.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
