### PR TITLE
Add guarded LLM fallback stage for recording intent

### DIFF
--- a/assistant/src/__tests__/recording-intent-fallback.test.ts
+++ b/assistant/src/__tests__/recording-intent-fallback.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+let mockProvider: object | null = null;
+let llmResponseText = '';
+
+mock.module('../providers/provider-send-message.js', () => ({
+  getConfiguredProvider: () => mockProvider,
+  createTimeout: (ms: number) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ms);
+    return {
+      signal: controller.signal,
+      cleanup: () => clearTimeout(timer),
+    };
+  },
+  extractText: (response: { content: Array<{ type: string; text?: string }> }) => {
+    const block = response.content.find((b) => b.type === 'text');
+    return block && 'text' in block ? (block.text ?? '').trim() : '';
+  },
+  userMessage: (text: string) => ({ role: 'user', content: [{ type: 'text', text }] }),
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    debug: () => {},
+    error: () => {},
+  }),
+}));
+
+import {
+  classifyRecordingIntentFallback,
+  containsRecordingKeywords,
+  type RecordingFallbackResult,
+} from '../daemon/recording-intent-fallback.js';
+
+beforeEach(() => {
+  mockProvider = null;
+  llmResponseText = '';
+});
+
+function setMockProvider(responseText: string) {
+  llmResponseText = responseText;
+  mockProvider = {
+    sendMessage: async () => ({
+      content: [{ type: 'text' as const, text: llmResponseText }],
+      model: 'test-model',
+      stopReason: 'end_turn',
+      usage: { inputTokens: 0, outputTokens: 0 },
+    }),
+  };
+}
+
+function setMockProviderThatThrows() {
+  mockProvider = {
+    sendMessage: async () => {
+      throw new Error('LLM call failed');
+    },
+  };
+}
+
+// ─── Module exports ──────────────────────────────────────────────────────────
+
+describe('recording-intent-fallback exports', () => {
+  test('exports classifyRecordingIntentFallback function', () => {
+    expect(typeof classifyRecordingIntentFallback).toBe('function');
+  });
+
+  test('exports containsRecordingKeywords function', () => {
+    expect(typeof containsRecordingKeywords).toBe('function');
+  });
+});
+
+// ─── containsRecordingKeywords ───────────────────────────────────────────────
+
+describe('containsRecordingKeywords', () => {
+  test.each([
+    'can you record this',
+    'start a recording please',
+    'I want screen capture',
+    'do a screencast of this',
+    'capture my screen now',
+    'how does screen rec work',
+  ])('returns true for text containing recording keyword: "%s"', (text) => {
+    expect(containsRecordingKeywords(text)).toBe(true);
+  });
+
+  test.each([
+    'hello world',
+    'open Safari',
+    'take a screenshot',
+    'what time is it?',
+    'start the timer',
+    'play a song',
+  ])('returns false for text without recording keywords: "%s"', (text) => {
+    expect(containsRecordingKeywords(text)).toBe(false);
+  });
+});
+
+// ─── classifyRecordingIntentFallback ─────────────────────────────────────────
+
+describe('classifyRecordingIntentFallback', () => {
+  test('returns safe default when no provider is configured', async () => {
+    mockProvider = null;
+    const result = await classifyRecordingIntentFallback('record this please');
+    expect(result).toEqual({ action: 'none', confidence: 'low' });
+  });
+
+  test('returns safe default when LLM call throws', async () => {
+    setMockProviderThatThrows();
+    const result = await classifyRecordingIntentFallback('record this please');
+    expect(result).toEqual({ action: 'none', confidence: 'low' });
+  });
+
+  test('parses valid start response', async () => {
+    setMockProvider('{"action": "start", "confidence": "high"}');
+    const result = await classifyRecordingIntentFallback('kick off a recording');
+    expect(result).toEqual({ action: 'start', confidence: 'high' });
+  });
+
+  test('parses valid stop response', async () => {
+    setMockProvider('{"action": "stop", "confidence": "high"}');
+    const result = await classifyRecordingIntentFallback('end the recording now');
+    expect(result).toEqual({ action: 'stop', confidence: 'high' });
+  });
+
+  test('parses valid none response for questions', async () => {
+    setMockProvider('{"action": "none", "confidence": "high"}');
+    const result = await classifyRecordingIntentFallback('how do I record my screen?');
+    expect(result).toEqual({ action: 'none', confidence: 'high' });
+  });
+
+  test('handles medium confidence correctly', async () => {
+    setMockProvider('{"action": "start", "confidence": "medium"}');
+    const result = await classifyRecordingIntentFallback('maybe record something');
+    expect(result).toEqual({ action: 'start', confidence: 'medium' });
+  });
+
+  test('handles JSON embedded in surrounding text', async () => {
+    setMockProvider('Here is my classification: {"action": "restart", "confidence": "high"} based on the input.');
+    const result = await classifyRecordingIntentFallback('restart the recording');
+    expect(result).toEqual({ action: 'restart', confidence: 'high' });
+  });
+
+  test('returns safe default for malformed JSON response', async () => {
+    setMockProvider('this is not json at all');
+    const result = await classifyRecordingIntentFallback('record something');
+    expect(result).toEqual({ action: 'none', confidence: 'low' });
+  });
+
+  test('returns safe default for invalid action in response', async () => {
+    setMockProvider('{"action": "explode", "confidence": "high"}');
+    const result = await classifyRecordingIntentFallback('record something');
+    expect(result).toEqual({ action: 'none', confidence: 'low' });
+  });
+
+  test('returns safe default for missing confidence field', async () => {
+    setMockProvider('{"action": "start"}');
+    const result = await classifyRecordingIntentFallback('record something');
+    expect(result).toEqual({ action: 'none', confidence: 'low' });
+  });
+
+  test('returns safe default for empty response', async () => {
+    setMockProvider('');
+    const result = await classifyRecordingIntentFallback('record something');
+    expect(result).toEqual({ action: 'none', confidence: 'low' });
+  });
+
+  test('correctly classifies pause action', async () => {
+    setMockProvider('{"action": "pause", "confidence": "high"}');
+    const result = await classifyRecordingIntentFallback('hold the recording');
+    expect(result).toEqual({ action: 'pause', confidence: 'high' });
+  });
+
+  test('correctly classifies resume action', async () => {
+    setMockProvider('{"action": "resume", "confidence": "high"}');
+    const result = await classifyRecordingIntentFallback('continue the recording');
+    expect(result).toEqual({ action: 'resume', confidence: 'high' });
+  });
+});

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -318,6 +318,12 @@ export async function handleTaskSubmit(
                 sessionId: activeSessionId,
               });
               ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+
+              // If recording was rejected (e.g. already active), unbind the
+              // socket so it doesn't stay bound to an orphaned conversation.
+              if (execResult.recordingStarted === false) {
+                ctx.socketToSession.delete(socket);
+              }
               return;
             }
           }

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -22,6 +22,7 @@ import type {
   TaskSubmit,
 } from '../ipc-protocol.js';
 import { executeRecordingIntent } from '../recording-executor.js';
+import { classifyRecordingIntentFallback, containsRecordingKeywords } from '../recording-intent-fallback.js';
 import { resolveRecordingIntent } from '../recording-intent.js';
 import { buildSessionErrorMessage,classifySessionError } from '../session-error.js';
 import { handleCuSessionCreate } from './computer-use.js';
@@ -279,7 +280,49 @@ export async function handleTaskSubmit(
         rlog.info({ remaining: intentResult.remainder }, 'Recording intent deferred, continuing with remaining text');
       }
 
-      // 'none' falls through to normal processing
+      // 'none' — deterministic resolver found nothing; try LLM fallback
+      // if the text contains recording-related keywords.
+      if (intentResult.kind === 'none' && containsRecordingKeywords(msg.task)) {
+        const fallback = await classifyRecordingIntentFallback(msg.task);
+        rlog.info({ fallbackAction: fallback.action, fallbackConfidence: fallback.confidence }, 'Recording intent LLM fallback result');
+
+        if (fallback.action !== 'none' && fallback.confidence === 'high') {
+          const kindMap: Record<string, import('../recording-intent.js').RecordingIntentResult> = {
+            start: { kind: 'start_only' },
+            stop: { kind: 'stop_only' },
+            restart: { kind: 'restart_only' },
+            pause: { kind: 'pause_only' },
+            resume: { kind: 'resume_only' },
+          };
+          const mapped = kindMap[fallback.action];
+          if (mapped) {
+            let activeSessionId = ctx.socketToSession.get(socket);
+            if (!activeSessionId) {
+              const conversation = conversationStore.createConversation(msg.task);
+              activeSessionId = conversation.id;
+              ctx.socketToSession.set(socket, activeSessionId);
+            }
+
+            const execResult = executeRecordingIntent(mapped, {
+              conversationId: activeSessionId,
+              socket,
+              ctx,
+            });
+
+            if (execResult.handled) {
+              rlog.info({ kind: mapped.kind, source: 'llm_fallback' }, 'Recording intent intercepted via LLM fallback');
+              ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
+              ctx.send(socket, {
+                type: 'assistant_text_delta',
+                text: execResult.responseText!,
+                sessionId: activeSessionId,
+              });
+              ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+              return;
+            }
+          }
+        }
+      }
     }
 
     // Slash candidates always route to text_qa — bypass classifier

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -35,6 +35,7 @@ import type {
 } from '../ipc-protocol.js';
 import { normalizeThreadType } from '../ipc-protocol.js';
 import { executeRecordingIntent } from '../recording-executor.js';
+import { classifyRecordingIntentFallback, containsRecordingKeywords } from '../recording-intent-fallback.js';
 import { resolveRecordingIntent } from '../recording-intent.js';
 import { buildSessionErrorMessage,classifySessionError } from '../session-error.js';
 import { generateVideoThumbnail } from '../video-thumbnail.js';
@@ -343,7 +344,41 @@ export async function handleUserMessage(
         rlog.info({ remaining: msg.content, kind: intentResult.kind }, 'Recording intent with remainder — continuing with remaining text');
       }
 
-      // 'none' falls through to normal processing
+      // 'none' — deterministic resolver found nothing; try LLM fallback
+      // if the text contains recording-related keywords.
+      if (intentResult.kind === 'none' && containsRecordingKeywords(messageText)) {
+        const fallback = await classifyRecordingIntentFallback(messageText);
+        rlog.info({ fallbackAction: fallback.action, fallbackConfidence: fallback.confidence }, 'Recording intent LLM fallback result');
+
+        if (fallback.action !== 'none' && fallback.confidence === 'high') {
+          const kindMap: Record<string, import('../recording-intent.js').RecordingIntentResult> = {
+            start: { kind: 'start_only' },
+            stop: { kind: 'stop_only' },
+            restart: { kind: 'restart_only' },
+            pause: { kind: 'pause_only' },
+            resume: { kind: 'resume_only' },
+          };
+          const mapped = kindMap[fallback.action];
+          if (mapped) {
+            const execResult = executeRecordingIntent(mapped, {
+              conversationId: msg.sessionId,
+              socket,
+              ctx,
+            });
+
+            if (execResult.handled) {
+              rlog.info({ kind: mapped.kind, source: 'llm_fallback' }, 'Recording intent intercepted via LLM fallback');
+              ctx.send(socket, {
+                type: 'assistant_text_delta',
+                text: execResult.responseText!,
+                sessionId: msg.sessionId,
+              });
+              ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+              return;
+            }
+          }
+        }
+      }
     }
 
     dispatchUserMessage(

--- a/assistant/src/daemon/recording-intent-fallback.ts
+++ b/assistant/src/daemon/recording-intent-fallback.ts
@@ -1,0 +1,132 @@
+// LLM-based fallback classifier for recording intent detection.
+// Fires only when the deterministic resolver returns `none` but the text
+// contains recording-related keywords that suggest an intent the regex missed.
+// Safety: returns `{ action: 'none', confidence: 'low' }` on any failure —
+// never triggers a recording action on error.
+
+import { createTimeout, extractText, getConfiguredProvider, userMessage } from '../providers/provider-send-message.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('recording-intent-fallback');
+
+const FALLBACK_TIMEOUT_MS = 5000;
+
+export type RecordingFallbackAction = 'start' | 'stop' | 'restart' | 'pause' | 'resume' | 'none';
+
+export interface RecordingFallbackResult {
+  action: RecordingFallbackAction;
+  confidence: 'high' | 'medium' | 'low';
+}
+
+const SAFE_DEFAULT: RecordingFallbackResult = { action: 'none', confidence: 'low' };
+
+/** Keywords that gate whether we spend an LLM call on fallback classification. */
+const RECORDING_KEYWORDS = [
+  'record',
+  'recording',
+  'screen capture',
+  'screencast',
+  'capture screen',
+  'capture my screen',
+  'screen rec',
+];
+
+const SYSTEM_PROMPT =
+  'You are classifying user messages for a screen recording assistant. ' +
+  'Determine if the user wants to: start a recording, stop a recording, restart a recording, ' +
+  'pause a recording, resume a recording, or none of these. ' +
+  'Only classify as an action if the user is giving an imperative command. ' +
+  'Questions about recording (e.g., "how do I record?", "what does recording do?") should be classified as "none". ' +
+  'Respond with a JSON object: {"action": "start|stop|restart|pause|resume|none", "confidence": "high|medium|low"}';
+
+const VALID_ACTIONS = new Set<RecordingFallbackAction>(['start', 'stop', 'restart', 'pause', 'resume', 'none']);
+const VALID_CONFIDENCES = new Set<string>(['high', 'medium', 'low']);
+
+/**
+ * Returns true if the text contains any recording-related keywords,
+ * indicating it is worth spending an LLM call on fallback classification.
+ */
+export function containsRecordingKeywords(text: string): boolean {
+  const lower = text.toLowerCase();
+  return RECORDING_KEYWORDS.some((kw) => lower.includes(kw));
+}
+
+/**
+ * Uses a lightweight LLM call to classify whether text contains a recording intent
+ * that the deterministic resolver missed.
+ *
+ * Returns `{ action: 'none', confidence: 'high' }` for informational questions.
+ * Only returns an actionable result with 'high' confidence for clear imperative commands.
+ */
+export async function classifyRecordingIntentFallback(
+  text: string,
+): Promise<RecordingFallbackResult> {
+  const provider = getConfiguredProvider();
+  if (!provider) {
+    log.debug('No configured provider available for fallback classification');
+    return SAFE_DEFAULT;
+  }
+
+  try {
+    const { signal, cleanup } = createTimeout(FALLBACK_TIMEOUT_MS);
+    try {
+      const response = await provider.sendMessage(
+        [userMessage(text)],
+        [], // no tools
+        SYSTEM_PROMPT,
+        {
+          config: {
+            modelIntent: 'latency-optimized',
+            max_tokens: 64,
+          },
+          signal,
+        },
+      );
+      cleanup();
+
+      const raw = extractText(response);
+      return parseClassificationResponse(raw);
+    } finally {
+      cleanup();
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn({ err: message }, 'LLM fallback classification failed');
+    return SAFE_DEFAULT;
+  }
+}
+
+/**
+ * Parse the LLM's JSON response into a validated RecordingFallbackResult.
+ * Returns safe default on any parse/validation failure.
+ */
+function parseClassificationResponse(raw: string): RecordingFallbackResult {
+  try {
+    // Extract JSON from the response — the LLM may include surrounding text
+    const jsonMatch = raw.match(/\{[^}]*\}/);
+    if (!jsonMatch) {
+      log.debug({ raw }, 'No JSON object found in LLM fallback response');
+      return SAFE_DEFAULT;
+    }
+
+    const parsed = JSON.parse(jsonMatch[0]) as { action?: string; confidence?: string };
+
+    const action = parsed.action as RecordingFallbackAction | undefined;
+    const confidence = parsed.confidence;
+
+    if (!action || !VALID_ACTIONS.has(action)) {
+      log.debug({ raw, action }, 'Invalid action in LLM fallback response');
+      return SAFE_DEFAULT;
+    }
+
+    if (!confidence || !VALID_CONFIDENCES.has(confidence)) {
+      log.debug({ raw, confidence }, 'Invalid confidence in LLM fallback response');
+      return SAFE_DEFAULT;
+    }
+
+    return { action, confidence: confidence as RecordingFallbackResult['confidence'] };
+  } catch (err) {
+    log.debug({ err, raw }, 'Failed to parse LLM fallback response as JSON');
+    return SAFE_DEFAULT;
+  }
+}


### PR DESCRIPTION
Adds a secondary LLM-based classification for recording intents that the deterministic resolver misses. Only executes on high-confidence imperative commands. Includes pre-filter to avoid unnecessary LLM calls and comprehensive safety gates.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
