### PR TITLE
M1: Deterministic First-Turn Guardian Routing

### DIFF
--- a/assistant/src/__tests__/guardian-verification-intent-routing.test.ts
+++ b/assistant/src/__tests__/guardian-verification-intent-routing.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveGuardianVerificationIntent } from '../daemon/guardian-verification-intent.js';
+
+// =====================================================================
+// 1. Direct guardian setup phrases => forced skill flow
+// =====================================================================
+
+describe('direct guardian setup phrases trigger forced routing', () => {
+  const directSetupPhrases = [
+    'help me confirm myself as your guardian by phone',
+    'verify me as guardian',
+    'set me as guardian for SMS',
+    'set me as guardian for voice',
+    'set me as guardian for telegram',
+    'verify my phone number',
+    'verify my Telegram account',
+    'verify voice channel',
+    'set up guardian verification',
+    'guardian verification setup',
+    'please verify me as guardian',
+    'can you verify me as guardian',
+    'I want to become your guardian',
+    'register me as your guardian',
+    'help me set myself up as your guardian via sms',
+    'I need to set myself as guardian',
+    'guardian verify',
+    'set me up as guardian for text message',
+  ];
+
+  for (const phrase of directSetupPhrases) {
+    test(`"${phrase}" => direct_setup`, () => {
+      const result = resolveGuardianVerificationIntent(phrase);
+      expect(result.kind).toBe('direct_setup');
+      if (result.kind === 'direct_setup') {
+        expect(result.rewrittenContent).toContain('guardian-verify-setup');
+        expect(result.rewrittenContent).toContain('skill_load');
+      }
+    });
+  }
+});
+
+// =====================================================================
+// 2. Conceptual / security questions => no forced routing
+// =====================================================================
+
+describe('conceptual questions do NOT trigger forced routing', () => {
+  const conceptualPhrases = [
+    "why can't you verify over phone?",
+    'what is guardian verification?',
+    'how does guardian verification work?',
+    'explain guardian verification to me',
+    'tell me about the guardian system',
+    'why do I need to be a guardian?',
+    'what does a guardian do?',
+    'how do I become a guardian? explain the process',
+    'is there a way to skip verification?',
+    'can you tell me about verification channels?',
+    'when was guardian verification added?',
+    'who can be a guardian?',
+  ];
+
+  for (const phrase of conceptualPhrases) {
+    test(`"${phrase}" => none`, () => {
+      const result = resolveGuardianVerificationIntent(phrase);
+      expect(result.kind).toBe('none');
+    });
+  }
+});
+
+// =====================================================================
+// 3. Non-guardian unrelated messages => unchanged
+// =====================================================================
+
+describe('non-guardian messages are not intercepted', () => {
+  const unrelatedPhrases = [
+    'what is the weather today?',
+    'help me write an email',
+    'set a reminder for 3pm',
+    'open Chrome and search for cats',
+    'record my screen',
+    'tell me a joke',
+    'create a new task',
+    'schedule a meeting for tomorrow',
+    'send a message to John',
+    '',
+  ];
+
+  for (const phrase of unrelatedPhrases) {
+    test(`"${phrase}" => none`, () => {
+      const result = resolveGuardianVerificationIntent(phrase);
+      expect(result.kind).toBe('none');
+    });
+  }
+});
+
+// =====================================================================
+// 4. Slash commands are never intercepted
+// =====================================================================
+
+describe('slash commands are never intercepted', () => {
+  const slashCommands = [
+    '/guardian-verify-setup',
+    '/model opus',
+    '/status',
+    '/commands',
+  ];
+
+  for (const cmd of slashCommands) {
+    test(`"${cmd}" => none`, () => {
+      const result = resolveGuardianVerificationIntent(cmd);
+      expect(result.kind).toBe('none');
+    });
+  }
+});
+
+// =====================================================================
+// 5. Channel hint extraction
+// =====================================================================
+
+describe('channel hint extraction', () => {
+  test('detects SMS channel hint', () => {
+    const result = resolveGuardianVerificationIntent('set me as guardian for SMS');
+    expect(result.kind).toBe('direct_setup');
+    if (result.kind === 'direct_setup') {
+      expect(result.channelHint).toBe('sms');
+      expect(result.rewrittenContent).toContain('sms channel');
+    }
+  });
+
+  test('detects voice channel hint', () => {
+    const result = resolveGuardianVerificationIntent('verify voice channel');
+    expect(result.kind).toBe('direct_setup');
+    if (result.kind === 'direct_setup') {
+      expect(result.channelHint).toBe('voice');
+      expect(result.rewrittenContent).toContain('voice channel');
+    }
+  });
+
+  test('detects Telegram channel hint', () => {
+    const result = resolveGuardianVerificationIntent('verify my Telegram account');
+    expect(result.kind).toBe('direct_setup');
+    if (result.kind === 'direct_setup') {
+      expect(result.channelHint).toBe('telegram');
+      expect(result.rewrittenContent).toContain('telegram channel');
+    }
+  });
+
+  test('no channel hint when unspecified', () => {
+    const result = resolveGuardianVerificationIntent('verify me as guardian');
+    expect(result.kind).toBe('direct_setup');
+    if (result.kind === 'direct_setup') {
+      expect(result.channelHint).toBeUndefined();
+    }
+  });
+});

--- a/assistant/src/daemon/guardian-verification-intent.ts
+++ b/assistant/src/daemon/guardian-verification-intent.ts
@@ -1,0 +1,121 @@
+// Guardian verification intent resolution for deterministic first-turn routing.
+// Exports `resolveGuardianVerificationIntent` as the single public entry point.
+// When a direct guardian setup request is detected, the session pipeline
+// rewrites the message to force immediate entry into the guardian-verify-setup
+// skill flow, bypassing the normal agent loop's tendency to produce conceptual
+// preambles before loading the skill.
+
+export type GuardianVerificationIntentResult =
+  | { kind: 'none' }
+  | { kind: 'direct_setup'; rewrittenContent: string; channelHint?: 'sms' | 'voice' | 'telegram' };
+
+// ── Direct setup patterns ────────────────────────────────────────────────
+// These capture imperative requests to start guardian verification.
+
+const DIRECT_SETUP_PATTERNS: RegExp[] = [
+  /\b(?:help\s+me\s+)?(?:confirm|verify)\s+(?:me|myself)\s+as\s+(?:your\s+|the\s+)?guardian\b/i,
+  /\b(?:set|add)\s+(?:me|myself)\s+(?:up\s+)?as\s+(?:your\s+|the\s+)?guardian\b/i,
+  /\bverify\s+(?:me\s+as\s+)?guardian\b/i,
+  /\bset\s+(?:me\s+as\s+)?guardian\b/i,
+  /\bguardian\s+verif(?:y|ication)\s*(?:setup|set\s*up)?\b/i,
+  /\bset\s*up\s+guardian\s+verif(?:y|ication)\b/i,
+  /\bverify\s+(?:my\s+)?(?:phone\s+(?:number)?|telegram(?:\s+account)?|voice\s+channel)\b/i,
+  /\b(?:help\s+me\s+)?set\s+(?:myself\s+)?(?:up\s+)?as\s+(?:your\s+)?guardian\s+(?:for|via|by|over|on|through)\s+/i,
+  /\bguardian\s+(?:for|via|by|over|on|through)\s+(?:sms|text|phone|voice|telegram|call)\b/i,
+  /\bbecome\s+(?:your\s+|the\s+)?guardian\b/i,
+  /\bregister\s+(?:me\s+)?as\s+(?:your\s+|the\s+)?guardian\b/i,
+];
+
+// ── Conceptual / security question patterns ──────────────────────────────
+// These indicate the user is asking *about* guardian verification
+// rather than requesting to start it. Return passthrough for these.
+
+const CONCEPTUAL_PATTERNS: RegExp[] = [
+  /^\s*(how|what|why|when|where|who|which)\b/i,
+  /\bwhat\s+is\s+(?:a\s+)?guardian\b/i,
+  /\bwhy\s+can'?t\s+(?:you|i)\b/i,
+  /\bhow\s+does\s+(?:guardian|verification)\s+work\b/i,
+  /\bexplain\s+(?:the\s+)?(?:guardian|verification)\b/i,
+  /\btell\s+me\s+about\s+(?:guardian|verification)\b/i,
+  /\bis\s+(?:there\s+)?(?:a\s+way|any\s+way)\s+to\b/i,
+  /\bcan\s+(?:you\s+)?(?:tell|explain|describe)\b/i,
+];
+
+// ── Channel hint extraction ──────────────────────────────────────────────
+
+const CHANNEL_HINT_PATTERNS: Array<{ pattern: RegExp; channel: 'sms' | 'voice' | 'telegram' }> = [
+  { pattern: /\b(?:sms|text\s*(?:message)?)\b/i, channel: 'sms' },
+  { pattern: /\b(?:voice|call|phone\s*call|by\s+phone)\b/i, channel: 'voice' },
+  { pattern: /\btelegram\b/i, channel: 'telegram' },
+];
+
+/** Common polite/filler words stripped before checking intent-only status. */
+const FILLER_PATTERN =
+  /\b(please|pls|plz|can\s+you|could\s+you|would\s+you|now|right\s+now|thanks|thank\s+you|thx|ty|for\s+me|ok(ay)?|hey|hi|hello|just|i\s+want\s+to|i'd\s+like\s+to|i\s+need\s+to|let's|let\s+me)\b/gi;
+
+// ── Internal helpers ─────────────────────────────────────────────────────
+
+function isConceptualQuestion(text: string): boolean {
+  const cleaned = text.replace(/^\s*(hey|hi|hello|please|pls|plz)[,\s]+/i, '');
+  return CONCEPTUAL_PATTERNS.some((p) => p.test(cleaned));
+}
+
+function isDirectSetupIntent(text: string): boolean {
+  return DIRECT_SETUP_PATTERNS.some((p) => p.test(text));
+}
+
+function extractChannelHint(text: string): 'sms' | 'voice' | 'telegram' | undefined {
+  for (const { pattern, channel } of CHANNEL_HINT_PATTERNS) {
+    if (pattern.test(text)) return channel;
+  }
+  return undefined;
+}
+
+// ── Structured intent resolver ───────────────────────────────────────────
+
+/**
+ * Resolves guardian verification intent from user text.
+ *
+ * Pipeline:
+ * 1. Skip slash commands entirely
+ * 2. Conceptual question gate -- questions return `none`
+ * 3. Detect direct setup patterns
+ * 4. On match, build a deterministic model instruction to load guardian-verify-setup
+ */
+export function resolveGuardianVerificationIntent(text: string): GuardianVerificationIntentResult {
+  const trimmed = text.trim();
+
+  // Never intercept slash commands
+  if (trimmed.startsWith('/')) {
+    return { kind: 'none' };
+  }
+
+  // Conceptual questions pass through to normal agent processing
+  if (isConceptualQuestion(trimmed)) {
+    return { kind: 'none' };
+  }
+
+  // Strip fillers for pattern matching but keep original for context
+  const withoutFillers = trimmed.replace(FILLER_PATTERN, '').replace(/\s{2,}/g, ' ').trim();
+
+  if (!isDirectSetupIntent(trimmed) && !isDirectSetupIntent(withoutFillers)) {
+    return { kind: 'none' };
+  }
+
+  const channelHint = extractChannelHint(trimmed);
+
+  // Build the rewritten content that deterministically loads the skill
+  const lines = [
+    'The user wants to verify themselves as the trusted guardian.',
+    'Please invoke the "Guardian Verify Setup" skill (ID: guardian-verify-setup) immediately using skill_load.',
+  ];
+  if (channelHint) {
+    lines.push(`The user specified the ${channelHint} channel. Pass this context when starting the verification flow.`);
+  }
+
+  return {
+    kind: 'direct_setup',
+    rewrittenContent: lines.join('\n'),
+    channelHint,
+  };
+}

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -27,6 +27,7 @@ import type { ServerMessage, UserMessageAttachment } from './ipc-protocol.js';
 import type { MessageQueue } from './session-queue-manager.js';
 import type { QueueDrainReason } from './session-queue-manager.js';
 import type { GuardianRuntimeContext } from './session-runtime-assembly.js';
+import { resolveGuardianVerificationIntent } from './guardian-verification-intent.js';
 import { resolveSlash, type SlashContext } from './session-slash.js';
 import type { TraceEmitter } from './trace-emitter.js';
 
@@ -241,11 +242,21 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
     return;
   }
 
-  const resolvedContent = slashResult.content;
+  let resolvedContent = slashResult.content;
 
   // Preactivate skill tools when slash resolution identifies a known skill
   if (slashResult.kind === 'rewritten') {
     session.preactivatedSkillIds = [slashResult.skillId];
+  }
+
+  // Guardian verification intent interception for queued messages
+  if (slashResult.kind === 'passthrough') {
+    const guardianIntent = resolveGuardianVerificationIntent(resolvedContent);
+    if (guardianIntent.kind === 'direct_setup') {
+      log.info({ conversationId: session.conversationId, channelHint: guardianIntent.channelHint }, 'Guardian verification intent intercepted in queue — forcing skill flow');
+      resolvedContent = guardianIntent.rewrittenContent;
+      session.preactivatedSkillIds = ['guardian-verify-setup'];
+    }
   }
 
   // Try to persist and run the dequeued message. If persistUserMessage
@@ -443,11 +454,23 @@ export async function processMessage(
     return persisted.id;
   }
 
-  const resolvedContent = slashResult.content;
+  let resolvedContent = slashResult.content;
 
   // Preactivate skill tools when slash resolution identifies a known skill
   if (slashResult.kind === 'rewritten') {
     session.preactivatedSkillIds = [slashResult.skillId];
+  }
+
+  // Guardian verification intent interception — force direct guardian
+  // verification requests into the guardian-verify-setup skill flow on
+  // the first turn, avoiding conceptual preambles from the agent.
+  if (slashResult.kind === 'passthrough') {
+    const guardianIntent = resolveGuardianVerificationIntent(resolvedContent);
+    if (guardianIntent.kind === 'direct_setup') {
+      log.info({ conversationId: session.conversationId, channelHint: guardianIntent.channelHint }, 'Guardian verification intent intercepted — forcing skill flow');
+      resolvedContent = guardianIntent.rewrittenContent;
+      session.preactivatedSkillIds = ['guardian-verify-setup'];
+    }
   }
 
   let userMessageId: string;


### PR DESCRIPTION
## Summary
- Adds guardian-verification-intent.ts resolver module (similar to recording-intent.ts pattern)
- Integrates into session-process.ts to intercept direct guardian verification requests before agent loop
- On matched intent, rewrites message to load guardian-verify-setup skill immediately
- Adds regression tests for routing behavior

Part of #9606. Closes #9607.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
