### PR TITLE
fix: gate channel isInteractive on actor role to prevent non-guardian self-approval

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -2510,7 +2510,15 @@ describe('non-decision status reply for different channels', () => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe('background channel processing approval prompts', () => {
-  test('marks channel turns interactive and delivers approval prompt when confirmation is pending', async () => {
+  test('marks guardian channel turns interactive and delivers approval prompt when confirmation is pending', async () => {
+    // Set up a guardian binding so the sender is recognized as a guardian
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'telegram-user-default',
+      guardianDeliveryChatId: 'chat-123',
+    });
+
     const deliverPromptSpy = spyOn(gatewayClient, 'deliverApprovalPrompt').mockResolvedValue(undefined);
     const processCalls: Array<{ options?: Record<string, unknown> }> = [];
 
@@ -2552,5 +2560,44 @@ describe('background channel processing approval prompts', () => {
     expect(approvalMeta?.requestId).toBe('req-bg-1');
 
     deliverPromptSpy.mockRestore();
+  });
+
+  test('non-guardian channel turns are not interactive to prevent self-approval', async () => {
+    // Set up a guardian binding for a DIFFERENT user so the sender is non-guardian
+    createBinding({
+      assistantId: 'self',
+      channel: 'telegram',
+      guardianExternalUserId: 'guardian-user-other',
+      guardianDeliveryChatId: 'guardian-chat-other',
+    });
+
+    const processCalls: Array<{ options?: Record<string, unknown> }> = [];
+
+    const processMessage = mock(async (
+      _conversationId: string,
+      _content: string,
+      _attachmentIds?: string[],
+      options?: Record<string, unknown>,
+    ) => {
+      processCalls.push({ options });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      return { messageId: 'msg-ng-1' };
+    });
+
+    const req = makeInboundRequest({
+      content: 'run something',
+      sourceChannel: 'telegram',
+      replyCallbackUrl: 'https://gateway.test/deliver/telegram',
+      externalMessageId: 'msg-ng-1',
+    });
+
+    const res = await handleChannelInbound(req, processMessage as unknown as typeof noopProcessMessage, 'token');
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.accepted).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(processCalls.length).toBeGreaterThan(0);
+    expect(processCalls[0].options?.isInteractive).toBe(false);
   });
 });

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1214,7 +1214,7 @@ function processChannelMessageInBackground(params: BackgroundProcessingParams): 
           },
           assistantId,
           guardianContext: toGuardianRuntimeContext(sourceChannel, guardianCtx),
-          isInteractive: true,
+          isInteractive: guardianCtx.actorRole === 'guardian',
           ...(cmdIntent ? { commandIntent: cmdIntent } : {}),
         },
         sourceChannel,


### PR DESCRIPTION
Only set isInteractive=true for channel turns when the actor is a guardian. Non-guardian requesters and unverified channel actors keep isInteractive=false to prevent bypassing guardian approval intent. When isInteractive=false, the tool executor auto-denies confirmation prompts instead of presenting actionable approval UI to actors who should not self-approve. Addresses feedback from PR #9380.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
