### PR TITLE
fix: guard hasNoClient reset against concurrent IPC client rebind

### DIFF
--- a/assistant/src/__tests__/daemon-server-session-init.test.ts
+++ b/assistant/src/__tests__/daemon-server-session-init.test.ts
@@ -31,6 +31,12 @@ let lastCreatedWorkingDir: string | undefined;
 let lastCreatedMemoryPolicy: MockMemoryPolicy | undefined;
 let lastCreateConversationArgs: unknown;
 
+// Module-level test hooks checked by MockSession.runAgentLoop. Using module
+// variables instead of class fields avoids the shadowing issue where class
+// field declarations create own-properties that mask prototype assignments.
+let mockConfirmationToEmitDuringLoop: Record<string, unknown> | undefined;
+let mockMidLoopCallback: ((session: MockSession) => void) | undefined;
+
 class MockSession {
   public readonly conversationId: string;
   public memoryPolicy: MockMemoryPolicy;
@@ -39,12 +45,11 @@ class MockSession {
   public lastUpdateClientSender: ((msg: Record<string, unknown>) => void) | undefined;
   public lastRunAgentLoopOptions: { skipPreMessageRollback?: boolean; isInteractive?: boolean } | undefined;
   public updateClientHistory: Array<{ hasNoClient: boolean }> = [];
-  /** When set, runAgentLoop will invoke onEvent with this message during execution. */
-  public confirmationToEmitDuringLoop: Record<string, unknown> | undefined;
   public setSandboxOverrideCalls = 0;
   private stale = false;
   private processing = false;
   public guardianContext: Record<string, unknown> | null = null;
+  private _currentSender: ((msg: Record<string, unknown>) => void) | undefined;
 
   constructor(
     conversationId: string,
@@ -69,6 +74,11 @@ class MockSession {
     this.lastUpdateClientSender = sender;
     this.lastUpdateClientHasNoClient = hasNoClient;
     this.updateClientHistory.push({ hasNoClient });
+    this._currentSender = sender;
+  }
+
+  getCurrentSender(): ((msg: Record<string, unknown>) => void) | undefined {
+    return this._currentSender;
   }
 
   setSandboxOverride(): void {
@@ -135,8 +145,11 @@ class MockSession {
     options?: { skipPreMessageRollback?: boolean; isInteractive?: boolean },
   ): Promise<void> {
     this.lastRunAgentLoopOptions = options;
-    if (this.confirmationToEmitDuringLoop) {
-      onEvent(this.confirmationToEmitDuringLoop);
+    if (mockConfirmationToEmitDuringLoop) {
+      onEvent(mockConfirmationToEmitDuringLoop);
+    }
+    if (mockMidLoopCallback) {
+      mockMidLoopCallback(this);
     }
     this.processing = false;
   }
@@ -297,6 +310,8 @@ describe('DaemonServer initial session hydration', () => {
     lastCreatedWorkingDir = undefined;
     lastCreatedMemoryPolicy = undefined;
     lastCreateConversationArgs = undefined;
+    mockConfirmationToEmitDuringLoop = undefined;
+    mockMidLoopCallback = undefined;
     pendingInteractions.clear();
   });
 
@@ -594,7 +609,7 @@ describe('DaemonServer initial session hydration', () => {
 
     // Pre-configure the mock to emit a confirmation_request during runAgentLoop,
     // simulating a tool requesting approval while the session is interactive.
-    MockSession.prototype.confirmationToEmitDuringLoop = {
+    mockConfirmationToEmitDuringLoop = {
       type: 'confirmation_request',
       requestId: 'req-interactive-1',
       toolName: 'notify_desktop',
@@ -614,7 +629,7 @@ describe('DaemonServer initial session hydration', () => {
       'telegram',
     );
 
-    MockSession.prototype.confirmationToEmitDuringLoop = undefined;
+    mockConfirmationToEmitDuringLoop = undefined;
 
     const session = internal.sessions.get(conversation.id);
     expect(session).toBeDefined();
@@ -636,5 +651,74 @@ describe('DaemonServer initial session hydration', () => {
     expect(interaction).toBeDefined();
     expect(interaction?.kind).toBe('confirmation');
     expect(interaction?.conversationId).toBe(conversation.id);
+  });
+
+  test('finally block does not overwrite IPC client that connected during interactive agent loop (processMessage)', async () => {
+    const server = new DaemonServer();
+    const internal = asDaemonServerTestAccess(server);
+
+    const ipcSender = (_msg: Record<string, unknown>) => {};
+
+    // Simulate a real IPC client connecting mid-loop by rebinding the session
+    // sender during runAgentLoop execution.
+    mockMidLoopCallback = (session) => {
+      session.updateClient(ipcSender, false);
+    };
+
+    await server.processMessage(
+      conversation.id,
+      'hello',
+      undefined,
+      { isInteractive: true },
+      'telegram',
+      'telegram',
+    );
+
+    mockMidLoopCallback = undefined;
+
+    const session = internal.sessions.get(conversation.id);
+    expect(session).toBeDefined();
+
+    // The finally block should NOT have reset the sender because the session's
+    // current sender was rebound to ipcSender mid-loop, which differs from the
+    // onEvent callback originally set for the interactive path.
+    expect(session!.getCurrentSender()).toBe(ipcSender);
+    expect(session!.lastUpdateClientHasNoClient).toBe(false);
+  });
+
+  test('finally block does not overwrite IPC client that connected during interactive agent loop (persistAndProcessMessage)', async () => {
+    const server = new DaemonServer();
+    const internal = asDaemonServerTestAccess(server);
+
+    const ipcSender = (_msg: Record<string, unknown>) => {};
+
+    // Simulate a real IPC client connecting mid-loop by rebinding the session
+    // sender during runAgentLoop execution.
+    mockMidLoopCallback = (session) => {
+      session.updateClient(ipcSender, false);
+    };
+
+    const { messageId } = await server.persistAndProcessMessage(
+      conversation.id,
+      'hello',
+      undefined,
+      { isInteractive: true },
+      'telegram',
+      'telegram',
+    );
+    expect(messageId).toBe('msg-1');
+
+    // persistAndProcessMessage fires the loop in the background; wait for it.
+    await new Promise((r) => setTimeout(r, 50));
+
+    mockMidLoopCallback = undefined;
+
+    const session = internal.sessions.get(conversation.id);
+    expect(session).toBeDefined();
+
+    // The finally block should NOT have reset the sender because the session's
+    // current sender was rebound to ipcSender mid-loop.
+    expect(session!.getCurrentSender()).toBe(ipcSender);
+    expect(session!.lastUpdateClientHasNoClient).toBe(false);
   });
 });

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -824,7 +824,9 @@ export class DaemonServer {
 
     session.runAgentLoop(content, messageId, onEvent, { isInteractive: options?.isInteractive ?? false })
       .finally(() => {
-        if (options?.isInteractive === true) {
+        // Only reset if no other caller (e.g. a real IPC client) has rebound
+        // the session's sender while the agent loop was running.
+        if (options?.isInteractive === true && session.getCurrentSender() === onEvent) {
           session.updateClient(() => {}, true);
         }
       })
@@ -931,7 +933,9 @@ export class DaemonServer {
         { isInteractive: options?.isInteractive ?? false },
       );
     } finally {
-      if (options?.isInteractive === true) {
+      // Only reset if no other caller (e.g. a real IPC client) has rebound
+      // the session's sender while the agent loop was running.
+      if (options?.isInteractive === true && session.getCurrentSender() === onEvent) {
         session.updateClient(() => {}, true);
       }
     }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -342,6 +342,11 @@ export class Session {
     this.traceEmitter.updateSender(sendToClient);
   }
 
+  /** Returns the current sendToClient reference for identity comparison. */
+  getCurrentSender(): (msg: ServerMessage) => void {
+    return this.sendToClient;
+  }
+
   setSandboxOverride(enabled: boolean | undefined): void {
     this.sandboxOverride = enabled;
   }


### PR DESCRIPTION
The finally blocks in persistAndProcessMessage and processMessage now check whether the session's client was re-bound by another connection before resetting. This prevents a real IPC client from being silently overwritten when the interactive HTTP agent loop completes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
