### PR TITLE
fix: resolve Swift compiler warnings in macOS Recording module

### DIFF
--- a/clients/macos/vellum-assistant/Recording/RecordingManager.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingManager.swift
@@ -129,7 +129,7 @@ final class RecordingManager: ObservableObject {
             // guard above to cancel a recording that actually succeeded on a later config.
             recorder.onStreamError = { [weak self] recorderError in
                 guard let self else { return }
-                let message = recorderError.localizedDescription ?? "Unknown stream error"
+                let message = recorderError.localizedDescription
                 log.error("Stream error during recording session \(sessionId, privacy: .public): \(message, privacy: .public)")
 
                 self.state = .failed(message)

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
@@ -404,7 +404,7 @@ final class RecordingSourcePickerViewModel: ObservableObject {
                 let totalDisplaySources = self.displays.count
                 await withTaskGroup(of: (UInt32, NSImage?, PreviewStatus, Int, Bool).self) { group in
                     for display in self.displays {
-                        group.addTask { [thumbnailProvider] in
+                        group.addTask { [thumbnailProvider = self.thumbnailProvider] in
                             // Check cancellation before starting each capture
                             guard !Task.isCancelled else {
                                 return (display.id, nil, PreviewStatus.failed(.cancelled), 0, false)
@@ -461,7 +461,7 @@ final class RecordingSourcePickerViewModel: ObservableObject {
                 let totalWindowSources = self.windows.count
                 await withTaskGroup(of: (Int, NSImage?, PreviewStatus, Int, Bool).self) { group in
                     for window in self.windows {
-                        group.addTask { [thumbnailProvider] in
+                        group.addTask { [thumbnailProvider = self.thumbnailProvider] in
                             guard !Task.isCancelled else {
                                 return (window.id, nil, PreviewStatus.failed(.cancelled), 0, false)
                             }

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerWindow.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerWindow.swift
@@ -80,7 +80,9 @@ final class RecordingSourcePickerWindow: NSObject, NSWindowDelegate {
             object: newWindow,
             queue: .main
         ) { [weak self] _ in
-            self?.viewModel?.updateCurrentDisplay()
+            Task { @MainActor in
+                self?.viewModel?.updateCurrentDisplay()
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
+++ b/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
@@ -424,7 +424,7 @@ final class ScreenRecorder: NSObject {
         set { pauseLock.withLock { _isPaused = newValue } }
     }
     private nonisolated(unsafe) var _isPaused = false
-    private nonisolated(unsafe) let pauseLock = NSLock()
+    private let pauseLock = NSLock()
 
     /// Background queue for processing sample buffers from ScreenCaptureKit.
     private let outputQueue = DispatchQueue(label: "com.vellum.screen-recorder.output", qos: .userInitiated)


### PR DESCRIPTION
## Summary
- Remove unnecessary `nonisolated(unsafe)` on `NSLock` constant (already `Sendable`)
- Remove dead nil coalescing on non-optional `localizedDescription`
- Make `thumbnailProvider` capture lists explicitly reference `self` for Swift 6 compatibility
- Wrap `updateCurrentDisplay()` call in `Task { @MainActor in }` to fix actor isolation warning

## Original prompt
fix: resolve Swift compiler warnings in macOS Recording module — `nonisolated(unsafe)` on Sendable, dead nil coalescing, implicit self capture, and actor isolation warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
