### PR TITLE
fix: resolve recording-state-machine test hang by capturing real fs/path modules before mock registration

### DIFF
--- a/assistant/src/__tests__/recording-state-machine.test.ts
+++ b/assistant/src/__tests__/recording-state-machine.test.ts
@@ -65,31 +65,32 @@ mock.module('../memory/attachments-store.js', () => ({
   setAttachmentThumbnail: noop,
 }));
 
+// Capture real modules BEFORE mocking to avoid circular resolution
+// (mock.module('node:fs') + require('fs') inside factory = deadlock)
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realFs = require('fs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realPath = require('path');
+
 // Mock node:fs
-mock.module('node:fs', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const realFs = require('fs');
-  return {
-    ...realFs,
-    existsSync: (p: string) => {
-      if (p.includes('recording') || p.includes('/tmp/')) return true;
-      return realFs.existsSync(p);
-    },
-    statSync: (p: string, opts?: any) => {
-      if (p.includes('recording') || p.includes('/tmp/')) return { size: 1024 };
-      return realFs.statSync(p, opts);
-    },
-    realpathSync: (p: string) => {
-      // Use path.resolve() to canonicalize `..` segments so traversal
-      // attacks like `${ALLOWED_DIR}/../outside.mov` are normalized,
-      // preserving the same semantics as the real realpathSync without
-      // hitting the filesystem (which would throw ENOENT for test paths).
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { resolve } = require('path');
-      return resolve(p);
-    },
-  };
-});
+mock.module('node:fs', () => ({
+  ...realFs,
+  existsSync: (p: string) => {
+    if (p.includes('recording') || p.includes('/tmp/')) return true;
+    return realFs.existsSync(p);
+  },
+  statSync: (p: string, opts?: any) => {
+    if (p.includes('recording') || p.includes('/tmp/')) return { size: 1024 };
+    return realFs.statSync(p, opts);
+  },
+  realpathSync: (p: string) => {
+    // Use path.resolve() to canonicalize `..` segments so traversal
+    // attacks like `${ALLOWED_DIR}/../outside.mov` are normalized,
+    // preserving the same semantics as the real realpathSync without
+    // hitting the filesystem (which would throw ENOENT for test paths).
+    return realPath.resolve(p);
+  },
+}));
 
 // Mock video thumbnail
 mock.module('../daemon/video-thumbnail.js', () => ({


### PR DESCRIPTION
## Summary
- Move `require('fs')` and `require('path')` calls outside the `mock.module('node:fs')` factory to prevent circular module resolution deadlock
- The deadlock occurred because `require('fs')` inside the mock factory for `node:fs` triggers the same mock, creating an infinite loop during module loading
- This was causing the CI test step to hang and timeout after 15 minutes

## Original prompt
fix: resolve recording-state-machine test hang by capturing real fs/path modules before mock registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
