### PR TITLE
fix: return early from requestNotificationAccess when already authorized

### DIFF
--- a/clients/macos/vellum-assistant/App/PermissionManager.swift
+++ b/clients/macos/vellum-assistant/App/PermissionManager.swift
@@ -137,7 +137,9 @@ enum PermissionManager {
             switch settings.authorizationStatus {
             case .notDetermined:
                 UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { _, _ in }
-            case .authorized, .provisional, .ephemeral, .denied:
+            case .authorized, .provisional, .ephemeral:
+                return
+            case .denied:
                 _ = openNotificationSettings()
             @unknown default:
                 _ = openNotificationSettings()


### PR DESCRIPTION
Separates the authorized/provisional/ephemeral cases from denied in requestNotificationAccess() so clicking the Notifications permission row when already granted doesn't unnecessarily open System Settings. Matches the pattern used by requestMicrophoneAccess() and requestSpeechRecognitionAccess().
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
