### PR TITLE
fix: add inputFull/inputRawValue length sentinels to ToolCallData Equatable

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -586,10 +586,16 @@ public struct ToolCallData: Identifiable, Equatable {
     public let inputSummary: String
     /// Full (untruncated) input text for display in expanded views.
     public var inputFull: String
+    /// Lightweight sentinel tracking `inputFull.count` so that `==` can detect
+    /// rehydration (empty -> populated) without expensive full-string comparison.
+    public var inputFullLength: Int = 0
     /// Untruncated raw value of the primary input key (e.g. file path).
     /// Unlike inputSummary (truncated to 80 chars) this preserves the full value
     /// for use in file existence checks and opening files.
     public var inputRawValue: String
+    /// Lightweight sentinel tracking `inputRawValue.count` so that `==` can detect
+    /// rehydration (empty -> populated) without expensive full-string comparison.
+    public var inputRawValueLength: Int = 0
     public var result: String?
     public var isError: Bool
     public var isComplete: Bool
@@ -625,9 +631,12 @@ public struct ToolCallData: Identifiable, Equatable {
             && lhs.isError == rhs.isError
             && lhs.isComplete == rhs.isComplete
             && lhs.arrivedBeforeText == rhs.arrivedBeforeText
-            // inputFull, inputRawValue, and imageData are intentionally excluded:
-            // they can be multi-MB / 10k+ chars and don't affect rendering state.
-            // SwiftUI diffing would do expensive string comparisons on every update.
+            // inputFull, inputRawValue, and imageData are intentionally excluded
+            // from direct comparison — they can be multi-MB / 10k+ chars.
+            // Instead, lightweight length sentinels detect rehydration changes
+            // (empty -> populated) without expensive full-string comparison.
+            && lhs.inputFullLength == rhs.inputFullLength
+            && lhs.inputRawValueLength == rhs.inputRawValueLength
             && lhs.buildingStatus == rhs.buildingStatus
             && lhs.claudeCodeSteps == rhs.claudeCodeSteps
     }
@@ -639,9 +648,11 @@ public struct ToolCallData: Identifiable, Equatable {
         var fullInput = inputFull ?? inputSummary
         if fullInput.count > 10_000 { fullInput = String(fullInput.prefix(10_000)) + "... [truncated]" }
         self.inputFull = fullInput
+        self.inputFullLength = fullInput.count
         var rawValue = inputRawValue ?? inputSummary
         if rawValue.count > 10_000 { rawValue = String(rawValue.prefix(10_000)) + "... [truncated]" }
         self.inputRawValue = rawValue
+        self.inputRawValueLength = rawValue.count
         self.result = result
         self.isError = isError
         self.isComplete = isComplete
@@ -1405,6 +1416,7 @@ public struct ChatMessage: Identifiable, Equatable {
             toolCalls[i].imageData = nil
             toolCalls[i].result = nil
             toolCalls[i].inputFull = ""
+            toolCalls[i].inputFullLength = 0
             toolCalls[i].inputRawDict = nil
         }
         for i in attachments.indices {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -550,7 +550,9 @@ public final class ChatViewModel: ObservableObject {
                     messages[idx].toolCalls[tcIdx].result = result
                 }
                 if let input = fullTC.input {
-                    messages[idx].toolCalls[tcIdx].inputFull = ToolCallData.formatAllToolInput(input)
+                    let formatted = ToolCallData.formatAllToolInput(input)
+                    messages[idx].toolCalls[tcIdx].inputFull = formatted
+                    messages[idx].toolCalls[tcIdx].inputFullLength = formatted.count
                     messages[idx].toolCalls[tcIdx].inputRawDict = input
                 }
             }
@@ -1917,7 +1919,9 @@ public final class ChatViewModel: ObservableObject {
                     if estimatedSize > 10_000 {
                         // Too large — format eagerly (with truncation) rather than
                         // retaining the full raw dictionary in memory.
-                        toolCall.inputFull = ToolCallData.formatAllToolInput(input)
+                        let formatted = ToolCallData.formatAllToolInput(input)
+                        toolCall.inputFull = formatted
+                        toolCall.inputFullLength = formatted.count
                     } else {
                         toolCall.inputRawDict = input
                     }


### PR DESCRIPTION
## Summary
Addresses Devin feedback on #9549. Excluding `inputFull` and `inputRawValue` from `ToolCallData.==` prevented SwiftUI from detecting rehydration changes (e.g., when `inputFull` is updated from empty/truncated to full content). The `.onChange(of: toolCall.inputFull)` modifier in ToolCallChip would not fire because SwiftUI skips body re-evaluation when `==` returns true.

## Implementation
Adds lightweight `inputFullLength: Int` and `inputRawValueLength: Int` sentinel fields to `ToolCallData` that track the `.count` of the corresponding strings. These sentinels are included in the custom `==` comparison, providing cheap change detection (O(1) integer comparison) without the expensive full-string comparison that was originally avoided.

## Files Changed
- `clients/shared/Features/Chat/ChatMessage.swift` — Added sentinel properties, updated `==`, `init`, and `stripHeavyContent`
- `clients/shared/Features/Chat/ChatViewModel.swift` — Updated both mutation sites to sync `inputFullLength` when `inputFull` is set

## Key Technical Choices
- **Length sentinel vs full string comparison**: Using `.count` as a proxy avoids O(n) string comparison on every SwiftUI diff pass while still detecting the meaningful state change (empty -> populated). A length collision (different content, same length) is acceptable since the semantic content difference doesn't affect rendering state.
- **Both `inputFull` and `inputRawValue`**: Applied the same pattern to `inputRawValue` since it's also excluded from `==` but may be rehydrated.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
