### PR TITLE
macOS Unseen Conversations Dock Badge

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -304,6 +304,13 @@ extension AppDelegate {
                 return false
             }
             threadManager.activeThreadId = thread.id
+            // Clear unseen state when deep-linking into a conversation.
+            // selectThread's unseen-clear is guarded by id != previousActiveId,
+            // which is false when activeThreadId was already set above, so we
+            // must clear it explicitly here to keep the dock badge accurate.
+            if let idx = threadManager.threads.firstIndex(where: { $0.sessionId == conversationId }) {
+                threadManager.threads[idx].hasUnseenLatestAssistantMessage = false
+            }
             return true
         }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -260,6 +260,7 @@ extension AppDelegate {
     /// app is active. All notification types get a fallback native alert when
     /// backgrounded to guarantee delivery if the notification_intent IPC is late.
     func handleNotificationThreadCreated(_ msg: IPCNotificationThreadCreated) {
+        ensureMainWindowExists()
         mainWindow?.threadManager.createNotificationThread(
             conversationId: msg.conversationId,
             title: msg.title,

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -304,13 +304,12 @@ extension AppDelegate {
                 return false
             }
             threadManager.activeThreadId = thread.id
-            // Clear unseen state when deep-linking into a conversation.
-            // selectThread's unseen-clear is guarded by id != previousActiveId,
-            // which is false when activeThreadId was already set above, so we
-            // must clear it explicitly here to keep the dock badge accurate.
-            if let idx = threadManager.threads.firstIndex(where: { $0.sessionId == conversationId }) {
-                threadManager.threads[idx].hasUnseenLatestAssistantMessage = false
-            }
+            // Clear unseen state and notify the daemon when deep-linking into a
+            // conversation. selectThread's unseen-clear is guarded by
+            // id != previousActiveId, which is false when activeThreadId was
+            // already set above, so we call markConversationSeen explicitly to
+            // keep both the local flag and the daemon's server-side state in sync.
+            threadManager.markConversationSeen(threadId: thread.id)
             return true
         }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -2015,7 +2015,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     /// Creates the MainWindow and wires callbacks, without showing it.
     /// Safe to call multiple times — no-ops if mainWindow already exists.
     @discardableResult
-    private func ensureMainWindowExists(isFirstLaunch: Bool = false) -> MainWindow {
+    func ensureMainWindowExists(isFirstLaunch: Bool = false) -> MainWindow {
         if let existing = mainWindow { return existing }
         let main = MainWindow(services: services, isFirstLaunch: isFirstLaunch)
         main.onMicrophoneToggle = { [weak self] in

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -168,6 +168,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var connectionStatusCancellable: AnyCancellable?
     private var quickInputAttachmentCancellable: AnyCancellable?
     private var conversationZoomEnabledCancellable: AnyCancellable?
+    private var conversationBadgeCancellable: AnyCancellable?
     /// Observable state for SwiftUI command group `.disabled()` modifiers.
     /// Updated via Combine subscription to `MainWindowState.objectWillChange`.
     @Published public var isConversationZoomEnabled: Bool = false
@@ -684,6 +685,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             mainWindow?.close()
             mainWindow = nil
             conversationZoomEnabledCancellable = nil
+            conversationBadgeCancellable?.cancel()
+            conversationBadgeCancellable = nil
+            NSApp.dockTile.badgeLabel = nil
             isConversationZoomEnabled = false
 
             if let hotKeyMonitor {
@@ -797,6 +801,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         mainWindow?.close()
         mainWindow = nil
         conversationZoomEnabledCancellable = nil
+        conversationBadgeCancellable?.cancel()
+        conversationBadgeCancellable = nil
+        NSApp.dockTile.badgeLabel = nil
         isConversationZoomEnabled = false
 
         if let hotKeyMonitor {
@@ -2024,6 +2031,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         mainWindow = main
         observeConversationZoomEnabled(main.windowState)
         observeAssistantStatus()
+        observeConversationBadge(main.threadManager)
         return main
     }
 
@@ -2096,6 +2104,31 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             .sink { [weak self] _ in
                 self?.updateMenuBarIcon()
             }
+    }
+
+    private func observeConversationBadge(_ threadManager: ThreadManager) {
+        conversationBadgeCancellable?.cancel()
+
+        applyDockConversationBadge(count: threadManager.unseenVisibleConversationCount)
+
+        conversationBadgeCancellable = threadManager.$threads
+            .map { threads in threads.filter { !$0.isArchived && $0.kind != .private && $0.hasUnseenLatestAssistantMessage }.count }
+            .removeDuplicates()
+            .sink { [weak self] count in
+                self?.applyDockConversationBadge(count: count)
+            }
+    }
+
+    /// Format the unseen conversation count for the dock badge.
+    /// Returns nil for 0 (clears badge), exact string for 1-99, "99+" for 100+.
+    func formatDockConversationBadge(count: Int) -> String? {
+        if count <= 0 { return nil }
+        if count >= 100 { return "99+" }
+        return "\(count)"
+    }
+
+    private func applyDockConversationBadge(count: Int) {
+        NSApp.dockTile.badgeLabel = formatDockConversationBadge(count: count)
     }
 
     // MARK: - About Panel
@@ -2173,6 +2206,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             NotificationCenter.default.removeObserver(observer)
         }
         statusIconCancellable?.cancel()
+        conversationBadgeCancellable?.cancel()
+        NSApp.dockTile.badgeLabel = nil
         connectionStatusCancellable?.cancel()
         pulseTimer?.invalidate()
         pulseTimer = nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -705,6 +705,18 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
     }
 
+    /// Clear the local unseen flag and notify the daemon that the conversation
+    /// has been seen. Use this from call-sites that bypass `selectThread` (e.g.
+    /// deep-link navigation in `openConversationThread`) where the `id != previousActiveId`
+    /// guard would skip the signal.
+    internal func markConversationSeen(threadId: UUID) {
+        guard let idx = threads.firstIndex(where: { $0.id == threadId }) else { return }
+        threads[idx].hasUnseenLatestAssistantMessage = false
+        if let sessionId = threads[idx].sessionId {
+            emitConversationSeenSignal(conversationId: sessionId)
+        }
+    }
+
     // MARK: - Private
 
     /// Send a `conversation_seen_signal` IPC message to the daemon.

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -95,6 +95,12 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
     }
 
+    /// Count of visible (non-archived, non-private) threads with unseen assistant messages.
+    /// Used by AppDelegate to drive the dock badge.
+    var unseenVisibleConversationCount: Int {
+        threads.filter { !$0.isArchived && $0.kind != .private && $0.hasUnseenLatestAssistantMessage }.count
+    }
+
     var archivedThreads: [ThreadModel] {
         threads.filter { $0.isArchived }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -183,6 +183,12 @@ final class ThreadSessionRestorer {
 
         var restoredThreads: [ThreadModel] = []
         for session in recentSessions {
+            // Skip sessions that already have a local thread (e.g. created by
+            // createNotificationThread before the session list response arrived).
+            // Without this, the same conversation can appear twice when
+            // defaultThreadIsEmpty is false and the existing threads are appended.
+            guard !delegate.threads.contains(where: { $0.sessionId == session.id }) else { continue }
+
             let kind: ThreadKind = session.threadType == "private" ? .private : .standard
 
             // Preserve user-set titles: if a thread with this session already

--- a/clients/macos/vellum-assistantTests/DockBadgeFormattingTests.swift
+++ b/clients/macos/vellum-assistantTests/DockBadgeFormattingTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class DockBadgeFormattingTests: XCTestCase {
+
+    private var appDelegate: AppDelegate!
+
+    override func setUp() {
+        super.setUp()
+        appDelegate = AppDelegate()
+    }
+
+    override func tearDown() {
+        appDelegate = nil
+        super.tearDown()
+    }
+
+    func testZeroReturnsNil() {
+        XCTAssertNil(appDelegate.formatDockConversationBadge(count: 0))
+    }
+
+    func testNegativeReturnsNil() {
+        XCTAssertNil(appDelegate.formatDockConversationBadge(count: -1))
+    }
+
+    func testOneReturnsExactString() {
+        XCTAssertEqual(appDelegate.formatDockConversationBadge(count: 1), "1")
+    }
+
+    func testNinetyNineReturnsExactString() {
+        XCTAssertEqual(appDelegate.formatDockConversationBadge(count: 99), "99")
+    }
+
+    func testHundredReturnsCappedString() {
+        XCTAssertEqual(appDelegate.formatDockConversationBadge(count: 100), "99+")
+    }
+
+    func testLargeNumberReturnsCappedString() {
+        XCTAssertEqual(appDelegate.formatDockConversationBadge(count: 999), "99+")
+    }
+}

--- a/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
@@ -229,9 +229,39 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         }
         XCTAssertEqual(threadManager.unseenVisibleConversationCount, 1)
 
-        // Select the unseen thread — should clear its unseen flag
+        sentMessages.removeAll()
+
+        // Select the unseen thread — should clear its unseen flag and emit seen signal
         threadManager.selectThread(id: firstId)
         XCTAssertEqual(threadManager.unseenVisibleConversationCount, 0)
+
+        let seenSignals = sentMessages.compactMap { $0 as? IPCConversationSeenSignal }
+        XCTAssertFalse(seenSignals.isEmpty, "selectThread should emit a seen signal to the daemon")
+        XCTAssertEqual(seenSignals.last?.conversationId, "session-first")
+    }
+
+    func testMarkConversationSeenEmitsSignalAndClearsFlag() {
+        guard let threadId = threadManager.activeThreadId,
+              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected an initial active thread")
+            return
+        }
+
+        threadManager.threads[index].sessionId = "session-mark-seen"
+        threadManager.threads[index].hasUnseenLatestAssistantMessage = true
+        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 1)
+
+        sentMessages.removeAll()
+
+        threadManager.markConversationSeen(threadId: threadId)
+
+        XCTAssertFalse(threadManager.threads[index].hasUnseenLatestAssistantMessage,
+                       "markConversationSeen should clear the unseen flag")
+        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 0)
+
+        let seenSignals = sentMessages.compactMap { $0 as? IPCConversationSeenSignal }
+        XCTAssertFalse(seenSignals.isEmpty, "markConversationSeen should emit a seen signal to the daemon")
+        XCTAssertEqual(seenSignals.last?.conversationId, "session-mark-seen")
     }
 
     func testActiveThreadAssistantReplyClearsUnseenAndEmitsSeenSignal() {

--- a/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
@@ -127,6 +127,113 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         XCTAssertEqual(seenSignals.last?.conversationId, "session-realtime")
     }
 
+    func testUnseenVisibleConversationCountExcludesArchivedThreads() {
+        // Start with the initial thread created by setUp
+        guard let threadId = threadManager.activeThreadId,
+              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected an initial active thread")
+            return
+        }
+
+        // Seed a user message so createThread doesn't skip
+        threadManager.chatViewModel(for: threadId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
+
+        // Switch away so the initial thread becomes inactive
+        threadManager.createThread()
+        XCTAssertNotEqual(threadManager.activeThreadId, threadId)
+
+        // Mark the initial thread as unseen
+        if let idx = threadManager.threads.firstIndex(where: { $0.id == threadId }) {
+            threadManager.threads[idx].hasUnseenLatestAssistantMessage = true
+        }
+        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 1)
+
+        // Archive it — count should drop to 0
+        threadManager.archiveThread(id: threadId)
+        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 0)
+    }
+
+    func testUnseenVisibleConversationCountExcludesPrivateThreads() {
+        // Create a private thread (this switches activeThreadId to the private thread)
+        threadManager.createPrivateThread()
+        guard let privateId = threadManager.activeThreadId,
+              let idx = threadManager.threads.firstIndex(where: { $0.id == privateId }) else {
+            XCTFail("Expected a private thread")
+            return
+        }
+
+        // Mark the private thread as unseen
+        threadManager.threads[idx].hasUnseenLatestAssistantMessage = true
+
+        // Private threads are excluded from the visible count
+        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 0)
+    }
+
+    func testUnseenVisibleConversationCountIncludesMultipleUnseen() {
+        // Start with the initial thread
+        guard let firstId = threadManager.activeThreadId else {
+            XCTFail("Expected an initial active thread")
+            return
+        }
+        // Seed a user message so createThread actually creates a new one
+        threadManager.chatViewModel(for: firstId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
+
+        // Create a second thread
+        threadManager.createThread()
+        guard let secondId = threadManager.activeThreadId, secondId != firstId else {
+            XCTFail("Expected a different second thread")
+            return
+        }
+        // Seed the second thread too
+        threadManager.chatViewModel(for: secondId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
+
+        // Create a third thread (becomes active)
+        threadManager.createThread()
+        guard let thirdId = threadManager.activeThreadId, thirdId != secondId else {
+            XCTFail("Expected a different third thread")
+            return
+        }
+
+        // Mark first and second as unseen
+        if let idx = threadManager.threads.firstIndex(where: { $0.id == firstId }) {
+            threadManager.threads[idx].hasUnseenLatestAssistantMessage = true
+        }
+        if let idx = threadManager.threads.firstIndex(where: { $0.id == secondId }) {
+            threadManager.threads[idx].hasUnseenLatestAssistantMessage = true
+        }
+
+        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 2)
+    }
+
+    func testSelectingThreadDecrementsUnseenCount() {
+        // Start with the initial thread
+        guard let firstId = threadManager.activeThreadId else {
+            XCTFail("Expected an initial active thread")
+            return
+        }
+        // Seed so createThread proceeds
+        threadManager.chatViewModel(for: firstId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
+
+        // Create a second thread (becomes active)
+        threadManager.createThread()
+        guard let secondId = threadManager.activeThreadId, secondId != firstId else {
+            XCTFail("Expected a different second thread")
+            return
+        }
+
+        // Mark the first (inactive) thread as unseen and give it a sessionId
+        // (selectThread only clears unseen when sessionId is present)
+        if let idx = threadManager.threads.firstIndex(where: { $0.id == firstId }) {
+            threadManager.threads[idx].hasUnseenLatestAssistantMessage = true
+            threadManager.threads[idx].sessionId = "session-first"
+        }
+        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 1)
+
+        // Select the unseen thread — should clear its unseen flag
+        threadManager.selectThread(id: firstId)
+        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 0)
+    }
+
     func testActiveThreadAssistantReplyClearsUnseenAndEmitsSeenSignal() {
         guard let threadId = threadManager.activeThreadId,
               let index = threadManager.threads.firstIndex(where: { $0.id == threadId }),


### PR DESCRIPTION
## Summary
Surface the unseen conversation count as a numeric badge on the macOS app dock icon. When one or more conversations have unseen assistant replies, show the count (capped at "99+"); when all are seen, clear the badge.

## Changes
- **ThreadManager**: Added `unseenVisibleConversationCount` computed property that counts non-archived, non-private threads with unseen assistant messages
- **AppDelegate**: Wired Combine observer that subscribes to thread changes and updates `NSApp.dockTile.badgeLabel` with the formatted count
- **AppDelegate+Sessions**: Ensured `MainWindow`/`ThreadManager` exists for background notification-created threads so badge updates even before window is shown
- **Teardown**: Badge observer canceled and dock badge cleared on logout, retire, and app termination
- **Tests**: 10 new unit tests covering unseen count semantics (archive/private exclusion, multi-unseen, select-to-decrement) and badge formatting (0→nil, 1→"1", 99→"99", 100→"99+")

## Milestone PRs (merged into feature branch)
- #9478: M1 — Add canonical unseen-count helper in ThreadManager
- #9482: M2 — Wire dock badge observation in AppDelegate
- #9486: M3 — Ensure background notification threads affect badge
- #9490: M5 — Add unit tests for badge count and formatting

(M4 teardown cleanup was addressed during M2 code review feedback)

## Project issue
Closes #9464

## Test plan
- [ ] Launch app with no unseen threads → no dock badge
- [ ] Receive notification thread while app backgrounded → badge increments
- [ ] Open that conversation → badge decrements immediately
- [ ] Multiple unseen conversations → count matches expected number
- [ ] Archive an unseen conversation → badge decrements
- [ ] Private unseen thread → does not affect badge
- [ ] Logout/retire → badge clears
- [ ] All 14 unit tests pass (`DockBadgeFormattingTests` + `ThreadManagerUnseenStateTests`)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
