### PR TITLE
fix: reset segment count on retry sweep to prevent garbled output

### DIFF
--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -133,7 +133,11 @@ export async function sweepFailedEvents(
           ? payload.externalChatId
           : undefined;
         if (externalChatId) {
-          const startFromSegment = channelDeliveryStore.getDeliveredSegmentCount(event.id);
+          // processMessage above generated a fresh assistant response, so any
+          // previously tracked segment progress belongs to the old response and
+          // must not carry over. Reset to 0 so we deliver all segments of the
+          // new response.
+          channelDeliveryStore.updateDeliveredSegmentCount(event.id, 0);
           await deliverReplyViaCallback(
             event.conversationId,
             externalChatId,
@@ -141,7 +145,7 @@ export async function sweepFailedEvents(
             bearerToken,
             assistantId,
             {
-              startFromSegment,
+              startFromSegment: 0,
               onSegmentDelivered: (count) =>
                 channelDeliveryStore.updateDeliveredSegmentCount(event.id, count),
             },


### PR DESCRIPTION
When the retry sweep re-runs processMessage it generates a new assistant response. The old deliveredSegmentCount no longer applies to the new response, so we must reset it to 0 before delivery to avoid skipping segments or producing garbled output. Addresses feedback from PR #9371.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
