### PR TITLE
fix: stop including guardian verification secret in Telegram delivery

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -3274,23 +3274,22 @@ describe('outbound Telegram verification', () => {
     expect(revoked).toBeNull();
   });
 
-  test('telegram template includes verification code in message', () => {
+  test('telegram template does not include verification code in message', () => {
     const msg = composeVerificationTelegram(
       GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST,
       { code: 'abc123', expiresInMinutes: 10 },
     );
-    // Code must be visible in-channel for bootstrap flows where the app cannot display it
-    expect(msg).toContain('abc123');
-    expect(msg).toContain('/guardian_verify abc123');
+    expect(msg).not.toContain('abc123');
+    expect(msg).toContain('/guardian_verify <code>');
   });
 
-  test('telegram resend template includes code and (resent) suffix', () => {
+  test('telegram resend template does not include code and includes (resent) suffix', () => {
     const msg = composeVerificationTelegram(
       GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_RESEND,
       { code: 'xyz789', expiresInMinutes: 5 },
     );
-    expect(msg).toContain('xyz789');
-    expect(msg).toContain('/guardian_verify xyz789');
+    expect(msg).not.toContain('xyz789');
+    expect(msg).toContain('/guardian_verify <code>');
     expect(msg).toContain('(resent)');
   });
 
@@ -3300,7 +3299,7 @@ describe('outbound Telegram verification', () => {
       { code: '999999', expiresInMinutes: 10, assistantName: 'MyBot' },
     );
     expect(msg).toContain('Vellum assistant');
-    expect(msg).toContain('999999');
+    expect(msg).not.toContain('999999');
   });
 
   test('start_outbound for telegram with missing destination fails', () => {

--- a/assistant/src/runtime/guardian-verification-templates.ts
+++ b/assistant/src/runtime/guardian-verification-templates.ts
@@ -17,9 +17,9 @@ export const GUARDIAN_VERIFY_TEMPLATE_KEYS = {
   RESEND: 'guardian_verify.sms.resend',
   /** Response when the user is already verified. */
   ALREADY_VERIFIED: 'guardian_verify.already_verified',
-  /** Initial outbound Telegram message with verification code. */
+  /** Initial outbound Telegram verification prompt (code is not included). */
   TELEGRAM_CHALLENGE_REQUEST: 'guardian_verify.telegram.challenge_request',
-  /** Resend Telegram message with verification code. */
+  /** Resend Telegram verification prompt (code is not included). */
   TELEGRAM_RESEND: 'guardian_verify.telegram.resend',
   /** Outbound voice call intro prompt: asks guardian to enter verification code via keypad. */
   VOICE_CALL_INTRO: 'guardian_verify.voice.call_intro',
@@ -91,12 +91,12 @@ const templates: Record<TextVerifyTemplateKey, (vars: GuardianVerifyTemplateVars
     return 'This channel is already verified. No further action is needed.';
   },
 
-  [GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST]: (vars) => {
-    return `Vellum assistant guardian verification requested. Your code is: ${vars.code}. Reply with this code or use /guardian_verify ${vars.code}`;
+  [GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST]: (_vars) => {
+    return 'Vellum assistant guardian verification requested. Reply with the 6-digit code you were given, or use /guardian_verify <code>.';
   },
 
-  [GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_RESEND]: (vars) => {
-    return `Vellum assistant guardian verification requested. Your code is: ${vars.code}. Reply with this code or use /guardian_verify ${vars.code} (resent)`;
+  [GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_RESEND]: (_vars) => {
+    return 'Vellum assistant guardian verification requested. Reply with the 6-digit code you were given, or use /guardian_verify <code>. (resent)';
   },
 };
 

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -569,7 +569,7 @@ export async function handleChannelInbound(
         destinationAddress: externalChatId,
       });
 
-      // Compose and send the verification code via Telegram
+      // Compose and send the verification prompt via Telegram
       const telegramBody = composeVerificationTelegram(
         GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST,
         {


### PR DESCRIPTION
## Summary
- remove secret interpolation from Telegram guardian verification outbound templates
- keep Telegram delivery prompt generic (`/guardian_verify <code>`) so the secret is only surfaced in assistant chat
- update outbound Telegram guardian tests to assert the secret is never included in Telegram-delivered copy
- update an inline bootstrap-flow comment to reflect prompt-only delivery

## Root cause
`assistant/src/runtime/guardian-verification-templates.ts` had Telegram templates that explicitly embedded `vars.code` in outbound Telegram text (`Your code is: ...` and `/guardian_verify <code_value>`), so the bot leaked the verification secret into Telegram messages.

## Validation
- `bun test src/__tests__/channel-guardian.test.ts --test-name-pattern "outbound Telegram verification"`
- `bunx tsc --noEmit`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
