### PR TITLE
fix: defer recording start until stop-ack to prevent restart race

### DIFF
--- a/assistant/src/__tests__/recording-state-machine.test.ts
+++ b/assistant/src/__tests__/recording-state-machine.test.ts
@@ -142,7 +142,7 @@ describe('handleRecordingRestart', () => {
     mockMessageIdCounter = 0;
   });
 
-  test('stops current recording and starts a new one with operation token', () => {
+  test('sends recording_stop and defers start until stop-ack', () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = 'conv-restart-1';
     ctx.socketToSession.set(fakeSocket, conversationId);
@@ -158,14 +158,25 @@ describe('handleRecordingRestart', () => {
     expect(result.operationToken).toBeTruthy();
     expect(result.responseText).toBe('Restarting screen recording.');
 
-    // Should have sent: recording_stop, recording_start
+    // Should have sent only recording_stop (start is deferred)
     const stopMsgs = sent.filter((m) => m.type === 'recording_stop');
     const startMsgs = sent.filter((m) => m.type === 'recording_start');
     expect(stopMsgs).toHaveLength(1);
-    expect(startMsgs).toHaveLength(1);
+    expect(startMsgs).toHaveLength(0);
 
-    // The new recording_start should have the operation token
-    expect(startMsgs[0].operationToken).toBe(result.operationToken);
+    // Simulate the client acknowledging the stop
+    const stoppedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: originalId!,
+      status: 'stopped',
+      attachToConversationId: conversationId,
+    };
+    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+
+    // NOW the deferred recording_start should have been sent
+    const startMsgsAfterAck = sent.filter((m) => m.type === 'recording_start');
+    expect(startMsgsAfterAck).toHaveLength(1);
+    expect(startMsgsAfterAck[0].operationToken).toBe(result.operationToken);
   });
 
   test('returns "no active recording" with reason when nothing is recording', () => {
@@ -184,8 +195,17 @@ describe('handleRecordingRestart', () => {
     ctx.socketToSession.set(fakeSocket, conversationId);
 
     // First restart cycle
-    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    const originalId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
     const result1 = handleRecordingRestart(conversationId, fakeSocket, ctx);
+
+    // Simulate the stop-ack to trigger the deferred start
+    const stoppedStatus1: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: originalId!,
+      status: 'stopped',
+      attachToConversationId: conversationId,
+    };
+    recordingHandlers.recording_status(stoppedStatus1, fakeSocket, ctx);
 
     // Simulate the first restart completing (started status)
     const startMsg1 = sent.filter((m) => m.type === 'recording_start').pop();
@@ -220,11 +240,20 @@ describe('restart_cancelled status', () => {
     ctx.socketToSession.set(fakeSocket, conversationId);
 
     // Start -> restart
-    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    const originalId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
     const restartResult = handleRecordingRestart(conversationId, fakeSocket, ctx);
     expect(restartResult.initiated).toBe(true);
 
-    // Get the new recording ID from the recording_start message
+    // Simulate the stop-ack to trigger the deferred start
+    const stoppedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: originalId!,
+      status: 'stopped',
+      attachToConversationId: conversationId,
+    };
+    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+
+    // Get the new recording ID from the deferred recording_start message
     const startMsg = sent.filter((m) => m.type === 'recording_start').pop();
     sent.length = 0;
 
@@ -259,10 +288,22 @@ describe('restart_cancelled status', () => {
     const conversationId = 'conv-cancel-cleanup';
     ctx.socketToSession.set(fakeSocket, conversationId);
 
-    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    const originalId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
     const restartResult = handleRecordingRestart(conversationId, fakeSocket, ctx);
 
-    // Before cancel: not idle (mid-restart)
+    // Before stop-ack: not idle (mid-restart)
+    expect(isRecordingIdle()).toBe(false);
+
+    // Simulate the stop-ack to trigger the deferred start
+    const stoppedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: originalId!,
+      status: 'stopped',
+      attachToConversationId: conversationId,
+    };
+    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+
+    // Still not idle — the new recording has started
     expect(isRecordingIdle()).toBe(false);
 
     const startMsg = sent.filter((m) => m.type === 'recording_start').pop();
@@ -296,9 +337,18 @@ describe('stale completion guard (operation token)', () => {
     ctx.socketToSession.set(fakeSocket, conversationId);
 
     // Start recording -> restart (creates operation token)
-    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    const originalId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
     const restartResult = handleRecordingRestart(conversationId, fakeSocket, ctx);
     expect(restartResult.initiated).toBe(true);
+
+    // Simulate the stop-ack to trigger the deferred start
+    const stoppedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: originalId!,
+      status: 'stopped',
+      attachToConversationId: conversationId,
+    };
+    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
 
     const startMsg = sent.filter((m) => m.type === 'recording_start').pop();
     sent.length = 0;
@@ -325,8 +375,17 @@ describe('stale completion guard (operation token)', () => {
     const conversationId = 'conv-matching-1';
     ctx.socketToSession.set(fakeSocket, conversationId);
 
-    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    const originalId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
     const restartResult = handleRecordingRestart(conversationId, fakeSocket, ctx);
+
+    // Simulate the stop-ack to trigger the deferred start
+    const stoppedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: originalId!,
+      status: 'stopped',
+      attachToConversationId: conversationId,
+    };
+    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
 
     const startMsg = sent.filter((m) => m.type === 'recording_start').pop();
 
@@ -381,15 +440,24 @@ describe('stale completion guard (operation token)', () => {
     const conversationId = 'conv-ghost-1';
     ctx.socketToSession.set(fakeSocket, conversationId);
 
-    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    const originalId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
 
-    // Restart cleans up old state atomically before starting new
+    // Restart sends stop and defers start until stop-ack
     const restartResult = handleRecordingRestart(conversationId, fakeSocket, ctx);
     expect(restartResult.initiated).toBe(true);
 
+    // Simulate the stop-ack to trigger the deferred start
+    const stoppedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: originalId!,
+      status: 'stopped',
+      attachToConversationId: conversationId,
+    };
+    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+
     // The new recording should be active (not the old one)
     const startMsgs = sent.filter((m) => m.type === 'recording_start');
-    expect(startMsgs.length).toBeGreaterThanOrEqual(2); // original + restart
+    expect(startMsgs.length).toBeGreaterThanOrEqual(2); // original + deferred restart
 
     // The last recording_start should have the operation token
     const lastStart = startMsgs[startMsgs.length - 1];
@@ -488,7 +556,7 @@ describe('isRecordingIdle', () => {
     expect(isRecordingIdle()).toBe(false);
   });
 
-  test('returns false when mid-restart (between stop and start confirmation)', () => {
+  test('returns false when mid-restart (between stop-ack and start confirmation)', () => {
     const { ctx, fakeSocket } = createCtx();
     const conversationId = 'conv-idle-restart';
     ctx.socketToSession.set(fakeSocket, conversationId);
@@ -496,7 +564,8 @@ describe('isRecordingIdle', () => {
     handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
     handleRecordingRestart(conversationId, fakeSocket, ctx);
 
-    // Mid-restart: there IS an active recording (the new one) AND a pending restart
+    // Mid-restart: the old recording maps are still present AND there's a
+    // pending restart, so the system is not idle
     expect(isRecordingIdle()).toBe(false);
   });
 
@@ -505,8 +574,17 @@ describe('isRecordingIdle', () => {
     const conversationId = 'conv-idle-complete';
     ctx.socketToSession.set(fakeSocket, conversationId);
 
-    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    const originalId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
     const restartResult = handleRecordingRestart(conversationId, fakeSocket, ctx);
+
+    // Simulate the stop-ack to trigger the deferred start
+    const stoppedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: originalId!,
+      status: 'stopped',
+      attachToConversationId: conversationId,
+    };
+    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
 
     // Simulate the new recording starting
     const startMsg = sent.filter((m) => m.type === 'recording_start').pop();
@@ -532,13 +610,13 @@ describe('executeRecordingIntent — restart/pause/resume', () => {
     __resetRecordingState();
   });
 
-  test('restart_only executes actual restart', () => {
+  test('restart_only executes actual restart (deferred start)', () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = 'conv-exec-restart';
     ctx.socketToSession.set(fakeSocket, conversationId);
 
     // Start a recording first
-    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    const originalId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
     sent.length = 0;
 
     const result = executeRecordingIntent(
@@ -549,11 +627,24 @@ describe('executeRecordingIntent — restart/pause/resume', () => {
     expect(result.handled).toBe(true);
     expect(result.responseText).toBe('Restarting screen recording.');
 
-    // Should have sent stop + start
+    // Should have sent only stop (start is deferred until stop-ack)
     const stopMsgs = sent.filter((m) => m.type === 'recording_stop');
     const startMsgs = sent.filter((m) => m.type === 'recording_start');
     expect(stopMsgs).toHaveLength(1);
-    expect(startMsgs).toHaveLength(1);
+    expect(startMsgs).toHaveLength(0);
+
+    // Simulate the stop-ack to trigger the deferred start
+    const stoppedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: originalId!,
+      status: 'stopped',
+      attachToConversationId: conversationId,
+    };
+    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+
+    // NOW the deferred start should have been sent
+    const startMsgsAfterAck = sent.filter((m) => m.type === 'recording_start');
+    expect(startMsgsAfterAck).toHaveLength(1);
   });
 
   test('restart_only returns "no active recording" when idle', () => {
@@ -699,13 +790,46 @@ describe('failure during restart', () => {
     mockMessageIdCounter = 0;
   });
 
-  test('failed status during restart clears pending restart state', () => {
+  test('failed status during restart clears pending restart state (old recording fails)', () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = 'conv-fail-restart';
     ctx.socketToSession.set(fakeSocket, conversationId);
 
-    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    const originalId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    handleRecordingRestart(conversationId, fakeSocket, ctx);
+    sent.length = 0;
+
+    // Simulate the old recording failing to stop (before stop-ack)
+    const failedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: originalId!,
+      status: 'failed',
+      error: 'Permission denied',
+      attachToConversationId: conversationId,
+    };
+    recordingHandlers.recording_status(failedStatus, fakeSocket, ctx);
+
+    // Restart state and deferred restart should be cleaned up
+    expect(getActiveRestartToken()).toBeNull();
+    expect(isRecordingIdle()).toBe(true);
+  });
+
+  test('failed status during restart clears state (new recording fails after deferred start)', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-fail-restart-new';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    const originalId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
     const restartResult = handleRecordingRestart(conversationId, fakeSocket, ctx);
+
+    // Simulate the stop-ack to trigger the deferred start
+    const stoppedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: originalId!,
+      status: 'stopped',
+      attachToConversationId: conversationId,
+    };
+    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
 
     const startMsg = sent.filter((m) => m.type === 'recording_start').pop();
     sent.length = 0;
@@ -757,7 +881,7 @@ describe('start_and_stop_only fallback to plain start when idle', () => {
     expect(startMsgs).toHaveLength(1);
   });
 
-  test('goes through restart when a recording is active', () => {
+  test('goes through restart when a recording is active (deferred start)', () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = 'conv-stop-start-active';
     ctx.socketToSession.set(fakeSocket, conversationId);
@@ -777,11 +901,24 @@ describe('start_and_stop_only fallback to plain start when idle', () => {
     expect(result.recordingStarted).toBe(true);
     expect(result.responseText).toBe('Stopping current recording and starting a new one.');
 
-    // Should have sent both stop and start (restart flow)
+    // Should have sent only stop (start is deferred until stop-ack)
     const stopMsgs = sent.filter((m) => m.type === 'recording_stop');
     const startMsgs = sent.filter((m) => m.type === 'recording_start');
     expect(stopMsgs).toHaveLength(1);
-    expect(startMsgs).toHaveLength(1);
+    expect(startMsgs).toHaveLength(0);
+
+    // Simulate the stop-ack to trigger the deferred start
+    const stoppedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: originalId!,
+      status: 'stopped',
+      attachToConversationId: conversationId,
+    };
+    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+
+    // NOW the deferred start should have been sent
+    const startMsgsAfterAck = sent.filter((m) => m.type === 'recording_start');
+    expect(startMsgsAfterAck).toHaveLength(1);
   });
 });
 
@@ -824,5 +961,77 @@ describe('start_and_stop_with_remainder fallback to plain start when idle', () =
     expect(result.pendingRestart).toBe(true);
     expect(result.pendingStart).toBeUndefined();
     expect(result.remainderText).toBe('do something');
+  });
+});
+
+// ─── Deferred restart race condition tests ───────────────────────────────────
+
+describe('deferred restart prevents race condition', () => {
+  beforeEach(() => {
+    __resetRecordingState();
+    mockMessages.length = 0;
+    mockMessageIdCounter = 0;
+  });
+
+  test('recording_start is NOT sent until client acks the stop', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-deferred-race';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    sent.length = 0;
+
+    handleRecordingRestart(conversationId, fakeSocket, ctx);
+
+    // Only recording_stop should have been sent — no recording_start yet
+    expect(sent.filter((m) => m.type === 'recording_stop')).toHaveLength(1);
+    expect(sent.filter((m) => m.type === 'recording_start')).toHaveLength(0);
+
+    // System is mid-restart — not idle
+    expect(isRecordingIdle()).toBe(false);
+  });
+
+  test('stop-ack timeout cleans up deferred restart state', () => {
+    // This test uses a real timer via bun's jest-compatible API
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-deferred-timeout';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    handleRecordingRestart(conversationId, fakeSocket, ctx);
+
+    // Mid-restart: not idle
+    expect(isRecordingIdle()).toBe(false);
+
+    // We cannot easily test the setTimeout firing here without mocking timers,
+    // but we can verify the state is correctly set up for the timeout to clean up.
+    expect(getActiveRestartToken()).not.toBeNull();
+  });
+
+  test('normal stop (non-restart) does not trigger deferred start', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-normal-stop';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    const recordingId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    expect(recordingId).not.toBeNull();
+
+    // Manually stop (not via restart)
+    handleRecordingStop(conversationId, ctx);
+    sent.length = 0;
+
+    // Simulate stop-ack without file path (e.g. very short recording)
+    const stoppedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: recordingId!,
+      status: 'stopped',
+      attachToConversationId: conversationId,
+    };
+    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+
+    // Should NOT have sent a recording_start (no deferred restart pending)
+    const startMsgs = sent.filter((m) => m.type === 'recording_start');
+    expect(startMsgs).toHaveLength(0);
+    expect(isRecordingIdle()).toBe(true);
   });
 });

--- a/assistant/src/__tests__/recording-state-machine.test.ts
+++ b/assistant/src/__tests__/recording-state-machine.test.ts
@@ -1043,6 +1043,38 @@ describe('deferred restart prevents race condition', () => {
     const startMsgs = sent.filter((m) => m.type === 'recording_start');
     expect(startMsgs).toHaveLength(1);
     expect(startMsgs[0].operationToken).toBe(result.operationToken);
+
+    // The new recording is owned by B (the requester). Simulate the client
+    // confirming the new recording started. The 'started' status resolves
+    // conversationId to B, so pendingRestartByConversation must have been
+    // migrated from A to B for the restart cycle to complete.
+    const newRecordingId = startMsgs[0].recordingId as string;
+    const startedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: newRecordingId,
+      status: 'started',
+      operationToken: result.operationToken,
+      attachToConversationId: convB,
+    };
+    recordingHandlers.recording_status(startedStatus, fakeSocket, ctx);
+
+    // Restart cycle must be fully complete: activeRestartToken cleared
+    expect(getActiveRestartToken()).toBeNull();
+
+    // Not idle yet because the new recording is still running
+    expect(isRecordingIdle()).toBe(false);
+
+    // Stop the new recording and verify system returns to idle
+    handleRecordingStop(convB, ctx);
+    const newStoppedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: newRecordingId,
+      status: 'stopped',
+      attachToConversationId: convB,
+    };
+    recordingHandlers.recording_status(newStoppedStatus, fakeSocket, ctx);
+
+    expect(isRecordingIdle()).toBe(true);
   });
 
   test('normal stop (non-restart) does not trigger deferred start', () => {

--- a/assistant/src/__tests__/recording-state-machine.test.ts
+++ b/assistant/src/__tests__/recording-state-machine.test.ts
@@ -1008,6 +1008,43 @@ describe('deferred restart prevents race condition', () => {
     expect(getActiveRestartToken()).not.toBeNull();
   });
 
+  test('cross-conversation restart: conversation B restarts recording owned by A', () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const convA = 'conv-owner-A';
+    const convB = 'conv-requester-B';
+    ctx.socketToSession.set(fakeSocket, convA);
+
+    // Conversation A starts a recording
+    const originalId = handleRecordingStart(convA, undefined, fakeSocket, ctx);
+    expect(originalId).not.toBeNull();
+    sent.length = 0;
+
+    // Conversation B requests a restart (cross-conversation via global fallback)
+    const result = handleRecordingRestart(convB, fakeSocket, ctx);
+    expect(result.initiated).toBe(true);
+    expect(result.operationToken).toBeTruthy();
+
+    // Should have sent recording_stop (start is deferred)
+    expect(sent.filter((m) => m.type === 'recording_stop')).toHaveLength(1);
+    expect(sent.filter((m) => m.type === 'recording_start')).toHaveLength(0);
+
+    // Simulate the client acknowledging the stop. The stopped status resolves
+    // conversationId from standaloneRecordingConversationId which maps to A.
+    const stoppedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: originalId!,
+      status: 'stopped',
+      attachToConversationId: convA,
+    };
+    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+
+    // The deferred recording_start MUST have been triggered even though the
+    // stopped callback resolved to conversation A (owner), not B (requester).
+    const startMsgs = sent.filter((m) => m.type === 'recording_start');
+    expect(startMsgs).toHaveLength(1);
+    expect(startMsgs[0].operationToken).toBe(result.operationToken);
+  });
+
   test('normal stop (non-restart) does not trigger deferred start', () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = 'conv-normal-stop';

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -46,6 +46,22 @@ let activeRestartToken: string | null = null;
  *  is only returned when the state is truly idle (not mid-restart). */
 const pendingRestartByConversation = new Map<string, string>();
 
+/** Deferred restart parameters stored when a restart is initiated. The actual
+ *  recording_start is sent only after the client acknowledges the stop (via a
+ *  'stopped' status callback), preventing the race where the macOS client's
+ *  async stop hasn't completed when the start arrives. */
+interface DeferredRestartParams {
+  conversationId: string;
+  socket: net.Socket;
+  ctx: HandlerContext;
+  operationToken: string;
+}
+
+/** Maps conversationId -> deferred restart parameters. Populated by
+ *  handleRecordingRestart, consumed by the 'stopped' branch of
+ *  handleRecordingStatus. */
+const deferredRestartByConversation = new Map<string, DeferredRestartParams>();
+
 // ─── Start ───────────────────────────────────────────────────────────────────
 
 /**
@@ -150,6 +166,16 @@ export function handleRecordingStop(
     pendingStopTimeouts.delete(recordingId);
     log.warn({ recordingId, conversationId: ownerConversationId, timeoutMs: STOP_ACK_TIMEOUT_MS }, 'Stop-acknowledgement timeout fired — cleaning up stale recording state');
     cleanupMaps(recordingId, ownerConversationId);
+
+    // Clean up any deferred restart that was waiting for this stop-ack
+    if (deferredRestartByConversation.has(ownerConversationId)) {
+      deferredRestartByConversation.delete(ownerConversationId);
+      pendingRestartByConversation.delete(ownerConversationId);
+      if (pendingRestartByConversation.size === 0) {
+        activeRestartToken = null;
+      }
+      log.warn({ recordingId, conversationId: ownerConversationId }, 'Deferred restart cleaned up due to stop-ack timeout');
+    }
   }, STOP_ACK_TIMEOUT_MS);
   pendingStopTimeouts.set(recordingId, timeoutHandle);
 
@@ -171,18 +197,23 @@ export interface RecordingRestartResult {
 }
 
 /**
- * Restart the active recording: stop the current one, then start a new one
- * with `promptForSource: true` (client reopens source picker).
+ * Restart the active recording: stop the current one, then defer starting a
+ * new one until the client acknowledges the stop via a 'stopped' status
+ * callback.
+ *
+ * This prevents a race condition where the macOS client processes
+ * recording_stop asynchronously — if recording_start arrives before the
+ * async stop completes, RecordingManager.start() rejects because state is
+ * still active.
  *
  * Uses an operation token to guard against stale async completions from
  * a previous restart cycle. The token is:
  * 1. Generated here and stored as `activeRestartToken`
- * 2. Threaded through to the new `recording_start` message
- * 3. Validated when `recording_status` callbacks arrive
+ * 2. Stored in `deferredRestartByConversation` for later use
+ * 3. Threaded through to the new `recording_start` message when the stop ack arrives
+ * 4. Validated when `recording_status` callbacks arrive
  *
- * If the picker is closed/canceled during restart, the client sends a
- * `restart_cancelled` status and the daemon emits a deterministic response
- * (never "new recording started").
+ * If the stop fails or times out, the deferred restart state is cleaned up.
  */
 export function handleRecordingRestart(
   conversationId: string,
@@ -220,45 +251,17 @@ export function handleRecordingRestart(
   activeRestartToken = operationToken;
   pendingRestartByConversation.set(conversationId, operationToken);
 
-  // Resolve the actual owner conversation ID. When conversation B requests
-  // a restart but the recording is owned by conversation A, the stop above
-  // used the global fallback to find A's recording. We need to pass A's
-  // conversationId to cleanupMaps so it can delete the correct map entry.
-  let ownerConversationId = conversationId;
-  if (recordingOwnerByConversation.get(conversationId) !== stoppedRecordingId && recordingOwnerByConversation.size > 0) {
-    const [activeConv, activeRec] = [...recordingOwnerByConversation.entries()][0];
-    if (activeRec === stoppedRecordingId) {
-      ownerConversationId = activeConv;
-      log.info({ conversationId, ownerConversationId, stoppedRecordingId }, 'Resolved restart cleanup to actual owner conversation');
-    }
-  }
-
-  // Immediately clean up the old recording maps so the start call
-  // doesn't hit the "already active" guard. The stop command has already
-  // been sent; we clean maps here to ensure atomic stop/start handoff.
-  cleanupMaps(stoppedRecordingId, ownerConversationId);
-  cancelStopTimeout(stoppedRecordingId);
-
-  // Start a new recording with the operation token
-  const newRecordingId = handleRecordingStart(
+  // Store the deferred restart parameters. The actual recording_start will
+  // be sent when the 'stopped' status callback arrives in handleRecordingStatus,
+  // ensuring the client has fully completed the async stop before we start.
+  deferredRestartByConversation.set(conversationId, {
     conversationId,
-    { promptForSource: true },
     socket,
     ctx,
     operationToken,
-  );
+  });
 
-  if (!newRecordingId) {
-    // Start failed (shouldn't happen after cleanup, but defensive)
-    activeRestartToken = null;
-    pendingRestartByConversation.delete(conversationId);
-    return {
-      initiated: false,
-      responseText: 'Failed to restart recording.',
-    };
-  }
-
-  log.info({ conversationId, operationToken, oldRecordingId: stoppedRecordingId, newRecordingId }, 'Recording restart initiated');
+  log.info({ conversationId, operationToken, stoppedRecordingId }, 'Recording restart initiated — start deferred until stop-ack');
 
   return {
     initiated: true,
@@ -494,6 +497,38 @@ async function handleRecordingStatus(
       // aren't blocked by thumbnail generation or attachment processing.
       cleanupMaps(recordingId, conversationId);
 
+      // Check for a deferred restart: if handleRecordingRestart stored
+      // pending start parameters for this conversation, trigger the start
+      // now that the client has fully completed the async stop.
+      const deferred = deferredRestartByConversation.get(conversationId);
+      if (deferred) {
+        deferredRestartByConversation.delete(conversationId);
+
+        log.info({ recordingId, conversationId, operationToken: deferred.operationToken }, 'Stop-ack received — triggering deferred restart start');
+
+        const newRecordingId = handleRecordingStart(
+          deferred.conversationId,
+          { promptForSource: true },
+          deferred.socket,
+          deferred.ctx,
+          deferred.operationToken,
+        );
+
+        if (!newRecordingId) {
+          // Start failed — clean up restart state
+          activeRestartToken = null;
+          pendingRestartByConversation.delete(conversationId);
+          log.warn({ conversationId }, 'Deferred restart start failed after stop-ack');
+        } else {
+          log.info({ conversationId, newRecordingId, operationToken: deferred.operationToken }, 'Deferred restart recording started');
+        }
+
+        // Skip normal file-attachment flow for the old recording during
+        // a restart — the user initiated a stop+start cycle, not a
+        // deliberate "stop and save".
+        break;
+      }
+
       // Finalize: attach the recording file to the conversation
       if (msg.filePath) {
         // Restrict accepted file paths to the app's recordings directory to
@@ -663,6 +698,8 @@ async function handleRecordingStatus(
       cleanupMaps(recordingId, conversationId);
 
       // If this failure was part of a restart cycle, clear restart state
+      // including any deferred start that will never fire
+      deferredRestartByConversation.delete(conversationId);
       if (pendingRestartByConversation.has(conversationId)) {
         pendingRestartByConversation.delete(conversationId);
         if (pendingRestartByConversation.size === 0) {
@@ -698,6 +735,7 @@ export function cleanupRecordingsOnDisconnect(
       standaloneRecordingConversationId.delete(recId);
       recordingOwnerByConversation.delete(convId);
       pendingRestartByConversation.delete(convId);
+      deferredRestartByConversation.delete(convId);
     }
   }
   // Clear restart token if all pending restarts were cleaned up
@@ -717,6 +755,7 @@ export function __resetRecordingState(): void {
   standaloneRecordingConversationId.clear();
   recordingOwnerByConversation.clear();
   pendingRestartByConversation.clear();
+  deferredRestartByConversation.clear();
   activeRestartToken = null;
 }
 

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -52,8 +52,6 @@ const pendingRestartByConversation = new Map<string, string>();
  *  async stop hasn't completed when the start arrives. */
 interface DeferredRestartParams {
   conversationId: string;
-  socket: net.Socket;
-  ctx: HandlerContext;
   operationToken: string;
 }
 
@@ -269,8 +267,6 @@ export function handleRecordingRestart(
   // conversationId from the recording's owner) can find this entry.
   deferredRestartByConversation.set(ownerConversationId, {
     conversationId,
-    socket,
-    ctx,
     operationToken,
   });
 
@@ -517,13 +513,26 @@ async function handleRecordingStatus(
       if (deferred) {
         deferredRestartByConversation.delete(conversationId);
 
+        // Resolve a fresh socket at stop-ack time instead of using the one
+        // captured at restart-request time, which may be stale (disconnected
+        // or replaced) by the time the async stop completes.
+        const freshSocket = findSocketForSession(deferred.conversationId, ctx)
+          ?? reportingSocket;
+
+        if (!freshSocket) {
+          log.warn({ conversationId, requesterId: deferred.conversationId }, 'Deferred restart aborted — no socket available at stop-ack time');
+          activeRestartToken = null;
+          pendingRestartByConversation.delete(conversationId);
+          break;
+        }
+
         log.info({ recordingId, conversationId, operationToken: deferred.operationToken }, 'Stop-ack received — triggering deferred restart start');
 
         const newRecordingId = handleRecordingStart(
           deferred.conversationId,
           { promptForSource: true },
-          deferred.socket,
-          deferred.ctx,
+          freshSocket,
+          ctx,
           deferred.operationToken,
         );
 

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -533,6 +533,15 @@ async function handleRecordingStatus(
           pendingRestartByConversation.delete(conversationId);
           log.warn({ conversationId }, 'Deferred restart start failed after stop-ack');
         } else {
+          // Cross-conversation restart: the pendingRestartByConversation entry
+          // is keyed by the old owner (conversationId), but the new recording
+          // is owned by the requester (deferred.conversationId). Migrate the
+          // entry so the 'started' handler can find it under the correct key.
+          if (conversationId !== deferred.conversationId) {
+            pendingRestartByConversation.delete(conversationId);
+            pendingRestartByConversation.set(deferred.conversationId, deferred.operationToken);
+            log.info({ oldKey: conversationId, newKey: deferred.conversationId }, 'Migrated pendingRestartByConversation key from owner to requester');
+          }
           log.info({ conversationId, newRecordingId, operationToken: deferred.operationToken }, 'Deferred restart recording started');
         }
 

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -245,23 +245,36 @@ export function handleRecordingRestart(
     };
   }
 
+  // Resolve the actual owner conversation ID. When conversation B requests
+  // a restart but the recording is owned by conversation A (cross-conversation
+  // restart via global fallback), the deferred restart must be keyed by A's
+  // conversationId because the stopped callback resolves the conversationId
+  // from standaloneRecordingConversationId (which maps to A, the owner).
+  // This lookup must happen BEFORE cleanupMaps removes the entry.
+  const ownerConversationId = standaloneRecordingConversationId.get(stoppedRecordingId) ?? conversationId;
+  if (ownerConversationId !== conversationId) {
+    log.info({ conversationId, ownerConversationId, stoppedRecordingId }, 'Cross-conversation restart: keying deferred restart by owner conversation');
+  }
+
   // Atomically set the restart token and pending state so that:
   // 1. Stale completions from a previous cycle are rejected
   // 2. "no active recording" checks know we're mid-restart
   activeRestartToken = operationToken;
-  pendingRestartByConversation.set(conversationId, operationToken);
+  pendingRestartByConversation.set(ownerConversationId, operationToken);
 
   // Store the deferred restart parameters. The actual recording_start will
   // be sent when the 'stopped' status callback arrives in handleRecordingStatus,
   // ensuring the client has fully completed the async stop before we start.
-  deferredRestartByConversation.set(conversationId, {
+  // Keyed by ownerConversationId so the stopped handler (which resolves
+  // conversationId from the recording's owner) can find this entry.
+  deferredRestartByConversation.set(ownerConversationId, {
     conversationId,
     socket,
     ctx,
     operationToken,
   });
 
-  log.info({ conversationId, operationToken, stoppedRecordingId }, 'Recording restart initiated — start deferred until stop-ack');
+  log.info({ conversationId, ownerConversationId, operationToken, stoppedRecordingId }, 'Recording restart initiated — start deferred until stop-ack');
 
   return {
     initiated: true,


### PR DESCRIPTION
The daemon was sending recording_stop and recording_start back-to-back synchronously, but the macOS client processes stop asynchronously. This caused RecordingManager.start() to reject the start because the async stop hadn't completed yet. Now handleRecordingRestart stores pending restart state and defers the start until the stopped status callback arrives.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
