### PR TITLE
Use user timezone for temporal context; keep daemon host clock authoritative

### DIFF
--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -387,8 +387,8 @@ graph TB
 ### Key design decisions
 
 - **Fresh each turn**: `buildTemporalContext()` is called at the start of every agent loop invocation, ensuring the model always sees the current date even in long-running conversations.
-- **Clock source invariant**: Absolute time (`now`) always comes from the daemon host clock (`Date.now()`), never from channel/client clocks.
-- **Timezone precedence**: If dynamic profile memory contains a valid user timezone, temporal context uses it for local-date interpretation. Otherwise it falls back to daemon host timezone.
+- **Clock source invariant**: Absolute time (`now`) always comes from the assistant host clock (`Date.now()`), never from channel/client clocks.
+- **Timezone precedence**: If `ui.userTimezone` is configured, temporal context uses it for local-date interpretation. Otherwise it falls back to dynamic profile memory, then assistant host timezone.
 - **Timezone-aware**: Uses `Intl.DateTimeFormat` APIs for DST-safe date arithmetic and timezone validation/canonicalization.
 - **Bounded output**: Hard-capped at 1500 characters and 14 horizon entries to prevent prompt bloat.
 - **Runtime-only**: The injected `<temporal_context>` block is stripped from `this.messages` after the agent loop completes via `stripTemporalContext`. It never persists in conversation history.

--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -366,14 +366,14 @@ The Anthropic provider places `cache_control: { type: 'ephemeral' }` on the **la
 
 ## Temporal Context Injection — Date Grounding
 
-The session injects a `<temporal_context>` block into every user message at runtime, giving the model awareness of the current date, timezone, upcoming weekend/work week windows, and a 14-day horizon of labelled future dates. This enables reliable reasoning about future dates (e.g. "plan a trip for next weekend") without persisting volatile temporal data in conversation history.
+The session injects a `<temporal_context>` block into every user message at runtime, giving the model awareness of the current date, current local time, current UTC time, timezone source metadata, upcoming weekend/work week windows, and a 14-day horizon of labelled future dates. This enables reliable reasoning about future dates (e.g. "plan a trip for next weekend") without persisting volatile temporal data in conversation history.
 
 ### Per-turn flow
 
 ```mermaid
 graph TB
     subgraph "Per-Turn Flow"
-        BUILD["buildTemporalContext(timeZone)<br/>→ compact XML block"]
+        BUILD["buildTemporalContext(timeZone, hostTimeZone, userTimeZone)<br/>→ compact XML block"]
         INJECT["applyRuntimeInjections<br/>prepend temporal block<br/>to user message"]
         AGENT["AgentLoop.run(runMessages)"]
         STRIP["stripTemporalContext<br/>remove block from persisted history"]
@@ -387,7 +387,9 @@ graph TB
 ### Key design decisions
 
 - **Fresh each turn**: `buildTemporalContext()` is called at the start of every agent loop invocation, ensuring the model always sees the current date even in long-running conversations.
-- **Timezone-aware**: Uses `Intl.DateTimeFormat` APIs for DST-safe date arithmetic. The host timezone (`Intl.DateTimeFormat().resolvedOptions().timeZone`) is used by default.
+- **Clock source invariant**: Absolute time (`now`) always comes from the daemon host clock (`Date.now()`), never from channel/client clocks.
+- **Timezone precedence**: If dynamic profile memory contains a valid user timezone, temporal context uses it for local-date interpretation. Otherwise it falls back to daemon host timezone.
+- **Timezone-aware**: Uses `Intl.DateTimeFormat` APIs for DST-safe date arithmetic and timezone validation/canonicalization.
 - **Bounded output**: Hard-capped at 1500 characters and 14 horizon entries to prevent prompt bloat.
 - **Runtime-only**: The injected `<temporal_context>` block is stripped from `this.messages` after the agent loop completes via `stripTemporalContext`. It never persists in conversation history.
 - **Specific strip prefix**: The strip function matches the exact injected prefix (`<temporal_context>\nToday:`) to avoid accidentally removing user-authored text that starts with `<temporal_context>`.
@@ -512,4 +514,3 @@ graph TB
 | `assistant/src/config/schema.ts` | `WorkspaceGitConfigSchema`: timeout, backoff, and enrichment queue configuration |
 
 ---
-

--- a/assistant/src/__tests__/date-context.test.ts
+++ b/assistant/src/__tests__/date-context.test.ts
@@ -105,6 +105,18 @@ describe('buildTemporalContext', () => {
     expect(result).toContain('Timezone source: daemon_host_fallback');
   });
 
+  test('accepts UTC/GMT offset-style user timezone values', () => {
+    const result = buildTemporalContext({
+      nowMs: WED_FEB_18,
+      hostTimeZone: 'UTC',
+      userTimeZone: 'UTC+2',
+    });
+    expect(result).toContain('Timezone: Etc/GMT-2');
+    expect(result).toContain('Current local time: 2026-02-18T14:00:00+02:00');
+    expect(result).toContain('User timezone: Etc/GMT-2');
+    expect(result).toContain('Timezone source: user_profile_memory');
+  });
+
   test('includes week definitions', () => {
     const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'UTC' });
     expect(result).toContain('work week = Monday–Friday');
@@ -145,6 +157,24 @@ describe('extractUserTimeZoneFromDynamicProfile', () => {
       '</dynamic-user-profile>',
     ].join('\n');
     expect(extractUserTimeZoneFromDynamicProfile(profile)).toBeNull();
+  });
+
+  test('extracts UTC/GMT offset tokens from explicit timezone profile line', () => {
+    const profile = [
+      '<dynamic-user-profile>',
+      '- timezone: UTC+2',
+      '</dynamic-user-profile>',
+    ].join('\n');
+    expect(extractUserTimeZoneFromDynamicProfile(profile)).toBe('Etc/GMT-2');
+  });
+
+  test('extracts GMT negative offset tokens from generic profile text', () => {
+    const profile = [
+      '<dynamic-user-profile>',
+      '- preferences: schedule notifications in GMT-5 whenever possible.',
+      '</dynamic-user-profile>',
+    ].join('\n');
+    expect(extractUserTimeZoneFromDynamicProfile(profile)).toBe('Etc/GMT+5');
   });
 });
 

--- a/assistant/src/__tests__/date-context.test.ts
+++ b/assistant/src/__tests__/date-context.test.ts
@@ -68,6 +68,32 @@ describe('buildTemporalContext', () => {
     expect(result).toContain('Timezone source: user_profile_memory');
   });
 
+  test('uses configured user timezone when profile timezone is unavailable', () => {
+    const result = buildTemporalContext({
+      nowMs: WED_FEB_18,
+      hostTimeZone: 'UTC',
+      configuredUserTimeZone: 'America/Chicago',
+      userTimeZone: null,
+    });
+    expect(result).toContain('Timezone: America/Chicago');
+    expect(result).toContain('Current local time: 2026-02-18T06:00:00-06:00');
+    expect(result).toContain('User timezone: America/Chicago');
+    expect(result).toContain('Timezone source: user_settings');
+  });
+
+  test('configured user timezone takes precedence over profile timezone', () => {
+    const result = buildTemporalContext({
+      nowMs: WED_FEB_18,
+      hostTimeZone: 'UTC',
+      configuredUserTimeZone: 'America/Los_Angeles',
+      userTimeZone: 'America/New_York',
+    });
+    expect(result).toContain('Timezone: America/Los_Angeles');
+    expect(result).toContain('Current local time: 2026-02-18T04:00:00-08:00');
+    expect(result).toContain('User timezone: America/Los_Angeles');
+    expect(result).toContain('Timezone source: user_settings');
+  });
+
   test('falls back to host timezone when user timezone is unavailable', () => {
     const result = buildTemporalContext({
       nowMs: WED_FEB_18,
@@ -83,6 +109,13 @@ describe('buildTemporalContext', () => {
     const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'UTC' });
     expect(result).toContain('work week = Monday–Friday');
     expect(result).toContain('weekend = Saturday–Sunday');
+  });
+
+  test('formats midnight hours as 00 (never 24) in local ISO output', () => {
+    const justAfterMidnight = Date.UTC(2026, 1, 19, 0, 5, 0);
+    const result = buildTemporalContext({ nowMs: justAfterMidnight, timeZone: 'UTC' });
+    expect(result).toContain('Current local time: 2026-02-19T00:05:00+00:00');
+    expect(result).not.toContain('T24:05:00');
   });
 });
 

--- a/assistant/src/__tests__/date-context.test.ts
+++ b/assistant/src/__tests__/date-context.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect,test } from 'bun:test';
 
-import { buildTemporalContext } from '../daemon/date-context.js';
+import { buildTemporalContext, extractUserTimeZoneFromDynamicProfile } from '../daemon/date-context.js';
 
 // Fixed timestamps for deterministic assertions (all UTC midday to avoid DST edge cases).
 
@@ -40,10 +40,78 @@ describe('buildTemporalContext', () => {
     expect(result).toContain('Timezone: America/New_York');
   });
 
+  test('includes current local time as ISO 8601 with offset', () => {
+    const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'UTC' });
+    expect(result).toContain('Current local time: 2026-02-18T12:00:00+00:00');
+  });
+
+  test('includes current UTC time from daemon host clock', () => {
+    const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'UTC' });
+    expect(result).toContain('Current UTC time: 2026-02-18T12:00:00.000Z');
+  });
+
+  test('documents daemon host as the authoritative clock source', () => {
+    const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'UTC' });
+    expect(result).toContain('Clock source: daemon host machine');
+  });
+
+  test('uses user timezone when provided and records source metadata', () => {
+    const result = buildTemporalContext({
+      nowMs: WED_FEB_18,
+      hostTimeZone: 'UTC',
+      userTimeZone: 'America/New_York',
+    });
+    expect(result).toContain('Timezone: America/New_York');
+    expect(result).toContain('Current local time: 2026-02-18T07:00:00-05:00');
+    expect(result).toContain('Daemon host timezone: UTC');
+    expect(result).toContain('User timezone: America/New_York');
+    expect(result).toContain('Timezone source: user_profile_memory');
+  });
+
+  test('falls back to host timezone when user timezone is unavailable', () => {
+    const result = buildTemporalContext({
+      nowMs: WED_FEB_18,
+      hostTimeZone: 'UTC',
+      userTimeZone: null,
+    });
+    expect(result).toContain('Timezone: UTC');
+    expect(result).toContain('User timezone: unknown');
+    expect(result).toContain('Timezone source: daemon_host_fallback');
+  });
+
   test('includes week definitions', () => {
     const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'UTC' });
     expect(result).toContain('work week = Monday–Friday');
     expect(result).toContain('weekend = Saturday–Sunday');
+  });
+});
+
+describe('extractUserTimeZoneFromDynamicProfile', () => {
+  test('extracts canonical timezone from explicit timezone profile line', () => {
+    const profile = [
+      '<dynamic-user-profile>',
+      '- timezone: Timezone is America/New_York.',
+      '</dynamic-user-profile>',
+    ].join('\n');
+    expect(extractUserTimeZoneFromDynamicProfile(profile)).toBe('America/New_York');
+  });
+
+  test('extracts timezone token from generic profile text when explicit line is absent', () => {
+    const profile = [
+      '<dynamic-user-profile>',
+      '- location: Travels often between Europe and Asia (currently Europe/Paris).',
+      '</dynamic-user-profile>',
+    ].join('\n');
+    expect(extractUserTimeZoneFromDynamicProfile(profile)).toBe('Europe/Paris');
+  });
+
+  test('returns null when no valid timezone is present', () => {
+    const profile = [
+      '<dynamic-user-profile>',
+      '- timezone: Pacific time',
+      '</dynamic-user-profile>',
+    ].join('\n');
+    expect(extractUserTimeZoneFromDynamicProfile(profile)).toBeNull();
   });
 });
 
@@ -186,6 +254,7 @@ describe('DST-safe timezone behavior', () => {
     // Feb 18 12:00 UTC = Feb 18 07:00 EST (same calendar date)
     const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'America/New_York' });
     expect(result).toContain('Today: 2026-02-18 (Wednesday)');
+    expect(result).toContain('Current local time: 2026-02-18T07:00:00-05:00');
   });
 
   test('date labels are correct in timezone ahead of UTC', () => {
@@ -233,6 +302,13 @@ describe('DST-safe timezone behavior', () => {
     expect(result).toContain('2026-02-20 Friday');
     expect(result).toContain('2026-02-21 Saturday');
     expect(result).toContain('2026-02-22 Sunday');
+  });
+
+  test('local offset tracks daylight saving changes', () => {
+    // Jul 1 12:00 UTC = Jul 1 08:00 EDT
+    const summer = Date.UTC(2026, 6, 1, 12, 0, 0);
+    const result = buildTemporalContext({ nowMs: summer, timeZone: 'America/New_York' });
+    expect(result).toContain('Current local time: 2026-07-01T08:00:00-04:00');
   });
 });
 

--- a/assistant/src/__tests__/date-context.test.ts
+++ b/assistant/src/__tests__/date-context.test.ts
@@ -45,14 +45,14 @@ describe('buildTemporalContext', () => {
     expect(result).toContain('Current local time: 2026-02-18T12:00:00+00:00');
   });
 
-  test('includes current UTC time from daemon host clock', () => {
+  test('includes current UTC time from assistant host clock', () => {
     const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'UTC' });
     expect(result).toContain('Current UTC time: 2026-02-18T12:00:00.000Z');
   });
 
-  test('documents daemon host as the authoritative clock source', () => {
+  test('documents assistant host as the authoritative clock source', () => {
     const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: 'UTC' });
-    expect(result).toContain('Clock source: daemon host machine');
+    expect(result).toContain('Clock source: assistant host machine');
   });
 
   test('uses user timezone when provided and records source metadata', () => {
@@ -63,7 +63,7 @@ describe('buildTemporalContext', () => {
     });
     expect(result).toContain('Timezone: America/New_York');
     expect(result).toContain('Current local time: 2026-02-18T07:00:00-05:00');
-    expect(result).toContain('Daemon host timezone: UTC');
+    expect(result).toContain('Assistant host timezone: UTC');
     expect(result).toContain('User timezone: America/New_York');
     expect(result).toContain('Timezone source: user_profile_memory');
   });
@@ -102,7 +102,7 @@ describe('buildTemporalContext', () => {
     });
     expect(result).toContain('Timezone: UTC');
     expect(result).toContain('User timezone: unknown');
-    expect(result).toContain('Timezone source: daemon_host_fallback');
+    expect(result).toContain('Timezone source: assistant_host_fallback');
   });
 
   test('accepts UTC/GMT offset-style user timezone values', () => {
@@ -114,6 +114,18 @@ describe('buildTemporalContext', () => {
     expect(result).toContain('Timezone: Etc/GMT-2');
     expect(result).toContain('Current local time: 2026-02-18T14:00:00+02:00');
     expect(result).toContain('User timezone: Etc/GMT-2');
+    expect(result).toContain('Timezone source: user_profile_memory');
+  });
+
+  test('accepts fractional UTC/GMT offset-style user timezone values', () => {
+    const result = buildTemporalContext({
+      nowMs: WED_FEB_18,
+      hostTimeZone: 'UTC',
+      userTimeZone: 'UTC+5:30',
+    });
+    expect(result).toContain('Timezone: +05:30');
+    expect(result).toContain('Current local time: 2026-02-18T17:30:00+05:30');
+    expect(result).toContain('User timezone: +05:30');
     expect(result).toContain('Timezone source: user_profile_memory');
   });
 
@@ -175,6 +187,24 @@ describe('extractUserTimeZoneFromDynamicProfile', () => {
       '</dynamic-user-profile>',
     ].join('\n');
     expect(extractUserTimeZoneFromDynamicProfile(profile)).toBe('Etc/GMT+5');
+  });
+
+  test('extracts fractional UTC offset tokens from explicit timezone profile line', () => {
+    const profile = [
+      '<dynamic-user-profile>',
+      '- timezone: UTC+5:30',
+      '</dynamic-user-profile>',
+    ].join('\n');
+    expect(extractUserTimeZoneFromDynamicProfile(profile)).toBe('+05:30');
+  });
+
+  test('extracts fractional GMT offset tokens from generic profile text', () => {
+    const profile = [
+      '<dynamic-user-profile>',
+      '- preferences: default reminders to GMT+5:45.',
+      '</dynamic-user-profile>',
+    ].join('\n');
+    expect(extractUserTimeZoneFromDynamicProfile(profile)).toBe('+05:45');
   });
 });
 

--- a/assistant/src/__tests__/date-context.test.ts
+++ b/assistant/src/__tests__/date-context.test.ts
@@ -206,6 +206,15 @@ describe('extractUserTimeZoneFromDynamicProfile', () => {
     ].join('\n');
     expect(extractUserTimeZoneFromDynamicProfile(profile)).toBe('+05:45');
   });
+
+  test('prefers IANA timezone tokens over UTC/GMT offsets in the same profile line', () => {
+    const profile = [
+      '<dynamic-user-profile>',
+      '- timezone: UTC+1 (Europe/Paris)',
+      '</dynamic-user-profile>',
+    ].join('\n');
+    expect(extractUserTimeZoneFromDynamicProfile(profile)).toBe('Europe/Paris');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/session-agent-loop.test.ts
+++ b/assistant/src/__tests__/session-agent-loop.test.ts
@@ -30,6 +30,7 @@ mock.module('../config/loader.js', () => ({
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     apiKeys: {},
     workspaceGit: { turnCommitMaxWaitMs: 10 },
+    ui: {},
   }),
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},

--- a/assistant/src/config/bundled-skills/time-based-actions/SKILL.md
+++ b/assistant/src/config/bundled-skills/time-based-actions/SKILL.md
@@ -37,10 +37,19 @@ If you use `send_notification` for any of these, the notification fires immediat
 
 `task_list_add` creates a work queue item. It does **NOT** fire at a specific time. NEVER use it as a workaround for delayed notifications. If the user wants a timed alert, use `reminder_create`.
 
+## Time Grounding Source
+
+Use the injected `<temporal_context>` block as the authoritative clock source:
+- `Current UTC time` is the canonical current instant (from daemon host clock).
+- `Current local time` + `Timezone` are the active local-calendar interpretation.
+- `User timezone` + `Timezone source` tell you whether local-time interpretation is user-specific or host fallback.
+
+When `User timezone: unknown` and the request is locale-specific (e.g. "at 3pm", "tomorrow morning", "tonight"), ask once for their timezone and then proceed.
+
 ## Relative Time Parsing
 
 When the user says "in X minutes/hours", compute the ISO 8601 timestamp yourself:
-- Take the current time
+- Take `Current UTC time` (or `Current local time` in the active `Timezone`)
 - Add the offset
 - Format as ISO 8601 with timezone: `2025-03-15T09:05:00-05:00`
 - Pass to `reminder_create` as `fire_at`

--- a/assistant/src/config/bundled-skills/time-based-actions/SKILL.md
+++ b/assistant/src/config/bundled-skills/time-based-actions/SKILL.md
@@ -45,6 +45,7 @@ Use the injected `<temporal_context>` block as the authoritative clock source:
 - `User timezone` + `Timezone source` tell you whether local-time interpretation is user-specific or host fallback.
 
 When `User timezone: unknown` and the request is locale-specific (e.g. "at 3pm", "tomorrow morning", "tonight"), ask once for their timezone and then proceed.
+If the user confirms a timezone, suggest saving it in Settings -> Appearance -> User timezone so future reminders resolve correctly without re-asking.
 
 ## Relative Time Parsing
 

--- a/assistant/src/config/bundled-skills/time-based-actions/SKILL.md
+++ b/assistant/src/config/bundled-skills/time-based-actions/SKILL.md
@@ -40,7 +40,7 @@ If you use `send_notification` for any of these, the notification fires immediat
 ## Time Grounding Source
 
 Use the injected `<temporal_context>` block as the authoritative clock source:
-- `Current UTC time` is the canonical current instant (from daemon host clock).
+- `Current UTC time` is the canonical current instant (from assistant host clock).
 - `Current local time` + `Timezone` are the active local-calendar interpretation.
 - `User timezone` + `Timezone source` tell you whether local-time interpretation is user-specific or host fallback.
 

--- a/assistant/src/config/core-schema.ts
+++ b/assistant/src/config/core-schema.ts
@@ -285,6 +285,12 @@ export const DaemonConfigSchema = z.object({
     .default(true),
 });
 
+export const UiConfigSchema = z.object({
+  userTimezone: z
+    .string({ error: 'ui.userTimezone must be a string' })
+    .optional(),
+});
+
 export type TimeoutConfig = z.infer<typeof TimeoutConfigSchema>;
 export type RateLimitConfig = z.infer<typeof RateLimitConfigSchema>;
 export type SecretDetectionConfig = z.infer<typeof SecretDetectionConfigSchema>;
@@ -299,3 +305,4 @@ export type IngressWebhookConfig = z.infer<typeof IngressWebhookConfigSchema>;
 export type IngressRateLimitConfig = z.infer<typeof IngressRateLimitConfigSchema>;
 export type DaemonConfig = z.infer<typeof DaemonConfigSchema>;
 export type IngressConfig = z.infer<typeof IngressConfigSchema>;
+export type UiConfig = z.infer<typeof UiConfigSchema>;

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -48,6 +48,7 @@ export type {
   SmsConfig,
   ThinkingConfig,
   TimeoutConfig,
+  UiConfig,
 } from './core-schema.js';
 export {
   AuditLogConfigSchema,
@@ -65,6 +66,7 @@ export {
   SmsConfigSchema,
   ThinkingConfigSchema,
   TimeoutConfigSchema,
+  UiConfigSchema,
 } from './core-schema.js';
 export type {
   MemoryCleanupConfig,
@@ -144,6 +146,7 @@ import {
   SmsConfigSchema,
   ThinkingConfigSchema,
   TimeoutConfigSchema,
+  UiConfigSchema,
 } from './core-schema.js';
 import { MemoryConfigSchema } from './memory-schema.js';
 import { NotificationsConfigSchema } from './notifications-schema.js';
@@ -214,6 +217,7 @@ export const AssistantConfigSchema = z.object({
   platform: PlatformConfigSchema.default({} as any),
   daemon: DaemonConfigSchema.default({} as any),
   notifications: NotificationsConfigSchema.default({} as any),
+  ui: UiConfigSchema.default({} as any),
 }).superRefine((config, ctx) => {
   if (config.contextWindow?.targetInputTokens != null && config.contextWindow?.maxInputTokens != null &&
       config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -40,5 +40,6 @@ export type {
   SwarmConfig,
   ThinkingConfig,
   TimeoutConfig,
+  UiConfig,
   WorkspaceGitConfig,
 } from './schema.js';

--- a/assistant/src/daemon/date-context.ts
+++ b/assistant/src/daemon/date-context.ts
@@ -11,6 +11,10 @@ export interface TemporalContextOptions {
   nowMs?: number;
   /** IANA timezone (e.g. "America/New_York"). Defaults to host timezone. */
   timeZone?: string;
+  /** IANA timezone for the daemon host clock (defaults to process local timezone). */
+  hostTimeZone?: string;
+  /** IANA timezone inferred from user profile/memory (if available). */
+  userTimeZone?: string | null;
   /** Number of future days to list (default 14, hard-capped at 14). */
   horizonDays?: number;
 }
@@ -19,6 +23,62 @@ const MAX_OUTPUT_CHARS = 1500;
 const MAX_HORIZON_ENTRIES = 14;
 
 const WEEKDAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'] as const;
+const TIMEZONE_SUBJECT_LINE_RE = /^\s*-\s*time\s*zone\s*:\s*(.+)$/i;
+const TIMEZONE_SUBJECT_COMPACT_RE = /^\s*-\s*timezone\s*:\s*(.+)$/i;
+const TIMEZONE_TOKEN_RE = /\b(?:[A-Za-z][A-Za-z0-9_+-]*(?:\/[A-Za-z0-9_+-]+)+|UTC|GMT)\b/g;
+
+function normalizeOffsetToken(offsetToken: string): string {
+  if (offsetToken === 'GMT' || offsetToken === 'UTC') {
+    return '+00:00';
+  }
+  const match = /^(?:GMT|UTC)([+-])(\d{1,2})(?::?(\d{2}))?$/i.exec(offsetToken);
+  if (!match) {
+    return '+00:00';
+  }
+  const [, sign, hours, minutes] = match;
+  return `${sign}${hours.padStart(2, '0')}:${(minutes ?? '00').padStart(2, '0')}`;
+}
+
+function canonicalizeTimeZone(timeZone: string): string | null {
+  try {
+    return new Intl.DateTimeFormat('en-US', { timeZone }).resolvedOptions().timeZone;
+  } catch {
+    return null;
+  }
+}
+
+function extractTimeZoneCandidates(text: string): string[] {
+  const matches = text.match(TIMEZONE_TOKEN_RE) ?? [];
+  return matches.map((token) => token.trim()).filter((token) => token.length > 0);
+}
+
+/**
+ * Extract a valid user timezone from compiled `<dynamic-user-profile>` text.
+ *
+ * Prefers explicit `timezone:` profile lines, then falls back to scanning the
+ * full profile body for valid IANA timezone identifiers.
+ */
+export function extractUserTimeZoneFromDynamicProfile(profileText: string): string | null {
+  const trimmed = profileText.trim();
+  if (trimmed.length === 0) return null;
+
+  const candidateTexts: string[] = [];
+  for (const line of trimmed.split('\n')) {
+    const match = line.match(TIMEZONE_SUBJECT_LINE_RE) ?? line.match(TIMEZONE_SUBJECT_COMPACT_RE);
+    if (match) {
+      candidateTexts.push(match[1]);
+    }
+  }
+  candidateTexts.push(trimmed);
+
+  for (const text of candidateTexts) {
+    for (const token of extractTimeZoneCandidates(text)) {
+      const canonical = canonicalizeTimeZone(token);
+      if (canonical) return canonical;
+    }
+  }
+  return null;
+}
 
 /**
  * Get the local date parts for a given instant in the specified timezone.
@@ -53,6 +113,33 @@ function formatLocalDate(date: Date, timeZone: string): string {
 }
 
 /**
+ * Format a Date as local ISO 8601 with timezone offset in the given timezone.
+ */
+function formatLocalIsoWithOffset(date: Date, timeZone: string): string {
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+    timeZoneName: 'shortOffset',
+  });
+  const parts = fmt.formatToParts(date);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? '';
+  const offset = normalizeOffsetToken(get('timeZoneName'));
+  const year = get('year');
+  const month = get('month');
+  const day = get('day');
+  const hour = get('hour');
+  const minute = get('minute');
+  const second = get('second');
+  return `${year}-${month}-${day}T${hour}:${minute}:${second}${offset}`;
+}
+
+/**
  * Advance a date by `days` calendar days in the given timezone.
  *
  * Computes the local date, adds days to the day component, then anchors
@@ -84,7 +171,16 @@ function addDays(date: Date, days: number, timeZone: string): Date {
  */
 export function buildTemporalContext(options: TemporalContextOptions = {}): string {
   const now = new Date(options.nowMs ?? Date.now());
-  const timeZone = options.timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const resolvedHostTimeZone = canonicalizeTimeZone(
+    options.hostTimeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
+  ) ?? 'UTC';
+  const resolvedUserTimeZone = options.userTimeZone
+    ? canonicalizeTimeZone(options.userTimeZone)
+    : null;
+  const resolvedTimeZone = options.timeZone
+    ? canonicalizeTimeZone(options.timeZone)
+    : null;
+  const timeZone = resolvedTimeZone ?? resolvedUserTimeZone ?? resolvedHostTimeZone;
   const horizonDays = Math.min(options.horizonDays ?? MAX_HORIZON_ENTRIES, MAX_HORIZON_ENTRIES);
 
   const todayParts = localDateParts(now, timeZone);
@@ -114,6 +210,12 @@ export function buildTemporalContext(options: TemporalContextOptions = {}): stri
     `<temporal_context>`,
     `Today: ${todayStr} (${todayWeekday})`,
     `Timezone: ${timeZone}`,
+    `Current local time: ${formatLocalIsoWithOffset(now, timeZone)}`,
+    `Current UTC time: ${now.toISOString()}`,
+    `Clock source: daemon host machine`,
+    `Daemon host timezone: ${resolvedHostTimeZone}`,
+    `User timezone: ${resolvedUserTimeZone ?? 'unknown'}`,
+    `Timezone source: ${resolvedUserTimeZone ? 'user_profile_memory' : 'daemon_host_fallback'}`,
     ``,
     `Week definitions: work week = Monday–Friday, weekend = Saturday–Sunday`,
     ``,

--- a/assistant/src/daemon/date-context.ts
+++ b/assistant/src/daemon/date-context.ts
@@ -11,7 +11,7 @@ export interface TemporalContextOptions {
   nowMs?: number;
   /** IANA timezone (e.g. "America/New_York"). Defaults to host timezone. */
   timeZone?: string;
-  /** IANA timezone for the daemon host clock (defaults to process local timezone). */
+  /** IANA timezone for the assistant host clock (defaults to process local timezone). */
   hostTimeZone?: string;
   /** IANA timezone configured in user settings (if available). */
   configuredUserTimeZone?: string | null;
@@ -66,13 +66,20 @@ function canonicalizeUtcGmtOffsetToken(offsetToken: string): string | null {
   if (totalMinutes === 0) {
     return 'UTC';
   }
-  // `Etc/GMT` uses POSIX sign semantics: east-of-UTC offsets use a minus sign.
-  if (Math.abs(totalMinutes) % 60 !== 0) {
-    return null;
+  const absTotalMinutes = Math.abs(totalMinutes);
+  const absHours = Math.floor(absTotalMinutes / 60);
+  const absMinutes = absTotalMinutes % 60;
+  const offsetSign = totalMinutes > 0 ? '+' : '-';
+
+  // For whole-hour offsets, prefer `Etc/GMT` for stable canonicalization.
+  if (absMinutes === 0) {
+    // `Etc/GMT` uses POSIX sign semantics: east-of-UTC offsets use a minus sign.
+    const etcSign = totalMinutes > 0 ? '-' : '+';
+    return `Etc/GMT${etcSign}${absHours}`;
   }
-  const etcSign = totalMinutes > 0 ? '-' : '+';
-  const absHours = Math.abs(totalMinutes) / 60;
-  return `Etc/GMT${etcSign}${absHours}`;
+
+  // Bun/Intl accepts fixed-offset IDs in ±HH:MM format.
+  return `${offsetSign}${String(absHours).padStart(2, '0')}:${String(absMinutes).padStart(2, '0')}`;
 }
 
 function canonicalizeTimeZone(timeZone: string): string | null {
@@ -242,7 +249,7 @@ export function buildTemporalContext(options: TemporalContextOptions = {}): stri
       ? 'user_settings'
       : resolvedUserTimeZone
         ? 'user_profile_memory'
-        : 'daemon_host_fallback';
+        : 'assistant_host_fallback';
   const horizonDays = Math.min(options.horizonDays ?? MAX_HORIZON_ENTRIES, MAX_HORIZON_ENTRIES);
 
   const todayParts = localDateParts(now, timeZone);
@@ -274,8 +281,8 @@ export function buildTemporalContext(options: TemporalContextOptions = {}): stri
     `Timezone: ${timeZone}`,
     `Current local time: ${formatLocalIsoWithOffset(now, timeZone)}`,
     `Current UTC time: ${now.toISOString()}`,
-    `Clock source: daemon host machine`,
-    `Daemon host timezone: ${resolvedHostTimeZone}`,
+    `Clock source: assistant host machine`,
+    `Assistant host timezone: ${resolvedHostTimeZone}`,
     `User timezone: ${userTimeZone ?? 'unknown'}`,
     `Timezone source: ${timeZoneSource}`,
     ``,

--- a/assistant/src/daemon/date-context.ts
+++ b/assistant/src/daemon/date-context.ts
@@ -103,8 +103,10 @@ function canonicalizeTimeZone(timeZone: string): string | null {
 }
 
 function extractTimeZoneCandidates(text: string): string[] {
-  const matches = text.match(TIMEZONE_TOKEN_RE) ?? [];
-  return matches.map((token) => token.trim()).filter((token) => token.length > 0);
+  const matches = (text.match(TIMEZONE_TOKEN_RE) ?? []).map((token) => token.trim()).filter((token) => token.length > 0);
+  const ianaTokens = matches.filter((token) => token.includes('/'));
+  const offsetTokens = matches.filter((token) => !token.includes('/'));
+  return [...ianaTokens, ...offsetTokens];
 }
 
 /**

--- a/assistant/src/daemon/date-context.ts
+++ b/assistant/src/daemon/date-context.ts
@@ -13,6 +13,8 @@ export interface TemporalContextOptions {
   timeZone?: string;
   /** IANA timezone for the daemon host clock (defaults to process local timezone). */
   hostTimeZone?: string;
+  /** IANA timezone configured in user settings (if available). */
+  configuredUserTimeZone?: string | null;
   /** IANA timezone inferred from user profile/memory (if available). */
   userTimeZone?: string | null;
   /** Number of future days to list (default 14, hard-capped at 14). */
@@ -124,7 +126,7 @@ function formatLocalIsoWithOffset(date: Date, timeZone: string): string {
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',
-    hour12: false,
+    hourCycle: 'h23',
     timeZoneName: 'shortOffset',
   });
   const parts = fmt.formatToParts(date);
@@ -174,13 +176,27 @@ export function buildTemporalContext(options: TemporalContextOptions = {}): stri
   const resolvedHostTimeZone = canonicalizeTimeZone(
     options.hostTimeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
   ) ?? 'UTC';
+  const resolvedConfiguredUserTimeZone = options.configuredUserTimeZone
+    ? canonicalizeTimeZone(options.configuredUserTimeZone)
+    : null;
   const resolvedUserTimeZone = options.userTimeZone
     ? canonicalizeTimeZone(options.userTimeZone)
     : null;
   const resolvedTimeZone = options.timeZone
     ? canonicalizeTimeZone(options.timeZone)
     : null;
-  const timeZone = resolvedTimeZone ?? resolvedUserTimeZone ?? resolvedHostTimeZone;
+  const timeZone = resolvedTimeZone
+    ?? resolvedConfiguredUserTimeZone
+    ?? resolvedUserTimeZone
+    ?? resolvedHostTimeZone;
+  const userTimeZone = resolvedConfiguredUserTimeZone ?? resolvedUserTimeZone;
+  const timeZoneSource = resolvedTimeZone
+    ? 'explicit_override'
+    : resolvedConfiguredUserTimeZone
+      ? 'user_settings'
+      : resolvedUserTimeZone
+        ? 'user_profile_memory'
+        : 'daemon_host_fallback';
   const horizonDays = Math.min(options.horizonDays ?? MAX_HORIZON_ENTRIES, MAX_HORIZON_ENTRIES);
 
   const todayParts = localDateParts(now, timeZone);
@@ -214,8 +230,8 @@ export function buildTemporalContext(options: TemporalContextOptions = {}): stri
     `Current UTC time: ${now.toISOString()}`,
     `Clock source: daemon host machine`,
     `Daemon host timezone: ${resolvedHostTimeZone}`,
-    `User timezone: ${resolvedUserTimeZone ?? 'unknown'}`,
-    `Timezone source: ${resolvedUserTimeZone ? 'user_profile_memory' : 'daemon_host_fallback'}`,
+    `User timezone: ${userTimeZone ?? 'unknown'}`,
+    `Timezone source: ${timeZoneSource}`,
     ``,
     `Week definitions: work week = Monday–Friday, weekend = Saturday–Sunday`,
     ``,

--- a/assistant/src/daemon/date-context.ts
+++ b/assistant/src/daemon/date-context.ts
@@ -27,7 +27,8 @@ const MAX_HORIZON_ENTRIES = 14;
 const WEEKDAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'] as const;
 const TIMEZONE_SUBJECT_LINE_RE = /^\s*-\s*time\s*zone\s*:\s*(.+)$/i;
 const TIMEZONE_SUBJECT_COMPACT_RE = /^\s*-\s*timezone\s*:\s*(.+)$/i;
-const TIMEZONE_TOKEN_RE = /\b(?:[A-Za-z][A-Za-z0-9_+-]*(?:\/[A-Za-z0-9_+-]+)+|UTC|GMT)\b/g;
+const TIMEZONE_TOKEN_RE = /\b(?:[A-Za-z][A-Za-z0-9_+-]*(?:\/[A-Za-z0-9_+-]+)+|(?:UTC|GMT)(?:[+-]\d{1,2}(?::?\d{2})?)?)\b/gi;
+const UTC_GMT_OFFSET_TOKEN_RE = /^(?:UTC|GMT)([+-])(\d{1,2})(?::?(\d{2}))?$/i;
 
 function normalizeOffsetToken(offsetToken: string): string {
   if (offsetToken === 'GMT' || offsetToken === 'UTC') {
@@ -41,9 +42,54 @@ function normalizeOffsetToken(offsetToken: string): string {
   return `${sign}${hours.padStart(2, '0')}:${(minutes ?? '00').padStart(2, '0')}`;
 }
 
+function canonicalizeUtcGmtOffsetToken(offsetToken: string): string | null {
+  if (/^(?:UTC|GMT)$/i.test(offsetToken)) {
+    return 'UTC';
+  }
+  const match = offsetToken.match(UTC_GMT_OFFSET_TOKEN_RE);
+  if (!match) {
+    return null;
+  }
+  const [, sign, hoursRaw, minutesRaw] = match;
+  const hours = Number.parseInt(hoursRaw, 10);
+  const minutes = Number.parseInt(minutesRaw ?? '0', 10);
+  if (!Number.isInteger(hours) || !Number.isInteger(minutes)) {
+    return null;
+  }
+  if (hours > 14 || minutes > 59) {
+    return null;
+  }
+  const totalMinutes = (hours * 60 + minutes) * (sign === '+' ? 1 : -1);
+  if (Math.abs(totalMinutes) > 14 * 60) {
+    return null;
+  }
+  if (totalMinutes === 0) {
+    return 'UTC';
+  }
+  // `Etc/GMT` uses POSIX sign semantics: east-of-UTC offsets use a minus sign.
+  if (Math.abs(totalMinutes) % 60 !== 0) {
+    return null;
+  }
+  const etcSign = totalMinutes > 0 ? '-' : '+';
+  const absHours = Math.abs(totalMinutes) / 60;
+  return `Etc/GMT${etcSign}${absHours}`;
+}
+
 function canonicalizeTimeZone(timeZone: string): string | null {
+  const trimmed = timeZone.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  const canonicalOffset = canonicalizeUtcGmtOffsetToken(trimmed);
+  if (canonicalOffset) {
+    try {
+      return new Intl.DateTimeFormat('en-US', { timeZone: canonicalOffset }).resolvedOptions().timeZone;
+    } catch {
+      return null;
+    }
+  }
   try {
-    return new Intl.DateTimeFormat('en-US', { timeZone }).resolvedOptions().timeZone;
+    return new Intl.DateTimeFormat('en-US', { timeZone: trimmed }).resolvedOptions().timeZone;
   } catch {
     return null;
   }

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -325,7 +325,7 @@ export async function runAgentLoopImpl(
     ctx.refreshWorkspaceTopLevelContextIfNeeded();
 
     // Compute fresh temporal context each turn for date grounding.
-    // Absolute "now" is always anchored to daemon host clock, while local
+    // Absolute "now" is always anchored to assistant host clock, while local
     // date semantics prefer configured user timezone, then profile memory.
     const hostTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const userTimeZone = extractUserTimeZoneFromDynamicProfile(dynamicProfile.text);

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -326,12 +326,13 @@ export async function runAgentLoopImpl(
 
     // Compute fresh temporal context each turn for date grounding.
     // Absolute "now" is always anchored to daemon host clock, while local
-    // date semantics prefer user timezone when available in profile memory.
+    // date semantics prefer configured user timezone, then profile memory.
     const hostTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const userTimeZone = extractUserTimeZoneFromDynamicProfile(dynamicProfile.text);
+    const configuredUserTimeZone = getConfig().ui.userTimezone ?? null;
     const temporalContext = buildTemporalContext({
-      timeZone: userTimeZone ?? hostTimeZone,
       hostTimeZone,
+      configuredUserTimeZone,
       userTimeZone,
     });
 

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -34,7 +34,7 @@ import {
   type AssistantAttachmentDraft,
   cleanAssistantContent,
 } from './assistant-attachments.js';
-import { buildTemporalContext } from './date-context.js';
+import { buildTemporalContext, extractUserTimeZoneFromDynamicProfile } from './date-context.js';
 import { deepRepairHistory,repairHistory } from './history-repair.js';
 import type { DynamicPageSurfaceData,ServerMessage, SurfaceData, SurfaceType, UsageStats } from './ipc-protocol.js';
 import {
@@ -325,8 +325,14 @@ export async function runAgentLoopImpl(
     ctx.refreshWorkspaceTopLevelContextIfNeeded();
 
     // Compute fresh temporal context each turn for date grounding.
+    // Absolute "now" is always anchored to daemon host clock, while local
+    // date semantics prefer user timezone when available in profile memory.
+    const hostTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const userTimeZone = extractUserTimeZoneFromDynamicProfile(dynamicProfile.text);
     const temporalContext = buildTemporalContext({
-      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      timeZone: userTimeZone ?? hostTimeZone,
+      hostTimeZone,
+      userTimeZone,
     });
 
     // Use the channel/interface context captured at the top of this function

--- a/clients/ARCHITECTURE.md
+++ b/clients/ARCHITECTURE.md
@@ -511,11 +511,12 @@ The video webview applies three hardening layers:
 
 ### Settings Persistence
 
-Media embed preferences live in the workspace config file (`~/.vellum/workspace/config.json`) under `ui.mediaEmbeds`:
+Appearance-related preferences that must be shared with the daemon live in the workspace config file (`~/.vellum/workspace/config.json`) under `ui`:
 
 ```json
 {
   "ui": {
+    "userTimezone": "America/New_York",
     "mediaEmbeds": {
       "enabled": true,
       "enabledSince": "2026-02-15T12:00:00Z",
@@ -525,7 +526,7 @@ Media embed preferences live in the workspace config file (`~/.vellum/workspace/
 }
 ```
 
-`SettingsStore` loads these values on init via `WorkspaceConfigIO.read` and writes them back via `WorkspaceConfigIO.merge` on toggle or allowlist update. The `enabledSince` timestamp ensures only messages created after the user enabled embeds are eligible, so toggling the feature on doesn't retroactively embed every historical link.
+`SettingsStore` loads these values on init via `WorkspaceConfigIO.read` and writes them back via `WorkspaceConfigIO.merge`. `ui.userTimezone` provides an explicit user-local timezone hint for daemon-side temporal grounding when profile memory is unavailable. The `enabledSince` timestamp ensures only messages created after the user enabled embeds are eligible, so toggling the feature on doesn't retroactively embed every historical link.
 
 ### Key Source Files
 
@@ -545,7 +546,7 @@ Media embed preferences live in the workspace config file (`~/.vellum/workspace/
 | `clients/macos/.../MediaEmbeds/InlineVideoWebView.swift` | Privacy-hardened WKWebView wrapper |
 | `clients/macos/.../MediaEmbeds/InlineVideoEmbedState.swift` | Video embed lifecycle state + manager |
 | `clients/macos/.../Features/Settings/MediaEmbedSettings.swift` | Centralized defaults and domain normalization |
-| `clients/macos/.../Features/Settings/SettingsStore.swift` | Settings persistence (reads/writes `ui.mediaEmbeds` in workspace config) |
+| `clients/macos/.../Features/Settings/SettingsStore.swift` | Settings persistence (reads/writes `ui.userTimezone` and `ui.mediaEmbeds` in workspace config) |
 
 ---
 
@@ -666,4 +667,3 @@ When the daemon is unreachable, outgoing user messages are buffered in `OfflineM
 Storage key: `offline_message_queue_v1` (UserDefaults).
 
 ---
-

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -10,6 +10,8 @@ struct SettingsAppearanceTab: View {
     @State private var isRecordingQuickInputHotkey = false
     @State private var shortcutMonitor: Any?
     @State private var shortcutConflictWarning: String?
+    @State private var timezoneDraft = ""
+    @State private var timezoneValidationError: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
@@ -37,6 +39,41 @@ struct SettingsAppearanceTab: View {
                     }
                     .pickerStyle(.segmented)
                     .frame(width: 200)
+                }
+
+                Divider()
+                    .background(VColor.surfaceBorder)
+
+                HStack(alignment: .top, spacing: VSpacing.sm) {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("User timezone")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                        Text("IANA identifier (e.g. America/New_York). Leave empty to use profile memory, then assistant host timezone.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    Spacer()
+                    TextField("America/New_York", text: $timezoneDraft)
+                        .vInputStyle()
+                        .frame(width: 220)
+                        .onSubmit {
+                            saveTimezone()
+                        }
+                    VButton(label: "Save", style: .tertiary) {
+                        saveTimezone()
+                    }
+                    VButton(label: "Clear", style: .tertiary) {
+                        store.clearUserTimezone()
+                        timezoneDraft = ""
+                        timezoneValidationError = nil
+                    }
+                }
+
+                if let timezoneValidationError {
+                    Text(timezoneValidationError)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.warning)
                 }
 
             }
@@ -198,9 +235,22 @@ struct SettingsAppearanceTab: View {
             .padding(VSpacing.lg)
             .vCard(background: VColor.surfaceSubtle)
         }
+        .onAppear {
+            timezoneDraft = store.userTimezone ?? ""
+        }
+        .onChange(of: store.userTimezone) { updated in
+            timezoneDraft = updated ?? ""
+        }
     }
 
     // MARK: - Shortcut Recording
+
+    private func saveTimezone() {
+        timezoneValidationError = store.saveUserTimezone(timezoneDraft)
+        if timezoneValidationError == nil {
+            timezoneDraft = store.userTimezone ?? ""
+        }
+    }
 
     private func startRecording() {
         startRecordingShortcut { shortcut, _ in

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -67,6 +67,7 @@ public final class SettingsStore: ObservableObject {
     @Published var mediaEmbedsEnabled: Bool
     @Published var mediaEmbedsEnabledSince: Date?
     @Published var mediaEmbedVideoAllowlistDomains: [String]
+    @Published var userTimezone: String?
 
     // MARK: - Twitter Integration State
 
@@ -249,6 +250,17 @@ public final class SettingsStore: ObservableObject {
         return nil
     }
 
+    private static let allKnownTimeZoneIdentifiersByLowercase: [String: String] = {
+        Dictionary(uniqueKeysWithValues: TimeZone.knownTimeZoneIdentifiers.map { ($0.lowercased(), $0) })
+    }()
+
+    private static func canonicalizeTimeZoneIdentifier(_ raw: String) -> String? {
+        if let tz = TimeZone(identifier: raw) {
+            return tz.identifier
+        }
+        return allKnownTimeZoneIdentifiersByLowercase[raw.lowercased()]
+    }
+
     init(
         daemonClient: DaemonClient? = nil,
         configPath: String? = nil,
@@ -306,6 +318,7 @@ public final class SettingsStore: ObservableObject {
         self.mediaEmbedsEnabled = mediaSettings.enabled
         self.mediaEmbedsEnabledSince = mediaSettings.enabledSince
         self.mediaEmbedVideoAllowlistDomains = mediaSettings.domains
+        self.userTimezone = Self.loadUserTimezone(from: configPath)
 
         // When enabledSince was defaulted to "now" (no value on disk),
         // persist it immediately so subsequent loads produce the same
@@ -1661,6 +1674,34 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
+    // MARK: - User Timezone Actions
+
+    /// Saves a user timezone override under `ui.userTimezone`.
+    ///
+    /// Returns an error string when the value is not a valid IANA timezone.
+    @discardableResult
+    func saveUserTimezone(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            clearUserTimezone()
+            return nil
+        }
+
+        guard let canonical = Self.canonicalizeTimeZoneIdentifier(trimmed) else {
+            return "Use an IANA timezone like America/New_York."
+        }
+
+        userTimezone = canonical
+        persistUserTimezone()
+        return nil
+    }
+
+    /// Removes the user timezone override so runtime falls back to profile memory or host timezone.
+    func clearUserTimezone() {
+        userTimezone = nil
+        persistUserTimezone()
+    }
+
     // MARK: - Media Embed Actions
 
     /// Toggles media embeds on or off and persists the change to the workspace config.
@@ -1800,5 +1841,36 @@ public final class SettingsStore: ObservableObject {
             domains: domains,
             didDefaultEnabledSince: didDefault
         )
+    }
+
+    // MARK: - User Timezone Loading/Persistence
+
+    private func persistUserTimezone() {
+        let existingConfig = WorkspaceConfigIO.read(from: configPath)
+        var existingUI = existingConfig["ui"] as? [String: Any] ?? [:]
+        if let timezone = userTimezone {
+            existingUI["userTimezone"] = timezone
+        } else {
+            existingUI.removeValue(forKey: "userTimezone")
+        }
+
+        do {
+            try WorkspaceConfigIO.merge(["ui": existingUI], into: configPath)
+        } catch {
+            log.error("Failed to merge workspace config for user timezone: \(error)")
+        }
+    }
+
+    private static func loadUserTimezone(from configPath: String? = nil) -> String? {
+        let config = WorkspaceConfigIO.read(from: configPath)
+        guard let ui = config["ui"] as? [String: Any],
+              let raw = ui["userTimezone"] as? String else {
+            return nil
+        }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+        return canonicalizeTimeZoneIdentifier(trimmed)
     }
 }

--- a/clients/macos/vellum-assistantTests/SettingsStoreUserTimezoneTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreUserTimezoneTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class SettingsStoreUserTimezoneTests: XCTestCase {
+
+    private var tempDir: URL!
+    private var configPath: String!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        configPath = tempDir.appendingPathComponent("config.json").path
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    private func seed(_ json: String) {
+        try! json.write(toFile: configPath, atomically: true, encoding: .utf8)
+    }
+
+    private func readConfig() -> [String: Any] {
+        WorkspaceConfigIO.read(from: configPath)
+    }
+
+    func testLoadsValidConfiguredTimezone() {
+        seed(#"{"ui":{"userTimezone":"America/New_York"}}"#)
+        let store = SettingsStore(configPath: configPath)
+
+        XCTAssertEqual(store.userTimezone, "America/New_York")
+    }
+
+    func testIgnoresInvalidConfiguredTimezone() {
+        seed(#"{"ui":{"userTimezone":"Not/ARealZone"}}"#)
+        let store = SettingsStore(configPath: configPath)
+
+        XCTAssertNil(store.userTimezone)
+    }
+
+    func testSaveUserTimezonePersistsCanonicalIdentifier() {
+        seed("{}")
+        let store = SettingsStore(configPath: configPath)
+
+        let error = store.saveUserTimezone("america/new_york")
+        XCTAssertNil(error)
+        XCTAssertEqual(store.userTimezone, "America/New_York")
+
+        let persisted = readConfig()
+        let ui = persisted["ui"] as? [String: Any]
+        XCTAssertEqual(ui?["userTimezone"] as? String, "America/New_York")
+    }
+
+    func testSaveUserTimezoneRejectsInvalidValueWithoutOverwritingExisting() {
+        seed(#"{"ui":{"userTimezone":"America/Los_Angeles"}}"#)
+        let store = SettingsStore(configPath: configPath)
+
+        let error = store.saveUserTimezone("not/a-timezone")
+        XCTAssertNotNil(error)
+        XCTAssertEqual(store.userTimezone, "America/Los_Angeles")
+
+        let persisted = readConfig()
+        let ui = persisted["ui"] as? [String: Any]
+        XCTAssertEqual(ui?["userTimezone"] as? String, "America/Los_Angeles")
+    }
+
+    func testClearUserTimezoneRemovesOnlyTimezoneKey() {
+        seed(#"{"ui":{"userTimezone":"America/New_York","mediaEmbeds":{"enabled":true}},"other":"value"}"#)
+        let store = SettingsStore(configPath: configPath)
+
+        store.clearUserTimezone()
+
+        let persisted = readConfig()
+        XCTAssertEqual(persisted["other"] as? String, "value")
+        let ui = persisted["ui"] as? [String: Any]
+        XCTAssertNil(ui?["userTimezone"])
+        XCTAssertNotNil(ui?["mediaEmbeds"])
+    }
+}


### PR DESCRIPTION
## Summary
- prefer user timezone (from dynamic profile memory) for temporal context local-time interpretation
- keep daemon host clock as authoritative instant source and expose `Current UTC time`
- include timezone source metadata in `<temporal_context>` (`Daemon host timezone`, `User timezone`, `Timezone source`)
- update time-based actions skill guidance to use the injected temporal context and ask once when timezone is unknown
- update memory architecture docs for the new host-clock + user-timezone model

## Testing
- `bun test src/__tests__/date-context.test.ts`
- `bunx tsc --noEmit`

## Notes
- No reminder storage/runtime behavior changed; this is temporal grounding + guidance updates only.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
