### PR TITLE
docs: correct SKILL.md cross-thread stop behavior description

### DIFF
--- a/assistant/src/config/bundled-skills/screen-recording/SKILL.md
+++ b/assistant/src/config/bundled-skills/screen-recording/SKILL.md
@@ -124,7 +124,7 @@ The remainder preserves the user's original phrasing (stripping is applied to th
 
 1. **Do not invoke computer use** for recording-only requests. The daemon handles these directly.
 2. **One recording at a time.** If a recording is already active, starting another returns an "already recording" message.
-3. **Conversation-scoped.** Each recording is linked to the conversation that started it. Stopping in a different thread does not affect unrelated recordings.
+3. **Conversation-linked.** Each recording is linked to the conversation that started it for attachment purposes. However, since only one recording can be active at a time, stop commands from any conversation will stop the active recording regardless of which conversation started it.
 4. **Permission required.** Screen recording requires macOS Screen Recording permission. If denied, the user sees actionable guidance to enable it in System Settings.
 5. **Mixed-intent prompts** (recording + other task) are NOT intercepted by the standalone route — the recording action is deferred and executed alongside the task.
 6. **Restart always reopens the source picker** and requires source reselection.


### PR DESCRIPTION
SKILL.md incorrectly stated that stopping in a different thread does not affect unrelated recordings. The daemon actually has a global fallback that resolves stop to the active recording regardless of which conversation started it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
