### PR TITLE
Fix remaining reminder multi-channel routing gaps

### DIFF
--- a/assistant/docs/architecture/scheduling.md
+++ b/assistant/docs/architecture/scheduling.md
@@ -91,7 +91,7 @@ The `enforceRoutingIntent()` step runs after the LLM produces a channel selectio
 | Intent | Enforcement Rule |
 |--------|-----------------|
 | `single_channel` | No override. The LLM's channel selection stands. |
-| `multi_channel` | If the LLM selected < 2 channels and 2+ are connected, expand to all connected channels. |
+| `multi_channel` | If the LLM selected < 2 channels and 2+ are connected, expand to at least two connected channels. |
 | `all_channels` | Replace the LLM's selection with all connected channels. |
 
 When enforcement changes the decision, the updated `selectedChannels` and annotated `reasoningSummary` are re-persisted to `notification_decisions` so the audit trail reflects what was actually dispatched.
@@ -355,4 +355,3 @@ Deletion uses optimistic UI with rollback:
 1. **Optimistic removal** — `TasksWindowViewModel.removeTask()` snapshots the current `items` array, then immediately removes the target item with animation.
 2. **IPC request** — Sends `work_item_delete` with the item ID. The daemon looks up the item; if found, deletes it and responds with `work_item_delete_response { success: true }`, then broadcasts `tasks_changed`.
 3. **Failure rollback** — If the send throws (socket error), the view model restores the snapshot with animation. If the daemon responds with `success: false` (item not found), the `onWorkItemDeleteResponse` callback triggers a full refetch to reconcile.
-

--- a/assistant/src/__tests__/emit-signal-routing-intent.test.ts
+++ b/assistant/src/__tests__/emit-signal-routing-intent.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const evaluateSignalMock = mock();
+const enforceRoutingIntentMock = mock();
+const updateDecisionMock = mock();
+const runDeterministicChecksMock = mock();
+const createEventMock = mock();
+const updateEventDedupeKeyMock = mock();
+const dispatchDecisionMock = mock();
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module('../channels/config.js', () => ({
+  getDeliverableChannels: () => ['vellum', 'telegram'],
+}));
+
+mock.module('../memory/channel-guardian-store.js', () => ({
+  getActiveBinding: (_assistantId: string, channel: string) =>
+    channel === 'telegram'
+      ? {
+        guardianDeliveryChatId: 'guardian-chat-123',
+        guardianExternalUserId: 'guardian-user-123',
+      }
+      : null,
+}));
+
+mock.module('../notifications/adapters/macos.js', () => ({
+  VellumAdapter: class {
+    constructor(_broadcastFn: unknown) {}
+  },
+}));
+
+mock.module('../notifications/adapters/sms.js', () => ({
+  SmsAdapter: class {},
+}));
+
+mock.module('../notifications/adapters/telegram.js', () => ({
+  TelegramAdapter: class {},
+}));
+
+mock.module('../notifications/broadcaster.js', () => ({
+  NotificationBroadcaster: class {
+    constructor(_adapters: unknown[]) {}
+    setOnThreadCreated(_fn: unknown) {}
+  },
+}));
+
+mock.module('../notifications/decision-engine.js', () => ({
+  evaluateSignal: (...args: unknown[]) => evaluateSignalMock(...args),
+  enforceRoutingIntent: (...args: unknown[]) => enforceRoutingIntentMock(...args),
+}));
+
+mock.module('../notifications/decisions-store.js', () => ({
+  updateDecision: (...args: unknown[]) => updateDecisionMock(...args),
+}));
+
+mock.module('../notifications/deterministic-checks.js', () => ({
+  runDeterministicChecks: (...args: unknown[]) => runDeterministicChecksMock(...args),
+}));
+
+mock.module('../notifications/events-store.js', () => ({
+  createEvent: (...args: unknown[]) => createEventMock(...args),
+  updateEventDedupeKey: (...args: unknown[]) => updateEventDedupeKeyMock(...args),
+}));
+
+mock.module('../notifications/runtime-dispatch.js', () => ({
+  dispatchDecision: (...args: unknown[]) => dispatchDecisionMock(...args),
+}));
+
+import { emitNotificationSignal } from '../notifications/emit-signal.js';
+
+describe('emitNotificationSignal routing intent re-persistence', () => {
+  beforeEach(() => {
+    evaluateSignalMock.mockReset();
+    enforceRoutingIntentMock.mockReset();
+    updateDecisionMock.mockReset();
+    runDeterministicChecksMock.mockReset();
+    createEventMock.mockReset();
+    updateEventDedupeKeyMock.mockReset();
+    dispatchDecisionMock.mockReset();
+
+    createEventMock.mockReturnValue({ id: 'evt-1' });
+    runDeterministicChecksMock.mockResolvedValue({ passed: true });
+    dispatchDecisionMock.mockResolvedValue({
+      dispatched: true,
+      reason: 'ok',
+      deliveryResults: [],
+    });
+  });
+
+  test('re-persists selectedChannels/reasoningSummary when enforcement changes the decision', async () => {
+    const preDecision = {
+      shouldNotify: true,
+      selectedChannels: ['vellum'],
+      reasoningSummary: 'LLM selected vellum only',
+      renderedCopy: {
+        vellum: { title: 'Reminder', body: 'Take out trash' },
+      },
+      dedupeKey: 'dedupe-rem-1',
+      confidence: 0.9,
+      fallbackUsed: false,
+      persistedDecisionId: 'dec-1',
+    };
+
+    const enforcedDecision = {
+      ...preDecision,
+      selectedChannels: ['vellum', 'telegram'],
+      reasoningSummary: `${preDecision.reasoningSummary} [routing_intent=all_channels enforced: vellum, telegram]`,
+    };
+
+    evaluateSignalMock.mockResolvedValue(preDecision);
+    enforceRoutingIntentMock.mockReturnValue(enforcedDecision);
+
+    const result = await emitNotificationSignal({
+      sourceEventName: 'reminder.fired',
+      sourceChannel: 'scheduler',
+      sourceSessionId: 'rem-1',
+      attentionHints: {
+        requiresAction: true,
+        urgency: 'high',
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
+      contextPayload: { reminderId: 'rem-1' },
+      routingIntent: 'all_channels',
+    });
+
+    expect(result.dispatched).toBe(true);
+    expect(updateDecisionMock).toHaveBeenCalledTimes(1);
+    expect(updateDecisionMock).toHaveBeenCalledWith('dec-1', {
+      selectedChannels: ['vellum', 'telegram'],
+      reasoningSummary: `${preDecision.reasoningSummary} [routing_intent=all_channels enforced: vellum, telegram]`,
+      validationResults: {
+        dedupeKey: 'dedupe-rem-1',
+        channelCount: 2,
+        hasCopy: true,
+      },
+    });
+  });
+
+  test('does not re-persist when enforcement leaves the decision unchanged', async () => {
+    const decision = {
+      shouldNotify: true,
+      selectedChannels: ['vellum'],
+      reasoningSummary: 'No routing override needed',
+      renderedCopy: {
+        vellum: { title: 'Reminder', body: 'Drink water' },
+      },
+      dedupeKey: 'dedupe-rem-2',
+      confidence: 0.8,
+      fallbackUsed: false,
+      persistedDecisionId: 'dec-2',
+    };
+
+    evaluateSignalMock.mockResolvedValue(decision);
+    enforceRoutingIntentMock.mockImplementation((inputDecision: unknown) => inputDecision);
+
+    await emitNotificationSignal({
+      sourceEventName: 'reminder.fired',
+      sourceChannel: 'scheduler',
+      sourceSessionId: 'rem-2',
+      attentionHints: {
+        requiresAction: false,
+        urgency: 'medium',
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
+      contextPayload: { reminderId: 'rem-2' },
+      routingIntent: 'single_channel',
+    });
+
+    expect(updateDecisionMock).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/__tests__/notification-routing-intent.test.ts
+++ b/assistant/src/__tests__/notification-routing-intent.test.ts
@@ -100,7 +100,7 @@ describe('routing intent enforcement', () => {
   });
 
   describe('multi_channel intent', () => {
-    test('expands to all connected when LLM picked fewer than 2 and 2+ are connected', () => {
+    test('expands to at least two channels when LLM picked fewer than 2 and 2+ are connected', () => {
       const decision = makeDecision({ selectedChannels: ['vellum'] });
       const connected: NotificationChannel[] = ['vellum', 'telegram'];
 
@@ -108,6 +108,16 @@ describe('routing intent enforcement', () => {
 
       expect(enforced.selectedChannels).toEqual(['vellum', 'telegram']);
       expect(enforced.reasoningSummary).toContain('routing_intent=multi_channel');
+    });
+
+    test('does not expand to all channels when 3+ are connected', () => {
+      const decision = makeDecision({ selectedChannels: ['telegram'] });
+      const connected: NotificationChannel[] = ['vellum', 'telegram', 'sms'];
+
+      const enforced = enforceRoutingIntent(decision, 'multi_channel', connected);
+
+      expect(enforced.selectedChannels).toEqual(['telegram', 'vellum']);
+      expect(enforced.selectedChannels).not.toContain('sms');
     });
 
     test('does not override when LLM already picked 2+ channels', () => {

--- a/assistant/src/__tests__/reminder.test.ts
+++ b/assistant/src/__tests__/reminder.test.ts
@@ -219,6 +219,19 @@ describe('reminder tool', () => {
     expect(result.content).toContain('Routing: multi_channel');
   });
 
+  test('create with routing_hints null returns error', async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const result = executeReminderCreate({
+      fire_at: future,
+      label: 'Bad hints',
+      message: 'Null hints should fail',
+      routing_hints: null,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('routing_hints must be a JSON object');
+  });
+
   test('create without routing fields still works (backward compat)', async () => {
     const future = new Date(Date.now() + 60_000).toISOString();
     const result = executeReminderCreate({

--- a/assistant/src/__tests__/scheduler-recurrence.test.ts
+++ b/assistant/src/__tests__/scheduler-recurrence.test.ts
@@ -36,6 +36,7 @@ import {
 } from '../schedule/schedule-store.js';
 import { startScheduler } from '../schedule/scheduler.js';
 import { createTask } from '../tasks/task-store.js';
+import { getReminder, insertReminder } from '../tools/reminder/reminder-store.js';
 
 initializeDb();
 
@@ -79,6 +80,7 @@ describe('scheduler RRULE execution', () => {
     const db = getDb();
     db.run('DELETE FROM cron_runs');
     db.run('DELETE FROM cron_jobs');
+    db.run('DELETE FROM reminders');
     db.run('DELETE FROM task_runs');
     db.run('DELETE FROM tasks');
     db.run('DELETE FROM messages');
@@ -436,5 +438,53 @@ describe('scheduler RRULE execution', () => {
     // After claiming, MINUTELY recurrence advances nextRunAt by ~60s, so allow up to 65s tolerance
     expect(Math.abs(after!.nextRunAt - originalNextRunAt)).toBeLessThan(65000);
     expect(after!.lastRunAt).not.toBeNull();
+  });
+
+  test('notify reminder passes routing metadata to notifyReminder callback', async () => {
+    const reminder = insertReminder({
+      label: 'Route this reminder',
+      message: 'Reminder body',
+      fireAt: Date.now() - 1000,
+      mode: 'notify',
+      routingIntent: 'multi_channel',
+      routingHints: {
+        requestedByUser: true,
+        channelMentions: ['telegram', 'sms'],
+      },
+    });
+
+    const notifyCalls: Array<{
+      id: string;
+      label: string;
+      message: string;
+      routingIntent: 'single_channel' | 'multi_channel' | 'all_channels';
+      routingHints: Record<string, unknown>;
+    }> = [];
+    const notifyReminder = (payload: {
+      id: string;
+      label: string;
+      message: string;
+      routingIntent: 'single_channel' | 'multi_channel' | 'all_channels';
+      routingHints: Record<string, unknown>;
+    }) => {
+      notifyCalls.push(payload);
+    };
+
+    const scheduler = startScheduler(async () => {}, notifyReminder, () => {});
+    await new Promise(resolve => setTimeout(resolve, 500));
+    scheduler.stop();
+
+    expect(notifyCalls).toHaveLength(1);
+    expect(notifyCalls[0]).toEqual({
+      id: reminder.id,
+      label: reminder.label,
+      message: reminder.message,
+      routingIntent: 'multi_channel',
+      routingHints: {
+        requestedByUser: true,
+        channelMentions: ['telegram', 'sms'],
+      },
+    });
+    expect(getReminder(reminder.id)?.status).toBe('fired');
   });
 });

--- a/assistant/src/notifications/README.md
+++ b/assistant/src/notifications/README.md
@@ -190,7 +190,7 @@ Reminder fires (scheduler)
 The `enforceRoutingIntent()` function in `decision-engine.ts` runs after the LLM produces its channel selection but before deterministic checks. It overrides the decision's `selectedChannels` based on the routing intent:
 
 - **`all_channels`**: Replaces `selectedChannels` with all connected channels (from `getConnectedChannels()`).
-- **`multi_channel`**: If the LLM selected fewer than 2 channels but 2+ are connected, expands `selectedChannels` to all connected channels.
+- **`multi_channel`**: If the LLM selected fewer than 2 channels but 2+ are connected, expands `selectedChannels` to at least two connected channels.
 - **`single_channel`**: No override -- the LLM's selection stands.
 
 When enforcement changes the decision, the updated channel selection is re-persisted to the `notification_decisions` table so the stored decision matches what was actually dispatched. The `reasoningSummary` is annotated with the enforcement action (e.g. `[routing_intent=all_channels enforced: vellum, telegram, sms]`).

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -432,12 +432,31 @@ export function enforceRoutingIntent(
   if (routingIntent === 'multi_channel') {
     // Ensure at least 2 channels when 2+ are connected
     if (connectedChannels.length >= 2 && decision.selectedChannels.length < 2) {
+      const connectedSet = new Set<NotificationChannel>(connectedChannels);
+      const selectedConnected = decision.selectedChannels.filter((ch) => connectedSet.has(ch));
+      const expanded: NotificationChannel[] = [];
+      const seen = new Set<NotificationChannel>();
+
+      // Preserve the decision's selected channels first, then add connected
+      // channels until we reach two channels total.
+      for (const ch of selectedConnected) {
+        if (seen.has(ch)) continue;
+        expanded.push(ch);
+        seen.add(ch);
+      }
+      for (const ch of connectedChannels) {
+        if (seen.has(ch)) continue;
+        expanded.push(ch);
+        seen.add(ch);
+        if (expanded.length >= 2) break;
+      }
+
       const enforced = { ...decision };
-      enforced.selectedChannels = [...connectedChannels];
-      enforced.reasoningSummary = `${decision.reasoningSummary} [routing_intent=multi_channel enforced: expanded to ${connectedChannels.join(', ')}]`;
+      enforced.selectedChannels = expanded;
+      enforced.reasoningSummary = `${decision.reasoningSummary} [routing_intent=multi_channel enforced: expanded to ${expanded.join(', ')}]`;
       log.info(
-        { routingIntent, connectedChannels, originalChannels: decision.selectedChannels },
-        'Routing intent enforcement: multi_channel → expanded to all connected channels',
+        { routingIntent, connectedChannels, originalChannels: decision.selectedChannels, enforcedChannels: expanded },
+        'Routing intent enforcement: multi_channel → expanded to at least two channels',
       );
       return enforced;
     }

--- a/assistant/src/tools/reminder/reminder.ts
+++ b/assistant/src/tools/reminder/reminder.ts
@@ -22,7 +22,7 @@ export function executeReminderCreate(input: Record<string, unknown>): ToolExecu
   const message = input.message as string | undefined;
   const mode = (input.mode as string | undefined) ?? 'notify';
   const routingIntentRaw = input.routing_intent as string | undefined;
-  const routingHintsRaw = input.routing_hints as Record<string, unknown> | undefined;
+  const routingHintsRaw = input.routing_hints as unknown;
 
   if (!fireAtStr) {
     return { content: 'Error: fire_at is required for create', isError: true };
@@ -47,10 +47,13 @@ export function executeReminderCreate(input: Record<string, unknown>): ToolExecu
   }
 
   // Validate routing_hints if provided
-  const routingHints: RoutingHints = (routingHintsRaw as RoutingHints) ?? {};
-  if (routingHintsRaw !== undefined && (typeof routingHintsRaw !== 'object' || Array.isArray(routingHintsRaw))) {
+  if (
+    routingHintsRaw !== undefined
+    && (!routingHintsRaw || typeof routingHintsRaw !== 'object' || Array.isArray(routingHintsRaw))
+  ) {
     return { content: 'Error: routing_hints must be a JSON object', isError: true };
   }
+  const routingHints: RoutingHints = routingHintsRaw === undefined ? {} : routingHintsRaw as RoutingHints;
 
   // Require strict ISO 8601 with timezone offset or Z to avoid ambiguous parsing
   if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:\d{2})$/.test(fireAtStr)) {


### PR DESCRIPTION
## Summary
Addresses the remaining gaps identified after reviewing #9498.

### 1) Tighten reminder contract validation
- Reject `routing_hints: null` in `reminder_create`.
- Keep default behavior (`routing_hints` omitted => `{}`) unchanged.

### 2) Align `multi_channel` enforcement semantics
- Update `enforceRoutingIntent()` so `multi_channel` ensures **at least two** channels (not all connected channels).
- Preserve already-selected channels first, then add connected channels deterministically until reaching 2.
- Keep `all_channels` behavior unchanged.

### 3) Add missing test coverage from original rollout plan
- Added scheduler plumbing test verifying reminder routing metadata is forwarded at fire time.
- Added emit-signal test verifying decision re-persistence after routing enforcement changes selected channels.

### 4) Documentation updates
- Updated routing enforcement docs to reflect `multi_channel => at least two connected channels`.

## Test coverage run
- `bun test src/__tests__/reminder.test.ts src/__tests__/notification-routing-intent.test.ts src/__tests__/scheduler-recurrence.test.ts src/__tests__/emit-signal-routing-intent.test.ts`
- `bunx tsc --noEmit`
- `bunx eslint -f json src/tools/reminder/reminder.ts src/notifications/decision-engine.ts src/__tests__/reminder.test.ts src/__tests__/notification-routing-intent.test.ts src/__tests__/scheduler-recurrence.test.ts src/__tests__/emit-signal-routing-intent.test.ts`

## Notes
- `bun run lint` currently errors in this environment due ESLint stylish formatter (`util.styleText is not a function`), so lint was run with JSON formatter for the touched files.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
