### PR TITLE
fix(macos): address review feedback on VInfoTooltip accessibility

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VInfoTooltip.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VInfoTooltip.swift
@@ -28,6 +28,7 @@ public struct VInfoTooltip: View {
             .frame(width: 16, height: 16)
             .contentShape(Rectangle())
             .help(tooltip)
+            .accessibilityElement(children: .ignore)
             .accessibilityLabel(tooltip)
     }
 }


### PR DESCRIPTION
Addresses review feedback from PR #9355 on VInfoTooltip accessibility improvements.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
