### PR TITLE
fix: propagate isInteractive in channel retry sweep for guardian actors

### DIFF
--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -117,6 +117,7 @@ export async function sweepFailedEvents(
           },
           assistantId,
           guardianContext,
+          isInteractive: guardianContext?.actorRole === 'guardian',
         },
         sourceChannel,
         sourceInterface,


### PR DESCRIPTION
The retry sweep in channel-retry-sweep.ts did not propagate isInteractive based on guardian role when replaying failed events. Guardian messages that transiently fail would have tool approvals auto-denied on retry. Now computes isInteractive from guardianContext.actorRole consistent with the primary inbound path. Addresses feedback from PR #9664.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
