### PR TITLE
M5: Guardian Follow-Up Conversation Engine (Structured Decisions)

### DIFF
--- a/assistant/src/__tests__/guardian-action-conversation-turn.test.ts
+++ b/assistant/src/__tests__/guardian-action-conversation-turn.test.ts
@@ -1,0 +1,451 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'guardian-action-conversation-turn-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { createCallSession, createPendingQuestion } from '../calls/call-store.js';
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import {
+  createGuardianActionDelivery,
+  createGuardianActionRequest,
+  finalizeFollowup,
+  getFollowupDeliveriesByDestination,
+  getFollowupDeliveryByConversation,
+  getGuardianActionRequest,
+  markTimedOutWithReason,
+  progressFollowupState,
+  startFollowupFromExpiredRequest,
+  updateDeliveryStatus,
+} from '../memory/guardian-action-store.js';
+import { processGuardianFollowUpTurn } from '../runtime/guardian-action-conversation-turn.js';
+import type {
+  GuardianFollowUpConversationContext,
+  GuardianFollowUpConversationGenerator,
+  GuardianFollowUpTurnResult,
+} from '../runtime/http-types.js';
+import { conversations } from '../memory/schema.js';
+
+initializeDb();
+
+function ensureConversation(id: string): void {
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations).values({
+    id,
+    title: `Conversation ${id}`,
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+}
+
+function resetTables(): void {
+  const db = getDb();
+  db.run('DELETE FROM guardian_action_deliveries');
+  db.run('DELETE FROM guardian_action_requests');
+  db.run('DELETE FROM call_pending_questions');
+  db.run('DELETE FROM call_events');
+  db.run('DELETE FROM call_sessions');
+  db.run('DELETE FROM messages');
+  db.run('DELETE FROM conversations');
+}
+
+function createAwaitingChoiceRequest(convId: string, opts?: {
+  chatId?: string;
+  externalUserId?: string;
+  conversationId?: string;
+}) {
+  ensureConversation(convId);
+  const session = createCallSession({
+    conversationId: convId,
+    provider: 'twilio',
+    fromNumber: '+15550001111',
+    toNumber: '+15550002222',
+  });
+  const pq = createPendingQuestion(session.id, 'What is the gate code?');
+  const request = createGuardianActionRequest({
+    kind: 'ask_guardian',
+    sourceChannel: 'voice',
+    sourceConversationId: convId,
+    callSessionId: session.id,
+    pendingQuestionId: pq.id,
+    questionText: pq.questionText,
+    expiresAt: Date.now() - 10_000,
+  });
+
+  const deliveryConvId = opts?.conversationId ?? `delivery-conv-${request.id}`;
+  if (opts?.conversationId) {
+    ensureConversation(opts.conversationId);
+  } else {
+    ensureConversation(deliveryConvId);
+  }
+  const delivery = createGuardianActionDelivery({
+    requestId: request.id,
+    destinationChannel: 'telegram',
+    destinationChatId: opts?.chatId ?? 'chat-123',
+    destinationExternalUserId: opts?.externalUserId ?? 'user-456',
+    destinationConversationId: deliveryConvId,
+  });
+  updateDeliveryStatus(delivery.id, 'sent');
+
+  // Expire the request
+  markTimedOutWithReason(request.id, 'call_timeout');
+
+  // Start follow-up (transitions to awaiting_guardian_choice)
+  startFollowupFromExpiredRequest(request.id, 'The gate code is 1234');
+
+  return { request: getGuardianActionRequest(request.id)!, delivery, deliveryConvId };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers for creating mock generators
+// ---------------------------------------------------------------------------
+
+function createMockGenerator(
+  result: GuardianFollowUpTurnResult,
+): GuardianFollowUpConversationGenerator {
+  return async (_context: GuardianFollowUpConversationContext) => result;
+}
+
+function createFailingGenerator(): GuardianFollowUpConversationGenerator {
+  return async () => {
+    throw new Error('LLM provider unavailable');
+  };
+}
+
+describe('guardian-action-conversation-turn', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  afterAll(() => {
+    resetDb();
+    try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+  });
+
+  // ── processGuardianFollowUpTurn: classification ─────────────────────
+
+  test('classifies "call them back" as call_back', async () => {
+    const generator = createMockGenerator({
+      disposition: 'call_back',
+      replyText: "Sure, I'll call them back right away.",
+    });
+
+    const result = await processGuardianFollowUpTurn(
+      {
+        questionText: 'What is the gate code?',
+        lateAnswerText: 'The gate code is 1234',
+        guardianReply: 'Yes, call them back',
+      },
+      generator,
+    );
+
+    expect(result.disposition).toBe('call_back');
+    expect(result.replyText).toBe("Sure, I'll call them back right away.");
+  });
+
+  test('classifies "send a text message" as message_back', async () => {
+    const generator = createMockGenerator({
+      disposition: 'message_back',
+      replyText: "Got it, I'll send them a text message.",
+    });
+
+    const result = await processGuardianFollowUpTurn(
+      {
+        questionText: 'What is the gate code?',
+        lateAnswerText: 'The gate code is 1234',
+        guardianReply: 'Just send them a text',
+      },
+      generator,
+    );
+
+    expect(result.disposition).toBe('message_back');
+    expect(result.replyText).toBe("Got it, I'll send them a text message.");
+  });
+
+  test('classifies "never mind" as decline', async () => {
+    const generator = createMockGenerator({
+      disposition: 'decline',
+      replyText: 'No problem. Let me know if you change your mind.',
+    });
+
+    const result = await processGuardianFollowUpTurn(
+      {
+        questionText: 'What is the gate code?',
+        lateAnswerText: 'The gate code is 1234',
+        guardianReply: 'Never mind, forget it',
+      },
+      generator,
+    );
+
+    expect(result.disposition).toBe('decline');
+    expect(result.replyText).toBe('No problem. Let me know if you change your mind.');
+  });
+
+  test('classifies ambiguous input as keep_pending with clarification', async () => {
+    const generator = createMockGenerator({
+      disposition: 'keep_pending',
+      replyText: 'Would you like to call them back or send a text message?',
+    });
+
+    const result = await processGuardianFollowUpTurn(
+      {
+        questionText: 'What is the gate code?',
+        lateAnswerText: 'The gate code is 1234',
+        guardianReply: 'hmm I dunno',
+      },
+      generator,
+    );
+
+    expect(result.disposition).toBe('keep_pending');
+    expect(result.replyText).toContain('call them back');
+  });
+
+  // ── Failure modes ───────────────────────────────────────────────────
+
+  test('generator failure returns keep_pending with safe fallback', async () => {
+    const generator = createFailingGenerator();
+
+    const result = await processGuardianFollowUpTurn(
+      {
+        questionText: 'What is the gate code?',
+        lateAnswerText: 'The gate code is 1234',
+        guardianReply: 'Call them back please',
+      },
+      generator,
+    );
+
+    expect(result.disposition).toBe('keep_pending');
+    expect(result.replyText.length).toBeGreaterThan(0);
+  });
+
+  test('no generator returns keep_pending with safe fallback', async () => {
+    const result = await processGuardianFollowUpTurn(
+      {
+        questionText: 'What is the gate code?',
+        lateAnswerText: 'The gate code is 1234',
+        guardianReply: 'Call them back',
+      },
+      undefined,
+    );
+
+    expect(result.disposition).toBe('keep_pending');
+    expect(result.replyText.length).toBeGreaterThan(0);
+  });
+
+  test('generator returning empty replyText falls back to keep_pending', async () => {
+    const generator = createMockGenerator({
+      disposition: 'call_back',
+      replyText: '',
+    });
+
+    const result = await processGuardianFollowUpTurn(
+      {
+        questionText: 'What is the gate code?',
+        lateAnswerText: 'The gate code is 1234',
+        guardianReply: 'Call them back',
+      },
+      generator,
+    );
+
+    expect(result.disposition).toBe('keep_pending');
+  });
+
+  test('generator returning invalid disposition falls back to keep_pending', async () => {
+    const generator: GuardianFollowUpConversationGenerator = async () => {
+      return {
+        disposition: 'invalid_value' as GuardianFollowUpTurnResult['disposition'],
+        replyText: 'Some reply',
+      };
+    };
+
+    const result = await processGuardianFollowUpTurn(
+      {
+        questionText: 'What is the gate code?',
+        lateAnswerText: 'The gate code is 1234',
+        guardianReply: 'Call them back',
+      },
+      generator,
+    );
+
+    expect(result.disposition).toBe('keep_pending');
+  });
+
+  test('reply text is always present in the result', async () => {
+    // With generator
+    const generatorResult = await processGuardianFollowUpTurn(
+      {
+        questionText: 'What is the gate code?',
+        lateAnswerText: 'The gate code is 1234',
+        guardianReply: 'Call them',
+      },
+      createMockGenerator({ disposition: 'call_back', replyText: 'Calling now!' }),
+    );
+    expect(typeof generatorResult.replyText).toBe('string');
+    expect(generatorResult.replyText.length).toBeGreaterThan(0);
+
+    // Without generator
+    const fallbackResult = await processGuardianFollowUpTurn(
+      {
+        questionText: 'What is the gate code?',
+        lateAnswerText: 'The gate code is 1234',
+        guardianReply: 'Call them',
+      },
+    );
+    expect(typeof fallbackResult.replyText).toBe('string');
+    expect(fallbackResult.replyText.length).toBeGreaterThan(0);
+
+    // With failing generator
+    const failResult = await processGuardianFollowUpTurn(
+      {
+        questionText: 'What is the gate code?',
+        lateAnswerText: 'The gate code is 1234',
+        guardianReply: 'Call them',
+      },
+      createFailingGenerator(),
+    );
+    expect(typeof failResult.replyText).toBe('string');
+    expect(failResult.replyText.length).toBeGreaterThan(0);
+  });
+
+  // ── Store queries for awaiting_guardian_choice ───────────────────────
+
+  test('getFollowupDeliveriesByDestination returns deliveries in awaiting_guardian_choice', () => {
+    const { request } = createAwaitingChoiceRequest('conv-turn-1', { chatId: 'chat-abc', externalUserId: 'user-xyz' });
+
+    const deliveries = getFollowupDeliveriesByDestination('self', 'telegram', 'chat-abc');
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].requestId).toBe(request.id);
+  });
+
+  test('getFollowupDeliveriesByDestination returns empty for non-matching channel', () => {
+    createAwaitingChoiceRequest('conv-turn-2', { chatId: 'chat-abc' });
+
+    const deliveries = getFollowupDeliveriesByDestination('self', 'sms', 'chat-abc');
+    expect(deliveries).toHaveLength(0);
+  });
+
+  test('getFollowupDeliveriesByDestination returns empty for expired with followup_state=none', () => {
+    // Create expired request WITHOUT starting follow-up
+    ensureConversation('conv-turn-3');
+    const session = createCallSession({
+      conversationId: 'conv-turn-3',
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15550002222',
+    });
+    const pq = createPendingQuestion(session.id, 'Question?');
+    const request = createGuardianActionRequest({
+      kind: 'ask_guardian',
+      sourceChannel: 'voice',
+      sourceConversationId: 'conv-turn-3',
+      callSessionId: session.id,
+      pendingQuestionId: pq.id,
+      questionText: pq.questionText,
+      expiresAt: Date.now() - 10_000,
+    });
+    ensureConversation(`delivery-conv-${request.id}`);
+    const delivery = createGuardianActionDelivery({
+      requestId: request.id,
+      destinationChannel: 'telegram',
+      destinationChatId: 'chat-none',
+      destinationExternalUserId: 'user-none',
+      destinationConversationId: `delivery-conv-${request.id}`,
+    });
+    updateDeliveryStatus(delivery.id, 'sent');
+    markTimedOutWithReason(request.id, 'call_timeout');
+
+    // followup_state is 'none' — should not appear
+    const deliveries = getFollowupDeliveriesByDestination('self', 'telegram', 'chat-none');
+    expect(deliveries).toHaveLength(0);
+  });
+
+  test('getFollowupDeliveryByConversation returns delivery in awaiting_guardian_choice', () => {
+    const { delivery, deliveryConvId } = createAwaitingChoiceRequest('conv-turn-4', { conversationId: 'mac-conv-1' });
+
+    const found = getFollowupDeliveryByConversation(deliveryConvId);
+    expect(found).not.toBeNull();
+    expect(found!.id).toBe(delivery.id);
+  });
+
+  test('getFollowupDeliveryByConversation returns null for non-matching conversation', () => {
+    createAwaitingChoiceRequest('conv-turn-5', { conversationId: 'mac-conv-2' });
+
+    const found = getFollowupDeliveryByConversation('nonexistent-conv');
+    expect(found).toBeNull();
+  });
+
+  // ── State transitions from conversation engine results ──────────────
+
+  test('call_back disposition transitions to dispatching with call_back action', () => {
+    const { request } = createAwaitingChoiceRequest('conv-turn-6');
+
+    // Simulate what the handler does with a call_back disposition
+    const updated = progressFollowupState(request.id, 'dispatching', 'call_back');
+    expect(updated).not.toBeNull();
+    expect(updated!.followupState).toBe('dispatching');
+    expect(updated!.followupAction).toBe('call_back');
+  });
+
+  test('message_back disposition transitions to dispatching with message_back action', () => {
+    const { request } = createAwaitingChoiceRequest('conv-turn-7');
+
+    const updated = progressFollowupState(request.id, 'dispatching', 'message_back');
+    expect(updated).not.toBeNull();
+    expect(updated!.followupState).toBe('dispatching');
+    expect(updated!.followupAction).toBe('message_back');
+  });
+
+  test('decline disposition finalizes to declined', () => {
+    const { request } = createAwaitingChoiceRequest('conv-turn-8');
+
+    const updated = finalizeFollowup(request.id, 'declined');
+    expect(updated).not.toBeNull();
+    expect(updated!.followupState).toBe('declined');
+    expect(updated!.followupCompletedAt).toBeGreaterThan(0);
+  });
+
+  test('keep_pending disposition does not change state', () => {
+    const { request } = createAwaitingChoiceRequest('conv-turn-9');
+
+    // No state change for keep_pending — just verify the state is still awaiting_guardian_choice
+    const reloaded = getGuardianActionRequest(request.id);
+    expect(reloaded!.followupState).toBe('awaiting_guardian_choice');
+  });
+
+  test('state transitions are atomic: second call_back after dispatching fails', () => {
+    const { request } = createAwaitingChoiceRequest('conv-turn-10');
+
+    const first = progressFollowupState(request.id, 'dispatching', 'call_back');
+    expect(first).not.toBeNull();
+
+    // Second attempt: already in dispatching, cannot re-enter dispatching
+    const second = progressFollowupState(request.id, 'dispatching', 'message_back');
+    expect(second).toBeNull();
+
+    // Original action preserved
+    const reloaded = getGuardianActionRequest(request.id);
+    expect(reloaded!.followupAction).toBe('call_back');
+  });
+});

--- a/assistant/src/daemon/guardian-action-generators.ts
+++ b/assistant/src/daemon/guardian-action-generators.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from '../config/loader.js';
-import { getFailoverProvider } from '../providers/registry.js';
+import { getFailoverProvider, listProviders } from '../providers/registry.js';
 import {
   buildGuardianActionGenerationPrompt,
   getGuardianActionFallbackMessage,
@@ -8,7 +8,12 @@ import {
   GUARDIAN_ACTION_COPY_TIMEOUT_MS,
   includesRequiredKeywords,
 } from '../runtime/guardian-action-message-composer.js';
-import type { GuardianActionCopyGenerator } from '../runtime/http-types.js';
+import type {
+  GuardianActionCopyGenerator,
+  GuardianFollowUpConversationGenerator,
+  GuardianFollowUpDisposition,
+  GuardianFollowUpTurnResult,
+} from '../runtime/http-types.js';
 
 /**
  * Create the daemon-owned guardian action copy generator that resolves
@@ -56,5 +61,118 @@ export function createGuardianActionCopyGenerator(): GuardianActionCopyGenerator
     if (!cleaned) return null;
     if (!includesRequiredKeywords(cleaned, requiredKeywords)) return null;
     return cleaned;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Guardian follow-up conversation generator
+// ---------------------------------------------------------------------------
+
+const FOLLOWUP_CONVERSATION_TIMEOUT_MS = 8_000;
+const FOLLOWUP_CONVERSATION_MAX_TOKENS = 300;
+
+const FOLLOWUP_CONVERSATION_SYSTEM_PROMPT =
+  'You are an assistant helping route a guardian\'s reply to a post-timeout follow-up message. '
+  + 'A voice caller asked a question, but the call timed out before the guardian could answer. '
+  + 'The guardian has now replied late, and was asked whether they want to call the caller back, '
+  + 'send them a text message, or skip it. '
+  + 'Analyze the guardian\'s latest reply to determine their intent. '
+  + 'When uncertain, default to keep_pending and ask a clarifying question. '
+  + 'Always provide a natural, helpful reply along with your decision.';
+
+const FOLLOWUP_CONVERSATION_TOOL_NAME = 'followup_decision';
+
+const FOLLOWUP_CONVERSATION_TOOL_SCHEMA = {
+  name: FOLLOWUP_CONVERSATION_TOOL_NAME,
+  description:
+    'Record the guardian\'s follow-up decision and a natural reply. '
+    + 'Call this tool with the determined disposition and a reply to the guardian.',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      disposition: {
+        type: 'string',
+        enum: ['call_back', 'message_back', 'decline', 'keep_pending'],
+        description:
+          'The guardian\'s intent: call_back to call the original caller, '
+          + 'message_back to send a text message, decline to skip the follow-up, '
+          + 'keep_pending if the intent is unclear (ask for clarification).',
+      },
+      replyText: {
+        type: 'string',
+        description: 'A natural language reply to send back to the guardian.',
+      },
+    },
+    required: ['disposition', 'replyText'],
+  },
+};
+
+const VALID_FOLLOWUP_DISPOSITIONS: ReadonlySet<string> = new Set([
+  'call_back',
+  'message_back',
+  'decline',
+  'keep_pending',
+]);
+
+/**
+ * Create the daemon-owned guardian follow-up conversation generator.
+ * Uses tool/function calling to produce structured dispositions alongside
+ * natural reply text. Follows the same pattern as
+ * createApprovalConversationGenerator().
+ */
+export function createGuardianFollowUpConversationGenerator(): GuardianFollowUpConversationGenerator {
+  return async (context) => {
+    const config = loadConfig();
+    if (!listProviders().includes(config.provider)) {
+      throw new Error('No provider available for guardian follow-up conversation');
+    }
+    const provider = getFailoverProvider(config.provider, config.providerOrder);
+
+    const userPrompt = [
+      `Original question from the voice call: "${context.questionText}"`,
+      `Guardian's late answer: "${context.lateAnswerText}"`,
+      `\nGuardian's latest reply: ${context.guardianReply}`,
+    ].join('\n');
+
+    const response = await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: userPrompt }] }],
+      [FOLLOWUP_CONVERSATION_TOOL_SCHEMA],
+      FOLLOWUP_CONVERSATION_SYSTEM_PROMPT,
+      {
+        config: {
+          max_tokens: FOLLOWUP_CONVERSATION_MAX_TOKENS,
+          modelIntent: 'latency-optimized',
+        },
+        signal: AbortSignal.timeout(FOLLOWUP_CONVERSATION_TIMEOUT_MS),
+      },
+    );
+
+    // Extract the tool_use block from the response
+    const toolUseBlock = response.content.find(
+      (block) => block.type === 'tool_use' && block.name === FOLLOWUP_CONVERSATION_TOOL_NAME,
+    );
+
+    if (!toolUseBlock || toolUseBlock.type !== 'tool_use') {
+      throw new Error('Provider did not return a tool_use block for follow-up decision');
+    }
+
+    const input = toolUseBlock.input as Record<string, unknown>;
+
+    // Strict validation of the structured output
+    const disposition = input.disposition;
+    if (typeof disposition !== 'string' || !VALID_FOLLOWUP_DISPOSITIONS.has(disposition)) {
+      throw new Error(`Invalid disposition: ${String(disposition)}`);
+    }
+
+    const replyText = input.replyText;
+    if (typeof replyText !== 'string' || replyText.trim().length === 0) {
+      throw new Error('Missing or empty replyText in tool_use response');
+    }
+
+    const result: GuardianFollowUpTurnResult = {
+      disposition: disposition as GuardianFollowUpDisposition,
+      replyText: replyText.trim(),
+    };
+    return result;
   };
 }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -46,7 +46,7 @@ import {
 import { listWorkItems, updateWorkItem } from '../work-items/work-item-store.js';
 import { WorkspaceHeartbeatService } from '../workspace/heartbeat-service.js';
 import { createApprovalConversationGenerator,createApprovalCopyGenerator } from './approval-generators.js';
-import { createGuardianActionCopyGenerator } from './guardian-action-generators.js';
+import { createGuardianActionCopyGenerator, createGuardianFollowUpConversationGenerator } from './guardian-action-generators.js';
 import { cleanupPidFile,writePid } from './daemon-control.js';
 import { initPairingHandlers } from './handlers/pairing.js';
 import { installCliLaunchers } from './install-cli-launchers.js';
@@ -284,6 +284,7 @@ export async function runDaemon(): Promise<void> {
     approvalCopyGenerator: createApprovalCopyGenerator(),
     approvalConversationGenerator: createApprovalConversationGenerator(),
     guardianActionCopyGenerator: createGuardianActionCopyGenerator(),
+    guardianFollowUpConversationGenerator: createGuardianFollowUpConversationGenerator(),
     sendMessageDeps: {
       getOrCreateSession: (conversationId) =>
         server.getSessionForMessages(conversationId),

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -48,6 +48,7 @@ import { WorkspaceHeartbeatService } from '../workspace/heartbeat-service.js';
 import { createApprovalConversationGenerator,createApprovalCopyGenerator } from './approval-generators.js';
 import { createGuardianActionCopyGenerator, createGuardianFollowUpConversationGenerator } from './guardian-action-generators.js';
 import { cleanupPidFile,writePid } from './daemon-control.js';
+import { setGuardianFollowUpConversationGenerator } from './session-process.js';
 import { initPairingHandlers } from './handlers/pairing.js';
 import { installCliLaunchers } from './install-cli-launchers.js';
 import type { ServerMessage } from './ipc-protocol.js';
@@ -284,7 +285,13 @@ export async function runDaemon(): Promise<void> {
     approvalCopyGenerator: createApprovalCopyGenerator(),
     approvalConversationGenerator: createApprovalConversationGenerator(),
     guardianActionCopyGenerator: createGuardianActionCopyGenerator(),
-    guardianFollowUpConversationGenerator: createGuardianFollowUpConversationGenerator(),
+    guardianFollowUpConversationGenerator: (() => {
+      const gen = createGuardianFollowUpConversationGenerator();
+      // Also inject into the session-process module so the mac/IPC channel
+      // path can classify follow-up replies using the same generator.
+      setGuardianFollowUpConversationGenerator(gen);
+      return gen;
+    })(),
     sendMessageDeps: {
       getOrCreateSession: (conversationId) =>
         server.getSessionForMessages(conversationId),

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -14,12 +14,16 @@ import { getConfig } from '../config/loader.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import {
+  finalizeFollowup,
   getExpiredDeliveryByConversation,
+  getFollowupDeliveryByConversation,
   getGuardianActionRequest,
   getPendingDeliveryByConversation,
+  progressFollowupState,
   resolveGuardianActionRequest,
   startFollowupFromExpiredRequest,
 } from '../memory/guardian-action-store.js';
+import { processGuardianFollowUpTurn } from '../runtime/guardian-action-conversation-turn.js';
 import { composeGuardianActionMessageGenerative } from '../runtime/guardian-action-message-composer.js';
 import { extractPreferences } from '../notifications/preference-extractor.js';
 import { createPreference } from '../notifications/preferences-store.js';
@@ -453,6 +457,55 @@ export async function processMessage(
         session.messages.push(staleMsg);
         onEvent({ type: 'assistant_text_delta', text: staleText });
       }
+      onEvent({ type: 'message_complete', sessionId: session.conversationId });
+      return persisted.id;
+    }
+  }
+
+  // ── Guardian follow-up conversation interception (mac channel) ──
+  // When a request is in `awaiting_guardian_choice` state, the guardian has
+  // already been asked "call back or send a message?". Their next message
+  // is the reply — route it through the conversation engine.
+  const followupDelivery = getFollowupDeliveryByConversation(session.conversationId);
+  if (followupDelivery) {
+    const followupRequest = getGuardianActionRequest(followupDelivery.requestId);
+    if (followupRequest && followupRequest.followupState === 'awaiting_guardian_choice') {
+      const guardianIfCtx = session.getTurnInterfaceContext();
+      const guardianChannelMeta = { userMessageChannel: 'vellum' as const, assistantMessageChannel: 'vellum' as const, userMessageInterface: guardianIfCtx?.userMessageInterface ?? 'vellum', assistantMessageInterface: guardianIfCtx?.assistantMessageInterface ?? 'vellum', provenanceActorRole: 'guardian' as const };
+      const userMsg = createUserMessage(content, attachments);
+      const persisted = conversationStore.addMessage(
+        session.conversationId,
+        'user',
+        JSON.stringify(userMsg.content),
+        guardianChannelMeta,
+      );
+      session.messages.push(userMsg);
+
+      const turnResult = await processGuardianFollowUpTurn(
+        {
+          questionText: followupRequest.questionText,
+          lateAnswerText: followupRequest.lateAnswerText ?? '',
+          guardianReply: content,
+        },
+      );
+
+      // Apply the disposition to the follow-up state machine
+      if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
+        progressFollowupState(followupRequest.id, 'dispatching', turnResult.disposition);
+      } else if (turnResult.disposition === 'decline') {
+        finalizeFollowup(followupRequest.id, 'declined');
+      }
+      // keep_pending: no state change — guardian can reply again
+
+      const replyMsg = createAssistantMessage(turnResult.replyText);
+      conversationStore.addMessage(
+        session.conversationId,
+        'assistant',
+        JSON.stringify(replyMsg.content),
+        guardianChannelMeta,
+      );
+      session.messages.push(replyMsg);
+      onEvent({ type: 'assistant_text_delta', text: turnResult.replyText });
       onEvent({ type: 'message_complete', sessionId: session.conversationId });
       return persisted.id;
     }

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -25,6 +25,7 @@ import {
 } from '../memory/guardian-action-store.js';
 import { processGuardianFollowUpTurn } from '../runtime/guardian-action-conversation-turn.js';
 import { composeGuardianActionMessageGenerative } from '../runtime/guardian-action-message-composer.js';
+import type { GuardianFollowUpConversationGenerator } from '../runtime/http-types.js';
 import { extractPreferences } from '../notifications/preference-extractor.js';
 import { createPreference } from '../notifications/preferences-store.js';
 import type { Message } from '../providers/types.js';
@@ -39,6 +40,19 @@ import { resolveSlash, type SlashContext } from './session-slash.js';
 import type { TraceEmitter } from './trace-emitter.js';
 
 const log = getLogger('session-process');
+
+// ---------------------------------------------------------------------------
+// Module-level generator injection
+// ---------------------------------------------------------------------------
+// The daemon lifecycle creates the generator once and injects it here so the
+// mac/IPC channel path can classify follow-up replies without threading the
+// generator through Session / DaemonServer constructors.
+let _guardianFollowUpGenerator: GuardianFollowUpConversationGenerator | undefined;
+
+/** Inject the guardian follow-up conversation generator (called from lifecycle.ts). */
+export function setGuardianFollowUpConversationGenerator(gen: GuardianFollowUpConversationGenerator): void {
+  _guardianFollowUpGenerator = gen;
+}
 
 /** Build a model_info event with fresh config data. */
 function buildModelInfoEvent(): ServerMessage {
@@ -487,6 +501,7 @@ export async function processMessage(
           lateAnswerText: followupRequest.lateAnswerText ?? '',
           guardianReply: content,
         },
+        _guardianFollowUpGenerator,
       );
 
       // Apply the disposition to the follow-up state machine

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -696,6 +696,83 @@ export function getExpiredDeliveryByConversation(conversationId: string): Guardi
   }
 }
 
+/**
+ * Look up deliveries for requests in `awaiting_guardian_choice` follow-up state.
+ * Used by inbound message routing to intercept guardian follow-up replies
+ * on channel paths (Telegram, SMS).
+ */
+export function getFollowupDeliveriesByDestination(
+  assistantId: string,
+  channel: string,
+  chatId: string,
+): GuardianActionDelivery[] {
+  try {
+    const db = getDb();
+
+    const rows = db
+      .select({
+        delivery: guardianActionDeliveries,
+      })
+      .from(guardianActionDeliveries)
+      .innerJoin(
+        guardianActionRequests,
+        eq(guardianActionDeliveries.requestId, guardianActionRequests.id),
+      )
+      .where(
+        and(
+          eq(guardianActionRequests.assistantId, assistantId),
+          eq(guardianActionRequests.status, 'expired'),
+          eq(guardianActionRequests.followupState, 'awaiting_guardian_choice'),
+          eq(guardianActionDeliveries.destinationChannel, channel),
+          eq(guardianActionDeliveries.destinationChatId, chatId),
+          eq(guardianActionDeliveries.status, 'expired'),
+        ),
+      )
+      .all();
+
+    return rows.map((r) => rowToDelivery(r.delivery));
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('no such table')) {
+      log.warn({ err }, 'guardian tables not yet created');
+      return [];
+    }
+    throw err;
+  }
+}
+
+/**
+ * Look up a delivery for a request in `awaiting_guardian_choice` follow-up
+ * state by destination conversation ID (for mac channel routing).
+ */
+export function getFollowupDeliveryByConversation(conversationId: string): GuardianActionDelivery | null {
+  try {
+    const db = getDb();
+    const rows = db
+      .select({ delivery: guardianActionDeliveries })
+      .from(guardianActionDeliveries)
+      .innerJoin(
+        guardianActionRequests,
+        eq(guardianActionDeliveries.requestId, guardianActionRequests.id),
+      )
+      .where(
+        and(
+          eq(guardianActionDeliveries.destinationConversationId, conversationId),
+          eq(guardianActionDeliveries.status, 'expired'),
+          eq(guardianActionRequests.status, 'expired'),
+          eq(guardianActionRequests.followupState, 'awaiting_guardian_choice'),
+        ),
+      )
+      .all();
+    return rows.length > 0 ? rowToDelivery(rows[0].delivery) : null;
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('no such table')) {
+      log.warn({ err }, 'guardian tables not yet created');
+      return null;
+    }
+    throw err;
+  }
+}
+
 export function updateDeliveryStatus(
   deliveryId: string,
   status: GuardianActionDeliveryStatus,

--- a/assistant/src/runtime/guardian-action-conversation-turn.ts
+++ b/assistant/src/runtime/guardian-action-conversation-turn.ts
@@ -1,0 +1,85 @@
+/**
+ * Guardian follow-up conversation engine.
+ *
+ * When a guardian replies to a post-timeout follow-up prompt (e.g. "would you
+ * like to call them back or send a message?"), this engine classifies the
+ * guardian's intent into a structured disposition and produces a natural reply.
+ *
+ * Dispositions:
+ *   - call_back:     Guardian wants to call the original caller back
+ *   - message_back:  Guardian wants to send a text/message to the caller
+ *   - decline:       Guardian declines to follow up ("never mind", "no thanks")
+ *   - keep_pending:  Intent is ambiguous — ask for clarification
+ *
+ * The engine uses the daemon-injected generator (LLM with tool calling) when
+ * available, with a safe fallback that keeps the follow-up pending and returns
+ * a retry prompt.
+ */
+
+import { getLogger } from '../util/logger.js';
+import type {
+  GuardianFollowUpConversationContext,
+  GuardianFollowUpConversationGenerator,
+  GuardianFollowUpDisposition,
+  GuardianFollowUpTurnResult,
+} from './http-types.js';
+
+const log = getLogger('guardian-action-conversation-turn');
+
+// ---------------------------------------------------------------------------
+// Fallback text
+// ---------------------------------------------------------------------------
+
+const FALLBACK_RETRY_TEXT =
+  "Sorry, I didn't quite catch that. Would you like to call them back, send them a message, or skip it for now?";
+
+const VALID_DISPOSITIONS: ReadonlySet<string> = new Set([
+  'call_back',
+  'message_back',
+  'decline',
+  'keep_pending',
+]);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Process one turn of the guardian follow-up conversation.
+ *
+ * Uses the daemon-injected generator when available; on failure or absence,
+ * returns a safe keep_pending result with a retry prompt so the follow-up
+ * stays open for the guardian to try again.
+ */
+export async function processGuardianFollowUpTurn(
+  context: GuardianFollowUpConversationContext,
+  generator?: GuardianFollowUpConversationGenerator,
+): Promise<GuardianFollowUpTurnResult> {
+  if (!generator) {
+    log.warn('No guardian follow-up conversation generator available, using fallback');
+    return { disposition: 'keep_pending', replyText: FALLBACK_RETRY_TEXT };
+  }
+
+  try {
+    const result = await generator(context);
+
+    // Validate the generator's output
+    if (!result || typeof result.replyText !== 'string' || result.replyText.trim().length === 0) {
+      log.warn('Guardian follow-up generator returned invalid result (missing replyText)');
+      return { disposition: 'keep_pending', replyText: FALLBACK_RETRY_TEXT };
+    }
+
+    if (!VALID_DISPOSITIONS.has(result.disposition)) {
+      log.warn({ disposition: result.disposition }, 'Guardian follow-up generator returned invalid disposition');
+      return { disposition: 'keep_pending', replyText: FALLBACK_RETRY_TEXT };
+    }
+
+    return {
+      disposition: result.disposition as GuardianFollowUpDisposition,
+      replyText: result.replyText.trim(),
+    };
+  } catch (err) {
+    log.warn({ err }, 'Guardian follow-up conversation generator failed, using fallback');
+    return { disposition: 'keep_pending', replyText: FALLBACK_RETRY_TEXT };
+  }
+}

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -134,6 +134,7 @@ export type {
   ApprovalConversationGenerator,
   ApprovalCopyGenerator,
   GuardianActionCopyGenerator,
+  GuardianFollowUpConversationGenerator,
   MessageProcessor,
   NonBlockingMessageProcessor,
   RuntimeAttachmentMetadata,
@@ -146,6 +147,7 @@ import type {
   ApprovalConversationGenerator,
   ApprovalCopyGenerator,
   GuardianActionCopyGenerator,
+  GuardianFollowUpConversationGenerator,
   MessageProcessor,
   NonBlockingMessageProcessor,
   RuntimeHttpServerOptions,
@@ -170,6 +172,7 @@ export class RuntimeHttpServer {
   private approvalCopyGenerator?: ApprovalCopyGenerator;
   private approvalConversationGenerator?: ApprovalConversationGenerator;
   private guardianActionCopyGenerator?: GuardianActionCopyGenerator;
+  private guardianFollowUpConversationGenerator?: GuardianFollowUpConversationGenerator;
   private interfacesDir: string | null;
   private suggestionCache = new Map<string, string>();
   private suggestionInFlight = new Map<string, Promise<string | null>>();
@@ -188,6 +191,7 @@ export class RuntimeHttpServer {
     this.approvalCopyGenerator = options.approvalCopyGenerator;
     this.approvalConversationGenerator = options.approvalConversationGenerator;
     this.guardianActionCopyGenerator = options.guardianActionCopyGenerator;
+    this.guardianFollowUpConversationGenerator = options.guardianFollowUpConversationGenerator;
     this.interfacesDir = options.interfacesDir ?? null;
     this.sendMessageDeps = options.sendMessageDeps;
   }
@@ -668,7 +672,7 @@ export class RuntimeHttpServer {
 
       if (endpoint === 'channels/inbound' && req.method === 'POST') {
         const gatewayOriginSecret = getRuntimeGatewayOriginSecret();
-        return await handleChannelInbound(req, this.processMessage, this.bearerToken, assistantId, gatewayOriginSecret, this.approvalCopyGenerator, this.approvalConversationGenerator, this.guardianActionCopyGenerator);
+        return await handleChannelInbound(req, this.processMessage, this.bearerToken, assistantId, gatewayOriginSecret, this.approvalCopyGenerator, this.approvalConversationGenerator, this.guardianActionCopyGenerator, this.guardianFollowUpConversationGenerator);
       }
 
       if (endpoint === 'channels/delivery-ack' && req.method === 'POST') return await handleChannelDeliveryAck(req);

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -64,6 +64,42 @@ export type GuardianActionCopyGenerator = (
   options?: ComposeGuardianActionMessageOptions,
 ) => Promise<string | null>;
 
+// ---------------------------------------------------------------------------
+// Guardian follow-up conversation flow types
+// ---------------------------------------------------------------------------
+
+/** The disposition returned by the guardian follow-up conversation engine. */
+export type GuardianFollowUpDisposition =
+  | 'call_back'
+  | 'message_back'
+  | 'decline'
+  | 'keep_pending';
+
+/** Structured result from a single turn of the guardian follow-up conversation. */
+export interface GuardianFollowUpTurnResult {
+  disposition: GuardianFollowUpDisposition;
+  replyText: string;
+}
+
+/** Input context for the guardian follow-up conversation engine. */
+export interface GuardianFollowUpConversationContext {
+  /** The original question that was asked during the voice call. */
+  questionText: string;
+  /** The guardian's late answer text that initiated the follow-up. */
+  lateAnswerText: string;
+  /** The guardian's latest reply in the follow-up conversation. */
+  guardianReply: string;
+}
+
+/**
+ * Daemon-injected function that processes one turn of a guardian follow-up
+ * conversation. Classifies the guardian's intent into a structured disposition
+ * and produces a natural reply.
+ */
+export type GuardianFollowUpConversationGenerator = (
+  context: GuardianFollowUpConversationContext,
+) => Promise<GuardianFollowUpTurnResult>;
+
 export interface RuntimeMessageSessionOptions {
   transport?: {
     channelId: ChannelId;
@@ -140,6 +176,8 @@ export interface RuntimeHttpServerOptions {
   approvalConversationGenerator?: ApprovalConversationGenerator;
   /** Daemon-injected generator for guardian action copy (provider-backed). */
   guardianActionCopyGenerator?: GuardianActionCopyGenerator;
+  /** Daemon-injected generator for guardian follow-up conversation (provider-backed). */
+  guardianFollowUpConversationGenerator?: GuardianFollowUpConversationGenerator;
   /** Dependencies for the POST /v1/messages queue-if-busy handler. */
   sendMessageDeps?: SendMessageDeps;
 }

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -987,47 +987,86 @@ export async function handleChannelInbound(
         (d) => d.destinationExternalUserId === body.senderExternalUserId,
       );
 
-      // Use first valid delivery (multiple awaiting_guardian_choice for same
-      // guardian+chat is unlikely but we handle it gracefully)
-      const matchedFollowup = validFollowup[0];
-      if (matchedFollowup) {
-        const followupRequest = getGuardianActionRequest(matchedFollowup.requestId);
+      if (validFollowup.length > 0) {
+        let matchedFollowup = validFollowup.length === 1 ? validFollowup[0] : null;
+        let followupReplyText = trimmedContent;
 
-        if (followupRequest && followupRequest.followupState === 'awaiting_guardian_choice') {
-          const turnResult = await processGuardianFollowUpTurn(
-            {
-              questionText: followupRequest.questionText,
-              lateAnswerText: followupRequest.lateAnswerText ?? '',
-              guardianReply: trimmedContent,
-            },
-            guardianFollowUpConversationGenerator,
-          );
-
-          // Apply the disposition to the follow-up state machine
-          if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
-            progressFollowupState(followupRequest.id, 'dispatching', turnResult.disposition);
-          } else if (turnResult.disposition === 'decline') {
-            finalizeFollowup(followupRequest.id, 'declined');
-          }
-          // keep_pending: no state change — guardian can reply again
-
-          // Deliver the generated reply to the guardian
-          try {
-            await deliverChannelReply(replyCallbackUrl, {
-              chatId: externalChatId,
-              text: turnResult.replyText,
-              assistantId,
-            }, bearerToken);
-          } catch (err) {
-            log.error({ err, externalChatId }, 'Failed to deliver guardian follow-up conversation reply');
+        // Multiple follow-up deliveries: require request code prefix for disambiguation
+        if (validFollowup.length > 1) {
+          for (const d of validFollowup) {
+            const req = getGuardianActionRequest(d.requestId);
+            if (req && trimmedContent.toUpperCase().startsWith(req.requestCode)) {
+              matchedFollowup = d;
+              followupReplyText = trimmedContent.slice(req.requestCode.length).trim();
+              break;
+            }
           }
 
-          return Response.json({
-            accepted: true,
-            duplicate: false,
-            eventId: result.eventId,
-            guardianFollowUp: turnResult.disposition,
-          });
+          if (!matchedFollowup) {
+            // Send disambiguation message listing the request codes
+            const codes = validFollowup
+              .map((d) => {
+                const req = getGuardianActionRequest(d.requestId);
+                return req ? req.requestCode : null;
+              })
+              .filter(Boolean);
+            try {
+              await deliverChannelReply(replyCallbackUrl, {
+                chatId: externalChatId,
+                text: `You have multiple pending follow-up questions. Please prefix your reply with the reference code (${codes.join(', ')}) to indicate which question you are responding to.`,
+                assistantId,
+              }, bearerToken);
+            } catch (err) {
+              log.error({ err, externalChatId }, 'Failed to deliver guardian follow-up disambiguation message');
+            }
+            return Response.json({
+              accepted: true,
+              duplicate: false,
+              eventId: result.eventId,
+              guardianFollowUp: 'disambiguation_sent',
+            });
+          }
+        }
+
+        if (matchedFollowup) {
+          const followupRequest = getGuardianActionRequest(matchedFollowup.requestId);
+
+          if (followupRequest && followupRequest.followupState === 'awaiting_guardian_choice') {
+            const turnResult = await processGuardianFollowUpTurn(
+              {
+                questionText: followupRequest.questionText,
+                lateAnswerText: followupRequest.lateAnswerText ?? '',
+                guardianReply: followupReplyText,
+              },
+              guardianFollowUpConversationGenerator,
+            );
+
+            // Apply the disposition to the follow-up state machine
+            if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
+              progressFollowupState(followupRequest.id, 'dispatching', turnResult.disposition);
+            } else if (turnResult.disposition === 'decline') {
+              finalizeFollowup(followupRequest.id, 'declined');
+            }
+            // keep_pending: no state change — guardian can reply again
+
+            // Deliver the generated reply to the guardian
+            try {
+              await deliverChannelReply(replyCallbackUrl, {
+                chatId: externalChatId,
+                text: turnResult.replyText,
+                assistantId,
+              }, bearerToken);
+            } catch (err) {
+              log.error({ err, externalChatId }, 'Failed to deliver guardian follow-up conversation reply');
+            }
+
+            return Response.json({
+              accepted: true,
+              duplicate: false,
+              eventId: result.eventId,
+              guardianFollowUp: turnResult.disposition,
+            });
+          }
         }
       }
     }

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -17,9 +17,12 @@ import { recordConversationSeenSignal } from '../../memory/conversation-attentio
 import * as conversationStore from '../../memory/conversation-store.js';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
 import {
+  finalizeFollowup,
   getExpiredDeliveriesByDestination,
+  getFollowupDeliveriesByDestination,
   getGuardianActionRequest,
   getPendingDeliveriesByDestination,
+  progressFollowupState,
   resolveGuardianActionRequest,
   startFollowupFromExpiredRequest,
 } from '../../memory/guardian-action-store.js';
@@ -56,8 +59,10 @@ import type {
   ApprovalConversationGenerator,
   ApprovalCopyGenerator,
   GuardianActionCopyGenerator,
+  GuardianFollowUpConversationGenerator,
   MessageProcessor,
 } from '../http-types.js';
+import { processGuardianFollowUpTurn } from '../guardian-action-conversation-turn.js';
 import { composeGuardianActionMessageGenerative } from '../guardian-action-message-composer.js';
 import { deliverReplyViaCallback } from './channel-delivery-routes.js';
 import {
@@ -97,6 +102,7 @@ export async function handleChannelInbound(
   approvalCopyGenerator?: ApprovalCopyGenerator,
   approvalConversationGenerator?: ApprovalConversationGenerator,
   guardianActionCopyGenerator?: GuardianActionCopyGenerator,
+  guardianFollowUpConversationGenerator?: GuardianFollowUpConversationGenerator,
 ): Promise<Response> {
   // Reject requests that lack valid gateway-origin proof. This ensures
   // channel inbound messages can only arrive via the gateway (which
@@ -958,6 +964,70 @@ export async function handleChannelInbound(
               });
             }
           }
+        }
+      }
+    }
+  }
+
+  // ── Guardian follow-up conversation interception ──
+  // When a request is in `awaiting_guardian_choice` state, the guardian has
+  // already been asked "call back or send a message?". Their next message
+  // is the reply to that prompt — route it through the conversation engine
+  // to classify their intent.
+  if (
+    !result.duplicate &&
+    !hasCallbackData &&
+    trimmedContent.length > 0 &&
+    body.senderExternalUserId &&
+    replyCallbackUrl
+  ) {
+    const followupDeliveries = getFollowupDeliveriesByDestination(canonicalAssistantId, sourceChannel, externalChatId);
+    if (followupDeliveries.length > 0) {
+      const validFollowup = followupDeliveries.filter(
+        (d) => d.destinationExternalUserId === body.senderExternalUserId,
+      );
+
+      // Use first valid delivery (multiple awaiting_guardian_choice for same
+      // guardian+chat is unlikely but we handle it gracefully)
+      const matchedFollowup = validFollowup[0];
+      if (matchedFollowup) {
+        const followupRequest = getGuardianActionRequest(matchedFollowup.requestId);
+
+        if (followupRequest && followupRequest.followupState === 'awaiting_guardian_choice') {
+          const turnResult = await processGuardianFollowUpTurn(
+            {
+              questionText: followupRequest.questionText,
+              lateAnswerText: followupRequest.lateAnswerText ?? '',
+              guardianReply: trimmedContent,
+            },
+            guardianFollowUpConversationGenerator,
+          );
+
+          // Apply the disposition to the follow-up state machine
+          if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
+            progressFollowupState(followupRequest.id, 'dispatching', turnResult.disposition);
+          } else if (turnResult.disposition === 'decline') {
+            finalizeFollowup(followupRequest.id, 'declined');
+          }
+          // keep_pending: no state change — guardian can reply again
+
+          // Deliver the generated reply to the guardian
+          try {
+            await deliverChannelReply(replyCallbackUrl, {
+              chatId: externalChatId,
+              text: turnResult.replyText,
+              assistantId,
+            }, bearerToken);
+          } catch (err) {
+            log.error({ err, externalChatId }, 'Failed to deliver guardian follow-up conversation reply');
+          }
+
+          return Response.json({
+            accepted: true,
+            duplicate: false,
+            eventId: result.eventId,
+            guardianFollowUp: turnResult.disposition,
+          });
         }
       }
     }


### PR DESCRIPTION
Implement structured decision engine for guardian follow-up replies. When a guardian responds to a post-timeout follow-up prompt, the engine classifies their intent into call_back, message_back, decline, or keep_pending dispositions using an LLM with tool calling. Each disposition triggers the appropriate follow-up state transition and sends a generated reply to the guardian. Includes fallback behavior for generation failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
