### PR TITLE
M4: Verification success -> trusted contact activation

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -426,7 +426,7 @@ describe('guardian service challenge validation', () => {
     );
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success && result.verificationType === 'guardian') {
       expect(result.bindingId).toBeDefined();
     }
   });
@@ -528,7 +528,7 @@ describe('guardian service challenge validation', () => {
     );
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success && result.verificationType === 'guardian') {
       expect(result.bindingId).toBeDefined();
     }
 
@@ -1616,7 +1616,7 @@ describe('voice guardian challenge validation', () => {
     );
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success && result.verificationType === 'guardian') {
       expect(result.bindingId).toBeDefined();
     }
   });
@@ -2261,7 +2261,7 @@ describe('outbound verification sessions', () => {
     );
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success && result.verificationType === 'guardian') {
       expect(result.bindingId).toBeDefined();
     }
   });
@@ -2740,7 +2740,9 @@ describe('outbound SMS verification', () => {
 
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.bindingId).toBeDefined();
+      // Identity-bound outbound sessions produce trusted_contact verification
+      // (no guardian binding created)
+      expect(result.verificationType).toBe('trusted_contact');
     }
   });
 

--- a/assistant/src/__tests__/trusted-contact-verification.test.ts
+++ b/assistant/src/__tests__/trusted-contact-verification.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Tests for M4: Verification success → trusted contact activation.
+ *
+ * When a requester successfully verifies their identity (enters the correct
+ * 6-digit code from an identity-bound outbound session), the system should:
+ * 1. Upsert an active member record in assistant_ingress_members
+ * 2. Allow subsequent messages through the ACL check
+ * 3. Scope the member correctly (no cross-assistant leakage)
+ * 4. Reactivate previously revoked members on re-verification
+ * 5. NOT create a guardian binding (trusted contacts are not guardians)
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Test isolation: in-memory SQLite via temp directory
+// ---------------------------------------------------------------------------
+
+const testDir = mkdtempSync(join(tmpdir(), 'trusted-contact-verify-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  normalizeAssistantId: (id: string) => id === 'self' ? 'self' : id,
+  readHttpToken: () => 'test-bearer-token',
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { initializeDb, resetDb } from '../memory/db.js';
+import {
+  createOutboundSession,
+  validateAndConsumeChallenge,
+} from '../runtime/channel-guardian-service.js';
+import {
+  findMember,
+  upsertMember,
+  revokeMember,
+} from '../memory/ingress-member-store.js';
+import {
+  getActiveBinding,
+  createBinding,
+} from '../memory/channel-guardian-store.js';
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetTables(): void {
+  const { getDb } = require('../memory/db.js');
+  const db = getDb();
+  db.run('DELETE FROM channel_guardian_verification_challenges');
+  db.run('DELETE FROM channel_guardian_bindings');
+  db.run('DELETE FROM channel_guardian_rate_limits');
+  db.run('DELETE FROM assistant_ingress_members');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('trusted contact verification → member activation', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test('successful verification creates active member with allow policy', () => {
+    // Simulate M3: guardian approves, outbound session created for the requester
+    const session = createOutboundSession({
+      assistantId: 'self',
+      channel: 'telegram',
+      expectedExternalUserId: 'requester-user-123',
+      expectedChatId: 'requester-chat-123',
+      identityBindingStatus: 'bound',
+      destinationAddress: 'requester-chat-123',
+    });
+
+    // Requester enters the 6-digit code
+    const result = validateAndConsumeChallenge(
+      'self',
+      'telegram',
+      session.secret,
+      'requester-user-123',
+      'requester-chat-123',
+      'requester_username',
+      'Requester Name',
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.verificationType).toBe('trusted_contact');
+    }
+
+    // Simulate the member upsert that inbound-message-handler performs on success
+    upsertMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'requester-user-123',
+      externalChatId: 'requester-chat-123',
+      status: 'active',
+      policy: 'allow',
+      displayName: 'Requester Name',
+      username: 'requester_username',
+    });
+
+    // Verify: active member record exists
+    const member = findMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'requester-user-123',
+    });
+
+    expect(member).not.toBeNull();
+    expect(member!.status).toBe('active');
+    expect(member!.policy).toBe('allow');
+    expect(member!.externalUserId).toBe('requester-user-123');
+    expect(member!.externalChatId).toBe('requester-chat-123');
+    expect(member!.displayName).toBe('Requester Name');
+    expect(member!.username).toBe('requester_username');
+    expect(member!.assistantId).toBe('self');
+    expect(member!.sourceChannel).toBe('telegram');
+  });
+
+  test('post-verify message is accepted (ACL check passes)', () => {
+    // Create and verify a trusted contact
+    const session = createOutboundSession({
+      assistantId: 'self',
+      channel: 'telegram',
+      expectedExternalUserId: 'requester-user-456',
+      expectedChatId: 'requester-chat-456',
+      identityBindingStatus: 'bound',
+      destinationAddress: 'requester-chat-456',
+    });
+
+    validateAndConsumeChallenge(
+      'self', 'telegram', session.secret,
+      'requester-user-456', 'requester-chat-456',
+    );
+
+    // Simulate member upsert on verification success
+    upsertMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'requester-user-456',
+      externalChatId: 'requester-chat-456',
+      status: 'active',
+      policy: 'allow',
+    });
+
+    // Simulate the ACL check that inbound-message-handler performs
+    const member = findMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'requester-user-456',
+      externalChatId: 'requester-chat-456',
+    });
+
+    expect(member).not.toBeNull();
+    expect(member!.status).toBe('active');
+    expect(member!.policy).toBe('allow');
+    // ACL check passes: member exists, is active, and has allow policy
+  });
+
+  test('no cross-assistant leakage (member scoped correctly)', () => {
+    // Create member for assistant 'self'
+    const session = createOutboundSession({
+      assistantId: 'self',
+      channel: 'telegram',
+      expectedExternalUserId: 'user-cross-test',
+      expectedChatId: 'chat-cross-test',
+      identityBindingStatus: 'bound',
+      destinationAddress: 'chat-cross-test',
+    });
+
+    validateAndConsumeChallenge(
+      'self', 'telegram', session.secret,
+      'user-cross-test', 'chat-cross-test',
+    );
+
+    upsertMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-cross-test',
+      externalChatId: 'chat-cross-test',
+      status: 'active',
+      policy: 'allow',
+    });
+
+    // Member should be found for 'self'
+    const selfMember = findMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-cross-test',
+    });
+    expect(selfMember).not.toBeNull();
+    expect(selfMember!.status).toBe('active');
+
+    // Member should NOT be found for a different assistant
+    const otherMember = findMember({
+      assistantId: 'other-assistant',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-cross-test',
+    });
+    expect(otherMember).toBeNull();
+  });
+
+  test('re-verification of previously revoked member reactivates them', () => {
+    // Create and activate a member
+    const member = upsertMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-revoked',
+      externalChatId: 'chat-revoked',
+      status: 'active',
+      policy: 'allow',
+      displayName: 'Revoked User',
+    });
+
+    // Revoke the member
+    const revoked = revokeMember(member.id, 'testing revocation');
+    expect(revoked).not.toBeNull();
+    expect(revoked!.status).toBe('revoked');
+
+    // Verify the member is indeed revoked (ACL would reject)
+    const revokedMember = findMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-revoked',
+    });
+    expect(revokedMember).not.toBeNull();
+    expect(revokedMember!.status).toBe('revoked');
+
+    // Guardian re-approves, new outbound session created
+    const session = createOutboundSession({
+      assistantId: 'self',
+      channel: 'telegram',
+      expectedExternalUserId: 'user-revoked',
+      expectedChatId: 'chat-revoked',
+      identityBindingStatus: 'bound',
+      destinationAddress: 'chat-revoked',
+    });
+
+    // Requester enters the new code
+    const result = validateAndConsumeChallenge(
+      'self', 'telegram', session.secret,
+      'user-revoked', 'chat-revoked',
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.verificationType).toBe('trusted_contact');
+    }
+
+    // upsertMember reactivates the existing record
+    upsertMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-revoked',
+      externalChatId: 'chat-revoked',
+      status: 'active',
+      policy: 'allow',
+    });
+
+    // Verify: member is now active again
+    const reactivated = findMember({
+      assistantId: 'self',
+      sourceChannel: 'telegram',
+      externalUserId: 'user-revoked',
+    });
+    expect(reactivated).not.toBeNull();
+    expect(reactivated!.status).toBe('active');
+    expect(reactivated!.policy).toBe('allow');
+  });
+
+  test('trusted contact verification does NOT create a guardian binding', () => {
+    // Ensure there's an existing guardian binding we want to preserve
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-user-original',
+      guardianDeliveryChatId: 'guardian-chat-original',
+      verifiedVia: 'challenge',
+      metadataJson: null,
+    });
+
+    // Create an outbound session for a requester (different user than guardian)
+    const session = createOutboundSession({
+      assistantId: 'self',
+      channel: 'telegram',
+      expectedExternalUserId: 'requester-user-789',
+      expectedChatId: 'requester-chat-789',
+      identityBindingStatus: 'bound',
+      destinationAddress: 'requester-chat-789',
+    });
+
+    const result = validateAndConsumeChallenge(
+      'self', 'telegram', session.secret,
+      'requester-user-789', 'requester-chat-789',
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.verificationType).toBe('trusted_contact');
+      // Should NOT have a bindingId — no guardian binding created
+      expect('bindingId' in result).toBe(false);
+    }
+
+    // The original guardian binding should remain intact
+    const binding = getActiveBinding('self', 'telegram');
+    expect(binding).not.toBeNull();
+    expect(binding!.guardianExternalUserId).toBe('guardian-user-original');
+  });
+
+  test('guardian inbound verification still creates binding (backward compat)', () => {
+    // Create an inbound challenge (no expected identity — guardian flow)
+    const { createVerificationChallenge } = require('../runtime/channel-guardian-service.js');
+    const { secret } = createVerificationChallenge('self', 'telegram');
+
+    const result = validateAndConsumeChallenge(
+      'self', 'telegram', secret,
+      'guardian-user', 'guardian-chat',
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success && result.verificationType === 'guardian') {
+      expect(result.bindingId).toBeDefined();
+    }
+
+    // Guardian binding should be created
+    const binding = getActiveBinding('self', 'telegram');
+    expect(binding).not.toBeNull();
+    expect(binding!.guardianExternalUserId).toBe('guardian-user');
+  });
+});

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -667,7 +667,7 @@ export class RelayConnection {
         : 'guardian_voice_verification_succeeded';
 
       recordCallEvent(this.callSessionId, eventName, {
-        bindingId: result.bindingId,
+        bindingId: 'bindingId' in result ? result.bindingId : undefined,
       });
       log.info(
         { callSessionId: this.callSessionId, isOutbound },

--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -62,7 +62,8 @@ export interface CreateChallengeResult {
 }
 
 export type ValidateChallengeResult =
-  | { success: true; bindingId: string }
+  | { success: true; bindingId: string; verificationType: 'guardian' }
+  | { success: true; verificationType: 'trusted_contact' }
   | { success: false; reason: string };
 
 // ---------------------------------------------------------------------------
@@ -272,6 +273,14 @@ export function validateAndConsumeChallenge(
   // Reset the rate-limit counter on success
   resetRateLimit(assistantId, channel, actorExternalUserId, actorChatId);
 
+  // Identity-bound outbound sessions (from the trusted contact access flow)
+  // should NOT create a guardian binding — the requester is becoming a trusted
+  // contact, not a guardian. Only unbound inbound challenges (guardian
+  // verification) create guardian bindings.
+  if (hasExpectedIdentity && challenge.identityBindingStatus === 'bound') {
+    return { success: true, verificationType: 'trusted_contact' };
+  }
+
   // Reject if a different user already holds the guardian binding
   const existingBinding = getActiveBinding(assistantId, channel);
   if (existingBinding && existingBinding.guardianExternalUserId !== actorExternalUserId) {
@@ -302,7 +311,7 @@ export function validateAndConsumeChallenge(
     metadataJson: Object.keys(metadata).length > 0 ? JSON.stringify(metadata) : null,
   });
 
-  return { success: true, bindingId: binding.id };
+  return { success: true, bindingId: binding.id, verificationType: 'guardian' };
 }
 
 /**

--- a/assistant/src/runtime/guardian-verification-templates.ts
+++ b/assistant/src/runtime/guardian-verification-templates.ts
@@ -35,6 +35,8 @@ export const GUARDIAN_VERIFY_TEMPLATE_KEYS = {
   CHANNEL_VERIFY_FAILED: 'guardian_verify.channel.failed',
   /** Deterministic reply for bootstrap deep-link success. */
   CHANNEL_BOOTSTRAP_BOUND: 'guardian_verify.channel.bootstrap_bound',
+  /** Deterministic reply after successful trusted contact verification. */
+  CHANNEL_TRUSTED_CONTACT_VERIFY_SUCCESS: 'guardian_verify.channel.trusted_contact_success',
 } as const;
 
 export type GuardianVerifyTemplateKey =
@@ -52,7 +54,8 @@ type TextVerifyTemplateKey =
 export type ChannelVerifyReplyTemplateKey =
   | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_VERIFY_SUCCESS
   | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_VERIFY_FAILED
-  | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_BOOTSTRAP_BOUND;
+  | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_BOOTSTRAP_BOUND
+  | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_TRUSTED_CONTACT_VERIFY_SUCCESS;
 
 // ---------------------------------------------------------------------------
 // Template Variables
@@ -173,6 +176,9 @@ const channelVerifyReplyTemplates: Record<ChannelVerifyReplyTemplateKey, (vars: 
 
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_BOOTSTRAP_BOUND]: () =>
     'Welcome! Your identity has been linked. Please check for a verification code message.',
+
+  [GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_TRUSTED_CONTACT_VERIFY_SUCCESS]: () =>
+    'Verification successful! You can now message the assistant.',
 };
 
 /**

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -656,17 +656,26 @@ export async function handleChannelInbound(
         displayName: body.senderName,
         username: body.senderUsername,
       });
-      log.info({ sourceChannel, externalUserId: body.senderExternalUserId }, 'Guardian verified: auto-upserted ingress member');
+
+      const verifyLogLabel = verifyResult.verificationType === 'trusted_contact'
+        ? 'Trusted contact verified'
+        : 'Guardian verified';
+      log.info({ sourceChannel, externalUserId: body.senderExternalUserId, verificationType: verifyResult.verificationType }, `${verifyLogLabel}: auto-upserted ingress member`);
     }
 
     // Deliver a deterministic template-driven reply and short-circuit.
     // Verification commands must never produce agent-generated copy.
     if (replyCallbackUrl) {
-      const replyText = verifyResult.success
-        ? composeChannelVerifyReply(GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_VERIFY_SUCCESS)
-        : composeChannelVerifyReply(GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_VERIFY_FAILED, {
-            failureReason: stripVerificationFailurePrefix(verifyResult.reason),
-          });
+      let replyText: string;
+      if (!verifyResult.success) {
+        replyText = composeChannelVerifyReply(GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_VERIFY_FAILED, {
+          failureReason: stripVerificationFailurePrefix(verifyResult.reason),
+        });
+      } else if (verifyResult.verificationType === 'trusted_contact') {
+        replyText = composeChannelVerifyReply(GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_TRUSTED_CONTACT_VERIFY_SUCCESS);
+      } else {
+        replyText = composeChannelVerifyReply(GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_VERIFY_SUCCESS);
+      }
       try {
         await deliverChannelReply(replyCallbackUrl, {
           chatId: externalChatId,


### PR DESCRIPTION
On successful verification of the 6-digit code, upserts assistant_ingress_members with status=active and policy=allow. The requester can immediately send messages after verification.

Key changes:
- validateAndConsumeChallenge now distinguishes guardian vs trusted contact verification via verificationType field
- Identity-bound outbound sessions (trusted contacts) no longer create guardian bindings
- New template for trusted contact verification success message
- Existing guardian verification flow unchanged (backward compatible)

Closes #9437
Part of #9432
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
