### PR TITLE
fix: wait for macOS app build to complete before launching

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -196,7 +196,12 @@ PY
    fi
    ```
 
-8. Build and launch the macOS app from source with gateway pinned to local `gateway/`:
+8. Build the macOS app from source synchronously (wait for build to complete before launching to avoid opening a stale build), then launch with file-watching in the background:
+   ```bash
+   REPO_ROOT="$(pwd)"
+   cd clients/macos && VELLUM_GATEWAY_DIR="$REPO_ROOT/gateway" ./build.sh
+   ```
+
    ```bash
    REPO_ROOT="$(pwd)"
    cd clients/macos && VELLUM_GATEWAY_DIR="$REPO_ROOT/gateway" ./build.sh run &


### PR DESCRIPTION
## Summary
- Split the update command's macOS app step into two phases: a synchronous build followed by a backgrounded launch+watch
- Prevents opening a stale .app bundle while the new build is still compiling
- The second `./build.sh run` invocation sees cached artifacts so it skips the rebuild and just launches + enters watch mode

## Original prompt
in our update command, wait to open the mac app until its fully done rebuilding and we're confident that we're not opening a stale build

🤖 Generated with [Claude Code](https://claude.com/claude-code)