### PR TITLE
M3: Restart-cancel truthfulness and comprehensive tests

### DIFF
--- a/assistant/src/__tests__/recording-state-machine.test.ts
+++ b/assistant/src/__tests__/recording-state-machine.test.ts
@@ -79,10 +79,12 @@ mock.module('node:fs', () => {
       return realFs.statSync(p, opts);
     },
     realpathSync: (p: string) => {
-      // For test paths under the recordings directory or /tmp/, return as-is
-      // to avoid hitting the filesystem (which would throw ENOENT)
-      if (p.includes('recording') || p.includes('/tmp/') || p.includes('vellum-assistant')) return p;
-      return realFs.realpathSync(p);
+      // Use path.resolve() to canonicalize `..` segments so traversal
+      // attacks like `${ALLOWED_DIR}/../outside.mov` are normalized,
+      // preserving the same semantics as the real realpathSync without
+      // hitting the filesystem (which would throw ENOENT for test paths).
+      const { resolve } = require('path');
+      return resolve(p);
     },
   };
 });
@@ -104,6 +106,7 @@ import {
   getActiveRestartToken,
   recordingHandlers,
   __resetRecordingState,
+  __injectRecordingOwner,
 } from '../daemon/handlers/recording.js';
 import { executeRecordingIntent } from '../daemon/recording-executor.js';
 import type { HandlerContext } from '../daemon/handlers/shared.js';
@@ -1291,20 +1294,13 @@ describe('restart finalization', () => {
     const restartResult = handleRecordingRestart(conversationId, fakeSocket, ctx);
     expect(restartResult.initiated).toBe(true);
 
-    // Simulate stopped for old recording with valid filePath.
-    // But first, start a SECOND recording on a different conversation to
-    // block the deferred start (global single-active guard will reject it).
-    // Actually, we can't do that because handleRecordingStop already cleared
-    // the old recording maps. Instead, we need the deferred start to fail
-    // naturally. The deferred start calls handleRecordingStart which checks
-    // recordingOwnerByConversation — since cleanupMaps was already called by
-    // the stopped handler, the start should succeed unless something else
-    // blocks it. Let's test the flow where start succeeds but the scenario
-    // is handled — this test verifies the "old-success + new-start-failure"
-    // code path. To trigger this, we need handleRecordingStart to return null.
-    // Since we can't easily make it fail after cleanupMaps, we'll verify
-    // the flow indirectly: the old recording attachment IS published even
-    // when the restart path encounters issues.
+    // Inject a blocker recording on a different conversation so that
+    // when the stopped handler calls cleanupMaps (removing conv-A's entry)
+    // and then tries handleRecordingStart, the global single-active guard
+    // sees the blocker entry and returns null — exercising the start-failure
+    // code path.
+    __injectRecordingOwner('conv-blocker', 'rec-blocker');
+
     sent.length = 0;
 
     const stoppedStatus: RecordingStatus = {
@@ -1317,7 +1313,7 @@ describe('restart finalization', () => {
     };
     await recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
 
-    // Verify: old recording attachment is published regardless
+    // Verify: old recording attachment is published (finalization succeeded)
     const textDeltas = sent.filter((m) => m.type === 'assistant_text_delta');
     const successMsg = textDeltas.find(
       (m) => typeof m.text === 'string' && m.text.includes('Screen recording complete'),
@@ -1328,9 +1324,15 @@ describe('restart finalization', () => {
     const attachmentComplete = completes.find((m) => m.attachments != null);
     expect(attachmentComplete).toBeTruthy();
 
-    // Verify: a new recording_start was sent (deferred start triggered)
+    // Verify: no recording_start was sent (deferred start was blocked)
     const startMsgs = sent.filter((m) => m.type === 'recording_start');
-    expect(startMsgs).toHaveLength(1);
+    expect(startMsgs).toHaveLength(0);
+
+    // Verify: follow-up message about the start failure was sent
+    const failureMsg = textDeltas.find(
+      (m) => typeof m.text === 'string' && m.text.includes('Previous recording saved. New recording failed to start.'),
+    );
+    expect(failureMsg).toBeTruthy();
 
     // Verify: old recording message exists in conversation store
     const assistantMsg = mockMessages.find((m) => m.role === 'assistant');

--- a/assistant/src/__tests__/recording-state-machine.test.ts
+++ b/assistant/src/__tests__/recording-state-machine.test.ts
@@ -78,6 +78,12 @@ mock.module('node:fs', () => {
       if (p.includes('recording') || p.includes('/tmp/')) return { size: 1024 };
       return realFs.statSync(p, opts);
     },
+    realpathSync: (p: string) => {
+      // For test paths under the recordings directory or /tmp/, return as-is
+      // to avoid hitting the filesystem (which would throw ENOENT)
+      if (p.includes('recording') || p.includes('/tmp/') || p.includes('vellum-assistant')) return p;
+      return realFs.realpathSync(p);
+    },
   };
 });
 
@@ -103,6 +109,9 @@ import { executeRecordingIntent } from '../daemon/recording-executor.js';
 import type { HandlerContext } from '../daemon/handlers/shared.js';
 import type { RecordingStatus } from '../daemon/ipc-contract/computer-use.js';
 import { DebouncerMap } from '../util/debounce.js';
+
+// The allowed recordings directory used by the recording handler
+const ALLOWED_RECORDINGS_DIR = `${process.env.HOME}/Library/Application Support/vellum-assistant/recordings`;
 
 // ─── Test helpers ───────────────────────────────────────────────────────────
 
@@ -429,13 +438,15 @@ describe('stale completion guard (operation token)', () => {
     };
     recordingHandlers.recording_status(tokenlessStatus, fakeSocket, ctx);
 
-    // Should have triggered the deferred restart start (not emitted text deltas)
+    // Should have triggered the deferred restart start
     const newStartMsgs = sent.filter((m) => m.type === 'recording_start');
     expect(newStartMsgs).toHaveLength(1);
 
-    // No text deltas — the stopped handler short-circuited to deferred restart
+    // The old recording finalization runs (no filePath → "no file was produced"
+    // text delta). This is expected after M2: the stopped handler finalizes the
+    // old recording before starting the new one.
     const textDeltas = sent.filter((m) => m.type === 'assistant_text_delta');
-    expect(textDeltas).toHaveLength(0);
+    expect(textDeltas.length).toBeGreaterThanOrEqual(1);
   });
 
   test('no ghost state after restart stop/start handoff', () => {
@@ -1105,5 +1116,300 @@ describe('deferred restart prevents race condition', () => {
     const startMsgs = sent.filter((m) => m.type === 'recording_start');
     expect(startMsgs).toHaveLength(0);
     expect(isRecordingIdle()).toBe(true);
+  });
+});
+
+// ─── Restart finalization tests ──────────────────────────────────────────────
+
+describe('restart finalization', () => {
+  beforeEach(() => {
+    __resetRecordingState();
+    mockMessages.length = 0;
+    mockMessageIdCounter = 0;
+  });
+
+  test('publishes previous recording attachment on restart', async () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-fin-publish';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    // Start a recording
+    const originalId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    expect(originalId).not.toBeNull();
+
+    // Trigger restart
+    const restartResult = handleRecordingRestart(conversationId, fakeSocket, ctx);
+    expect(restartResult.initiated).toBe(true);
+    sent.length = 0;
+
+    // Simulate stopped for old recording with filePath and durationMs
+    const stoppedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: originalId!,
+      status: 'stopped',
+      filePath: `${ALLOWED_RECORDINGS_DIR}/recording-old.mov`,
+      durationMs: 5000,
+      attachToConversationId: conversationId,
+    };
+    await recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+
+    // Verify: a new recording_start IPC was sent (deferred start triggered)
+    const startMsgs = sent.filter((m) => m.type === 'recording_start');
+    expect(startMsgs).toHaveLength(1);
+    expect(startMsgs[0].operationToken).toBe(restartResult.operationToken);
+
+    // Verify: finalizeAndPublishRecording was called — check that sent
+    // contains messages with attachment data (assistant_text_delta + message_complete)
+    const textDeltas = sent.filter((m) => m.type === 'assistant_text_delta');
+    expect(textDeltas.length).toBeGreaterThanOrEqual(1);
+    const successMsg = textDeltas.find(
+      (m) => typeof m.text === 'string' && m.text.includes('Screen recording complete'),
+    );
+    expect(successMsg).toBeTruthy();
+
+    const completes = sent.filter((m) => m.type === 'message_complete');
+    const attachmentComplete = completes.find((m) => m.attachments != null);
+    expect(attachmentComplete).toBeTruthy();
+
+    // Verify: a message was added to the conversation store
+    const assistantMsg = mockMessages.find((m) => m.role === 'assistant');
+    expect(assistantMsg).toBeTruthy();
+  });
+
+  test('restart + picker cancel preserves previous publish', async () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-fin-cancel-preserve';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    // Start a recording
+    const originalId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+
+    // Restart
+    const restartResult = handleRecordingRestart(conversationId, fakeSocket, ctx);
+    expect(restartResult.initiated).toBe(true);
+
+    // Simulate stopped for old recording with filePath
+    const stoppedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: originalId!,
+      status: 'stopped',
+      filePath: `${ALLOWED_RECORDINGS_DIR}/recording-preserved.mov`,
+      durationMs: 3000,
+      attachToConversationId: conversationId,
+    };
+    await recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+
+    // Capture sent messages so far (should include old recording's attachment)
+    const preCancelTextDeltas = sent.filter((m) => m.type === 'assistant_text_delta');
+    const oldAttachmentMsg = preCancelTextDeltas.find(
+      (m) => typeof m.text === 'string' && m.text.includes('Screen recording complete'),
+    );
+    expect(oldAttachmentMsg).toBeTruthy();
+
+    // Get the new recording ID from the deferred recording_start message
+    const startMsg = sent.filter((m) => m.type === 'recording_start').pop();
+    expect(startMsg).toBeTruthy();
+
+    // Client sends restart_cancelled (picker was closed)
+    const cancelStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: startMsg!.recordingId as string,
+      status: 'restart_cancelled',
+      attachToConversationId: conversationId,
+      operationToken: restartResult.operationToken,
+    };
+    await recordingHandlers.recording_status(cancelStatus, fakeSocket, ctx);
+
+    // Verify: the old recording's attachment messages are still in sent
+    const postCancelTextDeltas = sent.filter((m) => m.type === 'assistant_text_delta');
+    const oldMsgStillPresent = postCancelTextDeltas.find(
+      (m) => typeof m.text === 'string' && m.text.includes('Screen recording complete'),
+    );
+    expect(oldMsgStillPresent).toBeTruthy();
+
+    // Verify: restart_cancelled adds "Recording restart cancelled." text
+    const cancelMsg = postCancelTextDeltas.find(
+      (m) => typeof m.text === 'string' && m.text === 'Recording restart cancelled.',
+    );
+    expect(cancelMsg).toBeTruthy();
+
+    // Verify: the old recording's message was not removed from conversation store
+    const assistantMsg = mockMessages.find((m) => m.role === 'assistant');
+    expect(assistantMsg).toBeTruthy();
+  });
+
+  test('emits truthful failure text when previous finalize fails', async () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-fin-fail-truth';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    // Start a recording
+    const originalId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+
+    // Restart
+    const restartResult = handleRecordingRestart(conversationId, fakeSocket, ctx);
+    expect(restartResult.initiated).toBe(true);
+    sent.length = 0;
+
+    // Simulate stopped with missing filePath (no file produced)
+    const stoppedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: originalId!,
+      status: 'stopped',
+      // No filePath — recording stopped without producing a file
+      attachToConversationId: conversationId,
+    };
+    await recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+
+    // Verify: error message text is sent (not "Screen recording complete")
+    const textDeltas = sent.filter((m) => m.type === 'assistant_text_delta');
+    const hasSuccessMsg = textDeltas.some(
+      (m) => typeof m.text === 'string' && m.text.includes('Screen recording complete'),
+    );
+    expect(hasSuccessMsg).toBe(false);
+
+    const hasErrorMsg = textDeltas.some(
+      (m) => typeof m.text === 'string' && m.text.includes('no file was produced'),
+    );
+    expect(hasErrorMsg).toBe(true);
+
+    // Verify: new recording_start still triggers (deferred start)
+    const startMsgs = sent.filter((m) => m.type === 'recording_start');
+    expect(startMsgs).toHaveLength(1);
+    expect(startMsgs[0].operationToken).toBe(restartResult.operationToken);
+  });
+
+  test('preserves previous attachment when new start fails', async () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-fin-new-fail';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    // Start a recording
+    const originalId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+
+    // Restart
+    const restartResult = handleRecordingRestart(conversationId, fakeSocket, ctx);
+    expect(restartResult.initiated).toBe(true);
+
+    // Simulate stopped for old recording with valid filePath.
+    // But first, start a SECOND recording on a different conversation to
+    // block the deferred start (global single-active guard will reject it).
+    // Actually, we can't do that because handleRecordingStop already cleared
+    // the old recording maps. Instead, we need the deferred start to fail
+    // naturally. The deferred start calls handleRecordingStart which checks
+    // recordingOwnerByConversation — since cleanupMaps was already called by
+    // the stopped handler, the start should succeed unless something else
+    // blocks it. Let's test the flow where start succeeds but the scenario
+    // is handled — this test verifies the "old-success + new-start-failure"
+    // code path. To trigger this, we need handleRecordingStart to return null.
+    // Since we can't easily make it fail after cleanupMaps, we'll verify
+    // the flow indirectly: the old recording attachment IS published even
+    // when the restart path encounters issues.
+    sent.length = 0;
+
+    const stoppedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: originalId!,
+      status: 'stopped',
+      filePath: `${ALLOWED_RECORDINGS_DIR}/recording-old-success.mov`,
+      durationMs: 4000,
+      attachToConversationId: conversationId,
+    };
+    await recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+
+    // Verify: old recording attachment is published regardless
+    const textDeltas = sent.filter((m) => m.type === 'assistant_text_delta');
+    const successMsg = textDeltas.find(
+      (m) => typeof m.text === 'string' && m.text.includes('Screen recording complete'),
+    );
+    expect(successMsg).toBeTruthy();
+
+    const completes = sent.filter((m) => m.type === 'message_complete');
+    const attachmentComplete = completes.find((m) => m.attachments != null);
+    expect(attachmentComplete).toBeTruthy();
+
+    // Verify: a new recording_start was sent (deferred start triggered)
+    const startMsgs = sent.filter((m) => m.type === 'recording_start');
+    expect(startMsgs).toHaveLength(1);
+
+    // Verify: old recording message exists in conversation store
+    const assistantMsg = mockMessages.find((m) => m.role === 'assistant');
+    expect(assistantMsg).toBeTruthy();
+  });
+
+  test('duplicate stopped callback does not double-attach', async () => {
+    const { ctx, sent, fakeSocket } = createCtx();
+    const conversationId = 'conv-fin-dup-stop';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    // Start a recording
+    const originalId = handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+
+    // Restart
+    const restartResult = handleRecordingRestart(conversationId, fakeSocket, ctx);
+    expect(restartResult.initiated).toBe(true);
+    sent.length = 0;
+
+    // First stopped callback with filePath
+    const stoppedStatus: RecordingStatus = {
+      type: 'recording_status',
+      sessionId: originalId!,
+      status: 'stopped',
+      filePath: `${ALLOWED_RECORDINGS_DIR}/recording-dup.mov`,
+      durationMs: 2000,
+      attachToConversationId: conversationId,
+    };
+    await recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+
+    // Count attachment-related messages after first callback
+    const firstCallAttachmentMsgs = sent.filter(
+      (m) => m.type === 'assistant_text_delta' && typeof m.text === 'string' && m.text.includes('Screen recording complete'),
+    );
+    expect(firstCallAttachmentMsgs).toHaveLength(1);
+
+    const firstCallMsgCount = mockMessages.filter((m) => m.role === 'assistant').length;
+    expect(firstCallMsgCount).toBe(1);
+
+    // Send stopped again with same recordingId (duplicate)
+    await recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+
+    // Verify: only one attachment message exists in sent — the duplicate was
+    // rejected by the idempotency guard in finalizeAndPublishRecording
+    const allAttachmentMsgs = sent.filter(
+      (m) => m.type === 'assistant_text_delta' && typeof m.text === 'string' && m.text.includes('Screen recording complete'),
+    );
+    expect(allAttachmentMsgs).toHaveLength(1);
+
+    // Verify: only one assistant message in conversation store
+    const assistantMsgs = mockMessages.filter((m) => m.role === 'assistant');
+    expect(assistantMsgs).toHaveLength(1);
+  });
+
+  test('existing stale-token and restart-timeout protections still pass', () => {
+    // This test verifies that the module-level state functions are
+    // consistent and that __resetRecordingState properly clears all state.
+    // The actual stale-token and restart-timeout protection tests are in
+    // the 'stale completion guard' and 'deferred restart' describe blocks
+    // above — this test simply validates that state is clean after reset.
+    __resetRecordingState();
+    expect(isRecordingIdle()).toBe(true);
+    expect(getActiveRestartToken()).toBeNull();
+
+    // Start a recording, verify not idle
+    const { ctx, fakeSocket } = createCtx();
+    const conversationId = 'conv-fin-sanity';
+    ctx.socketToSession.set(fakeSocket, conversationId);
+
+    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    expect(isRecordingIdle()).toBe(false);
+
+    // Restart, verify token is set
+    handleRecordingRestart(conversationId, fakeSocket, ctx);
+    expect(getActiveRestartToken()).not.toBeNull();
+
+    // Reset everything, verify clean state
+    __resetRecordingState();
+    expect(isRecordingIdle()).toBe(true);
+    expect(getActiveRestartToken()).toBeNull();
   });
 });

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -881,6 +881,15 @@ export function cleanupRecordingsOnDisconnect(
 
 // ─── Test helpers ────────────────────────────────────────────────────────────
 
+/**
+ * Inject a recording owner entry. Only for use in tests.
+ * This allows tests to simulate a second active recording that blocks
+ * handleRecordingStart's global single-active guard.
+ */
+export function __injectRecordingOwner(conversationId: string, recordingId: string): void {
+  recordingOwnerByConversation.set(conversationId, recordingId);
+}
+
 /** Reset module-level state. Only for use in tests. */
 export function __resetRecordingState(): void {
   for (const handle of pendingStopTimeouts.values()) {


### PR DESCRIPTION
Adds comprehensive tests for restart finalization: publish on restart, picker cancel preserves publish, failure truthfulness, old-success+new-failure, duplicate stopped idempotency. Verifies restart_cancelled messaging is truthful after M2 changes. Part of #9509.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
