### PR TITLE
fix: silence build warnings (deprecated onChange, unused result)

### DIFF
--- a/clients/ios/Views/Settings/VoiceSettingsSection.swift
+++ b/clients/ios/Views/Settings/VoiceSettingsSection.swift
@@ -128,7 +128,7 @@ private struct ElevenLabsKeySection: View {
                     Text("API key saved")
                     Spacer()
                     Button("Remove", role: .destructive) {
-                        APIKeyManager.shared.deleteAPIKey(provider: "elevenlabs")
+                        _ = APIKeyManager.shared.deleteAPIKey(provider: "elevenlabs")
                         hasExistingKey = false
                         keyText = ""
                     }

--- a/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/UsedToolsList.swift
@@ -317,7 +317,7 @@ private struct UsedToolsRow: View {
             }
         }
         .animation(VAnimation.fast, value: isExpanded)
-        .onChange(of: isExpanded) { newValue in
+        .onChange(of: isExpanded) { _, newValue in
             // Populate the cache *before* the expanded body evaluates so that
             // `resolvedInputFull` returns the formatted input on the very first
             // render of the expanded section — avoiding a visible flash/pop-in
@@ -330,7 +330,7 @@ private struct UsedToolsRow: View {
                 }
             }
         }
-        .onChange(of: toolCall.inputFull) { _ in
+        .onChange(of: toolCall.inputFull) {
             // Invalidate the cached formatted input so the next render picks up
             // the fresh (rehydrated) value instead of the stale truncated one.
             cachedInputFull = nil

--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -200,7 +200,7 @@ public struct ToolCallChip: View {
                     ? VColor.error.opacity(0.3)
                     : VColor.surfaceBorder.opacity(0.5), lineWidth: 0.5)
         )
-        .onChange(of: isExpanded) { newValue in
+        .onChange(of: isExpanded) { _, newValue in
             // Populate the cache *before* the expanded body evaluates so that
             // `resolvedInputFull` returns the formatted input on the very first
             // render of the expanded section — avoiding a visible flash/pop-in
@@ -213,7 +213,7 @@ public struct ToolCallChip: View {
                 }
             }
         }
-        .onChange(of: toolCall.inputFull) { _ in
+        .onChange(of: toolCall.inputFull) {
             // Invalidate the cached formatted input so the next render picks up
             // the fresh (rehydrated) value instead of the stale truncated one.
             cachedInputFull = nil


### PR DESCRIPTION
## Summary

Fixes three build warnings:

1. **ToolCallChip + UsedToolsList**: `onChange(of:perform:)` was deprecated in iOS 17 / macOS 14. Updated to the new two-parameter `onChange(of:) { _, newValue in }` and zero-parameter `onChange(of:) { }` closure forms.

2. **VoiceSettingsSection**: `deleteAPIKey(provider:)` returns a `Bool` that was unused. Added `_ =` to silence the warning.

## Testing

`./build.sh` passes with no warnings for these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
