### PR TITLE
M2: Voice Auto-Followup in Guardian Verify Skill

### DIFF
--- a/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
+++ b/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression tests for the guardian-verify-setup SKILL.md voice path.
+ *
+ * Ensures the voice verification flow includes proactive auto-check polling
+ * so the user never has to manually ask whether verification succeeded.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, test } from 'bun:test';
+
+const ASSISTANT_DIR = resolve(__dirname, '..', '..');
+const REPO_ROOT = resolve(ASSISTANT_DIR, '..');
+
+const EMBEDDED_SKILL = resolve(
+  ASSISTANT_DIR,
+  'src',
+  'config',
+  'vellum-skills',
+  'guardian-verify-setup',
+  'SKILL.md',
+);
+
+const TOPLEVEL_SKILL = resolve(
+  REPO_ROOT,
+  'skills',
+  'guardian-verify-setup',
+  'SKILL.md',
+);
+
+function loadSkill(path: string): string {
+  return readFileSync(path, 'utf-8');
+}
+
+describe('guardian-verify-setup SKILL.md — voice auto-followup regression', () => {
+  for (const [label, skillPath] of [
+    ['embedded', EMBEDDED_SKILL],
+    ['top-level', TOPLEVEL_SKILL],
+  ] as const) {
+    describe(`${label} copy`, () => {
+      const content = loadSkill(skillPath);
+
+      test('voice path contains Step 3a auto-check/poll section', () => {
+        expect(content).toContain('Step 3a: Voice Auto-Check');
+      });
+
+      test('voice auto-check polls the guardian status endpoint', () => {
+        expect(content).toContain(
+          '/v1/integrations/guardian/status?channel=voice',
+        );
+      });
+
+      test('voice auto-check specifies polling interval (~15 seconds)', () => {
+        expect(content).toMatch(/every\s+~?15\s+seconds/i);
+      });
+
+      test('voice auto-check specifies a 2-minute timeout', () => {
+        expect(content).toMatch(/up\s+to\s+2\s+minutes/i);
+      });
+
+      test('voice auto-check detects bound: true and confirms proactively', () => {
+        expect(content).toContain('bound: true');
+        expect(content).toMatch(/proactively\s+(confirm|inform|send|tell)/i);
+      });
+
+      test('voice auto-check handles timeout with resend/restart offer', () => {
+        expect(content).toMatch(/poll\s+times?\s+out/i);
+        expect(content).toMatch(/resend|restart|new\s+verification/i);
+      });
+
+      test('Step 3 voice success path instructs proceeding to auto-check', () => {
+        // The voice bullet in Step 3 "On success" must reference Step 3a
+        const step3SuccessMatch = content.match(
+          /### On success[\s\S]*?### Step 3a/,
+        );
+        expect(step3SuccessMatch).not.toBeNull();
+
+        const step3SuccessBlock = step3SuccessMatch![0];
+        // Voice entry must tell the assistant to proceed to Step 3a
+        expect(step3SuccessBlock).toContain('Step 3a: Voice Auto-Check');
+      });
+
+      test('Step 4 voice resend path instructs proceeding to auto-check', () => {
+        // The voice bullet in Step 4 must also reference Step 3a
+        const step4Match = content.match(
+          /## Step 4: Handle Resend[\s\S]*?## Step 5/,
+        );
+        expect(step4Match).not.toBeNull();
+
+        const step4Block = step4Match![0];
+        expect(step4Block).toContain('Step 3a: Voice Auto-Check');
+      });
+
+      test('voice path does NOT instruct waiting for user to ask "did it work?"', () => {
+        // The voice sections should never tell the assistant to passively wait
+        // for the user to report whether verification succeeded. Phrases like
+        // "Do NOT wait for the user to ask" are fine -- they are prohibitions.
+        // We only flag affirmative instructions to wait.
+        const voiceAutoCheckSection = content.match(
+          /### Step 3a: Voice Auto-Check[\s\S]*?### On error/,
+        );
+        expect(voiceAutoCheckSection).not.toBeNull();
+
+        const autoCheckBlock = voiceAutoCheckSection![0];
+
+        // Strip lines containing "do NOT wait" or "don't wait" (prohibitions
+        // are the desired behavior, not violations).
+        const withoutProhibitions = autoCheckBlock
+          .split('\n')
+          .filter(
+            (line) =>
+              !/do\s+not\s+wait/i.test(line) && !/don't\s+wait/i.test(line),
+          )
+          .join('\n');
+
+        // After removing prohibition lines, there should be no remaining
+        // instruction telling the assistant to wait for user confirmation.
+        expect(withoutProhibitions).not.toMatch(
+          /wait\s+for\s+(the\s+)?user\s+to\s+(ask|report|confirm|tell)/i,
+        );
+      });
+
+      test('SMS and Telegram paths are unchanged (no auto-check reference)', () => {
+        // SMS bullet in Step 3 success should NOT mention Step 3a
+        const smsLine = content.match(
+          /- \*\*SMS\*\*:.*?verification.*?SMS channel\."/,
+        );
+        expect(smsLine).not.toBeNull();
+        expect(smsLine![0]).not.toContain('Step 3a');
+
+        // Telegram bullet should NOT mention Step 3a
+        const telegramLine = content.match(
+          /- \*\*Telegram with chat ID\*\*.*?Step 3/,
+        );
+        expect(telegramLine).not.toBeNull();
+        // The only "Step 3" reference in the Telegram line should be
+        // "retry from Step 3", not "Step 3a"
+        expect(telegramLine![0]).not.toContain('Step 3a');
+      });
+    });
+  }
+});

--- a/assistant/src/config/vellum-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/guardian-verify-setup/SKILL.md
@@ -52,11 +52,42 @@ Replace `<channel>` with `sms`, `voice`, or `telegram`, and `<destination>` with
 Report the exact next action based on the channel:
 
 - **SMS**: "I've sent a 6-digit verification code to [number]. Reply with the code from that SMS conversation (not here) to complete verification — the code can only be consumed through the SMS channel."
-- **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/start` API call already initiates the voice call. Do NOT place a separate `call_start` call.
+- **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/start` API call already initiates the voice call. Do NOT place a separate `call_start` call. After delivering the code, immediately proceed to **Step 3a: Voice Auto-Check** — do NOT wait for the user to ask whether it worked.
 - **Telegram with chat ID** (no `telegramBootstrapUrl` in response): The response includes a `secret` field. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and send `/guardian_verify [secret]` (or just reply with the code) to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4).
 - **Telegram with handle** (`telegramBootstrapUrl` present in response): "Tap this deep-link first: [telegramBootstrapUrl]. After Telegram binds your identity, I'll send your verification code."
 
 After reporting the bootstrap URL for Telegram handle flows, wait for the user to confirm they clicked the link. Then check guardian status (Step 6) to see if the bootstrap completed and a code was sent.
+
+### Step 3a: Voice Auto-Check (voice channel only)
+
+After delivering the verification code and instructing the user to enter it via keypad, **proactively poll** for completion instead of waiting for the user to ask. This eliminates the need for the user to manually report whether verification succeeded.
+
+Poll `GET /v1/integrations/guardian/status?channel=voice` every ~15 seconds for up to 2 minutes (8 attempts):
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+ATTEMPTS=0
+MAX_ATTEMPTS=8
+while [ $ATTEMPTS -lt $MAX_ATTEMPTS ]; do
+  sleep 15
+  ATTEMPTS=$((ATTEMPTS + 1))
+  RESULT=$(curl -s http://localhost:7821/v1/integrations/guardian/status?channel=voice \
+    -H "Authorization: Bearer $TOKEN")
+  BOUND=$(echo "$RESULT" | grep -o '"bound":\s*true')
+  if [ -n "$BOUND" ]; then
+    echo "BOUND"
+    break
+  fi
+done
+if [ -z "$BOUND" ]; then
+  echo "TIMEOUT"
+fi
+```
+
+- **If `bound: true` is detected**: Proactively confirm success in the current chat: "Guardian verified! Your voice identity is now the trusted guardian." Do NOT wait for the user to ask.
+- **If the poll times out after 2 minutes without `bound: true`**: Proactively inform the user: "Verification is still pending — I waited 2 minutes but haven't seen the code confirmed yet. Would you like me to resend the code (I'll call again), or start a new verification session?" Then follow Step 4 (resend) or Step 3 (restart) based on the user's choice.
+
+This auto-check applies only to the voice channel. SMS and Telegram flows continue to rely on the user completing verification through the respective channel and then checking status via Step 6.
 
 ### On error (`success: false`)
 
@@ -86,7 +117,7 @@ curl -s -X POST http://localhost:7821/v1/integrations/guardian/outbound/resend \
 On success, report the next action based on the channel:
 
 - **SMS**: "I've sent a new verification code to [number]. Reply with the code from that SMS conversation to complete verification."
-- **Voice**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/resend` API call already initiates the voice call. Do NOT place a separate `call_start` call.
+- **Voice**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/resend` API call already initiates the voice call. Do NOT place a separate `call_start` call. After delivering the new code, immediately proceed to **Step 3a: Voice Auto-Check** — do NOT wait for the user to ask whether it worked.
 - **Telegram**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and send `/guardian_verify [secret]` (or just reply with the code) to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3.
 
 ### Resend errors

--- a/skills/guardian-verify-setup/SKILL.md
+++ b/skills/guardian-verify-setup/SKILL.md
@@ -52,11 +52,42 @@ Replace `<channel>` with `sms`, `voice`, or `telegram`, and `<destination>` with
 Report the exact next action based on the channel:
 
 - **SMS**: "I've sent a 6-digit verification code to [number]. Reply with the code from that SMS conversation (not here) to complete verification — the code can only be consumed through the SMS channel."
-- **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/start` API call already initiates the voice call. Do NOT place a separate `call_start` call.
+- **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/start` API call already initiates the voice call. Do NOT place a separate `call_start` call. After delivering the code, immediately proceed to **Step 3a: Voice Auto-Check** — do NOT wait for the user to ask whether it worked.
 - **Telegram with chat ID** (no `telegramBootstrapUrl` in response): The response includes a `secret` field. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and send `/guardian_verify [secret]` (or just reply with the code) to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4).
 - **Telegram with handle** (`telegramBootstrapUrl` present in response): "Tap this deep-link first: [telegramBootstrapUrl]. After Telegram binds your identity, I'll send your verification code."
 
 After reporting the bootstrap URL for Telegram handle flows, wait for the user to confirm they clicked the link. Then check guardian status (Step 6) to see if the bootstrap completed and a code was sent.
+
+### Step 3a: Voice Auto-Check (voice channel only)
+
+After delivering the verification code and instructing the user to enter it via keypad, **proactively poll** for completion instead of waiting for the user to ask. This eliminates the need for the user to manually report whether verification succeeded.
+
+Poll `GET /v1/integrations/guardian/status?channel=voice` every ~15 seconds for up to 2 minutes (8 attempts):
+
+```bash
+TOKEN=$(cat ~/.vellum/http-token)
+ATTEMPTS=0
+MAX_ATTEMPTS=8
+while [ $ATTEMPTS -lt $MAX_ATTEMPTS ]; do
+  sleep 15
+  ATTEMPTS=$((ATTEMPTS + 1))
+  RESULT=$(curl -s http://localhost:7821/v1/integrations/guardian/status?channel=voice \
+    -H "Authorization: Bearer $TOKEN")
+  BOUND=$(echo "$RESULT" | grep -o '"bound":\s*true')
+  if [ -n "$BOUND" ]; then
+    echo "BOUND"
+    break
+  fi
+done
+if [ -z "$BOUND" ]; then
+  echo "TIMEOUT"
+fi
+```
+
+- **If `bound: true` is detected**: Proactively confirm success in the current chat: "Guardian verified! Your voice identity is now the trusted guardian." Do NOT wait for the user to ask.
+- **If the poll times out after 2 minutes without `bound: true`**: Proactively inform the user: "Verification is still pending — I waited 2 minutes but haven't seen the code confirmed yet. Would you like me to resend the code (I'll call again), or start a new verification session?" Then follow Step 4 (resend) or Step 3 (restart) based on the user's choice.
+
+This auto-check applies only to the voice channel. SMS and Telegram flows continue to rely on the user completing verification through the respective channel and then checking status via Step 6.
 
 ### On error (`success: false`)
 
@@ -86,7 +117,7 @@ curl -s -X POST http://localhost:7821/v1/integrations/guardian/outbound/resend \
 On success, report the next action based on the channel:
 
 - **SMS**: "I've sent a new verification code to [number]. Reply with the code from that SMS conversation to complete verification."
-- **Voice**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/resend` API call already initiates the voice call. Do NOT place a separate `call_start` call.
+- **Voice**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/resend` API call already initiates the voice call. Do NOT place a separate `call_start` call. After delivering the new code, immediately proceed to **Step 3a: Voice Auto-Check** — do NOT wait for the user to ask whether it worked.
 - **Telegram**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and send `/guardian_verify [secret]` (or just reply with the code) to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3.
 
 ### Resend errors


### PR DESCRIPTION
Updates guardian-verify-setup SKILL.md to add proactive voice verification polling. After providing the code and instructing keypad entry, the assistant auto-checks status every 15s for up to 2 minutes and confirms success or offers retry. Mirrored to both skill locations. Part of #9606.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
