### PR TITLE
M9: Selection-overlay containment

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -303,6 +303,7 @@ struct ChatBubble: View {
                     if hasRichContent {
                         MarkdownSegmentView(
                             segments: segments,
+                            isStreaming: message.isStreaming,
                             maxContentWidth: nil,
                             textColor: isUser ? VColor.userBubbleText : VColor.textPrimary,
                             secondaryTextColor: isUser ? VColor.userBubbleTextSecondary : VColor.textSecondary,
@@ -316,7 +317,7 @@ struct ChatBubble: View {
                             .font(.system(size: 13 * conversationZoomScale))
                             .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
                             .tint(isUser ? VColor.userBubbleText : VColor.accent)
-                            .textSelection(.enabled)
+                            .textSelection(message.isStreaming ? .disabled : .enabled)
                             .fixedSize(horizontal: false, vertical: true)
                     }
                 } else if !message.attachments.isEmpty {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -18,7 +18,7 @@ extension ChatBubble {
 
         bubbleChrome {
             if hasRichContent {
-                MarkdownSegmentView(segments: segments)
+                MarkdownSegmentView(segments: segments, isStreaming: streaming)
             } else {
                 let attributed = Self.cachedInlineMarkdown(for: segmentText, isStreaming: streaming)
                 Text(attributed)
@@ -26,7 +26,7 @@ extension ChatBubble {
                     .lineSpacing(3)
                     .foregroundColor(VColor.textPrimary)
                     .tint(VColor.accent)
-                    .textSelection(.enabled)
+                    .textSelection(streaming ? .disabled : .enabled)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: 520, alignment: .leading)
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -260,6 +260,7 @@ struct MarkdownTableView: View {
     let headers: [String]
     let rows: [[String]]
     var maxWidth: CGFloat = 520
+    var isStreaming: Bool = false
 
     @Environment(\.conversationZoomScale) private var zoomScale
 
@@ -274,7 +275,7 @@ struct MarkdownTableView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.sm)
-                        .textSelection(.enabled)
+                        .textSelection(isStreaming ? .disabled : .enabled)
                 }
             }
 
@@ -313,6 +314,6 @@ struct MarkdownTableView: View {
         return Text(attributed)
             .font(.custom("Inter", size: 13 * zoomScale))
             .foregroundColor(VColor.textPrimary)
-            .textSelection(.enabled)
+            .textSelection(isStreaming ? .disabled : .enabled)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -59,7 +59,7 @@ struct MarkdownSegmentView: View {
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
 
                 case .table(let headers, let rows):
-                    MarkdownTableView(headers: headers, rows: rows, maxWidth: maxContentWidth ?? .infinity)
+                    MarkdownTableView(headers: headers, rows: rows, maxWidth: maxContentWidth ?? .infinity, isStreaming: isStreaming)
 
                 case .image(let alt, let url):
                     AnimatedImageView(urlString: url)

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -7,6 +7,7 @@ import VellumAssistantShared
 /// unified Text views so that text selection can span across paragraphs.
 struct MarkdownSegmentView: View {
     let segments: [MarkdownSegment]
+    var isStreaming: Bool = false
     var maxContentWidth: CGFloat? = 520
     var textColor: Color = VColor.textPrimary
     var secondaryTextColor: Color = VColor.textSecondary
@@ -31,7 +32,7 @@ struct MarkdownSegmentView: View {
                         .lineSpacing(4)
                         .foregroundColor(textColor)
                         .tint(tintColor)
-                        .textSelection(.enabled)
+                        .textSelection(isStreaming ? .disabled : .enabled)
                         .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: maxContentWidth ?? .infinity, alignment: .leading)
 
@@ -48,7 +49,7 @@ struct MarkdownSegmentView: View {
                             Text(code)
                                 .font(.custom("DMMono-Regular", size: 13 * zoomScale))
                                 .foregroundColor(textColor)
-                                .textSelection(.enabled)
+                                .textSelection(isStreaming ? .disabled : .enabled)
                                 .fixedSize(horizontal: true, vertical: true)
                                 .padding(VSpacing.sm)
                         }


### PR DESCRIPTION
Conditionally disable .textSelection during streaming to prevent SelectionOverlay.updateNSView from dominating the main thread. The modifier is re-enabled once streaming completes, preserving copy/select functionality for finalized messages. Part of #9586.