### PR TITLE
fix: show unseen indicator for all unread assistant replies

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -866,7 +866,7 @@ struct MainWindowView: View {
                         .frame(width: 20, height: 20)
                         .background(VColor.backgroundSubtle)
                         .clipShape(Circle())
-                } else if thread.source == "notification" && thread.hasUnseenLatestAssistantMessage {
+                } else if thread.hasUnseenLatestAssistantMessage {
                     Circle()
                         .fill(Color.accentColor)
                         .frame(width: 8, height: 8)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -64,6 +64,11 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     private var activeViewModelCancellable: AnyCancellable?
     /// Subscriptions to per-thread busy-state changes (isSending, isThinking, pendingQueuedCount).
     private var busyStateCancellables: [UUID: Set<AnyCancellable>] = [:]
+    /// Subscription to the latest assistant message ID per thread.
+    /// Used to mark inactive threads as unseen when a new assistant reply arrives.
+    private var assistantActivityCancellables: [UUID: AnyCancellable] = [:]
+    /// Last observed assistant message ID per thread.
+    private var latestAssistantMessageIds: [UUID: UUID] = [:]
     /// Cached set of thread IDs whose ChatViewModel indicates active processing.
     @Published private(set) var busyThreadIds: Set<UUID> = []
 
@@ -135,6 +140,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         threads.insert(thread, at: 0)
         chatViewModels[thread.id] = viewModel
         subscribeToBusyState(for: thread.id, viewModel: viewModel)
+        subscribeToAssistantActivity(for: thread.id, viewModel: viewModel)
         touchVMAccessOrder(thread.id)
         evictStaleCachedViewModels()
         activeThreadId = thread.id
@@ -154,6 +160,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         threads.insert(thread, at: 0)
         chatViewModels[thread.id] = viewModel
         subscribeToBusyState(for: thread.id, viewModel: viewModel)
+        subscribeToAssistantActivity(for: thread.id, viewModel: viewModel)
         touchVMAccessOrder(thread.id)
         evictStaleCachedViewModels()
         activeThreadId = thread.id
@@ -183,6 +190,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         threads.insert(thread, at: 0)
         chatViewModels[thread.id] = viewModel
         subscribeToBusyState(for: thread.id, viewModel: viewModel)
+        subscribeToAssistantActivity(for: thread.id, viewModel: viewModel)
         touchVMAccessOrder(thread.id)
         evictStaleCachedViewModels()
 
@@ -209,6 +217,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         threads.insert(thread, at: 0)
         chatViewModels[thread.id] = viewModel
         subscribeToBusyState(for: thread.id, viewModel: viewModel)
+        subscribeToAssistantActivity(for: thread.id, viewModel: viewModel)
         touchVMAccessOrder(thread.id)
         evictStaleCachedViewModels()
 
@@ -397,6 +406,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             viewModel.sessionId = thread.sessionId
             chatViewModels[id] = viewModel
             subscribeToBusyState(for: id, viewModel: viewModel)
+            subscribeToAssistantActivity(for: id, viewModel: viewModel)
             evictStaleCachedViewModels()
         }
 
@@ -554,6 +564,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     func setChatViewModel(_ vm: ChatViewModel, for threadId: UUID) {
         chatViewModels[threadId] = vm
         subscribeToBusyState(for: threadId, viewModel: vm)
+        subscribeToAssistantActivity(for: threadId, viewModel: vm)
         touchVMAccessOrder(threadId)
         evictStaleCachedViewModels()
         // Re-subscribe if this is the active view model
@@ -747,6 +758,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
         chatViewModels[threadId] = viewModel
         subscribeToBusyState(for: threadId, viewModel: viewModel)
+        subscribeToAssistantActivity(for: threadId, viewModel: viewModel)
         touchVMAccessOrder(threadId)
         evictStaleCachedViewModels()
         return viewModel
@@ -851,9 +863,39 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         busyStateCancellables[threadId] = subs
     }
 
+    /// Subscribe to the latest assistant message ID for a thread.
+    /// When it changes and the thread is not active, mark that thread unseen.
+    private func subscribeToAssistantActivity(for threadId: UUID, viewModel: ChatViewModel) {
+        assistantActivityCancellables[threadId]?.cancel()
+        if let latestAssistantMessageId = viewModel.messages.reversed().first(where: { $0.role == .assistant })?.id {
+            latestAssistantMessageIds[threadId] = latestAssistantMessageId
+        } else {
+            latestAssistantMessageIds.removeValue(forKey: threadId)
+        }
+
+        assistantActivityCancellables[threadId] = viewModel.messageManager.$messages
+            .map { $0.reversed().first(where: { $0.role == .assistant })?.id }
+            .removeDuplicates()
+            .sink { [weak self] latestAssistantMessageId in
+                guard let self else { return }
+                let previousAssistantMessageId = self.latestAssistantMessageIds[threadId]
+                if let latestAssistantMessageId {
+                    self.latestAssistantMessageIds[threadId] = latestAssistantMessageId
+                } else {
+                    self.latestAssistantMessageIds.removeValue(forKey: threadId)
+                }
+                guard previousAssistantMessageId != latestAssistantMessageId,
+                      latestAssistantMessageId != nil else { return }
+                self.handleAssistantMessageArrival(threadId: threadId)
+            }
+    }
+
     /// Remove busy-state subscriptions for a thread (e.g. on archive/close).
     private func unsubscribeFromBusyState(for threadId: UUID) {
         busyStateCancellables.removeValue(forKey: threadId)
+        assistantActivityCancellables[threadId]?.cancel()
+        assistantActivityCancellables.removeValue(forKey: threadId)
+        latestAssistantMessageIds.removeValue(forKey: threadId)
         busyThreadIds.remove(threadId)
     }
 
@@ -876,5 +918,20 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
             }
+    }
+
+    /// Mark assistant activity on a thread as seen/unseen depending on whether
+    /// that thread is currently active.
+    private func handleAssistantMessageArrival(threadId: UUID) {
+        guard let index = threads.firstIndex(where: { $0.id == threadId }) else { return }
+        updateLastInteracted(threadId: threadId)
+        if threadId == activeThreadId {
+            threads[index].hasUnseenLatestAssistantMessage = false
+            if let sessionId = threads[index].sessionId {
+                emitConversationSeenSignal(conversationId: sessionId)
+            }
+        } else {
+            threads[index].hasUnseenLatestAssistantMessage = true
+        }
     }
 }

--- a/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class ThreadManagerUnseenStateTests: XCTestCase {
+
+    private var daemonClient: DaemonClient!
+    private var threadManager: ThreadManager!
+    private var sentMessages: [Any] = []
+
+    override func setUp() {
+        super.setUp()
+        daemonClient = DaemonClient()
+        daemonClient.isConnected = true
+        daemonClient.sendOverride = { [weak self] message in
+            self?.sentMessages.append(message)
+        }
+        threadManager = ThreadManager(daemonClient: daemonClient)
+    }
+
+    override func tearDown() {
+        daemonClient?.sendOverride = nil
+        threadManager = nil
+        daemonClient = nil
+        sentMessages = []
+        super.tearDown()
+    }
+
+    func testInactiveStandardThreadMarkedUnseenWhenAssistantReplies() {
+        guard let initialThreadId = threadManager.activeThreadId else {
+            XCTFail("Expected an initial active thread")
+            return
+        }
+        threadManager.chatViewModel(for: initialThreadId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
+
+        threadManager.createThread()
+        let activeThreadId = threadManager.activeThreadId
+        XCTAssertNotEqual(initialThreadId, activeThreadId)
+
+        guard let vm = threadManager.chatViewModel(for: initialThreadId) else {
+            XCTFail("Expected ChatViewModel for inactive thread")
+            return
+        }
+
+        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Background reply")))
+        vm.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+
+        waitForPropagation()
+
+        guard let updated = threadManager.threads.first(where: { $0.id == initialThreadId }) else {
+            XCTFail("Expected thread to exist")
+            return
+        }
+
+        XCTAssertNil(updated.source, "Regression guard: should work for normal (non-notification) threads")
+        XCTAssertTrue(updated.hasUnseenLatestAssistantMessage)
+    }
+
+    func testActiveThreadAssistantReplyClearsUnseenAndEmitsSeenSignal() {
+        guard let threadId = threadManager.activeThreadId,
+              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }),
+              let vm = threadManager.chatViewModel(for: threadId) else {
+            XCTFail("Expected active thread and view model")
+            return
+        }
+
+        threadManager.threads[index].sessionId = "session-active"
+        threadManager.threads[index].hasUnseenLatestAssistantMessage = true
+        vm.sessionId = "session-active"
+
+        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Visible reply", sessionId: "session-active")))
+        vm.handleServerMessage(.messageComplete(MessageCompleteMessage(sessionId: "session-active")))
+
+        waitForPropagation()
+
+        XCTAssertFalse(threadManager.threads[index].hasUnseenLatestAssistantMessage)
+
+        let seenSignals = sentMessages.compactMap { $0 as? IPCConversationSeenSignal }
+        XCTAssertEqual(seenSignals.last?.conversationId, "session-active")
+    }
+
+    private func waitForPropagation() {
+        let exp = expectation(description: "combine propagation")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+    }
+}


### PR DESCRIPTION
## Summary
- remove the mac sidebar gate that only rendered the blue unseen dot for `notification` threads
- add per-thread assistant-reply observers in `ThreadManager` so any new assistant reply on an inactive thread marks it unseen
- keep active-thread replies marked seen and emit `conversation_seen_signal` so daemon attention state stays in sync
- add regression tests for inactive-thread unseen marking and active-thread seen signaling

## Testing
- `swift test --filter ThreadManagerUnseenStateTests` (from `clients/macos`)

Apple refs checked (2026-02-26): no new Apple APIs adopted; change is state-flow logic only within existing SwiftUI/Combine patterns.