### PR TITLE
macOS: show all requested permissions in Settings

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -147,17 +147,9 @@ extension AppDelegate {
     }
 
     private func openNotificationSettings() {
-        let candidates = [
-            "x-apple.systempreferences:com.apple.preference.notifications?id=\(Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant")",
-            "x-apple.systempreferences:com.apple.preference.notifications",
-        ]
-        for candidate in candidates {
-            guard let url = URL(string: candidate) else { continue }
-            if NSWorkspace.shared.open(url) {
-                return
-            }
+        if !PermissionManager.openNotificationSettings() {
+            log.warning("Failed to open macOS Notification settings URL")
         }
-        log.warning("Failed to open macOS Notification settings URL")
     }
 
     private func normalizeNotificationUserInfoValue(_ value: Any?) -> Any? {

--- a/clients/macos/vellum-assistant/App/PermissionManager.swift
+++ b/clients/macos/vellum-assistant/App/PermissionManager.swift
@@ -1,5 +1,8 @@
 import ApplicationServices
 import AppKit
+import AVFoundation
+import Speech
+import UserNotifications
 
 enum PermissionStatus {
     case granted
@@ -16,6 +19,70 @@ enum PermissionManager {
 
     static func screenRecordingStatus() -> PermissionStatus {
         return CGPreflightScreenCaptureAccess() ? .granted : .denied
+    }
+
+    static func microphoneStatus() -> PermissionStatus {
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .authorized:
+            return .granted
+        case .denied, .restricted:
+            return .denied
+        case .notDetermined:
+            return .unknown
+        @unknown default:
+            return .unknown
+        }
+    }
+
+    static func speechRecognitionStatus() -> PermissionStatus {
+        switch SFSpeechRecognizer.authorizationStatus() {
+        case .authorized:
+            return .granted
+        case .denied, .restricted:
+            return .denied
+        case .notDetermined:
+            return .unknown
+        @unknown default:
+            return .unknown
+        }
+    }
+
+    static func notificationStatus() async -> PermissionStatus {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        switch settings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            return .granted
+        case .denied:
+            return .denied
+        case .notDetermined:
+            return .unknown
+        @unknown default:
+            return .unknown
+        }
+    }
+
+    static func notificationBadgeStatus() async -> PermissionStatus {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+
+        switch settings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            switch settings.badgeSetting {
+            case .enabled:
+                return .granted
+            case .disabled:
+                return .denied
+            case .notSupported:
+                return .unknown
+            @unknown default:
+                return .unknown
+            }
+        case .denied:
+            return .denied
+        case .notDetermined:
+            return .unknown
+        @unknown default:
+            return .unknown
+        }
     }
 
     private static let hasRequestedScreenRecordingFlag = "hasRequestedScreenRecording"
@@ -38,9 +105,98 @@ enum PermissionManager {
         }
     }
 
-    static func openScreenRecordingSettings() {
-        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture") {
-            NSWorkspace.shared.open(url)
+    static func requestMicrophoneAccess() {
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .authorized:
+            return
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .audio) { _ in }
+        case .denied, .restricted:
+            openMicrophoneSettings()
+        @unknown default:
+            openMicrophoneSettings()
         }
+    }
+
+    static func requestSpeechRecognitionAccess() {
+        switch SFSpeechRecognizer.authorizationStatus() {
+        case .authorized:
+            return
+        case .notDetermined:
+            SFSpeechRecognizer.requestAuthorization { _ in }
+        case .denied, .restricted:
+            openSpeechRecognitionSettings()
+        @unknown default:
+            openSpeechRecognitionSettings()
+        }
+    }
+
+    static func requestNotificationAccess() {
+        Task { @MainActor in
+            let settings = await UNUserNotificationCenter.current().notificationSettings()
+            switch settings.authorizationStatus {
+            case .notDetermined:
+                UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { _, _ in }
+            case .authorized, .provisional, .ephemeral, .denied:
+                _ = openNotificationSettings()
+            @unknown default:
+                _ = openNotificationSettings()
+            }
+        }
+    }
+
+    static func requestNotificationBadgeAccess() {
+        Task { @MainActor in
+            let settings = await UNUserNotificationCenter.current().notificationSettings()
+            switch settings.authorizationStatus {
+            case .notDetermined:
+                UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { _, _ in }
+            case .authorized, .provisional, .ephemeral:
+                if settings.badgeSetting != .enabled {
+                    _ = openNotificationSettings()
+                }
+            case .denied:
+                _ = openNotificationSettings()
+            @unknown default:
+                _ = openNotificationSettings()
+            }
+        }
+    }
+
+    static func openScreenRecordingSettings() {
+        _ = openPrivacySettingsPane("Privacy_ScreenCapture")
+    }
+
+    static func openMicrophoneSettings() {
+        _ = openPrivacySettingsPane("Privacy_Microphone")
+    }
+
+    static func openSpeechRecognitionSettings() {
+        _ = openPrivacySettingsPane("Privacy_SpeechRecognition")
+    }
+
+    @discardableResult
+    static func openNotificationSettings() -> Bool {
+        let bundleIdentifier = Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant"
+        let candidates = [
+            "x-apple.systempreferences:com.apple.preference.notifications?id=\(bundleIdentifier)",
+            "x-apple.systempreferences:com.apple.preference.notifications",
+        ]
+
+        for candidate in candidates {
+            guard let url = URL(string: candidate) else { continue }
+            if NSWorkspace.shared.open(url) {
+                return true
+            }
+        }
+        return false
+    }
+
+    @discardableResult
+    private static func openPrivacySettingsPane(_ pane: String) -> Bool {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?\(pane)") else {
+            return false
+        }
+        return NSWorkspace.shared.open(url)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -38,6 +38,10 @@ struct SettingsPanel: View {
     @State private var setupRequired: (id: String, skillId: String, hint: String)?
     @State private var accessibilityGranted: Bool = false
     @State private var screenRecordingGranted: Bool = false
+    @State private var microphoneGranted: Bool = false
+    @State private var speechRecognitionGranted: Bool = false
+    @State private var notificationsGranted: Bool = false
+    @State private var notificationBadgesGranted: Bool = false
     @State private var permissionCheckTask: Task<Void, Never>?
     @State private var showModelDropdown = false
     @State private var mouseDownMonitor: Any?
@@ -79,7 +83,7 @@ struct SettingsPanel: View {
         }
         .task {
             // Refresh permission status when the view appears
-            refreshPermissionStatus()
+            await refreshPermissionStatus()
         }
         .onAppear {
             store.refreshAPIKeyState()
@@ -137,7 +141,9 @@ struct SettingsPanel: View {
             // System Settings and returns to the app via Cmd+Tab or clicking.
             // Uses NSApplication notification instead of scenePhase because this
             // view is hosted in an NSHostingController, not a SwiftUI Scene.
-            refreshPermissionStatus()
+            Task { @MainActor in
+                await refreshPermissionStatus()
+            }
         }
         .sheet(isPresented: $showingTrustRules) {
             if let daemonClient {
@@ -676,27 +682,35 @@ struct SettingsPanel: View {
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
 
-                permissionRow(
-                    emoji: "\u{1F47B}",
-                    label: "Accessibility",
-                    granted: accessibilityGranted,
-                    action: {
-                        // Request accessibility permission (opens System Settings)
-                        _ = PermissionManager.accessibilityStatus(prompt: true)
-                        startPermissionPolling()
-                    }
-                )
+                permissionRow(label: "Accessibility", granted: accessibilityGranted) {
+                    _ = PermissionManager.accessibilityStatus(prompt: true)
+                    startPermissionPolling()
+                }
 
-                permissionRow(
-                    emoji: "\u{1F355}",
-                    label: "Screen Recording",
-                    granted: screenRecordingGranted,
-                    action: {
-                        // Request screen recording permission (opens System Settings)
-                        PermissionManager.requestScreenRecordingAccess()
-                        startPermissionPolling()
-                    }
-                )
+                permissionRow(label: "Screen Recording", granted: screenRecordingGranted) {
+                    PermissionManager.requestScreenRecordingAccess()
+                    startPermissionPolling()
+                }
+
+                permissionRow(label: "Microphone", granted: microphoneGranted) {
+                    PermissionManager.requestMicrophoneAccess()
+                    startPermissionPolling()
+                }
+
+                permissionRow(label: "Speech Recognition", granted: speechRecognitionGranted) {
+                    PermissionManager.requestSpeechRecognitionAccess()
+                    startPermissionPolling()
+                }
+
+                permissionRow(label: "Notifications", granted: notificationsGranted) {
+                    PermissionManager.requestNotificationAccess()
+                    startPermissionPolling()
+                }
+
+                permissionRow(label: "Notification Badges", granted: notificationBadgesGranted) {
+                    PermissionManager.requestNotificationBadgeAccess()
+                    startPermissionPolling()
+                }
             }
             .padding(VSpacing.lg)
             .vCard(background: VColor.surfaceSubtle)
@@ -948,14 +962,9 @@ struct SettingsPanel: View {
 
     // MARK: - Permission Row
 
-    private func permissionRow(emoji: String, label: String, granted: Bool, action: @escaping () -> Void) -> some View {
+    private func permissionRow(label: String, granted: Bool, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             HStack(spacing: VSpacing.md) {
-                Text(emoji)
-                    .font(.system(size: 14))
-                    .frame(width: 20)
-                    .accessibilityLabel(label)
-
                 Text(label)
                     .font(VFont.body)
                     .foregroundColor(VColor.textPrimary)
@@ -983,9 +992,13 @@ struct SettingsPanel: View {
 
     // MARK: - Permission Helpers
 
-    private func refreshPermissionStatus() {
+    private func refreshPermissionStatus() async {
         accessibilityGranted = PermissionManager.accessibilityStatus() == .granted
         screenRecordingGranted = PermissionManager.screenRecordingStatus() == .granted
+        microphoneGranted = PermissionManager.microphoneStatus() == .granted
+        speechRecognitionGranted = PermissionManager.speechRecognitionStatus() == .granted
+        notificationsGranted = await PermissionManager.notificationStatus() == .granted
+        notificationBadgesGranted = await PermissionManager.notificationBadgeStatus() == .granted
     }
 
     private func startPermissionPolling() {
@@ -995,8 +1008,6 @@ struct SettingsPanel: View {
         // 2. Fallback: Poll every 1 second for 15 seconds to catch edge cases where
         //    the notification doesn't fire (e.g., user grants permission while app
         //    stays focused)
-        //
-        // Polling stops early if both permissions are granted, minimizing overhead.
         permissionCheckTask?.cancel()
 
         permissionCheckTask = Task { @MainActor in
@@ -1005,12 +1016,7 @@ struct SettingsPanel: View {
                 try? await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
 
                 guard !Task.isCancelled else { return }
-                refreshPermissionStatus()
-
-                // Stop polling if both permissions are granted
-                if accessibilityGranted && screenRecordingGranted {
-                    return
-                }
+                await refreshPermissionStatus()
             }
         }
     }


### PR DESCRIPTION
## Summary
- add all requested macOS permissions to Settings > Trust > Permissions
- remove emoji icons from permission rows
- centralize permission status/request/open-settings helpers in `PermissionManager`
- include notification + badge permission status and actions in settings

## Validation
- cd clients/macos && ./build.sh lint