### PR TITLE
fix: remove heavy fields from ToolCallData Equatable comparison

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -625,9 +625,9 @@ public struct ToolCallData: Identifiable, Equatable {
             && lhs.isError == rhs.isError
             && lhs.isComplete == rhs.isComplete
             && lhs.arrivedBeforeText == rhs.arrivedBeforeText
-            && lhs.inputFull == rhs.inputFull
-            && lhs.inputRawValue == rhs.inputRawValue
-            && lhs.imageData == rhs.imageData
+            // inputFull, inputRawValue, and imageData are intentionally excluded:
+            // they can be multi-MB / 10k+ chars and don't affect rendering state.
+            // SwiftUI diffing would do expensive string comparisons on every update.
             && lhs.buildingStatus == rhs.buildingStatus
             && lhs.claudeCodeSteps == rhs.claudeCodeSteps
     }


### PR DESCRIPTION
## Summary
Remove imageData, inputFull, and inputRawValue from ToolCallData == comparison. These fields can be multi-MB or 10k+ chars and don't affect rendering — preventing expensive string comparisons on every SwiftUI diff.

Part of #9534
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
