### PR TITLE
M10: Add targeted regression tests

### DIFF
--- a/clients/shared/Tests/RenderChurnTests.swift
+++ b/clients/shared/Tests/RenderChurnTests.swift
@@ -1,0 +1,274 @@
+import Combine
+import XCTest
+@testable import VellumAssistantShared
+
+/// Regression tests for render-churn reduction and memory-retention fixes.
+/// Validates: SubagentDetailStore coalescing, stripHeavyContent surface stripping,
+/// attachment lifecycle clearing guards, and ToolCallData Equatable exclusions.
+@MainActor
+final class RenderChurnTests: XCTestCase {
+
+    // MARK: - SubagentDetailStore coalescing
+
+    /// Rapid-fire events should be coalesced into 1-2 objectWillChange publishes
+    /// within the 50ms debounce window, not fire once per event.
+    func testSubagentDetailStoreCoalescesRapidEvents() async {
+        let store = SubagentDetailStore()
+        var publishCount = 0
+        let cancellable = store.objectWillChange.sink { _ in
+            publishCount += 1
+        }
+
+        // Fire 10 rapid events synchronously (no awaits between them).
+        for i in 0..<10 {
+            store.handleEvent(
+                subagentId: "agent-1",
+                event: .assistantTextDelta(AssistantTextDeltaMessage(text: "chunk-\(i)"))
+            )
+        }
+
+        // Wait 150ms (3x the 50ms coalesce window) for the publish task to fire.
+        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        // The coalescing logic should collapse all 10 mutations into 1-2 publishes.
+        XCTAssertLessThanOrEqual(
+            publishCount, 2,
+            "Expected at most 2 objectWillChange publishes for 10 rapid events, got \(publishCount)"
+        )
+        XCTAssertGreaterThanOrEqual(
+            publishCount, 1,
+            "Expected at least 1 objectWillChange publish"
+        )
+
+        // Verify the events were actually recorded despite coalescing.
+        let events = store.eventsBySubagent["agent-1"] ?? []
+        XCTAssertEqual(events.count, 1, "Text deltas should accumulate into a single text event")
+        XCTAssertTrue(events[0].content.contains("chunk-9"), "Final chunk should be present in accumulated text")
+
+        cancellable.cancel()
+    }
+
+    // MARK: - stripHeavyContent surface stripping
+
+    /// Completed surfaces (non-nil completionState) should have their data replaced
+    /// with .stripped and actions cleared. Active surfaces should retain their data.
+    func testStripHeavyContentStripsCompletedSurfaces() {
+        let dynamicPageData = DynamicPageSurfaceData(
+            html: "<html><body>Heavy payload</body></html>",
+            width: 800,
+            height: 600
+        )
+        let action = SurfaceActionButton(id: "btn-1", label: "Submit", style: .primary)
+
+        let completedSurface = InlineSurfaceData(
+            id: "surface-completed",
+            surfaceType: .dynamicPage,
+            title: "Completed App",
+            data: .dynamicPage(dynamicPageData),
+            actions: [action],
+            completionState: SurfaceCompletionState(summary: "Done")
+        )
+
+        let activeSurface = InlineSurfaceData(
+            id: "surface-active",
+            surfaceType: .dynamicPage,
+            title: "Active App",
+            data: .dynamicPage(dynamicPageData),
+            actions: [action]
+        )
+
+        var message = ChatMessage(
+            role: .assistant,
+            text: "Here is your app",
+            inlineSurfaces: [completedSurface, activeSurface]
+        )
+
+        message.stripHeavyContent()
+
+        // Completed surface should be stripped.
+        XCTAssertEqual(message.inlineSurfaces[0].data, .stripped,
+                       "Completed surface data should be .stripped")
+        XCTAssertTrue(message.inlineSurfaces[0].actions.isEmpty,
+                      "Completed surface actions should be cleared")
+
+        // Active surface (no completionState) should retain its data.
+        if case .dynamicPage(let dp) = message.inlineSurfaces[1].data {
+            XCTAssertEqual(dp.html, "<html><body>Heavy payload</body></html>",
+                           "Active surface should retain its HTML payload")
+        } else {
+            XCTFail("Active surface data should still be .dynamicPage, got \(message.inlineSurfaces[1].data)")
+        }
+        XCTAssertEqual(message.inlineSurfaces[1].actions.count, 1,
+                       "Active surface should retain its actions")
+    }
+
+    /// Calling stripHeavyContent twice should be a no-op on the second call
+    /// (isContentStripped guard).
+    func testStripHeavyContentIsIdempotent() {
+        var message = ChatMessage(
+            role: .assistant,
+            text: "Hello",
+            toolCalls: [
+                ToolCallData(toolName: "bash", inputSummary: "ls", result: "output")
+            ]
+        )
+
+        message.stripHeavyContent()
+        XCTAssertTrue(message.isContentStripped)
+        XCTAssertNil(message.toolCalls[0].result)
+
+        // Mutate after first strip to prove second call is a no-op.
+        message.toolCalls[0].result = "re-added"
+        message.stripHeavyContent()
+        XCTAssertEqual(message.toolCalls[0].result, "re-added",
+                       "Second stripHeavyContent should be a no-op due to isContentStripped guard")
+    }
+
+    // MARK: - Attachment clearing guards (sizeBytes gate)
+
+    /// Lazy-loadable attachments (sizeBytes != nil) should have data cleared after
+    /// the dequeue/message-complete path, while locally-created attachments
+    /// (sizeBytes == nil) should retain their data.
+    func testAttachmentClearingRespectsLazyLoadGuard() {
+        // Lazy-loadable attachment (daemon-served, sizeBytes present).
+        var lazyAttachment = ChatAttachment(
+            id: "att-lazy",
+            filename: "photo.png",
+            mimeType: "image/png",
+            data: "base64encodeddata",
+            thumbnailData: nil,
+            dataLength: 17,
+            sizeBytes: 1024,
+            thumbnailImage: nil
+        )
+
+        // Locally-created attachment (sizeBytes nil).
+        var localAttachment = ChatAttachment(
+            id: "att-local",
+            filename: "note.txt",
+            mimeType: "text/plain",
+            data: "local file data",
+            thumbnailData: nil,
+            dataLength: 15,
+            sizeBytes: nil,
+            thumbnailImage: nil
+        )
+
+        // Simulate the dequeue clearing logic: only clear if sizeBytes != nil.
+        if lazyAttachment.sizeBytes != nil {
+            lazyAttachment.data = ""
+            lazyAttachment.dataLength = 0
+        }
+
+        if localAttachment.sizeBytes != nil {
+            localAttachment.data = ""
+            localAttachment.dataLength = 0
+        }
+
+        // Lazy-loadable should be cleared.
+        XCTAssertEqual(lazyAttachment.data, "",
+                       "Lazy-loadable attachment data should be cleared")
+        XCTAssertEqual(lazyAttachment.dataLength, 0,
+                       "Lazy-loadable attachment dataLength should be zeroed")
+        XCTAssertTrue(lazyAttachment.isLazyLoad,
+                      "Cleared lazy attachment should report isLazyLoad = true")
+
+        // Locally-created should NOT be cleared.
+        XCTAssertEqual(localAttachment.data, "local file data",
+                       "Local attachment data should NOT be cleared")
+        XCTAssertEqual(localAttachment.dataLength, 15,
+                       "Local attachment dataLength should be preserved")
+        XCTAssertFalse(localAttachment.isLazyLoad,
+                       "Local attachment with data should report isLazyLoad = false")
+    }
+
+    // MARK: - ToolCallData Equatable (imageData excluded)
+
+    /// Two ToolCallData instances that differ only in imageData should be equal
+    /// because imageData is intentionally excluded from the == implementation.
+    func testToolCallDataEqualityExcludesImageData() {
+        let id = UUID()
+        let a = ToolCallData(
+            id: id,
+            toolName: "browser_screenshot",
+            inputSummary: "screenshot",
+            result: nil,
+            isError: false,
+            isComplete: true,
+            arrivedBeforeText: true,
+            imageData: "AAAA"
+        )
+        let b = ToolCallData(
+            id: id,
+            toolName: "browser_screenshot",
+            inputSummary: "screenshot",
+            result: nil,
+            isError: false,
+            isComplete: true,
+            arrivedBeforeText: true,
+            imageData: "BBBB"
+        )
+
+        XCTAssertEqual(a, b,
+                       "ToolCallData instances differing only in imageData should be equal")
+    }
+
+    /// Two ToolCallData instances that differ in toolName should NOT be equal.
+    func testToolCallDataInequalityOnToolName() {
+        let id = UUID()
+        let a = ToolCallData(
+            id: id,
+            toolName: "bash",
+            inputSummary: "ls",
+            result: nil,
+            isError: false,
+            isComplete: true,
+            arrivedBeforeText: true
+        )
+        let b = ToolCallData(
+            id: id,
+            toolName: "file_read",
+            inputSummary: "ls",
+            result: nil,
+            isError: false,
+            isComplete: true,
+            arrivedBeforeText: true
+        )
+
+        XCTAssertNotEqual(a, b,
+                          "ToolCallData instances differing in toolName should NOT be equal")
+    }
+
+    /// Two ToolCallData instances that differ in inputFullLength should NOT be equal
+    /// (detects rehydration changes without comparing full strings).
+    func testToolCallDataInequalityOnInputFullLength() {
+        let id = UUID()
+        var a = ToolCallData(
+            id: id,
+            toolName: "bash",
+            inputSummary: "ls",
+            inputFull: "ls -la",
+            result: nil,
+            isError: false,
+            isComplete: true,
+            arrivedBeforeText: true
+        )
+        var b = ToolCallData(
+            id: id,
+            toolName: "bash",
+            inputSummary: "ls",
+            inputFull: "",
+            result: nil,
+            isError: false,
+            isComplete: true,
+            arrivedBeforeText: true
+        )
+
+        // Manually set inputFullLength to simulate rehydration difference.
+        a.inputFullLength = 6
+        b.inputFullLength = 0
+
+        XCTAssertNotEqual(a, b,
+                          "ToolCallData instances differing in inputFullLength should NOT be equal (rehydration sentinel)")
+    }
+}


### PR DESCRIPTION
Add focused regression tests verifying: SubagentDetailStore coalescing, stripHeavyContent surface stripping, attachment lifecycle clearing guards, and ToolCallData Equatable exclusions. Part of #9587.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
