### PR TITLE
M3: Remove unnecessary timeline ticks for terminal subagents

### DIFF
--- a/clients/shared/Features/Chat/SubagentThreadView.swift
+++ b/clients/shared/Features/Chat/SubagentThreadView.swift
@@ -72,18 +72,26 @@ public struct SubagentThreadView: View {
     }
 
     public var body: some View {
-        TimelineView(.periodic(from: .now, by: 0.4)) { context in
-            let phase = isRunning ? Int(context.date.timeIntervalSince1970 / 0.4) % 3 : 0
-            HStack(alignment: .center, spacing: 0) {
-                // L-shaped connector: vertical line from parent → curves right into the thread bar
-                LConnector()
-                    .stroke(statusColor.opacity(0.4), style: StrokeStyle(lineWidth: 2, lineCap: .round))
-                    .frame(width: 14, height: 28)
-                    .padding(.trailing, VSpacing.xs)
-
-                // Thread indicator content
-                threadBar(phase: phase)
+        if isRunning {
+            TimelineView(.periodic(from: .now, by: 0.4)) { context in
+                threadContent(phase: Int(context.date.timeIntervalSince1970 / 0.4) % 3)
             }
+        } else {
+            threadContent(phase: 0)
+        }
+    }
+
+    @ViewBuilder
+    private func threadContent(phase: Int) -> some View {
+        HStack(alignment: .center, spacing: 0) {
+            // L-shaped connector: vertical line from parent → curves right into the thread bar
+            LConnector()
+                .stroke(statusColor.opacity(0.4), style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                .frame(width: 14, height: 28)
+                .padding(.trailing, VSpacing.xs)
+
+            // Thread indicator content
+            threadBar(phase: phase)
         }
     }
 


### PR DESCRIPTION
Conditionally wrap SubagentThreadView body in TimelineView only when the subagent is running, matching the pattern already used by SubagentStatusChip. Terminal subagent rows no longer trigger periodic 0.4s view updates. Part of #9580.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
