### PR TITLE
fix: address review feedback on PR #9260

### DIFF
--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -110,9 +110,15 @@ export class NotificationBroadcaster {
         continue;
       }
 
-      // Pull rendered copy from the decision; fall back to copy-composer if missing
+      // Pull rendered copy from the decision; fall back to copy-composer if
+      // missing or effectively blank. The decision engine's LLM occasionally
+      // returns empty title/body strings that pass type-only validation, so
+      // treat copy with no usable content the same as missing copy.
       let copy = decision.renderedCopy[channel];
-      if (!copy) {
+      if (!copy || (!copy.title?.trim() && !copy.body?.trim())) {
+        if (copy) {
+          log.warn({ channel, signalId: signal.signalId }, 'Decision copy has empty title and body — using fallback');
+        }
         if (!fallbackCopy) {
           fallbackCopy = composeFallbackCopy(signal, decision.selectedChannels);
         }

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -248,6 +248,9 @@ function validateDecisionOutput(
       if (chCopy && typeof chCopy === 'object') {
         const c = chCopy as Record<string, unknown>;
         if (typeof c.title === 'string' && typeof c.body === 'string') {
+          if (!c.title.trim() && !c.body.trim()) {
+            log.warn({ channel: ch }, 'LLM returned empty title and body for channel copy — broadcaster will use fallback');
+          }
           renderedCopy[ch] = {
             title: c.title,
             body: c.body,


### PR DESCRIPTION
Addresses reviewer feedback from #9260

The Codex review on PR #9260 noted that `validateDecisionOutput` only checks types, allowing the LLM to return empty title/body strings that silently pass validation. While PR #9389 added a downstream safety net in thread-seed-composer, the broadcaster still treated empty-content copy as valid, affecting notification popups and delivery audit records.

Changes:
- **broadcaster.ts**: Treat copy with empty title AND body as missing, triggering the fallback copy path (same as null/undefined copy)
- **decision-engine.ts**: Log a warning when the LLM returns empty title/body so the issue is observable in logs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
