### PR TITLE
fix: enforce 6-digit guardian verification codes across guardian flows

### DIFF
--- a/assistant/README.md
+++ b/assistant/README.md
@@ -262,7 +262,7 @@ The channel guardian service generates verification challenge instructions with 
 
 ### Operator Notes
 
-- **Verification input format:** Channel verification accepts a bare 6-digit code reply only.
+- **Verification input format:** Channel verification accepts a bare code reply only (6-digit numeric for identity-bound sessions; 64-char hex for unbound inbound/bootstrap compatibility).
 - **Rebind requirement:** Creating a new guardian challenge when a binding already exists requires `rebind: true` in the IPC request. Without it, the daemon returns `already_bound`. This prevents accidental guardian replacement.
 - **Takeover prevention:** Verification is rejected when an active binding exists for a different external user. Same-user re-verification is allowed.
 
@@ -274,7 +274,7 @@ This section documents the end-to-end flow from guardian verification through in
 
 Guardian verification establishes a cryptographic trust binding between a human identity and an `(assistantId, channel)` pair. The flow is:
 
-1. **Challenge creation** — The owner initiates verification from the desktop UI, which sends a guardian-verification IPC message (`create_challenge` action) to the daemon. The daemon generates a 6-digit verification code, hashes it with SHA-256, stores the hash with a 10-minute TTL, and returns the raw code to the desktop.
+1. **Challenge creation** — The owner initiates verification from the desktop UI, which sends a guardian-verification IPC message (`create_challenge` action) to the daemon. The daemon generates a random secret (32-byte hex for unbound inbound/bootstrap sessions, 6-digit numeric for identity-bound sessions), hashes it with SHA-256, stores the hash with a 10-minute TTL, and returns the raw secret to the desktop.
 2. **Code sharing** — The desktop displays the code and instructs the owner to reply with that code in the target channel conversation (e.g., Telegram or SMS).
 3. **Verification** — When the message arrives at `/channels/inbound`, the handler intercepts valid verification-code replies before normal message processing. It hashes the provided code, looks up a matching pending challenge, validates expiry, and consumes the challenge (preventing replay).
 4. **Binding** — On success, any existing active binding for the `(assistantId, channel)` pair is revoked, and a new guardian binding is created with the verifier's `externalUserId` and `chatId`. The verifier receives a confirmation message.

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -262,7 +262,7 @@ The channel guardian service generates verification challenge instructions with 
 
 ### Operator Notes
 
-- **Verification input format:** Channel verification accepts a bare code reply only (6-digit numeric for outbound sessions; 64-char hex retained for legacy inbound challenge compatibility).
+- **Verification input format:** Channel verification accepts a bare 6-digit code reply only.
 - **Rebind requirement:** Creating a new guardian challenge when a binding already exists requires `rebind: true` in the IPC request. Without it, the daemon returns `already_bound`. This prevents accidental guardian replacement.
 - **Takeover prevention:** Verification is rejected when an active binding exists for a different external user. Same-user re-verification is allowed.
 
@@ -274,9 +274,9 @@ This section documents the end-to-end flow from guardian verification through in
 
 Guardian verification establishes a cryptographic trust binding between a human identity and an `(assistantId, channel)` pair. The flow is:
 
-1. **Challenge creation** — The owner initiates verification from the desktop UI, which sends a guardian-verification IPC message (`create_challenge` action) to the daemon. The daemon generates a random secret (32-byte hex for text channels, 6-digit numeric for voice), hashes it with SHA-256, stores the hash with a 10-minute TTL, and returns the raw secret to the desktop.
-2. **Secret sharing** — The desktop displays the secret and instructs the owner to reply with that code in the target channel conversation (e.g., Telegram or SMS).
-3. **Verification** — When the message arrives at `/channels/inbound`, the handler intercepts valid verification-code replies before normal message processing. It hashes the provided secret, looks up a matching pending challenge, validates expiry, and consumes the challenge (preventing replay).
+1. **Challenge creation** — The owner initiates verification from the desktop UI, which sends a guardian-verification IPC message (`create_challenge` action) to the daemon. The daemon generates a 6-digit verification code, hashes it with SHA-256, stores the hash with a 10-minute TTL, and returns the raw code to the desktop.
+2. **Code sharing** — The desktop displays the code and instructs the owner to reply with that code in the target channel conversation (e.g., Telegram or SMS).
+3. **Verification** — When the message arrives at `/channels/inbound`, the handler intercepts valid verification-code replies before normal message processing. It hashes the provided code, looks up a matching pending challenge, validates expiry, and consumes the challenge (preventing replay).
 4. **Binding** — On success, any existing active binding for the `(assistantId, channel)` pair is revoked, and a new guardian binding is created with the verifier's `externalUserId` and `chatId`. The verifier receives a confirmation message.
 
 Rate limiting protects against brute-force attempts: 5 invalid attempts within 15 minutes trigger a 30-minute lockout per `(assistantId, channel, actor)` tuple. The same generic failure message is returned for both invalid codes and rate-limited attempts to avoid leaking state.

--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -960,6 +960,42 @@ describe('SMS guardian verify intercept', () => {
 
     deliverSpy.mockRestore();
   });
+
+  test('64-char hex messages are not treated as guardian verification codes', async () => {
+    const { createVerificationChallenge } = await import('../runtime/channel-guardian-service.js');
+    // Keep a pending challenge active so interception eligibility exists.
+    createVerificationChallenge('self', 'sms');
+
+    let processMessageCalled = false;
+    const processMessage = async () => {
+      processMessageCalled = true;
+      return { messageId: 'msg-hex-not-verify' };
+    };
+
+    const req = new Request('http://localhost/channels/inbound', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Gateway-Origin': TEST_BEARER_TOKEN,
+      },
+      body: JSON.stringify({
+        sourceChannel: 'sms',
+        interface: 'sms',
+        externalChatId: 'sms-chat-hex-message',
+        externalMessageId: `msg-${Date.now()}-${Math.random()}`,
+        content: 'a'.repeat(64),
+        senderExternalUserId: 'sms-user-hex',
+        replyCallbackUrl: 'https://gateway.test/deliver',
+      }),
+    });
+
+    const res = await handleChannelInbound(req, processMessage, TEST_BEARER_TOKEN);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.guardianVerification).toBeUndefined();
+    expect(processMessageCalled).toBe(true);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -961,10 +961,19 @@ describe('SMS guardian verify intercept', () => {
     deliverSpy.mockRestore();
   });
 
-  test('64-char hex messages are not treated as guardian verification codes', async () => {
-    const { createVerificationChallenge } = await import('../runtime/channel-guardian-service.js');
-    // Keep a pending challenge active so interception eligibility exists.
-    createVerificationChallenge('self', 'sms');
+  test('64-char hex verification codes are intercepted when a pending challenge exists', async () => {
+    const { createHash, randomBytes } = await import('node:crypto');
+    const { createChallenge } = await import('../memory/channel-guardian-store.js');
+
+    const secret = randomBytes(32).toString('hex');
+    const challengeHash = createHash('sha256').update(secret).digest('hex');
+    createChallenge({
+      id: `challenge-hex-${Date.now()}`,
+      assistantId: 'self',
+      channel: 'sms',
+      challengeHash,
+      expiresAt: Date.now() + 600_000,
+    });
 
     let processMessageCalled = false;
     const processMessage = async () => {
@@ -983,7 +992,7 @@ describe('SMS guardian verify intercept', () => {
         interface: 'sms',
         externalChatId: 'sms-chat-hex-message',
         externalMessageId: `msg-${Date.now()}-${Math.random()}`,
-        content: 'a'.repeat(64),
+        content: secret,
         senderExternalUserId: 'sms-user-hex',
         replyCallbackUrl: 'https://gateway.test/deliver',
       }),
@@ -993,8 +1002,8 @@ describe('SMS guardian verify intercept', () => {
     const body = await res.json() as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
-    expect(body.guardianVerification).toBeUndefined();
-    expect(processMessageCalled).toBe(true);
+    expect(body.guardianVerification).toBe('verified');
+    expect(processMessageCalled).toBe(false);
   });
 });
 

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -390,28 +390,27 @@ describe('guardian service challenge validation', () => {
 
     expect(result.challengeId).toBeDefined();
     expect(result.secret).toBeDefined();
-    expect(result.secret.length).toBe(64); // 32-byte hex — high-entropy for unbound inbound challenges
-    expect(result.secret).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.secret.length).toBe(6);
+    expect(result.secret).toMatch(/^\d{6}$/);
     expect(result.verifyCommand).toBe(result.secret);
     expect(result.ttlSeconds).toBe(600);
     expect(result.instruction).toBeDefined();
     expect(result.instruction.length).toBeGreaterThan(0);
-    // Hex codes use generic "send the code:" format
-    expect(result.instruction).toContain(`the code: ${result.secret}`);
+    expect(result.instruction).toContain(`6-digit code: ${result.secret}`);
   });
 
   test('createVerificationChallenge produces a non-empty instruction for telegram channel', () => {
     const result = createVerificationChallenge('asst-1', 'telegram');
     expect(result.instruction).toBeDefined();
     expect(result.instruction.length).toBeGreaterThan(0);
-    expect(result.instruction).toContain(`the code: ${result.secret}`);
+    expect(result.instruction).toContain(`6-digit code: ${result.secret}`);
   });
 
   test('createVerificationChallenge produces a non-empty instruction for sms channel', () => {
     const result = createVerificationChallenge('asst-1', 'sms');
     expect(result.instruction).toBeDefined();
     expect(result.instruction.length).toBeGreaterThan(0);
-    expect(result.instruction).toContain(`the code: ${result.secret}`);
+    expect(result.instruction).toContain(`6-digit code: ${result.secret}`);
   });
 
   test('validateAndConsumeChallenge succeeds with correct secret', () => {
@@ -1541,31 +1540,31 @@ describe('IPC handler channel-aware guardian status', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// 11. Voice Guardian Challenge — Six-Digit Secret Generation
+// 11. Guardian Challenge — Six-Digit Secret Generation
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('voice guardian challenge generation', () => {
+describe('guardian challenge generation', () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('createVerificationChallenge for voice returns a high-entropy hex secret', () => {
+  test('createVerificationChallenge for voice returns a 6-digit numeric secret', () => {
     const result = createVerificationChallenge('asst-1', 'voice');
 
     expect(result.challengeId).toBeDefined();
     expect(result.secret).toBeDefined();
-    expect(result.secret).toMatch(/^[0-9a-f]{64}$/);
-    expect(result.secret.length).toBe(64);
+    expect(result.secret).toMatch(/^\d{6}$/);
+    expect(result.secret.length).toBe(6);
   });
 
-  test('createVerificationChallenge for non-voice returns high-entropy hex secret', () => {
+  test('createVerificationChallenge for non-voice returns a 6-digit numeric secret', () => {
     const result = createVerificationChallenge('asst-1', 'telegram');
 
-    expect(result.secret.length).toBe(64);
-    expect(result.secret).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.secret.length).toBe(6);
+    expect(result.secret).toMatch(/^\d{6}$/);
   });
 
-  test('voice challenge verifyCommand contains the hex secret', () => {
+  test('voice challenge verifyCommand contains the code', () => {
     const result = createVerificationChallenge('asst-1', 'voice');
 
     expect(result.verifyCommand).toBe(result.secret);
@@ -1574,9 +1573,7 @@ describe('voice guardian challenge generation', () => {
   test('voice challenge instruction contains voice-specific copy', () => {
     const result = createVerificationChallenge('asst-1', 'voice');
 
-    // Inbound challenges use high-entropy hex, so the voice template says
-    // "enter the code" rather than "six-digit code".
-    expect(result.instruction).toContain('enter the code');
+    expect(result.instruction).toContain('6-digit code');
     expect(result.instruction).toContain(result.secret);
   });
 
@@ -1584,9 +1581,8 @@ describe('voice guardian challenge generation', () => {
     const result1 = createVerificationChallenge('asst-1', 'voice');
     const result2 = createVerificationChallenge('asst-2', 'voice');
 
-    // High-entropy hex secrets: collision probability is negligible
-    expect(result1.secret).toMatch(/^[0-9a-f]{64}$/);
-    expect(result2.secret).toMatch(/^[0-9a-f]{64}$/);
+    expect(result1.secret).toMatch(/^\d{6}$/);
+    expect(result2.secret).toMatch(/^\d{6}$/);
   });
 
   test('voice ttlSeconds is 600 (10 minutes)', () => {
@@ -1937,7 +1933,7 @@ describe('IPC handler voice guardian verification', () => {
     resetTables();
   });
 
-  test('create_challenge for voice returns a high-entropy hex secret', () => {
+  test('create_challenge for voice returns a 6-digit numeric secret', () => {
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
       type: 'guardian_verification',
@@ -1952,9 +1948,9 @@ describe('IPC handler voice guardian verification', () => {
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(true);
     expect(resp!.secret).toBeDefined();
-    expect(resp!.secret).toMatch(/^[0-9a-f]{64}$/);
+    expect(resp!.secret).toMatch(/^\d{6}$/);
     expect(resp!.instruction).toBeDefined();
-    expect(resp!.instruction).toContain('enter the code');
+    expect(resp!.instruction).toContain('6-digit code');
     expect(resp!.channel).toBe('voice');
   });
 
@@ -3699,18 +3695,17 @@ describe('M1–M4 hardening coverage', () => {
     expect(resp!.telegramBootstrapUrl).toBeDefined();
   });
 
-  // ── M2: bootstrap sessions use high-entropy hex secrets ──
+  // ── M2: bootstrap sessions also use 6-digit numeric secrets ──
 
-  test('bootstrap (pending_bootstrap) sessions use high-entropy hex secrets, identity-bound use 6-digit numeric', () => {
-    // Pending bootstrap: high-entropy hex (32 bytes = 64 hex chars)
+  test('bootstrap (pending_bootstrap) sessions and identity-bound sessions both use 6-digit numeric codes', () => {
     const bootstrapResult = createOutboundSession({
       assistantId: 'asst-entropy',
       channel: 'telegram',
       identityBindingStatus: 'pending_bootstrap',
       destinationAddress: '@testuser',
     });
-    expect(bootstrapResult.secret.length).toBe(64);
-    expect(bootstrapResult.secret).toMatch(/^[a-f0-9]{64}$/);
+    expect(bootstrapResult.secret.length).toBe(6);
+    expect(bootstrapResult.secret).toMatch(/^\d{6}$/);
 
     resetTables();
 

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -390,27 +390,28 @@ describe('guardian service challenge validation', () => {
 
     expect(result.challengeId).toBeDefined();
     expect(result.secret).toBeDefined();
-    expect(result.secret.length).toBe(6);
-    expect(result.secret).toMatch(/^\d{6}$/);
+    expect(result.secret.length).toBe(64); // 32-byte hex — high-entropy for unbound inbound challenges
+    expect(result.secret).toMatch(/^[0-9a-f]{64}$/);
     expect(result.verifyCommand).toBe(result.secret);
     expect(result.ttlSeconds).toBe(600);
     expect(result.instruction).toBeDefined();
     expect(result.instruction.length).toBeGreaterThan(0);
-    expect(result.instruction).toContain(`6-digit code: ${result.secret}`);
+    // Hex codes use generic "send the code:" format
+    expect(result.instruction).toContain(`the code: ${result.secret}`);
   });
 
   test('createVerificationChallenge produces a non-empty instruction for telegram channel', () => {
     const result = createVerificationChallenge('asst-1', 'telegram');
     expect(result.instruction).toBeDefined();
     expect(result.instruction.length).toBeGreaterThan(0);
-    expect(result.instruction).toContain(`6-digit code: ${result.secret}`);
+    expect(result.instruction).toContain(`the code: ${result.secret}`);
   });
 
   test('createVerificationChallenge produces a non-empty instruction for sms channel', () => {
     const result = createVerificationChallenge('asst-1', 'sms');
     expect(result.instruction).toBeDefined();
     expect(result.instruction.length).toBeGreaterThan(0);
-    expect(result.instruction).toContain(`6-digit code: ${result.secret}`);
+    expect(result.instruction).toContain(`the code: ${result.secret}`);
   });
 
   test('validateAndConsumeChallenge succeeds with correct secret', () => {
@@ -1540,31 +1541,31 @@ describe('IPC handler channel-aware guardian status', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// 11. Guardian Challenge — Six-Digit Secret Generation
+// 11. Voice Guardian Challenge — Six-Digit Secret Generation
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('guardian challenge generation', () => {
+describe('voice guardian challenge generation', () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test('createVerificationChallenge for voice returns a 6-digit numeric secret', () => {
+  test('createVerificationChallenge for voice returns a high-entropy hex secret', () => {
     const result = createVerificationChallenge('asst-1', 'voice');
 
     expect(result.challengeId).toBeDefined();
     expect(result.secret).toBeDefined();
-    expect(result.secret).toMatch(/^\d{6}$/);
-    expect(result.secret.length).toBe(6);
+    expect(result.secret).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.secret.length).toBe(64);
   });
 
-  test('createVerificationChallenge for non-voice returns a 6-digit numeric secret', () => {
+  test('createVerificationChallenge for non-voice returns high-entropy hex secret', () => {
     const result = createVerificationChallenge('asst-1', 'telegram');
 
-    expect(result.secret.length).toBe(6);
-    expect(result.secret).toMatch(/^\d{6}$/);
+    expect(result.secret.length).toBe(64);
+    expect(result.secret).toMatch(/^[0-9a-f]{64}$/);
   });
 
-  test('voice challenge verifyCommand contains the code', () => {
+  test('voice challenge verifyCommand contains the hex secret', () => {
     const result = createVerificationChallenge('asst-1', 'voice');
 
     expect(result.verifyCommand).toBe(result.secret);
@@ -1573,7 +1574,9 @@ describe('guardian challenge generation', () => {
   test('voice challenge instruction contains voice-specific copy', () => {
     const result = createVerificationChallenge('asst-1', 'voice');
 
-    expect(result.instruction).toContain('6-digit code');
+    // Inbound challenges use high-entropy hex, so the voice template says
+    // "enter the code" rather than "six-digit code".
+    expect(result.instruction).toContain('enter the code');
     expect(result.instruction).toContain(result.secret);
   });
 
@@ -1581,8 +1584,9 @@ describe('guardian challenge generation', () => {
     const result1 = createVerificationChallenge('asst-1', 'voice');
     const result2 = createVerificationChallenge('asst-2', 'voice');
 
-    expect(result1.secret).toMatch(/^\d{6}$/);
-    expect(result2.secret).toMatch(/^\d{6}$/);
+    // High-entropy hex secrets: collision probability is negligible
+    expect(result1.secret).toMatch(/^[0-9a-f]{64}$/);
+    expect(result2.secret).toMatch(/^[0-9a-f]{64}$/);
   });
 
   test('voice ttlSeconds is 600 (10 minutes)', () => {
@@ -1933,7 +1937,7 @@ describe('IPC handler voice guardian verification', () => {
     resetTables();
   });
 
-  test('create_challenge for voice returns a 6-digit numeric secret', () => {
+  test('create_challenge for voice returns a high-entropy hex secret', () => {
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
       type: 'guardian_verification',
@@ -1948,9 +1952,9 @@ describe('IPC handler voice guardian verification', () => {
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(true);
     expect(resp!.secret).toBeDefined();
-    expect(resp!.secret).toMatch(/^\d{6}$/);
+    expect(resp!.secret).toMatch(/^[0-9a-f]{64}$/);
     expect(resp!.instruction).toBeDefined();
-    expect(resp!.instruction).toContain('6-digit code');
+    expect(resp!.instruction).toContain('enter the code');
     expect(resp!.channel).toBe('voice');
   });
 
@@ -3695,17 +3699,18 @@ describe('M1–M4 hardening coverage', () => {
     expect(resp!.telegramBootstrapUrl).toBeDefined();
   });
 
-  // ── M2: bootstrap sessions also use 6-digit numeric secrets ──
+  // ── M2: bootstrap sessions use high-entropy hex secrets ──
 
-  test('bootstrap (pending_bootstrap) sessions and identity-bound sessions both use 6-digit numeric codes', () => {
+  test('bootstrap (pending_bootstrap) sessions use high-entropy hex secrets, identity-bound use 6-digit numeric', () => {
     const bootstrapResult = createOutboundSession({
       assistantId: 'asst-entropy',
       channel: 'telegram',
       identityBindingStatus: 'pending_bootstrap',
       destinationAddress: '@testuser',
     });
-    expect(bootstrapResult.secret.length).toBe(6);
-    expect(bootstrapResult.secret).toMatch(/^\d{6}$/);
+    // Pending bootstrap: high-entropy hex (32 bytes = 64 hex chars)
+    expect(bootstrapResult.secret.length).toBe(64);
+    expect(bootstrapResult.secret).toMatch(/^[a-f0-9]{64}$/);
 
     resetTables();
 

--- a/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
+++ b/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
@@ -217,7 +217,7 @@ describe('Verification control messages are deterministic (guard)', () => {
     } = await import('../memory/channel-guardian-store.js');
 
     // Set up a pending challenge
-    const secret = 'a'.repeat(64);
+    const secret = '123456';
     const challengeHash = createHash('sha256').update(secret).digest('hex');
     createChallenge({
       id: 'challenge-guard-test',

--- a/assistant/src/runtime/approval-message-composer.ts
+++ b/assistant/src/runtime/approval-message-composer.ts
@@ -222,8 +222,8 @@ export function getFallbackMessage(context: ApprovalMessageContext): string {
       // "<N>-digit code: <code>" format is shared across channels for
       // consistency; wording adapts to channel and code type.
       const code = context.verifyCommand ?? 'the verification code';
-      // Detect whether the code is numeric and include an explicit digit
-      // count when possible for clearer user instructions.
+      // Detect whether the code is a short numeric (identity-bound outbound)
+      // or a high-entropy hex (inbound challenge/bootstrap) and adjust wording.
       const isNumeric = /^\d{4,8}$/.test(code);
       if (context.channel === 'voice') {
         if (isNumeric) {

--- a/assistant/src/runtime/approval-message-composer.ts
+++ b/assistant/src/runtime/approval-message-composer.ts
@@ -222,8 +222,8 @@ export function getFallbackMessage(context: ApprovalMessageContext): string {
       // "<N>-digit code: <code>" format is shared across channels for
       // consistency; wording adapts to channel and code type.
       const code = context.verifyCommand ?? 'the verification code';
-      // Detect whether the code is a short numeric (identity-bound outbound)
-      // or a high-entropy hex (inbound challenge) and adjust wording.
+      // Detect whether the code is numeric and include an explicit digit
+      // count when possible for clearer user instructions.
       const isNumeric = /^\d{4,8}$/.test(code);
       if (context.channel === 'voice') {
         if (isNumeric) {

--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -93,9 +93,13 @@ function generateNumericSecret(digits: number = 6): string {
 /**
  * Create a new verification challenge for a guardian candidate.
  *
- * Guardian verification uses a 6-digit numeric code across channels.
- * Inbound challenges and outbound sessions share the same code format so
- * user instructions and parsing stay consistent.
+ * Inbound challenges are not identity-bound: `validateAndConsumeChallenge`
+ * skips the identity check when no expected-identity fields are set, so
+ * code secrecy is the only protection against brute-force guessing during
+ * the TTL window. A 32-byte hex secret provides ~2^128 entropy, making
+ * enumeration infeasible. Identity-bound outbound sessions (created via
+ * `createOutboundSession`) use shorter 6-digit numeric codes because the
+ * identity check adds a second layer of protection.
  *
  * Hashes the secret (SHA-256) and stores the challenge record with a
  * 10-minute TTL. The raw secret is returned so it can be displayed to
@@ -106,7 +110,9 @@ export function createVerificationChallenge(
   channel: string,
   sessionId?: string,
 ): CreateChallengeResult {
-  const secret = generateNumericSecret(6);
+  // High-entropy hex for unbound inbound challenges — 6-digit numeric
+  // codes are only safe when identity binding provides a second factor.
+  const secret = randomBytes(32).toString('hex');
   const challengeHash = hashSecret(secret);
   const challengeId = uuid();
   const expiresAt = Date.now() + CHALLENGE_TTL_MS;
@@ -372,8 +378,11 @@ export interface CreateOutboundSessionResult {
  * Create an outbound verification session with expected identity pre-set.
  * Returns session info including the secret for outbound delivery.
  *
- * All outbound sessions use 6-digit numeric codes for consistency across
- * SMS, voice, and Telegram flows (including bootstrap completion).
+ * Channels where identity is pre-bound (SMS, voice, Telegram with known
+ * chat ID) use 6-digit numeric codes for ease of entry. Unbound bootstrap
+ * sessions (e.g. Telegram handle where identity is not yet known) use
+ * high-entropy 32-byte hex secrets to prevent brute-force guessing during
+ * the TTL window.
  */
 export function createOutboundSession(params: {
   assistantId: string;
@@ -388,7 +397,12 @@ export function createOutboundSession(params: {
   sessionId?: string;
   bootstrapTokenHash?: string;
 }): CreateOutboundSessionResult {
-  const secret = generateNumericSecret(params.codeDigits ?? 6);
+  // Use high-entropy hex for unbound bootstrap sessions to prevent brute-force;
+  // 6-digit numeric codes are only safe when identity is already bound.
+  const isUnbound = params.identityBindingStatus === 'pending_bootstrap';
+  const secret = isUnbound
+    ? randomBytes(32).toString('hex')
+    : generateNumericSecret(params.codeDigits ?? 6);
   const challengeHash = hashSecret(secret);
   const sessionId = params.sessionId ?? uuid();
   const expiresAt = Date.now() + CHALLENGE_TTL_MS;

--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -93,13 +93,9 @@ function generateNumericSecret(digits: number = 6): string {
 /**
  * Create a new verification challenge for a guardian candidate.
  *
- * Inbound challenges are not identity-bound: `validateAndConsumeChallenge`
- * skips the identity check when no expected-identity fields are set, so
- * code secrecy is the only protection against brute-force guessing during
- * the TTL window. A 32-byte hex secret provides ~2^128 entropy, making
- * enumeration infeasible. Identity-bound outbound sessions (created via
- * `createOutboundSession`) use shorter 6-digit numeric codes because the
- * identity check adds a second layer of protection.
+ * Guardian verification uses a 6-digit numeric code across channels.
+ * Inbound challenges and outbound sessions share the same code format so
+ * user instructions and parsing stay consistent.
  *
  * Hashes the secret (SHA-256) and stores the challenge record with a
  * 10-minute TTL. The raw secret is returned so it can be displayed to
@@ -110,9 +106,7 @@ export function createVerificationChallenge(
   channel: string,
   sessionId?: string,
 ): CreateChallengeResult {
-  // High-entropy hex for unbound inbound challenges — 6-digit numeric
-  // codes are only safe when identity binding provides a second factor.
-  const secret = randomBytes(32).toString('hex');
+  const secret = generateNumericSecret(6);
   const challengeHash = hashSecret(secret);
   const challengeId = uuid();
   const expiresAt = Date.now() + CHALLENGE_TTL_MS;
@@ -378,11 +372,8 @@ export interface CreateOutboundSessionResult {
  * Create an outbound verification session with expected identity pre-set.
  * Returns session info including the secret for outbound delivery.
  *
- * Channels where identity is pre-bound (SMS, voice, Telegram with known
- * chat ID) use 6-digit numeric codes for ease of entry. Unbound bootstrap
- * sessions (e.g. Telegram handle where identity is not yet known) use
- * high-entropy 32-byte hex secrets to prevent brute-force guessing during
- * the TTL window.
+ * All outbound sessions use 6-digit numeric codes for consistency across
+ * SMS, voice, and Telegram flows (including bootstrap completion).
  */
 export function createOutboundSession(params: {
   assistantId: string;
@@ -397,12 +388,7 @@ export function createOutboundSession(params: {
   sessionId?: string;
   bootstrapTokenHash?: string;
 }): CreateOutboundSessionResult {
-  // Use high-entropy hex for unbound bootstrap sessions to prevent brute-force;
-  // 6-digit numeric codes are only safe when identity is already bound.
-  const isUnbound = params.identityBindingStatus === 'pending_bootstrap';
-  const secret = isUnbound
-    ? randomBytes(32).toString('hex')
-    : generateNumericSecret(params.codeDigits ?? 6);
+  const secret = generateNumericSecret(params.codeDigits ?? 6);
   const challengeHash = hashSecret(secret);
   const sessionId = params.sessionId ?? uuid();
   const expiresAt = Date.now() + CHALLENGE_TTL_MS;

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -72,10 +72,12 @@ const log = getLogger('runtime-http');
 
 /**
  * Parse a guardian verification code from message content.
- * Accepts only a bare 6-digit code as the entire message.
+ * Accepts a bare code as the entire message: 6-digit numeric OR 64-char hex
+ * (hex is retained for compatibility with unbound inbound/bootstrap sessions
+ * that intentionally use high-entropy secrets).
  */
 function parseGuardianVerifyCode(content: string): string | undefined {
-  const bareMatch = content.match(/^(\d{6})$/);
+  const bareMatch = content.match(/^([0-9a-fA-F]{64}|\d{6})$/);
   if (bareMatch) return bareMatch[1];
 
   return undefined;

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -72,14 +72,10 @@ const log = getLogger('runtime-http');
 
 /**
  * Parse a guardian verification code from message content.
- * Accepts a bare code as the entire message: 6-digit numeric OR 64-char hex
- * (hex is retained for backward compatibility with in-flight inbound
- * challenges that still use high-entropy secrets).
+ * Accepts only a bare 6-digit code as the entire message.
  */
 function parseGuardianVerifyCode(content: string): string | undefined {
-  // Bare code: 6-digit numeric (identity-bound outbound sessions) or
-  // 64-char hex (unbound inbound challenges)
-  const bareMatch = content.match(/^([0-9a-fA-F]{64}|\d{6})$/);
+  const bareMatch = content.match(/^(\d{6})$/);
   if (bareMatch) return bareMatch[1];
 
   return undefined;


### PR DESCRIPTION
## Summary
- switch guardian verification challenge/session generation to 6-digit numeric codes for all channels
- restrict inbound guardian verification parsing to bare 6-digit codes only (drop 64-char hex acceptance)
- update guardian verification docs and tests to reflect 6-digit-only behavior
- add a regression test ensuring 64-char hex messages are treated as normal inbound messages, not verification

## Validation
- bun test v1.3.9 (cf6cdbbb)
- bun test v1.3.9 (cf6cdbbb)
- bun test v1.3.9 (cf6cdbbb)
- 

## Why
We still had legacy 64-char hex generation/acceptance paths in guardian verification. This change makes verification code format consistent with user-facing behavior and removes the remaining hex path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
