### PR TITLE
M3: Voice Timeout Flow Migration to Generated Assistant Turn

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -128,6 +128,10 @@ import {
 } from '../calls/call-store.js';
 import type { RelayConnection } from '../calls/relay-server.js';
 import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import {
+  getByPendingQuestionId,
+  getGuardianActionRequest,
+} from '../memory/guardian-action-store.js';
 import { conversations } from '../memory/schema.js';
 
 initializeDb();
@@ -1046,6 +1050,177 @@ describe('call-controller', () => {
     expect(turnContents.length).toBe(1);
     expect(turnContents[0]).toContain('[USER_INSTRUCTION: Suggest morning slots]');
     expect(turnContents[0]).toContain('Actually, I prefer 10am');
+
+    controller.destroy();
+  });
+
+  // ── Consultation timeout: instruction injection ───────────────────
+
+  test('consultation timeout: injects instruction instead of sending hardcoded text', async () => {
+    mockConsultationTimeoutMs = 50;
+
+    // Trigger ASK_GUARDIAN to enter waiting_on_user state
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Let me check. [ASK_GUARDIAN: What time works?]'],
+    ));
+    const { relay, controller } = setupController();
+    await controller.handleCallerUtterance('Book me in');
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    // Record relay tokens sent before the timeout
+    const tokensBefore = relay.sentTokens.length;
+
+    // Set up mock to capture what content the timeout-triggered turn receives
+    const turnContents: string[] = [];
+    mockStartVoiceTurn.mockImplementation(async (opts: { content: string; onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      turnContents.push(opts.content);
+      opts.onTextDelta('I was not able to reach your guardian.');
+      opts.onComplete();
+      return { turnId: `run-${turnContents.length}`, abort: () => {} };
+    });
+
+    // Wait for the short consultation timeout to fire
+    await new Promise((r) => setTimeout(r, 200));
+
+    // The timeout should NOT have sent the old hardcoded text directly via relay
+    const tokensAfterTimeout = relay.sentTokens.slice(tokensBefore);
+    const directText = tokensAfterTimeout.map((t) => t.token).join('');
+    expect(directText).not.toContain('I\'m sorry, I wasn\'t able to get that information in time');
+
+    // Instead, an instruction should have been injected and flushed as a turn
+    expect(turnContents.length).toBe(1);
+    expect(turnContents[0]).toContain('[USER_INSTRUCTION:');
+    expect(turnContents[0]).toContain('guardian could not be reached');
+    expect(turnContents[0]).toContain('called back');
+
+    controller.destroy();
+  });
+
+  test('consultation timeout: sets guardianUnavailableForCall flag', async () => {
+    mockConsultationTimeoutMs = 50;
+
+    // Trigger ASK_GUARDIAN to enter waiting_on_user state
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Checking. [ASK_GUARDIAN: Confirm time?]'],
+    ));
+    const { controller } = setupController();
+    await controller.handleCallerUtterance('Schedule please');
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    // Set up mock for the timeout-triggered turn
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(['Guardian is unavailable.']));
+
+    // Wait for the short consultation timeout
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Now trigger another ASK_GUARDIAN — the guard should prevent dispatch.
+    // Use a mock that emits ASK_GUARDIAN on the first call but plain text on
+    // subsequent calls (the instruction flush), avoiding an infinite loop.
+    const turnContents: string[] = [];
+    let askGuardianCallCount = 0;
+    mockStartVoiceTurn.mockImplementation(async (opts: { content: string; onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      turnContents.push(opts.content);
+      askGuardianCallCount++;
+      if (askGuardianCallCount === 1) {
+        opts.onTextDelta('I need to ask about insurance. [ASK_GUARDIAN: Insurance details?]');
+      } else {
+        opts.onTextDelta('Noted, I will check on that later.');
+      }
+      opts.onComplete();
+      return { turnId: `run-${turnContents.length}`, abort: () => {} };
+    });
+
+    await controller.handleCallerUtterance('What about my insurance?');
+
+    // Give the pending instruction flush time to fire
+    await new Promise((r) => setTimeout(r, 100));
+
+    // The second ASK_GUARDIAN should have been intercepted — the guard
+    // should have queued an instruction about guardian still being unavailable
+    expect(turnContents.length).toBeGreaterThanOrEqual(1);
+    const hasGuardianUnavailableInstruction = turnContents.some(
+      (c) => c.includes('guardian is still unavailable'),
+    );
+    expect(hasGuardianUnavailableInstruction).toBe(true);
+
+    controller.destroy();
+  });
+
+  test('consultation timeout: subsequent ASK_GUARDIAN when guard is active does not dispatch', async () => {
+    mockConsultationTimeoutMs = 50;
+
+    // Trigger ASK_GUARDIAN to enter waiting_on_user state
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Let me ask. [ASK_GUARDIAN: Preferred date?]'],
+    ));
+    const { session, controller } = setupController();
+    await controller.handleCallerUtterance('Schedule please');
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    // Let the timeout fire
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(['Moving on.']));
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Now the model emits another ASK_GUARDIAN. Use a counter-based mock
+    // so the instruction flush turn produces plain text (not another ASK_GUARDIAN).
+    let callCount = 0;
+    mockStartVoiceTurn.mockImplementation(async (opts: { content: string; onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      callCount++;
+      if (callCount === 1) {
+        opts.onTextDelta('Let me check insurance. [ASK_GUARDIAN: Insurance number?]');
+      } else {
+        opts.onTextDelta('I will follow up on that.');
+      }
+      opts.onComplete();
+      return { turnId: `run-${callCount}`, abort: () => {} };
+    });
+    await controller.handleCallerUtterance('What about insurance?');
+
+    // Give the pending instruction flush time to fire
+    await new Promise((r) => setTimeout(r, 100));
+
+    // No new pending question should have been created for the second ASK_GUARDIAN
+    // (the first one was expired by the timeout)
+    const pq = getPendingQuestion(session.id);
+    expect(pq).toBeNull();
+
+    controller.destroy();
+  });
+
+  test('consultation timeout: marks guardian action request as timed out with call_timeout reason', async () => {
+    mockConsultationTimeoutMs = 50;
+
+    // Trigger ASK_GUARDIAN to enter waiting_on_user state
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Let me check. [ASK_GUARDIAN: What time works?]'],
+    ));
+    const { session, controller } = setupController();
+    await controller.handleCallerUtterance('Book me in');
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    // The ASK_GUARDIAN path fires dispatchGuardianQuestion which creates a
+    // guardian action request linked to the pending question. Give the
+    // fire-and-forget dispatch a microtask tick to complete.
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Look up the guardian action request created by dispatchGuardianQuestion
+    const pq = getPendingQuestion(session.id);
+    expect(pq).not.toBeNull();
+    const actionRequest = getByPendingQuestionId(pq!.id);
+    expect(actionRequest).not.toBeNull();
+    expect(actionRequest!.status).toBe('pending');
+
+    // Set up mock for the timeout-triggered turn
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(['Guardian unavailable.']));
+
+    // Wait for the short consultation timeout
+    await new Promise((r) => setTimeout(r, 200));
+
+    // The guardian action request should now be marked as expired with 'call_timeout' reason
+    const updatedRequest = getGuardianActionRequest(actionRequest!.id);
+    expect(updatedRequest).not.toBeNull();
+    expect(updatedRequest!.status).toBe('expired');
+    expect(updatedRequest!.expiredReason).toBe('call_timeout');
 
     controller.destroy();
   });

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -19,10 +19,12 @@ import {
   createPendingQuestion,
   expirePendingQuestions,
   getCallSession,
+  getPendingQuestion,
   recordCallEvent,
   updateCallSession,
 } from './call-store.js';
 import { dispatchGuardianQuestion } from './guardian-dispatch.js';
+import { getByPendingQuestionId, markTimedOutWithReason } from '../memory/guardian-action-store.js';
 import type { RelayConnection } from './relay-server.js';
 import type { PromptSpeakerContext } from './speaker-identification.js';
 import { startVoiceTurn, type VoiceTurnHandle } from './voice-session-bridge.js';
@@ -92,6 +94,8 @@ export class CallController {
    * alternation in the underlying session pipeline.
    */
   private lastSentWasOpener = false;
+  /** Set to true after a guardian consultation timeout. Prevents repeated long waits if the model emits another ASK_GUARDIAN. */
+  private guardianUnavailableForCall = false;
 
   constructor(
     callSessionId: string,
@@ -514,6 +518,15 @@ export class CallController {
           log.info({ callSessionId: this.callSessionId }, 'Caller is guardian — skipping ASK_GUARDIAN dispatch, asking directly');
           this.pendingInstructions.push(`You just tried to use [ASK_GUARDIAN] but the person on the phone IS your guardian. Ask them directly: "${questionText}"`);
           // Fall through to normal turn completion (idle + flushPendingInstructions)
+        } else if (this.guardianUnavailableForCall) {
+          // Guardian was already unreachable this call — skip the long wait cycle.
+          log.info({ callSessionId: this.callSessionId }, 'Guardian still unavailable for this call — skipping ASK_GUARDIAN dispatch');
+          this.pendingInstructions.push(
+            `You tried to use [ASK_GUARDIAN] again, but the guardian is still unavailable for this call. `
+            + `Do not wait — continue the conversation without pausing. `
+            + `Note the question "${questionText}" for when the guardian becomes available.`,
+          );
+          // Fall through to normal turn completion (idle + flushPendingInstructions)
         } else {
           const pendingQuestion = createPendingQuestion(this.callSessionId, questionText);
           this.state = 'waiting_on_user';
@@ -538,13 +551,30 @@ export class CallController {
           this.consultationTimer = setTimeout(() => {
             if (this.state === 'waiting_on_user') {
               log.info({ callSessionId: this.callSessionId }, 'User consultation timed out');
-              this.relay.sendTextToken(
-                'I\'m sorry, I wasn\'t able to get that information in time. Let me move on.',
-                true,
-              );
+              this.guardianUnavailableForCall = true;
+
+              // Mark the linked guardian action request as timed out
+              const pq = getPendingQuestion(this.callSessionId);
+              if (pq) {
+                const actionRequest = getByPendingQuestionId(pq.id);
+                if (actionRequest) {
+                  markTimedOutWithReason(actionRequest.id, 'call_timeout');
+                }
+              }
+
               this.state = 'idle';
               updateCallSession(this.callSessionId, { status: 'in_progress' });
               expirePendingQuestions(this.callSessionId);
+
+              // Inject a system instruction so the model generates a natural
+              // timeout acknowledgment instead of a hardcoded utterance.
+              this.pendingInstructions.push(
+                `The guardian could not be reached in time. `
+                + `Acknowledge this to the caller naturally. `
+                + `Ask if they would like the guardian called back when available. `
+                + `Then continue the conversation by asking any remaining questions you need answered.`,
+              );
+
               // Restart silence detection now that we're back to idle.
               // flushPendingInstructions / drainPendingCallerUtterances will
               // reset it again when they start a new turn, but we need the

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -23,8 +23,11 @@ import {
   recordCallEvent,
   updateCallSession,
 } from './call-store.js';
+import { getGatewayInternalBaseUrl } from '../config/env.js';
+import { getByPendingQuestionId, getDeliveriesByRequestId, markTimedOutWithReason } from '../memory/guardian-action-store.js';
+import { readHttpToken } from '../util/platform.js';
 import { dispatchGuardianQuestion } from './guardian-dispatch.js';
-import { getByPendingQuestionId, markTimedOutWithReason } from '../memory/guardian-action-store.js';
+import { sendGuardianExpiryNotices } from './guardian-action-sweep.js';
 import type { RelayConnection } from './relay-server.js';
 import type { PromptSpeakerContext } from './speaker-identification.js';
 import { startVoiceTurn, type VoiceTurnHandle } from './voice-session-bridge.js';
@@ -553,12 +556,22 @@ export class CallController {
               log.info({ callSessionId: this.callSessionId }, 'User consultation timed out');
               this.guardianUnavailableForCall = true;
 
-              // Mark the linked guardian action request as timed out
+              // Mark the linked guardian action request as timed out and
+              // send expiry notices to guardian destinations. Deliveries
+              // must be captured before markTimedOutWithReason changes
+              // their status.
               const pq = getPendingQuestion(this.callSessionId);
               if (pq) {
                 const actionRequest = getByPendingQuestionId(pq.id);
                 if (actionRequest) {
+                  const deliveries = getDeliveriesByRequestId(actionRequest.id);
                   markTimedOutWithReason(actionRequest.id, 'call_timeout');
+                  sendGuardianExpiryNotices(
+                    deliveries,
+                    actionRequest.assistantId,
+                    getGatewayInternalBaseUrl(),
+                    readHttpToken() ?? undefined,
+                  );
                 }
               }
 

--- a/assistant/src/calls/guardian-action-sweep.ts
+++ b/assistant/src/calls/guardian-action-sweep.ts
@@ -39,7 +39,7 @@ export function sweepExpiredGuardianActions(
     const deliveries = getDeliveriesByRequestId(request.id);
 
     // Expire the request and all deliveries
-    expireGuardianActionRequest(request.id);
+    expireGuardianActionRequest(request.id, 'sweep_timeout');
 
     // Expire associated pending questions
     expirePendingQuestions(request.callSessionId);

--- a/assistant/src/calls/guardian-action-sweep.ts
+++ b/assistant/src/calls/guardian-action-sweep.ts
@@ -10,6 +10,7 @@
  */
 
 import { addMessage } from '../memory/conversation-store.js';
+import type { GuardianActionDelivery } from '../memory/guardian-action-store.js';
 import {
   expireGuardianActionRequest,
   getDeliveriesByRequestId,
@@ -24,6 +25,52 @@ const log = getLogger('guardian-action-sweep');
 const SWEEP_INTERVAL_MS = 60_000;
 
 let sweepTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Send expiry notices to all delivery destinations for a guardian action
+ * request. Handles both vellum/mac thread messages and external channel
+ * replies (telegram, sms).
+ *
+ * Deliveries must be captured *before* their status is changed to 'expired'
+ * so the sent/pending filter still matches.
+ */
+export function sendGuardianExpiryNotices(
+  deliveries: GuardianActionDelivery[],
+  assistantId: string,
+  gatewayBaseUrl: string,
+  bearerToken?: string,
+): void {
+  for (const delivery of deliveries) {
+    if (delivery.status !== 'sent' && delivery.status !== 'pending') continue;
+
+    if ((delivery.destinationChannel === 'vellum' || delivery.destinationChannel === 'macos' || delivery.destinationChannel === 'mac') && delivery.destinationConversationId) {
+      // Add expiry message to vellum guardian thread
+      addMessage(
+        delivery.destinationConversationId,
+        'assistant',
+        JSON.stringify([{ type: 'text', text: 'This guardian question has expired without a response.' }]),
+        { userMessageChannel: 'voice', assistantMessageChannel: 'vellum', userMessageInterface: 'voice', assistantMessageInterface: 'vellum' },
+      );
+    } else if (delivery.destinationChatId) {
+      // External channel — send expiry notice
+      const deliverUrl = `${gatewayBaseUrl}/deliver/${delivery.destinationChannel}`;
+      void (async () => {
+        try {
+          await deliverChannelReply(deliverUrl, {
+            chatId: delivery.destinationChatId!,
+            text: 'The guardian question has expired without a response. The call has moved on.',
+            assistantId,
+          }, bearerToken);
+        } catch (err) {
+          log.error(
+            { err, deliveryId: delivery.id, channel: delivery.destinationChannel },
+            'Failed to deliver guardian action expiry notice',
+          );
+        }
+      })();
+    }
+  }
+}
 
 /**
  * Sweep expired guardian action requests and clean up.
@@ -49,37 +96,7 @@ export function sweepExpiredGuardianActions(
       'Expired guardian action request',
     );
 
-    // Send expiry notices to each delivery destination
-    for (const delivery of deliveries) {
-      if (delivery.status !== 'sent' && delivery.status !== 'pending') continue;
-
-      if ((delivery.destinationChannel === 'vellum' || delivery.destinationChannel === 'macos' || delivery.destinationChannel === 'mac') && delivery.destinationConversationId) {
-        // Add expiry message to vellum guardian thread
-        addMessage(
-          delivery.destinationConversationId,
-          'assistant',
-          JSON.stringify([{ type: 'text', text: 'This guardian question has expired without a response.' }]),
-          { userMessageChannel: 'voice', assistantMessageChannel: 'vellum', userMessageInterface: 'voice', assistantMessageInterface: 'vellum' },
-        );
-      } else if (delivery.destinationChatId) {
-        // External channel — send expiry notice
-        const deliverUrl = `${gatewayBaseUrl}/deliver/${delivery.destinationChannel}`;
-        void (async () => {
-          try {
-            await deliverChannelReply(deliverUrl, {
-              chatId: delivery.destinationChatId!,
-              text: 'The guardian question has expired without a response. The call has moved on.',
-              assistantId: request.assistantId,
-            }, bearerToken);
-          } catch (err) {
-            log.error(
-              { err, deliveryId: delivery.id, channel: delivery.destinationChannel },
-              'Failed to deliver guardian action expiry notice',
-            );
-          }
-        })();
-      }
-    }
+    sendGuardianExpiryNotices(deliveries, request.assistantId, gatewayBaseUrl, bearerToken);
   }
 }
 


### PR DESCRIPTION
Replace deterministic timeout utterance in call controller with instruction-driven model turn. Adds guardianUnavailableForCall guard to prevent repeated long waits. On timeout, marks guardian action request as timed out with reason, injects system instruction for model to generate natural timeout acknowledgment with callback permission and continuation questions. Part of #9562.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
