### PR TITLE
fix: resolve type-check errors and stale test in recording state machine

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1077,6 +1077,15 @@ exports[`IPC message snapshots ClientMessage types ingress_member serializes to 
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types assistant_inbox_escalation serializes to expected JSON 1`] = `
+{
+  "action": "list",
+  "assistantId": "asst-001",
+  "status": "pending",
+  "type": "assistant_inbox_escalation",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types pairing_approval_response serializes to expected JSON 1`] = `
 {
   "decision": "approve_once",
@@ -2981,6 +2990,26 @@ exports[`IPC message snapshots ServerMessage types ingress_member_response seria
   },
   "success": true,
   "type": "ingress_member_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types assistant_inbox_escalation_response serializes to expected JSON 1`] = `
+{
+  "escalations": [
+    {
+      "channel": "telegram",
+      "conversationId": "conv-001",
+      "createdAt": 1700000000,
+      "id": "esc-001",
+      "requestSummary": "User needs help with something",
+      "requesterChatId": "chat-456",
+      "requesterExternalUserId": "user-123",
+      "runId": "run-001",
+      "status": "pending",
+    },
+  ],
+  "success": true,
+  "type": "assistant_inbox_escalation_response",
 }
 `;
 

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -668,6 +668,12 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     policy: 'allow',
     status: 'active',
   },
+  assistant_inbox_escalation: {
+    type: 'assistant_inbox_escalation',
+    action: 'list',
+    assistantId: 'asst-001',
+    status: 'pending',
+  },
   pairing_approval_response: {
     type: 'pairing_approval_response',
     pairingRequestId: 'pair-001',
@@ -1903,6 +1909,23 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
       lastSeenAt: 1700000000,
       createdAt: 1700000000,
     },
+  },
+  assistant_inbox_escalation_response: {
+    type: 'assistant_inbox_escalation_response',
+    success: true,
+    escalations: [
+      {
+        id: 'esc-001',
+        runId: 'run-001',
+        conversationId: 'conv-001',
+        channel: 'telegram',
+        requesterExternalUserId: 'user-123',
+        requesterChatId: 'chat-456',
+        status: 'pending',
+        requestSummary: 'User needs help with something',
+        createdAt: 1700000000,
+      },
+    ],
   },
   pairing_approval_request: {
     type: 'pairing_approval_request',

--- a/assistant/src/__tests__/recording-state-machine.test.ts
+++ b/assistant/src/__tests__/recording-state-machine.test.ts
@@ -367,7 +367,7 @@ describe('stale completion guard (operation token)', () => {
     expect(textDeltas).toHaveLength(0);
 
     // Active restart token should still be set (not cleared by stale completion)
-    expect(getActiveRestartToken()).toBe(restartResult.operationToken);
+    expect(getActiveRestartToken()).toBe(restartResult.operationToken!);
   });
 
   test('accepts recording_status with matching operation token', () => {
@@ -429,10 +429,13 @@ describe('stale completion guard (operation token)', () => {
     };
     recordingHandlers.recording_status(tokenlessStatus, fakeSocket, ctx);
 
-    // Should have been allowed through — the stopped handler processes normally
-    // (emits text delta about recording stopped/no file)
+    // Should have triggered the deferred restart start (not emitted text deltas)
+    const newStartMsgs = sent.filter((m) => m.type === 'recording_start');
+    expect(newStartMsgs).toHaveLength(1);
+
+    // No text deltas — the stopped handler short-circuited to deferred restart
     const textDeltas = sent.filter((m) => m.type === 'assistant_text_delta');
-    expect(textDeltas.length).toBeGreaterThan(0);
+    expect(textDeltas).toHaveLength(0);
   });
 
   test('no ghost state after restart stop/start handoff', () => {
@@ -483,7 +486,7 @@ describe('handleRecordingPause', () => {
 
     const result = handleRecordingPause(conversationId, ctx);
 
-    expect(result).toBe(recordingId);
+    expect(result).toBe(recordingId!);
     expect(sent).toHaveLength(1);
     expect(sent[0].type).toBe('recording_pause');
     expect(sent[0].recordingId).toBe(recordingId);
@@ -505,7 +508,7 @@ describe('handleRecordingPause', () => {
     sent.length = 0;
 
     const result = handleRecordingPause('conv-other-pause', ctx);
-    expect(result).toBe(recordingId);
+    expect(result).toBe(recordingId!);
   });
 });
 
@@ -525,7 +528,7 @@ describe('handleRecordingResume', () => {
 
     const result = handleRecordingResume(conversationId, ctx);
 
-    expect(result).toBe(recordingId);
+    expect(result).toBe(recordingId!);
     expect(sent).toHaveLength(1);
     expect(sent[0].type).toBe('recording_resume');
     expect(sent[0].recordingId).toBe(recordingId);


### PR DESCRIPTION
Fix 3 type-check errors:
- Add missing IPC snapshot entries for assistant_inbox_escalation
- Fix null vs undefined type mismatches in recording-state-machine tests
- Update stale test expectation for deferred restart stopped handler
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
