### PR TITLE
M0: Profiling harness + acceptance gates

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -30,6 +30,40 @@ public final class ChatViewModel: ObservableObject {
 
     private var cancellables: Set<AnyCancellable> = []
 
+    // MARK: - Debug publish-rate counters
+
+    #if DEBUG
+    private static let perfLog = OSLog(subsystem: "com.vellum.assistant", category: "PerfCounters")
+    private var publishCount = 0
+    private var messageManagerPublishCount = 0
+    private var attachmentManagerPublishCount = 0
+    private var errorManagerPublishCount = 0
+    private var lastRateLogTime = Date()
+
+    private func trackPublish(source: String) {
+        publishCount += 1
+        switch source {
+        case "messageManager": messageManagerPublishCount += 1
+        case "attachmentManager": attachmentManagerPublishCount += 1
+        case "errorManager": errorManagerPublishCount += 1
+        default: break
+        }
+        let now = Date()
+        if now.timeIntervalSince(lastRateLogTime) >= 5 {
+            os_log(
+                .debug, log: Self.perfLog,
+                "ChatViewModel publish rate: %d/5s (msg=%d, attach=%d, err=%d)",
+                publishCount, messageManagerPublishCount, attachmentManagerPublishCount, errorManagerPublishCount
+            )
+            publishCount = 0
+            messageManagerPublishCount = 0
+            attachmentManagerPublishCount = 0
+            errorManagerPublishCount = 0
+            lastRateLogTime = now
+        }
+    }
+    #endif
+
     // MARK: - Forwarding properties — ChatMessageManager
 
     public var messages: [ChatMessage] {
@@ -625,13 +659,28 @@ public final class ChatViewModel: ObservableObject {
         // SwiftUI views observing ChatViewModel are notified whenever any
         // sub-manager @Published property changes.
         messageManager.objectWillChange
-            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+                #if DEBUG
+                self?.trackPublish(source: "messageManager")
+                #endif
+            }
             .store(in: &cancellables)
         attachmentManager.objectWillChange
-            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+                #if DEBUG
+                self?.trackPublish(source: "attachmentManager")
+                #endif
+            }
             .store(in: &cancellables)
         errorManager.objectWillChange
-            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+                #if DEBUG
+                self?.trackPublish(source: "errorManager")
+                #endif
+            }
             .store(in: &cancellables)
 
         // Surface attachment validation errors in the error manager so the UI

--- a/clients/shared/Features/Chat/SubagentDetailStore.swift
+++ b/clients/shared/Features/Chat/SubagentDetailStore.swift
@@ -1,4 +1,6 @@
+import Combine
 import Foundation
+import os
 
 /// Represents a single event in a subagent's activity stream.
 public struct SubagentEventItem: Identifiable {
@@ -59,7 +61,32 @@ public final class SubagentDetailStore: ObservableObject {
     @Published public var objectives: [String: String] = [:]
     @Published public var usageStats: [String: SubagentUsageStats] = [:]
 
-    public init() {}
+    // MARK: - Debug publish-rate counters
+
+    #if DEBUG
+    private static let perfLog = OSLog(subsystem: "com.vellum.assistant", category: "PerfCounters")
+    private var publishCount = 0
+    private var lastRateLogTime = Date()
+    private var debugCancellable: AnyCancellable?
+
+    private func trackPublish() {
+        publishCount += 1
+        let now = Date()
+        if now.timeIntervalSince(lastRateLogTime) >= 5 {
+            os_log(.debug, log: Self.perfLog, "SubagentDetailStore publish rate: %d/5s", publishCount)
+            publishCount = 0
+            lastRateLogTime = now
+        }
+    }
+    #endif
+
+    public init() {
+        #if DEBUG
+        // Observe own objectWillChange to track publish frequency.
+        debugCancellable = self.objectWillChange
+            .sink { [weak self] _ in self?.trackPublish() }
+        #endif
+    }
 
     /// Record that a subagent was spawned with an objective.
     public func recordSpawned(subagentId: String, objective: String) {

--- a/clients/shared/Features/Chat/TaskProgressOverlayManager.swift
+++ b/clients/shared/Features/Chat/TaskProgressOverlayManager.swift
@@ -1,4 +1,5 @@
 #if os(macOS)
+import Combine
 import SwiftUI
 import AppKit
 import os
@@ -19,7 +20,32 @@ public final class TaskProgressOverlayManager: ObservableObject {
     private var panel: NSPanel?
     private var dismissTask: Task<Void, Never>?
 
-    private init() {}
+    // MARK: - Debug publish-rate counters
+
+    #if DEBUG
+    private static let perfLog = OSLog(subsystem: "com.vellum.assistant", category: "PerfCounters")
+    private var publishCount = 0
+    private var lastRateLogTime = Date()
+    private var debugCancellable: AnyCancellable?
+
+    private func trackPublish() {
+        publishCount += 1
+        let now = Date()
+        if now.timeIntervalSince(lastRateLogTime) >= 5 {
+            os_log(.debug, log: Self.perfLog, "TaskProgressOverlayManager publish rate: %d/5s", publishCount)
+            publishCount = 0
+            lastRateLogTime = now
+        }
+    }
+    #endif
+
+    private init() {
+        #if DEBUG
+        // Observe own objectWillChange to track publish frequency.
+        debugCancellable = self.objectWillChange
+            .sink { [weak self] _ in self?.trackPublish() }
+        #endif
+    }
 
     // MARK: - Public API
 


### PR DESCRIPTION
Add #if DEBUG publish-rate counters and os_log instrumentation to ChatViewModel, SubagentDetailStore, and TaskProgressOverlayManager. Logs publish frequency every 5 seconds to enable objective before/after measurement for render-churn fixes. Part of #9577.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
