### PR TITLE
fix: regenerate Swift IPC code for originConversationId field

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1852,8 +1852,10 @@ public struct IPCGuardianVerificationRequest: Codable, Sendable {
     public let rebind: Bool?
     /// E.164 phone number for SMS/voice, Telegram handle/chat-id. Used by outbound actions.
     public let destination: String?
+    /// Origin conversation ID so completion/failure pointers can route back.
+    public let originConversationId: String?
 
-    public init(type: String, action: String, channel: String? = nil, sessionId: String? = nil, assistantId: String? = nil, rebind: Bool? = nil, destination: String? = nil) {
+    public init(type: String, action: String, channel: String? = nil, sessionId: String? = nil, assistantId: String? = nil, rebind: Bool? = nil, destination: String? = nil, originConversationId: String? = nil) {
         self.type = type
         self.action = action
         self.channel = channel
@@ -1861,6 +1863,7 @@ public struct IPCGuardianVerificationRequest: Codable, Sendable {
         self.assistantId = assistantId
         self.rebind = rebind
         self.destination = destination
+        self.originConversationId = originConversationId
     }
 }
 


### PR DESCRIPTION
## Summary

- Regenerate `IPCContractGenerated.swift` to include the `originConversationId` field added to `IPCGuardianVerificationRequest` in commit 16bf24fe9.
- Fixes the `check:ipc-generated` CI step that was failing because the Swift code was out of sync with the IPC contract.

## Original prompt
fix: regenerate Swift IPC code for originConversationId field

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
