### PR TITLE
Persist recording-related messages across app restart

### DIFF
--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -93,7 +93,7 @@ export async function handleTaskSubmit(
         conversationStore.addMessage(conversation.id, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         // Sync in-memory session if one exists for this conversation
         const startSession = ctx.sessions.get(conversation.id);
-        if (startSession) {
+        if (startSession && !startSession.isProcessing()) {
           startSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
           startSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
         }
@@ -118,7 +118,7 @@ export async function handleTaskSubmit(
         conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         const stopSession = ctx.sessions.get(activeSessionId);
-        if (stopSession) {
+        if (stopSession && !stopSession.isProcessing()) {
           stopSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
           stopSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
         }
@@ -141,7 +141,7 @@ export async function handleTaskSubmit(
         conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: restartResult.responseText }]));
         const restartSession = ctx.sessions.get(activeSessionId);
-        if (restartSession) {
+        if (restartSession && !restartSession.isProcessing()) {
           restartSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
           restartSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: restartResult.responseText }] });
         }
@@ -165,7 +165,7 @@ export async function handleTaskSubmit(
         conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         const pauseSession = ctx.sessions.get(activeSessionId);
-        if (pauseSession) {
+        if (pauseSession && !pauseSession.isProcessing()) {
           pauseSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
           pauseSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
         }
@@ -189,7 +189,7 @@ export async function handleTaskSubmit(
         conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         const resumeSession = ctx.sessions.get(activeSessionId);
-        if (resumeSession) {
+        if (resumeSession && !resumeSession.isProcessing()) {
           resumeSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
           resumeSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
         }
@@ -228,7 +228,7 @@ export async function handleTaskSubmit(
         conversationStore.addMessage(conversation.id, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(conversation.id, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
         const startOnlySession = ctx.sessions.get(conversation.id);
-        if (startOnlySession) {
+        if (startOnlySession && !startOnlySession.isProcessing()) {
           startOnlySession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
           startOnlySession.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
         }
@@ -263,7 +263,7 @@ export async function handleTaskSubmit(
         conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
         const stopOnlySession = ctx.sessions.get(activeSessionId);
-        if (stopOnlySession) {
+        if (stopOnlySession && !stopOnlySession.isProcessing()) {
           stopOnlySession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
           stopOnlySession.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
         }
@@ -291,7 +291,7 @@ export async function handleTaskSubmit(
         conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
         const startStopOnlySession = ctx.sessions.get(activeSessionId);
-        if (startStopOnlySession) {
+        if (startStopOnlySession && !startStopOnlySession.isProcessing()) {
           startStopOnlySession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
           startStopOnlySession.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
         }
@@ -320,7 +320,7 @@ export async function handleTaskSubmit(
         conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
         conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
         const handledSession = ctx.sessions.get(activeSessionId);
-        if (handledSession) {
+        if (handledSession && !handledSession.isProcessing()) {
           handledSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
           handledSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
         }
@@ -392,7 +392,7 @@ export async function handleTaskSubmit(
               conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
               conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
               const fallbackSession = ctx.sessions.get(activeSessionId);
-              if (fallbackSession) {
+              if (fallbackSession && !fallbackSession.isProcessing()) {
                 fallbackSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
                 fallbackSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
               }

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -81,13 +81,22 @@ export async function handleTaskSubmit(
         const conversation = conversationStore.createConversation(msg.task || 'Screen Recording');
         ctx.socketToSession.set(socket, conversation.id);
         const recordingId = handleRecordingStart(conversation.id, { promptForSource: true }, socket, ctx);
+        const responseText = recordingId ? 'Starting screen recording.' : 'A recording is already active.';
         ctx.send(socket, { type: 'task_routed', sessionId: conversation.id, interactionType: 'text_qa' });
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: recordingId ? 'Starting screen recording.' : 'A recording is already active.',
+          text: responseText,
           sessionId: conversation.id,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
+        conversationStore.addMessage(conversation.id, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
+        conversationStore.addMessage(conversation.id, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        // Sync in-memory session if one exists for this conversation
+        const startSession = ctx.sessions.get(conversation.id);
+        if (startSession) {
+          startSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
+          startSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
+        }
         if (!recordingId) ctx.socketToSession.delete(socket);
         return;
       } else if (action === 'stop') {
@@ -98,13 +107,21 @@ export async function handleTaskSubmit(
           ctx.socketToSession.set(socket, activeSessionId);
         }
         const stopped = handleRecordingStop(activeSessionId, ctx) !== undefined;
+        const responseText = stopped ? 'Stopping the recording.' : 'No active recording to stop.';
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',
+          text: responseText,
           sessionId: activeSessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
+        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        const stopSession = ctx.sessions.get(activeSessionId);
+        if (stopSession) {
+          stopSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
+          stopSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
+        }
         return;
       } else if (action === 'restart') {
         let activeSessionId = ctx.socketToSession.get(socket);
@@ -121,6 +138,13 @@ export async function handleTaskSubmit(
           sessionId: activeSessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
+        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: restartResult.responseText }]));
+        const restartSession = ctx.sessions.get(activeSessionId);
+        if (restartSession) {
+          restartSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
+          restartSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: restartResult.responseText }] });
+        }
         return;
       } else if (action === 'pause') {
         let activeSessionId = ctx.socketToSession.get(socket);
@@ -130,13 +154,21 @@ export async function handleTaskSubmit(
           ctx.socketToSession.set(socket, activeSessionId);
         }
         const paused = handleRecordingPause(activeSessionId, ctx) !== undefined;
+        const responseText = paused ? 'Pausing the recording.' : 'No active recording to pause.';
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: paused ? 'Pausing the recording.' : 'No active recording to pause.',
+          text: responseText,
           sessionId: activeSessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
+        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        const pauseSession = ctx.sessions.get(activeSessionId);
+        if (pauseSession) {
+          pauseSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
+          pauseSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
+        }
         return;
       } else if (action === 'resume') {
         let activeSessionId = ctx.socketToSession.get(socket);
@@ -146,13 +178,21 @@ export async function handleTaskSubmit(
           ctx.socketToSession.set(socket, activeSessionId);
         }
         const resumed = handleRecordingResume(activeSessionId, ctx) !== undefined;
+        const responseText = resumed ? 'Resuming the recording.' : 'No active recording to resume.';
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: resumed ? 'Resuming the recording.' : 'No active recording to resume.',
+          text: responseText,
           sessionId: activeSessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
+        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        const resumeSession = ctx.sessions.get(activeSessionId);
+        if (resumeSession) {
+          resumeSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
+          resumeSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
+        }
         return;
       } else {
         // Unrecognized action — fall through to normal text handling so the
@@ -185,6 +225,13 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'task_routed', sessionId: conversation.id, interactionType: 'text_qa' });
         ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: conversation.id });
         ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
+        conversationStore.addMessage(conversation.id, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
+        conversationStore.addMessage(conversation.id, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+        const startOnlySession = ctx.sessions.get(conversation.id);
+        if (startOnlySession) {
+          startOnlySession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
+          startOnlySession.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
+        }
 
         // If recording rejected, unbind socket
         if (execResult.recordingStarted === false) {
@@ -213,6 +260,13 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: activeSessionId });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
+        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+        const stopOnlySession = ctx.sessions.get(activeSessionId);
+        if (stopOnlySession) {
+          stopOnlySession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
+          stopOnlySession.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
+        }
         return;
       }
 
@@ -234,6 +288,13 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: activeSessionId });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
+        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+        const startStopOnlySession = ctx.sessions.get(activeSessionId);
+        if (startStopOnlySession) {
+          startStopOnlySession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
+          startStopOnlySession.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
+        }
         return;
       }
 
@@ -256,6 +317,13 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: activeSessionId });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
+        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+        const handledSession = ctx.sessions.get(activeSessionId);
+        if (handledSession) {
+          handledSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
+          handledSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
+        }
         return;
       }
 
@@ -321,6 +389,13 @@ export async function handleTaskSubmit(
                 sessionId: activeSessionId,
               });
               ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
+              conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
+              conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+              const fallbackSession = ctx.sessions.get(activeSessionId);
+              if (fallbackSession) {
+                fallbackSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
+                fallbackSession.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
+              }
 
               // If recording was rejected (e.g. already active), unbind the
               // socket so it doesn't stay bound to an orphaned conversation.

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -165,6 +165,7 @@ export async function handleTaskSubmit(
     let pendingRecordingStart = false;
     let pendingRecordingStop = false;
     let pendingRecordingRestart: 'restart_with_remainder' | 'start_and_stop_with_remainder' | false = false;
+    let originalTaskBeforeStrip: string | undefined;
     if (config.daemon.standaloneRecording) {
       const name = getAssistantName();
       const dynamicNames = [name].filter(Boolean) as string[];
@@ -276,6 +277,8 @@ export async function handleTaskSubmit(
           pendingRecordingStart = intentResult.kind === 'start_with_remainder';
           pendingRecordingRestart = intentResult.kind === 'restart_with_remainder' ? 'restart_with_remainder' : false;
         }
+        // Preserve the original text so the DB stores the full message
+        originalTaskBeforeStrip = msg.task;
         (msg as { task: string }).task = intentResult.remainder;
         rlog.info({ remaining: intentResult.remainder }, 'Recording intent deferred, continuing with remaining text');
       }
@@ -409,7 +412,7 @@ export async function handleTaskSubmit(
       // Start streaming immediately — client doesn't need to send user_message
       session.processMessage(msg.task, msg.attachments ?? [], (event) => {
         ctx.send(socket, event);
-      }, requestId).catch((err) => {
+      }, requestId, undefined, undefined, undefined, originalTaskBeforeStrip).catch((err) => {
         const message = err instanceof Error ? err.message : String(err);
         rlog.error({ err }, 'Error processing task_submit text QA');
         ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -444,9 +444,19 @@ export async function finalizeAndPublishRecording(params: {
   if (!filePath) {
     // No file path — recording stopped without producing a file
     log.warn({ recordingId, conversationId }, 'Recording stopped without file path');
+    const errorText = 'Recording stopped but no file was produced.';
+    try {
+      conversationStore.addMessage(
+        conversationId,
+        'assistant',
+        JSON.stringify([{ type: 'text', text: errorText }]),
+      );
+    } catch (persistErr) {
+      log.warn({ err: persistErr, recordingId, conversationId }, 'Failed to persist recording error message');
+    }
     ctx.send(notifySocket, {
       type: 'assistant_text_delta',
-      text: 'Recording stopped but no file was produced.',
+      text: errorText,
       sessionId: conversationId,
     });
     ctx.send(notifySocket, { type: 'message_complete', sessionId: conversationId });
@@ -475,9 +485,19 @@ export async function finalizeAndPublishRecording(params: {
   }
   if (!resolvedPath.startsWith(resolvedAllowedDir + path.sep) && resolvedPath !== resolvedAllowedDir) {
     log.warn({ recordingId, filePath, allowedDir, resolvedAllowedDir }, 'Recording file path outside allowed directory — rejecting');
+    const errorText = 'Recording file is unavailable or expired.';
+    try {
+      conversationStore.addMessage(
+        conversationId,
+        'assistant',
+        JSON.stringify([{ type: 'text', text: errorText }]),
+      );
+    } catch (persistErr) {
+      log.warn({ err: persistErr, recordingId, conversationId }, 'Failed to persist recording error message');
+    }
     ctx.send(notifySocket, {
       type: 'assistant_text_delta',
-      text: 'Recording file is unavailable or expired.',
+      text: errorText,
       sessionId: conversationId,
     });
     ctx.send(notifySocket, { type: 'message_complete', sessionId: conversationId });
@@ -487,9 +507,19 @@ export async function finalizeAndPublishRecording(params: {
   try {
     if (!existsSync(resolvedPath)) {
       log.error({ recordingId, filePath }, 'Recording file does not exist');
+      const errorText = 'Recording failed to save.';
+      try {
+        conversationStore.addMessage(
+          conversationId,
+          'assistant',
+          JSON.stringify([{ type: 'text', text: errorText }]),
+        );
+      } catch (persistErr) {
+        log.warn({ err: persistErr, recordingId, conversationId }, 'Failed to persist recording error message');
+      }
       ctx.send(notifySocket, {
         type: 'assistant_text_delta',
-        text: 'Recording failed to save.',
+        text: errorText,
         sessionId: conversationId,
       });
       ctx.send(notifySocket, { type: 'message_complete', sessionId: conversationId });
@@ -501,9 +531,19 @@ export async function finalizeAndPublishRecording(params: {
 
     if (sizeBytes === 0) {
       log.error({ recordingId, filePath }, 'Recording file is zero-length — treating as failed');
+      const errorText = 'Recording failed to save.';
+      try {
+        conversationStore.addMessage(
+          conversationId,
+          'assistant',
+          JSON.stringify([{ type: 'text', text: errorText }]),
+        );
+      } catch (persistErr) {
+        log.warn({ err: persistErr, recordingId, conversationId }, 'Failed to persist recording error message');
+      }
       ctx.send(notifySocket, {
         type: 'assistant_text_delta',
-        text: 'Recording failed to save.',
+        text: errorText,
         sessionId: conversationId,
       });
       ctx.send(notifySocket, { type: 'message_complete', sessionId: conversationId });
@@ -523,10 +563,11 @@ export async function finalizeAndPublishRecording(params: {
     // Always create a new assistant message for the recording attachment.
     // Reusing the last assistant message would attach the recording to an
     // unrelated older message after reload.
+    const msgText = 'Screen recording complete. Your recording has been saved.';
     const newMsg = conversationStore.addMessage(
       conversationId,
       'assistant',
-      JSON.stringify([{ type: 'text', text: 'Screen recording attached.' }]),
+      JSON.stringify([{ type: 'text', text: msgText }]),
     );
     const messageId = newMsg.id;
     log.info({ recordingId, conversationId, messageId }, 'Created assistant message for recording attachment');
@@ -551,7 +592,7 @@ export async function finalizeAndPublishRecording(params: {
     // Notify the client via the reporting socket
     ctx.send(notifySocket, {
       type: 'assistant_text_delta',
-      text: 'Screen recording complete. Your recording has been saved.',
+      text: msgText,
       sessionId: conversationId,
     });
     ctx.send(notifySocket, {
@@ -570,9 +611,19 @@ export async function finalizeAndPublishRecording(params: {
     return { success: true, messageId };
   } catch (err) {
     log.error({ err, recordingId, filePath }, 'Failed to create attachment for standalone recording');
+    const errorText = 'Recording saved but failed to attach to conversation.';
+    try {
+      conversationStore.addMessage(
+        conversationId,
+        'assistant',
+        JSON.stringify([{ type: 'text', text: errorText }]),
+      );
+    } catch (persistErr) {
+      log.warn({ err: persistErr, recordingId, conversationId }, 'Failed to persist recording error message');
+    }
     ctx.send(notifySocket, {
       type: 'assistant_text_delta',
-      text: 'Recording saved but failed to attach to conversation.',
+      text: errorText,
       sessionId: conversationId,
     });
     ctx.send(notifySocket, { type: 'message_complete', sessionId: conversationId });

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -238,21 +238,33 @@ export async function handleUserMessage(
       rlog.info({ action, source: 'commandIntent' }, 'Recording command intent received in user_message');
       if (action === 'start') {
         const recordingId = handleRecordingStart(msg.sessionId, { promptForSource: true }, socket, ctx);
+        const responseText = recordingId ? 'Starting screen recording.' : 'A recording is already active.';
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: recordingId ? 'Starting screen recording.' : 'A recording is already active.',
+          text: responseText,
           sessionId: msg.sessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+        conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+        conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        // Keep in-memory session history aligned with DB so regenerate() and
+        // other history operations that rely on session.messages stay consistent.
+        session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+        session.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
         return;
       } else if (action === 'stop') {
         const stopped = handleRecordingStop(msg.sessionId, ctx) !== undefined;
+        const responseText = stopped ? 'Stopping the recording.' : 'No active recording to stop.';
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: stopped ? 'Stopping the recording.' : 'No active recording to stop.',
+          text: responseText,
           sessionId: msg.sessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+        conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+        conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+        session.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
         return;
       } else if (action === 'restart') {
         const restartResult = handleRecordingRestart(msg.sessionId, socket, ctx);
@@ -262,24 +274,38 @@ export async function handleUserMessage(
           sessionId: msg.sessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+        conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+        conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: restartResult.responseText }]));
+        session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+        session.messages.push({ role: 'assistant', content: [{ type: 'text', text: restartResult.responseText }] });
         return;
       } else if (action === 'pause') {
         const paused = handleRecordingPause(msg.sessionId, ctx) !== undefined;
+        const responseText = paused ? 'Pausing the recording.' : 'No active recording to pause.';
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: paused ? 'Pausing the recording.' : 'No active recording to pause.',
+          text: responseText,
           sessionId: msg.sessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+        conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+        conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+        session.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
         return;
       } else if (action === 'resume') {
         const resumed = handleRecordingResume(msg.sessionId, ctx) !== undefined;
+        const responseText = resumed ? 'Resuming the recording.' : 'No active recording to resume.';
         ctx.send(socket, {
           type: 'assistant_text_delta',
-          text: resumed ? 'Resuming the recording.' : 'No active recording to resume.',
+          text: responseText,
           sessionId: msg.sessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+        conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+        conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+        session.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
         return;
       } else {
         // Unrecognized action — fall through to normal text handling
@@ -312,6 +338,10 @@ export async function handleUserMessage(
             sessionId: msg.sessionId,
           });
           ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+          conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+          conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+          session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+          session.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
           return;
         }
       }
@@ -383,6 +413,10 @@ export async function handleUserMessage(
                 sessionId: msg.sessionId,
               });
               ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
+              conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+              conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+              session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+              session.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
               return;
             }
           }

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -95,6 +95,7 @@ export async function handleUserMessage(
       source: 'user_message' | 'secure_redirect_resume',
       activeSurfaceId?: string,
       currentPage?: string,
+      displayContent?: string,
     ): void => {
       const receivedDescription = source === 'user_message'
         ? 'User message received'
@@ -117,6 +118,8 @@ export async function handleUserMessage(
         activeSurfaceId,
         currentPage,
         queuedChannelMetadata,
+        undefined,
+        displayContent,
       );
       if (result.rejected) {
         rlog.warn({ source }, 'Message rejected — queue is full');
@@ -167,7 +170,7 @@ export async function handleUserMessage(
       // Fire-and-forget: don't block the IPC handler so the connection can
       // continue receiving messages (e.g. cancel, confirmations, or
       // additional user_message that will be queued by the session).
-      session.processMessage(content, attachments, sendEvent, dispatchRequestId, activeSurfaceId, currentPage).catch((err) => {
+      session.processMessage(content, attachments, sendEvent, dispatchRequestId, activeSurfaceId, currentPage, undefined, displayContent).catch((err) => {
         const message = err instanceof Error ? err.message : String(err);
         rlog.error({ err, source }, 'Error processing user message (session or provider failure)');
         ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });
@@ -285,6 +288,7 @@ export async function handleUserMessage(
     }
 
     // ── Standalone recording intent interception ──────────────────────────
+    let originalContentBeforeStrip: string | undefined;
     if (config.daemon.standaloneRecording && messageText) {
       const name = getAssistantName();
       const dynamicNames = [name].filter(Boolean) as string[];
@@ -319,6 +323,9 @@ export async function handleUserMessage(
           socket,
           ctx,
         });
+
+        // Preserve the original text so the DB stores the full message
+        originalContentBeforeStrip = messageText;
 
         // Continue with stripped text for downstream processing
         msg.content = execResult.remainderText ?? messageText;
@@ -390,6 +397,7 @@ export async function handleUserMessage(
       'user_message',
       msg.activeSurfaceId,
       msg.currentPage,
+      originalContentBeforeStrip,
     );
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -249,8 +249,11 @@ export async function handleUserMessage(
         conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         // Keep in-memory session history aligned with DB so regenerate() and
         // other history operations that rely on session.messages stay consistent.
-        session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
-        session.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
+        // Only push when agent loop is NOT active to avoid corrupting role alternation.
+        if (!session.isProcessing()) {
+          session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+          session.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
+        }
         return;
       } else if (action === 'stop') {
         const stopped = handleRecordingStop(msg.sessionId, ctx) !== undefined;
@@ -263,8 +266,10 @@ export async function handleUserMessage(
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
         conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
         conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
-        session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
-        session.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
+        if (!session.isProcessing()) {
+          session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+          session.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
+        }
         return;
       } else if (action === 'restart') {
         const restartResult = handleRecordingRestart(msg.sessionId, socket, ctx);
@@ -276,8 +281,10 @@ export async function handleUserMessage(
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
         conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
         conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: restartResult.responseText }]));
-        session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
-        session.messages.push({ role: 'assistant', content: [{ type: 'text', text: restartResult.responseText }] });
+        if (!session.isProcessing()) {
+          session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+          session.messages.push({ role: 'assistant', content: [{ type: 'text', text: restartResult.responseText }] });
+        }
         return;
       } else if (action === 'pause') {
         const paused = handleRecordingPause(msg.sessionId, ctx) !== undefined;
@@ -290,8 +297,10 @@ export async function handleUserMessage(
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
         conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
         conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
-        session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
-        session.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
+        if (!session.isProcessing()) {
+          session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+          session.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
+        }
         return;
       } else if (action === 'resume') {
         const resumed = handleRecordingResume(msg.sessionId, ctx) !== undefined;
@@ -304,8 +313,10 @@ export async function handleUserMessage(
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
         conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
         conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
-        session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
-        session.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
+        if (!session.isProcessing()) {
+          session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+          session.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
+        }
         return;
       } else {
         // Unrecognized action — fall through to normal text handling
@@ -340,8 +351,10 @@ export async function handleUserMessage(
           ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
           conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
           conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
-          session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
-          session.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
+          if (!session.isProcessing()) {
+            session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+            session.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
+          }
           return;
         }
       }
@@ -415,8 +428,10 @@ export async function handleUserMessage(
               ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
               conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
               conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
-              session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
-              session.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
+              if (!session.isProcessing()) {
+                session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
+                session.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
+              }
               return;
             }
           }

--- a/assistant/src/daemon/session-messaging.ts
+++ b/assistant/src/daemon/session-messaging.ts
@@ -124,6 +124,7 @@ export function enqueueMessage(
   currentPage?: string,
   metadata?: Record<string, unknown>,
   options?: { isInteractive?: boolean },
+  displayContent?: string,
 ): { queued: boolean; rejected?: boolean; requestId: string } {
   if (!ctx.processing) {
     return { queued: false, requestId };
@@ -143,6 +144,7 @@ export function enqueueMessage(
     turnInterfaceContext,
     isInteractive: options?.isInteractive,
     queuedAt: Date.now(),
+    displayContent,
   });
   if (!pushed) {
     return { queued: false, rejected: true, requestId };
@@ -158,6 +160,7 @@ export function persistUserMessage(
   attachments: UserMessageAttachment[],
   requestId?: string,
   metadata?: Record<string, unknown>,
+  displayContent?: string,
 ): string {
   if (ctx.processing) {
     throw new Error('Session is already processing a message');
@@ -202,10 +205,19 @@ export function persistUserMessage(
         : {}),
     };
 
+    // When displayContent is provided (e.g. original text before recording
+    // intent stripping), persist that to DB so users see the full message
+    // after restart. The in-memory userMessage (sent to the LLM) still uses
+    // the stripped content.
+    const contentToPersist = displayContent
+      ? JSON.stringify(createUserMessage(displayContent, attachments.map((a) => ({
+          id: a.id, filename: a.filename, mimeType: a.mimeType, data: a.data, extractedText: a.extractedText,
+        }))).content)
+      : JSON.stringify(userMessage.content);
     const persistedUserMessage = conversationStore.addMessage(
       ctx.conversationId,
       'user',
-      JSON.stringify(userMessage.content),
+      contentToPersist,
       mergedMetadata,
     );
 

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -76,7 +76,7 @@ export interface ProcessSessionContext {
   /** Assistant identity — used for scoping notification preferences. */
   readonly assistantId?: string;
   guardianContext?: GuardianRuntimeContext;
-  persistUserMessage(content: string, attachments: UserMessageAttachment[], requestId?: string, metadata?: Record<string, unknown>): string;
+  persistUserMessage(content: string, attachments: UserMessageAttachment[], requestId?: string, metadata?: Record<string, unknown>, displayContent?: string): string;
   runAgentLoop(
     content: string,
     userMessageId: string,
@@ -192,10 +192,16 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
           : {}),
       };
       const userMsg = createUserMessage(next.content, next.attachments);
+      // When displayContent is provided (e.g. original text before recording
+      // intent stripping), persist that to DB so users see the full message.
+      // The in-memory userMessage (sent to the LLM) still uses the stripped content.
+      const contentToPersist = next.displayContent
+        ? JSON.stringify(createUserMessage(next.displayContent, next.attachments).content)
+        : JSON.stringify(userMsg.content);
       conversationStore.addMessage(
         session.conversationId,
         'user',
-        JSON.stringify(userMsg.content),
+        contentToPersist,
         drainChannelMeta,
       );
       session.messages.push(userMsg);
@@ -265,7 +271,7 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
   // resolves early (no runAgentLoop call), so we must continue draining.
   let userMessageId: string;
   try {
-    userMessageId = session.persistUserMessage(resolvedContent, next.attachments, next.requestId, next.metadata);
+    userMessageId = session.persistUserMessage(resolvedContent, next.attachments, next.requestId, next.metadata, next.displayContent);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, conversationId: session.conversationId, requestId: next.requestId }, 'Failed to persist queued message');
@@ -336,6 +342,7 @@ export async function processMessage(
   activeSurfaceId?: string,
   currentPage?: string,
   options?: { isInteractive?: boolean },
+  displayContent?: string,
 ): Promise<string> {
   session.currentActiveSurfaceId = activeSurfaceId;
   session.currentPage = currentPage;
@@ -416,10 +423,16 @@ export async function processMessage(
         : {}),
     };
     const userMsg = createUserMessage(content, attachments);
+    // When displayContent is provided (e.g. original text before recording
+    // intent stripping), persist that to DB so users see the full message.
+    // The in-memory userMessage (sent to the LLM) still uses the stripped content.
+    const contentToPersist = displayContent
+      ? JSON.stringify(createUserMessage(displayContent, attachments).content)
+      : JSON.stringify(userMsg.content);
     const persisted = conversationStore.addMessage(
       session.conversationId,
       'user',
-      JSON.stringify(userMsg.content),
+      contentToPersist,
       pmChannelMeta,
     );
     session.messages.push(userMsg);
@@ -475,7 +488,7 @@ export async function processMessage(
 
   let userMessageId: string;
   try {
-    userMessageId = session.persistUserMessage(resolvedContent, attachments, requestId);
+    userMessageId = session.persistUserMessage(resolvedContent, attachments, requestId, undefined, displayContent);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     onEvent({ type: 'error', message });

--- a/assistant/src/daemon/session-queue-manager.ts
+++ b/assistant/src/daemon/session-queue-manager.ts
@@ -25,6 +25,8 @@ export interface QueuedMessage {
   isInteractive?: boolean;
   /** Timestamp (ms) when the message was enqueued. */
   queuedAt: number;
+  /** Original user message text to persist to DB when recording intent stripping produced a different `content`. */
+  displayContent?: string;
 }
 
 export const MAX_QUEUE_DEPTH = 10;

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -397,8 +397,9 @@ export class Session {
     currentPage?: string,
     metadata?: Record<string, unknown>,
     options?: { isInteractive?: boolean },
+    displayContent?: string,
   ): { queued: boolean; rejected?: boolean; requestId: string } {
-    return enqueueMessageImpl(this, content, attachments, onEvent, requestId, activeSurfaceId, currentPage, metadata, options);
+    return enqueueMessageImpl(this, content, attachments, onEvent, requestId, activeSurfaceId, currentPage, metadata, options, displayContent);
   }
 
   getQueueDepth(): number {
@@ -494,8 +495,9 @@ export class Session {
     attachments: UserMessageAttachment[],
     requestId?: string,
     metadata?: Record<string, unknown>,
+    displayContent?: string,
   ): string {
-    return persistUserMessageImpl(this, content, attachments, requestId, metadata);
+    return persistUserMessageImpl(this, content, attachments, requestId, metadata, displayContent);
   }
 
   // ── Agent Loop ───────────────────────────────────────────────────
@@ -522,8 +524,9 @@ export class Session {
     activeSurfaceId?: string,
     currentPage?: string,
     options?: { isInteractive?: boolean },
+    displayContent?: string,
   ): Promise<string> {
-    return processMessageImpl(this as ProcessSessionContext, content, attachments, onEvent, requestId, activeSurfaceId, currentPage, options);
+    return processMessageImpl(this as ProcessSessionContext, content, attachments, onEvent, requestId, activeSurfaceId, currentPage, options, displayContent);
   }
 
   // ── History ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Recording command acknowledgments and user messages containing recording intents were not persisted to the database, causing them to vanish on app restart. This PR ensures all recording-related messages survive restart while preserving the existing recording functionality and LLM behavior.

## Changes
- **M1 (#9634):** Thread original (unstripped) user message through to `persistUserMessage` so the DB stores the full text while the LLM still processes the stripped remainder. Covers `processMessage`, `drainQueue`, and unknown-slash paths.
- **M2 (#9647):** Persist both user message and assistant acknowledgment for pure recording commands (`start_only`, `stop_only`, `restart_only`, `pause_only`, `resume_only`) that previously sent IPC-only responses. Also sync `session.messages` to keep in-memory and DB state aligned.
- **M3 (#9662):** Align finalization success text between DB and IPC ("Screen recording complete. Your recording has been saved." consistently). Persist all error-path messages with try/catch guards.

## Milestone PRs (merged into feature branch)
- #9634: M1: Persist original user message for _with_remainder recording intents
- #9647: M2: Persist user + assistant messages for _only recording commands
- #9662: M3: Align finalization text and persist error-path messages

## Project issue
Closes #9628

## Test plan
- [ ] Send "record my screen" — verify both user msg and "Starting screen recording." persist after restart
- [ ] Send "json record my screen and check my email" — verify full original message persists (not truncated)
- [ ] Complete a recording — verify "Screen recording complete. Your recording has been saved." text persists
- [ ] Restart app — verify all recording-related messages remain visible in chat history

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
