### PR TITLE
fix: resolve all lint errors to unblock CI

### DIFF
--- a/assistant/src/daemon/recording-intent.ts
+++ b/assistant/src/daemon/recording-intent.ts
@@ -7,8 +7,6 @@
 // Internal helpers (detect/strip/classify) are kept as private utilities
 // consumed only by `resolveRecordingIntent`.
 
-type RecordingIntentClass = 'start_only' | 'stop_only' | 'mixed' | 'none';
-
 export type RecordingIntentResult =
   | { kind: 'none' }
   | { kind: 'start_only' }
@@ -368,45 +366,6 @@ function isInterrogative(text: string, dynamicNames?: string[]): boolean {
   }
 
   return false;
-}
-
-// ─── Unified classification ─────────────────────────────────────────────────
-
-/**
- * Classifies the recording intent of a user message into one of four categories:
- * - 'start_only': the prompt is purely about starting a recording
- * - 'stop_only': the prompt is purely about stopping a recording
- * - 'mixed': the prompt contains recording intent mixed with other tasks,
- *            or contains both start and stop recording patterns
- * - 'none': no recording intent detected
- *
- * If `dynamicNames` are provided, they are stripped from the beginning of the
- * text before classification (e.g., "Nova, record my screen" -> "record my screen").
- */
-function _classifyRecordingIntent(
-  taskText: string,
-  dynamicNames?: string[],
-): RecordingIntentClass {
-  const normalized =
-    dynamicNames && dynamicNames.length > 0
-      ? stripDynamicNames(taskText, dynamicNames)
-      : taskText;
-
-  const hasStart = detectRecordingIntent(normalized);
-  const hasStop = detectStopRecordingIntent(normalized);
-
-  // Both start and stop patterns present -> mixed
-  if (hasStart && hasStop) return 'mixed';
-
-  if (hasStop) {
-    return isStopRecordingOnly(normalized) ? 'stop_only' : 'mixed';
-  }
-
-  if (hasStart) {
-    return isRecordingOnly(normalized) ? 'start_only' : 'mixed';
-  }
-
-  return 'none';
 }
 
 // ─── Structured intent resolver ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Auto-fixed import sorting errors across 14 files
- Replaced strict null comparisons (`!== null` / `=== null`) with loose equality (`!= null` / `== null`) in attention state handling to satisfy lint while preserving null-safe behavior for DB values
- Fixed unused variables: prefixed with `_`, removed unused imports (`PolicyContext`, `RiskLevel`, `RoutingIntent`, `RecordingFallbackResult`, `RecordingIntentResult`), removed dead `classifyRecordingIntent` function
- Added eslint-disable comments for intentional `require()` calls in test transparent mock patterns

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22445094908

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
