### PR TITLE
fix: move IPC JSON decoding off main thread

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -507,7 +507,14 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     var authTimeoutTask: Task<Void, Never>?
 
     /// Buffer for accumulating incoming data until we have complete newline-delimited messages.
+    /// Legacy — only cleared on disconnect. Buffering + decoding now happens on the
+    /// NWConnection queue via `decodeBuffer`.
     var receiveBuffer = Data()
+
+    /// Buffer for accumulating incoming data on the NWConnection background queue.
+    /// Accessed ONLY from NWConnection receive callbacks (which run on `queue`),
+    /// so concurrent access is safe despite the @MainActor class isolation.
+    nonisolated(unsafe) var decodeBuffer = Data()
 
     /// Maximum line size: 96 MB (for screenshots with base64).
     let maxLineSize = 96 * 1024 * 1024

--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -300,6 +300,7 @@ extension DaemonClient {
         }
 
         receiveBuffer = Data()
+        decodeBuffer = Data()
         cuObservationSequenceBySession.removeAll()
         isConnected = false
         isConnecting = false
@@ -325,57 +326,67 @@ extension DaemonClient {
         conn.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] content, _, isComplete, error in
             guard let self else { return }
 
-            Task { @MainActor in
-                if let data = content, !data.isEmpty {
-                    self.processReceivedData(data)
-                }
+            // Buffer and decode on the NWConnection background queue to avoid
+            // blocking the main thread with potentially large JSON payloads.
+            if let data = content, !data.isEmpty {
+                self.decodeBuffer.append(data)
 
-                if isComplete {
-                    log.info("Connection received EOF")
-                    self.handleUnexpectedDisconnect()
-                    return
-                }
+                // Check max buffer size.
+                if self.decodeBuffer.count > self.maxLineSize {
+                    log.error("Receive buffer exceeded max line size (\(self.maxLineSize) bytes), clearing buffer")
+                    self.decodeBuffer = Data()
+                } else {
+                    // Split on newlines and decode each complete line.
+                    let newline = UInt8(0x0A)
+                    var decoded: [ServerMessage] = []
+                    while let newlineIndex = self.decodeBuffer.firstIndex(of: newline) {
+                        let lineData = self.decodeBuffer[self.decodeBuffer.startIndex..<newlineIndex]
+                        self.decodeBuffer = self.decodeBuffer[(newlineIndex + 1)...]
 
-                if let error {
-                    log.error("Receive error: \(error.localizedDescription)")
-                    self.handleUnexpectedDisconnect()
-                    return
-                }
+                        // Skip empty lines.
+                        guard !lineData.isEmpty else { continue }
 
-                // Continue reading.
-                self.receiveData(on: conn)
+                        do {
+                            let message = try self.decoder.decode(ServerMessage.self, from: Data(lineData))
+                            decoded.append(message)
+                        } catch {
+                            // Log a safe summary — never include raw line content which may contain secrets.
+                            let byteCount = lineData.count
+                            let typeHint = self.extractMessageType(from: Data(lineData))
+                            log.error("Failed to decode server message: \(error.localizedDescription), bytes: \(byteCount), type: \(typeHint)")
+                        }
+                    }
+
+                    // Dispatch decoded messages to MainActor for routing.
+                    if !decoded.isEmpty {
+                        Task { @MainActor [weak self] in
+                            guard let self else { return }
+                            for message in decoded {
+                                self.handleServerMessage(message)
+                            }
+                        }
+                    }
+                }
             }
-        }
-    }
 
-    /// Buffer incoming data, split on newlines, decode each complete line as ServerMessage.
-    func processReceivedData(_ data: Data) {
-        receiveBuffer.append(data)
-
-        // Check max buffer size.
-        if receiveBuffer.count > maxLineSize {
-            log.error("Receive buffer exceeded max line size (\(self.maxLineSize) bytes), clearing buffer")
-            receiveBuffer = Data()
-            return
-        }
-
-        // Split on newlines.
-        let newline = UInt8(0x0A)
-        while let newlineIndex = receiveBuffer.firstIndex(of: newline) {
-            let lineData = receiveBuffer[receiveBuffer.startIndex..<newlineIndex]
-            receiveBuffer = receiveBuffer[(newlineIndex + 1)...]
-
-            // Skip empty lines.
-            guard !lineData.isEmpty else { continue }
-
-            do {
-                let message = try decoder.decode(ServerMessage.self, from: Data(lineData))
-                handleServerMessage(message)
-            } catch {
-                // Log a safe summary — never include raw line content which may contain secrets.
-                let byteCount = lineData.count
-                let typeHint = extractMessageType(from: Data(lineData))
-                log.error("Failed to decode server message: \(error.localizedDescription), bytes: \(byteCount), type: \(typeHint)")
+            // Handle EOF and errors on MainActor; continue the receive loop.
+            if isComplete || error != nil {
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    if isComplete {
+                        log.info("Connection received EOF")
+                    }
+                    if let error {
+                        log.error("Receive error: \(error.localizedDescription)")
+                    }
+                    self.handleUnexpectedDisconnect()
+                }
+            } else {
+                // Continue reading — dispatch back to MainActor to call
+                // receiveData which sets up the next NWConnection receive.
+                Task { @MainActor [weak self] in
+                    self?.receiveData(on: conn)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
Move ServerMessage JSON decoding from the MainActor to the NWConnection background queue. Only the decoded messages are dispatched to MainActor for routing. Prevents UI freezes when decoding large tool results (up to 96MB buffer limit).

Part of #9534
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
