### PR TITLE
fix: accept conversation_seen_signal in IPC validator

### DIFF
--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -70,6 +70,7 @@
     "channel_readiness",
     "confirmation_response",
     "conversation_search",
+    "conversation_seen_signal",
     "cu_observation",
     "cu_session_abort",
     "cu_session_create",


### PR DESCRIPTION
## Summary\n- regenerate IPC contract inventory snapshot to include `conversation_seen_signal` in `clientWireTypes`\n- unblocks daemon-side message validation that was rejecting the new seen signal\n\n## Validation\n- `bun run ipc:inventory`\n- `bun test src/__tests__/ipc-validate.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
