### PR TITLE
feat: skip plan approval step in safe-blitz command

### DIFF
--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -53,9 +53,7 @@ Read and follow `.claude/phases/plan-and-spec.md`. For safe-blitz mode, replace 
 `<feature-branch-name>`
 ```
 
-When presenting the plan for approval, also show:
-- The feature branch name
-- Note: "All milestone PRs will target the feature branch `<name>`. A final PR into main will be created at the end for your review."
+**Skip the approval step** (step 5 in plan-and-spec.md). Do NOT pause for user confirmation after creating the plan. Instead, log a summary of the plan (project issue link, milestone list, feature branch name) and proceed directly to the next phase. Safe-blitz already has review gates on every milestone PR and a final PR into main, so an upfront approval is unnecessary.
 
 ## Phase 3: Prepare Milestone List
 


### PR DESCRIPTION
## Summary
- Removes the approval/pause step after the plan is created in the safe-blitz command
- The plan summary is still logged, but execution proceeds immediately without waiting for user confirmation
- Safe-blitz already has review gates on every milestone PR and a final PR into main, making the upfront approval redundant

## Original prompt
remove the approval step in the safe-blitz command after the plan is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
