### PR TITLE
macOS: add permission usage subtitles in Settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -682,32 +682,56 @@ struct SettingsPanel: View {
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
 
-                permissionRow(label: "Accessibility", granted: accessibilityGranted) {
+                permissionRow(
+                    label: "Accessibility",
+                    subtitle: "Allows Vellum to click, type, and control apps on your behalf.",
+                    granted: accessibilityGranted
+                ) {
                     _ = PermissionManager.accessibilityStatus(prompt: true)
                     startPermissionPolling()
                 }
 
-                permissionRow(label: "Screen Recording", granted: screenRecordingGranted) {
+                permissionRow(
+                    label: "Screen Recording",
+                    subtitle: "Allows Vellum to capture screen context during computer-use tasks.",
+                    granted: screenRecordingGranted
+                ) {
                     PermissionManager.requestScreenRecordingAccess()
                     startPermissionPolling()
                 }
 
-                permissionRow(label: "Microphone", granted: microphoneGranted) {
+                permissionRow(
+                    label: "Microphone",
+                    subtitle: "Allows Vellum to capture audio for voice input and recordings.",
+                    granted: microphoneGranted
+                ) {
                     PermissionManager.requestMicrophoneAccess()
                     startPermissionPolling()
                 }
 
-                permissionRow(label: "Speech Recognition", granted: speechRecognitionGranted) {
+                permissionRow(
+                    label: "Speech Recognition",
+                    subtitle: "Allows on-device transcription of your speech into text.",
+                    granted: speechRecognitionGranted
+                ) {
                     PermissionManager.requestSpeechRecognitionAccess()
                     startPermissionPolling()
                 }
 
-                permissionRow(label: "Notifications", granted: notificationsGranted) {
+                permissionRow(
+                    label: "Notifications",
+                    subtitle: "Allows macOS alerts for approvals, messages, and task updates.",
+                    granted: notificationsGranted
+                ) {
                     PermissionManager.requestNotificationAccess()
                     startPermissionPolling()
                 }
 
-                permissionRow(label: "Notification Badges", granted: notificationBadgesGranted) {
+                permissionRow(
+                    label: "Notification Badges",
+                    subtitle: "Allows unseen conversation counts on the Dock icon.",
+                    granted: notificationBadgesGranted
+                ) {
                     PermissionManager.requestNotificationBadgeAccess()
                     startPermissionPolling()
                 }
@@ -962,12 +986,18 @@ struct SettingsPanel: View {
 
     // MARK: - Permission Row
 
-    private func permissionRow(label: String, granted: Bool, action: @escaping () -> Void) -> some View {
+    private func permissionRow(label: String, subtitle: String, granted: Bool, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             HStack(spacing: VSpacing.md) {
-                Text(label)
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textPrimary)
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text(label)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                    Text(subtitle)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
 
                 Spacer()
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -684,7 +684,7 @@ struct SettingsPanel: View {
 
                 permissionRow(
                     label: "Accessibility",
-                    subtitle: "Allows Vellum to click, type, and control apps on your behalf.",
+                    subtitle: "Allows your assistant to click, type, and control apps on your behalf.",
                     granted: accessibilityGranted
                 ) {
                     _ = PermissionManager.accessibilityStatus(prompt: true)
@@ -693,7 +693,7 @@ struct SettingsPanel: View {
 
                 permissionRow(
                     label: "Screen Recording",
-                    subtitle: "Allows Vellum to capture screen context during computer-use tasks.",
+                    subtitle: "Allows your assistant to capture screen context during computer-use tasks.",
                     granted: screenRecordingGranted
                 ) {
                     PermissionManager.requestScreenRecordingAccess()
@@ -702,7 +702,7 @@ struct SettingsPanel: View {
 
                 permissionRow(
                     label: "Microphone",
-                    subtitle: "Allows Vellum to capture audio for voice input and recordings.",
+                    subtitle: "Allows your assistant to capture audio for voice input and recordings.",
                     granted: microphoneGranted
                 ) {
                     PermissionManager.requestMicrophoneAccess()
@@ -711,7 +711,7 @@ struct SettingsPanel: View {
 
                 permissionRow(
                     label: "Speech Recognition",
-                    subtitle: "Allows on-device transcription of your speech into text.",
+                    subtitle: "Allows your assistant to transcribe your speech into text on-device.",
                     granted: speechRecognitionGranted
                 ) {
                     PermissionManager.requestSpeechRecognitionAccess()
@@ -720,7 +720,7 @@ struct SettingsPanel: View {
 
                 permissionRow(
                     label: "Notifications",
-                    subtitle: "Allows macOS alerts for approvals, messages, and task updates.",
+                    subtitle: "Allows your assistant to send macOS alerts for approvals, messages, and task updates.",
                     granted: notificationsGranted
                 ) {
                     PermissionManager.requestNotificationAccess()
@@ -729,7 +729,7 @@ struct SettingsPanel: View {
 
                 permissionRow(
                     label: "Notification Badges",
-                    subtitle: "Allows unseen conversation counts on the Dock icon.",
+                    subtitle: "Allows your assistant to show unseen conversation counts on the Dock icon.",
                     granted: notificationBadgesGranted
                 ) {
                     PermissionManager.requestNotificationBadgeAccess()


### PR DESCRIPTION
## Summary
- add explanatory subtext under each permission row in Settings > Trust > Permissions
- clarify what each permission is used for: Accessibility, Screen Recording, Microphone, Speech Recognition, Notifications, and Notification Badges
- keep existing permission request/status behavior unchanged

## Validation
- cd clients/macos && ./build.sh lint

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
