### PR TITLE
fix: resolve ActorIsolatedCall warning in DaemonConnection

### DIFF
--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -563,7 +563,7 @@ extension DaemonClient {
     /// Extract the "type" field from raw JSON data for safe logging.
     /// Returns the type string if parseable, otherwise "<unknown>".
     /// This avoids logging the entire line which may contain sensitive values.
-    func extractMessageType(from data: Data) -> String {
+    nonisolated func extractMessageType(from data: Data) -> String {
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let type = json["type"] as? String else {
             return "<unknown>"


### PR DESCRIPTION
## Summary
- Mark `extractMessageType(from:)` as `nonisolated` since it's a pure function that only operates on its parameter and doesn't access any actor-isolated state
- Fixes `#ActorIsolatedCall` warning when calling the method from a non-isolated context in the data processing closure

## Original prompt
fix this: ~v/clients/macos git:(main❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
Building (debug)...
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/shared/IPC/DaemonConnection.swift:357:49: warning: call to main actor-isolated instance method 'extractMessageType(from:)' in a synchronous nonisolated context [#ActorIsolatedCall]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
