### PR TITLE
fix: add missing mock exports to recording test files

### DIFF
--- a/assistant/src/__tests__/recording-intent-handler.test.ts
+++ b/assistant/src/__tests__/recording-intent-handler.test.ts
@@ -199,6 +199,9 @@ mock.module('../daemon/handlers/computer-use.js', () => ({
 
 mock.module('../providers/provider-send-message.js', () => ({
   getConfiguredProvider: () => null,
+  extractText: (_response: unknown) => '',
+  createTimeout: (_ms: number) => ({ signal: new AbortController().signal, cleanup: () => {} }),
+  userMessage: (text: string) => ({ role: 'user', content: text }),
 }));
 
 // ── Mock external conversation store ───────────────────────────────────────

--- a/assistant/src/__tests__/recording-intent.test.ts
+++ b/assistant/src/__tests__/recording-intent.test.ts
@@ -601,6 +601,7 @@ describe('executeRecordingIntent', () => {
     handleRecordingRestart: mockHandleRecordingRestart,
     handleRecordingPause: mockHandleRecordingPause,
     handleRecordingResume: mockHandleRecordingResume,
+    isRecordingIdle: () => true,
   }));
 
   // Dynamically import so the mock takes effect
@@ -732,7 +733,7 @@ describe('executeRecordingIntent', () => {
     });
   });
 
-  test('start_and_stop_with_remainder → returns not handled with remainder and pendingRestart', () => {
+  test('start_and_stop_with_remainder → returns not handled with remainder and pendingStart when idle', () => {
     const result = executeRecordingIntent(
       { kind: 'start_and_stop_with_remainder', remainder: 'open Safari' },
       mockContext,
@@ -740,7 +741,7 @@ describe('executeRecordingIntent', () => {
     expect(result).toEqual({
       handled: false,
       remainderText: 'open Safari',
-      pendingRestart: true,
+      pendingStart: true,
     });
   });
 


### PR DESCRIPTION
Two test files had stale mocks after the LLM fallback module (recording-intent-fallback.ts) was added. The provider-send-message mock was missing extractText/createTimeout/userMessage exports, and the recording handlers mock was missing isRecordingIdle. Both caused bun module resolution errors. Also fixed a test expectation for start_and_stop_with_remainder to match the implementation (pendingStart when idle, not pendingRestart).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
