### PR TITLE
M2: Decouple task-progress overlay updates from chat list

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1,3 +1,4 @@
+import Combine
 import SwiftUI
 import VellumAssistantShared
 
@@ -47,8 +48,10 @@ struct MessageListView: View {
     /// Read once at the list level and passed down to each ChatBubble so that
     /// individual bubbles don't each subscribe to the shared ObservableObject.
     @State private var scrollDebounceTask: Task<Void, Never>?
-    @ObservedObject private var taskProgressOverlay = TaskProgressOverlayManager.shared
-    private var activeSurfaceId: String? { taskProgressOverlay.activeSurfaceId }
+    /// Only the active surface ID is needed here (to suppress inline rendering).
+    /// Observing the full TaskProgressOverlayManager would cause the entire
+    /// message list to re-render on every frequent `data` progress tick.
+    @State private var activeSurfaceId: String?
 
     /// The subset of messages actually shown, honoring the pagination window.
     private var visibleMessages: [ChatMessage] {
@@ -398,6 +401,9 @@ struct MessageListView: View {
                     proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                 }
                 // When mid-scroll, do nothing — let SwiftUI handle the text reflow naturally.
+            }
+            .onReceive(TaskProgressOverlayManager.shared.$activeSurfaceId) { newId in
+                activeSurfaceId = newId
             }
         }
         .id(threadId)


### PR DESCRIPTION
Change MessageListView to observe only activeSurfaceId from TaskProgressOverlayManager instead of the full @ObservedObject. This prevents frequent task-progress data mutations from invalidating the entire message list. Part of #9579.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
