### PR TITLE
fix: include senderIdentifier in thread seed context fallback keys

### DIFF
--- a/assistant/src/__tests__/thread-seed-composer.test.ts
+++ b/assistant/src/__tests__/thread-seed-composer.test.ts
@@ -371,6 +371,16 @@ describe('composeThreadSeed', () => {
       expect(seed.trim().length).toBeGreaterThan(0);
     });
 
+    test('uses context payload "senderIdentifier" for escalation events', () => {
+      const signal = makeSignal({
+        sourceEventName: 'ingress.escalation',
+        contextPayload: { senderIdentifier: 'Alice' },
+      });
+      const copy = makeCopy({ title: '', body: '' });
+      const seed = composeThreadSeed(signal, 'vellum' as NotificationChannel, copy);
+      expect(seed).toBe('Ingress escalation: Alice');
+    });
+
     test('prefers "message" over "summary" in context payload', () => {
       const signal = makeSignal({
         sourceEventName: 'test.event',

--- a/assistant/src/notifications/thread-seed-composer.ts
+++ b/assistant/src/notifications/thread-seed-composer.ts
@@ -85,7 +85,7 @@ function humanizeEventName(eventName: string): string {
  * Derive a fallback seed from signal metadata when rendered copy is blank.
  *
  * Extracts the most useful fields from `contextPayload` (common keys like
- * message, summary, body, preview, title, label, questionText) and combines
+ * message, summary, body, preview, senderIdentifier, title, label, questionText) and combines
  * them with a humanized event name. This ensures notification threads retain
  * usable audit context even when the decision engine produces empty copy.
  */
@@ -94,7 +94,7 @@ function buildContextFallback(signal: NotificationSignal): string {
   const payload = signal.contextPayload;
 
   // Try common payload keys in priority order
-  const candidateKeys = ['message', 'summary', 'body', 'preview', 'title', 'label', 'questionText', 'name'];
+  const candidateKeys = ['message', 'summary', 'body', 'preview', 'senderIdentifier', 'title', 'label', 'questionText', 'name'];
   for (const key of candidateKeys) {
     const val = payload[key];
     if (typeof val === 'string' && val.trim().length > 0) {


### PR DESCRIPTION
Addresses review feedback from PR #9260 (via PR #9389). Adds senderIdentifier to the candidateKeys list in buildContextFallback() so that ingress.escalation threads show who triggered the escalation when LLM copy is blank.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
