### PR TITLE
M5: Add unit tests for badge count and formatting

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -2015,7 +2015,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     /// Creates the MainWindow and wires callbacks, without showing it.
     /// Safe to call multiple times — no-ops if mainWindow already exists.
     @discardableResult
-    private func ensureMainWindowExists(isFirstLaunch: Bool = false) -> MainWindow {
+    func ensureMainWindowExists(isFirstLaunch: Bool = false) -> MainWindow {
         if let existing = mainWindow { return existing }
         let main = MainWindow(services: services, isFirstLaunch: isFirstLaunch)
         main.onMicrophoneToggle = { [weak self] in

--- a/clients/macos/vellum-assistantTests/DockBadgeFormattingTests.swift
+++ b/clients/macos/vellum-assistantTests/DockBadgeFormattingTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class DockBadgeFormattingTests: XCTestCase {
+
+    private var appDelegate: AppDelegate!
+
+    override func setUp() {
+        super.setUp()
+        appDelegate = AppDelegate()
+    }
+
+    override func tearDown() {
+        appDelegate = nil
+        super.tearDown()
+    }
+
+    func testZeroReturnsNil() {
+        XCTAssertNil(appDelegate.formatDockConversationBadge(count: 0))
+    }
+
+    func testNegativeReturnsNil() {
+        XCTAssertNil(appDelegate.formatDockConversationBadge(count: -1))
+    }
+
+    func testOneReturnsExactString() {
+        XCTAssertEqual(appDelegate.formatDockConversationBadge(count: 1), "1")
+    }
+
+    func testNinetyNineReturnsExactString() {
+        XCTAssertEqual(appDelegate.formatDockConversationBadge(count: 99), "99")
+    }
+
+    func testHundredReturnsCappedString() {
+        XCTAssertEqual(appDelegate.formatDockConversationBadge(count: 100), "99+")
+    }
+
+    func testLargeNumberReturnsCappedString() {
+        XCTAssertEqual(appDelegate.formatDockConversationBadge(count: 999), "99+")
+    }
+}

--- a/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
@@ -127,6 +127,113 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         XCTAssertEqual(seenSignals.last?.conversationId, "session-realtime")
     }
 
+    func testUnseenVisibleConversationCountExcludesArchivedThreads() {
+        // Start with the initial thread created by setUp
+        guard let threadId = threadManager.activeThreadId,
+              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected an initial active thread")
+            return
+        }
+
+        // Seed a user message so createThread doesn't skip
+        threadManager.chatViewModel(for: threadId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
+
+        // Switch away so the initial thread becomes inactive
+        threadManager.createThread()
+        XCTAssertNotEqual(threadManager.activeThreadId, threadId)
+
+        // Mark the initial thread as unseen
+        if let idx = threadManager.threads.firstIndex(where: { $0.id == threadId }) {
+            threadManager.threads[idx].hasUnseenLatestAssistantMessage = true
+        }
+        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 1)
+
+        // Archive it — count should drop to 0
+        threadManager.archiveThread(id: threadId)
+        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 0)
+    }
+
+    func testUnseenVisibleConversationCountExcludesPrivateThreads() {
+        // Create a private thread (this switches activeThreadId to the private thread)
+        threadManager.createPrivateThread()
+        guard let privateId = threadManager.activeThreadId,
+              let idx = threadManager.threads.firstIndex(where: { $0.id == privateId }) else {
+            XCTFail("Expected a private thread")
+            return
+        }
+
+        // Mark the private thread as unseen
+        threadManager.threads[idx].hasUnseenLatestAssistantMessage = true
+
+        // Private threads are excluded from the visible count
+        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 0)
+    }
+
+    func testUnseenVisibleConversationCountIncludesMultipleUnseen() {
+        // Start with the initial thread
+        guard let firstId = threadManager.activeThreadId else {
+            XCTFail("Expected an initial active thread")
+            return
+        }
+        // Seed a user message so createThread actually creates a new one
+        threadManager.chatViewModel(for: firstId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
+
+        // Create a second thread
+        threadManager.createThread()
+        guard let secondId = threadManager.activeThreadId, secondId != firstId else {
+            XCTFail("Expected a different second thread")
+            return
+        }
+        // Seed the second thread too
+        threadManager.chatViewModel(for: secondId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
+
+        // Create a third thread (becomes active)
+        threadManager.createThread()
+        guard let thirdId = threadManager.activeThreadId, thirdId != secondId else {
+            XCTFail("Expected a different third thread")
+            return
+        }
+
+        // Mark first and second as unseen
+        if let idx = threadManager.threads.firstIndex(where: { $0.id == firstId }) {
+            threadManager.threads[idx].hasUnseenLatestAssistantMessage = true
+        }
+        if let idx = threadManager.threads.firstIndex(where: { $0.id == secondId }) {
+            threadManager.threads[idx].hasUnseenLatestAssistantMessage = true
+        }
+
+        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 2)
+    }
+
+    func testSelectingThreadDecrementsUnseenCount() {
+        // Start with the initial thread
+        guard let firstId = threadManager.activeThreadId else {
+            XCTFail("Expected an initial active thread")
+            return
+        }
+        // Seed so createThread proceeds
+        threadManager.chatViewModel(for: firstId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
+
+        // Create a second thread (becomes active)
+        threadManager.createThread()
+        guard let secondId = threadManager.activeThreadId, secondId != firstId else {
+            XCTFail("Expected a different second thread")
+            return
+        }
+
+        // Mark the first (inactive) thread as unseen and give it a sessionId
+        // (selectThread only clears unseen when sessionId is present)
+        if let idx = threadManager.threads.firstIndex(where: { $0.id == firstId }) {
+            threadManager.threads[idx].hasUnseenLatestAssistantMessage = true
+            threadManager.threads[idx].sessionId = "session-first"
+        }
+        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 1)
+
+        // Select the unseen thread — should clear its unseen flag
+        threadManager.selectThread(id: firstId)
+        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 0)
+    }
+
     func testActiveThreadAssistantReplyClearsUnseenAndEmitsSeenSignal() {
         guard let threadId = threadManager.activeThreadId,
               let index = threadManager.threads.firstIndex(where: { $0.id == threadId }),


### PR DESCRIPTION
Add tests for ThreadManager.unseenVisibleConversationCount (archive exclusion, private thread exclusion, multi-unseen count, select-to-decrement) and AppDelegate.formatDockConversationBadge (0→nil, 1→'1', 99→'99', 100→'99+'). Closes #9469.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
