### PR TITLE
M3: Channel coverage expansion

### DIFF
--- a/assistant/src/__tests__/channel-policy.test.ts
+++ b/assistant/src/__tests__/channel-policy.test.ts
@@ -97,6 +97,7 @@ describe('channel policy registry', () => {
     const expectedStrategies: [ChannelId, ConversationStrategy][] = [
       ['vellum', 'start_new_conversation'],
       ['telegram', 'continue_existing_conversation'],
+      ['sms', 'continue_existing_conversation'],
       ['voice', 'not_deliverable'],
     ];
 
@@ -116,6 +117,24 @@ describe('channel policy registry', () => {
       const strategy = getConversationStrategy(channelId);
       expect(validStrategies.has(strategy)).toBe(true);
     }
+  });
+
+  // ── SMS channel policy ───────────────────────────────────────────────
+
+  test('SMS is a deliverable notification channel', () => {
+    expect(isNotificationDeliverable('sms')).toBe(true);
+    expect(getDeliverableChannels()).toContain('sms');
+  });
+
+  test('SMS uses continue_existing_conversation strategy', () => {
+    expect(getConversationStrategy('sms')).toBe('continue_existing_conversation');
+  });
+
+  test('all_channels includes SMS when SMS is deliverable', () => {
+    const deliverable = getDeliverableChannels();
+    expect(deliverable).toContain('vellum');
+    expect(deliverable).toContain('telegram');
+    expect(deliverable).toContain('sms');
   });
 
   // ── Consistency checks ────────────────────────────────────────────────

--- a/assistant/src/__tests__/notification-routing-intent.test.ts
+++ b/assistant/src/__tests__/notification-routing-intent.test.ts
@@ -78,6 +78,26 @@ describe('routing intent enforcement', () => {
       const enforced = enforceRoutingIntent(decision, 'all_channels', connected);
       expect(enforced.selectedChannels).toEqual(['vellum']);
     });
+
+    test('includes SMS when SMS is among connected channels', () => {
+      const decision = makeDecision({ selectedChannels: ['vellum'] });
+      const connected: NotificationChannel[] = ['vellum', 'telegram', 'sms'];
+
+      const enforced = enforceRoutingIntent(decision, 'all_channels', connected);
+
+      expect(enforced.selectedChannels).toEqual(['vellum', 'telegram', 'sms']);
+      expect(enforced.reasoningSummary).toContain('routing_intent=all_channels');
+    });
+
+    test('excludes SMS when SMS is not among connected channels', () => {
+      const decision = makeDecision({ selectedChannels: ['vellum'] });
+      const connected: NotificationChannel[] = ['vellum', 'telegram'];
+
+      const enforced = enforceRoutingIntent(decision, 'all_channels', connected);
+
+      expect(enforced.selectedChannels).toEqual(['vellum', 'telegram']);
+      expect(enforced.selectedChannels).not.toContain('sms');
+    });
   });
 
   describe('multi_channel intent', () => {

--- a/assistant/src/channels/config.ts
+++ b/assistant/src/channels/config.ts
@@ -35,7 +35,7 @@ const CHANNEL_POLICIES = {
   },
   sms: {
     notification: {
-      deliveryEnabled: false,
+      deliveryEnabled: true,
       conversationStrategy: 'continue_existing_conversation',
     },
   },

--- a/assistant/src/notifications/adapters/sms.ts
+++ b/assistant/src/notifications/adapters/sms.ts
@@ -1,0 +1,80 @@
+/**
+ * SMS channel adapter — delivers notifications to phone numbers
+ * via the gateway's SMS delivery endpoint (`/deliver/sms`).
+ *
+ * Follows the same delivery pattern as the Telegram adapter: POST to
+ * the gateway's `/deliver/sms` endpoint with a phone number (as chatId)
+ * and text payload. The gateway forwards the message to the Twilio
+ * Messages API.
+ *
+ * Graceful degradation: when the gateway is unreachable or SMS is not
+ * configured, the adapter returns a failed DeliveryResult without throwing,
+ * so the broadcaster continues delivering to other channels.
+ */
+
+import { getGatewayInternalBaseUrl } from '../../config/env.js';
+import { deliverChannelReply } from '../../runtime/gateway-client.js';
+import { getLogger } from '../../util/logger.js';
+import { readHttpToken } from '../../util/platform.js';
+import { nonEmpty } from '../copy-composer.js';
+import type {
+  ChannelAdapter,
+  ChannelDeliveryPayload,
+  ChannelDestination,
+  DeliveryResult,
+  NotificationChannel,
+} from '../types.js';
+
+const log = getLogger('notif-adapter-sms');
+
+function resolveSmsMessageText(payload: ChannelDeliveryPayload): string {
+  const deliveryText = nonEmpty(payload.copy.deliveryText);
+  if (deliveryText) return deliveryText;
+
+  const body = nonEmpty(payload.copy.body);
+  if (body) return body;
+
+  const title = nonEmpty(payload.copy.title);
+  if (title) return title;
+
+  return payload.sourceEventName.replace(/[._]/g, ' ');
+}
+
+export class SmsAdapter implements ChannelAdapter {
+  readonly channel: NotificationChannel = 'sms';
+
+  async send(payload: ChannelDeliveryPayload, destination: ChannelDestination): Promise<DeliveryResult> {
+    const phoneNumber = destination.endpoint;
+    if (!phoneNumber) {
+      log.warn({ sourceEventName: payload.sourceEventName }, 'SMS destination has no phone number — skipping');
+      return { success: false, error: 'No phone number configured for SMS destination' };
+    }
+
+    const gatewayBase = getGatewayInternalBaseUrl();
+    const deliverUrl = `${gatewayBase}/deliver/sms`;
+
+    const messageText = resolveSmsMessageText(payload);
+
+    try {
+      await deliverChannelReply(
+        deliverUrl,
+        { chatId: phoneNumber, text: messageText },
+        readHttpToken() ?? undefined,
+      );
+
+      log.info(
+        { sourceEventName: payload.sourceEventName, phoneNumber },
+        'SMS notification delivered',
+      );
+
+      return { success: true };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error(
+        { err, sourceEventName: payload.sourceEventName, phoneNumber },
+        'Failed to deliver SMS notification',
+      );
+      return { success: false, error: message };
+    }
+  }
+}

--- a/assistant/src/notifications/adapters/sms.ts
+++ b/assistant/src/notifications/adapters/sms.ts
@@ -58,7 +58,7 @@ export class SmsAdapter implements ChannelAdapter {
     try {
       await deliverChannelReply(
         deliverUrl,
-        { chatId: phoneNumber, text: messageText },
+        { chatId: phoneNumber, text: messageText, assistantId: payload.assistantId },
         readHttpToken() ?? undefined,
       );
 

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -174,6 +174,7 @@ export class NotificationBroadcaster {
       const payload: ChannelDeliveryPayload = {
         deliveryId,
         sourceEventName: signal.sourceEventName,
+        assistantId: signal.assistantId,
         copy,
         deepLinkTarget,
       };

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -115,14 +115,14 @@ function applyChannelDefaults(
 ): RenderedChannelCopy {
   const copy: RenderedChannelCopy = { ...baseCopy };
 
-  if (channel === 'telegram') {
-    copy.deliveryText = buildTelegramFallbackDeliveryText(baseCopy, signal);
+  if (channel === 'telegram' || channel === 'sms') {
+    copy.deliveryText = buildChatSurfaceFallbackDeliveryText(baseCopy, signal);
   }
 
   return copy;
 }
 
-function buildTelegramFallbackDeliveryText(
+function buildChatSurfaceFallbackDeliveryText(
   baseCopy: RenderedChannelCopy,
   signal: NotificationSignal,
 ): string {

--- a/assistant/src/notifications/destination-resolver.ts
+++ b/assistant/src/notifications/destination-resolver.ts
@@ -38,7 +38,8 @@ export function resolveDestinations(
         result.set('vellum', { channel: 'vellum' });
         break;
       }
-      case 'telegram': {
+      case 'telegram':
+      case 'sms': {
         const binding = getActiveBinding(assistantId, channel);
         if (binding) {
           result.set(channel as NotificationChannel, {

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -15,6 +15,7 @@ import { getDeliverableChannels } from '../channels/config.js';
 import { getActiveBinding } from '../memory/channel-guardian-store.js';
 import { getLogger } from '../util/logger.js';
 import { type BroadcastFn, VellumAdapter } from './adapters/macos.js';
+import { SmsAdapter } from './adapters/sms.js';
 import { TelegramAdapter } from './adapters/telegram.js';
 import { NotificationBroadcaster,type ThreadCreatedInfo } from './broadcaster.js';
 import { enforceRoutingIntent, evaluateSignal } from './decision-engine.js';
@@ -47,6 +48,7 @@ function getBroadcaster(): NotificationBroadcaster {
   if (!broadcasterInstance) {
     const adapters = [
       new TelegramAdapter(),
+      new SmsAdapter(),
     ];
     if (registeredBroadcastFn) {
       adapters.unshift(new VellumAdapter(registeredBroadcastFn));
@@ -91,6 +93,7 @@ function getConnectedChannels(assistantId: string): NotificationChannel[] {
         channels.push(channel);
         break;
       case 'telegram':
+      case 'sms':
         // Only report binding-based channels as connected when there is
         // an active guardian binding for this assistant. Without a
         // binding, the destination resolver will fail to resolve a

--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -54,6 +54,9 @@ export interface ChannelDeliveryPayload {
   /** Delivery audit record ID — passed through to the client for ack correlation. */
   deliveryId?: string;
   sourceEventName: string;
+  /** Originating assistant — used by channel adapters that need assistant-specific
+   *  routing (e.g. SMS outbound number selection via the gateway). */
+  assistantId?: string;
   copy: RenderedChannelCopy;
   deepLinkTarget?: Record<string, unknown>;
 }


### PR DESCRIPTION
Enable SMS as a deliverable notification channel. Add SMS adapter following existing patterns. Wire into emit-signal and channel config. When SMS is connected, all_channels includes SMS. Graceful degradation when SMS is unavailable. Part of #9454.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
