### PR TITLE
feat: surface bearer token in Gateway section of Connect settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -338,6 +338,11 @@ struct SettingsConnectTab: View {
                             .foregroundColor(VColor.warning)
                     }
                 }
+
+                Divider()
+                    .background(VColor.surfaceBorder)
+
+                bearerTokenContent
             }
         }
         .padding(VSpacing.lg)


### PR DESCRIPTION
## Summary
- Add bearer token display (reveal/copy/regenerate) to the Gateway card in Settings > Connect
- Previously the token was buried under Mobile > Advanced, making it hard to find for Chrome extension setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
