### PR TITLE
Fix: Preserve origin conversation across voice resends

### DIFF
--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -289,6 +289,49 @@ describe('resendOutbound', () => {
     expect(resendResult.verificationSessionId).toBeDefined();
     expect(resendResult.sendCount).toBe(2);
   });
+
+  test('SMS: preserves originConversationId on resend', () => {
+    const startResult = startOutbound({ channel: 'sms', destination: '+15551113333' });
+    expect(startResult.success).toBe(true);
+
+    if (startResult.verificationSessionId) {
+      updateSessionDelivery(startResult.verificationSessionId, Date.now() - 60_000, 1, Date.now() - 1);
+    }
+
+    const resendResult = resendOutbound({
+      channel: 'sms',
+      originConversationId: 'conv-resend-sms-origin',
+    });
+    expect(resendResult.success).toBe(true);
+    expect(resendResult.originConversationId).toBe('conv-resend-sms-origin');
+  });
+
+  test('voice: preserves originConversationId on resend and passes it to call initiation', async () => {
+    voiceCallInitCalls.length = 0;
+    const startResult = startOutbound({ channel: 'voice', destination: '+15559991111' });
+    expect(startResult.success).toBe(true);
+
+    if (startResult.verificationSessionId) {
+      updateSessionDelivery(startResult.verificationSessionId, Date.now() - 60_000, 1, Date.now() - 1);
+    }
+
+    const resendResult = resendOutbound({
+      channel: 'voice',
+      originConversationId: 'conv-resend-voice-origin',
+    });
+    expect(resendResult.success).toBe(true);
+    expect(resendResult.originConversationId).toBe('conv-resend-voice-origin');
+
+    // Allow the fire-and-forget async call to flush
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // The resend voice call should carry the origin conversation ID
+    const resendCall = voiceCallInitCalls.find(
+      (c) => c.originConversationId === 'conv-resend-voice-origin',
+    );
+    expect(resendCall).toBeDefined();
+    expect(resendCall!.phoneNumber).toBe('+15559991111');
+  });
 });
 
 // ===========================================================================
@@ -358,6 +401,29 @@ describe('HTTP route: handleResendOutbound', () => {
     expect(resp.status).toBe(400);
     const body = await resp.json() as Record<string, unknown>;
     expect(body.error).toBe('no_active_session');
+  });
+
+  test('passes originConversationId through on successful resend', async () => {
+    // Start a session first
+    const startReq = jsonRequest({ channel: 'sms', destination: '+15556667777' });
+    const startResp = await handleStartOutbound(startReq);
+    expect(startResp.status).toBe(200);
+    const startBody = await startResp.json() as Record<string, unknown>;
+
+    // Expire the cooldown so resend is allowed
+    if (startBody.verificationSessionId) {
+      updateSessionDelivery(startBody.verificationSessionId as string, Date.now() - 60_000, 1, Date.now() - 1);
+    }
+
+    const resendReq = jsonRequest({
+      channel: 'sms',
+      originConversationId: 'conv-resend-http-origin',
+    });
+    const resendResp = await handleResendOutbound(resendReq);
+    expect(resendResp.status).toBe(200);
+    const resendBody = await resendResp.json() as Record<string, unknown>;
+    expect(resendBody.success).toBe(true);
+    expect(resendBody.originConversationId).toBe('conv-resend-http-origin');
   });
 });
 
@@ -466,5 +532,35 @@ describe('origin conversation linkage', () => {
     const lastCall = voiceCallInitCalls[voiceCallInitCalls.length - 1];
     expect(lastCall.phoneNumber).toBe('+15554443333');
     expect(lastCall.originConversationId).toBe('conv-origin-voice-init');
+  });
+
+  test('resendOutbound voice carries originConversationId to call initiation', async () => {
+    voiceCallInitCalls.length = 0;
+
+    // Start a voice session (no origin initially)
+    const startResult = startOutbound({ channel: 'voice', destination: '+15552228888' });
+    expect(startResult.success).toBe(true);
+
+    // Expire cooldown
+    if (startResult.verificationSessionId) {
+      updateSessionDelivery(startResult.verificationSessionId, Date.now() - 60_000, 1, Date.now() - 1);
+    }
+
+    // Resend with origin conversation ID
+    const resendResult = resendOutbound({
+      channel: 'voice',
+      originConversationId: 'conv-resend-origin-linkage',
+    });
+    expect(resendResult.success).toBe(true);
+    expect(resendResult.originConversationId).toBe('conv-resend-origin-linkage');
+
+    // Allow fire-and-forget async call to flush
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const resendCall = voiceCallInitCalls.find(
+      (c) => c.originConversationId === 'conv-resend-origin-linkage',
+    );
+    expect(resendCall).toBeDefined();
+    expect(resendCall!.phoneNumber).toBe('+15552228888');
   });
 });

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -185,7 +185,7 @@ export function handleGuardianVerification(
       const result = startOutbound({ channel, assistantId, destination: msg.destination, rebind: msg.rebind, originConversationId: msg.originConversationId });
       ctx.send(socket, { type: 'guardian_verification_response', ...result });
     } else if (msg.action === 'resend_outbound') {
-      const result = resendOutbound({ channel, assistantId });
+      const result = resendOutbound({ channel, assistantId, originConversationId: msg.originConversationId });
       ctx.send(socket, { type: 'guardian_verification_response', ...result });
     } else if (msg.action === 'cancel_outbound') {
       const result = cancelOutbound({ channel, assistantId });

--- a/assistant/src/runtime/guardian-outbound-actions.ts
+++ b/assistant/src/runtime/guardian-outbound-actions.ts
@@ -103,6 +103,8 @@ export interface StartOutboundParams {
 export interface ResendOutboundParams {
   channel: ChannelId;
   assistantId?: string;
+  /** Origin conversation ID so completion/failure pointers can route back on resend. */
+  originConversationId?: string;
 }
 
 export interface CancelOutboundParams {
@@ -541,6 +543,7 @@ function startOutboundVoice(
 export function resendOutbound(params: ResendOutboundParams): OutboundActionResult {
   const assistantId = normalizeAssistantId(params.assistantId ?? 'self');
   const channel = params.channel;
+  const originConversationId = params.originConversationId;
 
   const session = findActiveSession(assistantId, channel);
   if (!session) {
@@ -634,6 +637,7 @@ export function resendOutbound(params: ResendOutboundParams): OutboundActionResu
       nextResendAt,
       sendCount: newSendCount,
       channel,
+      originConversationId,
     };
   } else if (channel === 'voice') {
     const newSession = createOutboundSession({
@@ -650,7 +654,7 @@ export function resendOutbound(params: ResendOutboundParams): OutboundActionResu
     const nextResendAt = now + RESEND_COOLDOWN_MS;
 
     updateSessionDelivery(newSession.sessionId, now, newSendCount, nextResendAt);
-    initiateGuardianVoiceCall(destination, newSession.sessionId, assistantId);
+    initiateGuardianVoiceCall(destination, newSession.sessionId, assistantId, originConversationId);
 
     return {
       success: true,
@@ -659,6 +663,7 @@ export function resendOutbound(params: ResendOutboundParams): OutboundActionResu
       nextResendAt,
       sendCount: newSendCount,
       channel,
+      originConversationId,
     };
   }
 
@@ -693,6 +698,7 @@ export function resendOutbound(params: ResendOutboundParams): OutboundActionResu
     nextResendAt,
     sendCount: newSendCount,
     channel,
+    originConversationId,
   };
 }
 

--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -161,12 +161,13 @@ export async function handleStartOutbound(req: Request): Promise<Response> {
 /**
  * POST /v1/integrations/guardian/outbound/resend
  *
- * Body: { channel: ChannelId; assistantId?: string }
+ * Body: { channel: ChannelId; assistantId?: string; originConversationId?: string }
  */
 export async function handleResendOutbound(req: Request): Promise<Response> {
   const body = (await req.json()) as {
     channel?: ChannelId;
     assistantId?: string;
+    originConversationId?: string;
   };
   if (!body.channel) {
     return Response.json(
@@ -177,6 +178,7 @@ export async function handleResendOutbound(req: Request): Promise<Response> {
   const result = resendOutbound({
     channel: body.channel,
     assistantId: body.assistantId,
+    originConversationId: body.originConversationId,
   });
   const status = result.success ? 200 : 400;
   return Response.json(result, { status });


### PR DESCRIPTION
## Summary
- Threads originConversationId through resendOutbound path
- HTTP and IPC resend handlers now extract and pass origin conversation ID
- New call sessions from resend carry origin linkage for pointer message routing
- Updates tests to verify resend preserves origin linkage

Addresses feedback from #9617. Part of #9606.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
