### PR TITLE
fix: scope tool result fallback search to current turn

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1153,8 +1153,10 @@ extension ChatViewModel {
                 targetMsgIndex = msgIndex
                 targetTcIndex = tcIndex
             } else {
-                // Fallback: search backward for any assistant message with incomplete tool calls
-                for i in messages.indices.reversed() {
+                // Fallback: search backward for assistant messages with incomplete tool calls,
+                // but only within the current turn (after the last user message).
+                let lastUserIndex = messages.lastIndex(where: { $0.role == .user }) ?? 0
+                for i in stride(from: messages.count - 1, through: lastUserIndex, by: -1) {
                     guard messages[i].role == .assistant else { continue }
                     if let tcIndex = messages[i].toolCalls.lastIndex(where: { !$0.isComplete }) {
                         targetMsgIndex = i


### PR DESCRIPTION
Addresses Codex feedback on #9553. The fallback tool result search previously walked the entire message transcript, which could bind results to older turns' unfinished tool calls. Now restricted to only search assistant messages after the last user message (current turn).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
