### PR TITLE
M2: Fix guardian-verify-setup voice regression test false positive

### DIFF
--- a/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
+++ b/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
@@ -106,12 +106,18 @@ describe('guardian-verify-setup skill — voice auto-followup', () => {
     expect(voiceAutoCheckSection).toContain(
       'Do NOT require the user to ask',
     );
-    // There should be no phrase like "wait for the user to confirm" or
-    // "ask the user if it worked" in the voice-related sections.
-    const step3VoiceLine = skillContent
+    // The voice bullet in Step 3 should not instruct the assistant to wait
+    // for the user to confirm or ask if it worked. Narrow to just the voice
+    // bullet line to avoid false positives from Telegram's "wait for the
+    // user to confirm they clicked the link" which is unrelated to voice.
+    const step3Section = skillContent
       .split('## Step 3')[1]
       ?.split('## Step 4')[0] ?? '';
-    expect(step3VoiceLine).not.toContain('wait for the user to confirm');
-    expect(step3VoiceLine).not.toContain('ask the user if it worked');
+    const voiceBullet = step3Section
+      .split('\n')
+      .filter((line) => /^\s*-\s+\*\*Voice\*\*/.test(line))
+      .join('\n');
+    expect(voiceBullet).not.toContain('wait for the user to confirm');
+    expect(voiceBullet).not.toContain('ask the user if it worked');
   });
 });


### PR DESCRIPTION
The regression test from #9612 checks that Step 3 has no instruction to wait for user confirmation in the voice flow. But the check was too broad -- it matched the Telegram handle flow's legitimate 'wait for the user to confirm they clicked the link' instruction. Narrows the assertion to only the Voice bullet line. Part of #9606.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
