### PR TITLE
fix: clear decodeBuffer on NWConnection queue to prevent data race

### DIFF
--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -300,7 +300,9 @@ extension DaemonClient {
         }
 
         receiveBuffer = Data()
-        decodeBuffer = Data()
+        queue.async { [weak self] in
+            self?.decodeBuffer = Data()
+        }
         cuObservationSequenceBySession.removeAll()
         isConnected = false
         isConnecting = false


### PR DESCRIPTION
## Summary
Addresses feedback from both Codex and Devin on #9551. The `decodeBuffer` was being cleared directly from MainActor in `disconnectInternal` while the NWConnection receive callback could still be accessing it from the background queue, creating a data race.

## Implementation
In `disconnectInternal`, replaced the direct `decodeBuffer = Data()` assignment with `queue.async { [weak self] in self?.decodeBuffer = Data() }`. This ensures all reads and writes to `decodeBuffer` happen on the same serial queue (`self.queue`), eliminating the race condition.

## Files Changed
- `clients/shared/IPC/DaemonConnection.swift` — dispatch `decodeBuffer` clear to `self.queue` in `disconnectInternal`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
