### PR TITLE
fix: anchor tool result fallback to currentAssistantMessageId position

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1152,9 +1152,21 @@ extension ChatViewModel {
                let tcIndex = messages[msgIndex].toolCalls.lastIndex(where: { !$0.isComplete }) {
                 targetMsgIndex = msgIndex
                 targetTcIndex = tcIndex
+            } else if let existingId = currentAssistantMessageId,
+                      let currentIdx = messages.firstIndex(where: { $0.id == existingId }) {
+                // Current assistant message has no incomplete tool calls.
+                // Search backward from current message position for rotated messages.
+                for i in stride(from: currentIdx - 1, through: max(0, currentIdx - 5), by: -1) {
+                    guard messages[i].role == .assistant else { continue }
+                    if let tcIndex = messages[i].toolCalls.lastIndex(where: { !$0.isComplete }) {
+                        targetMsgIndex = i
+                        targetTcIndex = tcIndex
+                        break
+                    }
+                }
             } else {
-                // Fallback: search backward for assistant messages with incomplete tool calls,
-                // but only within the current turn (after the last user message).
+                // currentAssistantMessageId is nil — search backward within current turn
+                // (reconnect scenario where there are no queued messages).
                 let lastUserIndex = messages.lastIndex(where: { $0.role == .user }) ?? 0
                 for i in stride(from: messages.count - 1, through: lastUserIndex, by: -1) {
                     guard messages[i].role == .assistant else { continue }


### PR DESCRIPTION
Addresses Codex feedback on #9558. The lastUserIndex boundary could point to a queued user message, causing the fallback to miss the active turn's incomplete tool calls. Now uses two fallback strategies: (1) when currentAssistantMessageId is set, searches backward from that position (handles rotation), (2) when nil, falls back to user-message-scoped search (handles reconnect).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
