### PR TITLE
M2: Voice Auto-Followup in Guardian Verify Skill

### DIFF
--- a/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
+++ b/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Regression tests for the guardian-verify-setup skill.
+ *
+ * Ensures the voice verification flow includes proactive auto-check polling
+ * so the user does not have to manually ask whether verification succeeded.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, test } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Locate the skill SKILL.md
+// ---------------------------------------------------------------------------
+
+const ASSISTANT_DIR = resolve(import.meta.dirname ?? __dirname, '..', '..');
+const SKILL_PATH = resolve(
+  ASSISTANT_DIR,
+  'src',
+  'config',
+  'vellum-skills',
+  'guardian-verify-setup',
+  'SKILL.md',
+);
+
+const skillContent = readFileSync(SKILL_PATH, 'utf-8');
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('guardian-verify-setup skill — voice auto-followup', () => {
+  test('voice path in Step 3 references the auto-check polling loop', () => {
+    // The voice success instruction in Step 3 must direct the assistant to
+    // begin the polling loop rather than waiting for the user to report back.
+    expect(skillContent).toContain(
+      'immediately begin the voice auto-check polling loop',
+    );
+  });
+
+  test('voice path in Step 4 (resend) references the auto-check polling loop', () => {
+    // After a voice resend, the same auto-check behavior must kick in.
+    const resendSection = skillContent.split('## Step 4')[1]?.split('## Step 5')[0] ?? '';
+    expect(resendSection).toContain(
+      'voice auto-check polling loop',
+    );
+  });
+
+  test('contains a Voice Auto-Check Polling section', () => {
+    expect(skillContent).toContain('## Voice Auto-Check Polling');
+  });
+
+  test('polling section specifies the correct status endpoint for voice', () => {
+    const pollingSection =
+      skillContent.split('## Voice Auto-Check Polling')[1]?.split('## Step 6')[0] ?? '';
+    expect(pollingSection).toContain(
+      '/v1/integrations/guardian/status?channel=voice',
+    );
+  });
+
+  test('polling section includes ~15 second interval', () => {
+    const pollingSection =
+      skillContent.split('## Voice Auto-Check Polling')[1]?.split('## Step 6')[0] ?? '';
+    expect(pollingSection).toContain('~15 seconds');
+  });
+
+  test('polling section includes 2-minute timeout', () => {
+    const pollingSection =
+      skillContent.split('## Voice Auto-Check Polling')[1]?.split('## Step 6')[0] ?? '';
+    expect(pollingSection).toContain('2 minutes');
+  });
+
+  test('polling section checks for bound: true', () => {
+    const pollingSection =
+      skillContent.split('## Voice Auto-Check Polling')[1]?.split('## Step 6')[0] ?? '';
+    expect(pollingSection).toContain('bound: true');
+  });
+
+  test('polling section includes proactive success confirmation', () => {
+    const pollingSection =
+      skillContent.split('## Voice Auto-Check Polling')[1]?.split('## Step 6')[0] ?? '';
+    expect(pollingSection).toContain('proactive success message');
+  });
+
+  test('polling section includes timeout fallback with resend/restart offer', () => {
+    const pollingSection =
+      skillContent.split('## Voice Auto-Check Polling')[1]?.split('## Step 6')[0] ?? '';
+    expect(pollingSection).toContain('timeout');
+    expect(pollingSection).toContain('resend');
+  });
+
+  test('polling is voice-only — does not apply to SMS or Telegram', () => {
+    const pollingSection =
+      skillContent.split('## Voice Auto-Check Polling')[1]?.split('## Step 6')[0] ?? '';
+    expect(pollingSection).toContain('voice-only');
+    expect(pollingSection).toContain('Do NOT poll for SMS or Telegram');
+  });
+
+  test('no instruction requires waiting for user to ask "did it work?"', () => {
+    // The skill should never instruct the assistant to wait for the user to
+    // confirm that voice verification worked. The auto-check polling loop
+    // makes this unnecessary.
+    const voiceAutoCheckSection =
+      skillContent.split('## Voice Auto-Check Polling')[1]?.split('## Step 6')[0] ?? '';
+    expect(voiceAutoCheckSection).toContain(
+      'Do NOT require the user to ask',
+    );
+    // There should be no phrase like "wait for the user to confirm" or
+    // "ask the user if it worked" in the voice-related sections.
+    const step3VoiceLine = skillContent
+      .split('## Step 3')[1]
+      ?.split('## Step 4')[0] ?? '';
+    expect(step3VoiceLine).not.toContain('wait for the user to confirm');
+    expect(step3VoiceLine).not.toContain('ask the user if it worked');
+  });
+});

--- a/assistant/src/config/vellum-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/guardian-verify-setup/SKILL.md
@@ -52,7 +52,7 @@ Replace `<channel>` with `sms`, `voice`, or `telegram`, and `<destination>` with
 Report the exact next action based on the channel:
 
 - **SMS**: "I've sent a 6-digit verification code to [number]. Reply with the code from that SMS conversation (not here) to complete verification — the code can only be consumed through the SMS channel."
-- **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/start` API call already initiates the voice call. Do NOT place a separate `call_start` call.
+- **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/start` API call already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
 - **Telegram with chat ID** (no `telegramBootstrapUrl` in response): The response includes a `secret` field. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and send `/guardian_verify [secret]` (or just reply with the code) to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4).
 - **Telegram with handle** (`telegramBootstrapUrl` present in response): "Tap this deep-link first: [telegramBootstrapUrl]. After Telegram binds your identity, I'll send your verification code."
 
@@ -86,7 +86,7 @@ curl -s -X POST http://localhost:7821/v1/integrations/guardian/outbound/resend \
 On success, report the next action based on the channel:
 
 - **SMS**: "I've sent a new verification code to [number]. Reply with the code from that SMS conversation to complete verification."
-- **Voice**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/resend` API call already initiates the voice call. Do NOT place a separate `call_start` call.
+- **Voice**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/resend` API call already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
 - **Telegram**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and send `/guardian_verify [secret]` (or just reply with the code) to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3.
 
 ### Resend errors
@@ -114,6 +114,31 @@ curl -s -X POST http://localhost:7821/v1/integrations/guardian/outbound/cancel \
 ```
 
 Confirm cancellation to the user. On `no_active_session`, tell them there is nothing to cancel.
+
+## Voice Auto-Check Polling
+
+For **voice** verification only: after telling the user their code and instructing keypad entry (in Step 3 or Step 4), do NOT wait for the user to report back. Instead, proactively poll for completion so the user gets instant confirmation without having to ask "did it work?"
+
+**Polling procedure:**
+
+1. Wait ~15 seconds after delivering the code (to give the user time to answer the call and enter the code).
+2. Check the binding status:
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+curl -s http://localhost:7821/v1/integrations/guardian/status?channel=voice \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+3. If the response shows `bound: true`: immediately send a proactive success message in the current chat — "Voice verification complete! Your phone number is now the trusted guardian." Stop polling.
+4. If not yet bound: wait ~15 seconds and poll again.
+5. Continue polling for up to **2 minutes** (approximately 8 attempts).
+6. If the 2-minute timeout is reached without `bound: true`: proactively tell the user — "I've been checking for about 2 minutes but verification hasn't completed yet. The code may have expired or wasn't entered. Would you like me to resend a new code (Step 4) or start a new session (Step 3)?"
+
+**Important polling rules:**
+- This polling loop is voice-only. Do NOT poll for SMS or Telegram channels (SMS codes are entered through the SMS channel itself; Telegram has its own bot-driven flow).
+- Do NOT require the user to ask "did it work?" — the whole point is proactive confirmation.
+- If the user sends a message while polling is in progress, handle their message normally. If their message is about verification status, the next poll iteration will provide the answer.
 
 ## Step 6: Check Guardian Status
 

--- a/skills/guardian-verify-setup/SKILL.md
+++ b/skills/guardian-verify-setup/SKILL.md
@@ -52,7 +52,7 @@ Replace `<channel>` with `sms`, `voice`, or `telegram`, and `<destination>` with
 Report the exact next action based on the channel:
 
 - **SMS**: "I've sent a 6-digit verification code to [number]. Reply with the code from that SMS conversation (not here) to complete verification — the code can only be consumed through the SMS channel."
-- **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/start` API call already initiates the voice call. Do NOT place a separate `call_start` call.
+- **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/start` API call already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
 - **Telegram with chat ID** (no `telegramBootstrapUrl` in response): The response includes a `secret` field. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and send `/guardian_verify [secret]` (or just reply with the code) to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4).
 - **Telegram with handle** (`telegramBootstrapUrl` present in response): "Tap this deep-link first: [telegramBootstrapUrl]. After Telegram binds your identity, I'll send your verification code."
 
@@ -86,7 +86,7 @@ curl -s -X POST http://localhost:7821/v1/integrations/guardian/outbound/resend \
 On success, report the next action based on the channel:
 
 - **SMS**: "I've sent a new verification code to [number]. Reply with the code from that SMS conversation to complete verification."
-- **Voice**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/resend` API call already initiates the voice call. Do NOT place a separate `call_start` call.
+- **Voice**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/resend` API call already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
 - **Telegram**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and send `/guardian_verify [secret]` (or just reply with the code) to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3.
 
 ### Resend errors
@@ -114,6 +114,31 @@ curl -s -X POST http://localhost:7821/v1/integrations/guardian/outbound/cancel \
 ```
 
 Confirm cancellation to the user. On `no_active_session`, tell them there is nothing to cancel.
+
+## Voice Auto-Check Polling
+
+For **voice** verification only: after telling the user their code and instructing keypad entry (in Step 3 or Step 4), do NOT wait for the user to report back. Instead, proactively poll for completion so the user gets instant confirmation without having to ask "did it work?"
+
+**Polling procedure:**
+
+1. Wait ~15 seconds after delivering the code (to give the user time to answer the call and enter the code).
+2. Check the binding status:
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+curl -s http://localhost:7821/v1/integrations/guardian/status?channel=voice \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+3. If the response shows `bound: true`: immediately send a proactive success message in the current chat — "Voice verification complete! Your phone number is now the trusted guardian." Stop polling.
+4. If not yet bound: wait ~15 seconds and poll again.
+5. Continue polling for up to **2 minutes** (approximately 8 attempts).
+6. If the 2-minute timeout is reached without `bound: true`: proactively tell the user — "I've been checking for about 2 minutes but verification hasn't completed yet. The code may have expired or wasn't entered. Would you like me to resend a new code (Step 4) or start a new session (Step 3)?"
+
+**Important polling rules:**
+- This polling loop is voice-only. Do NOT poll for SMS or Telegram channels (SMS codes are entered through the SMS channel itself; Telegram has its own bot-driven flow).
+- Do NOT require the user to ask "did it work?" — the whole point is proactive confirmation.
+- If the user sends a message while polling is in progress, handle their message normally. If their message is about verification status, the next poll iteration will provide the answer.
 
 ## Step 6: Check Guardian Status
 


### PR DESCRIPTION
## Summary
- Updates guardian-verify-setup SKILL.md with voice auto-polling for completion status
- After instructing keypad entry, skill now polls /v1/integrations/guardian/status every ~15s for 2 min
- Proactively confirms success or offers resend on timeout
- Mirrors changes to top-level skills/ directory
- Adds skill regression tests

Part of #9606. Closes #9608.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
