### PR TITLE
fix: truncate history tool results and discard failed image data

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1881,16 +1881,29 @@ public final class ChatViewModel: ObservableObject {
             let toolsBeforeText = item.toolCallsBeforeText ?? true
             if let historyToolCalls = item.toolCalls {
                 toolCalls = historyToolCalls.map { tc in
+                    // Truncate tool result for memory safety
+                    let truncatedResult: String? = {
+                        guard let result = tc.result else { return nil }
+                        return result.count > 2000 ? String(result.prefix(2000)) + "...[truncated]" : result
+                    }()
+
+                    // Discard base64 image data that fails to decode — don't retain failed base64
+                    let validImageData: String? = {
+                        guard let imgData = tc.imageData else { return nil }
+                        let decoded = ToolCallData.decodeImage(from: imgData)
+                        return decoded != nil ? imgData : nil
+                    }()
+
                     var toolCall = ToolCallData(
                         toolName: tc.name,
                         inputSummary: summarizeToolInput(tc.input),
                         inputFull: "",
                         inputRawValue: extractToolInput(tc.input),
-                        result: tc.result,
+                        result: truncatedResult,
                         isError: tc.isError ?? false,
                         isComplete: true,
                         arrivedBeforeText: toolsBeforeText,
-                        imageData: tc.imageData
+                        imageData: validImageData
                     )
                     // Defer expensive formatting — store the raw dict for lazy computation
                     // when the user expands the tool call chip. Cap the raw dict size


### PR DESCRIPTION
## Summary
Truncate tool results to 2000 chars during history load and discard base64 image data that fails to decode, instead of retaining multi-MB useless strings in memory.

Part of #9534
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
