### PR TITLE
fix: always emit seen signal for active thread assistant replies

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -952,11 +952,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// that thread is currently active.
     private func handleAssistantMessageArrival(threadId: UUID) {
         guard let index = threads.firstIndex(where: { $0.id == threadId }) else { return }
-        let wasUnseen = threads[index].hasUnseenLatestAssistantMessage
         updateLastInteracted(threadId: threadId)
         if threadId == activeThreadId {
             threads[index].hasUnseenLatestAssistantMessage = false
-            if wasUnseen, let sessionId = threads[index].sessionId {
+            if let sessionId = threads[index].sessionId {
                 emitConversationSeenSignal(conversationId: sessionId)
             }
         } else {

--- a/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
@@ -103,6 +103,30 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         XCTAssertTrue(updated.hasUnseenLatestAssistantMessage)
     }
 
+    func testActiveThreadEmitsSeenSignalEvenWhenAlreadySeen() {
+        guard let threadId = threadManager.activeThreadId,
+              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }),
+              let vm = threadManager.chatViewModel(for: threadId) else {
+            XCTFail("Expected active thread and view model")
+            return
+        }
+
+        threadManager.threads[index].sessionId = "session-realtime"
+        threadManager.threads[index].hasUnseenLatestAssistantMessage = false
+        vm.sessionId = "session-realtime"
+
+        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Streaming reply", sessionId: "session-realtime")))
+        vm.handleServerMessage(.messageComplete(MessageCompleteMessage(sessionId: "session-realtime")))
+
+        waitForPropagation()
+
+        XCTAssertFalse(threadManager.threads[index].hasUnseenLatestAssistantMessage)
+
+        let seenSignals = sentMessages.compactMap { $0 as? IPCConversationSeenSignal }
+        XCTAssertFalse(seenSignals.isEmpty, "Seen signal should be emitted even when thread was already marked as seen")
+        XCTAssertEqual(seenSignals.last?.conversationId, "session-realtime")
+    }
+
     func testActiveThreadAssistantReplyClearsUnseenAndEmitsSeenSignal() {
         guard let threadId = threadManager.activeThreadId,
               let index = threadManager.threads.firstIndex(where: { $0.id == threadId }),


### PR DESCRIPTION
## Summary
- Remove `wasUnseen` guard before emitting seen signal in `handleAssistantMessageArrival`
- Always emit `emitConversationSeenSignal` when the active thread receives assistant activity, so the server-side seen cursor advances even during real-time streaming
- Add regression test `testActiveThreadEmitsSeenSignalEvenWhenAlreadySeen` covering the real-time watching scenario

## Original prompt
address feedback on https://github.com/vellum-ai/vellum-assistant/pull/9453

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
