### PR TITLE
M2: Persist user + assistant messages for _only recording commands

### DIFF
--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -89,7 +89,7 @@ export async function handleTaskSubmit(
           sessionId: conversation.id,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
-        conversationStore.addMessage(conversation.id, 'user', JSON.stringify([{ type: 'text', text: msg.task }]));
+        conversationStore.addMessage(conversation.id, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(conversation.id, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         if (!recordingId) ctx.socketToSession.delete(socket);
         return;
@@ -109,7 +109,7 @@ export async function handleTaskSubmit(
           sessionId: activeSessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
-        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task }]));
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         return;
       } else if (action === 'restart') {
@@ -127,7 +127,7 @@ export async function handleTaskSubmit(
           sessionId: activeSessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
-        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task }]));
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: restartResult.responseText }]));
         return;
       } else if (action === 'pause') {
@@ -146,7 +146,7 @@ export async function handleTaskSubmit(
           sessionId: activeSessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
-        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task }]));
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         return;
       } else if (action === 'resume') {
@@ -165,7 +165,7 @@ export async function handleTaskSubmit(
           sessionId: activeSessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
-        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task }]));
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         return;
       } else {
@@ -199,7 +199,7 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'task_routed', sessionId: conversation.id, interactionType: 'text_qa' });
         ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: conversation.id });
         ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
-        conversationStore.addMessage(conversation.id, 'user', JSON.stringify([{ type: 'text', text: msg.task }]));
+        conversationStore.addMessage(conversation.id, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(conversation.id, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
 
         // If recording rejected, unbind socket
@@ -229,7 +229,7 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: activeSessionId });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
-        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task }]));
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
         return;
       }
@@ -252,7 +252,7 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: activeSessionId });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
-        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task }]));
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
         return;
       }
@@ -276,7 +276,7 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: activeSessionId });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
-        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task }]));
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
         return;
       }
@@ -343,7 +343,7 @@ export async function handleTaskSubmit(
                 sessionId: activeSessionId,
               });
               ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
-              conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task }]));
+              conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
               conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
 
               // If recording was rejected (e.g. already active), unbind the

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -81,13 +81,16 @@ export async function handleTaskSubmit(
         const conversation = conversationStore.createConversation(msg.task || 'Screen Recording');
         ctx.socketToSession.set(socket, conversation.id);
         const recordingId = handleRecordingStart(conversation.id, { promptForSource: true }, socket, ctx);
+        const responseText = recordingId ? 'Starting screen recording.' : 'A recording is already active.';
         ctx.send(socket, { type: 'task_routed', sessionId: conversation.id, interactionType: 'text_qa' });
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: recordingId ? 'Starting screen recording.' : 'A recording is already active.',
+          text: responseText,
           sessionId: conversation.id,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
+        conversationStore.addMessage(conversation.id, 'user', JSON.stringify([{ type: 'text', text: msg.task }]));
+        conversationStore.addMessage(conversation.id, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         if (!recordingId) ctx.socketToSession.delete(socket);
         return;
       } else if (action === 'stop') {
@@ -98,13 +101,16 @@ export async function handleTaskSubmit(
           ctx.socketToSession.set(socket, activeSessionId);
         }
         const stopped = handleRecordingStop(activeSessionId, ctx) !== undefined;
+        const responseText = stopped ? 'Stopping the recording.' : 'No active recording to stop.';
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',
+          text: responseText,
           sessionId: activeSessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task }]));
+        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         return;
       } else if (action === 'restart') {
         let activeSessionId = ctx.socketToSession.get(socket);
@@ -121,6 +127,8 @@ export async function handleTaskSubmit(
           sessionId: activeSessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task }]));
+        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: restartResult.responseText }]));
         return;
       } else if (action === 'pause') {
         let activeSessionId = ctx.socketToSession.get(socket);
@@ -130,13 +138,16 @@ export async function handleTaskSubmit(
           ctx.socketToSession.set(socket, activeSessionId);
         }
         const paused = handleRecordingPause(activeSessionId, ctx) !== undefined;
+        const responseText = paused ? 'Pausing the recording.' : 'No active recording to pause.';
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: paused ? 'Pausing the recording.' : 'No active recording to pause.',
+          text: responseText,
           sessionId: activeSessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task }]));
+        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         return;
       } else if (action === 'resume') {
         let activeSessionId = ctx.socketToSession.get(socket);
@@ -146,13 +157,16 @@ export async function handleTaskSubmit(
           ctx.socketToSession.set(socket, activeSessionId);
         }
         const resumed = handleRecordingResume(activeSessionId, ctx) !== undefined;
+        const responseText = resumed ? 'Resuming the recording.' : 'No active recording to resume.';
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: resumed ? 'Resuming the recording.' : 'No active recording to resume.',
+          text: responseText,
           sessionId: activeSessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task }]));
+        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         return;
       } else {
         // Unrecognized action — fall through to normal text handling so the
@@ -185,6 +199,8 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'task_routed', sessionId: conversation.id, interactionType: 'text_qa' });
         ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: conversation.id });
         ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
+        conversationStore.addMessage(conversation.id, 'user', JSON.stringify([{ type: 'text', text: msg.task }]));
+        conversationStore.addMessage(conversation.id, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
 
         // If recording rejected, unbind socket
         if (execResult.recordingStarted === false) {
@@ -213,6 +229,8 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: activeSessionId });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task }]));
+        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
         return;
       }
 
@@ -234,6 +252,8 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: activeSessionId });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task }]));
+        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
         return;
       }
 
@@ -256,6 +276,8 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: activeSessionId });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task }]));
+        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
         return;
       }
 
@@ -321,6 +343,8 @@ export async function handleTaskSubmit(
                 sessionId: activeSessionId,
               });
               ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+              conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task }]));
+              conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
 
               // If recording was rejected (e.g. already active), unbind the
               // socket so it doesn't stay bound to an orphaned conversation.

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -91,6 +91,12 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
         conversationStore.addMessage(conversation.id, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(conversation.id, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        // Sync in-memory session if one exists for this conversation
+        const startSession = ctx.sessions.get(conversation.id);
+        if (startSession) {
+          startSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
+          startSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
+        }
         if (!recordingId) ctx.socketToSession.delete(socket);
         return;
       } else if (action === 'stop') {
@@ -111,6 +117,11 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
         conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        const stopSession = ctx.sessions.get(activeSessionId);
+        if (stopSession) {
+          stopSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
+          stopSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
+        }
         return;
       } else if (action === 'restart') {
         let activeSessionId = ctx.socketToSession.get(socket);
@@ -129,6 +140,11 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
         conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: restartResult.responseText }]));
+        const restartSession = ctx.sessions.get(activeSessionId);
+        if (restartSession) {
+          restartSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
+          restartSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: restartResult.responseText }] });
+        }
         return;
       } else if (action === 'pause') {
         let activeSessionId = ctx.socketToSession.get(socket);
@@ -148,6 +164,11 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
         conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        const pauseSession = ctx.sessions.get(activeSessionId);
+        if (pauseSession) {
+          pauseSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
+          pauseSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
+        }
         return;
       } else if (action === 'resume') {
         let activeSessionId = ctx.socketToSession.get(socket);
@@ -167,6 +188,11 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
         conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        const resumeSession = ctx.sessions.get(activeSessionId);
+        if (resumeSession) {
+          resumeSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
+          resumeSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
+        }
         return;
       } else {
         // Unrecognized action — fall through to normal text handling so the
@@ -201,6 +227,11 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
         conversationStore.addMessage(conversation.id, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(conversation.id, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+        const startOnlySession = ctx.sessions.get(conversation.id);
+        if (startOnlySession) {
+          startOnlySession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
+          startOnlySession.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
+        }
 
         // If recording rejected, unbind socket
         if (execResult.recordingStarted === false) {
@@ -231,6 +262,11 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
         conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+        const stopOnlySession = ctx.sessions.get(activeSessionId);
+        if (stopOnlySession) {
+          stopOnlySession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
+          stopOnlySession.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
+        }
         return;
       }
 
@@ -254,6 +290,11 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
         conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+        const startStopOnlySession = ctx.sessions.get(activeSessionId);
+        if (startStopOnlySession) {
+          startStopOnlySession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
+          startStopOnlySession.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
+        }
         return;
       }
 
@@ -278,6 +319,11 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
         conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+        const handledSession = ctx.sessions.get(activeSessionId);
+        if (handledSession) {
+          handledSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
+          handledSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
+        }
         return;
       }
 
@@ -345,6 +391,11 @@ export async function handleTaskSubmit(
               ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
               conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
               conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+              const fallbackSession = ctx.sessions.get(activeSessionId);
+              if (fallbackSession) {
+                fallbackSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
+                fallbackSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
+              }
 
               // If recording was rejected (e.g. already active), unbind the
               // socket so it doesn't stay bound to an orphaned conversation.

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -238,21 +238,27 @@ export async function handleUserMessage(
       rlog.info({ action, source: 'commandIntent' }, 'Recording command intent received in user_message');
       if (action === 'start') {
         const recordingId = handleRecordingStart(msg.sessionId, { promptForSource: true }, socket, ctx);
+        const responseText = recordingId ? 'Starting screen recording.' : 'A recording is already active.';
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: recordingId ? 'Starting screen recording.' : 'A recording is already active.',
+          text: responseText,
           sessionId: msg.sessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+        conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+        conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         return;
       } else if (action === 'stop') {
         const stopped = handleRecordingStop(msg.sessionId, ctx) !== undefined;
+        const responseText = stopped ? 'Stopping the recording.' : 'No active recording to stop.';
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',
+          text: responseText,
           sessionId: msg.sessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+        conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+        conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         return;
       } else if (action === 'restart') {
         const restartResult = handleRecordingRestart(msg.sessionId, socket, ctx);
@@ -262,24 +268,32 @@ export async function handleUserMessage(
           sessionId: msg.sessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+        conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+        conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: restartResult.responseText }]));
         return;
       } else if (action === 'pause') {
         const paused = handleRecordingPause(msg.sessionId, ctx) !== undefined;
+        const responseText = paused ? 'Pausing the recording.' : 'No active recording to pause.';
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: paused ? 'Pausing the recording.' : 'No active recording to pause.',
+          text: responseText,
           sessionId: msg.sessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+        conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+        conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         return;
       } else if (action === 'resume') {
         const resumed = handleRecordingResume(msg.sessionId, ctx) !== undefined;
+        const responseText = resumed ? 'Resuming the recording.' : 'No active recording to resume.';
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: resumed ? 'Resuming the recording.' : 'No active recording to resume.',
+          text: responseText,
           sessionId: msg.sessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+        conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+        conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         return;
       } else {
         // Unrecognized action — fall through to normal text handling
@@ -312,6 +326,8 @@ export async function handleUserMessage(
             sessionId: msg.sessionId,
           });
           ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+          conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+          conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
           return;
         }
       }
@@ -383,6 +399,8 @@ export async function handleUserMessage(
                 sessionId: msg.sessionId,
               });
               ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+              conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+              conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
               return;
             }
           }

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -247,6 +247,10 @@ export async function handleUserMessage(
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
         conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
         conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        // Keep in-memory session history aligned with DB so regenerate() and
+        // other history operations that rely on session.messages stay consistent.
+        session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+        session.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
         return;
       } else if (action === 'stop') {
         const stopped = handleRecordingStop(msg.sessionId, ctx) !== undefined;
@@ -259,6 +263,8 @@ export async function handleUserMessage(
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
         conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
         conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+        session.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
         return;
       } else if (action === 'restart') {
         const restartResult = handleRecordingRestart(msg.sessionId, socket, ctx);
@@ -270,6 +276,8 @@ export async function handleUserMessage(
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
         conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
         conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: restartResult.responseText }]));
+        session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+        session.messages.push({ role: 'assistant', content: [{ type: 'text', text: restartResult.responseText }] });
         return;
       } else if (action === 'pause') {
         const paused = handleRecordingPause(msg.sessionId, ctx) !== undefined;
@@ -282,6 +290,8 @@ export async function handleUserMessage(
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
         conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
         conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+        session.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
         return;
       } else if (action === 'resume') {
         const resumed = handleRecordingResume(msg.sessionId, ctx) !== undefined;
@@ -294,6 +304,8 @@ export async function handleUserMessage(
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
         conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
         conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+        session.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
         return;
       } else {
         // Unrecognized action — fall through to normal text handling
@@ -328,6 +340,8 @@ export async function handleUserMessage(
           ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
           conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
           conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+          session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+          session.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
           return;
         }
       }
@@ -401,6 +415,8 @@ export async function handleUserMessage(
               ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
               conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
               conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+              session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+              session.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
               return;
             }
           }


### PR DESCRIPTION
Persist both the user message and assistant acknowledgment to the database for pure recording commands (start_only, stop_only, restart_only, pause_only, resume_only) that previously sent IPC-only responses and returned early. Closes #9630.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
