### PR TITLE
Fix: Restrict guardian intent patterns to require guardian context

### DIFF
--- a/assistant/src/__tests__/guardian-verification-intent-routing.test.ts
+++ b/assistant/src/__tests__/guardian-verification-intent-routing.test.ts
@@ -18,10 +18,6 @@ describe('direct guardian setup phrases trigger forced routing', () => {
     'set me as guardian for telegram',
     'set me up as guardian',
     'set me up as your guardian',
-    'verify my phone number',
-    'verify my phone',
-    'verify my Telegram account',
-    'verify voice channel',
     'set up guardian verification',
     'setup guardian verification',
     'guardian verification setup',
@@ -102,7 +98,27 @@ describe('non-guardian messages are not intercepted', () => {
 });
 
 // =====================================================================
-// 4. Slash commands are never intercepted
+// 4. Ambiguous verify phrases without guardian context => no forced routing
+// =====================================================================
+
+describe('ambiguous verify phrases without guardian context do NOT trigger forced routing', () => {
+  const ambiguousPhrases = [
+    'verify my phone number',
+    'verify my phone',
+    'verify my Telegram account',
+    'verify voice channel',
+  ];
+
+  for (const phrase of ambiguousPhrases) {
+    test(`"${phrase}" => none`, () => {
+      const result = resolveGuardianVerificationIntent(phrase);
+      expect(result.kind).toBe('none');
+    });
+  }
+});
+
+// =====================================================================
+// 5. Slash commands are never intercepted
 // =====================================================================
 
 describe('slash commands are never intercepted', () => {
@@ -122,7 +138,7 @@ describe('slash commands are never intercepted', () => {
 });
 
 // =====================================================================
-// 5. Channel hint extraction
+// 6. Channel hint extraction
 // =====================================================================
 
 describe('channel hint extraction', () => {
@@ -136,7 +152,7 @@ describe('channel hint extraction', () => {
   });
 
   test('detects voice channel hint', () => {
-    const result = resolveGuardianVerificationIntent('verify voice channel');
+    const result = resolveGuardianVerificationIntent('set me as guardian for voice');
     expect(result.kind).toBe('direct_setup');
     if (result.kind === 'direct_setup') {
       expect(result.channelHint).toBe('voice');
@@ -145,7 +161,7 @@ describe('channel hint extraction', () => {
   });
 
   test('detects Telegram channel hint', () => {
-    const result = resolveGuardianVerificationIntent('verify my Telegram account');
+    const result = resolveGuardianVerificationIntent('set me as guardian for telegram');
     expect(result.kind).toBe('direct_setup');
     if (result.kind === 'direct_setup') {
       expect(result.channelHint).toBe('telegram');

--- a/assistant/src/daemon/guardian-verification-intent.ts
+++ b/assistant/src/daemon/guardian-verification-intent.ts
@@ -19,7 +19,6 @@ const DIRECT_SETUP_PATTERNS: RegExp[] = [
   /\bset\s+(?:me\s+as\s+)?guardian\b/i,
   /\bguardian\s+verif(?:y|ication)\s*(?:setup|set\s*up)?\b/i,
   /\bset\s*up\s+guardian\s+verif(?:y|ication)\b/i,
-  /\bverify\s+(?:my\s+)?(?:phone\s+(?:number)?|telegram(?:\s+account)?|voice\s+channel)\b/i,
   /\b(?:help\s+me\s+)?set\s+(?:myself\s+)?(?:up\s+)?as\s+(?:your\s+)?guardian\s+(?:for|via|by|over|on|through)\s+/i,
   /\bguardian\s+(?:for|via|by|over|on|through)\s+(?:sms|text|phone|voice|telegram|call)\b/i,
   /\bbecome\s+(?:your\s+|the\s+)?guardian\b/i,


### PR DESCRIPTION
## Summary
- Removes overly broad 'verify my phone number' pattern that could hijack non-guardian requests
- Updates tests to verify ambiguous phrases without guardian context do NOT trigger routing
- Existing guardian-specific patterns already cover the intended use cases

Addresses feedback from #9613. Part of #9606.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
