### PR TITLE
chore: remove accidentally committed gitlink vellum-assistant-safe-do-permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ next-env.d.ts
 
 # bun build artifacts
 *.bun-build
+vellum-assistant-safe-do-permissions


### PR DESCRIPTION
Removes the `vellum-assistant-safe-do-permissions` directory that was accidentally committed as a gitlink (submodule pointer). Adds it to .gitignore to prevent re-adding.\n\nCloses #9596\n\nGenerated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
