### PR TITLE
fix: resolve all 27 lint errors to unbreak CI

### DIFF
--- a/assistant/src/__tests__/recording-state-machine.test.ts
+++ b/assistant/src/__tests__/recording-state-machine.test.ts
@@ -83,6 +83,7 @@ mock.module('node:fs', async () => {
       // attacks like `${ALLOWED_DIR}/../outside.mov` are normalized,
       // preserving the same semantics as the real realpathSync without
       // hitting the filesystem (which would throw ENOENT for test paths).
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { resolve } = require('path');
       return resolve(p);
     },


### PR DESCRIPTION
## Summary
- Add eslint-disable-next-line for `require('path')` in recording-state-machine test (the only remaining lint error after upstream fixes landed)
- This `require()` is inside a synchronous `mock.module` callback where dynamic `import()` cannot be used

## Original prompt
fix: resolve all 27 lint errors to unbreak CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
