### PR TITLE
fix: make Track consecutive failures CI step resilient to transient failures

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -86,6 +86,7 @@ jobs:
 
       - name: Track consecutive failures
         if: always()
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/ci-main-cli.yaml
+++ b/.github/workflows/ci-main-cli.yaml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Track consecutive failures
         if: always()
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/ci-main-gateway.yaml
+++ b/.github/workflows/ci-main-gateway.yaml
@@ -39,6 +39,7 @@ jobs:
 
       - name: Track consecutive failures
         if: always()
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -107,6 +107,7 @@ jobs:
 
       - name: Track consecutive failures
         if: always()
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to the "Track consecutive failures" step in all four CI main workflows (assistant, cli, gateway, macos)
- This step is purely informational (counts consecutive failures) and should never fail the build — the macOS CI run failed due to a transient GitHub API network timeout (`dial tcp i/o timeout`) in this step

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22444922154

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
