### PR TITLE
M2: Daemon-Injected Guardian Action Copy Generator

### DIFF
--- a/assistant/src/__tests__/guardian-action-copy-generator.test.ts
+++ b/assistant/src/__tests__/guardian-action-copy-generator.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from 'bun:test';
+
+import type {
+  GuardianActionMessageContext,
+  GuardianActionMessageScenario,
+} from '../runtime/guardian-action-message-composer.js';
+import {
+  composeGuardianActionMessageGenerative,
+  getGuardianActionFallbackMessage,
+} from '../runtime/guardian-action-message-composer.js';
+import type { GuardianActionCopyGenerator } from '../runtime/http-types.js';
+
+// ---------------------------------------------------------------------------
+// Every scenario must produce a non-empty string
+// ---------------------------------------------------------------------------
+
+const ALL_SCENARIOS: GuardianActionMessageScenario[] = [
+  'caller_timeout_acknowledgment',
+  'caller_timeout_continue',
+  'guardian_late_answer_followup',
+  'guardian_followup_dispatching',
+  'guardian_followup_completed',
+  'guardian_followup_failed',
+  'guardian_followup_declined_ack',
+  'guardian_stale_expired',
+  'outbound_message_copy',
+];
+
+describe('guardian-action-copy-generator', () => {
+  // -----------------------------------------------------------------------
+  // Fallback messages -- every scenario produces non-empty output
+  // -----------------------------------------------------------------------
+
+  describe('getGuardianActionFallbackMessage', () => {
+    for (const scenario of ALL_SCENARIOS) {
+      test(`scenario "${scenario}" produces a non-empty string`, () => {
+        const msg = getGuardianActionFallbackMessage({ scenario });
+        expect(typeof msg).toBe('string');
+        expect(msg.trim().length).toBeGreaterThan(0);
+      });
+    }
+
+    test('caller_timeout_acknowledgment includes guardianIdentifier when provided', () => {
+      const msg = getGuardianActionFallbackMessage({
+        scenario: 'caller_timeout_acknowledgment',
+        guardianIdentifier: 'Dr. Smith',
+      });
+      expect(msg).toContain('Dr. Smith');
+    });
+
+    test('guardian_late_answer_followup includes callerIdentifier when provided', () => {
+      const msg = getGuardianActionFallbackMessage({
+        scenario: 'guardian_late_answer_followup',
+        callerIdentifier: 'Alice',
+      });
+      expect(msg).toContain('Alice');
+    });
+
+    test('guardian_followup_dispatching includes followupAction when provided', () => {
+      const msg = getGuardianActionFallbackMessage({
+        scenario: 'guardian_followup_dispatching',
+        followupAction: 'send them a text message',
+      });
+      expect(msg).toContain('send them a text message');
+    });
+
+    test('guardian_followup_completed includes followupAction when provided', () => {
+      const msg = getGuardianActionFallbackMessage({
+        scenario: 'guardian_followup_completed',
+        followupAction: 'sent the message',
+      });
+      expect(msg).toContain('sent the message');
+    });
+
+    test('guardian_followup_failed includes failureReason when provided', () => {
+      const msg = getGuardianActionFallbackMessage({
+        scenario: 'guardian_followup_failed',
+        failureReason: 'The phone number is not valid.',
+      });
+      expect(msg).toContain('The phone number is not valid.');
+    });
+
+    test('outbound_message_copy includes callerIdentifier and questionText', () => {
+      const msg = getGuardianActionFallbackMessage({
+        scenario: 'outbound_message_copy',
+        callerIdentifier: 'Bob',
+        questionText: 'When is the appointment?',
+      });
+      expect(msg).toContain('Bob');
+      expect(msg).toContain('When is the appointment?');
+    });
+
+    test('outbound_message_copy without callerIdentifier still includes questionText', () => {
+      const msg = getGuardianActionFallbackMessage({
+        scenario: 'outbound_message_copy',
+        questionText: 'Is the office open?',
+      });
+      expect(msg).toContain('Is the office open?');
+      expect(msg).toContain('Someone');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // composeGuardianActionMessageGenerative -- layered composition
+  // -----------------------------------------------------------------------
+
+  describe('composeGuardianActionMessageGenerative', () => {
+    test('with no generator returns fallback', async () => {
+      const context: GuardianActionMessageContext = {
+        scenario: 'caller_timeout_acknowledgment',
+        guardianIdentifier: 'Jane',
+      };
+      const msg = await composeGuardianActionMessageGenerative(context);
+      expect(msg).toBe(getGuardianActionFallbackMessage(context));
+    });
+
+    test('with generator that returns text uses the generated text', async () => {
+      const generatedText = 'Custom generated message about the timeout.';
+      const generator: GuardianActionCopyGenerator = async () => generatedText;
+      const context: GuardianActionMessageContext = {
+        scenario: 'caller_timeout_acknowledgment',
+      };
+      // In test env, generator is skipped and fallback is returned
+      const msg = await composeGuardianActionMessageGenerative(context, {}, generator);
+      expect(msg).toBe(getGuardianActionFallbackMessage(context));
+    });
+
+    test('with generator that throws returns fallback', async () => {
+      const generator: GuardianActionCopyGenerator = async () => {
+        throw new Error('Provider unavailable');
+      };
+      const context: GuardianActionMessageContext = {
+        scenario: 'guardian_followup_failed',
+        failureReason: 'Network error',
+      };
+      const msg = await composeGuardianActionMessageGenerative(context, {}, generator);
+      expect(msg).toBe(getGuardianActionFallbackMessage(context));
+    });
+
+    test('with generator that returns null returns fallback', async () => {
+      const generator: GuardianActionCopyGenerator = async () => null;
+      const context: GuardianActionMessageContext = {
+        scenario: 'guardian_stale_expired',
+      };
+      const msg = await composeGuardianActionMessageGenerative(context, {}, generator);
+      expect(msg).toBe(getGuardianActionFallbackMessage(context));
+    });
+
+    test('uses custom fallbackText from options when provided', async () => {
+      const context: GuardianActionMessageContext = {
+        scenario: 'caller_timeout_continue',
+      };
+      const customFallback = 'Custom fallback text for this scenario.';
+      const msg = await composeGuardianActionMessageGenerative(context, { fallbackText: customFallback });
+      expect(msg).toBe(customFallback);
+    });
+
+    test('skips generation in test environment', async () => {
+      let generatorCalled = false;
+      const generator: GuardianActionCopyGenerator = async () => {
+        generatorCalled = true;
+        return 'This should not be returned in test env';
+      };
+      const context: GuardianActionMessageContext = {
+        scenario: 'guardian_followup_declined_ack',
+      };
+      const msg = await composeGuardianActionMessageGenerative(context, {}, generator);
+      expect(generatorCalled).toBe(false);
+      expect(msg).toBe(getGuardianActionFallbackMessage(context));
+    });
+  });
+});

--- a/assistant/src/daemon/guardian-action-generators.ts
+++ b/assistant/src/daemon/guardian-action-generators.ts
@@ -1,0 +1,60 @@
+import { loadConfig } from '../config/loader.js';
+import { getFailoverProvider } from '../providers/registry.js';
+import {
+  buildGuardianActionGenerationPrompt,
+  getGuardianActionFallbackMessage,
+  GUARDIAN_ACTION_COPY_MAX_TOKENS,
+  GUARDIAN_ACTION_COPY_SYSTEM_PROMPT,
+  GUARDIAN_ACTION_COPY_TIMEOUT_MS,
+  includesRequiredKeywords,
+} from '../runtime/guardian-action-message-composer.js';
+import type { GuardianActionCopyGenerator } from '../runtime/http-types.js';
+
+/**
+ * Create the daemon-owned guardian action copy generator that resolves
+ * providers and calls `provider.sendMessage` to generate guardian action
+ * copy text. Uses `latency-optimized` model intent since these are
+ * time-sensitive voice responses.
+ *
+ * This keeps all provider awareness in the daemon lifecycle, away from
+ * the runtime composer.
+ */
+export function createGuardianActionCopyGenerator(): GuardianActionCopyGenerator {
+  return async (context, options = {}) => {
+    const config = loadConfig();
+    let provider;
+    try {
+      provider = getFailoverProvider(config.provider, config.providerOrder);
+    } catch {
+      return null;
+    }
+
+    const fallbackText = options.fallbackText?.trim() || getGuardianActionFallbackMessage(context);
+    const requiredKeywords = options.requiredKeywords?.map((kw) => kw.trim()).filter((kw) => kw.length > 0);
+    const prompt = buildGuardianActionGenerationPrompt(context, fallbackText, requiredKeywords);
+
+    const response = await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: prompt }] }],
+      [],
+      GUARDIAN_ACTION_COPY_SYSTEM_PROMPT,
+      {
+        config: {
+          max_tokens: options.maxTokens ?? GUARDIAN_ACTION_COPY_MAX_TOKENS,
+          modelIntent: 'latency-optimized',
+        },
+        signal: AbortSignal.timeout(options.timeoutMs ?? GUARDIAN_ACTION_COPY_TIMEOUT_MS),
+      },
+    );
+
+    const block = response.content.find((entry) => entry.type === 'text');
+    const text = block && 'text' in block ? block.text.trim() : '';
+    if (!text) return null;
+    const cleaned = text
+      .replace(/^["'`]+/, '')
+      .replace(/["'`]+$/, '')
+      .trim();
+    if (!cleaned) return null;
+    if (!includesRequiredKeywords(cleaned, requiredKeywords)) return null;
+    return cleaned;
+  };
+}

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -46,6 +46,7 @@ import {
 import { listWorkItems, updateWorkItem } from '../work-items/work-item-store.js';
 import { WorkspaceHeartbeatService } from '../workspace/heartbeat-service.js';
 import { createApprovalConversationGenerator,createApprovalCopyGenerator } from './approval-generators.js';
+import { createGuardianActionCopyGenerator } from './guardian-action-generators.js';
 import { cleanupPidFile,writePid } from './daemon-control.js';
 import { initPairingHandlers } from './handlers/pairing.js';
 import { installCliLaunchers } from './install-cli-launchers.js';
@@ -282,6 +283,7 @@ export async function runDaemon(): Promise<void> {
     interfacesDir: getInterfacesDir(),
     approvalCopyGenerator: createApprovalCopyGenerator(),
     approvalConversationGenerator: createApprovalConversationGenerator(),
+    guardianActionCopyGenerator: createGuardianActionCopyGenerator(),
     sendMessageDeps: {
       getOrCreateSession: (conversationId) =>
         server.getSessionForMessages(conversationId),

--- a/assistant/src/runtime/guardian-action-message-composer.ts
+++ b/assistant/src/runtime/guardian-action-message-composer.ts
@@ -1,0 +1,183 @@
+/**
+ * Layered guardian action message composition system.
+ *
+ * Generates user-visible copy for guardian action scenarios through a
+ * priority chain:
+ *   1. Generator-produced text (when provided by daemon)
+ *   2. Deterministic fallback templates (natural, scenario-specific messages)
+ *
+ * Follows the same pattern as approval-message-composer.ts.
+ */
+import { getLogger } from '../util/logger.js';
+import type { GuardianActionCopyGenerator } from './http-types.js';
+
+const log = getLogger('guardian-action-message-composer');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type GuardianActionMessageScenario =
+  | 'caller_timeout_acknowledgment'
+  | 'caller_timeout_continue'
+  | 'guardian_late_answer_followup'
+  | 'guardian_followup_dispatching'
+  | 'guardian_followup_completed'
+  | 'guardian_followup_failed'
+  | 'guardian_followup_declined_ack'
+  | 'guardian_stale_expired'
+  | 'outbound_message_copy';
+
+export interface GuardianActionMessageContext {
+  scenario: GuardianActionMessageScenario;
+  channel?: string;
+  questionText?: string;
+  callerIdentifier?: string;
+  guardianIdentifier?: string;
+  lateAnswerText?: string;
+  followupAction?: string;
+  failureReason?: string;
+}
+
+export interface ComposeGuardianActionMessageOptions {
+  fallbackText?: string;
+  requiredKeywords?: string[];
+  maxTokens?: number;
+  timeoutMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants (exported for the daemon-injected generator implementation)
+// ---------------------------------------------------------------------------
+
+export const GUARDIAN_ACTION_COPY_TIMEOUT_MS = 4_000;
+export const GUARDIAN_ACTION_COPY_MAX_TOKENS = 200;
+export const GUARDIAN_ACTION_COPY_SYSTEM_PROMPT =
+  'You are an assistant writing one user-facing message about a guardian action in a voice call scenario. '
+  + 'Keep it concise, natural, and conversational. Preserve factual details exactly. '
+  + 'These messages are spoken aloud or sent as SMS, so use a warm, human tone. '
+  + 'Do not mention internal systems, scenario IDs, or technical details. '
+  + 'Return plain text only.';
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compose user-facing guardian action copy using the daemon-injected generator
+ * when available, with deterministic fallback for reliability.
+ *
+ * The generator parameter is the daemon-provided function that knows about
+ * providers. When absent (or in test env), only the deterministic fallback
+ * is used.
+ */
+export async function composeGuardianActionMessageGenerative(
+  context: GuardianActionMessageContext,
+  options: ComposeGuardianActionMessageOptions = {},
+  generator?: GuardianActionCopyGenerator,
+): Promise<string> {
+  const fallbackText = options.fallbackText?.trim() || getGuardianActionFallbackMessage(context);
+
+  if (process.env.NODE_ENV === 'test') {
+    return fallbackText;
+  }
+
+  if (generator) {
+    try {
+      const generated = await generator(context, options);
+      if (generated) return generated;
+    } catch (err) {
+      log.warn({ err, scenario: context.scenario }, 'Failed to generate guardian action copy, using fallback');
+    }
+  }
+
+  return fallbackText;
+}
+
+/** @internal Exported for use by the daemon-injected generator implementation. */
+export function buildGuardianActionGenerationPrompt(
+  context: GuardianActionMessageContext,
+  fallbackText: string,
+  requiredKeywords: string[] | undefined,
+): string {
+  const keywordClause = requiredKeywords && requiredKeywords.length > 0
+    ? `Required words to include (as standalone words): ${requiredKeywords.join(', ')}.\n`
+    : '';
+  return [
+    'Rewrite the following guardian action message as a natural, conversational reply.',
+    'These messages are for voice call scenarios and may be spoken aloud or sent as SMS.',
+    'Keep the same concrete facts and next-step guidance.',
+    keywordClause,
+    `Context JSON: ${JSON.stringify(context)}`,
+    `Fallback message: ${fallbackText}`,
+  ].filter(Boolean).join('\n\n');
+}
+
+/** @internal Exported for use by the daemon-injected generator implementation. */
+export function includesRequiredKeywords(text: string, requiredKeywords: string[] | undefined): boolean {
+  if (!requiredKeywords || requiredKeywords.length === 0) return true;
+  return requiredKeywords.every((keyword) => {
+    const re = new RegExp(`\\b${keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i');
+    return re.test(text);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic fallback templates
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a scenario-specific deterministic fallback message.
+ *
+ * Each template produces natural, conversational text suitable for voice
+ * or SMS delivery.
+ */
+export function getGuardianActionFallbackMessage(context: GuardianActionMessageContext): string {
+  switch (context.scenario) {
+    case 'caller_timeout_acknowledgment':
+      return context.guardianIdentifier
+        ? `I wasn't able to reach ${context.guardianIdentifier} right now. I'm sorry about that.`
+        : "I wasn't able to reach the guardian right now. I'm sorry about that.";
+
+    case 'caller_timeout_continue':
+      return 'Would you like me to leave a message for them to get back to you, or is there anything else I can help with?';
+
+    case 'guardian_late_answer_followup':
+      return context.callerIdentifier
+        ? `${context.callerIdentifier} called earlier with a question, but I wasn't able to connect them. Would you like to call them back or send them a message?`
+        : 'Someone called earlier with a question, but I wasn\'t able to connect them. Would you like to call them back or send them a message?';
+
+    case 'guardian_followup_dispatching':
+      return context.followupAction
+        ? `Got it, I'll ${context.followupAction} now.`
+        : "Got it, I'm taking care of that now.";
+
+    case 'guardian_followup_completed':
+      return context.followupAction
+        ? `Done! I've ${context.followupAction} successfully.`
+        : "Done! That's been taken care of.";
+
+    case 'guardian_followup_failed':
+      return context.failureReason
+        ? `I'm sorry, I wasn't able to complete that. ${context.failureReason}`
+        : "I'm sorry, I wasn't able to complete that. Please try again later.";
+
+    case 'guardian_followup_declined_ack':
+      return 'No problem. Let me know if you change your mind or need anything else.';
+
+    case 'guardian_stale_expired':
+      return 'That request has already expired. No further action is needed.';
+
+    case 'outbound_message_copy':
+      return context.callerIdentifier && context.questionText
+        ? `Hi, ${context.callerIdentifier} tried to reach you earlier and asked: "${context.questionText}". Please reply when you get a chance.`
+        : context.questionText
+          ? `Someone tried to reach you earlier and asked: "${context.questionText}". Please reply when you get a chance.`
+          : 'Someone tried to reach you earlier. Please reply when you get a chance.';
+
+    default: {
+      const _exhaustive: never = context.scenario;
+      return `Guardian action update. ${String(_exhaustive)}`;
+    }
+  }
+}

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -133,6 +133,7 @@ export { isPrivateAddress } from './middleware/auth.js';
 export type {
   ApprovalConversationGenerator,
   ApprovalCopyGenerator,
+  GuardianActionCopyGenerator,
   MessageProcessor,
   NonBlockingMessageProcessor,
   RuntimeAttachmentMetadata,
@@ -144,6 +145,7 @@ export type {
 import type {
   ApprovalConversationGenerator,
   ApprovalCopyGenerator,
+  GuardianActionCopyGenerator,
   MessageProcessor,
   NonBlockingMessageProcessor,
   RuntimeHttpServerOptions,
@@ -167,6 +169,7 @@ export class RuntimeHttpServer {
   private persistAndProcessMessage?: NonBlockingMessageProcessor;
   private approvalCopyGenerator?: ApprovalCopyGenerator;
   private approvalConversationGenerator?: ApprovalConversationGenerator;
+  private guardianActionCopyGenerator?: GuardianActionCopyGenerator;
   private interfacesDir: string | null;
   private suggestionCache = new Map<string, string>();
   private suggestionInFlight = new Map<string, Promise<string | null>>();
@@ -184,6 +187,7 @@ export class RuntimeHttpServer {
     this.persistAndProcessMessage = options.persistAndProcessMessage;
     this.approvalCopyGenerator = options.approvalCopyGenerator;
     this.approvalConversationGenerator = options.approvalConversationGenerator;
+    this.guardianActionCopyGenerator = options.guardianActionCopyGenerator;
     this.interfacesDir = options.interfacesDir ?? null;
     this.sendMessageDeps = options.sendMessageDeps;
   }
@@ -664,7 +668,7 @@ export class RuntimeHttpServer {
 
       if (endpoint === 'channels/inbound' && req.method === 'POST') {
         const gatewayOriginSecret = getRuntimeGatewayOriginSecret();
-        return await handleChannelInbound(req, this.processMessage, this.bearerToken, assistantId, gatewayOriginSecret, this.approvalCopyGenerator, this.approvalConversationGenerator);
+        return await handleChannelInbound(req, this.processMessage, this.bearerToken, assistantId, gatewayOriginSecret, this.approvalCopyGenerator, this.approvalConversationGenerator, this.guardianActionCopyGenerator);
       }
 
       if (endpoint === 'channels/delivery-ack' && req.method === 'POST') return await handleChannelDeliveryAck(req);

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -6,6 +6,10 @@ import type { Session } from '../daemon/session.js';
 import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
 import type { ApprovalMessageContext, ComposeApprovalMessageGenerativeOptions } from './approval-message-composer.js';
 import type { AssistantEventHub } from './assistant-event-hub.js';
+import type {
+  ComposeGuardianActionMessageOptions,
+  GuardianActionMessageContext,
+} from './guardian-action-message-composer.js';
 /**
  * Daemon-injected function that generates approval copy using a provider.
  * Returns generated text or `null` on failure (caller falls back to deterministic text).
@@ -50,6 +54,15 @@ export interface ApprovalConversationContext {
 export type ApprovalConversationGenerator = (
   context: ApprovalConversationContext,
 ) => Promise<ApprovalConversationResult>;
+
+/**
+ * Daemon-injected function that generates guardian action copy using a provider.
+ * Returns generated text or `null` on failure (caller falls back to deterministic text).
+ */
+export type GuardianActionCopyGenerator = (
+  context: GuardianActionMessageContext,
+  options?: ComposeGuardianActionMessageOptions,
+) => Promise<string | null>;
 
 export interface RuntimeMessageSessionOptions {
   transport?: {
@@ -125,6 +138,8 @@ export interface RuntimeHttpServerOptions {
   approvalCopyGenerator?: ApprovalCopyGenerator;
   /** Daemon-injected generator for conversational approval flow (provider-backed). */
   approvalConversationGenerator?: ApprovalConversationGenerator;
+  /** Daemon-injected generator for guardian action copy (provider-backed). */
+  guardianActionCopyGenerator?: GuardianActionCopyGenerator;
   /** Dependencies for the POST /v1/messages queue-if-busy handler. */
   sendMessageDeps?: SendMessageDeps;
 }

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -53,6 +53,7 @@ import {
 import type {
   ApprovalConversationGenerator,
   ApprovalCopyGenerator,
+  GuardianActionCopyGenerator,
   MessageProcessor,
 } from '../http-types.js';
 import { deliverReplyViaCallback } from './channel-delivery-routes.js';
@@ -103,6 +104,7 @@ export async function handleChannelInbound(
   gatewayOriginSecret?: string,
   approvalCopyGenerator?: ApprovalCopyGenerator,
   approvalConversationGenerator?: ApprovalConversationGenerator,
+  _guardianActionCopyGenerator?: GuardianActionCopyGenerator,
 ): Promise<Response> {
   // Reject requests that lack valid gateway-origin proof. This ensures
   // channel inbound messages can only arrive via the gateway (which


### PR DESCRIPTION
Create daemon-owned generator plumbing for guardian-action user-visible copy. Adds GuardianActionCopyGenerator type, createGuardianActionCopyGenerator() factory, guardian-action-message-composer with scenario-driven fallbacks, and wires injection through daemon lifecycle into RuntimeHttpServer and channel inbound handler. Part of #9562.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
