### PR TITLE
fix: keep mid-response thread updates when switching threads

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -16,12 +16,22 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     @Published var threads: [ThreadModel] = []
     @Published var hasMoreThreads: Bool = false
     @Published var isLoadingMoreThreads: Bool = false
+    private struct AssistantActivitySnapshot: Equatable {
+        let messageId: UUID
+        let textLength: Int
+        let toolCallCount: Int
+        let completedToolCallCount: Int
+        let surfaceCount: Int
+        let isStreaming: Bool
+    }
     /// Tracks the number of rows already fetched from the daemon so pagination
     /// offsets stay correct even when the client filters out some sessions.
     var serverOffset: Int = 0
     @Published var activeThreadId: UUID? {
         didSet {
             if let activeThreadId {
+                let activeViewModel = getOrCreateViewModel(for: activeThreadId)
+                activeViewModel?.ensureMessageLoopStarted()
                 sessionRestorer.loadHistoryIfNeeded(threadId: activeThreadId)
                 // Only persist the active thread ID if we're not in the middle of restoration.
                 // During init and session restoration, the didSet fires multiple times and would
@@ -32,7 +42,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 // Notify the daemon so it rebinds the socket to this thread's session.
                 // Without this, socketToSession stays stale after thread switches,
                 // causing ownership checks (e.g. subagent abort) to fail.
-                if let sessionId = getOrCreateViewModel(for: activeThreadId)?.sessionId {
+                if let sessionId = activeViewModel?.sessionId {
                     do {
                         try daemonClient.send(IPCSessionSwitchRequest(sessionId: sessionId))
                     } catch {
@@ -64,11 +74,11 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     private var activeViewModelCancellable: AnyCancellable?
     /// Subscriptions to per-thread busy-state changes (isSending, isThinking, pendingQueuedCount).
     private var busyStateCancellables: [UUID: Set<AnyCancellable>] = [:]
-    /// Subscription to the latest assistant message ID per thread.
-    /// Used to mark inactive threads as unseen when a new assistant reply arrives.
+    /// Subscription to assistant activity per thread.
+    /// Used to mark inactive threads as unseen when assistant output changes.
     private var assistantActivityCancellables: [UUID: AnyCancellable] = [:]
-    /// Last observed assistant message ID per thread.
-    private var latestAssistantMessageIds: [UUID: UUID] = [:]
+    /// Last observed assistant activity snapshot per thread.
+    private var latestAssistantActivitySnapshots: [UUID: AssistantActivitySnapshot] = [:]
     /// Cached set of thread IDs whose ChatViewModel indicates active processing.
     @Published private(set) var busyThreadIds: Set<UUID> = []
 
@@ -776,11 +786,14 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// keeping at most `maxCachedViewModels` entries in the dictionary.
     private func evictStaleCachedViewModels() {
         while chatViewModels.count > maxCachedViewModels {
-            // Find the oldest entry in vmAccessOrder that is not the active thread.
-            guard let victim = vmAccessOrder.first(where: { $0 != activeThreadId && chatViewModels[$0] != nil }) else {
+            // Find the oldest non-active, non-busy VM so we never cancel an in-flight response
+            // just because the user switched threads.
+            guard let victim = vmAccessOrder.first(where: {
+                guard $0 != activeThreadId, let vm = chatViewModels[$0] else { return false }
+                return !vm.isSending && !vm.isThinking && vm.pendingQueuedCount == 0
+            }) else {
                 break
             }
-            chatViewModels[victim]?.stopGenerating()
             chatViewModels.removeValue(forKey: victim)
             unsubscribeFromBusyState(for: victim)
             vmAccessOrder.removeAll { $0 == victim }
@@ -863,31 +876,46 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         busyStateCancellables[threadId] = subs
     }
 
-    /// Subscribe to the latest assistant message ID for a thread.
-    /// When it changes and the thread is not active, mark that thread unseen.
+    /// Subscribe to assistant activity for a thread.
+    /// Any change to the latest assistant message's rendered content marks
+    /// inactive threads unseen, including mid-stream continuation updates.
     private func subscribeToAssistantActivity(for threadId: UUID, viewModel: ChatViewModel) {
         assistantActivityCancellables[threadId]?.cancel()
-        if let latestAssistantMessageId = viewModel.messages.reversed().first(where: { $0.role == .assistant })?.id {
-            latestAssistantMessageIds[threadId] = latestAssistantMessageId
+        if let snapshot = latestAssistantActivitySnapshot(in: viewModel.messages) {
+            latestAssistantActivitySnapshots[threadId] = snapshot
         } else {
-            latestAssistantMessageIds.removeValue(forKey: threadId)
+            latestAssistantActivitySnapshots.removeValue(forKey: threadId)
         }
 
         assistantActivityCancellables[threadId] = viewModel.messageManager.$messages
-            .map { $0.reversed().first(where: { $0.role == .assistant })?.id }
+            .map { [weak self] messages in
+                self?.latestAssistantActivitySnapshot(in: messages)
+            }
             .removeDuplicates()
-            .sink { [weak self] latestAssistantMessageId in
+            .sink { [weak self] latestSnapshot in
                 guard let self else { return }
-                let previousAssistantMessageId = self.latestAssistantMessageIds[threadId]
-                if let latestAssistantMessageId {
-                    self.latestAssistantMessageIds[threadId] = latestAssistantMessageId
+                let previousSnapshot = self.latestAssistantActivitySnapshots[threadId]
+                if let latestSnapshot {
+                    self.latestAssistantActivitySnapshots[threadId] = latestSnapshot
                 } else {
-                    self.latestAssistantMessageIds.removeValue(forKey: threadId)
+                    self.latestAssistantActivitySnapshots.removeValue(forKey: threadId)
                 }
-                guard previousAssistantMessageId != latestAssistantMessageId,
-                      latestAssistantMessageId != nil else { return }
+                guard previousSnapshot != latestSnapshot,
+                      latestSnapshot != nil else { return }
                 self.handleAssistantMessageArrival(threadId: threadId)
             }
+    }
+
+    private func latestAssistantActivitySnapshot(in messages: [ChatMessage]) -> AssistantActivitySnapshot? {
+        guard let message = messages.reversed().first(where: { $0.role == .assistant }) else { return nil }
+        return AssistantActivitySnapshot(
+            messageId: message.id,
+            textLength: message.text.count,
+            toolCallCount: message.toolCalls.count,
+            completedToolCallCount: message.toolCalls.filter(\.isComplete).count,
+            surfaceCount: message.inlineSurfaces.count,
+            isStreaming: message.isStreaming
+        )
     }
 
     /// Remove busy-state subscriptions for a thread (e.g. on archive/close).
@@ -895,7 +923,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         busyStateCancellables.removeValue(forKey: threadId)
         assistantActivityCancellables[threadId]?.cancel()
         assistantActivityCancellables.removeValue(forKey: threadId)
-        latestAssistantMessageIds.removeValue(forKey: threadId)
+        latestAssistantActivitySnapshots.removeValue(forKey: threadId)
         busyThreadIds.remove(threadId)
     }
 
@@ -924,10 +952,11 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// that thread is currently active.
     private func handleAssistantMessageArrival(threadId: UUID) {
         guard let index = threads.firstIndex(where: { $0.id == threadId }) else { return }
+        let wasUnseen = threads[index].hasUnseenLatestAssistantMessage
         updateLastInteracted(threadId: threadId)
         if threadId == activeThreadId {
             threads[index].hasUnseenLatestAssistantMessage = false
-            if let sessionId = threads[index].sessionId {
+            if wasUnseen, let sessionId = threads[index].sessionId {
                 emitConversationSeenSignal(conversationId: sessionId)
             }
         } else {

--- a/clients/macos/vellum-assistantTests/ThreadManagerBusyStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerBusyStateTests.swift
@@ -95,4 +95,38 @@ final class ThreadManagerBusyStateTests: XCTestCase {
         XCTAssertFalse(threadManager.isThreadBusy(threadId), "Thread should not be busy after all states return to idle")
         XCTAssertTrue(threadManager.busyThreadIds.isEmpty)
     }
+
+    func testLRUEvictionSkipsBusyBackgroundThread() {
+        guard let originalThreadId = threadManager.activeThreadId else {
+            XCTFail("Expected initial active thread")
+            return
+        }
+
+        for _ in 0..<9 {
+            threadManager.activeViewModel?.messages.append(ChatMessage(role: .user, text: "seed"))
+            threadManager.createThread()
+        }
+
+        guard let busyVm = threadManager.existingChatViewModel(for: originalThreadId) else {
+            XCTFail("Expected original thread view model")
+            return
+        }
+        busyVm.isSending = true
+
+        let expBusy = expectation(description: "busy thread marked")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { expBusy.fulfill() }
+        wait(for: [expBusy], timeout: 1.0)
+        XCTAssertTrue(threadManager.isThreadBusy(originalThreadId))
+
+        // Trigger one more creation to force an LRU eviction pass.
+        threadManager.activeViewModel?.messages.append(ChatMessage(role: .user, text: "seed"))
+        threadManager.createThread()
+
+        let expEvict = expectation(description: "eviction pass complete")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { expEvict.fulfill() }
+        wait(for: [expEvict], timeout: 1.0)
+
+        XCTAssertNotNil(threadManager.existingChatViewModel(for: originalThreadId), "Busy thread should not be evicted")
+        XCTAssertTrue(threadManager.isThreadBusy(originalThreadId), "Busy state should be preserved after eviction pass")
+    }
 }

--- a/clients/macos/vellum-assistantTests/ThreadManagerSessionLoopTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerSessionLoopTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class ThreadManagerSessionLoopTests: XCTestCase {
+    private var daemonClient: DaemonClient!
+    private var threadManager: ThreadManager!
+
+    override func setUp() {
+        super.setUp()
+        daemonClient = DaemonClient()
+        daemonClient.isConnected = true
+        daemonClient.sendOverride = { _ in }
+        threadManager = ThreadManager(daemonClient: daemonClient)
+    }
+
+    override func tearDown() {
+        daemonClient?.sendOverride = nil
+        threadManager = nil
+        daemonClient = nil
+        super.tearDown()
+    }
+
+    func testSelectingSessionBackedThreadStartsMessageLoop() {
+        guard let threadId = threadManager.activeThreadId,
+              let vm = threadManager.chatViewModel(for: threadId),
+              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected active thread and view model")
+            return
+        }
+
+        threadManager.threads[index].sessionId = "session-active"
+        vm.sessionId = "session-active"
+
+        XCTAssertEqual(daemonClient.subscribers.count, 0)
+        threadManager.selectThread(id: threadId)
+        XCTAssertEqual(daemonClient.subscribers.count, 1)
+    }
+
+    func testSelectingSameSessionBackedThreadDoesNotDuplicateMessageLoop() {
+        guard let threadId = threadManager.activeThreadId,
+              let vm = threadManager.chatViewModel(for: threadId),
+              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected active thread and view model")
+            return
+        }
+
+        threadManager.threads[index].sessionId = "session-active"
+        vm.sessionId = "session-active"
+
+        threadManager.selectThread(id: threadId)
+        threadManager.selectThread(id: threadId)
+
+        XCTAssertEqual(daemonClient.subscribers.count, 1)
+    }
+}

--- a/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
@@ -57,6 +57,52 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         XCTAssertTrue(updated.hasUnseenLatestAssistantMessage)
     }
 
+    func testInactiveThreadMarkedUnseenWhenAssistantContinuesSameMessageAfterSwitch() {
+        guard let initialThreadId = threadManager.activeThreadId,
+              let initialVm = threadManager.chatViewModel(for: initialThreadId),
+              let initialIndex = threadManager.threads.firstIndex(where: { $0.id == initialThreadId }) else {
+            XCTFail("Expected an initial active thread and VM")
+            return
+        }
+
+        threadManager.threads[initialIndex].sessionId = "session-initial"
+        initialVm.sessionId = "session-initial"
+        initialVm.messages.append(ChatMessage(role: .user, text: "Seed"))
+
+        initialVm.handleServerMessage(.assistantTextDelta(
+            AssistantTextDeltaMessage(text: "First chunk", sessionId: "session-initial")
+        ))
+        waitForPropagation()
+        XCTAssertFalse(threadManager.threads[initialIndex].hasUnseenLatestAssistantMessage)
+
+        threadManager.createThread()
+        guard let secondaryThreadId = threadManager.activeThreadId,
+              let secondaryIndex = threadManager.threads.firstIndex(where: { $0.id == secondaryThreadId }),
+              let secondaryVm = threadManager.chatViewModel(for: secondaryThreadId) else {
+            XCTFail("Expected a secondary active thread and VM")
+            return
+        }
+
+        threadManager.threads[secondaryIndex].sessionId = "session-secondary"
+        secondaryVm.sessionId = "session-secondary"
+        threadManager.selectThread(id: secondaryThreadId)
+
+        initialVm.handleServerMessage(.assistantTextDelta(
+            AssistantTextDeltaMessage(text: " + second chunk", sessionId: "session-initial")
+        ))
+        initialVm.handleServerMessage(.messageComplete(
+            MessageCompleteMessage(sessionId: "session-initial")
+        ))
+
+        waitForPropagation()
+
+        guard let updated = threadManager.threads.first(where: { $0.id == initialThreadId }) else {
+            XCTFail("Expected thread to exist")
+            return
+        }
+        XCTAssertTrue(updated.hasUnseenLatestAssistantMessage)
+    }
+
     func testActiveThreadAssistantReplyClearsUnseenAndEmitsSeenSignal() {
         guard let threadId = threadManager.activeThreadId,
               let index = threadManager.threads.firstIndex(where: { $0.id == threadId }),

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1102,6 +1102,13 @@ public final class ChatViewModel: ObservableObject {
         }
     }
 
+    /// Start the daemon message stream if this chat has a bound session and
+    /// no active loop yet.
+    public func ensureMessageLoopStarted() {
+        guard sessionId != nil, messageLoopTask == nil else { return }
+        startMessageLoop()
+    }
+
     /// Send a message to the daemon without showing a user bubble in the chat.
     /// Used for automated actions like inline model picker selections.
     /// Returns `true` if the message was sent (or a session bootstrap was started),


### PR DESCRIPTION
## Summary
- fix unseen tracking to observe assistant activity progress (same message continuing) instead of only new assistant message IDs
- ensure the active session-backed chat view model always has a running daemon message loop after thread activation
- prevent LRU VM eviction from removing busy threads, which could cancel in-flight responses
- add regression tests for mid-response switch behavior, session-loop activation, and busy-thread eviction safety

## Root cause
- unseen state only changed when the latest assistant message UUID changed; if you switched away after the assistant started a reply, continuation in the same message was ignored
- session-backed threads could be re-activated without an active message loop, so late completion updates could be missed
- LRU eviction was allowed to evict busy background threads and call `stopGenerating()`, which can cancel in-flight work

## Testing
- `cd clients/macos && swift test --filter ThreadManagerUnseenStateTests --filter ThreadManagerSessionLoopTests --filter ThreadManagerBusyStateTests`
- `cd clients/macos && swift test --filter ThreadManager` *(existing unrelated failure remains in `ThreadManagerPrivateThreadTests testCreatePrivateThreadCallsCreateSessionIfNeeded`)*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
