### PR TITLE
fix: wrap guardian notification in try-catch

### DIFF
--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -275,14 +275,18 @@ export async function handleChannelInbound(
         // Notify the guardian about the access request so they can approve/deny.
         // Only fires when a guardian binding exists and no duplicate pending
         // request already exists for this requester.
-        notifyGuardianOfAccessRequest({
-          canonicalAssistantId,
-          sourceChannel,
-          externalChatId,
-          senderExternalUserId: body.senderExternalUserId,
-          senderName: body.senderName,
-          senderUsername: body.senderUsername,
-        });
+        try {
+          notifyGuardianOfAccessRequest({
+            canonicalAssistantId,
+            sourceChannel,
+            externalChatId,
+            senderExternalUserId: body.senderExternalUserId,
+            senderName: body.senderName,
+            senderUsername: body.senderUsername,
+          });
+        } catch (err) {
+          log.error({ err, sourceChannel, externalChatId }, 'Failed to notify guardian of access request');
+        }
 
         return Response.json({ accepted: true, denied: true, reason: 'not_a_member' });
       }


### PR DESCRIPTION
Wraps the notifyGuardianOfAccessRequest call in the non-member deny block with try-catch so DB errors don't turn the denial response into a 500. The notification is best-effort and should not break the primary deny path.

Part of #9432
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
