### PR TITLE
M1: Screen recording picker UI polish

### DIFF
--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -282,7 +282,7 @@ struct RecordingSourcePickerView: View {
                     .font(VFont.body)
                     .foregroundColor(VColor.textPrimary)
                 Spacer()
-                VToggle(isOn: $viewModel.includeAudio)
+                VToggle(isOn: $viewModel.includeAudio, label: "System audio")
             }
             .padding(.horizontal, VSpacing.xl)
 
@@ -294,7 +294,7 @@ struct RecordingSourcePickerView: View {
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
                     Spacer()
-                    VToggle(isOn: $viewModel.includeMicrophone)
+                    VToggle(isOn: $viewModel.includeMicrophone, label: "Microphone")
                 }
                 .padding(.horizontal, VSpacing.xl)
             }
@@ -313,7 +313,7 @@ struct RecordingSourcePickerView: View {
             .background {
                 // Hidden buttons for keyboard shortcuts
                 Button("") { onCancel() }.keyboardShortcut(.cancelAction).opacity(0).frame(width: 0, height: 0)
-                Button("") { onStart(viewModel.selectedRecordingOptions) }.keyboardShortcut(.defaultAction).opacity(0).frame(width: 0, height: 0)
+                Button("") { guard viewModel.canStart else { return }; onStart(viewModel.selectedRecordingOptions) }.keyboardShortcut(.defaultAction).disabled(!viewModel.canStart).opacity(0).frame(width: 0, height: 0)
             }
         }
         .padding(.vertical, VSpacing.lg)

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -282,7 +282,8 @@ struct RecordingSourcePickerView: View {
                     .font(VFont.body)
                     .foregroundColor(VColor.textPrimary)
                 Spacer()
-                VToggle(isOn: $viewModel.includeAudio, label: "System audio")
+                VToggle(isOn: $viewModel.includeAudio)
+                    .accessibilityLabel("System audio")
             }
             .padding(.horizontal, VSpacing.xl)
 
@@ -294,7 +295,8 @@ struct RecordingSourcePickerView: View {
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
                     Spacer()
-                    VToggle(isOn: $viewModel.includeMicrophone, label: "Microphone")
+                    VToggle(isOn: $viewModel.includeMicrophone)
+                        .accessibilityLabel("Microphone")
                 }
                 .padding(.horizontal, VSpacing.xl)
             }

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -275,29 +275,29 @@ struct RecordingSourcePickerView: View {
     private var bottomBar: some View {
         VStack(spacing: VSpacing.lg) {
             // Audio toggles
-            HStack {
-                Image(systemName: "speaker.wave.2")
-                    .foregroundColor(VColor.textSecondary)
-                Text("System audio")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textPrimary)
-                Spacer()
-                VToggle(isOn: $viewModel.includeAudio)
-                    .accessibilityLabel("System audio")
+            Toggle(isOn: $viewModel.includeAudio) {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "speaker.wave.2")
+                        .foregroundColor(VColor.textSecondary)
+                    Text("System audio")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                }
             }
+            .toggleStyle(.switch)
             .padding(.horizontal, VSpacing.xl)
 
             if #available(macOS 14, *) {
-                HStack {
-                    Image(systemName: "mic")
-                        .foregroundColor(VColor.textSecondary)
-                    Text("Microphone")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
-                    Spacer()
-                    VToggle(isOn: $viewModel.includeMicrophone)
-                        .accessibilityLabel("Microphone")
+                Toggle(isOn: $viewModel.includeMicrophone) {
+                    HStack(spacing: VSpacing.sm) {
+                        Image(systemName: "mic")
+                            .foregroundColor(VColor.textSecondary)
+                        Text("Microphone")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                    }
                 }
+                .toggleStyle(.switch)
                 .padding(.horizontal, VSpacing.xl)
             }
 

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -22,6 +22,11 @@ struct RecordingSourcePickerView: View {
                 .font(VFont.title)
                 .foregroundColor(VColor.textPrimary)
                 .padding(.top, VSpacing.xl)
+                .padding(.bottom, VSpacing.xxs)
+
+            Text("Choose what to record")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
                 .padding(.bottom, VSpacing.md)
 
             // Scope picker (Display / Window)
@@ -31,6 +36,7 @@ struct RecordingSourcePickerView: View {
                 }
             }
             .pickerStyle(.segmented)
+            .labelsHidden()
             .padding(.horizontal, VSpacing.xl)
             .padding(.bottom, VSpacing.lg)
 
@@ -267,53 +273,48 @@ struct RecordingSourcePickerView: View {
     // MARK: - Bottom Bar
 
     private var bottomBar: some View {
-        VStack(spacing: VSpacing.md) {
+        VStack(spacing: VSpacing.lg) {
             // Audio toggles
-            Toggle(isOn: $viewModel.includeAudio) {
-                HStack(spacing: VSpacing.sm) {
-                    Image(systemName: "speaker.wave.2")
-                        .foregroundColor(VColor.textSecondary)
-                    Text("Include system audio")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
-                }
+            HStack {
+                Image(systemName: "speaker.wave.2")
+                    .foregroundColor(VColor.textSecondary)
+                Text("System audio")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                Spacer()
+                VToggle(isOn: $viewModel.includeAudio)
             }
-            .toggleStyle(.switch)
             .padding(.horizontal, VSpacing.xl)
 
             if #available(macOS 14, *) {
-                Toggle(isOn: $viewModel.includeMicrophone) {
-                    HStack(spacing: VSpacing.sm) {
-                        Image(systemName: "mic")
-                            .foregroundColor(VColor.textSecondary)
-                        Text("Include microphone")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textPrimary)
-                    }
+                HStack {
+                    Image(systemName: "mic")
+                        .foregroundColor(VColor.textSecondary)
+                    Text("Microphone")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                    Spacer()
+                    VToggle(isOn: $viewModel.includeMicrophone)
                 }
-                .toggleStyle(.switch)
                 .padding(.horizontal, VSpacing.xl)
             }
 
             // Buttons
             HStack(spacing: VSpacing.md) {
-                Button("Cancel") {
+                VButton(label: "Cancel", style: .secondary, size: .large) {
                     onCancel()
                 }
-                .keyboardShortcut(.cancelAction)
-                .buttonStyle(.bordered)
-
                 Spacer()
-
-                Button("Start Recording") {
+                VButton(label: "Start Recording", style: .primary, size: .large, isDisabled: !viewModel.canStart) {
                     onStart(viewModel.selectedRecordingOptions)
                 }
-                .keyboardShortcut(.defaultAction)
-                .buttonStyle(.borderedProminent)
-                .tint(Color(VColor.accent))
-                .disabled(!viewModel.canStart)
             }
             .padding(.horizontal, VSpacing.xl)
+            .background {
+                // Hidden buttons for keyboard shortcuts
+                Button("") { onCancel() }.keyboardShortcut(.cancelAction).opacity(0).frame(width: 0, height: 0)
+                Button("") { onStart(viewModel.selectedRecordingOptions) }.keyboardShortcut(.defaultAction).opacity(0).frame(width: 0, height: 0)
+            }
         }
         .padding(.vertical, VSpacing.lg)
     }


### PR DESCRIPTION
Remove Capture label, add Choose what to record subtitle, simplify audio toggle labels, use VButton for taller buttons. Closes #9526.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
