### PR TITLE
fix: avoid double image decode in populateFromHistory

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1887,12 +1887,9 @@ public final class ChatViewModel: ObservableObject {
                         return result.count > 2000 ? String(result.prefix(2000)) + "...[truncated]" : result
                     }()
 
-                    // Discard base64 image data that fails to decode — don't retain failed base64
-                    let validImageData: String? = {
-                        guard let imgData = tc.imageData else { return nil }
-                        let decoded = ToolCallData.decodeImage(from: imgData)
-                        return decoded != nil ? imgData : nil
-                    }()
+                    // Decode image once — pass decoded image directly to avoid double-decode
+                    // (ToolCallData.init also decodes base64, so skip that by passing imageData: nil)
+                    let decodedImage = ToolCallData.decodeImage(from: tc.imageData)
 
                     var toolCall = ToolCallData(
                         toolName: tc.name,
@@ -1903,8 +1900,9 @@ public final class ChatViewModel: ObservableObject {
                         isError: tc.isError ?? false,
                         isComplete: true,
                         arrivedBeforeText: toolsBeforeText,
-                        imageData: validImageData
+                        imageData: nil
                     )
+                    toolCall.cachedImage = decodedImage
                     // Defer expensive formatting — store the raw dict for lazy computation
                     // when the user expands the tool call chip. Cap the raw dict size
                     // to prevent unbounded memory from large tool inputs (mirrors the


### PR DESCRIPTION
Addresses Codex feedback on #9546. The populateFromHistory path was decoding base64 image data to validate it, then passing the raw base64 to ToolCallData init which decoded it again. Now decodes once and sets cachedImage directly, passing imageData: nil to skip the redundant decode in the constructor.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
