### PR TITLE
Fix macOS dock badge not showing for unseen conversations

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -2063,6 +2063,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
         if let existing = mainWindow {
             existing.show()
+            refreshDockConversationBadge()
             return
         }
         let main = ensureMainWindowExists(isFirstLaunch: isFirstLaunch)
@@ -2079,6 +2080,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             }
         }
         main.show()
+        refreshDockConversationBadge()
     }
 
     private func observeAssistantStatus() {
@@ -2129,6 +2131,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
     private func applyDockConversationBadge(count: Int) {
         NSApp.dockTile.badgeLabel = formatDockConversationBadge(count: count)
+        // Activation-policy transitions can recreate Dock tile presentation;
+        // force a redraw so badge updates are immediately reflected.
+        NSApp.dockTile.display()
+    }
+
+    private func refreshDockConversationBadge() {
+        applyDockConversationBadge(count: mainWindow?.threadManager.unseenVisibleConversationCount ?? 0)
     }
 
     // MARK: - About Panel
@@ -2189,6 +2198,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             tasksWindow = window
         }
         tasksWindow?.show()
+        refreshDockConversationBadge()
     }
 
     // MARK: - Application Lifecycle


### PR DESCRIPTION
## Summary
- reapply the current conversation badge count after showing the main window
- reapply badge after showing the Tasks window (also flips activation policy)
- force dock tile redraw after badge updates so badge state is reflected immediately

## Why
Activation-policy transitions (`.accessory` -> `.regular`) can recreate Dock tile presentation state and drop an already-set badge label. Reapplying after show paths keeps the dock badge in sync with unseen thread state.

## Testing
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter DockBadgeFormattingTests`
