### PR TITLE
M1: Reminder contract + persistence

### DIFF
--- a/assistant/src/__tests__/reminder-store.test.ts
+++ b/assistant/src/__tests__/reminder-store.test.ts
@@ -45,8 +45,46 @@ describe('reminder-store', () => {
     expect(r.status).toBe('pending');
     expect(r.firedAt).toBeNull();
     expect(r.conversationId).toBeNull();
+    expect(r.routingIntent).toBe('single_channel');
+    expect(r.routingHints).toEqual({});
     expect(r.createdAt).toBeGreaterThan(0);
     expect(r.updatedAt).toBeGreaterThan(0);
+  });
+
+  test('insertReminder persists routing_intent and routing_hints', () => {
+    const hints = { preferred: ['telegram'], fallback: 'sms' };
+    const r = insertReminder({
+      label: 'Multi-channel',
+      message: 'Deliver to multiple channels',
+      fireAt: Date.now() + 60_000,
+      mode: 'notify',
+      routingIntent: 'multi_channel',
+      routingHints: hints,
+    });
+
+    expect(r.routingIntent).toBe('multi_channel');
+    expect(r.routingHints).toEqual(hints);
+
+    const fetched = getReminder(r.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.routingIntent).toBe('multi_channel');
+    expect(fetched!.routingHints).toEqual(hints);
+  });
+
+  test('insertReminder defaults routing_intent to single_channel when omitted', () => {
+    const r = insertReminder({
+      label: 'Default routing',
+      message: 'No routing specified',
+      fireAt: Date.now() + 60_000,
+      mode: 'execute',
+    });
+
+    expect(r.routingIntent).toBe('single_channel');
+    expect(r.routingHints).toEqual({});
+
+    const fetched = getReminder(r.id);
+    expect(fetched!.routingIntent).toBe('single_channel');
+    expect(fetched!.routingHints).toEqual({});
   });
 
   // ── getReminder ─────────────────────────────────────────────────────
@@ -71,12 +109,15 @@ describe('reminder-store', () => {
 
   // ── listReminders ──────────────────────────────────────────────────
 
-  test('listReminders returns all reminders', () => {
+  test('listReminders returns all reminders with routing fields', () => {
     insertReminder({ label: 'A', message: 'a', fireAt: Date.now() + 60_000, mode: 'notify' });
-    insertReminder({ label: 'B', message: 'b', fireAt: Date.now() + 120_000, mode: 'execute' });
+    insertReminder({ label: 'B', message: 'b', fireAt: Date.now() + 120_000, mode: 'execute', routingIntent: 'all_channels', routingHints: { urgent: true } });
 
     const all = listReminders();
     expect(all).toHaveLength(2);
+    expect(all[0].routingIntent).toBe('single_channel');
+    expect(all[1].routingIntent).toBe('all_channels');
+    expect(all[1].routingHints).toEqual({ urgent: true });
   });
 
   test('listReminders with pendingOnly filters to pending only', () => {
@@ -119,9 +160,9 @@ describe('reminder-store', () => {
 
   // ── claimDueReminders ──────────────────────────────────────────────
 
-  test('claimDueReminders claims reminders where fireAt <= now', () => {
+  test('claimDueReminders claims reminders where fireAt <= now and preserves routing', () => {
     const now = Date.now();
-    insertReminder({ label: 'Past', message: 'x', fireAt: now - 5000, mode: 'notify' });
+    insertReminder({ label: 'Past', message: 'x', fireAt: now - 5000, mode: 'notify', routingIntent: 'all_channels', routingHints: { foo: 'bar' } });
     insertReminder({ label: 'Future', message: 'y', fireAt: now + 60_000, mode: 'notify' });
 
     const claimed = claimDueReminders(now);
@@ -129,6 +170,8 @@ describe('reminder-store', () => {
     expect(claimed[0].label).toBe('Past');
     expect(claimed[0].status).toBe('firing');
     expect(claimed[0].firedAt).toBe(now);
+    expect(claimed[0].routingIntent).toBe('all_channels');
+    expect(claimed[0].routingHints).toEqual({ foo: 'bar' });
   });
 
   test('claimDueReminders skips already-fired reminders', () => {

--- a/assistant/src/__tests__/reminder.test.ts
+++ b/assistant/src/__tests__/reminder.test.ts
@@ -120,6 +120,73 @@ describe('reminder tool', () => {
     expect(result.content).toContain('Mode: execute');
   });
 
+  // ── routing_intent ──────────────────────────────────────────────────
+
+  test('create defaults routing_intent to single_channel', async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const result = executeReminderCreate({
+      fire_at: future,
+      label: 'Default routing',
+      message: 'Should default to single_channel',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Routing: single_channel');
+  });
+
+  test('create with routing_intent multi_channel succeeds', async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const result = executeReminderCreate({
+      fire_at: future,
+      label: 'Multi routing',
+      message: 'Multi-channel delivery',
+      routing_intent: 'multi_channel',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Routing: multi_channel');
+  });
+
+  test('create with routing_intent all_channels succeeds', async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const result = executeReminderCreate({
+      fire_at: future,
+      label: 'All routing',
+      message: 'All-channel delivery',
+      routing_intent: 'all_channels',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Routing: all_channels');
+  });
+
+  test('create with invalid routing_intent returns error', async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const result = executeReminderCreate({
+      fire_at: future,
+      label: 'Bad routing',
+      message: 'Invalid routing intent',
+      routing_intent: 'invalid_value',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('routing_intent must be one of');
+  });
+
+  test('create with routing_hints passes through', async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const result = executeReminderCreate({
+      fire_at: future,
+      label: 'With hints',
+      message: 'Has routing hints',
+      routing_intent: 'multi_channel',
+      routing_hints: { preferred: ['telegram', 'sms'], fallback: 'email' },
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Routing: multi_channel');
+  });
+
   test('create requires fire_at', async () => {
     const result = executeReminderCreate({
       label: 'No fire_at',
@@ -160,18 +227,20 @@ describe('reminder tool', () => {
     expect(result.content).toContain('No reminders found');
   });
 
-  test('list returns formatted reminders', async () => {
+  test('list returns formatted reminders with routing metadata', async () => {
     const future = new Date(Date.now() + 60_000).toISOString();
     executeReminderCreate({
       fire_at: future,
       label: 'Test reminder',
       message: 'Test message',
+      routing_intent: 'all_channels',
     });
 
     const result = executeReminderList();
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Test reminder');
     expect(result.content).toContain('pending');
+    expect(result.content).toContain('routing:all_channels');
   });
 
   // ── cancel ──────────────────────────────────────────────────────────

--- a/assistant/src/config/bundled-skills/reminder/SKILL.md
+++ b/assistant/src/config/bundled-skills/reminder/SKILL.md
@@ -11,6 +11,18 @@ Create, list, and cancel one-time reminders. Reminders fire at a specific future
 - **notify** (default) — shows a notification to the user when the reminder fires
 - **execute** — sends the reminder message to a background assistant conversation for autonomous handling
 
+## Routing
+
+When creating a reminder, you can specify how it should be delivered at trigger time:
+
+- **`routing_intent`** — controls how many channels receive the reminder:
+  - `single_channel` (default) — deliver to the originating channel only
+  - `multi_channel` — deliver to a subset of available channels
+  - `all_channels` — deliver to every connected channel
+- **`routing_hints`** — optional free-form JSON object with hints for trigger-time routing (e.g. preferred channels, fallback order). These are model-authored and not parsed server-side.
+
+If `routing_intent` is omitted, it defaults to `single_channel`.
+
 ## Usage Notes
 
 - Use reminders ONLY for time-triggered notifications (e.g. "remind me at 3pm", "remind me in 2 hours").

--- a/assistant/src/config/bundled-skills/reminder/TOOLS.json
+++ b/assistant/src/config/bundled-skills/reminder/TOOLS.json
@@ -25,6 +25,15 @@
             "type": "string",
             "enum": ["notify", "execute"],
             "description": "How the reminder fires. Defaults to notify."
+          },
+          "routing_intent": {
+            "type": "string",
+            "enum": ["single_channel", "multi_channel", "all_channels"],
+            "description": "How many channels should receive the reminder at trigger time. Defaults to single_channel."
+          },
+          "routing_hints": {
+            "type": "object",
+            "description": "Optional free-form hints for trigger-time channel routing (e.g. preferred channels, fallback order). Model-authored, not parsed server-side."
           }
         },
         "required": ["fire_at", "label", "message"]

--- a/assistant/src/config/bundled-skills/time-based-actions/SKILL.md
+++ b/assistant/src/config/bundled-skills/time-based-actions/SKILL.md
@@ -64,6 +64,15 @@ The word "remind" is ambiguous. Route based on whether a time is specified:
 
 Use `notify` for simple alerts. Use `execute` when the reminder should trigger the assistant to do something (e.g., "in 30 minutes, check if the build passed").
 
+## Reminder Routing
+
+`reminder_create` accepts optional routing fields that control multi-channel delivery at trigger time:
+
+- **`routing_intent`** — `single_channel` (default), `multi_channel`, or `all_channels`
+- **`routing_hints`** — optional free-form JSON object with delivery hints (e.g. preferred channels, fallback order)
+
+These fields are model-authored metadata stored with the reminder and evaluated at trigger time. If omitted, the reminder defaults to `single_channel` delivery.
+
 ## Tool Summary
 
 | Tool | Timing | Recurrence | Purpose |

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -21,6 +21,7 @@ import {
   migrateGuardianBootstrapToken,
   migrateGuardianVerificationSessions,
   migrateMessagesFtsBackfill,
+  migrateReminderRoutingColumns,
   runComplexMigrations,
   runLateMigrations,
   validateMigrationState,
@@ -95,6 +96,9 @@ export function initializeDb(): void {
 
   // 18. Conversation attention (seen-state tracking)
   createConversationAttentionTables(database);
+
+  // 19. Reminder routing columns (routing_intent, routing_hints_json)
+  migrateReminderRoutingColumns(database);
 
   validateMigrationState(database);
 }

--- a/assistant/src/memory/migrations/030-reminder-routing-columns.ts
+++ b/assistant/src/memory/migrations/030-reminder-routing-columns.ts
@@ -1,0 +1,22 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Add routing_intent and routing_hints_json columns to reminders.
+ *
+ * These fields let the model specify how the reminder should be delivered
+ * at trigger time (single channel, multiple channels, or all channels).
+ * Existing reminders default to single_channel with no routing hints.
+ */
+export function migrateReminderRoutingColumns(database: DrizzleDb): void {
+  try {
+    database.run(
+      /*sql*/ `ALTER TABLE reminders ADD COLUMN routing_intent TEXT NOT NULL DEFAULT 'single_channel'`,
+    );
+  } catch { /* Column already exists */ }
+
+  try {
+    database.run(
+      /*sql*/ `ALTER TABLE reminders ADD COLUMN routing_hints_json TEXT NOT NULL DEFAULT '{}'`,
+    );
+  } catch { /* Column already exists */ }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -47,6 +47,7 @@ export { createNotificationTables } from './114-notifications.js';
 export { createSequenceTables } from './115-sequences.js';
 export { createMessagesFts } from './116-messages-fts.js';
 export { createConversationAttentionTables } from './117-conversation-attention.js';
+export { migrateReminderRoutingColumns } from './030-reminder-routing-columns.js';
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema-migration.ts
+++ b/assistant/src/memory/schema-migration.ts
@@ -22,6 +22,7 @@ export {
   migrateNotificationDeliveryPairingColumns,
   migrateNotificationTablesSchema,
   migrateRemainingTableIndexes,
+  migrateReminderRoutingColumns,
   migrateRemoveAssistantIdColumns,
   migrateToolInvocationsFk,
   MIGRATION_REGISTRY,

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -242,6 +242,8 @@ export const reminders = sqliteTable('reminders', {
   status: text('status').notNull(),               // 'pending' | 'firing' | 'fired' | 'cancelled'
   firedAt: integer('fired_at'),
   conversationId: text('conversation_id'),
+  routingIntent: text('routing_intent').notNull().default('single_channel'),  // 'single_channel' | 'multi_channel' | 'all_channels'
+  routingHintsJson: text('routing_hints_json').notNull().default('{}'),       // free-form JSON object, model-authored
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 });

--- a/assistant/src/tools/reminder/reminder-store.ts
+++ b/assistant/src/tools/reminder/reminder-store.ts
@@ -3,7 +3,9 @@ import { v4 as uuid } from 'uuid';
 
 import { getDb } from '../../memory/db.js';
 import { reminders } from '../../memory/schema.js';
-import { cast,createRowMapper } from '../../util/row-mapper.js';
+import { cast,createRowMapper, parseJson } from '../../util/row-mapper.js';
+
+export type RoutingIntent = 'single_channel' | 'multi_channel' | 'all_channels';
 
 export interface ReminderRow {
   id: string;
@@ -14,6 +16,8 @@ export interface ReminderRow {
   status: 'pending' | 'firing' | 'fired' | 'cancelled';
   firedAt: number | null;
   conversationId: string | null;
+  routingIntent: RoutingIntent;
+  routingHints: Record<string, unknown>;
   createdAt: number;
   updatedAt: number;
 }
@@ -27,6 +31,8 @@ const parseRow = createRowMapper<typeof reminders.$inferSelect, ReminderRow>({
   status: { from: 'status', transform: cast<ReminderRow['status']>() },
   firedAt: 'firedAt',
   conversationId: 'conversationId',
+  routingIntent: { from: 'routingIntent', transform: cast<RoutingIntent>() },
+  routingHints: { from: 'routingHintsJson', transform: parseJson<Record<string, unknown>>({}) },
   createdAt: 'createdAt',
   updatedAt: 'updatedAt',
 });
@@ -36,11 +42,30 @@ export function insertReminder(params: {
   message: string;
   fireAt: number;
   mode: 'notify' | 'execute';
+  routingIntent?: RoutingIntent;
+  routingHints?: Record<string, unknown>;
 }): ReminderRow {
   const db = getDb();
   const id = uuid();
   const now = Date.now();
-  const row: ReminderRow = {
+  const routingIntent = params.routingIntent ?? 'single_channel';
+  const routingHints = params.routingHints ?? {};
+  const row = {
+    id,
+    label: params.label,
+    message: params.message,
+    fireAt: params.fireAt,
+    mode: params.mode,
+    status: 'pending' as const,
+    firedAt: null,
+    conversationId: null,
+    routingIntent,
+    routingHintsJson: JSON.stringify(routingHints),
+    createdAt: now,
+    updatedAt: now,
+  };
+  db.insert(reminders).values(row).run();
+  return {
     id,
     label: params.label,
     message: params.message,
@@ -49,11 +74,11 @@ export function insertReminder(params: {
     status: 'pending',
     firedAt: null,
     conversationId: null,
+    routingIntent,
+    routingHints,
     createdAt: now,
     updatedAt: now,
   };
-  db.insert(reminders).values(row).run();
-  return row;
 }
 
 export function getReminder(id: string): ReminderRow | null {

--- a/assistant/src/tools/reminder/reminder.ts
+++ b/assistant/src/tools/reminder/reminder.ts
@@ -5,6 +5,9 @@ import {
   insertReminder,
   listReminders,
 } from './reminder-store.js';
+import type { RoutingIntent } from './reminder-store.js';
+
+const VALID_ROUTING_INTENTS: ReadonlySet<string> = new Set(['single_channel', 'multi_channel', 'all_channels']);
 
 // ── Exported execute functions ──────────────────────────────────────
 
@@ -13,6 +16,8 @@ export function executeReminderCreate(input: Record<string, unknown>): ToolExecu
   const label = input.label as string | undefined;
   const message = input.message as string | undefined;
   const mode = (input.mode as string | undefined) ?? 'notify';
+  const routingIntentRaw = (input.routing_intent as string | undefined) ?? 'single_channel';
+  const routingHints = (input.routing_hints as Record<string, unknown> | undefined) ?? undefined;
 
   if (!fireAtStr) {
     return { content: 'Error: fire_at is required for create', isError: true };
@@ -26,6 +31,10 @@ export function executeReminderCreate(input: Record<string, unknown>): ToolExecu
   if (mode !== 'notify' && mode !== 'execute') {
     return { content: 'Error: mode must be "notify" or "execute"', isError: true };
   }
+  if (!VALID_ROUTING_INTENTS.has(routingIntentRaw)) {
+    return { content: 'Error: routing_intent must be one of: single_channel, multi_channel, all_channels', isError: true };
+  }
+  const routingIntent = routingIntentRaw as RoutingIntent;
 
   // Require strict ISO 8601 with timezone offset or Z to avoid ambiguous parsing
   if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:\d{2})$/.test(fireAtStr)) {
@@ -39,10 +48,10 @@ export function executeReminderCreate(input: Record<string, unknown>): ToolExecu
     return { content: 'Error: fire_at must be in the future', isError: true };
   }
 
-  const reminder = insertReminder({ label, message, fireAt, mode });
+  const reminder = insertReminder({ label, message, fireAt, mode, routingIntent, routingHints });
 
   return {
-    content: `Reminder created.\n  ID: ${reminder.id}\n  Label: ${reminder.label}\n  Fires at: ${formatLocalDate(reminder.fireAt)}\n  Mode: ${reminder.mode}`,
+    content: `Reminder created.\n  ID: ${reminder.id}\n  Label: ${reminder.label}\n  Fires at: ${formatLocalDate(reminder.fireAt)}\n  Mode: ${reminder.mode}\n  Routing: ${reminder.routingIntent}`,
     isError: false,
   };
 }
@@ -59,7 +68,7 @@ export function executeReminderList(): ToolExecutionResult {
       : r.status === 'firing'
         ? 'firing'
         : r.status;
-    return `  - [${r.id}] "${r.label}" — ${formatLocalDate(r.fireAt)} (${r.mode}, ${status})`;
+    return `  - [${r.id}] "${r.label}" — ${formatLocalDate(r.fireAt)} (${r.mode}, ${status}, routing:${r.routingIntent})`;
   });
 
   return { content: `Reminders:\n${lines.join('\n')}`, isError: false };


### PR DESCRIPTION
Add routing_intent (single_channel | multi_channel | all_channels) and routing_hints fields to the reminder create contract. Persist them in the DB via a new migration. Update tool schema, skill docs, reminder store, and tests. Part of #9454.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
