### PR TITLE
fix: use sync require in recording-state-machine test to prevent mock deadlock

### DIFF
--- a/assistant/src/__tests__/recording-state-machine.test.ts
+++ b/assistant/src/__tests__/recording-state-machine.test.ts
@@ -66,8 +66,9 @@ mock.module('../memory/attachments-store.js', () => ({
 }));
 
 // Mock node:fs
-mock.module('node:fs', async () => {
-  const realFs = await import('fs');
+mock.module('node:fs', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const realFs = require('fs');
   return {
     ...realFs,
     existsSync: (p: string) => {


### PR DESCRIPTION
## Summary
- Reverted `mock.module('node:fs', async () => { await import('fs') })` back to synchronous `require('fs')` with eslint-disable
- The async pattern caused a deadlock in bun's module resolution (mock intercepts the dynamic import of the same module being mocked), making this test hang indefinitely and timing out CI

## Original prompt
fix: use sync require in recording-state-machine test to prevent mock deadlock

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
