### PR TITLE
M1: Coalesce SubagentDetailStore publishes

### DIFF
--- a/clients/shared/Features/Chat/SubagentDetailStore.swift
+++ b/clients/shared/Features/Chat/SubagentDetailStore.swift
@@ -55,11 +55,35 @@ public final class SubagentDetailStore: ObservableObject {
     /// Maximum UTF-8 byte count for accumulated text content before truncation.
     static let textByteCap = 50_000
 
-    @Published public var eventsBySubagent: [String: [SubagentEventItem]] = [:]
-    @Published public var objectives: [String: String] = [:]
-    @Published public var usageStats: [String: SubagentUsageStats] = [:]
+    /// Event, objective, and usage data are mutated immediately but SwiftUI
+    /// notifications are coalesced to a single `objectWillChange` per 50ms
+    /// window, matching the streaming text flush interval.
+    public var eventsBySubagent: [String: [SubagentEventItem]] = [:]
+    public var objectives: [String: String] = [:]
+    public var usageStats: [String: SubagentUsageStats] = [:]
+
+    /// Coalescing task: fires objectWillChange once per 50ms burst window.
+    private var publishTask: Task<Void, Never>?
 
     public init() {}
+
+    deinit {
+        publishTask?.cancel()
+        publishTask = nil
+    }
+
+    /// Schedule a single coalesced `objectWillChange` notification.
+    /// The first mutation in a burst schedules the publish; subsequent mutations
+    /// within the 50ms window piggyback on the same notification.
+    private func schedulePublish() {
+        guard publishTask == nil else { return }
+        publishTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 50_000_000) // 50ms
+            guard !Task.isCancelled else { return }
+            self?.objectWillChange.send()
+            self?.publishTask = nil
+        }
+    }
 
     /// Record that a subagent was spawned with an objective.
     public func recordSpawned(subagentId: String, objective: String) {
@@ -67,6 +91,7 @@ public final class SubagentDetailStore: ObservableObject {
         if eventsBySubagent[subagentId] == nil {
             eventsBySubagent[subagentId] = []
         }
+        schedulePublish()
     }
 
     /// Record a status change with optional usage stats.
@@ -77,6 +102,7 @@ public final class SubagentDetailStore: ObservableObject {
                 outputTokens: usage.outputTokens,
                 estimatedCost: usage.estimatedCost
             )
+            schedulePublish()
         }
     }
 
@@ -107,6 +133,7 @@ public final class SubagentDetailStore: ObservableObject {
                 eventsBySubagent[subagentId, default: []].append(item)
                 trimEvents(for: subagentId)
             }
+            schedulePublish()
 
         case .toolUseStart(let msg):
             let item = SubagentEventItem(
@@ -116,6 +143,7 @@ public final class SubagentDetailStore: ObservableObject {
             )
             eventsBySubagent[subagentId, default: []].append(item)
             trimEvents(for: subagentId)
+            schedulePublish()
 
         case .toolResult(let msg):
             let truncated = msg.result.count > 500 ? String(msg.result.prefix(497)) + "..." : msg.result
@@ -126,6 +154,7 @@ public final class SubagentDetailStore: ObservableObject {
             )
             eventsBySubagent[subagentId, default: []].append(item)
             trimEvents(for: subagentId)
+            schedulePublish()
 
         case .error(let err):
             let item = SubagentEventItem(
@@ -135,6 +164,7 @@ public final class SubagentDetailStore: ObservableObject {
             )
             eventsBySubagent[subagentId, default: []].append(item)
             trimEvents(for: subagentId)
+            schedulePublish()
 
         default:
             break
@@ -154,6 +184,7 @@ public final class SubagentDetailStore: ObservableObject {
         let subagentId = response.subagentId
         if let objective = response.objective {
             objectives[subagentId] = objective
+            schedulePublish()
         }
         // Only populate if we don't already have events (avoid duplicates on re-open)
         guard (eventsBySubagent[subagentId] ?? []).isEmpty else { return }


### PR DESCRIPTION
Remove @Published from SubagentDetailStore properties and replace with manual coalesced objectWillChange.send() on a 50ms window. Data mutations remain immediate but SwiftUI notifications are batched, reducing publish rate from 20+/sec to ~4/sec max during streaming. Part of #9578.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
