### PR TITLE
M1: Persist original user message for _with_remainder recording intents

### DIFF
--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -165,6 +165,7 @@ export async function handleTaskSubmit(
     let pendingRecordingStart = false;
     let pendingRecordingStop = false;
     let pendingRecordingRestart: 'restart_with_remainder' | 'start_and_stop_with_remainder' | false = false;
+    let originalTaskBeforeStrip: string | undefined;
     if (config.daemon.standaloneRecording) {
       const name = getAssistantName();
       const dynamicNames = [name].filter(Boolean) as string[];
@@ -276,6 +277,8 @@ export async function handleTaskSubmit(
           pendingRecordingStart = intentResult.kind === 'start_with_remainder';
           pendingRecordingRestart = intentResult.kind === 'restart_with_remainder' ? 'restart_with_remainder' : false;
         }
+        // Preserve the original text so the DB stores the full message
+        originalTaskBeforeStrip = msg.task;
         (msg as { task: string }).task = intentResult.remainder;
         rlog.info({ remaining: intentResult.remainder }, 'Recording intent deferred, continuing with remaining text');
       }
@@ -409,7 +412,7 @@ export async function handleTaskSubmit(
       // Start streaming immediately — client doesn't need to send user_message
       session.processMessage(msg.task, msg.attachments ?? [], (event) => {
         ctx.send(socket, event);
-      }, requestId).catch((err) => {
+      }, requestId, undefined, undefined, undefined, originalTaskBeforeStrip).catch((err) => {
         const message = err instanceof Error ? err.message : String(err);
         rlog.error({ err }, 'Error processing task_submit text QA');
         ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -95,6 +95,7 @@ export async function handleUserMessage(
       source: 'user_message' | 'secure_redirect_resume',
       activeSurfaceId?: string,
       currentPage?: string,
+      displayContent?: string,
     ): void => {
       const receivedDescription = source === 'user_message'
         ? 'User message received'
@@ -117,6 +118,8 @@ export async function handleUserMessage(
         activeSurfaceId,
         currentPage,
         queuedChannelMetadata,
+        undefined,
+        displayContent,
       );
       if (result.rejected) {
         rlog.warn({ source }, 'Message rejected — queue is full');
@@ -167,7 +170,7 @@ export async function handleUserMessage(
       // Fire-and-forget: don't block the IPC handler so the connection can
       // continue receiving messages (e.g. cancel, confirmations, or
       // additional user_message that will be queued by the session).
-      session.processMessage(content, attachments, sendEvent, dispatchRequestId, activeSurfaceId, currentPage).catch((err) => {
+      session.processMessage(content, attachments, sendEvent, dispatchRequestId, activeSurfaceId, currentPage, undefined, displayContent).catch((err) => {
         const message = err instanceof Error ? err.message : String(err);
         rlog.error({ err, source }, 'Error processing user message (session or provider failure)');
         ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });
@@ -285,6 +288,7 @@ export async function handleUserMessage(
     }
 
     // ── Standalone recording intent interception ──────────────────────────
+    let originalContentBeforeStrip: string | undefined;
     if (config.daemon.standaloneRecording && messageText) {
       const name = getAssistantName();
       const dynamicNames = [name].filter(Boolean) as string[];
@@ -319,6 +323,9 @@ export async function handleUserMessage(
           socket,
           ctx,
         });
+
+        // Preserve the original text so the DB stores the full message
+        originalContentBeforeStrip = messageText;
 
         // Continue with stripped text for downstream processing
         msg.content = execResult.remainderText ?? messageText;
@@ -390,6 +397,7 @@ export async function handleUserMessage(
       'user_message',
       msg.activeSurfaceId,
       msg.currentPage,
+      originalContentBeforeStrip,
     );
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/session-messaging.ts
+++ b/assistant/src/daemon/session-messaging.ts
@@ -124,6 +124,7 @@ export function enqueueMessage(
   currentPage?: string,
   metadata?: Record<string, unknown>,
   options?: { isInteractive?: boolean },
+  displayContent?: string,
 ): { queued: boolean; rejected?: boolean; requestId: string } {
   if (!ctx.processing) {
     return { queued: false, requestId };
@@ -143,6 +144,7 @@ export function enqueueMessage(
     turnInterfaceContext,
     isInteractive: options?.isInteractive,
     queuedAt: Date.now(),
+    displayContent,
   });
   if (!pushed) {
     return { queued: false, rejected: true, requestId };
@@ -158,6 +160,7 @@ export function persistUserMessage(
   attachments: UserMessageAttachment[],
   requestId?: string,
   metadata?: Record<string, unknown>,
+  displayContent?: string,
 ): string {
   if (ctx.processing) {
     throw new Error('Session is already processing a message');
@@ -202,10 +205,19 @@ export function persistUserMessage(
         : {}),
     };
 
+    // When displayContent is provided (e.g. original text before recording
+    // intent stripping), persist that to DB so users see the full message
+    // after restart. The in-memory userMessage (sent to the LLM) still uses
+    // the stripped content.
+    const contentToPersist = displayContent
+      ? JSON.stringify(createUserMessage(displayContent, attachments.map((a) => ({
+          id: a.id, filename: a.filename, mimeType: a.mimeType, data: a.data, extractedText: a.extractedText,
+        }))).content)
+      : JSON.stringify(userMessage.content);
     const persistedUserMessage = conversationStore.addMessage(
       ctx.conversationId,
       'user',
-      JSON.stringify(userMessage.content),
+      contentToPersist,
       mergedMetadata,
     );
 

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -417,10 +417,16 @@ export async function processMessage(
         : {}),
     };
     const userMsg = createUserMessage(content, attachments);
+    // When displayContent is provided (e.g. original text before recording
+    // intent stripping), persist that to DB so users see the full message.
+    // The in-memory userMessage (sent to the LLM) still uses the stripped content.
+    const contentToPersist = displayContent
+      ? JSON.stringify(createUserMessage(displayContent, attachments).content)
+      : JSON.stringify(userMsg.content);
     const persisted = conversationStore.addMessage(
       session.conversationId,
       'user',
-      JSON.stringify(userMsg.content),
+      contentToPersist,
       pmChannelMeta,
     );
     session.messages.push(userMsg);

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -76,7 +76,7 @@ export interface ProcessSessionContext {
   /** Assistant identity — used for scoping notification preferences. */
   readonly assistantId?: string;
   guardianContext?: GuardianRuntimeContext;
-  persistUserMessage(content: string, attachments: UserMessageAttachment[], requestId?: string, metadata?: Record<string, unknown>): string;
+  persistUserMessage(content: string, attachments: UserMessageAttachment[], requestId?: string, metadata?: Record<string, unknown>, displayContent?: string): string;
   runAgentLoop(
     content: string,
     userMessageId: string,
@@ -265,7 +265,7 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
   // resolves early (no runAgentLoop call), so we must continue draining.
   let userMessageId: string;
   try {
-    userMessageId = session.persistUserMessage(resolvedContent, next.attachments, next.requestId, next.metadata);
+    userMessageId = session.persistUserMessage(resolvedContent, next.attachments, next.requestId, next.metadata, next.displayContent);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, conversationId: session.conversationId, requestId: next.requestId }, 'Failed to persist queued message');
@@ -336,6 +336,7 @@ export async function processMessage(
   activeSurfaceId?: string,
   currentPage?: string,
   options?: { isInteractive?: boolean },
+  displayContent?: string,
 ): Promise<string> {
   session.currentActiveSurfaceId = activeSurfaceId;
   session.currentPage = currentPage;
@@ -475,7 +476,7 @@ export async function processMessage(
 
   let userMessageId: string;
   try {
-    userMessageId = session.persistUserMessage(resolvedContent, attachments, requestId);
+    userMessageId = session.persistUserMessage(resolvedContent, attachments, requestId, undefined, displayContent);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     onEvent({ type: 'error', message });

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -192,10 +192,16 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
           : {}),
       };
       const userMsg = createUserMessage(next.content, next.attachments);
+      // When displayContent is provided (e.g. original text before recording
+      // intent stripping), persist that to DB so users see the full message.
+      // The in-memory userMessage (sent to the LLM) still uses the stripped content.
+      const contentToPersist = next.displayContent
+        ? JSON.stringify(createUserMessage(next.displayContent, next.attachments).content)
+        : JSON.stringify(userMsg.content);
       conversationStore.addMessage(
         session.conversationId,
         'user',
-        JSON.stringify(userMsg.content),
+        contentToPersist,
         drainChannelMeta,
       );
       session.messages.push(userMsg);

--- a/assistant/src/daemon/session-queue-manager.ts
+++ b/assistant/src/daemon/session-queue-manager.ts
@@ -25,6 +25,8 @@ export interface QueuedMessage {
   isInteractive?: boolean;
   /** Timestamp (ms) when the message was enqueued. */
   queuedAt: number;
+  /** Original user message text to persist to DB when recording intent stripping produced a different `content`. */
+  displayContent?: string;
 }
 
 export const MAX_QUEUE_DEPTH = 10;

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -397,8 +397,9 @@ export class Session {
     currentPage?: string,
     metadata?: Record<string, unknown>,
     options?: { isInteractive?: boolean },
+    displayContent?: string,
   ): { queued: boolean; rejected?: boolean; requestId: string } {
-    return enqueueMessageImpl(this, content, attachments, onEvent, requestId, activeSurfaceId, currentPage, metadata, options);
+    return enqueueMessageImpl(this, content, attachments, onEvent, requestId, activeSurfaceId, currentPage, metadata, options, displayContent);
   }
 
   getQueueDepth(): number {
@@ -494,8 +495,9 @@ export class Session {
     attachments: UserMessageAttachment[],
     requestId?: string,
     metadata?: Record<string, unknown>,
+    displayContent?: string,
   ): string {
-    return persistUserMessageImpl(this, content, attachments, requestId, metadata);
+    return persistUserMessageImpl(this, content, attachments, requestId, metadata, displayContent);
   }
 
   // ── Agent Loop ───────────────────────────────────────────────────
@@ -522,8 +524,9 @@ export class Session {
     activeSurfaceId?: string,
     currentPage?: string,
     options?: { isInteractive?: boolean },
+    displayContent?: string,
   ): Promise<string> {
-    return processMessageImpl(this as ProcessSessionContext, content, attachments, onEvent, requestId, activeSurfaceId, currentPage, options);
+    return processMessageImpl(this as ProcessSessionContext, content, attachments, onEvent, requestId, activeSurfaceId, currentPage, options, displayContent);
   }
 
   // ── History ──────────────────────────────────────────────────────


### PR DESCRIPTION
Thread original (unstripped) user message through to persistUserMessage so the DB stores the full text while the LLM still processes the stripped remainder. Closes #9629.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
