### PR TITLE
fix: debounce seen-signal emission during streaming

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -901,8 +901,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                     self.latestAssistantActivitySnapshots.removeValue(forKey: threadId)
                 }
                 guard previousSnapshot != latestSnapshot,
-                      latestSnapshot != nil else { return }
-                self.handleAssistantMessageArrival(threadId: threadId)
+                      let latestSnapshot else { return }
+                self.handleAssistantMessageArrival(threadId: threadId, previousSnapshot: previousSnapshot, currentSnapshot: latestSnapshot)
             }
     }
 
@@ -950,7 +950,13 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
     /// Mark assistant activity on a thread as seen/unseen depending on whether
     /// that thread is currently active.
-    private func handleAssistantMessageArrival(threadId: UUID) {
+    ///
+    /// For the active thread, the seen signal is only emitted on meaningful
+    /// transitions — when a new assistant message first appears (new messageId)
+    /// or when streaming completes (isStreaming goes from true to false). This
+    /// avoids O(n) IPC calls per streaming response (one per text delta) while
+    /// still advancing the server-side seen cursor.
+    private func handleAssistantMessageArrival(threadId: UUID, previousSnapshot: AssistantActivitySnapshot?, currentSnapshot: AssistantActivitySnapshot) {
         // Skip during thread restoration — loadHistoryIfNeeded populates
         // messages which triggers the Combine publisher, but those are
         // historical messages, not fresh assistant replies. Without this
@@ -960,8 +966,15 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         updateLastInteracted(threadId: threadId)
         if threadId == activeThreadId {
             threads[index].hasUnseenLatestAssistantMessage = false
-            if let sessionId = threads[index].sessionId {
-                emitConversationSeenSignal(conversationId: sessionId)
+            // Only emit the IPC seen signal on meaningful transitions:
+            // 1. A new assistant message appeared (different messageId)
+            // 2. Streaming just completed (isStreaming went true -> false)
+            let isNewMessage = previousSnapshot?.messageId != currentSnapshot.messageId
+            let streamingJustCompleted = previousSnapshot?.isStreaming == true && !currentSnapshot.isStreaming
+            if isNewMessage || streamingJustCompleted {
+                if let sessionId = threads[index].sessionId {
+                    emitConversationSeenSignal(conversationId: sessionId)
+                }
             }
         } else {
             threads[index].hasUnseenLatestAssistantMessage = true

--- a/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
@@ -103,7 +103,7 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         XCTAssertTrue(updated.hasUnseenLatestAssistantMessage)
     }
 
-    func testActiveThreadEmitsSeenSignalEvenWhenAlreadySeen() {
+    func testActiveThreadEmitsSeenSignalOnNewMessageAndStreamCompletion() {
         guard let threadId = threadManager.activeThreadId,
               let index = threadManager.threads.firstIndex(where: { $0.id == threadId }),
               let vm = threadManager.chatViewModel(for: threadId) else {
@@ -123,8 +123,49 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         XCTAssertFalse(threadManager.threads[index].hasUnseenLatestAssistantMessage)
 
         let seenSignals = sentMessages.compactMap { $0 as? IPCConversationSeenSignal }
-        XCTAssertFalse(seenSignals.isEmpty, "Seen signal should be emitted even when thread was already marked as seen")
+        XCTAssertFalse(seenSignals.isEmpty, "Seen signal should be emitted on new message arrival and stream completion")
         XCTAssertEqual(seenSignals.last?.conversationId, "session-realtime")
+    }
+
+    func testActiveThreadDoesNotEmitSeenSignalOnEveryStreamingDelta() {
+        guard let threadId = threadManager.activeThreadId,
+              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }),
+              let vm = threadManager.chatViewModel(for: threadId) else {
+            XCTFail("Expected active thread and view model")
+            return
+        }
+
+        threadManager.threads[index].sessionId = "session-streaming"
+        threadManager.threads[index].hasUnseenLatestAssistantMessage = false
+        vm.sessionId = "session-streaming"
+
+        // First delta creates a new message — should emit one seen signal
+        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "chunk1", sessionId: "session-streaming")))
+        waitForPropagation()
+
+        let signalsAfterFirstDelta = sentMessages.compactMap { $0 as? IPCConversationSeenSignal }
+            .filter { $0.conversationId == "session-streaming" }
+        let countAfterFirst = signalsAfterFirstDelta.count
+
+        // Subsequent deltas on the same message should NOT emit additional seen signals
+        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " chunk2", sessionId: "session-streaming")))
+        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " chunk3", sessionId: "session-streaming")))
+        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " chunk4", sessionId: "session-streaming")))
+        waitForPropagation()
+
+        let signalsAfterMoreDeltas = sentMessages.compactMap { $0 as? IPCConversationSeenSignal }
+            .filter { $0.conversationId == "session-streaming" }
+        XCTAssertEqual(signalsAfterMoreDeltas.count, countAfterFirst,
+                       "Mid-stream text deltas should not emit additional seen signals (was O(n), should be O(1))")
+
+        // Stream completion should emit one more seen signal
+        vm.handleServerMessage(.messageComplete(MessageCompleteMessage(sessionId: "session-streaming")))
+        waitForPropagation()
+
+        let signalsAfterComplete = sentMessages.compactMap { $0 as? IPCConversationSeenSignal }
+            .filter { $0.conversationId == "session-streaming" }
+        XCTAssertEqual(signalsAfterComplete.count, countAfterFirst + 1,
+                       "Stream completion should emit exactly one additional seen signal")
     }
 
     func testActiveThreadAssistantReplyClearsUnseenAndEmitsSeenSignal() {


### PR DESCRIPTION
Addresses review feedback on #9462. During streaming, emitConversationSeenSignal was firing on every text delta (O(n) IPC calls per response). Now only emits on new message arrival or streaming completion.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
