### PR TITLE
M4: Tune streaming publish rate

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -499,14 +499,14 @@ extension ChatViewModel {
             guard !isCancelling else { return }
             if isWorkspaceRefinementInFlight {
                 refinementTextBuffer += delta.text
-                // Throttle refinement streaming updates with 50ms coalescing
+                // Throttle refinement streaming updates with 100ms coalescing
                 // to prevent republishing the entire accumulated buffer on
                 // every single token (same guard-based throttle pattern as
                 // scheduleStreamingFlush — not debounce, so flushes fire
-                // during streaming even when tokens arrive faster than 50ms).
+                // during streaming even when tokens arrive faster than 100ms).
                 if refinementFlushTask == nil {
                     refinementFlushTask = Task { @MainActor [weak self] in
-                        try? await Task.sleep(nanoseconds: 50_000_000)
+                        try? await Task.sleep(nanoseconds: UInt64(Self.streamingFlushInterval * 1_000_000_000))
                         guard !Task.isCancelled, let self else { return }
                         self.refinementFlushTask = nil
                         self.refinementStreamingText = self.refinementTextBuffer

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -325,7 +325,7 @@ public final class ChatViewModel: ObservableObject {
     /// `@Published messages` array.  Coalescing multiple token deltas
     /// into a single array mutation dramatically reduces SwiftUI
     /// view-graph invalidation frequency during streaming.
-    static let streamingFlushInterval: TimeInterval = 0.05 // 50 ms
+    static let streamingFlushInterval: TimeInterval = 0.1 // 100 ms
 
     /// Buffered text that has not yet been flushed to `messages`.
     var streamingDeltaBuffer: String = ""


### PR DESCRIPTION
Increase streamingFlushInterval from 50ms to 100ms, reducing streaming render rate from 20/sec to 10/sec. The immediate final flush on message completion is preserved. 10fps is well above the perceptual threshold for text streaming. Part of #9581.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
