### PR TITLE
Fix guardian verification UX/routing guardrails and prevent duplicate call_start

### DIFF
--- a/assistant/src/__tests__/call-start-guardian-guard.test.ts
+++ b/assistant/src/__tests__/call-start-guardian-guard.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+import type { ToolContext } from '../tools/types.js';
+
+let callsEnabled = true;
+const startCallInputs: Array<Record<string, unknown>> = [];
+let activeVoiceSession: {
+  destinationAddress: string | null;
+  expectedPhoneE164: string | null;
+} | null = null;
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    calls: { enabled: callsEnabled },
+  }),
+}));
+
+mock.module('../calls/call-domain.js', () => ({
+  startCall: async (input: Record<string, unknown>) => {
+    startCallInputs.push(input);
+    return {
+      ok: true,
+      session: {
+        id: 'call-session-1',
+        toNumber: String(input.phoneNumber ?? ''),
+        fromNumber: '+14155550000',
+      },
+      callSid: 'CA-mock',
+      callerIdentityMode: 'assistant_number',
+    };
+  },
+}));
+
+mock.module('../runtime/channel-guardian-service.js', () => ({
+  findActiveSession: () => activeVoiceSession,
+}));
+
+const { executeCallStart } = await import('../tools/calls/call-start.js');
+
+function makeContext(): ToolContext {
+  return {
+    workingDir: '/tmp',
+    sessionId: 'session-1',
+    conversationId: 'conversation-1',
+    assistantId: 'self',
+  };
+}
+
+describe('call_start guardian verification guard', () => {
+  beforeEach(() => {
+    callsEnabled = true;
+    startCallInputs.length = 0;
+    activeVoiceSession = null;
+  });
+
+  test('blocks call_start when voice guardian verification is active for the same number', async () => {
+    activeVoiceSession = {
+      destinationAddress: '+14155551234',
+      expectedPhoneE164: '+14155551234',
+    };
+
+    const result = await executeCallStart(
+      {
+        phone_number: '(415) 555-1234',
+        task: 'Test call while verification is active',
+      },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('guardian voice verification call is already active');
+    expect(startCallInputs.length).toBe(0);
+  });
+
+  test('allows call_start when active guardian verification targets a different number', async () => {
+    activeVoiceSession = {
+      destinationAddress: '+14155550001',
+      expectedPhoneE164: '+14155550001',
+    };
+
+    const result = await executeCallStart(
+      {
+        phone_number: '+14155551234',
+        task: 'Normal outbound call',
+      },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Call initiated successfully.');
+    expect(startCallInputs.length).toBe(1);
+  });
+});

--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -312,4 +312,18 @@ describe('Guardian verification routing section in system prompt', () => {
     // Must advise not to re-ask channel if already specified
     expect(lower.includes('do not re-ask') || lower.includes('already specified')).toBe(true);
   });
+
+  test('routing section disambiguates "set myself up as your guardian" phrasing', () => {
+    const prompt = buildSystemPrompt();
+    const lower = prompt.toLowerCase();
+    expect(lower).toContain('help me set myself up as your guardian');
+    expect(lower).toContain('asking to verify themselves as guardian');
+  });
+
+  test('routing section discourages conceptual detours for direct setup requests', () => {
+    const prompt = buildSystemPrompt();
+    const lower = prompt.toLowerCase();
+    expect(lower).toContain('do not give conceptual');
+    expect(lower).toContain('unless the user explicitly asks');
+  });
 });

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -364,7 +364,7 @@ No additional configuration is needed beyond the standard Twilio setup (Steps 1-
 
 ### Guardian voice verification for inbound calls
 
-For guardian verification setup, first install the skill via `vellum_skills_catalog` with `action: "install"` and `skill_id: "guardian-verify-setup"`, then load it with `skill_load` using `skill: "guardian-verify-setup"`. This skill handles the full outbound verification flow; `phone-calls` does not orchestrate it inline.
+For guardian verification setup, first install the skill via `vellum_skills_catalog` with `action: "install"` and `skill_id: "guardian-verify-setup"`, then load it with `skill_load` using `skill: "guardian-verify-setup"`. This skill handles the full outbound verification flow; `phone-calls` does not orchestrate it inline. Do not use `call_start` to place guardian verification calls — the guardian outbound verification endpoints already place those calls.
 
 Once a guardian binding exists for the voice channel, inbound callers may be prompted for verification before calls proceed. The relay server detects pending challenges and prompts callers: "Please enter your six-digit verification code using your keypad, or speak the digits now." If verification fails after 3 attempts, the call ends with "Verification failed. Goodbye."
 

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -192,6 +192,8 @@ export function buildGuardianVerificationRoutingSection(): string {
     '## Routing: Guardian Verification',
     '',
     'When the user wants to verify their identity as the trusted guardian for a messaging channel, load the **Guardian Verify Setup** skill.',
+    'Interpret phrasing like "help me set myself up as your guardian" as the user asking to verify themselves as guardian (not asking the assistant to self-assign permissions).',
+    'Do not give conceptual "I cannot set myself as guardian" explanations unless the user explicitly asks a conceptual/security question.',
     '',
     '### Trigger phrases',
     '- "verify guardian"',
@@ -213,6 +215,7 @@ export function buildGuardianVerificationRoutingSection(): string {
     '### Exclusivity rules',
     '- Guardian verification intents must only be handled by `guardian-verify-setup` — load it exclusively.',
     '- Do NOT load `phone-calls` for guardian verification intent routing. The phone-calls skill does not orchestrate verification flows.',
+    '- If the user asks to "load phone-calls and guardian verification", prioritize `guardian-verify-setup` and continue the verification flow. Only load `phone-calls` if the user also asks to configure or place regular calls.',
     '- If the user has already explicitly specified a channel (e.g., "verify my phone for SMS", "verify my Telegram"), do not re-ask which channel unless the input is contradictory. Note: "verify my phone number" alone is ambiguous (phone numbers apply to both sms and voice) — ask which channel.',
   ].join('\n');
 }

--- a/assistant/src/config/vellum-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/guardian-verify-setup/SKILL.md
@@ -11,6 +11,8 @@ You are helping your user set up guardian verification for a messaging channel (
 
 - The runtime HTTP API is available at `http://localhost:7821` (or the configured `RUNTIME_HTTP_PORT`).
 - The bearer token is stored at `~/.vellum/http-token`. Read it with: `TOKEN=$(cat ~/.vellum/http-token)`.
+- Run shell commands for this skill with `host_bash` (not sandbox `bash`) so host auth/token and localhost routing are reliable.
+- Keep narration minimal: execute required calls first, then provide a concise status update. Do not narrate internal install/check/load chatter unless something fails.
 
 ## Step 1: Confirm Channel
 
@@ -50,7 +52,7 @@ Replace `<channel>` with `sms`, `voice`, or `telegram`, and `<destination>` with
 Report the exact next action based on the channel:
 
 - **SMS**: "I've sent a 6-digit verification code to [number]. Reply with the code from that SMS conversation (not here) to complete verification — the code can only be consumed through the SMS channel."
-- **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad."
+- **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/start` API call already initiates the voice call. Do NOT place a separate `call_start` call.
 - **Telegram with chat ID** (no `telegramBootstrapUrl` in response): The response includes a `secret` field. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and send `/guardian_verify [secret]` (or just reply with the code) to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4).
 - **Telegram with handle** (`telegramBootstrapUrl` present in response): "Tap this deep-link first: [telegramBootstrapUrl]. After Telegram binds your identity, I'll send your verification code."
 
@@ -84,7 +86,7 @@ curl -s -X POST http://localhost:7821/v1/integrations/guardian/outbound/resend \
 On success, report the next action based on the channel:
 
 - **SMS**: "I've sent a new verification code to [number]. Reply with the code from that SMS conversation to complete verification."
-- **Voice**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad."
+- **Voice**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/resend` API call already initiates the voice call. Do NOT place a separate `call_start` call.
 - **Telegram**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and send `/guardian_verify [secret]` (or just reply with the code) to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3.
 
 ### Resend errors

--- a/assistant/src/tools/calls/call-start.ts
+++ b/assistant/src/tools/calls/call-start.ts
@@ -1,5 +1,7 @@
 import { startCall } from '../../calls/call-domain.js';
 import { getConfig } from '../../config/loader.js';
+import { findActiveSession } from '../../runtime/channel-guardian-service.js';
+import { normalizePhoneNumber } from '../../util/phone.js';
 import type { ToolContext, ToolExecutionResult } from '../types.js';
 
 export async function executeCallStart(
@@ -8,6 +10,24 @@ export async function executeCallStart(
 ): Promise<ToolExecutionResult> {
   if (!getConfig().calls.enabled) {
     return { content: 'Error: Calls feature is disabled via configuration. Set calls.enabled to true to use this feature.', isError: true };
+  }
+
+  const requestedPhone = typeof input.phone_number === 'string'
+    ? normalizePhoneNumber(input.phone_number)
+    : null;
+  if (requestedPhone) {
+    const assistantId = context.assistantId ?? 'self';
+    const activeVoiceVerification = findActiveSession(assistantId, 'voice');
+    const verificationDestination = activeVoiceVerification?.destinationAddress ?? activeVoiceVerification?.expectedPhoneE164;
+    if (verificationDestination === requestedPhone) {
+      return {
+        content: [
+          'Error: A guardian voice verification call is already active for this number.',
+          'Use the guardian outbound verification flow (`/v1/integrations/guardian/outbound/start` or `/resend`) and wait for completion before using `call_start`.',
+        ].join(' '),
+        isError: true,
+      };
+    }
   }
 
   const result = await startCall({

--- a/skills/guardian-verify-setup/SKILL.md
+++ b/skills/guardian-verify-setup/SKILL.md
@@ -11,6 +11,8 @@ You are helping your user set up guardian verification for a messaging channel (
 
 - The runtime HTTP API is available at `http://localhost:7821` (or the configured `RUNTIME_HTTP_PORT`).
 - The bearer token is stored at `~/.vellum/http-token`. Read it with: `TOKEN=$(cat ~/.vellum/http-token)`.
+- Run shell commands for this skill with `host_bash` (not sandbox `bash`) so host auth/token and localhost routing are reliable.
+- Keep narration minimal: execute required calls first, then provide a concise status update. Do not narrate internal install/check/load chatter unless something fails.
 
 ## Step 1: Confirm Channel
 
@@ -50,7 +52,7 @@ Replace `<channel>` with `sms`, `voice`, or `telegram`, and `<destination>` with
 Report the exact next action based on the channel:
 
 - **SMS**: "I've sent a 6-digit verification code to [number]. Reply with the code from that SMS conversation (not here) to complete verification — the code can only be consumed through the SMS channel."
-- **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad."
+- **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/start` API call already initiates the voice call. Do NOT place a separate `call_start` call.
 - **Telegram with chat ID** (no `telegramBootstrapUrl` in response): The response includes a `secret` field. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and send `/guardian_verify [secret]` (or just reply with the code) to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4).
 - **Telegram with handle** (`telegramBootstrapUrl` present in response): "Tap this deep-link first: [telegramBootstrapUrl]. After Telegram binds your identity, I'll send your verification code."
 
@@ -84,7 +86,7 @@ curl -s -X POST http://localhost:7821/v1/integrations/guardian/outbound/resend \
 On success, report the next action based on the channel:
 
 - **SMS**: "I've sent a new verification code to [number]. Reply with the code from that SMS conversation to complete verification."
-- **Voice**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad."
+- **Voice**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/resend` API call already initiates the voice call. Do NOT place a separate `call_start` call.
 - **Telegram**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and send `/guardian_verify [secret]` (or just reply with the code) to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3.
 
 ### Resend errors


### PR DESCRIPTION
## Summary
- tighten guardian verification routing guidance to avoid misreading phrases like "help me set myself up as your guardian"
- update guardian verification skill docs (bundled + catalog source) to require host_bash, keep narration concise, and explicitly forbid separate call_start for outbound verification voice flows
- add runtime guard in call_start to block regular outbound calls to a number that already has an active voice guardian verification session
- extend routing regression tests and add a dedicated call_start guardian-guard test

## Validation
- bun test v1.3.9 (cf6cdbbb)
- 
- 

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
