### PR TITLE
fix: remove redundant nil coalescing warnings in ScreenRecorder

### DIFF
--- a/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
+++ b/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
@@ -720,7 +720,7 @@ final class ScreenRecorder: NSObject {
                                 sourceWidth: telemetrySourceWidth,
                                 sourceHeight: telemetrySourceHeight,
                                 configLabel: encodeConfig.label,
-                                message: typedError.localizedDescription ?? reason
+                                message: typedError.localizedDescription
                             )
                             throw typedError
                         default:
@@ -945,7 +945,7 @@ final class ScreenRecorder: NSObject {
         // Propagate the typed error (e.g. permission denied, source unavailable)
         // instead of collapsing it to the generic .noFramesReceived path.
         if let streamError = pendingStreamError {
-            log.warning("Startup attempt failed with stream error for config '\(encodeConfig.label, privacy: .public)': \(streamError.localizedDescription ?? "unknown", privacy: .public)")
+            log.warning("Startup attempt failed with stream error for config '\(encodeConfig.label, privacy: .public)': \(streamError.localizedDescription, privacy: .public)")
             // handleStreamError already cleaned up writer/stream/file — just
             // clean up the output file if it wasn't already removed.
             try? FileManager.default.removeItem(at: outputURL)


### PR DESCRIPTION
## Summary
- Remove `?? reason` and `?? "unknown"` from two `localizedDescription` calls in ScreenRecorder.swift
- `localizedDescription` returns `String` (non-optional), so the `??` operator right side is never used

## Original prompt
Fix nil coalescing warnings in ScreenRecorder.swift where `localizedDescription` (non-optional `String`) was used with `??`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
