### PR TITLE
Animate thread reorder on pin/unpin in sidebar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -909,10 +909,12 @@ struct MainWindowView: View {
         .overlay(alignment: .leading) {
             if isHovered {
                 Button {
-                    if thread.isPinned {
-                        threadManager.unpinThread(id: thread.id)
-                    } else {
-                        threadManager.pinThread(id: thread.id)
+                    withAnimation(VAnimation.standard) {
+                        if thread.isPinned {
+                            threadManager.unpinThread(id: thread.id)
+                        } else {
+                            threadManager.pinThread(id: thread.id)
+                        }
                     }
                 } label: {
                     Image(systemName: thread.isPinned ? "pin.fill" : "pin")
@@ -966,10 +968,12 @@ struct MainWindowView: View {
         .padding(.horizontal, VSpacing.sm)
         .contextMenu {
             Button {
-                if thread.isPinned {
-                    threadManager.unpinThread(id: thread.id)
-                } else {
-                    threadManager.pinThread(id: thread.id)
+                withAnimation(VAnimation.standard) {
+                    if thread.isPinned {
+                        threadManager.unpinThread(id: thread.id)
+                    } else {
+                        threadManager.pinThread(id: thread.id)
+                    }
                 }
             } label: {
                 Label(thread.isPinned ? "Unpin" : "Pin to Top", systemImage: thread.isPinned ? "pin.slash" : "pin")


### PR DESCRIPTION
## Summary
- Wrap pin/unpin state changes in `withAnimation(VAnimation.standard)` so threads smoothly slide to their new position instead of jumping
- Applies to both the hover overlay pin button and the right-click context menu pin/unpin action

## Original prompt
When I pin or unpin a conversation thread from the side nav of the macp app, it should smoothly slide to where it's supposed to be, rather than suddenly
  jumping there

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
