### PR TITLE
Fix macOS badge auth request for dock unread count

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -117,7 +117,7 @@ extension AppDelegate {
 
     private func requestNotificationAuthorization(trigger: String, showDeniedToast: Bool) {
         let center = UNUserNotificationCenter.current()
-        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+        center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
             if granted {
                 log.info("Notification authorization granted (\(trigger))")
                 return
@@ -138,7 +138,7 @@ extension AppDelegate {
         lastNotificationPermissionToastAtMs = nowMs
 
         mainWindow?.windowState.showToast(
-            message: "Notifications are off for Vellum. Turn them on in System Settings to receive banners.",
+            message: "Notifications are off for Vellum. Turn them on in System Settings to receive banners and dock badges.",
             style: .warning,
             primaryAction: VToastAction(label: "Open Settings") { [weak self] in
                 self?.openNotificationSettings()


### PR DESCRIPTION
## Summary
- request notification authorization with `.badge` in addition to `.alert` and `.sound`
- update denied-notifications toast copy to mention dock badges

## Why
The app was not explicitly requesting badge authorization, which can prevent dock icon badge display even when unseen-conversation counts are computed and set on `NSApp.dockTile.badgeLabel`.

## Testing
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter DockBadgeFormattingTests`
