### PR TITLE
M8: Attachment lifecycle tightening

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -57,9 +57,11 @@ extension ChatBubble {
                 .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
                 .lineLimit(1)
 
-            Text(formattedFileSize(base64Length: attachment.dataLength))
-                .font(VFont.small)
-                .foregroundColor(isUser ? VColor.userBubbleTextSecondary : VColor.textMuted)
+            if attachment.dataLength > 0 {
+                Text(formattedFileSize(base64Length: attachment.dataLength))
+                    .font(VFont.small)
+                    .foregroundColor(isUser ? VColor.userBubbleTextSecondary : VColor.textMuted)
+            }
         }
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.xs)
@@ -96,7 +98,9 @@ extension ChatBubble {
     }
 
     func openImageInPreview(_ attachment: ChatAttachment) {
-        guard let data = Data(base64Encoded: attachment.data) else { return }
+        guard !attachment.data.isEmpty,
+              let data = Data(base64Encoded: attachment.data),
+              !data.isEmpty else { return }
         let tempDir = FileManager.default.temporaryDirectory
         let sanitized = (attachment.filename as NSString).lastPathComponent
         let fileURL = tempDir.appendingPathComponent(sanitized.isEmpty ? "image" : sanitized)
@@ -109,7 +113,9 @@ extension ChatBubble {
     }
 
     func saveFileAttachment(_ attachment: ChatAttachment) {
-        guard let data = Data(base64Encoded: attachment.data) else { return }
+        guard !attachment.data.isEmpty,
+              let data = Data(base64Encoded: attachment.data),
+              !data.isEmpty else { return }
         let panel = NSSavePanel()
         panel.nameFieldStringValue = (attachment.filename as NSString).lastPathComponent
         panel.canCreateDirectories = true

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -822,8 +822,10 @@ extension ChatViewModel {
                 currentTurnUserText = messages[index].text.trimmingCharacters(in: .whitespacesAndNewlines)
                 // Clear attachment binary payloads now that the daemon has persisted them.
                 // Keep thumbnailImage for display; the full data can be re-fetched via HTTP if needed.
+                // Only clear for lazy-loadable attachments (sizeBytes != nil); locally-created
+                // attachments (sizeBytes == nil) can't be re-fetched and need their data preserved.
                 for a in messages[index].attachments.indices {
-                    if !messages[index].attachments[a].data.isEmpty {
+                    if !messages[index].attachments[a].data.isEmpty && messages[index].attachments[a].sizeBytes != nil {
                         messages[index].attachments[a].data = ""
                         messages[index].attachments[a].dataLength = 0
                     }
@@ -858,12 +860,14 @@ extension ChatViewModel {
             currentTurnUserText = nil
             currentAssistantHasText = false
             lastContentWasToolCall = false
-            // Reset processing messages to sent and clear attachment binary payloads
+            // Reset processing messages to sent and clear attachment binary payloads.
+            // Only clear for lazy-loadable attachments (sizeBytes != nil); locally-created
+            // attachments (sizeBytes == nil) can't be re-fetched and need their data preserved.
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {
                     messages[i].status = .sent
                     for a in messages[i].attachments.indices {
-                        if !messages[i].attachments[a].data.isEmpty {
+                        if !messages[i].attachments[a].data.isEmpty && messages[i].attachments[a].sizeBytes != nil {
                             messages[i].attachments[a].data = ""
                             messages[i].attachments[a].dataLength = 0
                         }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -820,6 +820,14 @@ extension ChatViewModel {
                let index = messages.firstIndex(where: { $0.id == messageId }) {
                 messages[index].status = .processing
                 currentTurnUserText = messages[index].text.trimmingCharacters(in: .whitespacesAndNewlines)
+                // Clear attachment binary payloads now that the daemon has persisted them.
+                // Keep thumbnailImage for display; the full data can be re-fetched via HTTP if needed.
+                for a in messages[index].attachments.indices {
+                    if !messages[index].attachments[a].data.isEmpty {
+                        messages[index].attachments[a].data = ""
+                        messages[index].attachments[a].dataLength = 0
+                    }
+                }
             }
             // Recompute positions for remaining queued messages
             for i in messages.indices {
@@ -850,10 +858,16 @@ extension ChatViewModel {
             currentTurnUserText = nil
             currentAssistantHasText = false
             lastContentWasToolCall = false
-            // Reset processing messages to sent
+            // Reset processing messages to sent and clear attachment binary payloads
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {
                     messages[i].status = .sent
+                    for a in messages[i].attachments.indices {
+                        if !messages[i].attachments[a].data.isEmpty {
+                            messages[i].attachments[a].data = ""
+                            messages[i].attachments[a].dataLength = 0
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
Clear base64 attachment data from ChatMessage as soon as the daemon dequeues the message, rather than waiting for stripHeavyContent() to run 200+ messages later. The thumbnailImage is preserved for display. Part of #9585.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
