### PR TITLE
M2: Fire-time routing behavior

### DIFF
--- a/assistant/src/__tests__/notification-routing-intent.test.ts
+++ b/assistant/src/__tests__/notification-routing-intent.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for fire-time routing intent enforcement.
+ *
+ * Validates that the post-decision enforcement step correctly overrides
+ * the decision engine's channel selection based on the routing intent
+ * persisted on the reminder at create time.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  isDebug: () => false,
+  truncateForLog: (v: string) => v,
+}));
+
+import { enforceRoutingIntent } from '../notifications/decision-engine.js';
+import type { RoutingIntent } from '../notifications/signal.js';
+import type { NotificationChannel, NotificationDecision } from '../notifications/types.js';
+
+// -- Helpers -----------------------------------------------------------------
+
+function makeDecision(overrides?: Partial<NotificationDecision>): NotificationDecision {
+  return {
+    shouldNotify: true,
+    selectedChannels: ['vellum'],
+    reasoningSummary: 'LLM selected vellum only',
+    renderedCopy: {
+      vellum: { title: 'Reminder', body: 'Test reminder' },
+    },
+    dedupeKey: 'routing-test-001',
+    confidence: 0.9,
+    fallbackUsed: false,
+    ...overrides,
+  };
+}
+
+// -- Tests -------------------------------------------------------------------
+
+describe('routing intent enforcement', () => {
+  describe('all_channels intent', () => {
+    test('forces selection to all connected channels', () => {
+      const decision = makeDecision({ selectedChannels: ['vellum'] });
+      const connected: NotificationChannel[] = ['vellum', 'telegram'];
+
+      const enforced = enforceRoutingIntent(decision, 'all_channels', connected);
+
+      expect(enforced.selectedChannels).toEqual(['vellum', 'telegram']);
+      expect(enforced.reasoningSummary).toContain('routing_intent=all_channels');
+    });
+
+    test('selects all channels even when LLM picked none', () => {
+      const decision = makeDecision({ selectedChannels: [] });
+      const connected: NotificationChannel[] = ['vellum', 'telegram'];
+
+      // shouldNotify must be true for enforcement to apply
+      const enforced = enforceRoutingIntent(decision, 'all_channels', connected);
+      expect(enforced.selectedChannels).toEqual(['vellum', 'telegram']);
+    });
+
+    test('does not modify decision when shouldNotify is false', () => {
+      const decision = makeDecision({ shouldNotify: false, selectedChannels: [] });
+      const connected: NotificationChannel[] = ['vellum', 'telegram'];
+
+      const enforced = enforceRoutingIntent(decision, 'all_channels', connected);
+
+      expect(enforced.shouldNotify).toBe(false);
+      expect(enforced.selectedChannels).toEqual([]);
+    });
+
+    test('single connected channel selects that channel', () => {
+      const decision = makeDecision({ selectedChannels: ['vellum'] });
+      const connected: NotificationChannel[] = ['vellum'];
+
+      const enforced = enforceRoutingIntent(decision, 'all_channels', connected);
+      expect(enforced.selectedChannels).toEqual(['vellum']);
+    });
+  });
+
+  describe('multi_channel intent', () => {
+    test('expands to all connected when LLM picked fewer than 2 and 2+ are connected', () => {
+      const decision = makeDecision({ selectedChannels: ['vellum'] });
+      const connected: NotificationChannel[] = ['vellum', 'telegram'];
+
+      const enforced = enforceRoutingIntent(decision, 'multi_channel', connected);
+
+      expect(enforced.selectedChannels).toEqual(['vellum', 'telegram']);
+      expect(enforced.reasoningSummary).toContain('routing_intent=multi_channel');
+    });
+
+    test('does not override when LLM already picked 2+ channels', () => {
+      const decision = makeDecision({ selectedChannels: ['vellum', 'telegram'] });
+      const connected: NotificationChannel[] = ['vellum', 'telegram'];
+
+      const enforced = enforceRoutingIntent(decision, 'multi_channel', connected);
+
+      expect(enforced.selectedChannels).toEqual(['vellum', 'telegram']);
+      // No enforcement annotation since decision already satisfied the intent
+      expect(enforced.reasoningSummary).not.toContain('routing_intent=multi_channel');
+    });
+
+    test('does not expand when only 1 channel is connected', () => {
+      const decision = makeDecision({ selectedChannels: ['vellum'] });
+      const connected: NotificationChannel[] = ['vellum'];
+
+      const enforced = enforceRoutingIntent(decision, 'multi_channel', connected);
+
+      // Cannot expand to 2+ when only 1 is available
+      expect(enforced.selectedChannels).toEqual(['vellum']);
+    });
+
+    test('does not modify decision when shouldNotify is false', () => {
+      const decision = makeDecision({ shouldNotify: false, selectedChannels: [] });
+      const connected: NotificationChannel[] = ['vellum', 'telegram'];
+
+      const enforced = enforceRoutingIntent(decision, 'multi_channel', connected);
+
+      expect(enforced.shouldNotify).toBe(false);
+      expect(enforced.selectedChannels).toEqual([]);
+    });
+  });
+
+  describe('single_channel intent', () => {
+    test('does not modify the decision', () => {
+      const decision = makeDecision({ selectedChannels: ['vellum'] });
+      const connected: NotificationChannel[] = ['vellum', 'telegram'];
+
+      const enforced = enforceRoutingIntent(decision, 'single_channel', connected);
+
+      expect(enforced.selectedChannels).toEqual(['vellum']);
+      expect(enforced.reasoningSummary).toBe(decision.reasoningSummary);
+    });
+  });
+
+  describe('undefined routing intent', () => {
+    test('does not modify the decision', () => {
+      const decision = makeDecision({ selectedChannels: ['vellum'] });
+      const connected: NotificationChannel[] = ['vellum', 'telegram'];
+
+      const enforced = enforceRoutingIntent(decision, undefined, connected);
+
+      expect(enforced.selectedChannels).toEqual(['vellum']);
+    });
+  });
+
+  describe('copy generation at fire time', () => {
+    test('existing rendered copy is preserved through enforcement', () => {
+      const decision = makeDecision({
+        selectedChannels: ['vellum'],
+        renderedCopy: {
+          vellum: { title: 'Reminder', body: 'Pick up groceries' },
+        },
+      });
+      const connected: NotificationChannel[] = ['vellum', 'telegram'];
+
+      const enforced = enforceRoutingIntent(decision, 'all_channels', connected);
+
+      // Channels expanded but copy from LLM is preserved
+      expect(enforced.selectedChannels).toEqual(['vellum', 'telegram']);
+      expect(enforced.renderedCopy.vellum?.body).toBe('Pick up groceries');
+    });
+  });
+});

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -184,6 +184,8 @@ export async function runDaemon(): Promise<void> {
           label: reminder.label,
           message: reminder.message,
         },
+        routingIntent: reminder.routingIntent,
+        routingHints: reminder.routingHints,
         dedupeKey: `reminder:${reminder.id}`,
       });
     },

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -18,7 +18,7 @@ import type { ModelIntent } from '../providers/types.js';
 import { getLogger } from '../util/logger.js';
 import { createDecision } from './decisions-store.js';
 import { getPreferenceSummary } from './preference-summary.js';
-import type { NotificationSignal } from './signal.js';
+import type { NotificationSignal, RoutingIntent } from './signal.js';
 import type { NotificationChannel, NotificationDecision, RenderedChannelCopy } from './types.js';
 
 const log = getLogger('notification-decision-engine');
@@ -56,6 +56,12 @@ function buildSystemPrompt(
     `- For low-urgency background events, suppress unless they match user preferences.`,
     `- Generate a stable dedupeKey derived from the signal context so duplicate signals can be suppressed.`,
     ``,
+    `Routing intent (when present in the signal):`,
+    `- \`all_channels\`: The source explicitly requests notification on ALL connected channels.`,
+    `- \`multi_channel\`: The source prefers 2+ channels when 2+ are connected.`,
+    `- \`single_channel\`: Default routing behavior — use your best judgment (no override).`,
+    `When a routing intent is present, respect it in your channel selection. A post-decision guard will enforce the intent.`,
+    ``,
     `Copy guidelines (three distinct outputs):`,
     `- \`title\` and \`body\` are for native notification popups (e.g. vellum desktop/mobile) — keep them short and glanceable (title ≤ 8 words, body ≤ 2 sentences).`,
     `- \`deliveryText\` is the channel-native message for chat channels (e.g. telegram). It must read naturally as a standalone message.`,
@@ -89,6 +95,14 @@ function buildUserPrompt(signal: NotificationSignal): string {
 
   if (signal.attentionHints.deadlineAt) {
     parts.push(`Deadline: ${new Date(signal.attentionHints.deadlineAt).toISOString()}`);
+  }
+
+  if (signal.routingIntent && signal.routingIntent !== 'single_channel') {
+    parts.push(`Routing intent: ${signal.routingIntent}`);
+  }
+
+  if (signal.routingHints && Object.keys(signal.routingHints).length > 0) {
+    parts.push(`Routing hints: ${JSON.stringify(signal.routingHints)}`);
   }
 
   const payloadStr = JSON.stringify(signal.contextPayload);
@@ -375,6 +389,61 @@ async function classifyWithLLM(
   } finally {
     cleanup();
   }
+}
+
+// ── Post-decision routing intent enforcement ───────────────────────────
+
+/**
+ * Enforce routing intent policy on a decision after the LLM has produced it.
+ * This is a fire-time guard: it overrides channel selection to match the
+ * routing intent specified by the signal source (e.g. a reminder).
+ *
+ * - `all_channels`: force selected channels to all connected channels.
+ * - `multi_channel`: ensure at least 2 channels when 2+ are connected.
+ * - `single_channel`: no override (default behavior).
+ */
+export function enforceRoutingIntent(
+  decision: NotificationDecision,
+  routingIntent: RoutingIntent | undefined,
+  connectedChannels: NotificationChannel[],
+): NotificationDecision {
+  if (!routingIntent || routingIntent === 'single_channel') {
+    return decision;
+  }
+
+  if (!decision.shouldNotify) {
+    return decision;
+  }
+
+  if (routingIntent === 'all_channels') {
+    // Force all connected channels
+    if (connectedChannels.length > 0) {
+      const enforced = { ...decision };
+      enforced.selectedChannels = [...connectedChannels];
+      enforced.reasoningSummary = `${decision.reasoningSummary} [routing_intent=all_channels enforced: ${connectedChannels.join(', ')}]`;
+      log.info(
+        { routingIntent, connectedChannels, originalChannels: decision.selectedChannels },
+        'Routing intent enforcement: all_channels → forced all connected channels',
+      );
+      return enforced;
+    }
+  }
+
+  if (routingIntent === 'multi_channel') {
+    // Ensure at least 2 channels when 2+ are connected
+    if (connectedChannels.length >= 2 && decision.selectedChannels.length < 2) {
+      const enforced = { ...decision };
+      enforced.selectedChannels = [...connectedChannels];
+      enforced.reasoningSummary = `${decision.reasoningSummary} [routing_intent=multi_channel enforced: expanded to ${connectedChannels.join(', ')}]`;
+      log.info(
+        { routingIntent, connectedChannels, originalChannels: decision.selectedChannels },
+        'Routing intent enforcement: multi_channel → expanded to all connected channels',
+      );
+      return enforced;
+    }
+  }
+
+  return decision;
 }
 
 // ── Persistence ────────────────────────────────────────────────────────

--- a/assistant/src/notifications/decisions-store.ts
+++ b/assistant/src/notifications/decisions-store.ts
@@ -79,6 +79,30 @@ export function createDecision(params: CreateDecisionParams): NotificationDecisi
   };
 }
 
+export interface UpdateDecisionParams {
+  selectedChannels?: string[];
+  reasoningSummary?: string;
+  validationResults?: Record<string, unknown>;
+}
+
+/** Update an existing decision row (e.g. after routing intent enforcement). */
+export function updateDecision(id: string, params: UpdateDecisionParams): void {
+  const db = getDb();
+  const updates: Record<string, unknown> = {};
+  if (params.selectedChannels !== undefined) {
+    updates.selectedChannels = JSON.stringify(params.selectedChannels);
+  }
+  if (params.reasoningSummary !== undefined) {
+    updates.reasoningSummary = params.reasoningSummary;
+  }
+  if (params.validationResults !== undefined) {
+    updates.validationResults = JSON.stringify(params.validationResults);
+  }
+  if (Object.keys(updates).length === 0) return;
+
+  db.update(notificationDecisions).set(updates).where(eq(notificationDecisions.id, id)).run();
+}
+
 /** Fetch a single decision by ID. */
 export function getDecisionById(id: string): NotificationDecisionRow | null {
   const db = getDb();

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -18,6 +18,7 @@ import { type BroadcastFn, VellumAdapter } from './adapters/macos.js';
 import { TelegramAdapter } from './adapters/telegram.js';
 import { NotificationBroadcaster,type ThreadCreatedInfo } from './broadcaster.js';
 import { enforceRoutingIntent, evaluateSignal } from './decision-engine.js';
+import { updateDecision } from './decisions-store.js';
 import { type DeterministicCheckContext, runDeterministicChecks } from './deterministic-checks.js';
 import { createEvent, updateEventDedupeKey } from './events-store.js';
 import { dispatchDecision } from './runtime-dispatch.js';
@@ -204,7 +205,26 @@ export async function emitNotificationSignal(params: EmitSignalParams): Promise<
     let decision = await evaluateSignal(signal, connectedChannels);
 
     // Step 2.5: Enforce routing intent policy (fire-time guard)
+    const preEnforcementDecision = decision;
     decision = enforceRoutingIntent(decision, signal.routingIntent, connectedChannels);
+
+    // Re-persist the decision if routing intent enforcement changed it,
+    // so the stored decision row matches what is actually dispatched.
+    if (decision !== preEnforcementDecision && decision.persistedDecisionId) {
+      try {
+        updateDecision(decision.persistedDecisionId, {
+          selectedChannels: decision.selectedChannels,
+          reasoningSummary: decision.reasoningSummary,
+          validationResults: {
+            dedupeKey: decision.dedupeKey,
+            channelCount: decision.selectedChannels.length,
+            hasCopy: Object.keys(decision.renderedCopy).length > 0,
+          },
+        });
+      } catch (err) {
+        log.warn({ err, signalId }, 'Failed to re-persist decision after routing intent enforcement');
+      }
+    }
 
     // Persist model-generated dedupeKey back to the event row so future
     // signals can deduplicate against it (the event was created with

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -17,11 +17,11 @@ import { getLogger } from '../util/logger.js';
 import { type BroadcastFn, VellumAdapter } from './adapters/macos.js';
 import { TelegramAdapter } from './adapters/telegram.js';
 import { NotificationBroadcaster,type ThreadCreatedInfo } from './broadcaster.js';
-import { evaluateSignal } from './decision-engine.js';
+import { enforceRoutingIntent, evaluateSignal } from './decision-engine.js';
 import { type DeterministicCheckContext, runDeterministicChecks } from './deterministic-checks.js';
 import { createEvent, updateEventDedupeKey } from './events-store.js';
 import { dispatchDecision } from './runtime-dispatch.js';
-import type { AttentionHints, NotificationSignal } from './signal.js';
+import type { AttentionHints, NotificationSignal, RoutingIntent } from './signal.js';
 import type { NotificationChannel, NotificationDeliveryResult } from './types.js';
 
 const log = getLogger('emit-signal');
@@ -125,6 +125,10 @@ export interface EmitSignalParams {
   attentionHints: AttentionHints;
   /** Arbitrary context payload passed to the decision engine. */
   contextPayload?: Record<string, unknown>;
+  /** Routing intent from the source (e.g. reminder). Controls post-decision channel enforcement. */
+  routingIntent?: RoutingIntent;
+  /** Free-form hints from the source for the decision engine. */
+  routingHints?: Record<string, unknown>;
   /** Optional deduplication key. */
   dedupeKey?: string;
   /**
@@ -167,6 +171,8 @@ export async function emitNotificationSignal(params: EmitSignalParams): Promise<
     sourceEventName: params.sourceEventName,
     contextPayload: params.contextPayload ?? {},
     attentionHints: params.attentionHints,
+    routingIntent: params.routingIntent,
+    routingHints: params.routingHints,
   };
 
   try {
@@ -195,7 +201,10 @@ export async function emitNotificationSignal(params: EmitSignalParams): Promise<
 
     // Step 2: Evaluate the signal through the decision engine
     const connectedChannels = getConnectedChannels(assistantId);
-    const decision = await evaluateSignal(signal, connectedChannels);
+    let decision = await evaluateSignal(signal, connectedChannels);
+
+    // Step 2.5: Enforce routing intent policy (fire-time guard)
+    decision = enforceRoutingIntent(decision, signal.routingIntent, connectedChannels);
 
     // Persist model-generated dedupeKey back to the event row so future
     // signals can deduplicate against it (the event was created with

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -12,6 +12,8 @@ export interface AttentionHints {
   visibleInSourceNow: boolean;
 }
 
+export type RoutingIntent = 'single_channel' | 'multi_channel' | 'all_channels';
+
 export interface NotificationSignal {
   signalId: string;
   assistantId: string;
@@ -21,4 +23,8 @@ export interface NotificationSignal {
   sourceEventName: string; // free-form: 'reminder_fired', 'schedule_complete', 'guardian_question', etc.
   contextPayload: Record<string, unknown>;
   attentionHints: AttentionHints;
+  /** Routing intent from the source (e.g. reminder). Controls post-decision channel enforcement. */
+  routingIntent?: RoutingIntent;
+  /** Free-form hints from the source for the decision engine (e.g. preferred channels). */
+  routingHints?: Record<string, unknown>;
 }

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -2,7 +2,7 @@ import { createConversation } from '../memory/conversation-store.js';
 import { GENERATING_TITLE, queueGenerateConversationTitle } from '../memory/conversation-title-service.js';
 import { invalidateAssistantInferredItemsForConversation } from '../memory/task-memory-cleanup.js';
 import { runSequencesOnce } from '../sequence/engine.js';
-import { claimDueReminders, completeReminder, failReminder, setReminderConversationId } from '../tools/reminder/reminder-store.js';
+import { claimDueReminders, completeReminder, failReminder, setReminderConversationId, type RoutingIntent } from '../tools/reminder/reminder-store.js';
 import { getLogger } from '../util/logger.js';
 import { runWatchersOnce, type WatcherEscalator,type WatcherNotifier } from '../watcher/engine.js';
 import { hasSetConstructs } from './recurrence-engine.js';
@@ -19,7 +19,13 @@ export type ScheduleMessageProcessor = (
   message: string,
 ) => Promise<unknown>;
 
-export type ReminderNotifier = (reminder: { id: string; label: string; message: string }) => void;
+export type ReminderNotifier = (reminder: {
+  id: string;
+  label: string;
+  message: string;
+  routingIntent: RoutingIntent;
+  routingHints: Record<string, unknown>;
+}) => void;
 
 export type ScheduleNotifier = (schedule: { id: string; name: string }) => void;
 
@@ -165,7 +171,13 @@ async function runScheduleOnce(
     } else {
       try {
         log.info({ reminderId: reminder.id, label: reminder.label }, 'Firing reminder notification');
-        notifyReminder({ id: reminder.id, label: reminder.label, message: reminder.message });
+        notifyReminder({
+          id: reminder.id,
+          label: reminder.label,
+          message: reminder.message,
+          routingIntent: reminder.routingIntent,
+          routingHints: reminder.routingHints,
+        });
         completeReminder(reminder.id);
       } catch (err) {
         log.warn({ err, reminderId: reminder.id }, 'Reminder notification failed, reverting to pending');


### PR DESCRIPTION
Plumb routing_intent and routing_hints through scheduler → notification signal → decision engine. Add post-decision enforcement for all_channels and multi_channel intents. One reminder fire event now fans out to multiple channels based on routing intent. Part of #9454.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
