### PR TITLE
Guardian Verification: Guardian-Only Invocation + Skill/Routing Fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,8 @@ When a notification flow creates a server-side conversation (e.g. guardian quest
 
 Guardian verification consumption must be identity-bound to the expected recipient identity. Every outbound verification session stores the expected identity (phone E.164, Telegram user/chat ID), and the consume path rejects attempts where the responding actor's identity does not match.
 
+Conversational guardian verification control-plane invocation is guardian-only. Non-guardian and unverified-channel actors cannot invoke guardian verification endpoints (`/v1/integrations/guardian/*`) conversationally via tools. Enforcement is a deterministic gate in the tool execution layer (`assistant/src/tools/executor.ts`) using actor-role context — only `guardian` and `undefined` (desktop/trusted) actor roles pass. The policy module is at `assistant/src/tools/guardian-control-plane-policy.ts`.
+
 ## Memory Provenance Invariant
 
 All memory extraction and retrieval decisions must consider actor-role provenance. Untrusted actors (non-guardian, unverified_channel) must not trigger profile extraction or receive memory recall/conflict disclosures. This invariant is enforced in `indexer.ts` (write gate) and `session-memory.ts` (read gate).

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -57,6 +57,14 @@ The HTTP route handlers (`integration-routes.ts`) and the legacy IPC handlers (`
 | `src/daemon/handlers/config-channels.ts` | IPC handler that delegates to the same shared actions |
 | `src/config/vellum-skills/guardian-verify-setup/SKILL.md` | Skill that teaches the assistant how to orchestrate guardian verification via chat |
 
+**Guardian-Only Tool Invocation Gate:**
+
+Guardian verification control-plane endpoints (`/v1/integrations/guardian/*`) are protected by a deterministic gate in the tool executor (`src/tools/executor.ts`). Before any tool invocation proceeds, the executor checks whether the invocation targets a guardian control-plane endpoint and whether the actor role is allowed. The policy uses an allowlist: only `guardian` and `undefined` (desktop/trusted) actor roles can invoke these endpoints. Non-guardian and unverified-channel actors receive a denial message explaining the restriction.
+
+The policy is implemented in `src/tools/guardian-control-plane-policy.ts`, which inspects tool inputs (bash commands, URLs) for guardian endpoint paths. This is a defense-in-depth measure — even if the LLM attempts to call guardian endpoints on behalf of a non-guardian actor, the tool executor blocks it deterministically.
+
+The `guardian-verify-setup` skill is the exclusive handler for guardian verification intents in the system prompt. Other skills (e.g., `phone-calls`) hand off to `guardian-verify-setup` rather than orchestrating verification directly.
+
 ### SMS Channel (Twilio)
 
 The SMS channel provides text-only messaging via Twilio, sharing the same telephony provider as voice calls. It follows the same ingress/egress pattern as Telegram but uses Twilio's HMAC-SHA1 signature validation instead of a secret header.

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -343,6 +343,8 @@ Guardian verification can also be initiated through normal desktop chat. When th
 
 These endpoints share the same business logic as the IPC-based verification flow via `guardian-outbound-actions.ts`.
 
+**Security constraint:** Guardian verification control-plane endpoints are restricted to guardian and desktop (trusted) actors only. Non-guardian and unverified-channel actors cannot invoke these endpoints conversationally via tools. Attempts are denied with a message explaining that guardian verification actions are restricted to guardian users.
+
 ## Channel Readiness
 
 The `channel_readiness` IPC contract provides a unified way to check whether a channel (SMS, Telegram, etc.) is fully configured and operational. It runs local checks (credential presence, phone number assignment, ingress config) synchronously and optional remote checks (API reachability) asynchronously with a 5-minute TTL cache.

--- a/assistant/src/__tests__/guardian-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/guardian-control-plane-policy.test.ts
@@ -144,10 +144,10 @@ describe('isGuardianControlPlaneInvocation', () => {
       })).toBe(false);
     });
 
-    test('does not match similar but different paths', () => {
+    test('matches unknown sub-path under guardian control-plane (broad pattern)', () => {
       expect(isGuardianControlPlaneInvocation('bash', {
         command: 'curl http://localhost:3000/v1/integrations/guardian/other',
-      })).toBe(false);
+      })).toBe(true);
     });
 
     test('handles missing command field gracefully', () => {
@@ -253,6 +253,68 @@ describe('isGuardianControlPlaneInvocation', () => {
       expect(isGuardianControlPlaneInvocation('bash', {
         command: 'echo \'{"phone":"+1234567890"}\' | curl -X POST -d @- http://localhost:3000/v1/integrations/guardian/outbound/resend',
       })).toBe(true);
+    });
+  });
+
+  describe('obfuscation resistance', () => {
+    test('detects URL-encoded path (%2F encoding)', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {
+        command: 'curl http://localhost:3000/v1/integrations%2Fguardian%2Foutbound%2Fstart',
+      })).toBe(true);
+    });
+
+    test('detects double-encoded path (%252F encoding)', () => {
+      expect(isGuardianControlPlaneInvocation('network_request', {
+        url: 'http://localhost:3000/v1/integrations%252Fguardian%252Fchallenge',
+      })).toBe(true);
+    });
+
+    test('detects double slashes in path', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {
+        command: 'curl http://localhost:3000/v1/integrations//guardian/outbound/start',
+      })).toBe(true);
+    });
+
+    test('detects triple slashes in path', () => {
+      expect(isGuardianControlPlaneInvocation('network_request', {
+        url: 'http://localhost:3000/v1///integrations///guardian///status',
+      })).toBe(true);
+    });
+
+    test('detects mixed case path', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {
+        command: 'curl http://localhost:3000/V1/Integrations/Guardian/Outbound/Start',
+      })).toBe(true);
+    });
+
+    test('detects ALL CAPS path', () => {
+      expect(isGuardianControlPlaneInvocation('network_request', {
+        url: 'http://localhost:3000/V1/INTEGRATIONS/GUARDIAN/CHALLENGE',
+      })).toBe(true);
+    });
+
+    test('detects combined obfuscation: URL-encoding + mixed case', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {
+        command: 'curl http://localhost:3000/V1/Integrations%2FGuardian%2FOutbound%2FCancel',
+      })).toBe(true);
+    });
+
+    test('detects combined obfuscation: double slashes + URL-encoding', () => {
+      expect(isGuardianControlPlaneInvocation('network_request', {
+        url: 'http://localhost:3000/v1//integrations%2Fguardian%2Fstatus',
+      })).toBe(true);
+    });
+
+    test('detects URL-encoded path in web_fetch tool', () => {
+      expect(isGuardianControlPlaneInvocation('web_fetch', {
+        url: 'http://localhost:3000/v1/integrations%2Fguardian%2Foutbound%2Fresend',
+      })).toBe(true);
+    });
+
+    test('does not false-positive on unrelated encoded paths', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {
+        command: 'curl http://localhost:3000/v1/integrations%2Fother%2Fservice',
+      })).toBe(false);
     });
   });
 });

--- a/assistant/src/__tests__/guardian-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/guardian-control-plane-policy.test.ts
@@ -138,10 +138,12 @@ describe('isGuardianControlPlaneInvocation', () => {
       })).toBe(false);
     });
 
-    test('does not match partial path prefix', () => {
+    test('matches partial path prefix via fragment detection (fail-closed for shell tools)', () => {
+      // Even without a trailing sub-path, the presence of both /v1/integrations and guardian
+      // in a bash command triggers the conservative fragment detector.
       expect(isGuardianControlPlaneInvocation('bash', {
         command: 'curl http://localhost:3000/v1/integrations/guardian',
-      })).toBe(false);
+      })).toBe(true);
     });
 
     test('matches unknown sub-path under guardian control-plane (broad pattern)', () => {
@@ -322,6 +324,52 @@ describe('isGuardianControlPlaneInvocation', () => {
         command: 'curl -H "X: %ZZ" http://localhost:3000/v1/integrations%2Fguardian%2Foutbound%2Fstart -d \'{"channel":"sms"}\'',
       });
       expect(result).toBe(true);
+    });
+  });
+
+  describe('shell expansion resistance', () => {
+    test('detects guardian endpoint constructed via shell variable concatenation', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {
+        command: 'base=http://localhost:7821/v1/integrations; seg=guardian; curl "$base/$seg/status"',
+      })).toBe(true);
+    });
+
+    test('detects guardian endpoint with split variable assignment', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {
+        command: 'API=/v1/integrations; curl "http://localhost:3000${API}/guardian/outbound/start"',
+      })).toBe(true);
+    });
+
+    test('detects guardian endpoint with path built across multiple variables', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {
+        command: 'HOST=http://localhost:7821; PATH_PREFIX=/v1/integrations; SVC=guardian; curl "$HOST$PATH_PREFIX/$SVC/challenge"',
+      })).toBe(true);
+    });
+
+    test('detects guardian endpoint via heredoc-style construction', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {
+        command: 'url="http://localhost:3000/v1/integrations"; curl "${url}/guardian/outbound/resend"',
+      })).toBe(true);
+    });
+
+    test('does not false-positive when only /v1/integrations is present without guardian', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {
+        command: 'curl http://localhost:3000/v1/integrations/other/service',
+      })).toBe(false);
+    });
+
+    test('does not false-positive when only guardian is present without /v1/integrations', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {
+        command: 'echo "guardian notification sent"',
+      })).toBe(false);
+    });
+
+    test('shell fragment detection does not apply to URL tools', () => {
+      // URL tools pass structured URLs, not shell commands. The fragment detector
+      // is bash/host_bash only. For URL tools, we rely on exact/normalized matching.
+      expect(isGuardianControlPlaneInvocation('network_request', {
+        url: 'https://api.example.com/v1/messages',
+      })).toBe(false);
     });
   });
 });

--- a/assistant/src/__tests__/guardian-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/guardian-control-plane-policy.test.ts
@@ -316,6 +316,13 @@ describe('isGuardianControlPlaneInvocation', () => {
         command: 'curl http://localhost:3000/v1/integrations%2Fother%2Fservice',
       })).toBe(false);
     });
+
+    test('detects guardian endpoint despite malformed percent-encoding elsewhere in command', () => {
+      const result = isGuardianControlPlaneInvocation('bash', {
+        command: 'curl -H "X: %ZZ" http://localhost:3000/v1/integrations%2Fguardian%2Foutbound%2Fstart -d \'{"channel":"sms"}\'',
+      });
+      expect(result).toBe(true);
+    });
   });
 });
 

--- a/assistant/src/__tests__/guardian-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/guardian-control-plane-policy.test.ts
@@ -1,0 +1,467 @@
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+import type { PolicyContext } from '../permissions/types.js';
+import { RiskLevel } from '../permissions/types.js';
+import type { ToolExecutionResult, ToolLifecycleEvent, ToolPermissionDeniedEvent } from '../tools/types.js';
+
+// ── Module mocks (must precede real imports) ─────────────────────────
+
+const mockConfig = {
+  provider: 'anthropic',
+  model: 'test',
+  apiKeys: {},
+  maxTokens: 4096,
+  dataDir: '/tmp',
+  timeouts: { shellDefaultTimeoutSec: 120, shellMaxTimeoutSec: 600, permissionTimeoutSec: 300 },
+  sandbox: { enabled: false, backend: 'native' as const, docker: { image: 'vellum-sandbox:latest', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' as const } },
+  rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  secretDetection: { enabled: false, action: 'warn' as const, entropyThreshold: 4.0 },
+};
+
+let fakeToolResult: ToolExecutionResult = { content: 'ok', isError: false };
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+  invalidateConfigCache: () => {},
+  saveConfig: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+  isDebug: () => false,
+  truncateForLog: (value: string) => value,
+}));
+
+mock.module('../permissions/checker.js', () => ({
+  classifyRisk: async () => 'low',
+  check: async () => ({ decision: 'allow', reason: 'allowed' }),
+  generateAllowlistOptions: () => [],
+  generateScopeOptions: () => [],
+}));
+
+mock.module('../memory/tool-usage-store.js', () => ({
+  recordToolInvocation: () => {},
+}));
+
+mock.module('../tools/registry.js', () => ({
+  getTool: (name: string) => {
+    if (name === 'unknown_tool') return undefined;
+    return {
+      name,
+      description: 'test tool',
+      category: 'test',
+      defaultRiskLevel: 'low',
+      getDefinition: () => ({}),
+      execute: async () => fakeToolResult,
+    };
+  },
+  getAllTools: () => [],
+}));
+
+mock.module('../tools/shared/filesystem/path-policy.js', () => ({
+  sandboxPolicy: () => ({ ok: false }),
+  hostPolicy: () => ({ ok: false }),
+}));
+
+mock.module('../tools/terminal/sandbox.js', () => ({
+  wrapCommand: () => ({ command: '', sandboxed: false }),
+}));
+
+// ── Real imports ─────────────────────────────────────────────────────
+
+import { PermissionPrompter } from '../permissions/prompter.js';
+import { ToolExecutor } from '../tools/executor.js';
+import {
+  enforceGuardianOnlyPolicy,
+  isGuardianControlPlaneInvocation,
+} from '../tools/guardian-control-plane-policy.js';
+import type { ToolContext } from '../tools/types.js';
+
+function makeContext(overrides?: Partial<ToolContext>): ToolContext {
+  return {
+    workingDir: '/tmp/project',
+    sessionId: 'session-1',
+    conversationId: 'conversation-1',
+    ...overrides,
+  };
+}
+
+function makePrompter(): PermissionPrompter {
+  return {
+    prompt: async () => ({ decision: 'allow' as const }),
+    resolveConfirmation: () => {},
+    updateSender: () => {},
+    dispose: () => {},
+  } as unknown as PermissionPrompter;
+}
+
+afterAll(() => { mock.restore(); });
+
+// =====================================================================
+// Unit tests: isGuardianControlPlaneInvocation
+// =====================================================================
+
+describe('isGuardianControlPlaneInvocation', () => {
+  const guardianPaths = [
+    '/v1/integrations/guardian/challenge',
+    '/v1/integrations/guardian/status',
+    '/v1/integrations/guardian/outbound/start',
+    '/v1/integrations/guardian/outbound/resend',
+    '/v1/integrations/guardian/outbound/cancel',
+  ];
+
+  describe('bash tool with guardian endpoint in command', () => {
+    for (const path of guardianPaths) {
+      test(`detects curl to ${path}`, () => {
+        expect(isGuardianControlPlaneInvocation('bash', {
+          command: `curl -X POST http://localhost:3000${path}`,
+        })).toBe(true);
+      });
+
+      test(`detects wget to ${path}`, () => {
+        expect(isGuardianControlPlaneInvocation('bash', {
+          command: `wget https://api.example.com${path}`,
+        })).toBe(true);
+      });
+    }
+
+    test('does not match unrelated commands', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {
+        command: 'git status',
+      })).toBe(false);
+    });
+
+    test('does not match partial path prefix', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {
+        command: 'curl http://localhost:3000/v1/integrations/guardian',
+      })).toBe(false);
+    });
+
+    test('does not match similar but different paths', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {
+        command: 'curl http://localhost:3000/v1/integrations/guardian/other',
+      })).toBe(false);
+    });
+
+    test('handles missing command field gracefully', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {})).toBe(false);
+    });
+
+    test('handles non-string command field gracefully', () => {
+      expect(isGuardianControlPlaneInvocation('bash', { command: 42 })).toBe(false);
+    });
+  });
+
+  describe('host_bash tool with guardian endpoint in command', () => {
+    test('detects guardian endpoint', () => {
+      expect(isGuardianControlPlaneInvocation('host_bash', {
+        command: 'curl -H "Authorization: Bearer token" https://internal:8080/v1/integrations/guardian/outbound/start',
+      })).toBe(true);
+    });
+  });
+
+  describe('network_request tool with guardian endpoint in url', () => {
+    for (const path of guardianPaths) {
+      test(`detects ${path}`, () => {
+        expect(isGuardianControlPlaneInvocation('network_request', {
+          url: `https://api.vellum.ai${path}`,
+        })).toBe(true);
+      });
+    }
+
+    test('detects proxied local URL', () => {
+      expect(isGuardianControlPlaneInvocation('network_request', {
+        url: 'http://127.0.0.1:3000/v1/integrations/guardian/challenge',
+      })).toBe(true);
+    });
+
+    test('does not match unrelated URLs', () => {
+      expect(isGuardianControlPlaneInvocation('network_request', {
+        url: 'https://api.example.com/v1/messages',
+      })).toBe(false);
+    });
+
+    test('handles missing url field gracefully', () => {
+      expect(isGuardianControlPlaneInvocation('network_request', {})).toBe(false);
+    });
+  });
+
+  describe('web_fetch tool with guardian endpoint in url', () => {
+    test('detects guardian endpoint', () => {
+      expect(isGuardianControlPlaneInvocation('web_fetch', {
+        url: 'https://api.example.com/v1/integrations/guardian/outbound/cancel',
+      })).toBe(true);
+    });
+
+    test('does not match unrelated URL', () => {
+      expect(isGuardianControlPlaneInvocation('web_fetch', {
+        url: 'https://docs.example.com/api/v1/help',
+      })).toBe(false);
+    });
+  });
+
+  describe('browser_navigate tool with guardian endpoint in url', () => {
+    test('detects guardian endpoint', () => {
+      expect(isGuardianControlPlaneInvocation('browser_navigate', {
+        url: 'http://localhost:3000/v1/integrations/guardian/status',
+      })).toBe(true);
+    });
+  });
+
+  describe('unrelated tools are not flagged', () => {
+    test('file_read is never a guardian invocation', () => {
+      expect(isGuardianControlPlaneInvocation('file_read', {
+        path: '/v1/integrations/guardian/challenge',
+      })).toBe(false);
+    });
+
+    test('file_write is never a guardian invocation', () => {
+      expect(isGuardianControlPlaneInvocation('file_write', {
+        path: '/tmp/test.txt',
+        content: 'curl /v1/integrations/guardian/outbound/start',
+      })).toBe(false);
+    });
+
+    test('web_search is never a guardian invocation', () => {
+      expect(isGuardianControlPlaneInvocation('web_search', {
+        query: '/v1/integrations/guardian/status',
+      })).toBe(false);
+    });
+  });
+
+  describe('path matching covers proxied and local variants', () => {
+    test('matches endpoint with query string', () => {
+      expect(isGuardianControlPlaneInvocation('network_request', {
+        url: 'https://api.example.com/v1/integrations/guardian/challenge?token=abc',
+      })).toBe(true);
+    });
+
+    test('matches endpoint with trailing slash', () => {
+      expect(isGuardianControlPlaneInvocation('network_request', {
+        url: 'https://api.example.com/v1/integrations/guardian/outbound/start/',
+      })).toBe(true);
+    });
+
+    test('matches endpoint in piped bash command', () => {
+      expect(isGuardianControlPlaneInvocation('bash', {
+        command: 'echo \'{"phone":"+1234567890"}\' | curl -X POST -d @- http://localhost:3000/v1/integrations/guardian/outbound/resend',
+      })).toBe(true);
+    });
+  });
+});
+
+// =====================================================================
+// Unit tests: enforceGuardianOnlyPolicy
+// =====================================================================
+
+describe('enforceGuardianOnlyPolicy', () => {
+  test('non-guardian actor denied for guardian endpoint', () => {
+    const result = enforceGuardianOnlyPolicy('bash', {
+      command: 'curl http://localhost:3000/v1/integrations/guardian/outbound/start',
+    }, 'non-guardian');
+    expect(result.denied).toBe(true);
+    expect(result.reason).toContain('restricted to guardian users');
+  });
+
+  test('unverified_channel actor denied for guardian endpoint', () => {
+    const result = enforceGuardianOnlyPolicy('network_request', {
+      url: 'https://api.example.com/v1/integrations/guardian/challenge',
+    }, 'unverified_channel');
+    expect(result.denied).toBe(true);
+    expect(result.reason).toContain('restricted to guardian users');
+  });
+
+  test('guardian actor is NOT denied for guardian endpoint', () => {
+    const result = enforceGuardianOnlyPolicy('bash', {
+      command: 'curl http://localhost:3000/v1/integrations/guardian/outbound/start',
+    }, 'guardian');
+    expect(result.denied).toBe(false);
+    expect(result.reason).toBeUndefined();
+  });
+
+  test('undefined actor role is NOT denied for guardian endpoint', () => {
+    const result = enforceGuardianOnlyPolicy('bash', {
+      command: 'curl http://localhost:3000/v1/integrations/guardian/outbound/start',
+    }, undefined);
+    expect(result.denied).toBe(false);
+  });
+
+  test('unknown actor role is denied for guardian endpoint (allowlist, not denylist)', () => {
+    const result = enforceGuardianOnlyPolicy('bash', {
+      command: 'curl http://localhost:3000/v1/integrations/guardian/outbound/start',
+    }, 'some_future_role');
+    expect(result.denied).toBe(true);
+    expect(result.reason).toContain('restricted to guardian users');
+  });
+
+  test('non-guardian actor is NOT denied for unrelated endpoint', () => {
+    const result = enforceGuardianOnlyPolicy('bash', {
+      command: 'curl http://localhost:3000/v1/messages',
+    }, 'non-guardian');
+    expect(result.denied).toBe(false);
+  });
+
+  test('non-guardian actor is NOT denied for unrelated tool', () => {
+    const result = enforceGuardianOnlyPolicy('file_read', {
+      path: 'README.md',
+    }, 'non-guardian');
+    expect(result.denied).toBe(false);
+  });
+});
+
+// =====================================================================
+// Integration tests: ToolExecutor guardian-only policy gate
+// =====================================================================
+
+describe('ToolExecutor guardian-only policy gate', () => {
+  beforeEach(() => {
+    fakeToolResult = { content: 'ok', isError: false };
+  });
+
+  test('non-guardian actor blocked from bash curl to guardian outbound/start', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'bash',
+      { command: 'curl -X POST http://localhost:3000/v1/integrations/guardian/outbound/start' },
+      makeContext({ guardianActorRole: 'non-guardian' }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('restricted to guardian users');
+  });
+
+  test('unverified_channel actor blocked from network_request to guardian endpoint', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'network_request',
+      { url: 'https://api.example.com/v1/integrations/guardian/challenge' },
+      makeContext({ guardianActorRole: 'unverified_channel' }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('restricted to guardian users');
+  });
+
+  test('guardian actor is NOT blocked from the same invocation', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'bash',
+      { command: 'curl -X POST http://localhost:3000/v1/integrations/guardian/outbound/start' },
+      makeContext({ guardianActorRole: 'guardian' }),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe('ok');
+  });
+
+  test('undefined guardianActorRole is NOT blocked from guardian endpoint', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'bash',
+      { command: 'curl http://localhost:3000/v1/integrations/guardian/status' },
+      makeContext(), // no guardianActorRole set
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe('ok');
+  });
+
+  test('non-guardian invocation of unrelated endpoint is unaffected', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'bash',
+      { command: 'curl http://localhost:3000/v1/messages' },
+      makeContext({ guardianActorRole: 'non-guardian' }),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe('ok');
+  });
+
+  test('non-guardian invocation of unrelated tool is unaffected', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'file_read',
+      { path: 'README.md' },
+      makeContext({ guardianActorRole: 'non-guardian' }),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe('ok');
+  });
+
+  test('permission_denied lifecycle event is emitted on guardian policy block', async () => {
+    let capturedEvent: ToolPermissionDeniedEvent | undefined;
+    const executor = new ToolExecutor(makePrompter());
+    await executor.execute(
+      'bash',
+      { command: 'curl http://localhost:3000/v1/integrations/guardian/outbound/cancel' },
+      makeContext({
+        guardianActorRole: 'non-guardian',
+        onToolLifecycleEvent: (event: ToolLifecycleEvent) => {
+          if (event.type === 'permission_denied') {
+            capturedEvent = event as ToolPermissionDeniedEvent;
+          }
+        },
+      }),
+    );
+    expect(capturedEvent).toBeDefined();
+    expect(capturedEvent!.decision).toBe('deny');
+    expect(capturedEvent!.reason).toContain('restricted to guardian users');
+  });
+
+  test('non-guardian blocked from web_fetch to guardian endpoint', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'web_fetch',
+      { url: 'http://localhost:3000/v1/integrations/guardian/outbound/resend' },
+      makeContext({ guardianActorRole: 'non-guardian' }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('restricted to guardian users');
+  });
+
+  test('non-guardian blocked from browser_navigate to guardian endpoint', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'browser_navigate',
+      { url: 'http://localhost:3000/v1/integrations/guardian/status' },
+      makeContext({ guardianActorRole: 'non-guardian' }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('restricted to guardian users');
+  });
+
+  test('non-guardian blocked from host_bash with guardian endpoint', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'host_bash',
+      { command: 'curl -X POST https://internal:8080/v1/integrations/guardian/challenge' },
+      makeContext({ guardianActorRole: 'non-guardian' }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('restricted to guardian users');
+  });
+
+  test('all five guardian endpoints are blocked for non-guardian via network_request', async () => {
+    const endpoints = [
+      '/v1/integrations/guardian/challenge',
+      '/v1/integrations/guardian/status',
+      '/v1/integrations/guardian/outbound/start',
+      '/v1/integrations/guardian/outbound/resend',
+      '/v1/integrations/guardian/outbound/cancel',
+    ];
+
+    for (const path of endpoints) {
+      const executor = new ToolExecutor(makePrompter());
+      const result = await executor.execute(
+        'network_request',
+        { url: `https://api.example.com${path}` },
+        makeContext({ guardianActorRole: 'non-guardian' }),
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('restricted to guardian users');
+    }
+  });
+});

--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -290,4 +290,26 @@ describe('Guardian verification routing section in system prompt', () => {
     expect(routingSection).toContain('voice');
     expect(routingSection).toContain('telegram');
   });
+
+  test('routing section contains exclusivity wording', () => {
+    const prompt = buildSystemPrompt();
+    const lower = prompt.toLowerCase();
+    // Must contain "exclusively" or "must only" to enforce exclusive handling
+    expect(lower.includes('exclusively') || lower.includes('must only')).toBe(true);
+  });
+
+  test('routing section prohibits loading phone-calls for guardian verification', () => {
+    const prompt = buildSystemPrompt();
+    const lower = prompt.toLowerCase();
+    // Must explicitly prohibit phone-calls for guardian verification intents
+    expect(lower).toContain('do not load');
+    expect(lower).toContain('phone-calls');
+  });
+
+  test('routing section includes channel-preservation guidance', () => {
+    const prompt = buildSystemPrompt();
+    const lower = prompt.toLowerCase();
+    // Must advise not to re-ask channel if already specified
+    expect(lower.includes('do not re-ask') || lower.includes('already specified')).toBe(true);
+  });
 });

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -364,7 +364,7 @@ No additional configuration is needed beyond the standard Twilio setup (Steps 1-
 
 ### Guardian voice verification for inbound calls
 
-For guardian verification setup, load `guardian-verify-setup`; this skill does not orchestrate that flow inline.
+For guardian verification setup, first install the skill via `vellum_skills_catalog` with `action: "install"` and `skill_id: "guardian-verify-setup"`, then load it with `skill_load` using `skill: "guardian-verify-setup"`. This skill handles the full outbound verification flow; `phone-calls` does not orchestrate it inline.
 
 Once a guardian binding exists for the voice channel, inbound callers may be prompted for verification before calls proceed. The relay server detects pending challenges and prompts callers: "Please enter your six-digit verification code using your keypad, or speak the digits now." If verification fails after 3 attempts, the call ends with "Verification failed. Goodbye."
 

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -364,17 +364,7 @@ No additional configuration is needed beyond the standard Twilio setup (Steps 1-
 
 ### Guardian voice verification for inbound calls
 
-To link the user's phone number as the trusted voice guardian, install and load the **guardian-verify-setup** skill. This skill handles the full outbound verification flow:
-
-- Call `vellum_skills_catalog` with `action: "install"` and `skill_id: "guardian-verify-setup"`.
-- Then call `skill_load` with `skill: "guardian-verify-setup"`.
-
-When invoked for the `voice` channel, the guardian-verify-setup skill:
-1. Collects the user's phone number as the destination
-2. Starts an outbound verification session via `POST /v1/integrations/guardian/outbound/start` with `channel: "voice"`
-3. The API initiates a phone call to the user's number. The response includes a `secret` field with the verification code -- the code is shared with the user BEFORE the call connects so they know what to enter
-4. When the user answers, they enter the verification code via their phone's keypad (DTMF)
-5. If the code matches, a guardian binding is created for the voice channel
+For guardian verification setup, load `guardian-verify-setup`; this skill does not orchestrate that flow inline.
 
 Once a guardian binding exists for the voice channel, inbound callers may be prompted for verification before calls proceed. The relay server detects pending challenges and prompts callers: "Please enter your six-digit verification code using your keypad, or speak the digits now." If verification fails after 3 attempts, the call ends with "Verification failed. Goodbye."
 

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -209,6 +209,11 @@ export function buildGuardianVerificationRoutingSection(): string {
     '4. Guide the user through code entry, resend, or cancel',
     '',
     'Load with: `skill_load` using `skill: "guardian-verify-setup"`',
+    '',
+    '### Exclusivity rules',
+    '- Guardian verification intents must only be handled by `guardian-verify-setup` — load it exclusively.',
+    '- Do NOT load `phone-calls` for guardian verification intent routing. The phone-calls skill does not orchestrate verification flows.',
+    '- If the user has already explicitly specified a channel (e.g., "verify my phone for SMS", "verify my Telegram"), do not re-ask which channel unless the input is contradictory. Note: "verify my phone number" alone is ambiguous (phone numbers apply to both sms and voice) — ask which channel.',
   ].join('\n');
 }
 

--- a/assistant/src/config/vellum-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/guardian-verify-setup/SKILL.md
@@ -51,7 +51,7 @@ Report the exact next action based on the channel:
 
 - **SMS**: "I've sent a 6-digit verification code to [number]. Reply with the code from that SMS conversation (not here) to complete verification — the code can only be consumed through the SMS channel."
 - **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad."
-- **Telegram with chat ID** (no `telegramBootstrapUrl` in response): "I've sent a verification code to your Telegram. Send the code back to me in the Telegram bot chat to complete verification."
+- **Telegram with chat ID** (no `telegramBootstrapUrl` in response): The response includes a `secret` field with the verification code. Show it to the user in the current chat first: "Your verification code is **[secret]**. Now open the Telegram bot chat and send `/guardian_verify [secret]` to complete verification."
 - **Telegram with handle** (`telegramBootstrapUrl` present in response): "Tap this deep-link first: [telegramBootstrapUrl]. After Telegram binds your identity, I'll send your verification code."
 
 After reporting the bootstrap URL for Telegram handle flows, wait for the user to confirm they clicked the link. Then check guardian status (Step 6) to see if the bootstrap completed and a code was sent.
@@ -85,7 +85,7 @@ On success, report the next action based on the channel:
 
 - **SMS**: "I've sent a new verification code to [number]. Reply with the code from that SMS conversation to complete verification."
 - **Voice**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad."
-- **Telegram**: "I've sent a new verification code to your Telegram. Send the code back to me in the Telegram bot chat to complete verification."
+- **Telegram**: The resend response includes a fresh `secret` field with a new verification code. Show it to the user in the current chat first — just like the initial start flow: "Your new verification code is **[secret]**. Now open the Telegram bot chat and send `/guardian_verify [secret]` to complete verification."
 
 ### Resend errors
 
@@ -133,3 +133,4 @@ If not yet bound, offer to resend (Step 4) or generate a new session (Step 3).
 - The resend cooldown is 15 seconds between sends, with a maximum of 5 sends per session.
 - Per-destination rate limiting allows up to 10 sends within a 1-hour rolling window.
 - Guardian verification is identity-bound: the code can only be consumed by the identity matching the destination provided at start time.
+- **Missing `secret` guardrail**: For voice and Telegram chat-ID flows, the API response MUST include a `secret` field. If `secret` is unexpectedly absent from a start or resend response that otherwise indicates success, treat this as a control-plane error. Do NOT fabricate a code or tell the user to proceed without one. Instead, tell the user something went wrong and ask them to retry the start (Step 3) or resend (Step 4).

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -26,6 +26,7 @@ import type { ProxyApprovalCallback, ProxyApprovalRequest } from '../tools/netwo
 import { getAllToolDefinitions } from '../tools/registry.js';
 import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
 import { projectSkillTools, type SkillProjectionCache } from './session-skill-tools.js';
+import type { GuardianRuntimeContext } from './session-runtime-assembly.js';
 import type { SurfaceSessionContext } from './session-surfaces.js';
 import {
   surfaceProxyResolver,
@@ -55,6 +56,8 @@ export interface ToolSetupContext extends SurfaceSessionContext {
   headlessLock?: boolean;
   /** When set, this session is executing a task run. Used to retrieve ephemeral permission rules. */
   taskRunId?: string;
+  /** Guardian runtime context for the session — actorRole is propagated into ToolContext for control-plane policy enforcement. */
+  guardianContext?: GuardianRuntimeContext;
 }
 
 // ── buildToolDefinitions ─────────────────────────────────────────────
@@ -105,6 +108,7 @@ export function createToolExecutor(
       assistantId: ctx.assistantId,
       requestId: ctx.currentRequestId,
       taskRunId: ctx.taskRunId,
+      guardianActorRole: ctx.guardianContext?.actorRole,
       onOutput,
       signal: ctx.abortController?.signal,
       sandboxOverride: ctx.sandboxOverride,

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -15,6 +15,7 @@ import { PermissionDeniedError,ToolError } from '../util/errors.js';
 import { pathExists, safeStatSync } from '../util/fs.js';
 import { getLogger } from '../util/logger.js';
 import { resolveExecutionTarget } from './execution-target.js';
+import { enforceGuardianOnlyPolicy } from './guardian-control-plane-policy.js';
 import { executeWithTimeout,safeTimeoutMs } from './execution-timeout.js';
 import { buildPolicyContext } from './policy-context.js';
 import { getAllTools,getTool } from './registry.js';
@@ -109,6 +110,34 @@ export class ToolExecutor {
         durationMs,
       });
       return { content: 'This tool is blocked by parental control settings.', isError: true };
+    }
+
+    // Reject tool invocations targeting guardian control-plane endpoints from non-guardian actors.
+    const guardianCheck = enforceGuardianOnlyPolicy(name, input, context.guardianActorRole);
+    if (guardianCheck.denied) {
+      log.warn({
+        toolName: name,
+        sessionId: context.sessionId,
+        conversationId: context.conversationId,
+        actorRole: context.guardianActorRole,
+        reason: 'guardian_only_policy',
+      }, 'Guardian-only policy blocked tool invocation');
+      const durationMs = Date.now() - startTime;
+      emitLifecycleEvent(context, {
+        type: 'permission_denied',
+        toolName: name,
+        executionTarget,
+        input,
+        workingDir: context.workingDir,
+        sessionId: context.sessionId,
+        conversationId: context.conversationId,
+        requestId: context.requestId,
+        riskLevel,
+        decision: 'deny',
+        reason: guardianCheck.reason!,
+        durationMs,
+      });
+      return { content: guardianCheck.reason!, isError: true };
     }
 
     // Gate tools not active for the current turn

--- a/assistant/src/tools/guardian-control-plane-policy.ts
+++ b/assistant/src/tools/guardian-control-plane-policy.ts
@@ -41,15 +41,18 @@ const URL_TOOLS = new Set(['network_request', 'web_fetch', 'browser_navigate']);
 function normalizeForMatching(value: string): string {
   let normalized = value;
   // Iteratively decode percent-encoding to handle double-encoding (%252F → %2F → /)
+  // Use per-sequence replacement instead of decodeURIComponent to avoid a single
+  // malformed sequence (e.g. %ZZ) preventing all other valid sequences from decoding.
   let prev = '';
   while (prev !== normalized) {
     prev = normalized;
-    try {
-      normalized = decodeURIComponent(normalized);
-    } catch {
-      // If decoding fails (malformed sequence), stop and use what we have
-      break;
-    }
+    normalized = normalized.replace(/%[0-9a-fA-F]{2}/g, (match) => {
+      try {
+        return decodeURIComponent(match);
+      } catch {
+        return match;
+      }
+    });
   }
   // Collapse consecutive slashes (but preserve the double slash in protocol e.g. https://)
   normalized = normalized.replace(/(?<!:)\/{2,}/g, '/');

--- a/assistant/src/tools/guardian-control-plane-policy.ts
+++ b/assistant/src/tools/guardian-control-plane-policy.ts
@@ -1,0 +1,85 @@
+/**
+ * Guardian control-plane policy \u2014 deterministic gate that prevents non-guardian
+ * and unverified_channel actors from invoking guardian verification endpoints
+ * conversationally via tools.
+ *
+ * Protected endpoints:
+ *   /v1/integrations/guardian/challenge
+ *   /v1/integrations/guardian/status
+ *   /v1/integrations/guardian/outbound/start
+ *   /v1/integrations/guardian/outbound/resend
+ *   /v1/integrations/guardian/outbound/cancel
+ */
+
+const GUARDIAN_ENDPOINT_PATHS = [
+  '/v1/integrations/guardian/challenge',
+  '/v1/integrations/guardian/status',
+  '/v1/integrations/guardian/outbound/start',
+  '/v1/integrations/guardian/outbound/resend',
+  '/v1/integrations/guardian/outbound/cancel',
+] as const;
+
+/** Tools whose `input.command` (string) may contain guardian endpoint paths. */
+const COMMAND_TOOLS = new Set(['bash', 'host_bash']);
+
+/** Tools whose `input.url` (string) may contain guardian endpoint paths. */
+const URL_TOOLS = new Set(['network_request', 'web_fetch', 'browser_navigate']);
+
+/**
+ * Check whether a string contains any of the guardian control-plane endpoint paths.
+ * Matches at the path level (not hostname-specific) to catch proxied/local variants.
+ */
+function containsGuardianEndpointPath(value: string): boolean {
+  for (const path of GUARDIAN_ENDPOINT_PATHS) {
+    if (value.includes(path)) return true;
+  }
+  return false;
+}
+
+/**
+ * Pure function that determines whether a tool invocation targets a guardian
+ * control-plane endpoint based on the tool name and its input.
+ */
+export function isGuardianControlPlaneInvocation(
+  toolName: string,
+  input: Record<string, unknown>,
+): boolean {
+  if (COMMAND_TOOLS.has(toolName)) {
+    const command = input.command;
+    if (typeof command === 'string' && containsGuardianEndpointPath(command)) {
+      return true;
+    }
+  }
+
+  if (URL_TOOLS.has(toolName)) {
+    const url = input.url;
+    if (typeof url === 'string' && containsGuardianEndpointPath(url)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Enforce the guardian-only policy: if the invocation targets a guardian
+ * control-plane endpoint and the actor is not a guardian, deny.
+ */
+export function enforceGuardianOnlyPolicy(
+  toolName: string,
+  input: Record<string, unknown>,
+  actorRole: string | undefined,
+): { denied: boolean; reason?: string } {
+  if (!isGuardianControlPlaneInvocation(toolName, input)) {
+    return { denied: false };
+  }
+
+  if (actorRole === 'guardian' || actorRole === undefined) {
+    return { denied: false };
+  }
+
+  return {
+    denied: true,
+    reason: 'Guardian verification control-plane actions are restricted to guardian users. This is a security restriction \u2014 please wait for the designated guardian to perform this action.',
+  };
+}

--- a/assistant/src/tools/guardian-control-plane-policy.ts
+++ b/assistant/src/tools/guardian-control-plane-policy.ts
@@ -19,6 +19,13 @@ const GUARDIAN_ENDPOINT_PATHS = [
   '/v1/integrations/guardian/outbound/cancel',
 ] as const;
 
+/**
+ * Broad regex that catches any path targeting the guardian control-plane,
+ * even if the exact sub-path differs from the hardcoded list above.
+ * Anchored on a path separator so it won't match inside unrelated words.
+ */
+const GUARDIAN_PATH_REGEX = /\/v1\/integrations\/guardian\//;
+
 /** Tools whose `input.command` (string) may contain guardian endpoint paths. */
 const COMMAND_TOOLS = new Set(['bash', 'host_bash']);
 
@@ -26,13 +33,43 @@ const COMMAND_TOOLS = new Set(['bash', 'host_bash']);
 const URL_TOOLS = new Set(['network_request', 'web_fetch', 'browser_navigate']);
 
 /**
+ * Normalize a string to defeat common URL obfuscation techniques before matching:
+ * - Decode percent-encoded characters (e.g. %2F → /)
+ * - Collapse consecutive slashes into a single slash (preserving protocol://)
+ * - Lowercase everything
+ */
+function normalizeForMatching(value: string): string {
+  let normalized = value;
+  // Iteratively decode percent-encoding to handle double-encoding (%252F → %2F → /)
+  let prev = '';
+  while (prev !== normalized) {
+    prev = normalized;
+    try {
+      normalized = decodeURIComponent(normalized);
+    } catch {
+      // If decoding fails (malformed sequence), stop and use what we have
+      break;
+    }
+  }
+  // Collapse consecutive slashes (but preserve the double slash in protocol e.g. https://)
+  normalized = normalized.replace(/(?<!:)\/{2,}/g, '/');
+  return normalized.toLowerCase();
+}
+
+/**
  * Check whether a string contains any of the guardian control-plane endpoint paths.
- * Matches at the path level (not hostname-specific) to catch proxied/local variants.
+ * Normalizes the input first to catch percent-encoding, double slashes, and case
+ * variations. Also matches a broad regex pattern to catch paths that target the
+ * guardian control-plane but aren't in the exact hardcoded list.
  */
 function containsGuardianEndpointPath(value: string): boolean {
+  const normalized = normalizeForMatching(value);
+  // Check exact hardcoded paths against the normalized string
   for (const path of GUARDIAN_ENDPOINT_PATHS) {
-    if (value.includes(path)) return true;
+    if (normalized.includes(path)) return true;
   }
+  // Broad pattern match to catch any /v1/integrations/guardian/... path
+  if (GUARDIAN_PATH_REGEX.test(normalized)) return true;
   return false;
 }
 

--- a/assistant/src/tools/guardian-control-plane-policy.ts
+++ b/assistant/src/tools/guardian-control-plane-policy.ts
@@ -77,6 +77,19 @@ function containsGuardianEndpointPath(value: string): boolean {
 }
 
 /**
+ * Conservative fallback for shell tools: detects when a command contains the
+ * key fragments of a guardian control-plane path even if they are not contiguous
+ * (e.g. constructed via shell variable expansion like `base=/v1/integrations; curl "$base/guardian/status"`).
+ *
+ * Only applied to bash/host_bash — URL tools pass structured URLs that cannot
+ * be split by shell expansion.
+ */
+function containsGuardianFragments(command: string): boolean {
+  const lower = command.toLowerCase();
+  return lower.includes('/v1/integrations') && lower.includes('guardian');
+}
+
+/**
  * Pure function that determines whether a tool invocation targets a guardian
  * control-plane endpoint based on the tool name and its input.
  */
@@ -86,8 +99,11 @@ export function isGuardianControlPlaneInvocation(
 ): boolean {
   if (COMMAND_TOOLS.has(toolName)) {
     const command = input.command;
-    if (typeof command === 'string' && containsGuardianEndpointPath(command)) {
-      return true;
+    if (typeof command === 'string') {
+      // Primary: exact/normalized path matching
+      if (containsGuardianEndpointPath(command)) return true;
+      // Fallback: detect shell-expanded construction of guardian paths
+      if (containsGuardianFragments(command)) return true;
     }
   }
 

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -136,6 +136,8 @@ export interface ToolContext {
   proxyApprovalCallback?: import('./network/script-proxy/types.js').ProxyApprovalCallback;
   /** Optional principal identifier propagated to sub-tool confirmation flows. */
   principal?: string;
+  /** Guardian actor role for the session — used by the guardian control-plane policy gate. */
+  guardianActorRole?: 'guardian' | 'non-guardian' | 'unverified_channel';
 }
 
 export interface DiffInfo {

--- a/skills/guardian-verify-setup/SKILL.md
+++ b/skills/guardian-verify-setup/SKILL.md
@@ -51,7 +51,7 @@ Report the exact next action based on the channel:
 
 - **SMS**: "I've sent a 6-digit verification code to [number]. Reply with the code from that SMS conversation (not here) to complete verification — the code can only be consumed through the SMS channel."
 - **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad."
-- **Telegram with chat ID** (no `telegramBootstrapUrl` in response): "I've sent a verification code to your Telegram. Send the code back to me in the Telegram bot chat to complete verification."
+- **Telegram with chat ID** (no `telegramBootstrapUrl` in response): The response includes a `secret` field with the verification code. Show it to the user in the current chat first: "Your verification code is **[secret]**. Now open the Telegram bot chat and send `/guardian_verify [secret]` to complete verification."
 - **Telegram with handle** (`telegramBootstrapUrl` present in response): "Tap this deep-link first: [telegramBootstrapUrl]. After Telegram binds your identity, I'll send your verification code."
 
 After reporting the bootstrap URL for Telegram handle flows, wait for the user to confirm they clicked the link. Then check guardian status (Step 6) to see if the bootstrap completed and a code was sent.
@@ -85,7 +85,7 @@ On success, report the next action based on the channel:
 
 - **SMS**: "I've sent a new verification code to [number]. Reply with the code from that SMS conversation to complete verification."
 - **Voice**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad."
-- **Telegram**: "I've sent a new verification code to your Telegram. Send the code back to me in the Telegram bot chat to complete verification."
+- **Telegram**: The resend response includes a fresh `secret` field with a new verification code. Show it to the user in the current chat first — just like the initial start flow: "Your new verification code is **[secret]**. Now open the Telegram bot chat and send `/guardian_verify [secret]` to complete verification."
 
 ### Resend errors
 
@@ -133,3 +133,4 @@ If not yet bound, offer to resend (Step 4) or generate a new session (Step 3).
 - The resend cooldown is 15 seconds between sends, with a maximum of 5 sends per session.
 - Per-destination rate limiting allows up to 10 sends within a 1-hour rolling window.
 - Guardian verification is identity-bound: the code can only be consumed by the identity matching the destination provided at start time.
+- **Missing `secret` guardrail**: For voice and Telegram chat-ID flows, the API response MUST include a `secret` field. If `secret` is unexpectedly absent from a start or resend response that otherwise indicates success, treat this as a control-plane error. Do NOT fabricate a code or tell the user to proceed without one. Instead, tell the user something went wrong and ask them to retry the start (Step 3) or resend (Step 4).


### PR DESCRIPTION
## Summary
Close the remaining conversational guardian-verification gaps by implementing guardian-only invocation enforcement, Telegram flow copy fixes, routing precedence fixes, and documentation updates.

## Changes
- **M1 (#9451)**: Guardian-only tool invocation gate — non-guardian channel actors cannot invoke guardian verification control-plane endpoints conversationally via tools. Enforced in tool executor with allowlist pattern.
- **M2 (#9461)**: Telegram skill copy fix — surfaces verification `secret` in current chat before instructing Telegram-side submission. Added missing-secret guardrail.
- **M3 (#9474)**: Routing precedence fix — `guardian-verify-setup` is the exclusive skill handler for guardian verification intents. Replaced competing orchestration in `phone-calls` with a concise handoff.
- **M4 (#9484)**: Documentation and invariant updates — recorded guardian-only security invariant in AGENTS.md, ARCHITECTURE.md, and README.md.
- **Sweep fix (#9485)**: Restored install prerequisite in phone-calls guardian verification handoff.

## Milestone PRs (merged into feature branch)
- #9451: M1: Guardian-Only Tool Invocation Gate
- #9461: M2: Telegram Skill Copy Fix — Surface Secret in Current Chat
- #9474: M3: Routing Precedence Fix — Guardian Verify Setup is Exclusive
- #9484: M4: Documentation and Invariant Updates
- #9485: fix: restore install prerequisite in phone-calls guardian verification handoff

## Project issue
Closes #9445

## Test plan
- [ ] Non-guardian channel actors cannot invoke guardian verification control-plane endpoints via tools
- [ ] Guardian actors can still invoke the verification flow
- [ ] Telegram chat-ID flow surfaces verification secret in current chat
- [ ] Guardian verification intents route exclusively to guardian-verify-setup
- [ ] phone-calls skill does not provide competing guardian verification orchestration
- [ ] Documentation reflects guardian-only invariant

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
