### PR TITLE
Fix interrogative guard for indirect informational questions

### DIFF
--- a/assistant/src/__tests__/recording-intent.test.ts
+++ b/assistant/src/__tests__/recording-intent.test.ts
@@ -271,6 +271,84 @@ describe('resolveRecordingIntent', () => {
     test('returns none for question about resume', () => {
       expect(resolveRecordingIntent('how do I resume recording?')).toEqual({ kind: 'none' });
     });
+
+    // ── Indirect informational patterns ───────────────────────────────────
+
+    test.each([
+      'can you tell me how to stop recording?',
+      'could you tell me how to stop recording?',
+      'would you tell me how to stop recording?',
+      'explain how to stop the recording',
+      'tell me how recording works',
+      'describe how screen recording works',
+      'show me how to record my screen',
+      'is there a way to stop recording?',
+      'is there a method to pause recording?',
+      'are there any ways to record my screen?',
+      "I'd like to know how to stop recording",
+      "I would like to know how to pause the recording",
+      'I want to know how to start recording',
+      'do you know how to start recording?',
+      'can I learn how to record my screen?',
+      'can you explain how to record my screen?',
+      'tell me about how screen recording works',
+      'explain to me how to stop recording',
+      'tell me what screen recording does',
+      'describe how to start a recording',
+      'please, tell me how to stop recording',
+      'hey, can you explain how to record my screen?',
+    ])('returns none for indirect informational question: "%s"', (text) => {
+      expect(resolveRecordingIntent(text)).toEqual({ kind: 'none' });
+    });
+
+    test('indirect informational with dynamic name returns none', () => {
+      expect(resolveRecordingIntent('Nova, can you tell me how to stop recording?', ['Nova'])).toEqual({ kind: 'none' });
+      expect(resolveRecordingIntent('Nova, explain how to record my screen', ['Nova'])).toEqual({ kind: 'none' });
+      expect(resolveRecordingIntent('hey Nova, is there a way to stop recording?', ['Nova'])).toEqual({ kind: 'none' });
+    });
+
+    // ── Polite imperatives that should still execute (NOT none) ──────────
+
+    test.each([
+      ['can you stop recording?', 'stop_only'],
+      ['could you record my screen?', 'start_only'],
+      ['can you pause the recording?', 'pause_only'],
+      ['would you resume recording?', 'resume_only'],
+      ['please stop recording', 'stop_only'],
+      ['can you start recording?', 'start_only'],
+      ['could you stop the recording please', 'stop_only'],
+    ] as const)('polite imperative "%s" resolves to %s (not none)', (text, expected) => {
+      expect(resolveRecordingIntent(text).kind).toBe(expected);
+    });
+  });
+
+  // ── Mixed-intent with remainder (regression coverage) ────────────────────
+
+  describe('mixed-intent with remainder', () => {
+    test('"stop recording and start a new one and open safari" → restart_with_remainder', () => {
+      const result = resolveRecordingIntent('stop recording and start a new one and open safari');
+      expect(result.kind).toBe('restart_with_remainder');
+      if (result.kind === 'restart_with_remainder') {
+        expect(result.remainder).toContain('open safari');
+      }
+    });
+
+    test('"record my screen and open Chrome and go to google.com" → start_with_remainder', () => {
+      const result = resolveRecordingIntent('record my screen and open Chrome and go to google.com');
+      expect(result.kind).toBe('start_with_remainder');
+      if (result.kind === 'start_with_remainder') {
+        expect(result.remainder).toContain('open Chrome');
+        expect(result.remainder).toContain('google.com');
+      }
+    });
+
+    test('"stop recording and send the file to Bob" → stop_with_remainder', () => {
+      const result = resolveRecordingIntent('stop recording and send the file to Bob');
+      expect(result.kind).toBe('stop_with_remainder');
+      if (result.kind === 'stop_with_remainder') {
+        expect(result.remainder).toContain('send the file to Bob');
+      }
+    });
   });
 
   // ── Dynamic names ──────────────────────────────────────────────────────────

--- a/assistant/src/daemon/recording-intent.ts
+++ b/assistant/src/daemon/recording-intent.ts
@@ -307,12 +307,46 @@ function hasSubstantiveContent(text: string, dynamicNames?: string[]): boolean {
 const WH_INTERROGATIVE = /^\s*(how|what|why|when|where|who|which)\b/i;
 
 /**
+ * Indirect informational patterns that indicate the user is asking *about*
+ * recording rather than commanding a recording action. These catch prompts
+ * where the WH-word is buried after polite filler or an informational verb:
+ *
+ * - "can you tell me how to stop recording?"
+ * - "explain how to stop the recording"
+ * - "is there a way to stop recording?"
+ * - "I'd like to know how to pause the recording"
+ * - "do you know how to start recording?"
+ *
+ * Critical: these must NOT match polite imperatives like "can you stop
+ * recording?" — the key distinction is the intermediary informational
+ * verb/phrase (tell/explain/describe/show + how, "is there a way", etc.).
+ */
+const INDIRECT_INFORMATIONAL_PATTERNS: RegExp[] = [
+  // "tell me how...", "can you explain how...", "show me how..."
+  /^\s*(can\s+you\s+|could\s+you\s+|would\s+you\s+)?(tell|explain|describe|show)\s+(me\s+)?how\b/i,
+  // "is there a way to...", "are there any ways to..."
+  /^\s*(is\s+there|are\s+there)\s+(a\s+|any\s+)?(ways?|methods?|options?|means)\s+to\b/i,
+  // "I'd like to know...", "I want to know..."
+  /^\s*(i('d|\s+would)\s+like\s+to\s+know|i\s+want\s+to\s+know)\b/i,
+  // "do you know how to...", "can I learn how to..."
+  /^\s*(do\s+you\s+know\s+how|can\s+i\s+learn(\s+how)?)\s+to\b/i,
+  // Bare informational verbs at start: "explain how...", "tell me how..."
+  /^\s*(explain|describe)\s+(to\s+me\s+)?how\b/i,
+  // "tell me about..." (informational, not imperative)
+  /^\s*(tell|explain|describe|show)\s+(me\s+)?(about\s+)?(how|what|why|when|where)\b/i,
+];
+
+/**
  * Returns true if the text appears to be a question about recording rather
  * than an imperative command that includes recording.
  *
  * "how do I stop recording?" → true  (question — don't trigger side effects)
+ * "can you tell me how to stop recording?" → true  (informational — don't trigger)
+ * "explain how to stop the recording" → true  (informational — don't trigger)
+ * "is there a way to stop recording?" → true  (capability question — don't trigger)
  * "open Chrome and record my screen" → false  (command — trigger recording)
  * "can you record my screen?" → false  (polite imperative — trigger recording)
+ * "can you stop recording?" → false  (polite imperative — trigger stop)
  */
 function isInterrogative(text: string, dynamicNames?: string[]): boolean {
   let cleaned = text;
@@ -321,7 +355,19 @@ function isInterrogative(text: string, dynamicNames?: string[]): boolean {
   }
   // Strip polite prefixes that don't change interrogative status
   cleaned = cleaned.replace(/^\s*(hey|hi|hello|please|pls|plz)[,\s]+/i, '');
-  return WH_INTERROGATIVE.test(cleaned);
+
+  // Direct WH-questions (how/what/why/when/where/who/which)
+  if (WH_INTERROGATIVE.test(cleaned)) {
+    return true;
+  }
+
+  // Indirect informational patterns — checked on cleaned text after
+  // stripping polite prefixes, so "please tell me how..." is caught
+  if (INDIRECT_INFORMATIONAL_PATTERNS.some((p) => p.test(cleaned))) {
+    return true;
+  }
+
+  return false;
 }
 
 // ─── Unified classification ─────────────────────────────────────────────────
@@ -392,8 +438,9 @@ export function resolveRecordingIntent(
   // Step 2: Strip leading polite wrappers for normalization
   normalized = normalized.replace(/^\s*(hey|hi|hello|please|pls|plz)[,\s]+/i, '');
 
-  // Step 3: Interrogative gate — WH-questions are not commands
-  if (WH_INTERROGATIVE.test(normalized)) {
+  // Step 3: Interrogative gate — questions (WH-words and indirect
+  // informational patterns) are not commands
+  if (isInterrogative(normalized, dynamicNames)) {
     return { kind: 'none' };
   }
 


### PR DESCRIPTION
Strengthens the interrogative detector to catch indirect informational patterns like 'can you tell me how to stop recording?' and 'explain how to stop the recording' while preserving polite imperatives like 'can you stop recording?'. Adds comprehensive test coverage for interrogative detection and mixed-intent remainder handling.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
