### PR TITLE
M2: Wire dock badge observation in AppDelegate

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -168,6 +168,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var connectionStatusCancellable: AnyCancellable?
     private var quickInputAttachmentCancellable: AnyCancellable?
     private var conversationZoomEnabledCancellable: AnyCancellable?
+    private var conversationBadgeCancellable: AnyCancellable?
     /// Observable state for SwiftUI command group `.disabled()` modifiers.
     /// Updated via Combine subscription to `MainWindowState.objectWillChange`.
     @Published public var isConversationZoomEnabled: Bool = false
@@ -2024,6 +2025,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         mainWindow = main
         observeConversationZoomEnabled(main.windowState)
         observeAssistantStatus()
+        observeConversationBadge(main.threadManager)
         return main
     }
 
@@ -2096,6 +2098,31 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             .sink { [weak self] _ in
                 self?.updateMenuBarIcon()
             }
+    }
+
+    private func observeConversationBadge(_ threadManager: ThreadManager) {
+        conversationBadgeCancellable?.cancel()
+
+        applyDockConversationBadge(count: threadManager.unseenVisibleConversationCount)
+
+        conversationBadgeCancellable = threadManager.$threads
+            .map { _ in threadManager.unseenVisibleConversationCount }
+            .removeDuplicates()
+            .sink { [weak self] count in
+                self?.applyDockConversationBadge(count: count)
+            }
+    }
+
+    /// Format the unseen conversation count for the dock badge.
+    /// Returns nil for 0 (clears badge), exact string for 1-99, "99+" for 100+.
+    func formatDockConversationBadge(count: Int) -> String? {
+        if count <= 0 { return nil }
+        if count >= 100 { return "99+" }
+        return "\(count)"
+    }
+
+    private func applyDockConversationBadge(count: Int) {
+        NSApp.dockTile.badgeLabel = formatDockConversationBadge(count: count)
     }
 
     // MARK: - About Panel

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -685,6 +685,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             mainWindow?.close()
             mainWindow = nil
             conversationZoomEnabledCancellable = nil
+            conversationBadgeCancellable?.cancel()
+            conversationBadgeCancellable = nil
+            NSApp.dockTile.badgeLabel = nil
             isConversationZoomEnabled = false
 
             if let hotKeyMonitor {
@@ -798,6 +801,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         mainWindow?.close()
         mainWindow = nil
         conversationZoomEnabledCancellable = nil
+        conversationBadgeCancellable?.cancel()
+        conversationBadgeCancellable = nil
+        NSApp.dockTile.badgeLabel = nil
         isConversationZoomEnabled = false
 
         if let hotKeyMonitor {
@@ -2106,7 +2112,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         applyDockConversationBadge(count: threadManager.unseenVisibleConversationCount)
 
         conversationBadgeCancellable = threadManager.$threads
-            .map { _ in threadManager.unseenVisibleConversationCount }
+            .map { threads in threads.filter { !$0.isArchived && $0.kind != .private && $0.hasUnseenLatestAssistantMessage }.count }
             .removeDuplicates()
             .sink { [weak self] count in
                 self?.applyDockConversationBadge(count: count)
@@ -2200,6 +2206,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             NotificationCenter.default.removeObserver(observer)
         }
         statusIconCancellable?.cancel()
+        conversationBadgeCancellable?.cancel()
+        NSApp.dockTile.badgeLabel = nil
         connectionStatusCancellable?.cancel()
         pulseTimer?.invalidate()
         pulseTimer = nil


### PR DESCRIPTION
Subscribe to ThreadManager thread changes and update NSApp.dockTile.badgeLabel with the unseen visible conversation count. Badge shows exact count for 1-99, 99+ for >= 100, and clears when 0. Closes #9466.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
