### PR TITLE
M4: Documentation and architecture updates

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,7 +19,7 @@ This file is the cross-system architecture index. Detailed designs live in domai
 
 - Public ingress is gateway-only; external webhook/API routes are implemented in `gateway/` and forwarded internally.
 - Production LLM calls go through the provider abstraction, not provider SDKs in feature code.
-- Notification producers emit through `emitNotificationSignal()` to preserve decisioning and audit invariants.
+- Notification producers emit through `emitNotificationSignal()` to preserve decisioning and audit invariants. Reminder routing metadata (`routingIntent`, `routingHints`) flows through the signal and is enforced post-decision to control multi-channel fanout.
 - Memory extraction/recall must enforce actor-role provenance gates for untrusted actors.
 
 ## System Overview
@@ -134,7 +134,7 @@ graph TB
             DB_ATTACH["attachments"]
             DB_CHAN["channel_inbound_events"]
             DB_KEYS["conversation_keys"]
-            DB_REMINDERS["reminders"]
+            DB_REMINDERS["reminders<br/>(routing_intent, routing_hints_json)"]
             DB_SCHED_JOBS["cron_jobs (recurrence schedules)"]
             DB_SCHED_RUNS["cron_runs (schedule execution history)"]
             DB_HOME["home_base_app_links"]

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -170,7 +170,7 @@ graph LR
         EMB["memory_embeddings<br/>───────────────<br/>target: segment | item | summary<br/>provider + model metadata<br/>vector_json (float array)<br/>Powers semantic search"]
         JOBS["memory_jobs<br/>───────────────<br/>Async task queue<br/>Types: embed, extract,<br/>summarize, backfill,<br/>conflict resolution, cleanup<br/>Status: pending → running →<br/>completed | failed"]
         ATT["attachments<br/>───────────────<br/>base64-encoded file data<br/>mime_type, size_bytes<br/>Linked to messages via<br/>message_attachments join"]
-        REM["reminders<br/>───────────────<br/>One-time scheduled reminders<br/>label, message, fireAt<br/>mode: notify | execute<br/>status: pending → fired | cancelled<br/>routing_intent: single | multi | all<br/>routing_hints_json (free-form)"]
+        REM["reminders<br/>───────────────<br/>One-time scheduled reminders<br/>label, message, fireAt<br/>mode: notify | execute<br/>status: pending → fired | cancelled<br/>routing_intent: single_channel |<br/>multi_channel | all_channels<br/>routing_hints_json (free-form)"]
         SCHED_JOBS["cron_jobs (recurrence schedules)<br/>───────────────<br/>Recurring schedule definitions<br/>cron_expression: cron or RRULE string<br/>schedule_syntax: 'cron' | 'rrule'<br/>timezone, message, next_run_at<br/>enabled, retry_count<br/>Legacy alias: scheduleJobs"]
         SCHED_RUNS["cron_runs (schedule runs)<br/>───────────────<br/>Execution history per schedule<br/>job_id (FK → cron_jobs)<br/>status: ok | error<br/>duration_ms, output, error<br/>Legacy alias: scheduleRuns"]
         TASKS["tasks<br/>───────────────<br/>Reusable prompt templates<br/>title, Handlebars template<br/>inputSchema, contextFlags<br/>requiredTools, status"]

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -170,7 +170,7 @@ graph LR
         EMB["memory_embeddings<br/>───────────────<br/>target: segment | item | summary<br/>provider + model metadata<br/>vector_json (float array)<br/>Powers semantic search"]
         JOBS["memory_jobs<br/>───────────────<br/>Async task queue<br/>Types: embed, extract,<br/>summarize, backfill,<br/>conflict resolution, cleanup<br/>Status: pending → running →<br/>completed | failed"]
         ATT["attachments<br/>───────────────<br/>base64-encoded file data<br/>mime_type, size_bytes<br/>Linked to messages via<br/>message_attachments join"]
-        REM["reminders<br/>───────────────<br/>One-time scheduled reminders<br/>label, message, fireAt<br/>mode: notify | execute<br/>status: pending → fired | cancelled"]
+        REM["reminders<br/>───────────────<br/>One-time scheduled reminders<br/>label, message, fireAt<br/>mode: notify | execute<br/>status: pending → fired | cancelled<br/>routing_intent: single | multi | all<br/>routing_hints_json (free-form)"]
         SCHED_JOBS["cron_jobs (recurrence schedules)<br/>───────────────<br/>Recurring schedule definitions<br/>cron_expression: cron or RRULE string<br/>schedule_syntax: 'cron' | 'rrule'<br/>timezone, message, next_run_at<br/>enabled, retry_count<br/>Legacy alias: scheduleJobs"]
         SCHED_RUNS["cron_runs (schedule runs)<br/>───────────────<br/>Execution history per schedule<br/>job_id (FK → cron_jobs)<br/>status: ok | error<br/>duration_ms, output, error<br/>Legacy alias: scheduleRuns"]
         TASKS["tasks<br/>───────────────<br/>Reusable prompt templates<br/>title, Handlebars template<br/>inputSchema, contextFlags<br/>requiredTools, status"]
@@ -1440,14 +1440,19 @@ Two IPC push events surface new threads in the macOS/iOS client sidebar:
 
 All events follow the same pattern: the daemon creates a server-side conversation, persists an initial message, and broadcasts the IPC event so the macOS `ThreadManager` can create a visible thread in the sidebar.
 
+### Reminder Routing Metadata
+
+Reminders carry optional `routingIntent` (`single_channel` | `multi_channel` | `all_channels`) and free-form `routingHints` metadata. When a reminder fires, this metadata flows through the notification signal into a post-decision enforcement step (`enforceRoutingIntent()` in `decision-engine.ts`) that overrides the LLM's channel selection to match the requested coverage. This enables single-reminder fanout: one reminder can produce multi-channel delivery without duplicate reminders. See `assistant/docs/architecture/scheduling.md` for the full trigger-time data flow.
+
 ### Channel Delivery
 
-Notifications are delivered to two channel types:
+Notifications are delivered to three channel types:
 
 - **Vellum (always connected)**: Local IPC via the daemon's broadcast mechanism. The `VellumAdapter` emits a `notification_intent` message with rendered copy and optional `deepLinkMetadata`.
 - **Telegram (when guardian binding exists)**: HTTP POST to the gateway's `/deliver/telegram` endpoint. Requires an active guardian binding for the assistant.
+- **SMS (when guardian binding exists)**: HTTP POST to the gateway's `/deliver/sms` endpoint. Follows the same pattern as Telegram; the `SmsAdapter` sends text-only messages via the Twilio Messages API. The `assistantId` is threaded through the delivery payload for multi-assistant phone number resolution.
 
-Connected channels are resolved at signal emission time: vellum is always included, and binding-based channels (Telegram) are included only when an active guardian binding exists for the assistant.
+Connected channels are resolved at signal emission time: vellum is always included, and binding-based channels (Telegram, SMS) are included only when an active guardian binding exists for the assistant.
 
 **Key modules:**
 
@@ -1461,6 +1466,7 @@ Connected channels are resolved at signal emission time: vellum is always includ
 | `assistant/src/notifications/conversation-pairing.ts` | Materializes conversation + message per delivery based on channel strategy |
 | `assistant/src/notifications/adapters/macos.ts` | Vellum adapter — broadcasts `notification_intent` via IPC with deep-link metadata |
 | `assistant/src/notifications/adapters/telegram.ts` | Telegram adapter — POSTs to gateway `/deliver/telegram` |
+| `assistant/src/notifications/adapters/sms.ts` | SMS adapter — POSTs to gateway `/deliver/sms` via Twilio Messages API |
 | `assistant/src/notifications/destination-resolver.ts` | Resolves per-channel endpoints (vellum IPC, Telegram chat ID from guardian binding) |
 | `assistant/src/notifications/copy-composer.ts` | Template-based fallback copy when LLM copy is unavailable |
 | `assistant/src/notifications/preference-extractor.ts` | Detects preference statements in conversation messages |

--- a/assistant/docs/architecture/scheduling.md
+++ b/assistant/docs/architecture/scheduling.md
@@ -43,6 +43,87 @@ The database column is named `cron_expression` and the Drizzle table is `cronJob
 
 ---
 
+## Reminder Routing — Trigger-Time Multi-Channel Delivery
+
+Reminders support optional routing metadata that controls how the notification pipeline fans out delivery across channels when a reminder fires. This allows a single reminder to reach the user on multiple channels (desktop, Telegram, SMS) without requiring duplicate reminders.
+
+### Routing Metadata Model
+
+Two columns on the `reminders` table carry routing metadata:
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `routing_intent` | TEXT | `'single_channel'` | Controls channel coverage: `single_channel`, `multi_channel`, or `all_channels` |
+| `routing_hints_json` | TEXT (JSON) | `'{}'` | Free-form hints for the decision engine (e.g. preferred channels) |
+
+### Trigger-Time Data Flow
+
+When the scheduler fires a reminder, routing metadata flows through the full notification pipeline:
+
+```mermaid
+sequenceDiagram
+    participant Scheduler as Scheduler<br/>(15s tick)
+    participant Store as ReminderStore<br/>(SQLite)
+    participant Lifecycle as Daemon Lifecycle<br/>(notifyReminder)
+    participant Signal as emitNotificationSignal
+    participant Engine as Decision Engine<br/>(LLM)
+    participant Enforce as enforceRoutingIntent
+    participant Broadcaster as Broadcaster
+    participant Adapters as Channel Adapters<br/>(Vellum, Telegram, SMS)
+
+    Scheduler->>Store: claimDueReminders(now)
+    Store-->>Scheduler: ReminderRow[] (with routingIntent, routingHints)
+    Scheduler->>Lifecycle: notifyReminder({ id, label, message, routingIntent, routingHints })
+    Lifecycle->>Signal: emitNotificationSignal({ routingIntent, routingHints, ... })
+    Signal->>Engine: evaluateSignal(signal, connectedChannels)
+    Engine-->>Signal: NotificationDecision (LLM channel selection)
+    Signal->>Enforce: enforceRoutingIntent(decision, routingIntent, connectedChannels)
+    Note over Enforce: Override channel selection<br/>based on routing intent
+    Enforce-->>Signal: Enforced decision (re-persisted if changed)
+    Signal->>Broadcaster: dispatchDecision(signal, decision)
+    Broadcaster->>Adapters: Fan-out to each selected channel
+```
+
+### Enforcement Behavior
+
+The `enforceRoutingIntent()` step runs after the LLM produces a channel selection but before deterministic checks. It acts as a post-decision guard:
+
+| Intent | Enforcement Rule |
+|--------|-----------------|
+| `single_channel` | No override. The LLM's channel selection stands. |
+| `multi_channel` | If the LLM selected < 2 channels and 2+ are connected, expand to all connected channels. |
+| `all_channels` | Replace the LLM's selection with all connected channels. |
+
+When enforcement changes the decision, the updated `selectedChannels` and annotated `reasoningSummary` are re-persisted to `notification_decisions` so the audit trail reflects what was actually dispatched.
+
+### Single-Reminder Fanout
+
+One reminder creates one notification signal. The routing intent on that single signal controls how many channels receive the notification. The notification pipeline handles per-channel copy rendering, conversation pairing, and delivery through existing adapters. No duplicate reminders are needed for multi-channel delivery.
+
+### Connected Channels at Fire Time
+
+Channel availability is resolved when the signal is emitted (not when the reminder is created):
+
+- **Vellum** — always connected (local IPC)
+- **Telegram** — connected when an active guardian binding exists
+- **SMS** — connected when an active guardian binding exists
+
+If a channel becomes unavailable between reminder creation and fire time, it is silently excluded from delivery. The routing intent enforcement operates only on channels that are connected at fire time.
+
+### Key Source Files
+
+| File | Responsibility |
+|------|---------------|
+| `assistant/src/tools/reminder/reminder-store.ts` | CRUD with `routingIntent` and `routingHints` fields |
+| `assistant/src/memory/schema.ts` | `reminders` table schema with `routing_intent` and `routing_hints_json` columns |
+| `assistant/src/schedule/scheduler.ts` | Claims due reminders and passes routing metadata to the notifier |
+| `assistant/src/daemon/lifecycle.ts` | Wires the reminder notifier to `emitNotificationSignal()` with routing metadata |
+| `assistant/src/notifications/emit-signal.ts` | Orchestrates the full pipeline including routing intent enforcement |
+| `assistant/src/notifications/decision-engine.ts` | `enforceRoutingIntent()` post-decision guard |
+| `assistant/src/notifications/signal.ts` | `RoutingIntent` type and `NotificationSignal` fields |
+
+---
+
 ## Watcher System — Event-Driven Polling
 
 Watchers poll external APIs on an interval, detect new events via watermark-based change tracking, and process them through a background LLM session.

--- a/assistant/src/notifications/README.md
+++ b/assistant/src/notifications/README.md
@@ -154,9 +154,66 @@ The macOS/iOS client listens for this event and surfaces the thread in the sideb
 
 `emitNotificationSignal()` accepts an optional `onThreadCreated` callback. This lets producers run domain side effects (for example, creating cross-channel guardian delivery rows) as soon as vellum pairing occurs, without introducing a second thread-creation path.
 
+## Reminder Routing Metadata and Trigger-Time Enforcement
+
+Reminders carry optional routing metadata that controls how notifications fan out across channels when the reminder fires. This enables a single reminder to produce multi-channel delivery without requiring the user to create duplicate reminders per channel.
+
+### Routing Intent Model
+
+The `routing_intent` field on each reminder row specifies the desired channel coverage:
+
+| Intent | Behavior | When to use |
+|--------|----------|-------------|
+| `single_channel` | Default LLM-driven routing (no override) | Standard reminders where the decision engine picks the best channel |
+| `multi_channel` | Ensures delivery on 2+ channels when 2+ are connected | Important reminders the user wants on both desktop and phone |
+| `all_channels` | Forces delivery on every connected channel | Critical reminders that must reach the user everywhere |
+
+The default is `single_channel`, preserving backward compatibility. Routing intent is persisted in the `reminders` table (`routing_intent` column) and carried through the notification signal as `routingIntent`.
+
+### Routing Hints
+
+The `routing_hints` field is free-form JSON metadata passed alongside the routing intent. It flows through the signal as `routingHints` and is included in the decision engine prompt, allowing producers to communicate channel preferences or contextual hints without requiring schema changes.
+
+### Trigger-Time Enforcement Flow
+
+When a reminder fires, the routing metadata flows through the notification pipeline with a post-decision enforcement step:
+
+```
+Reminder fires (scheduler)
+  → emitNotificationSignal({ routingIntent, routingHints })
+    → Decision Engine (LLM selects channels)
+      → enforceRoutingIntent() (post-decision guard)
+        → Deterministic Checks
+          → Broadcaster → Adapters → Delivery
+```
+
+The `enforceRoutingIntent()` function in `decision-engine.ts` runs after the LLM produces its channel selection but before deterministic checks. It overrides the decision's `selectedChannels` based on the routing intent:
+
+- **`all_channels`**: Replaces `selectedChannels` with all connected channels (from `getConnectedChannels()`).
+- **`multi_channel`**: If the LLM selected fewer than 2 channels but 2+ are connected, expands `selectedChannels` to all connected channels.
+- **`single_channel`**: No override -- the LLM's selection stands.
+
+When enforcement changes the decision, the updated channel selection is re-persisted to the `notification_decisions` table so the stored decision matches what was actually dispatched. The `reasoningSummary` is annotated with the enforcement action (e.g. `[routing_intent=all_channels enforced: vellum, telegram, sms]`).
+
+### Single-Reminder Fanout
+
+A key design principle: **one reminder produces one notification signal that fans out to multiple channels**. The user never needs to create separate reminders for each channel. The routing intent metadata on the single reminder controls the fanout behavior, and the notification pipeline handles per-channel copy rendering, conversation pairing, and delivery through the existing adapter infrastructure.
+
+### Data Flow
+
+```
+reminders table (routing_intent, routing_hints_json)
+  → scheduler.ts: claimDueReminders() reads routing metadata
+    → lifecycle.ts: notifyReminder({ routingIntent, routingHints })
+      → emitNotificationSignal({ routingIntent, routingHints })
+        → signal.ts: NotificationSignal.routingIntent / routingHints
+          → decision-engine.ts: evaluateSignal() → enforceRoutingIntent()
+            → broadcaster.ts: fan-out to selected channel adapters
+```
+
 ## Channel Delivery Architecture
 
-The notification system delivers to two channel types:
+The notification system delivers to three channel types:
 
 ### Vellum (always connected)
 
@@ -172,12 +229,19 @@ The macOS/iOS client posts a native `UNUserNotificationCenter` notification from
 
 HTTP POST to the gateway's `/deliver/telegram` endpoint. The `TelegramAdapter` sends channel-native text (`deliveryText` when present) to the guardian's chat ID (resolved from the active guardian binding), with deterministic fallbacks when model copy is unavailable.
 
+### SMS (when guardian binding exists)
+
+HTTP POST to the gateway's `/deliver/sms` endpoint. The `SmsAdapter` follows the same pattern as the Telegram adapter: it resolves a phone number from the active guardian binding and sends text via the gateway, which forwards to the Twilio Messages API. The adapter resolves message text via a priority chain: `deliveryText` > `body` > `title` > humanized event name. The `assistantId` is threaded through the `ChannelDeliveryPayload` so the gateway can resolve the correct outbound phone number for multi-assistant deployments.
+
+SMS delivery is text-only (no MMS). Graceful degradation: when the gateway is unreachable or SMS is not configured, the adapter returns a failed `DeliveryResult` without throwing, so the broadcaster continues delivering to other channels.
+
 ### Channel Connectivity
 
 Connected channels are resolved at signal emission time by `getConnectedChannels()` in `emit-signal.ts`:
 
 - **Vellum** is always considered connected (IPC socket is always available when the daemon is running)
 - **Telegram** is considered connected only when an active guardian binding exists for the assistant (checked via `getActiveBinding()`)
+- **SMS** is considered connected only when an active guardian binding exists for the assistant (same check as Telegram)
 
 ## Conversation Materialization
 
@@ -211,6 +275,7 @@ For notification flows that create conversations, the conversation must be creat
 | `destination-resolver.ts` | Resolves per-channel endpoints (vellum IPC, Telegram chat ID) |
 | `adapters/macos.ts` | Vellum adapter -- broadcasts `notification_intent` via IPC with deep-link metadata |
 | `adapters/telegram.ts` | Telegram adapter -- POSTs to gateway `/deliver/telegram` |
+| `adapters/sms.ts` | SMS adapter -- POSTs to gateway `/deliver/sms` via Twilio Messages API |
 | `preference-extractor.ts` | Detects notification preferences in conversation messages |
 | `preference-summary.ts` | Builds preference context string for the decision engine prompt |
 | `preferences-store.ts` | CRUD for `notification_preferences` table |
@@ -237,6 +302,9 @@ await emitNotificationSignal({
     visibleInSourceNow: false,
   },
   contextPayload: { /* arbitrary data for the decision engine */ },
+  // Optional: control multi-channel fanout behavior
+  routingIntent: 'multi_channel',   // 'single_channel' | 'multi_channel' | 'all_channels'
+  routingHints: { preferredChannels: ['telegram', 'sms'] },
 });
 ```
 


### PR DESCRIPTION
Update notifications README, scheduling architecture, and top-level architecture docs to document the new reminder trigger-time multi-channel routing flow including routing metadata model, fire-time enforcement, single-reminder fanout, and SMS channel enablement.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
