### PR TITLE
fix: resolve all eslint lint errors

### DIFF
--- a/assistant/src/__tests__/recording-intent.test.ts
+++ b/assistant/src/__tests__/recording-intent.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach,describe, expect, mock, test } from 'bun:test';
 
 import {
+  type RecordingIntentResult as _RecordingIntentResult,
   resolveRecordingIntent,
 } from '../daemon/recording-intent.js';
 

--- a/assistant/src/__tests__/recording-state-machine.test.ts
+++ b/assistant/src/__tests__/recording-state-machine.test.ts
@@ -83,6 +83,7 @@ mock.module('node:fs', async () => {
       // attacks like `${ALLOWED_DIR}/../outside.mov` are normalized,
       // preserving the same semantics as the real realpathSync without
       // hitting the filesystem (which would throw ENOENT for test paths).
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { resolve } = require('path');
       return resolve(p);
     },
@@ -97,6 +98,7 @@ mock.module('../daemon/video-thumbnail.js', () => ({
 // ─── Imports (after mocks) ──────────────────────────────────────────────────
 
 import {
+  __injectRecordingOwner,
   __resetRecordingState,
   getActiveRestartToken,
   handleRecordingPause,
@@ -106,8 +108,6 @@ import {
   handleRecordingStop,
   isRecordingIdle,
   recordingHandlers,
-  __resetRecordingState,
-  __injectRecordingOwner,
 } from '../daemon/handlers/recording.js';
 import type { HandlerContext } from '../daemon/handlers/shared.js';
 import type { RecordingStatus } from '../daemon/ipc-contract/computer-use.js';

--- a/assistant/src/daemon/recording-intent.ts
+++ b/assistant/src/daemon/recording-intent.ts
@@ -7,8 +7,6 @@
 // Internal helpers (detect/strip/classify) are kept as private utilities
 // consumed only by `resolveRecordingIntent`.
 
-type RecordingIntentClass = 'start_only' | 'stop_only' | 'mixed' | 'none';
-
 export type RecordingIntentResult =
   | { kind: 'none' }
   | { kind: 'start_only' }
@@ -368,45 +366,6 @@ function isInterrogative(text: string, dynamicNames?: string[]): boolean {
   }
 
   return false;
-}
-
-// ─── Unified classification ─────────────────────────────────────────────────
-
-/**
- * Classifies the recording intent of a user message into one of four categories:
- * - 'start_only': the prompt is purely about starting a recording
- * - 'stop_only': the prompt is purely about stopping a recording
- * - 'mixed': the prompt contains recording intent mixed with other tasks,
- *            or contains both start and stop recording patterns
- * - 'none': no recording intent detected
- *
- * If `dynamicNames` are provided, they are stripped from the beginning of the
- * text before classification (e.g., "Nova, record my screen" -> "record my screen").
- */
-function _classifyRecordingIntent(
-  taskText: string,
-  dynamicNames?: string[],
-): RecordingIntentClass {
-  const normalized =
-    dynamicNames && dynamicNames.length > 0
-      ? stripDynamicNames(taskText, dynamicNames)
-      : taskText;
-
-  const hasStart = detectRecordingIntent(normalized);
-  const hasStop = detectStopRecordingIntent(normalized);
-
-  // Both start and stop patterns present -> mixed
-  if (hasStart && hasStop) return 'mixed';
-
-  if (hasStop) {
-    return isStopRecordingOnly(normalized) ? 'stop_only' : 'mixed';
-  }
-
-  if (hasStart) {
-    return isRecordingOnly(normalized) ? 'start_only' : 'mixed';
-  }
-
-  return 'none';
 }
 
 // ─── Structured intent resolver ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fix import/export sorting across 12+ files (eslint autofix)
- Replace `=== null`/`!== null` with loose equality `== null`/`!= null` to satisfy the `no-restricted-syntax` rule while preserving correct null-checking for Drizzle DB fields
- Prefix unused variables with `_` to satisfy `@typescript-eslint/no-unused-vars`
- Remove dead `classifyRecordingIntent` function and its unused `RecordingIntentClass` type (superseded by `resolveRecordingIntent`)
- Add `eslint-disable` comments for intentional `require()` calls used for pre-mock module captures in test files

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22440158475

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
