### PR TITLE
M1: Guardian-Only Tool Invocation Gate

### DIFF
--- a/assistant/src/__tests__/guardian-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/guardian-control-plane-policy.test.ts
@@ -293,6 +293,14 @@ describe('enforceGuardianOnlyPolicy', () => {
     expect(result.denied).toBe(false);
   });
 
+  test('unknown actor role is denied for guardian endpoint (allowlist, not denylist)', () => {
+    const result = enforceGuardianOnlyPolicy('bash', {
+      command: 'curl http://localhost:3000/v1/integrations/guardian/outbound/start',
+    }, 'some_future_role');
+    expect(result.denied).toBe(true);
+    expect(result.reason).toContain('restricted to guardian users');
+  });
+
   test('non-guardian actor is NOT denied for unrelated endpoint', () => {
     const result = enforceGuardianOnlyPolicy('bash', {
       command: 'curl http://localhost:3000/v1/messages',

--- a/assistant/src/__tests__/guardian-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/guardian-control-plane-policy.test.ts
@@ -1,0 +1,459 @@
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+import type { PolicyContext } from '../permissions/types.js';
+import { RiskLevel } from '../permissions/types.js';
+import type { ToolExecutionResult, ToolLifecycleEvent, ToolPermissionDeniedEvent } from '../tools/types.js';
+
+// ── Module mocks (must precede real imports) ─────────────────────────
+
+const mockConfig = {
+  provider: 'anthropic',
+  model: 'test',
+  apiKeys: {},
+  maxTokens: 4096,
+  dataDir: '/tmp',
+  timeouts: { shellDefaultTimeoutSec: 120, shellMaxTimeoutSec: 600, permissionTimeoutSec: 300 },
+  sandbox: { enabled: false, backend: 'native' as const, docker: { image: 'vellum-sandbox:latest', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' as const } },
+  rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  secretDetection: { enabled: false, action: 'warn' as const, entropyThreshold: 4.0 },
+};
+
+let fakeToolResult: ToolExecutionResult = { content: 'ok', isError: false };
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+  invalidateConfigCache: () => {},
+  saveConfig: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+  isDebug: () => false,
+  truncateForLog: (value: string) => value,
+}));
+
+mock.module('../permissions/checker.js', () => ({
+  classifyRisk: async () => 'low',
+  check: async () => ({ decision: 'allow', reason: 'allowed' }),
+  generateAllowlistOptions: () => [],
+  generateScopeOptions: () => [],
+}));
+
+mock.module('../memory/tool-usage-store.js', () => ({
+  recordToolInvocation: () => {},
+}));
+
+mock.module('../tools/registry.js', () => ({
+  getTool: (name: string) => {
+    if (name === 'unknown_tool') return undefined;
+    return {
+      name,
+      description: 'test tool',
+      category: 'test',
+      defaultRiskLevel: 'low',
+      getDefinition: () => ({}),
+      execute: async () => fakeToolResult,
+    };
+  },
+  getAllTools: () => [],
+}));
+
+mock.module('../tools/shared/filesystem/path-policy.js', () => ({
+  sandboxPolicy: () => ({ ok: false }),
+  hostPolicy: () => ({ ok: false }),
+}));
+
+mock.module('../tools/terminal/sandbox.js', () => ({
+  wrapCommand: () => ({ command: '', sandboxed: false }),
+}));
+
+// ── Real imports ─────────────────────────────────────────────────────
+
+import { PermissionPrompter } from '../permissions/prompter.js';
+import { ToolExecutor } from '../tools/executor.js';
+import {
+  enforceGuardianOnlyPolicy,
+  isGuardianControlPlaneInvocation,
+} from '../tools/guardian-control-plane-policy.js';
+import type { ToolContext } from '../tools/types.js';
+
+function makeContext(overrides?: Partial<ToolContext>): ToolContext {
+  return {
+    workingDir: '/tmp/project',
+    sessionId: 'session-1',
+    conversationId: 'conversation-1',
+    ...overrides,
+  };
+}
+
+function makePrompter(): PermissionPrompter {
+  return {
+    prompt: async () => ({ decision: 'allow' as const }),
+    resolveConfirmation: () => {},
+    updateSender: () => {},
+    dispose: () => {},
+  } as unknown as PermissionPrompter;
+}
+
+afterAll(() => { mock.restore(); });
+
+// =====================================================================
+// Unit tests: isGuardianControlPlaneInvocation
+// =====================================================================
+
+describe('isGuardianControlPlaneInvocation', () => {
+  const guardianPaths = [
+    '/v1/integrations/guardian/challenge',
+    '/v1/integrations/guardian/status',
+    '/v1/integrations/guardian/outbound/start',
+    '/v1/integrations/guardian/outbound/resend',
+    '/v1/integrations/guardian/outbound/cancel',
+  ];
+
+  describe('bash tool with guardian endpoint in command', () => {
+    for (const path of guardianPaths) {
+      test(`detects curl to ${path}`, () => {
+        expect(isGuardianControlPlaneInvocation('bash', {
+          command: `curl -X POST http://localhost:3000${path}`,
+        })).toBe(true);
+      });
+
+      test(`detects wget to ${path}`, () => {
+        expect(isGuardianControlPlaneInvocation('bash', {
+          command: `wget https://api.example.com${path}`,
+        })).toBe(true);
+      });
+    }
+
+    test('does not match unrelated commands', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {
+        command: 'git status',
+      })).toBe(false);
+    });
+
+    test('does not match partial path prefix', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {
+        command: 'curl http://localhost:3000/v1/integrations/guardian',
+      })).toBe(false);
+    });
+
+    test('does not match similar but different paths', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {
+        command: 'curl http://localhost:3000/v1/integrations/guardian/other',
+      })).toBe(false);
+    });
+
+    test('handles missing command field gracefully', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {})).toBe(false);
+    });
+
+    test('handles non-string command field gracefully', () => {
+      expect(isGuardianControlPlaneInvocation('bash', { command: 42 })).toBe(false);
+    });
+  });
+
+  describe('host_bash tool with guardian endpoint in command', () => {
+    test('detects guardian endpoint', () => {
+      expect(isGuardianControlPlaneInvocation('host_bash', {
+        command: 'curl -H "Authorization: Bearer token" https://internal:8080/v1/integrations/guardian/outbound/start',
+      })).toBe(true);
+    });
+  });
+
+  describe('network_request tool with guardian endpoint in url', () => {
+    for (const path of guardianPaths) {
+      test(`detects ${path}`, () => {
+        expect(isGuardianControlPlaneInvocation('network_request', {
+          url: `https://api.vellum.ai${path}`,
+        })).toBe(true);
+      });
+    }
+
+    test('detects proxied local URL', () => {
+      expect(isGuardianControlPlaneInvocation('network_request', {
+        url: 'http://127.0.0.1:3000/v1/integrations/guardian/challenge',
+      })).toBe(true);
+    });
+
+    test('does not match unrelated URLs', () => {
+      expect(isGuardianControlPlaneInvocation('network_request', {
+        url: 'https://api.example.com/v1/messages',
+      })).toBe(false);
+    });
+
+    test('handles missing url field gracefully', () => {
+      expect(isGuardianControlPlaneInvocation('network_request', {})).toBe(false);
+    });
+  });
+
+  describe('web_fetch tool with guardian endpoint in url', () => {
+    test('detects guardian endpoint', () => {
+      expect(isGuardianControlPlaneInvocation('web_fetch', {
+        url: 'https://api.example.com/v1/integrations/guardian/outbound/cancel',
+      })).toBe(true);
+    });
+
+    test('does not match unrelated URL', () => {
+      expect(isGuardianControlPlaneInvocation('web_fetch', {
+        url: 'https://docs.example.com/api/v1/help',
+      })).toBe(false);
+    });
+  });
+
+  describe('browser_navigate tool with guardian endpoint in url', () => {
+    test('detects guardian endpoint', () => {
+      expect(isGuardianControlPlaneInvocation('browser_navigate', {
+        url: 'http://localhost:3000/v1/integrations/guardian/status',
+      })).toBe(true);
+    });
+  });
+
+  describe('unrelated tools are not flagged', () => {
+    test('file_read is never a guardian invocation', () => {
+      expect(isGuardianControlPlaneInvocation('file_read', {
+        path: '/v1/integrations/guardian/challenge',
+      })).toBe(false);
+    });
+
+    test('file_write is never a guardian invocation', () => {
+      expect(isGuardianControlPlaneInvocation('file_write', {
+        path: '/tmp/test.txt',
+        content: 'curl /v1/integrations/guardian/outbound/start',
+      })).toBe(false);
+    });
+
+    test('web_search is never a guardian invocation', () => {
+      expect(isGuardianControlPlaneInvocation('web_search', {
+        query: '/v1/integrations/guardian/status',
+      })).toBe(false);
+    });
+  });
+
+  describe('path matching covers proxied and local variants', () => {
+    test('matches endpoint with query string', () => {
+      expect(isGuardianControlPlaneInvocation('network_request', {
+        url: 'https://api.example.com/v1/integrations/guardian/challenge?token=abc',
+      })).toBe(true);
+    });
+
+    test('matches endpoint with trailing slash', () => {
+      expect(isGuardianControlPlaneInvocation('network_request', {
+        url: 'https://api.example.com/v1/integrations/guardian/outbound/start/',
+      })).toBe(true);
+    });
+
+    test('matches endpoint in piped bash command', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {
+        command: 'echo \'{"phone":"+1234567890"}\' | curl -X POST -d @- http://localhost:3000/v1/integrations/guardian/outbound/resend',
+      })).toBe(true);
+    });
+  });
+});
+
+// =====================================================================
+// Unit tests: enforceGuardianOnlyPolicy
+// =====================================================================
+
+describe('enforceGuardianOnlyPolicy', () => {
+  test('non-guardian actor denied for guardian endpoint', () => {
+    const result = enforceGuardianOnlyPolicy('bash', {
+      command: 'curl http://localhost:3000/v1/integrations/guardian/outbound/start',
+    }, 'non-guardian');
+    expect(result.denied).toBe(true);
+    expect(result.reason).toContain('restricted to guardian users');
+  });
+
+  test('unverified_channel actor denied for guardian endpoint', () => {
+    const result = enforceGuardianOnlyPolicy('network_request', {
+      url: 'https://api.example.com/v1/integrations/guardian/challenge',
+    }, 'unverified_channel');
+    expect(result.denied).toBe(true);
+    expect(result.reason).toContain('restricted to guardian users');
+  });
+
+  test('guardian actor is NOT denied for guardian endpoint', () => {
+    const result = enforceGuardianOnlyPolicy('bash', {
+      command: 'curl http://localhost:3000/v1/integrations/guardian/outbound/start',
+    }, 'guardian');
+    expect(result.denied).toBe(false);
+    expect(result.reason).toBeUndefined();
+  });
+
+  test('undefined actor role is NOT denied for guardian endpoint', () => {
+    const result = enforceGuardianOnlyPolicy('bash', {
+      command: 'curl http://localhost:3000/v1/integrations/guardian/outbound/start',
+    }, undefined);
+    expect(result.denied).toBe(false);
+  });
+
+  test('non-guardian actor is NOT denied for unrelated endpoint', () => {
+    const result = enforceGuardianOnlyPolicy('bash', {
+      command: 'curl http://localhost:3000/v1/messages',
+    }, 'non-guardian');
+    expect(result.denied).toBe(false);
+  });
+
+  test('non-guardian actor is NOT denied for unrelated tool', () => {
+    const result = enforceGuardianOnlyPolicy('file_read', {
+      path: 'README.md',
+    }, 'non-guardian');
+    expect(result.denied).toBe(false);
+  });
+});
+
+// =====================================================================
+// Integration tests: ToolExecutor guardian-only policy gate
+// =====================================================================
+
+describe('ToolExecutor guardian-only policy gate', () => {
+  beforeEach(() => {
+    fakeToolResult = { content: 'ok', isError: false };
+  });
+
+  test('non-guardian actor blocked from bash curl to guardian outbound/start', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'bash',
+      { command: 'curl -X POST http://localhost:3000/v1/integrations/guardian/outbound/start' },
+      makeContext({ guardianActorRole: 'non-guardian' }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('restricted to guardian users');
+  });
+
+  test('unverified_channel actor blocked from network_request to guardian endpoint', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'network_request',
+      { url: 'https://api.example.com/v1/integrations/guardian/challenge' },
+      makeContext({ guardianActorRole: 'unverified_channel' }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('restricted to guardian users');
+  });
+
+  test('guardian actor is NOT blocked from the same invocation', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'bash',
+      { command: 'curl -X POST http://localhost:3000/v1/integrations/guardian/outbound/start' },
+      makeContext({ guardianActorRole: 'guardian' }),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe('ok');
+  });
+
+  test('undefined guardianActorRole is NOT blocked from guardian endpoint', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'bash',
+      { command: 'curl http://localhost:3000/v1/integrations/guardian/status' },
+      makeContext(), // no guardianActorRole set
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe('ok');
+  });
+
+  test('non-guardian invocation of unrelated endpoint is unaffected', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'bash',
+      { command: 'curl http://localhost:3000/v1/messages' },
+      makeContext({ guardianActorRole: 'non-guardian' }),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe('ok');
+  });
+
+  test('non-guardian invocation of unrelated tool is unaffected', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'file_read',
+      { path: 'README.md' },
+      makeContext({ guardianActorRole: 'non-guardian' }),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe('ok');
+  });
+
+  test('permission_denied lifecycle event is emitted on guardian policy block', async () => {
+    let capturedEvent: ToolPermissionDeniedEvent | undefined;
+    const executor = new ToolExecutor(makePrompter());
+    await executor.execute(
+      'bash',
+      { command: 'curl http://localhost:3000/v1/integrations/guardian/outbound/cancel' },
+      makeContext({
+        guardianActorRole: 'non-guardian',
+        onToolLifecycleEvent: (event: ToolLifecycleEvent) => {
+          if (event.type === 'permission_denied') {
+            capturedEvent = event as ToolPermissionDeniedEvent;
+          }
+        },
+      }),
+    );
+    expect(capturedEvent).toBeDefined();
+    expect(capturedEvent!.decision).toBe('deny');
+    expect(capturedEvent!.reason).toContain('restricted to guardian users');
+  });
+
+  test('non-guardian blocked from web_fetch to guardian endpoint', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'web_fetch',
+      { url: 'http://localhost:3000/v1/integrations/guardian/outbound/resend' },
+      makeContext({ guardianActorRole: 'non-guardian' }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('restricted to guardian users');
+  });
+
+  test('non-guardian blocked from browser_navigate to guardian endpoint', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'browser_navigate',
+      { url: 'http://localhost:3000/v1/integrations/guardian/status' },
+      makeContext({ guardianActorRole: 'non-guardian' }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('restricted to guardian users');
+  });
+
+  test('non-guardian blocked from host_bash with guardian endpoint', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'host_bash',
+      { command: 'curl -X POST https://internal:8080/v1/integrations/guardian/challenge' },
+      makeContext({ guardianActorRole: 'non-guardian' }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('restricted to guardian users');
+  });
+
+  test('all five guardian endpoints are blocked for non-guardian via network_request', async () => {
+    const endpoints = [
+      '/v1/integrations/guardian/challenge',
+      '/v1/integrations/guardian/status',
+      '/v1/integrations/guardian/outbound/start',
+      '/v1/integrations/guardian/outbound/resend',
+      '/v1/integrations/guardian/outbound/cancel',
+    ];
+
+    for (const path of endpoints) {
+      const executor = new ToolExecutor(makePrompter());
+      const result = await executor.execute(
+        'network_request',
+        { url: `https://api.example.com${path}` },
+        makeContext({ guardianActorRole: 'non-guardian' }),
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('restricted to guardian users');
+    }
+  });
+});

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -55,6 +55,8 @@ export interface ToolSetupContext extends SurfaceSessionContext {
   headlessLock?: boolean;
   /** When set, this session is executing a task run. Used to retrieve ephemeral permission rules. */
   taskRunId?: string;
+  /** Guardian actor role for the session — propagated into ToolContext for control-plane policy enforcement. */
+  guardianActorRole?: 'guardian' | 'non-guardian' | 'unverified_channel';
 }
 
 // ── buildToolDefinitions ─────────────────────────────────────────────
@@ -105,6 +107,7 @@ export function createToolExecutor(
       assistantId: ctx.assistantId,
       requestId: ctx.currentRequestId,
       taskRunId: ctx.taskRunId,
+      guardianActorRole: ctx.guardianActorRole,
       onOutput,
       signal: ctx.abortController?.signal,
       sandboxOverride: ctx.sandboxOverride,

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -26,6 +26,7 @@ import type { ProxyApprovalCallback, ProxyApprovalRequest } from '../tools/netwo
 import { getAllToolDefinitions } from '../tools/registry.js';
 import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
 import { projectSkillTools, type SkillProjectionCache } from './session-skill-tools.js';
+import type { GuardianRuntimeContext } from './session-runtime-assembly.js';
 import type { SurfaceSessionContext } from './session-surfaces.js';
 import {
   surfaceProxyResolver,
@@ -55,8 +56,8 @@ export interface ToolSetupContext extends SurfaceSessionContext {
   headlessLock?: boolean;
   /** When set, this session is executing a task run. Used to retrieve ephemeral permission rules. */
   taskRunId?: string;
-  /** Guardian actor role for the session — propagated into ToolContext for control-plane policy enforcement. */
-  guardianActorRole?: 'guardian' | 'non-guardian' | 'unverified_channel';
+  /** Guardian runtime context for the session — actorRole is propagated into ToolContext for control-plane policy enforcement. */
+  guardianContext?: GuardianRuntimeContext;
 }
 
 // ── buildToolDefinitions ─────────────────────────────────────────────
@@ -107,7 +108,7 @@ export function createToolExecutor(
       assistantId: ctx.assistantId,
       requestId: ctx.currentRequestId,
       taskRunId: ctx.taskRunId,
-      guardianActorRole: ctx.guardianActorRole,
+      guardianActorRole: ctx.guardianContext?.actorRole,
       onOutput,
       signal: ctx.abortController?.signal,
       sandboxOverride: ctx.sandboxOverride,

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -15,6 +15,7 @@ import { PermissionDeniedError,ToolError } from '../util/errors.js';
 import { pathExists, safeStatSync } from '../util/fs.js';
 import { getLogger } from '../util/logger.js';
 import { resolveExecutionTarget } from './execution-target.js';
+import { enforceGuardianOnlyPolicy } from './guardian-control-plane-policy.js';
 import { executeWithTimeout,safeTimeoutMs } from './execution-timeout.js';
 import { buildPolicyContext } from './policy-context.js';
 import { getAllTools,getTool } from './registry.js';
@@ -109,6 +110,34 @@ export class ToolExecutor {
         durationMs,
       });
       return { content: 'This tool is blocked by parental control settings.', isError: true };
+    }
+
+    // Reject tool invocations targeting guardian control-plane endpoints from non-guardian actors.
+    const guardianCheck = enforceGuardianOnlyPolicy(name, input, context.guardianActorRole);
+    if (guardianCheck.denied) {
+      log.warn({
+        toolName: name,
+        sessionId: context.sessionId,
+        conversationId: context.conversationId,
+        actorRole: context.guardianActorRole,
+        reason: 'guardian_only_policy',
+      }, 'Guardian-only policy blocked tool invocation');
+      const durationMs = Date.now() - startTime;
+      emitLifecycleEvent(context, {
+        type: 'permission_denied',
+        toolName: name,
+        executionTarget,
+        input,
+        workingDir: context.workingDir,
+        sessionId: context.sessionId,
+        conversationId: context.conversationId,
+        requestId: context.requestId,
+        riskLevel,
+        decision: 'deny',
+        reason: guardianCheck.reason!,
+        durationMs,
+      });
+      return { content: guardianCheck.reason!, isError: true };
     }
 
     // Gate tools not active for the current turn

--- a/assistant/src/tools/guardian-control-plane-policy.ts
+++ b/assistant/src/tools/guardian-control-plane-policy.ts
@@ -1,0 +1,85 @@
+/**
+ * Guardian control-plane policy — deterministic gate that prevents non-guardian
+ * and unverified_channel actors from invoking guardian verification endpoints
+ * conversationally via tools.
+ *
+ * Protected endpoints:
+ *   /v1/integrations/guardian/challenge
+ *   /v1/integrations/guardian/status
+ *   /v1/integrations/guardian/outbound/start
+ *   /v1/integrations/guardian/outbound/resend
+ *   /v1/integrations/guardian/outbound/cancel
+ */
+
+const GUARDIAN_ENDPOINT_PATHS = [
+  '/v1/integrations/guardian/challenge',
+  '/v1/integrations/guardian/status',
+  '/v1/integrations/guardian/outbound/start',
+  '/v1/integrations/guardian/outbound/resend',
+  '/v1/integrations/guardian/outbound/cancel',
+] as const;
+
+/** Tools whose `input.command` (string) may contain guardian endpoint paths. */
+const COMMAND_TOOLS = new Set(['bash', 'host_bash']);
+
+/** Tools whose `input.url` (string) may contain guardian endpoint paths. */
+const URL_TOOLS = new Set(['network_request', 'web_fetch', 'browser_navigate']);
+
+/**
+ * Check whether a string contains any of the guardian control-plane endpoint paths.
+ * Matches at the path level (not hostname-specific) to catch proxied/local variants.
+ */
+function containsGuardianEndpointPath(value: string): boolean {
+  for (const path of GUARDIAN_ENDPOINT_PATHS) {
+    if (value.includes(path)) return true;
+  }
+  return false;
+}
+
+/**
+ * Pure function that determines whether a tool invocation targets a guardian
+ * control-plane endpoint based on the tool name and its input.
+ */
+export function isGuardianControlPlaneInvocation(
+  toolName: string,
+  input: Record<string, unknown>,
+): boolean {
+  if (COMMAND_TOOLS.has(toolName)) {
+    const command = input.command;
+    if (typeof command === 'string' && containsGuardianEndpointPath(command)) {
+      return true;
+    }
+  }
+
+  if (URL_TOOLS.has(toolName)) {
+    const url = input.url;
+    if (typeof url === 'string' && containsGuardianEndpointPath(url)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Enforce the guardian-only policy: if the invocation targets a guardian
+ * control-plane endpoint and the actor is not a guardian, deny.
+ */
+export function enforceGuardianOnlyPolicy(
+  toolName: string,
+  input: Record<string, unknown>,
+  actorRole: string | undefined,
+): { denied: boolean; reason?: string } {
+  if (!isGuardianControlPlaneInvocation(toolName, input)) {
+    return { denied: false };
+  }
+
+  if (actorRole === 'non-guardian' || actorRole === 'unverified_channel') {
+    return {
+      denied: true,
+      reason: 'Guardian verification control-plane actions are restricted to guardian users. This is a security restriction \u2014 please wait for the designated guardian to perform this action.',
+    };
+  }
+
+  return { denied: false };
+}

--- a/assistant/src/tools/guardian-control-plane-policy.ts
+++ b/assistant/src/tools/guardian-control-plane-policy.ts
@@ -1,5 +1,5 @@
 /**
- * Guardian control-plane policy — deterministic gate that prevents non-guardian
+ * Guardian control-plane policy \u2014 deterministic gate that prevents non-guardian
  * and unverified_channel actors from invoking guardian verification endpoints
  * conversationally via tools.
  *
@@ -74,12 +74,12 @@ export function enforceGuardianOnlyPolicy(
     return { denied: false };
   }
 
-  if (actorRole === 'non-guardian' || actorRole === 'unverified_channel') {
-    return {
-      denied: true,
-      reason: 'Guardian verification control-plane actions are restricted to guardian users. This is a security restriction \u2014 please wait for the designated guardian to perform this action.',
-    };
+  if (actorRole === 'guardian' || actorRole === undefined) {
+    return { denied: false };
   }
 
-  return { denied: false };
+  return {
+    denied: true,
+    reason: 'Guardian verification control-plane actions are restricted to guardian users. This is a security restriction \u2014 please wait for the designated guardian to perform this action.',
+  };
 }

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -136,6 +136,8 @@ export interface ToolContext {
   proxyApprovalCallback?: import('./network/script-proxy/types.js').ProxyApprovalCallback;
   /** Optional principal identifier propagated to sub-tool confirmation flows. */
   principal?: string;
+  /** Guardian actor role for the session — used by the guardian control-plane policy gate. */
+  guardianActorRole?: 'guardian' | 'non-guardian' | 'unverified_channel';
 }
 
 export interface DiffInfo {


### PR DESCRIPTION
Security: Thread guardian actor role into tool execution context, add deterministic guardian endpoint detector, and enforce guardian-only policy in ToolExecutor before permission checks. Non-guardian and unverified_channel actors are denied access to guardian verification control-plane endpoints conversationally. Closes #9446.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
