### PR TITLE
fix: scope notification dedupe key per approval request

### DIFF
--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1130,7 +1130,7 @@ function notifyGuardianOfAccessRequest(params: {
 
   const senderIdentifier = senderName || senderUsername || senderExternalUserId;
 
-  createApprovalRequest({
+  const approvalRequest = createApprovalRequest({
     runId: `ingress-access-request-${Date.now()}`,
     conversationId: `access-req-${sourceChannel}-${senderExternalUserId}`,
     assistantId: canonicalAssistantId,
@@ -1164,9 +1164,10 @@ function notifyGuardianOfAccessRequest(params: {
       senderUsername: senderUsername ?? null,
       senderIdentifier,
     },
-    // Deduplicate at the notification pipeline level too, keyed on the
-    // requester identity so repeated messages don't flood the guardian.
-    dedupeKey: `access-request:${canonicalAssistantId}:${sourceChannel}:${senderExternalUserId}`,
+    // Scoped to the approval request ID so duplicate notifications for the
+    // same request are suppressed, but a new request (after deny/expire)
+    // gets its own dedupe key and the guardian is notified again.
+    dedupeKey: `access-request:${approvalRequest.id}`,
   });
 
   log.info(


### PR DESCRIPTION
Changes the dedupeKey for access request notifications to include the approval request ID instead of just the requester identity. This ensures the guardian is notified of new access requests even after previous ones were denied or expired.

Part of #9432
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
