### PR TITLE
fix: remove duplicate import causing CI type check failure

### DIFF
--- a/assistant/src/__tests__/recording-state-machine.test.ts
+++ b/assistant/src/__tests__/recording-state-machine.test.ts
@@ -97,6 +97,7 @@ mock.module('../daemon/video-thumbnail.js', () => ({
 // ─── Imports (after mocks) ──────────────────────────────────────────────────
 
 import {
+  __injectRecordingOwner,
   __resetRecordingState,
   getActiveRestartToken,
   handleRecordingPause,
@@ -106,8 +107,6 @@ import {
   handleRecordingStop,
   isRecordingIdle,
   recordingHandlers,
-  __resetRecordingState,
-  __injectRecordingOwner,
 } from '../daemon/handlers/recording.js';
 import type { HandlerContext } from '../daemon/handlers/shared.js';
 import type { RecordingStatus } from '../daemon/ipc-contract/computer-use.js';


### PR DESCRIPTION
## Summary
- Remove duplicate `__resetRecordingState` import in `recording-state-machine.test.ts` that caused a `TS2300: Duplicate identifier` type check failure on CI

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22429388176

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
