### PR TITLE
M3: Routing Precedence Fix — Guardian Verify Setup is Exclusive

### DIFF
--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -290,4 +290,26 @@ describe('Guardian verification routing section in system prompt', () => {
     expect(routingSection).toContain('voice');
     expect(routingSection).toContain('telegram');
   });
+
+  test('routing section contains exclusivity wording', () => {
+    const prompt = buildSystemPrompt();
+    const lower = prompt.toLowerCase();
+    // Must contain "exclusively" or "must only" to enforce exclusive handling
+    expect(lower.includes('exclusively') || lower.includes('must only')).toBe(true);
+  });
+
+  test('routing section prohibits loading phone-calls for guardian verification', () => {
+    const prompt = buildSystemPrompt();
+    const lower = prompt.toLowerCase();
+    // Must explicitly prohibit phone-calls for guardian verification intents
+    expect(lower).toContain('do not load');
+    expect(lower).toContain('phone-calls');
+  });
+
+  test('routing section includes channel-preservation guidance', () => {
+    const prompt = buildSystemPrompt();
+    const lower = prompt.toLowerCase();
+    // Must advise not to re-ask channel if already specified
+    expect(lower.includes('do not re-ask') || lower.includes('already specified')).toBe(true);
+  });
 });

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -364,17 +364,7 @@ No additional configuration is needed beyond the standard Twilio setup (Steps 1-
 
 ### Guardian voice verification for inbound calls
 
-To link the user's phone number as the trusted voice guardian, install and load the **guardian-verify-setup** skill. This skill handles the full outbound verification flow:
-
-- Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "guardian-verify-setup"`.
-- Then call `skill_load` with `skill: "guardian-verify-setup"`.
-
-When invoked for the `voice` channel, the guardian-verify-setup skill:
-1. Collects the user's phone number as the destination
-2. Starts an outbound verification session via `POST /v1/integrations/guardian/outbound/start` with `channel: "voice"`
-3. The API initiates a phone call to the user's number. The response includes a `secret` field with the verification code -- the code is shared with the user BEFORE the call connects so they know what to enter
-4. When the user answers, they enter the verification code via their phone's keypad (DTMF)
-5. If the code matches, a guardian binding is created for the voice channel
+For guardian verification setup, load `guardian-verify-setup`; this skill does not orchestrate that flow inline.
 
 Once a guardian binding exists for the voice channel, inbound callers may be prompted for verification before calls proceed. The relay server detects pending challenges and prompts callers: "Please enter your six-digit verification code using your keypad, or speak the digits now." If verification fails after 3 attempts, the call ends with "Verification failed. Goodbye."
 

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -209,6 +209,11 @@ export function buildGuardianVerificationRoutingSection(): string {
     '4. Guide the user through code entry, resend, or cancel',
     '',
     'Load with: `skill_load` using `skill: "guardian-verify-setup"`',
+    '',
+    '### Exclusivity rules',
+    '- Guardian verification intents must only be handled by `guardian-verify-setup` — load it exclusively.',
+    '- Do NOT load `phone-calls` for guardian verification intent routing. The phone-calls skill does not orchestrate verification flows.',
+    '- If the user has already specified a channel (e.g., "verify my phone number" implies voice), do not re-ask which channel unless the input is contradictory.',
   ].join('\n');
 }
 

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -213,7 +213,7 @@ export function buildGuardianVerificationRoutingSection(): string {
     '### Exclusivity rules',
     '- Guardian verification intents must only be handled by `guardian-verify-setup` — load it exclusively.',
     '- Do NOT load `phone-calls` for guardian verification intent routing. The phone-calls skill does not orchestrate verification flows.',
-    '- If the user has already specified a channel (e.g., "verify my phone number" implies voice), do not re-ask which channel unless the input is contradictory.',
+    '- If the user has already explicitly specified a channel (e.g., "verify my phone for SMS", "verify my Telegram"), do not re-ask which channel unless the input is contradictory. Note: "verify my phone number" alone is ambiguous (phone numbers apply to both sms and voice) — ask which channel.',
   ].join('\n');
 }
 


### PR DESCRIPTION
Make guardian verification routing explicit and exclusive in system prompt. Replace competing orchestration instructions in phone-calls skill with a concise handoff to guardian-verify-setup. Add routing exclusivity tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
