### PR TITLE
fix: resolve Swift compiler warnings in ScreenRecorder and PermissionManager

### DIFF
--- a/clients/macos/vellum-assistant/App/PermissionManager.swift
+++ b/clients/macos/vellum-assistant/App/PermissionManager.swift
@@ -136,7 +136,7 @@ enum PermissionManager {
             let settings = await UNUserNotificationCenter.current().notificationSettings()
             switch settings.authorizationStatus {
             case .notDetermined:
-                UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { _, _ in }
+                try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
             case .authorized, .provisional, .ephemeral:
                 return
             case .denied:
@@ -152,7 +152,7 @@ enum PermissionManager {
             let settings = await UNUserNotificationCenter.current().notificationSettings()
             switch settings.authorizationStatus {
             case .notDetermined:
-                UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { _, _ in }
+                try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
             case .authorized, .provisional, .ephemeral:
                 if settings.badgeSetting != .enabled {
                     _ = openNotificationSettings()

--- a/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
+++ b/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
@@ -952,7 +952,7 @@ final class ScreenRecorder: NSObject {
             // Do NOT clear pendingStreamError here — start() reads it in the
             // .streamStartFailed branch to decide if the error is non-retriable
             // (e.g. permissionDenied, sourceUnavailable). It clears it there.
-            return .streamStartFailed(streamError.localizedDescription ?? "Stream error during startup")
+            return .streamStartFailed(streamError.localizedDescription)
         }
 
         // No frames arrived — tear down this attempt
@@ -1228,7 +1228,7 @@ final class ScreenRecorder: NSObject {
                 sourceWidth: telemetrySourceWidth,
                 sourceHeight: telemetrySourceHeight,
                 configLabel: activeConfigLabel,
-                message: recorderError.localizedDescription ?? "Unknown stream error"
+                message: recorderError.localizedDescription
             )
 
             // Unregister display monitoring since the recording session is ending.


### PR DESCRIPTION
## Summary
- Remove redundant nil coalescing on non-optional `localizedDescription` in `ScreenRecorder.swift` (lines 955 and 1231)
- Switch to async `requestAuthorization` in `PermissionManager.swift` to silence "consider using asynchronous alternative" warnings (lines 139 and 155)

## Original prompt
Fix Swift compiler warnings from macOS build: redundant `??` on non-optional `localizedDescription` and callback-based `requestAuthorization` in async context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
