### PR TITLE
fix: add JSON body to telegram setup curl command

### DIFF
--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -38,7 +38,8 @@ After the token is collected, call the composite setup endpoint which validates 
 ```bash
 curl -sf -X POST http://localhost:7821/v1/integrations/telegram/setup \
   -H "Authorization: Bearer $(cat ~/.vellum/http-token)" \
-  -H "Content-Type: application/json"
+  -H "Content-Type: application/json" \
+  -d '{}'
 ```
 
 This endpoint automatically:


### PR DESCRIPTION
Adds -d '{}' to the curl POST command for /v1/integrations/telegram/setup in skills/telegram-setup/SKILL.md to prevent 'Unexpected end of JSON input' when handleSetupTelegram parses the request body with req.json(). The vellum-skills copy uses IPC instead of curl, so only the skills/ version needed this fix. The sms-setup blank line issue (Devin feedback) does not exist on main — the blank line is already present.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
