### PR TITLE
M1: Add canonical unseen-count helper in ThreadManager

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -95,6 +95,12 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
     }
 
+    /// Count of visible (non-archived, non-private) threads with unseen assistant messages.
+    /// Used by AppDelegate to drive the dock badge.
+    var unseenVisibleConversationCount: Int {
+        threads.filter { !$0.isArchived && $0.kind != .private && $0.hasUnseenLatestAssistantMessage }.count
+    }
+
     var archivedThreads: [ThreadModel] {
         threads.filter { $0.isArchived }
     }


### PR DESCRIPTION
Add a computed property unseenVisibleConversationCount to ThreadManager that counts non-archived, non-private threads with unseen assistant messages. This centralizes badge count logic for the dock badge feature. Closes #9465.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
