### PR TITLE
M3: Align finalization text and persist error-path messages

### DIFF
--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -444,9 +444,15 @@ export async function finalizeAndPublishRecording(params: {
   if (!filePath) {
     // No file path — recording stopped without producing a file
     log.warn({ recordingId, conversationId }, 'Recording stopped without file path');
+    const errorText = 'Recording stopped but no file was produced.';
+    conversationStore.addMessage(
+      conversationId,
+      'assistant',
+      JSON.stringify([{ type: 'text', text: errorText }]),
+    );
     ctx.send(notifySocket, {
       type: 'assistant_text_delta',
-      text: 'Recording stopped but no file was produced.',
+      text: errorText,
       sessionId: conversationId,
     });
     ctx.send(notifySocket, { type: 'message_complete', sessionId: conversationId });
@@ -475,9 +481,15 @@ export async function finalizeAndPublishRecording(params: {
   }
   if (!resolvedPath.startsWith(resolvedAllowedDir + path.sep) && resolvedPath !== resolvedAllowedDir) {
     log.warn({ recordingId, filePath, allowedDir, resolvedAllowedDir }, 'Recording file path outside allowed directory — rejecting');
+    const errorText = 'Recording file is unavailable or expired.';
+    conversationStore.addMessage(
+      conversationId,
+      'assistant',
+      JSON.stringify([{ type: 'text', text: errorText }]),
+    );
     ctx.send(notifySocket, {
       type: 'assistant_text_delta',
-      text: 'Recording file is unavailable or expired.',
+      text: errorText,
       sessionId: conversationId,
     });
     ctx.send(notifySocket, { type: 'message_complete', sessionId: conversationId });
@@ -487,9 +499,15 @@ export async function finalizeAndPublishRecording(params: {
   try {
     if (!existsSync(resolvedPath)) {
       log.error({ recordingId, filePath }, 'Recording file does not exist');
+      const errorText = 'Recording failed to save.';
+      conversationStore.addMessage(
+        conversationId,
+        'assistant',
+        JSON.stringify([{ type: 'text', text: errorText }]),
+      );
       ctx.send(notifySocket, {
         type: 'assistant_text_delta',
-        text: 'Recording failed to save.',
+        text: errorText,
         sessionId: conversationId,
       });
       ctx.send(notifySocket, { type: 'message_complete', sessionId: conversationId });
@@ -501,9 +519,15 @@ export async function finalizeAndPublishRecording(params: {
 
     if (sizeBytes === 0) {
       log.error({ recordingId, filePath }, 'Recording file is zero-length — treating as failed');
+      const errorText = 'Recording failed to save.';
+      conversationStore.addMessage(
+        conversationId,
+        'assistant',
+        JSON.stringify([{ type: 'text', text: errorText }]),
+      );
       ctx.send(notifySocket, {
         type: 'assistant_text_delta',
-        text: 'Recording failed to save.',
+        text: errorText,
         sessionId: conversationId,
       });
       ctx.send(notifySocket, { type: 'message_complete', sessionId: conversationId });
@@ -523,10 +547,11 @@ export async function finalizeAndPublishRecording(params: {
     // Always create a new assistant message for the recording attachment.
     // Reusing the last assistant message would attach the recording to an
     // unrelated older message after reload.
+    const msgText = 'Screen recording complete. Your recording has been saved.';
     const newMsg = conversationStore.addMessage(
       conversationId,
       'assistant',
-      JSON.stringify([{ type: 'text', text: 'Screen recording attached.' }]),
+      JSON.stringify([{ type: 'text', text: msgText }]),
     );
     const messageId = newMsg.id;
     log.info({ recordingId, conversationId, messageId }, 'Created assistant message for recording attachment');
@@ -551,7 +576,7 @@ export async function finalizeAndPublishRecording(params: {
     // Notify the client via the reporting socket
     ctx.send(notifySocket, {
       type: 'assistant_text_delta',
-      text: 'Screen recording complete. Your recording has been saved.',
+      text: msgText,
       sessionId: conversationId,
     });
     ctx.send(notifySocket, {
@@ -570,9 +595,15 @@ export async function finalizeAndPublishRecording(params: {
     return { success: true, messageId };
   } catch (err) {
     log.error({ err, recordingId, filePath }, 'Failed to create attachment for standalone recording');
+    const errorText = 'Recording saved but failed to attach to conversation.';
+    conversationStore.addMessage(
+      conversationId,
+      'assistant',
+      JSON.stringify([{ type: 'text', text: errorText }]),
+    );
     ctx.send(notifySocket, {
       type: 'assistant_text_delta',
-      text: 'Recording saved but failed to attach to conversation.',
+      text: errorText,
       sessionId: conversationId,
     });
     ctx.send(notifySocket, { type: 'message_complete', sessionId: conversationId });

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -445,11 +445,15 @@ export async function finalizeAndPublishRecording(params: {
     // No file path — recording stopped without producing a file
     log.warn({ recordingId, conversationId }, 'Recording stopped without file path');
     const errorText = 'Recording stopped but no file was produced.';
-    conversationStore.addMessage(
-      conversationId,
-      'assistant',
-      JSON.stringify([{ type: 'text', text: errorText }]),
-    );
+    try {
+      conversationStore.addMessage(
+        conversationId,
+        'assistant',
+        JSON.stringify([{ type: 'text', text: errorText }]),
+      );
+    } catch (persistErr) {
+      log.warn({ err: persistErr, recordingId, conversationId }, 'Failed to persist recording error message');
+    }
     ctx.send(notifySocket, {
       type: 'assistant_text_delta',
       text: errorText,
@@ -482,11 +486,15 @@ export async function finalizeAndPublishRecording(params: {
   if (!resolvedPath.startsWith(resolvedAllowedDir + path.sep) && resolvedPath !== resolvedAllowedDir) {
     log.warn({ recordingId, filePath, allowedDir, resolvedAllowedDir }, 'Recording file path outside allowed directory — rejecting');
     const errorText = 'Recording file is unavailable or expired.';
-    conversationStore.addMessage(
-      conversationId,
-      'assistant',
-      JSON.stringify([{ type: 'text', text: errorText }]),
-    );
+    try {
+      conversationStore.addMessage(
+        conversationId,
+        'assistant',
+        JSON.stringify([{ type: 'text', text: errorText }]),
+      );
+    } catch (persistErr) {
+      log.warn({ err: persistErr, recordingId, conversationId }, 'Failed to persist recording error message');
+    }
     ctx.send(notifySocket, {
       type: 'assistant_text_delta',
       text: errorText,
@@ -500,11 +508,15 @@ export async function finalizeAndPublishRecording(params: {
     if (!existsSync(resolvedPath)) {
       log.error({ recordingId, filePath }, 'Recording file does not exist');
       const errorText = 'Recording failed to save.';
-      conversationStore.addMessage(
-        conversationId,
-        'assistant',
-        JSON.stringify([{ type: 'text', text: errorText }]),
-      );
+      try {
+        conversationStore.addMessage(
+          conversationId,
+          'assistant',
+          JSON.stringify([{ type: 'text', text: errorText }]),
+        );
+      } catch (persistErr) {
+        log.warn({ err: persistErr, recordingId, conversationId }, 'Failed to persist recording error message');
+      }
       ctx.send(notifySocket, {
         type: 'assistant_text_delta',
         text: errorText,
@@ -520,11 +532,15 @@ export async function finalizeAndPublishRecording(params: {
     if (sizeBytes === 0) {
       log.error({ recordingId, filePath }, 'Recording file is zero-length — treating as failed');
       const errorText = 'Recording failed to save.';
-      conversationStore.addMessage(
-        conversationId,
-        'assistant',
-        JSON.stringify([{ type: 'text', text: errorText }]),
-      );
+      try {
+        conversationStore.addMessage(
+          conversationId,
+          'assistant',
+          JSON.stringify([{ type: 'text', text: errorText }]),
+        );
+      } catch (persistErr) {
+        log.warn({ err: persistErr, recordingId, conversationId }, 'Failed to persist recording error message');
+      }
       ctx.send(notifySocket, {
         type: 'assistant_text_delta',
         text: errorText,
@@ -596,11 +612,15 @@ export async function finalizeAndPublishRecording(params: {
   } catch (err) {
     log.error({ err, recordingId, filePath }, 'Failed to create attachment for standalone recording');
     const errorText = 'Recording saved but failed to attach to conversation.';
-    conversationStore.addMessage(
-      conversationId,
-      'assistant',
-      JSON.stringify([{ type: 'text', text: errorText }]),
-    );
+    try {
+      conversationStore.addMessage(
+        conversationId,
+        'assistant',
+        JSON.stringify([{ type: 'text', text: errorText }]),
+      );
+    } catch (persistErr) {
+      log.warn({ err: persistErr, recordingId, conversationId }, 'Failed to persist recording error message');
+    }
     ctx.send(notifySocket, {
       type: 'assistant_text_delta',
       text: errorText,


### PR DESCRIPTION
Align the success text between DB and IPC in finalizeAndPublishRecording(), and persist all error-path messages to the database so they survive app restart. Closes #9631.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
