### PR TITLE
M1: Guardian Action Follow-Up Data Model + Store Transitions

### DIFF
--- a/assistant/src/__tests__/guardian-action-followup-store.test.ts
+++ b/assistant/src/__tests__/guardian-action-followup-store.test.ts
@@ -242,8 +242,23 @@ describe('guardian-action-followup-store', () => {
     expect(result).toBeNull();
   });
 
-  test('progressFollowupState rejects non-expired request', () => {
+  test('progressFollowupState rejects none -> awaiting_guardian_choice even on expired request', () => {
     const request = createTestRequest('conv-followup-13b');
+    markTimedOutWithReason(request.id, 'call_timeout');
+
+    // none -> awaiting_guardian_choice must only go through startFollowupFromExpiredRequest
+    // (which atomically sets lateAnswerText and lateAnsweredAt)
+    const result = progressFollowupState(request.id, 'awaiting_guardian_choice');
+    expect(result).toBeNull();
+
+    // Verify followup_state unchanged
+    const reloaded = getGuardianActionRequest(request.id);
+    expect(reloaded!.followupState).toBe('none');
+    expect(reloaded!.status).toBe('expired');
+  });
+
+  test('progressFollowupState rejects non-expired request', () => {
+    const request = createTestRequest('conv-followup-13c');
 
     // Request is still 'pending', not 'expired' — follow-up transitions must not apply
     const result = progressFollowupState(request.id, 'awaiting_guardian_choice');

--- a/assistant/src/__tests__/guardian-action-followup-store.test.ts
+++ b/assistant/src/__tests__/guardian-action-followup-store.test.ts
@@ -239,6 +239,19 @@ describe('guardian-action-followup-store', () => {
     expect(result).toBeNull();
   });
 
+  test('progressFollowupState rejects non-expired request', () => {
+    const request = createTestRequest('conv-followup-13b');
+
+    // Request is still 'pending', not 'expired' — follow-up transitions must not apply
+    const result = progressFollowupState(request.id, 'awaiting_guardian_choice');
+    expect(result).toBeNull();
+
+    // Verify followup_state unchanged
+    const reloaded = getGuardianActionRequest(request.id);
+    expect(reloaded!.followupState).toBe('none');
+    expect(reloaded!.status).toBe('pending');
+  });
+
   // ── finalizeFollowup ────────────────────────────────────────────────
 
   test('finalizeFollowup sets followup_completed_at for completed', () => {
@@ -283,6 +296,19 @@ describe('guardian-action-followup-store', () => {
     // followup_state is 'none', cannot finalize
     const result = finalizeFollowup(request.id, 'completed');
     expect(result).toBeNull();
+  });
+
+  test('finalizeFollowup rejects non-expired request', () => {
+    const request = createTestRequest('conv-followup-17b');
+
+    // Request is still 'pending', not 'expired' — finalize must not apply
+    const result = finalizeFollowup(request.id, 'completed');
+    expect(result).toBeNull();
+
+    // Verify followup_state unchanged
+    const reloaded = getGuardianActionRequest(request.id);
+    expect(reloaded!.followupState).toBe('none');
+    expect(reloaded!.status).toBe('pending');
   });
 
   // ── Existing behavior preserved ─────────────────────────────────────

--- a/assistant/src/__tests__/guardian-action-followup-store.test.ts
+++ b/assistant/src/__tests__/guardian-action-followup-store.test.ts
@@ -1,0 +1,332 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'guardian-action-followup-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { createCallSession, createPendingQuestion } from '../calls/call-store.js';
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import {
+  createGuardianActionRequest,
+  expireGuardianActionRequest,
+  finalizeFollowup,
+  getGuardianActionRequest,
+  markTimedOutWithReason,
+  progressFollowupState,
+  resolveGuardianActionRequest,
+  startFollowupFromExpiredRequest,
+} from '../memory/guardian-action-store.js';
+import { conversations } from '../memory/schema.js';
+
+initializeDb();
+
+function ensureConversation(id: string): void {
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations).values({
+    id,
+    title: `Conversation ${id}`,
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+}
+
+function resetTables(): void {
+  const db = getDb();
+  db.run('DELETE FROM guardian_action_deliveries');
+  db.run('DELETE FROM guardian_action_requests');
+  db.run('DELETE FROM call_pending_questions');
+  db.run('DELETE FROM call_events');
+  db.run('DELETE FROM call_sessions');
+  db.run('DELETE FROM messages');
+  db.run('DELETE FROM conversations');
+}
+
+function createTestRequest(convId: string) {
+  ensureConversation(convId);
+  const session = createCallSession({
+    conversationId: convId,
+    provider: 'twilio',
+    fromNumber: '+15550001111',
+    toNumber: '+15550002222',
+  });
+  const pq = createPendingQuestion(session.id, 'What is the gate code?');
+  return createGuardianActionRequest({
+    kind: 'ask_guardian',
+    sourceChannel: 'voice',
+    sourceConversationId: convId,
+    callSessionId: session.id,
+    pendingQuestionId: pq.id,
+    questionText: pq.questionText,
+    expiresAt: Date.now() + 60_000,
+  });
+}
+
+describe('guardian-action-followup-store', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  afterAll(() => {
+    resetDb();
+    try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+  });
+
+  // ── markTimedOutWithReason ──────────────────────────────────────────
+
+  test('markTimedOutWithReason sets expired_reason correctly for call_timeout', () => {
+    const request = createTestRequest('conv-followup-1');
+    const result = markTimedOutWithReason(request.id, 'call_timeout');
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe('expired');
+    expect(result!.expiredReason).toBe('call_timeout');
+  });
+
+  test('markTimedOutWithReason sets expired_reason correctly for sweep_timeout', () => {
+    const request = createTestRequest('conv-followup-2');
+    const result = markTimedOutWithReason(request.id, 'sweep_timeout');
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe('expired');
+    expect(result!.expiredReason).toBe('sweep_timeout');
+  });
+
+  test('markTimedOutWithReason returns null for already-expired request', () => {
+    const request = createTestRequest('conv-followup-3');
+
+    // First call succeeds
+    const first = markTimedOutWithReason(request.id, 'call_timeout');
+    expect(first).not.toBeNull();
+
+    // Second call returns null (already expired)
+    const second = markTimedOutWithReason(request.id, 'sweep_timeout');
+    expect(second).toBeNull();
+
+    // Verify the original reason is preserved
+    const reloaded = getGuardianActionRequest(request.id);
+    expect(reloaded!.expiredReason).toBe('call_timeout');
+  });
+
+  test('markTimedOutWithReason returns null for answered request', () => {
+    const request = createTestRequest('conv-followup-4');
+    resolveGuardianActionRequest(request.id, 'The code is 1234', 'telegram');
+
+    const result = markTimedOutWithReason(request.id, 'call_timeout');
+    expect(result).toBeNull();
+  });
+
+  // ── startFollowupFromExpiredRequest ─────────────────────────────────
+
+  test('startFollowupFromExpiredRequest transitions correctly', () => {
+    const request = createTestRequest('conv-followup-5');
+    markTimedOutWithReason(request.id, 'call_timeout');
+
+    const result = startFollowupFromExpiredRequest(request.id, 'The code is 5678');
+    expect(result).not.toBeNull();
+    expect(result!.followupState).toBe('awaiting_guardian_choice');
+    expect(result!.lateAnswerText).toBe('The code is 5678');
+    expect(result!.lateAnsweredAt).toBeGreaterThan(0);
+  });
+
+  test('startFollowupFromExpiredRequest rejects pending request', () => {
+    const request = createTestRequest('conv-followup-6');
+
+    const result = startFollowupFromExpiredRequest(request.id, 'Late answer');
+    expect(result).toBeNull();
+
+    // Verify followup_state unchanged
+    const reloaded = getGuardianActionRequest(request.id);
+    expect(reloaded!.followupState).toBe('none');
+  });
+
+  test('startFollowupFromExpiredRequest rejects answered request', () => {
+    const request = createTestRequest('conv-followup-7');
+    resolveGuardianActionRequest(request.id, 'Original answer', 'telegram');
+
+    const result = startFollowupFromExpiredRequest(request.id, 'Late answer');
+    expect(result).toBeNull();
+  });
+
+  test('startFollowupFromExpiredRequest rejects already-in-followup request', () => {
+    const request = createTestRequest('conv-followup-8');
+    markTimedOutWithReason(request.id, 'call_timeout');
+    startFollowupFromExpiredRequest(request.id, 'First late answer');
+
+    // Second attempt should fail
+    const result = startFollowupFromExpiredRequest(request.id, 'Another late answer');
+    expect(result).toBeNull();
+
+    // Verify original late answer preserved
+    const reloaded = getGuardianActionRequest(request.id);
+    expect(reloaded!.lateAnswerText).toBe('First late answer');
+  });
+
+  // ── progressFollowupState ───────────────────────────────────────────
+
+  test('progressFollowupState valid transition: awaiting_guardian_choice -> dispatching', () => {
+    const request = createTestRequest('conv-followup-9');
+    markTimedOutWithReason(request.id, 'call_timeout');
+    startFollowupFromExpiredRequest(request.id, 'Late answer');
+
+    const result = progressFollowupState(request.id, 'dispatching', 'call_back');
+    expect(result).not.toBeNull();
+    expect(result!.followupState).toBe('dispatching');
+    expect(result!.followupAction).toBe('call_back');
+  });
+
+  test('progressFollowupState valid transition: awaiting_guardian_choice -> declined', () => {
+    const request = createTestRequest('conv-followup-10');
+    markTimedOutWithReason(request.id, 'call_timeout');
+    startFollowupFromExpiredRequest(request.id, 'Late answer');
+
+    const result = progressFollowupState(request.id, 'declined', 'decline');
+    expect(result).not.toBeNull();
+    expect(result!.followupState).toBe('declined');
+    expect(result!.followupAction).toBe('decline');
+  });
+
+  test('progressFollowupState rejects invalid transition: none -> dispatching', () => {
+    const request = createTestRequest('conv-followup-11');
+    markTimedOutWithReason(request.id, 'call_timeout');
+
+    // followup_state is 'none', cannot jump to 'dispatching'
+    const result = progressFollowupState(request.id, 'dispatching');
+    expect(result).toBeNull();
+  });
+
+  test('progressFollowupState rejects invalid transition: dispatching -> awaiting_guardian_choice', () => {
+    const request = createTestRequest('conv-followup-12');
+    markTimedOutWithReason(request.id, 'call_timeout');
+    startFollowupFromExpiredRequest(request.id, 'Late answer');
+    progressFollowupState(request.id, 'dispatching', 'call_back');
+
+    // Cannot go back to awaiting_guardian_choice
+    const result = progressFollowupState(request.id, 'awaiting_guardian_choice');
+    expect(result).toBeNull();
+  });
+
+  test('progressFollowupState rejects transition from terminal state', () => {
+    const request = createTestRequest('conv-followup-13');
+    markTimedOutWithReason(request.id, 'call_timeout');
+    startFollowupFromExpiredRequest(request.id, 'Late answer');
+    progressFollowupState(request.id, 'dispatching', 'call_back');
+    progressFollowupState(request.id, 'completed');
+
+    // completed is terminal
+    const result = progressFollowupState(request.id, 'dispatching');
+    expect(result).toBeNull();
+  });
+
+  // ── finalizeFollowup ────────────────────────────────────────────────
+
+  test('finalizeFollowup sets followup_completed_at for completed', () => {
+    const request = createTestRequest('conv-followup-14');
+    markTimedOutWithReason(request.id, 'call_timeout');
+    startFollowupFromExpiredRequest(request.id, 'Late answer');
+    progressFollowupState(request.id, 'dispatching', 'call_back');
+
+    const result = finalizeFollowup(request.id, 'completed');
+    expect(result).not.toBeNull();
+    expect(result!.followupState).toBe('completed');
+    expect(result!.followupCompletedAt).toBeGreaterThan(0);
+  });
+
+  test('finalizeFollowup sets followup_completed_at for failed', () => {
+    const request = createTestRequest('conv-followup-15');
+    markTimedOutWithReason(request.id, 'call_timeout');
+    startFollowupFromExpiredRequest(request.id, 'Late answer');
+    progressFollowupState(request.id, 'dispatching', 'message_back');
+
+    const result = finalizeFollowup(request.id, 'failed');
+    expect(result).not.toBeNull();
+    expect(result!.followupState).toBe('failed');
+    expect(result!.followupCompletedAt).toBeGreaterThan(0);
+  });
+
+  test('finalizeFollowup with declined from awaiting_guardian_choice', () => {
+    const request = createTestRequest('conv-followup-16');
+    markTimedOutWithReason(request.id, 'call_timeout');
+    startFollowupFromExpiredRequest(request.id, 'Late answer');
+
+    const result = finalizeFollowup(request.id, 'declined');
+    expect(result).not.toBeNull();
+    expect(result!.followupState).toBe('declined');
+    expect(result!.followupCompletedAt).toBeGreaterThan(0);
+  });
+
+  test('finalizeFollowup rejects invalid transition from none', () => {
+    const request = createTestRequest('conv-followup-17');
+    markTimedOutWithReason(request.id, 'call_timeout');
+
+    // followup_state is 'none', cannot finalize
+    const result = finalizeFollowup(request.id, 'completed');
+    expect(result).toBeNull();
+  });
+
+  // ── Existing behavior preserved ─────────────────────────────────────
+
+  test('resolve/expire behavior unchanged: resolveGuardianActionRequest still works', () => {
+    const request = createTestRequest('conv-followup-18');
+
+    const resolved = resolveGuardianActionRequest(request.id, 'Answer here', 'telegram', 'user-1');
+    expect(resolved).not.toBeNull();
+    expect(resolved!.status).toBe('answered');
+    expect(resolved!.answerText).toBe('Answer here');
+    // Follow-up fields remain at defaults
+    expect(resolved!.followupState).toBe('none');
+    expect(resolved!.expiredReason).toBeNull();
+  });
+
+  test('expireGuardianActionRequest defaults to sweep_timeout reason', () => {
+    const request = createTestRequest('conv-followup-19');
+
+    expireGuardianActionRequest(request.id);
+
+    const reloaded = getGuardianActionRequest(request.id);
+    expect(reloaded!.status).toBe('expired');
+    expect(reloaded!.expiredReason).toBe('sweep_timeout');
+  });
+
+  test('expireGuardianActionRequest accepts explicit reason', () => {
+    const request = createTestRequest('conv-followup-20');
+
+    expireGuardianActionRequest(request.id, 'call_timeout');
+
+    const reloaded = getGuardianActionRequest(request.id);
+    expect(reloaded!.status).toBe('expired');
+    expect(reloaded!.expiredReason).toBe('call_timeout');
+  });
+
+  test('new fields default correctly on freshly created request', () => {
+    const request = createTestRequest('conv-followup-21');
+
+    expect(request.expiredReason).toBeNull();
+    expect(request.followupState).toBe('none');
+    expect(request.lateAnswerText).toBeNull();
+    expect(request.lateAnsweredAt).toBeNull();
+    expect(request.followupAction).toBeNull();
+    expect(request.followupCompletedAt).toBeNull();
+  });
+});

--- a/assistant/src/__tests__/guardian-action-followup-store.test.ts
+++ b/assistant/src/__tests__/guardian-action-followup-store.test.ts
@@ -196,15 +196,18 @@ describe('guardian-action-followup-store', () => {
     expect(result!.followupAction).toBe('call_back');
   });
 
-  test('progressFollowupState valid transition: awaiting_guardian_choice -> declined', () => {
+  test('progressFollowupState rejects terminal transition: awaiting_guardian_choice -> declined', () => {
     const request = createTestRequest('conv-followup-10');
     markTimedOutWithReason(request.id, 'call_timeout');
     startFollowupFromExpiredRequest(request.id, 'Late answer');
 
+    // Terminal transitions must go through finalizeFollowup, not progressFollowupState
     const result = progressFollowupState(request.id, 'declined', 'decline');
-    expect(result).not.toBeNull();
-    expect(result!.followupState).toBe('declined');
-    expect(result!.followupAction).toBe('decline');
+    expect(result).toBeNull();
+
+    // Verify state unchanged
+    const reloaded = getGuardianActionRequest(request.id);
+    expect(reloaded!.followupState).toBe('awaiting_guardian_choice');
   });
 
   test('progressFollowupState rejects invalid transition: none -> dispatching', () => {
@@ -232,9 +235,9 @@ describe('guardian-action-followup-store', () => {
     markTimedOutWithReason(request.id, 'call_timeout');
     startFollowupFromExpiredRequest(request.id, 'Late answer');
     progressFollowupState(request.id, 'dispatching', 'call_back');
-    progressFollowupState(request.id, 'completed');
+    finalizeFollowup(request.id, 'completed');
 
-    // completed is terminal
+    // completed is terminal — progressFollowupState cannot leave it
     const result = progressFollowupState(request.id, 'dispatching');
     expect(result).toBeNull();
   });

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -18,6 +18,7 @@ import {
   createWatchersAndLogsTables,
   migrateCallSessionMode,
   migrateChannelInboundDeliveredSegments,
+  migrateGuardianActionFollowup,
   migrateGuardianBootstrapToken,
   migrateGuardianVerificationSessions,
   migrateMessagesFtsBackfill,
@@ -83,6 +84,9 @@ export function initializeDb(): void {
 
   // 14b. Track per-segment delivery progress for split channel replies
   migrateChannelInboundDeliveredSegments(database);
+
+  // 14c. Guardian action follow-up lifecycle columns (timeout reason, late answers)
+  migrateGuardianActionFollowup(database);
 
   // 15. Notification system
   createNotificationTables(database);

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -25,6 +25,9 @@ const log = getLogger('guardian-action-store');
 
 export type GuardianActionRequestStatus = 'pending' | 'answered' | 'expired' | 'cancelled';
 export type GuardianActionDeliveryStatus = 'pending' | 'sent' | 'failed' | 'answered' | 'expired' | 'cancelled';
+export type ExpiredReason = 'call_timeout' | 'sweep_timeout' | 'cancelled';
+export type FollowupState = 'none' | 'awaiting_guardian_choice' | 'dispatching' | 'completed' | 'declined' | 'failed';
+export type FollowupAction = 'call_back' | 'message_back' | 'decline';
 
 export interface GuardianActionRequest {
   id: string;
@@ -42,6 +45,12 @@ export interface GuardianActionRequest {
   answeredByExternalUserId: string | null;
   answeredAt: number | null;
   expiresAt: number;
+  expiredReason: ExpiredReason | null;
+  followupState: FollowupState;
+  lateAnswerText: string | null;
+  lateAnsweredAt: number | null;
+  followupAction: FollowupAction | null;
+  followupCompletedAt: number | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -82,6 +91,12 @@ function rowToRequest(row: typeof guardianActionRequests.$inferSelect): Guardian
     answeredByExternalUserId: row.answeredByExternalUserId,
     answeredAt: row.answeredAt,
     expiresAt: row.expiresAt,
+    expiredReason: (row.expiredReason as ExpiredReason) ?? null,
+    followupState: (row.followupState as FollowupState) ?? 'none',
+    lateAnswerText: row.lateAnswerText ?? null,
+    lateAnsweredAt: row.lateAnsweredAt ?? null,
+    followupAction: (row.followupAction as FollowupAction) ?? null,
+    followupCompletedAt: row.followupCompletedAt ?? null,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -143,6 +158,12 @@ export function createGuardianActionRequest(params: {
     answeredByExternalUserId: null,
     answeredAt: null,
     expiresAt: params.expiresAt,
+    expiredReason: null,
+    followupState: 'none' as const,
+    lateAnswerText: null,
+    lateAnsweredAt: null,
+    followupAction: null,
+    followupCompletedAt: null,
     createdAt: now,
     updatedAt: now,
   };
@@ -217,13 +238,14 @@ export function resolveGuardianActionRequest(
 
 /**
  * Expire a guardian action request and all its deliveries.
+ * When reason is not provided, defaults to 'sweep_timeout' for backward compatibility.
  */
-export function expireGuardianActionRequest(id: string): void {
+export function expireGuardianActionRequest(id: string, reason?: ExpiredReason): void {
   const db = getDb();
   const now = Date.now();
 
   db.update(guardianActionRequests)
-    .set({ status: 'expired', updatedAt: now })
+    .set({ status: 'expired', expiredReason: reason ?? 'sweep_timeout', updatedAt: now })
     .where(
       and(
         eq(guardianActionRequests.id, id),
@@ -301,6 +323,163 @@ export function cancelGuardianActionRequest(id: string): void {
       ),
     )
     .run();
+}
+
+// ---------------------------------------------------------------------------
+// Follow-up lifecycle helpers
+// ---------------------------------------------------------------------------
+
+/** Valid followup_state transitions: from -> allowed next states */
+const FOLLOWUP_TRANSITIONS: Record<FollowupState, FollowupState[]> = {
+  none: ['awaiting_guardian_choice'],
+  awaiting_guardian_choice: ['dispatching', 'declined'],
+  dispatching: ['completed', 'failed'],
+  completed: [],
+  declined: [],
+  failed: [],
+};
+
+/**
+ * Atomically set status='expired' and expired_reason on a pending request.
+ * Returns the updated request on success, or null if the request was not
+ * in 'pending' status (first-writer-wins).
+ */
+export function markTimedOutWithReason(id: string, reason: ExpiredReason): GuardianActionRequest | null {
+  const db = getDb();
+  const now = Date.now();
+
+  db.update(guardianActionRequests)
+    .set({ status: 'expired', expiredReason: reason, updatedAt: now })
+    .where(
+      and(
+        eq(guardianActionRequests.id, id),
+        eq(guardianActionRequests.status, 'pending'),
+      ),
+    )
+    .run();
+
+  if (rawChanges() === 0) return null;
+
+  // Also expire active deliveries
+  db.update(guardianActionDeliveries)
+    .set({ status: 'expired', updatedAt: now })
+    .where(
+      and(
+        eq(guardianActionDeliveries.requestId, id),
+        inArray(guardianActionDeliveries.status, ['pending', 'sent']),
+      ),
+    )
+    .run();
+
+  return getGuardianActionRequest(id);
+}
+
+/**
+ * Atomically transition an expired request into the follow-up flow.
+ * Sets followup_state='awaiting_guardian_choice', records the late answer
+ * text and timestamp. Only succeeds if status='expired' and followup_state='none'.
+ * Returns the updated request on success, or null on conflict.
+ */
+export function startFollowupFromExpiredRequest(
+  id: string,
+  lateAnswerText: string,
+): GuardianActionRequest | null {
+  const db = getDb();
+  const now = Date.now();
+
+  db.update(guardianActionRequests)
+    .set({
+      followupState: 'awaiting_guardian_choice',
+      lateAnswerText,
+      lateAnsweredAt: now,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(guardianActionRequests.id, id),
+        eq(guardianActionRequests.status, 'expired'),
+        eq(guardianActionRequests.followupState, 'none'),
+      ),
+    )
+    .run();
+
+  if (rawChanges() === 0) return null;
+  return getGuardianActionRequest(id);
+}
+
+/**
+ * Atomically progress the followup_state. Validates that the transition
+ * is allowed (see FOLLOWUP_TRANSITIONS). Optionally sets the followup_action.
+ * Returns the updated request on success, or null if the transition was
+ * invalid or the prior state didn't match.
+ */
+export function progressFollowupState(
+  id: string,
+  newState: FollowupState,
+  action?: FollowupAction,
+): GuardianActionRequest | null {
+  const request = getGuardianActionRequest(id);
+  if (!request) return null;
+
+  const allowed = FOLLOWUP_TRANSITIONS[request.followupState];
+  if (!allowed.includes(newState)) return null;
+
+  const db = getDb();
+  const now = Date.now();
+
+  const updates: Record<string, unknown> = {
+    followupState: newState,
+    updatedAt: now,
+  };
+  if (action !== undefined) updates.followupAction = action;
+
+  db.update(guardianActionRequests)
+    .set(updates)
+    .where(
+      and(
+        eq(guardianActionRequests.id, id),
+        eq(guardianActionRequests.followupState, request.followupState),
+      ),
+    )
+    .run();
+
+  if (rawChanges() === 0) return null;
+  return getGuardianActionRequest(id);
+}
+
+/**
+ * Finalize a follow-up by setting the terminal followup_state and
+ * recording followup_completed_at. Only succeeds from a non-terminal state.
+ */
+export function finalizeFollowup(
+  id: string,
+  finalState: 'completed' | 'declined' | 'failed',
+): GuardianActionRequest | null {
+  const request = getGuardianActionRequest(id);
+  if (!request) return null;
+
+  const allowed = FOLLOWUP_TRANSITIONS[request.followupState];
+  if (!allowed.includes(finalState)) return null;
+
+  const db = getDb();
+  const now = Date.now();
+
+  db.update(guardianActionRequests)
+    .set({
+      followupState: finalState,
+      followupCompletedAt: now,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(guardianActionRequests.id, id),
+        eq(guardianActionRequests.followupState, request.followupState),
+      ),
+    )
+    .run();
+
+  if (rawChanges() === 0) return null;
+  return getGuardianActionRequest(id);
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -333,7 +333,7 @@ export function cancelGuardianActionRequest(id: string): void {
  * Terminal states (completed, declined, failed) are only reachable via
  * finalizeFollowup, which properly sets followupCompletedAt. */
 const FOLLOWUP_TRANSITIONS: Record<FollowupState, FollowupState[]> = {
-  none: ['awaiting_guardian_choice'],
+  none: [],
   awaiting_guardian_choice: ['dispatching'],
   dispatching: [],
   completed: [],

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -438,6 +438,7 @@ export function progressFollowupState(
     .where(
       and(
         eq(guardianActionRequests.id, id),
+        eq(guardianActionRequests.status, 'expired'),
         eq(guardianActionRequests.followupState, request.followupState),
       ),
     )
@@ -449,7 +450,8 @@ export function progressFollowupState(
 
 /**
  * Finalize a follow-up by setting the terminal followup_state and
- * recording followup_completed_at. Only succeeds from a non-terminal state.
+ * recording followup_completed_at. Only succeeds from a non-terminal state
+ * and only on expired requests.
  */
 export function finalizeFollowup(
   id: string,
@@ -473,6 +475,7 @@ export function finalizeFollowup(
     .where(
       and(
         eq(guardianActionRequests.id, id),
+        eq(guardianActionRequests.status, 'expired'),
         eq(guardianActionRequests.followupState, request.followupState),
       ),
     )

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -329,14 +329,23 @@ export function cancelGuardianActionRequest(id: string): void {
 // Follow-up lifecycle helpers
 // ---------------------------------------------------------------------------
 
-/** Valid followup_state transitions: from -> allowed next states */
+/** Valid non-terminal followup_state transitions for progressFollowupState.
+ * Terminal states (completed, declined, failed) are only reachable via
+ * finalizeFollowup, which properly sets followupCompletedAt. */
 const FOLLOWUP_TRANSITIONS: Record<FollowupState, FollowupState[]> = {
   none: ['awaiting_guardian_choice'],
-  awaiting_guardian_choice: ['dispatching', 'declined'],
-  dispatching: ['completed', 'failed'],
+  awaiting_guardian_choice: ['dispatching'],
+  dispatching: [],
   completed: [],
   declined: [],
   failed: [],
+};
+
+/** Valid terminal transitions for finalizeFollowup. Maps from current
+ * followup_state to the terminal states reachable from it. */
+const FOLLOWUP_FINALIZE_TRANSITIONS: Partial<Record<FollowupState, FollowupState[]>> = {
+  awaiting_guardian_choice: ['declined'],
+  dispatching: ['completed', 'failed'],
 };
 
 /**
@@ -460,8 +469,8 @@ export function finalizeFollowup(
   const request = getGuardianActionRequest(id);
   if (!request) return null;
 
-  const allowed = FOLLOWUP_TRANSITIONS[request.followupState];
-  if (!allowed.includes(finalState)) return null;
+  const allowed = FOLLOWUP_FINALIZE_TRANSITIONS[request.followupState];
+  if (!allowed?.includes(finalState)) return null;
 
   const db = getDb();
   const now = Date.now();

--- a/assistant/src/memory/migrations/030-guardian-action-followup.ts
+++ b/assistant/src/memory/migrations/030-guardian-action-followup.ts
@@ -1,0 +1,21 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Add follow-up lifecycle columns to guardian_action_requests.
+ *
+ * These columns track why a request expired (expired_reason), the
+ * post-timeout follow-up state machine (followup_state), and any
+ * late answer that arrived after the timeout.
+ *
+ * Uses ALTER TABLE ADD COLUMN with try/catch for idempotency.
+ */
+export function migrateGuardianActionFollowup(database: DrizzleDb): void {
+  try { database.run(/*sql*/ `ALTER TABLE guardian_action_requests ADD COLUMN expired_reason TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE guardian_action_requests ADD COLUMN followup_state TEXT NOT NULL DEFAULT 'none'`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE guardian_action_requests ADD COLUMN late_answer_text TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE guardian_action_requests ADD COLUMN late_answered_at INTEGER`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE guardian_action_requests ADD COLUMN followup_action TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE guardian_action_requests ADD COLUMN followup_completed_at INTEGER`); } catch { /* already exists */ }
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_action_requests_followup_state ON guardian_action_requests(followup_state)`);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -29,6 +29,7 @@ export { migrateGuardianBootstrapToken } from './027-guardian-bootstrap-token.js
 export { migrateNotificationDeliveryPairingColumns } from './027-notification-delivery-pairing-columns.js';
 export { migrateCallSessionMode } from './028-call-session-mode.js';
 export { migrateChannelInboundDeliveredSegments } from './029-channel-inbound-delivered-segments.js';
+export { migrateGuardianActionFollowup } from './030-guardian-action-followup.js';
 export { createCoreTables } from './100-core-tables.js';
 export { createWatchersAndLogsTables } from './101-watchers-and-logs.js';
 export { addCoreColumns } from './102-alter-table-columns.js';

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -827,6 +827,12 @@ export const guardianActionRequests = sqliteTable('guardian_action_requests', {
   answeredByExternalUserId: text('answered_by_external_user_id'),
   answeredAt: integer('answered_at'),
   expiresAt: integer('expires_at').notNull(),
+  expiredReason: text('expired_reason'),                            // call_timeout | sweep_timeout | cancelled
+  followupState: text('followup_state').notNull().default('none'),  // none | awaiting_guardian_choice | dispatching | completed | declined | failed
+  lateAnswerText: text('late_answer_text'),
+  lateAnsweredAt: integer('late_answered_at'),
+  followupAction: text('followup_action'),                          // call_back | message_back | decline
+  followupCompletedAt: integer('followup_completed_at'),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 });


### PR DESCRIPTION
Add durable state for timeout reason and post-timeout follow-up lifecycle to guardian_action_requests. Includes new migration (030), schema columns, atomic store transition helpers (markTimedOutWithReason, startFollowupFromExpiredRequest, progressFollowupState, finalizeFollowup), and comprehensive tests. Part of #9562.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
