### PR TITLE
fix: cap claudeCodeSteps at 200 and tool calls at 100 per message

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1054,9 +1054,12 @@ extension ChatViewModel {
                 startedAt: Date()
             )
             toolCall.buildingStatus = buildingStatus
-            // Add to existing assistant message or create one
+            // Add to existing assistant message or create one.
+            // Cap at 100 tool calls per message to prevent unbounded memory growth;
+            // overflow falls through to create a new message.
             if let existingId = currentAssistantMessageId,
-               let index = messages.firstIndex(where: { $0.id == existingId }) {
+               let index = messages.firstIndex(where: { $0.id == existingId }),
+               messages[index].toolCalls.count < 100 {
                 let tcIdx = messages[index].toolCalls.count
                 messages[index].toolCalls.append(toolCall)
                 messages[index].contentOrder.append(.toolCall(tcIdx))
@@ -1101,6 +1104,12 @@ extension ChatViewModel {
                             subToolId: msg.subToolId
                         )
                         messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps.append(step)
+                        // Cap sub-steps to prevent unbounded memory growth
+                        if messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps.count > 200 {
+                            messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps.removeFirst(
+                                messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps.count - 200
+                            )
+                        }
                     }
                 case "tool_complete":
                     // Prefer matching by subToolId (stable SDK identifier) over tool name.


### PR DESCRIPTION
## Summary
Add retention caps to prevent unbounded array growth during long file operation sessions: max 200 claudeCodeSteps per tool call (oldest trimmed) and max 100 tool calls per message (overflow creates new message).

Part of #9534
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
