### PR TITLE
M4: Late Reply Interception + Generated Guardian Follow-Up Prompt

### DIFF
--- a/assistant/src/__tests__/guardian-action-late-reply.test.ts
+++ b/assistant/src/__tests__/guardian-action-late-reply.test.ts
@@ -1,0 +1,294 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'guardian-action-late-reply-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module('../runtime/gateway-client.js', () => ({
+  deliverChannelReply: async () => {},
+}));
+
+import { createCallSession, createPendingQuestion } from '../calls/call-store.js';
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import {
+  createGuardianActionDelivery,
+  createGuardianActionRequest,
+  expireGuardianActionRequest,
+  getExpiredDeliveriesByDestination,
+  getExpiredDeliveryByConversation,
+  getGuardianActionRequest,
+  resolveGuardianActionRequest,
+  startFollowupFromExpiredRequest,
+  updateDeliveryStatus,
+} from '../memory/guardian-action-store.js';
+import { conversations } from '../memory/schema.js';
+
+initializeDb();
+
+function ensureConversation(id: string): void {
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations).values({
+    id,
+    title: `Conversation ${id}`,
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+}
+
+function resetTables(): void {
+  const db = getDb();
+  db.run('DELETE FROM guardian_action_deliveries');
+  db.run('DELETE FROM guardian_action_requests');
+  db.run('DELETE FROM call_pending_questions');
+  db.run('DELETE FROM call_events');
+  db.run('DELETE FROM call_sessions');
+  db.run('DELETE FROM messages');
+  db.run('DELETE FROM conversations');
+}
+
+function createExpiredRequest(convId: string, opts?: { chatId?: string; externalUserId?: string; conversationId?: string }) {
+  ensureConversation(convId);
+  const session = createCallSession({
+    conversationId: convId,
+    provider: 'twilio',
+    fromNumber: '+15550001111',
+    toNumber: '+15550002222',
+  });
+  const pq = createPendingQuestion(session.id, 'What is the gate code?');
+  const request = createGuardianActionRequest({
+    kind: 'ask_guardian',
+    sourceChannel: 'voice',
+    sourceConversationId: convId,
+    callSessionId: session.id,
+    pendingQuestionId: pq.id,
+    questionText: pq.questionText,
+    expiresAt: Date.now() - 10_000, // already expired
+  });
+
+  // Create delivery
+  const deliveryConvId = opts?.conversationId ?? `delivery-conv-${request.id}`;
+  if (opts?.conversationId) {
+    ensureConversation(opts.conversationId);
+  } else {
+    ensureConversation(deliveryConvId);
+  }
+  const delivery = createGuardianActionDelivery({
+    requestId: request.id,
+    destinationChannel: 'telegram',
+    destinationChatId: opts?.chatId ?? 'chat-123',
+    destinationExternalUserId: opts?.externalUserId ?? 'user-456',
+    destinationConversationId: deliveryConvId,
+  });
+  updateDeliveryStatus(delivery.id, 'sent');
+
+  // Expire the request and delivery
+  expireGuardianActionRequest(request.id, 'sweep_timeout');
+
+  return { request: getGuardianActionRequest(request.id)!, delivery, deliveryConvId };
+}
+
+describe('guardian-action-late-reply', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  afterAll(() => {
+    resetDb();
+    try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+  });
+
+  // ── getExpiredDeliveriesByDestination ──────────────────────────────
+
+  test('getExpiredDeliveriesByDestination returns expired deliveries for follow-up eligible requests', () => {
+    const { request } = createExpiredRequest('conv-late-1', { chatId: 'chat-abc', externalUserId: 'user-xyz' });
+
+    const deliveries = getExpiredDeliveriesByDestination('self', 'telegram', 'chat-abc');
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].requestId).toBe(request.id);
+    expect(deliveries[0].status).toBe('expired');
+  });
+
+  test('getExpiredDeliveriesByDestination returns empty for non-matching channel', () => {
+    createExpiredRequest('conv-late-2', { chatId: 'chat-abc' });
+
+    const deliveries = getExpiredDeliveriesByDestination('self', 'sms', 'chat-abc');
+    expect(deliveries).toHaveLength(0);
+  });
+
+  test('getExpiredDeliveriesByDestination returns empty when followup already started', () => {
+    const { request } = createExpiredRequest('conv-late-3', { chatId: 'chat-started' });
+
+    // Start a follow-up, transitioning followup_state from 'none' to 'awaiting_guardian_choice'
+    startFollowupFromExpiredRequest(request.id, 'late answer text');
+
+    const deliveries = getExpiredDeliveriesByDestination('self', 'telegram', 'chat-started');
+    expect(deliveries).toHaveLength(0);
+  });
+
+  // ── getExpiredDeliveryByConversation ───────────────────────────────
+
+  test('getExpiredDeliveryByConversation returns expired delivery for mac channel', () => {
+    const { delivery, deliveryConvId } = createExpiredRequest('conv-late-4', { conversationId: 'mac-conv-1' });
+
+    const found = getExpiredDeliveryByConversation(deliveryConvId);
+    expect(found).not.toBeNull();
+    expect(found!.id).toBe(delivery.id);
+  });
+
+  test('getExpiredDeliveryByConversation returns null for non-matching conversation', () => {
+    createExpiredRequest('conv-late-5', { conversationId: 'mac-conv-2' });
+
+    const found = getExpiredDeliveryByConversation('nonexistent-conv');
+    expect(found).toBeNull();
+  });
+
+  test('getExpiredDeliveryByConversation returns null when followup already started', () => {
+    const { request, deliveryConvId } = createExpiredRequest('conv-late-6', { conversationId: 'mac-conv-3' });
+
+    startFollowupFromExpiredRequest(request.id, 'already answered');
+
+    const found = getExpiredDeliveryByConversation(deliveryConvId);
+    expect(found).toBeNull();
+  });
+
+  // ── startFollowupFromExpiredRequest ───────────────────────────────
+
+  test('startFollowupFromExpiredRequest transitions to awaiting_guardian_choice and records late answer', () => {
+    const { request } = createExpiredRequest('conv-late-7');
+
+    const updated = startFollowupFromExpiredRequest(request.id, 'The gate code is 1234');
+    expect(updated).not.toBeNull();
+    expect(updated!.followupState).toBe('awaiting_guardian_choice');
+    expect(updated!.lateAnswerText).toBe('The gate code is 1234');
+    expect(updated!.lateAnsweredAt).toBeGreaterThan(0);
+  });
+
+  test('startFollowupFromExpiredRequest returns null if followup already started', () => {
+    const { request } = createExpiredRequest('conv-late-8');
+
+    // First call succeeds
+    const first = startFollowupFromExpiredRequest(request.id, 'answer 1');
+    expect(first).not.toBeNull();
+
+    // Second call fails — already in awaiting_guardian_choice
+    const second = startFollowupFromExpiredRequest(request.id, 'answer 2');
+    expect(second).toBeNull();
+  });
+
+  test('startFollowupFromExpiredRequest returns null for pending requests (not expired)', () => {
+    const convId = 'conv-late-9';
+    ensureConversation(convId);
+    const session = createCallSession({
+      conversationId: convId,
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15550002222',
+    });
+    const pq = createPendingQuestion(session.id, 'Still pending question');
+    const request = createGuardianActionRequest({
+      kind: 'ask_guardian',
+      sourceChannel: 'voice',
+      sourceConversationId: convId,
+      callSessionId: session.id,
+      pendingQuestionId: pq.id,
+      questionText: pq.questionText,
+      expiresAt: Date.now() + 60_000, // not expired
+    });
+
+    const result = startFollowupFromExpiredRequest(request.id, 'late answer');
+    expect(result).toBeNull();
+  });
+
+  // ── Follow-up flow for already-answered requests ──────────────────
+
+  test('already-answered requests do not appear in expired delivery queries', () => {
+    const convId = 'conv-late-10';
+    ensureConversation(convId);
+    const session = createCallSession({
+      conversationId: convId,
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15550002222',
+    });
+    const pq = createPendingQuestion(session.id, 'Already answered question');
+    const request = createGuardianActionRequest({
+      kind: 'ask_guardian',
+      sourceChannel: 'voice',
+      sourceConversationId: convId,
+      callSessionId: session.id,
+      pendingQuestionId: pq.id,
+      questionText: pq.questionText,
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const answeredConvId = 'answered-conv-1';
+    ensureConversation(answeredConvId);
+    const delivery = createGuardianActionDelivery({
+      requestId: request.id,
+      destinationChannel: 'telegram',
+      destinationChatId: 'chat-answered',
+      destinationExternalUserId: 'user-answered',
+      destinationConversationId: answeredConvId,
+    });
+    updateDeliveryStatus(delivery.id, 'sent');
+
+    // Answer the request (transitions to 'answered', not 'expired')
+    resolveGuardianActionRequest(request.id, 'the code is 5678', 'telegram', 'user-answered');
+
+    // Should not appear in expired queries
+    const expiredByDest = getExpiredDeliveriesByDestination('self', 'telegram', 'chat-answered');
+    expect(expiredByDest).toHaveLength(0);
+
+    const expiredByConv = getExpiredDeliveryByConversation(answeredConvId);
+    expect(expiredByConv).toBeNull();
+  });
+
+  // ── Composed follow-up text verification ──────────────────────────
+
+  test('composeGuardianActionMessageGenerative produces follow-up text for late answer scenario', async () => {
+    // The composer is tested directly rather than through the handler
+    const { composeGuardianActionMessageGenerative } = await import('../runtime/guardian-action-message-composer.js');
+
+    const text = await composeGuardianActionMessageGenerative({
+      scenario: 'guardian_late_answer_followup',
+      questionText: 'What is the gate code?',
+      lateAnswerText: 'The gate code is 1234',
+    });
+
+    // In test mode, the deterministic fallback is used
+    expect(text).toContain('called earlier');
+    expect(text).toContain('call them back');
+  });
+
+  test('composeGuardianActionMessageGenerative produces stale text for expired scenario', async () => {
+    const { composeGuardianActionMessageGenerative } = await import('../runtime/guardian-action-message-composer.js');
+
+    const text = await composeGuardianActionMessageGenerative({
+      scenario: 'guardian_stale_expired',
+    });
+
+    expect(text).toContain('expired');
+  });
+});

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -14,10 +14,13 @@ import { getConfig } from '../config/loader.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import {
+  getExpiredDeliveryByConversation,
   getGuardianActionRequest,
   getPendingDeliveryByConversation,
   resolveGuardianActionRequest,
+  startFollowupFromExpiredRequest,
 } from '../memory/guardian-action-store.js';
+import { composeGuardianActionMessageGenerative } from '../runtime/guardian-action-message-composer.js';
 import { extractPreferences } from '../notifications/preference-extractor.js';
 import { createPreference } from '../notifications/preferences-store.js';
 import type { Message } from '../providers/types.js';
@@ -390,6 +393,65 @@ export async function processMessage(
         );
         session.messages.push(failMsg);
         onEvent({ type: 'assistant_text_delta', text: 'Failed to deliver your answer to the call. Please try again.' });
+      }
+      onEvent({ type: 'message_complete', sessionId: session.conversationId });
+      return persisted.id;
+    }
+  }
+
+  // ── Expired guardian action late answer interception (mac channel) ──
+  // If no pending delivery was found, check for expired requests eligible
+  // for follow-up (status='expired', followup_state='none').
+  const expiredDelivery = getExpiredDeliveryByConversation(session.conversationId);
+  if (expiredDelivery) {
+    const expiredRequest = getGuardianActionRequest(expiredDelivery.requestId);
+    if (expiredRequest && expiredRequest.status === 'expired' && expiredRequest.followupState === 'none') {
+      const guardianIfCtx = session.getTurnInterfaceContext();
+      const guardianChannelMeta = { userMessageChannel: 'vellum' as const, assistantMessageChannel: 'vellum' as const, userMessageInterface: guardianIfCtx?.userMessageInterface ?? 'vellum', assistantMessageInterface: guardianIfCtx?.assistantMessageInterface ?? 'vellum', provenanceActorRole: 'guardian' as const };
+      const userMsg = createUserMessage(content, attachments);
+      const persisted = conversationStore.addMessage(
+        session.conversationId,
+        'user',
+        JSON.stringify(userMsg.content),
+        guardianChannelMeta,
+      );
+      session.messages.push(userMsg);
+
+      const followupResult = startFollowupFromExpiredRequest(expiredRequest.id, content);
+      if (followupResult) {
+        // Use the composer without a generator — the daemon's mac path may not
+        // have direct access to the provider-backed generator, so deterministic
+        // fallback text is used.
+        const followupText = await composeGuardianActionMessageGenerative(
+          {
+            scenario: 'guardian_late_answer_followup',
+            questionText: expiredRequest.questionText,
+            lateAnswerText: content,
+          },
+        );
+        const replyMsg = createAssistantMessage(followupText);
+        conversationStore.addMessage(
+          session.conversationId,
+          'assistant',
+          JSON.stringify(replyMsg.content),
+          guardianChannelMeta,
+        );
+        session.messages.push(replyMsg);
+        onEvent({ type: 'assistant_text_delta', text: followupText });
+      } else {
+        // Follow-up already started or conflict — send stale message
+        const staleText = await composeGuardianActionMessageGenerative(
+          { scenario: 'guardian_stale_expired' },
+        );
+        const staleMsg = createAssistantMessage(staleText);
+        conversationStore.addMessage(
+          session.conversationId,
+          'assistant',
+          JSON.stringify(staleMsg.content),
+          guardianChannelMeta,
+        );
+        session.messages.push(staleMsg);
+        onEvent({ type: 'assistant_text_delta', text: staleText });
       }
       onEvent({ type: 'message_complete', sessionId: session.conversationId });
       return persisted.id;

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -371,7 +371,7 @@ export async function processMessage(
         const resolved = resolveGuardianActionRequest(guardianRequest.id, content, 'vellum');
         const replyText = resolved
           ? 'Your answer has been relayed to the call.'
-          : 'This question has already been answered from another channel.';
+          : await composeGuardianActionMessageGenerative({ scenario: 'guardian_stale_answered' });
         const replyMsg = createAssistantMessage(replyText);
         conversationStore.addMessage(
           session.conversationId,

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -621,6 +621,81 @@ export function getPendingDeliveryByConversation(conversationId: string): Guardi
   }
 }
 
+/**
+ * Look up sent deliveries for expired requests eligible for follow-up.
+ * Used by inbound message routing to match late guardian answers to expired requests.
+ */
+export function getExpiredDeliveriesByDestination(
+  assistantId: string,
+  channel: string,
+  chatId: string,
+): GuardianActionDelivery[] {
+  try {
+    const db = getDb();
+
+    const rows = db
+      .select({
+        delivery: guardianActionDeliveries,
+      })
+      .from(guardianActionDeliveries)
+      .innerJoin(
+        guardianActionRequests,
+        eq(guardianActionDeliveries.requestId, guardianActionRequests.id),
+      )
+      .where(
+        and(
+          eq(guardianActionRequests.assistantId, assistantId),
+          eq(guardianActionRequests.status, 'expired'),
+          eq(guardianActionRequests.followupState, 'none'),
+          eq(guardianActionDeliveries.destinationChannel, channel),
+          eq(guardianActionDeliveries.destinationChatId, chatId),
+          eq(guardianActionDeliveries.status, 'expired'),
+        ),
+      )
+      .all();
+
+    return rows.map((r) => rowToDelivery(r.delivery));
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('no such table')) {
+      log.warn({ err }, 'guardian tables not yet created');
+      return [];
+    }
+    throw err;
+  }
+}
+
+/**
+ * Look up an expired delivery by destination conversation ID (for mac channel routing).
+ */
+export function getExpiredDeliveryByConversation(conversationId: string): GuardianActionDelivery | null {
+  try {
+    const db = getDb();
+    const rows = db
+      .select({ delivery: guardianActionDeliveries })
+      .from(guardianActionDeliveries)
+      .innerJoin(
+        guardianActionRequests,
+        eq(guardianActionDeliveries.requestId, guardianActionRequests.id),
+      )
+      .where(
+        and(
+          eq(guardianActionDeliveries.destinationConversationId, conversationId),
+          eq(guardianActionDeliveries.status, 'expired'),
+          eq(guardianActionRequests.status, 'expired'),
+          eq(guardianActionRequests.followupState, 'none'),
+        ),
+      )
+      .all();
+    return rows.length > 0 ? rowToDelivery(rows[0].delivery) : null;
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('no such table')) {
+      log.warn({ err }, 'guardian tables not yet created');
+      return null;
+    }
+    throw err;
+  }
+}
+
 export function updateDeliveryStatus(
   deliveryId: string,
   status: GuardianActionDeliveryStatus,

--- a/assistant/src/runtime/guardian-action-message-composer.ts
+++ b/assistant/src/runtime/guardian-action-message-composer.ts
@@ -25,6 +25,7 @@ export type GuardianActionMessageScenario =
   | 'guardian_followup_completed'
   | 'guardian_followup_failed'
   | 'guardian_followup_declined_ack'
+  | 'guardian_stale_answered'
   | 'guardian_stale_expired'
   | 'outbound_message_copy';
 
@@ -164,6 +165,9 @@ export function getGuardianActionFallbackMessage(context: GuardianActionMessageC
 
     case 'guardian_followup_declined_ack':
       return 'No problem. Let me know if you change your mind or need anything else.';
+
+    case 'guardian_stale_answered':
+      return 'This question has already been answered from another channel.';
 
     case 'guardian_stale_expired':
       return 'That request has already expired. No further action is needed.';

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -17,9 +17,11 @@ import { recordConversationSeenSignal } from '../../memory/conversation-attentio
 import * as conversationStore from '../../memory/conversation-store.js';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
 import {
+  getExpiredDeliveriesByDestination,
   getGuardianActionRequest,
   getPendingDeliveriesByDestination,
   resolveGuardianActionRequest,
+  startFollowupFromExpiredRequest,
 } from '../../memory/guardian-action-store.js';
 import { findMember, updateLastSeen, upsertMember } from '../../memory/ingress-member-store.js';
 import { emitNotificationSignal } from '../../notifications/emit-signal.js';
@@ -56,6 +58,7 @@ import type {
   GuardianActionCopyGenerator,
   MessageProcessor,
 } from '../http-types.js';
+import { composeGuardianActionMessageGenerative } from '../guardian-action-message-composer.js';
 import { deliverReplyViaCallback } from './channel-delivery-routes.js';
 import {
   canonicalChannelAssistantId,
@@ -93,7 +96,7 @@ export async function handleChannelInbound(
   gatewayOriginSecret?: string,
   approvalCopyGenerator?: ApprovalCopyGenerator,
   approvalConversationGenerator?: ApprovalConversationGenerator,
-  _guardianActionCopyGenerator?: GuardianActionCopyGenerator,
+  guardianActionCopyGenerator?: GuardianActionCopyGenerator,
 ): Promise<Response> {
   // Reject requests that lack valid gateway-origin proof. This ensures
   // channel inbound messages can only arrive via the gateway (which
@@ -798,11 +801,51 @@ export async function handleChannelInbound(
                 guardianAnswer: 'resolved',
               });
             } else {
-              // Already answered from another channel
+              // resolveGuardianActionRequest returned null — request was no
+              // longer pending. Check if it expired (could have timed out
+              // between the delivery lookup and the resolve attempt).
+              const freshRequest = getGuardianActionRequest(request.id);
+              if (freshRequest && freshRequest.status === 'expired' && freshRequest.followupState === 'none') {
+                // Expired between lookup and resolve — initiate follow-up
+                const followupResult = startFollowupFromExpiredRequest(freshRequest.id, answerText);
+                if (followupResult) {
+                  const followupText = await composeGuardianActionMessageGenerative(
+                    {
+                      scenario: 'guardian_late_answer_followup',
+                      questionText: freshRequest.questionText,
+                      lateAnswerText: answerText,
+                    },
+                    {},
+                    guardianActionCopyGenerator,
+                  );
+                  try {
+                    await deliverChannelReply(replyCallbackUrl, {
+                      chatId: externalChatId,
+                      text: followupText,
+                      assistantId,
+                    }, bearerToken);
+                  } catch (err) {
+                    log.error({ err, externalChatId }, 'Failed to deliver guardian action follow-up prompt');
+                  }
+                  return Response.json({
+                    accepted: true,
+                    duplicate: false,
+                    eventId: result.eventId,
+                    guardianAnswer: 'followup_initiated',
+                  });
+                }
+              }
+
+              // Already answered from another channel (or follow-up already started)
+              const staleText = await composeGuardianActionMessageGenerative(
+                { scenario: 'guardian_stale_expired' },
+                {},
+                guardianActionCopyGenerator,
+              );
               try {
                 await deliverChannelReply(replyCallbackUrl, {
                   chatId: externalChatId,
-                  text: 'This question has already been answered from another channel.',
+                  text: staleText,
                   assistantId,
                 }, bearerToken);
               } catch (err) {
@@ -815,6 +858,59 @@ export async function handleChannelInbound(
                 guardianAnswer: 'stale',
               });
             }
+          }
+        }
+      }
+    }
+  }
+
+  // ── Expired guardian action late answer interception ──
+  // When no pending delivery was found above, check for expired requests
+  // eligible for follow-up (status='expired', followup_state='none').
+  if (
+    !result.duplicate &&
+    trimmedContent.length > 0 &&
+    body.senderExternalUserId &&
+    replyCallbackUrl
+  ) {
+    const expiredDeliveries = getExpiredDeliveriesByDestination(canonicalAssistantId, sourceChannel, externalChatId);
+    if (expiredDeliveries.length > 0) {
+      const validExpired = expiredDeliveries.filter(
+        (d) => d.destinationExternalUserId === body.senderExternalUserId,
+      );
+
+      if (validExpired.length > 0) {
+        // Take the first matching expired delivery
+        const expiredDelivery = validExpired[0];
+        const expiredRequest = getGuardianActionRequest(expiredDelivery.requestId);
+
+        if (expiredRequest && expiredRequest.status === 'expired' && expiredRequest.followupState === 'none') {
+          const followupResult = startFollowupFromExpiredRequest(expiredRequest.id, trimmedContent);
+          if (followupResult) {
+            const followupText = await composeGuardianActionMessageGenerative(
+              {
+                scenario: 'guardian_late_answer_followup',
+                questionText: expiredRequest.questionText,
+                lateAnswerText: trimmedContent,
+              },
+              {},
+              guardianActionCopyGenerator,
+            );
+            try {
+              await deliverChannelReply(replyCallbackUrl, {
+                chatId: externalChatId,
+                text: followupText,
+                assistantId,
+              }, bearerToken);
+            } catch (err) {
+              log.error({ err, externalChatId }, 'Failed to deliver guardian action late answer follow-up');
+            }
+            return Response.json({
+              accepted: true,
+              duplicate: false,
+              eventId: result.eventId,
+              guardianAnswer: 'followup_initiated',
+            });
           }
         }
       }

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -836,9 +836,12 @@ export async function handleChannelInbound(
                 }
               }
 
-              // Already answered from another channel (or follow-up already started)
+              // Already answered from another channel, or follow-up already started / expired
+              const staleScenario = freshRequest?.status === 'answered'
+                ? 'guardian_stale_answered' as const
+                : 'guardian_stale_expired' as const;
               const staleText = await composeGuardianActionMessageGenerative(
-                { scenario: 'guardian_stale_expired' },
+                { scenario: staleScenario },
                 {},
                 guardianActionCopyGenerator,
               );
@@ -867,8 +870,11 @@ export async function handleChannelInbound(
   // ── Expired guardian action late answer interception ──
   // When no pending delivery was found above, check for expired requests
   // eligible for follow-up (status='expired', followup_state='none').
+  // Exclude callback payloads — inline button presses should not be
+  // misclassified as late guardian answers.
   if (
     !result.duplicate &&
+    !hasCallbackData &&
     trimmedContent.length > 0 &&
     body.senderExternalUserId &&
     replyCallbackUrl
@@ -880,37 +886,77 @@ export async function handleChannelInbound(
       );
 
       if (validExpired.length > 0) {
-        // Take the first matching expired delivery
-        const expiredDelivery = validExpired[0];
-        const expiredRequest = getGuardianActionRequest(expiredDelivery.requestId);
+        let matchedExpired = validExpired.length === 1 ? validExpired[0] : null;
+        let expiredAnswerText = trimmedContent;
 
-        if (expiredRequest && expiredRequest.status === 'expired' && expiredRequest.followupState === 'none') {
-          const followupResult = startFollowupFromExpiredRequest(expiredRequest.id, trimmedContent);
-          if (followupResult) {
-            const followupText = await composeGuardianActionMessageGenerative(
-              {
-                scenario: 'guardian_late_answer_followup',
-                questionText: expiredRequest.questionText,
-                lateAnswerText: trimmedContent,
-              },
-              {},
-              guardianActionCopyGenerator,
-            );
+        // Multiple expired deliveries: require request code prefix for disambiguation
+        if (validExpired.length > 1) {
+          for (const d of validExpired) {
+            const req = getGuardianActionRequest(d.requestId);
+            if (req && trimmedContent.toUpperCase().startsWith(req.requestCode)) {
+              matchedExpired = d;
+              expiredAnswerText = trimmedContent.slice(req.requestCode.length).trim();
+              break;
+            }
+          }
+
+          if (!matchedExpired) {
+            // Send disambiguation message listing the request codes
+            const codes = validExpired
+              .map((d) => {
+                const req = getGuardianActionRequest(d.requestId);
+                return req ? req.requestCode : null;
+              })
+              .filter(Boolean);
             try {
               await deliverChannelReply(replyCallbackUrl, {
                 chatId: externalChatId,
-                text: followupText,
+                text: `You have multiple expired guardian questions. Please prefix your reply with the reference code (${codes.join(', ')}) to indicate which question you are answering.`,
                 assistantId,
               }, bearerToken);
             } catch (err) {
-              log.error({ err, externalChatId }, 'Failed to deliver guardian action late answer follow-up');
+              log.error({ err, externalChatId }, 'Failed to deliver guardian action expired disambiguation message');
             }
             return Response.json({
               accepted: true,
               duplicate: false,
               eventId: result.eventId,
-              guardianAnswer: 'followup_initiated',
+              guardianAnswer: 'disambiguation_sent',
             });
+          }
+        }
+
+        if (matchedExpired) {
+          const expiredRequest = getGuardianActionRequest(matchedExpired.requestId);
+
+          if (expiredRequest && expiredRequest.status === 'expired' && expiredRequest.followupState === 'none') {
+            const followupResult = startFollowupFromExpiredRequest(expiredRequest.id, expiredAnswerText);
+            if (followupResult) {
+              const followupText = await composeGuardianActionMessageGenerative(
+                {
+                  scenario: 'guardian_late_answer_followup',
+                  questionText: expiredRequest.questionText,
+                  lateAnswerText: expiredAnswerText,
+                },
+                {},
+                guardianActionCopyGenerator,
+              );
+              try {
+                await deliverChannelReply(replyCallbackUrl, {
+                  chatId: externalChatId,
+                  text: followupText,
+                  assistantId,
+                }, bearerToken);
+              } catch (err) {
+                log.error({ err, externalChatId }, 'Failed to deliver guardian action late answer follow-up');
+              }
+              return Response.json({
+                accepted: true,
+                duplicate: false,
+                eventId: result.eventId,
+                guardianAnswer: 'followup_initiated',
+              });
+            }
           }
         }
       }


### PR DESCRIPTION
Convert late guardian answers into follow-up negotiation. When a guardian answers after timeout, transitions to awaiting_guardian_choice state and sends generated follow-up prompt asking whether to call back or message back. Adds expired delivery queries, follow-up initiation in both channel and mac paths, and replaces deterministic stale text with generated messages. Part of #9562.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
