### PR TITLE
M6: Compact inline surface payloads

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -98,6 +98,8 @@ struct SurfaceContainerView: View {
             case .table, .browserView, .documentPreview:
                 // These surfaces are rendered inline in chat, not in floating panels.
                 EmptyView()
+            case .stripped:
+                EmptyView()
             }
 
             // Action buttons for card/list surfaces
@@ -114,7 +116,7 @@ struct SurfaceContainerView: View {
         switch surface.data {
         case .form, .confirmation, .dynamicPage, .fileUpload:
             return true
-        case .card, .list, .table, .browserView, .documentPreview:
+        case .card, .list, .table, .browserView, .documentPreview, .stripped:
             return false
         }
     }

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1143,8 +1143,8 @@ public struct InlineSurfaceData: Identifiable, Equatable {
     public let id: String
     public let surfaceType: SurfaceType
     public let title: String?
-    public let data: SurfaceData
-    public let actions: [SurfaceActionButton]
+    public var data: SurfaceData
+    public var actions: [SurfaceActionButton]
     /// Lightweight reference for dynamic pages, used to re-open the workspace.
     /// Replaces the former full UiSurfaceShowMessage to avoid retaining
     /// entire HTML payloads in memory.
@@ -1424,19 +1424,10 @@ public struct ChatMessage: Identifiable, Equatable {
             attachments[i].dataLength = 0
         }
         for i in inlineSurfaces.indices {
-            if inlineSurfaces[i].completionState != nil {
-                // Surface is completed — keep the SurfaceRef but clear the data payload.
-                // The surface can be re-fetched from the daemon if the user scrolls back.
-                inlineSurfaces[i] = InlineSurfaceData(
-                    id: inlineSurfaces[i].id,
-                    surfaceType: inlineSurfaces[i].surfaceType,
-                    title: inlineSurfaces[i].title,
-                    data: inlineSurfaces[i].data,
-                    actions: [],
-                    surfaceRef: inlineSurfaces[i].surfaceRef,
-                    completionState: inlineSurfaces[i].completionState
-                )
-            }
+            // Strip all surfaces in old messages — clear the heavy data payload.
+            // The surface can be re-fetched from the daemon if the user scrolls back.
+            inlineSurfaces[i].data = .stripped
+            inlineSurfaces[i].actions = []
         }
         isContentStripped = true
     }

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1424,10 +1424,12 @@ public struct ChatMessage: Identifiable, Equatable {
             attachments[i].dataLength = 0
         }
         for i in inlineSurfaces.indices {
-            // Strip all surfaces in old messages — clear the heavy data payload.
-            // The surface can be re-fetched from the daemon if the user scrolls back.
-            inlineSurfaces[i].data = .stripped
-            inlineSurfaces[i].actions = []
+            if inlineSurfaces[i].completionState != nil {
+                // Surface is completed — clear the heavy data payload.
+                // The surface can be re-fetched from the daemon if the user scrolls back.
+                inlineSurfaces[i].data = .stripped
+                inlineSurfaces[i].actions = []
+            }
         }
         isContentStripped = true
     }

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -453,6 +453,9 @@ public enum SurfaceData: Sendable, Equatable {
     case fileUpload(FileUploadSurfaceData)
     case browserView(BrowserViewSurfaceData)
     case documentPreview(DocumentPreviewSurfaceData)
+    /// Placeholder for data that was cleared during memory compaction.
+    /// The surface can be re-fetched from the daemon if the user scrolls back.
+    case stripped
 }
 
 public struct SurfaceActionButton: Identifiable, Equatable, Sendable {
@@ -619,6 +622,8 @@ public extension Surface {
             return .browserView(mergeBrowserViewData(existing: bv, update: update))
         case .documentPreview(let dp):
             return .documentPreview(dp)
+        case .stripped:
+            return .stripped
         }
     }
 


### PR DESCRIPTION
Fix critical memory retention bug where stripHeavyContent() preserved full SurfaceData payloads (including MB-scale HTML for dynamic pages) instead of clearing them. Added .stripped case to SurfaceData enum and simplified the stripping logic to clear data for all completed surfaces. Part of #9583.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
