### PR TITLE
feat(parental): settings defaults and Select All/None per section

### DIFF
--- a/assistant/src/daemon/handlers/config-parental.ts
+++ b/assistant/src/daemon/handlers/config-parental.ts
@@ -143,10 +143,23 @@ export function handleParentalControlUpdate(
     }
   }
 
+  // When enabling for the first time (no existing restrictions), default all
+  // restrictions to ON so the parent starts from a safe baseline rather than
+  // having to manually configure everything.
+  const isFirstEnable = msg.enabled === true && !settings.enabled
+    && settings.contentRestrictions.length === 0
+    && settings.blockedToolCategories.length === 0;
+
+  const effectiveMsg = isFirstEnable ? {
+    ...msg,
+    content_restrictions: msg.content_restrictions ?? ['violence', 'adult_content', 'political', 'gambling', 'drugs'],
+    blocked_tool_categories: msg.blocked_tool_categories ?? ['computer_use', 'network', 'shell', 'file_write'],
+  } : msg;
+
   const updated = updateParentalControlSettings({
-    enabled: msg.enabled,
-    contentRestrictions: msg.content_restrictions,
-    blockedToolCategories: msg.blocked_tool_categories,
+    enabled: effectiveMsg.enabled,
+    contentRestrictions: effectiveMsg.content_restrictions,
+    blockedToolCategories: effectiveMsg.blocked_tool_categories,
   });
 
   log.info({ enabled: updated.enabled }, 'Parental control settings updated');

--- a/assistant/src/daemon/handlers/config-parental.ts
+++ b/assistant/src/daemon/handlers/config-parental.ts
@@ -143,12 +143,12 @@ export function handleParentalControlUpdate(
     }
   }
 
-  // When enabling for the first time (no existing restrictions), default all
-  // restrictions to ON so the parent starts from a safe baseline rather than
-  // having to manually configure everything.
-  const isFirstEnable = msg.enabled === true && !settings.enabled
-    && settings.contentRestrictions.length === 0
-    && settings.blockedToolCategories.length === 0;
+  // When enabling for the very first time, default all restrictions to ON so
+  // the parent starts from a safe baseline. We track first-time initialization
+  // with an explicit `initialized` flag rather than inferring it from empty
+  // arrays, which would incorrectly re-apply defaults if the user intentionally
+  // set both sections to "None" and then toggled parental controls off/on.
+  const isFirstEnable = msg.enabled === true && !settings.initialized;
 
   const effectiveMsg = isFirstEnable ? {
     ...msg,
@@ -160,6 +160,9 @@ export function handleParentalControlUpdate(
     enabled: effectiveMsg.enabled,
     contentRestrictions: effectiveMsg.content_restrictions,
     blockedToolCategories: effectiveMsg.blocked_tool_categories,
+    // Mark as initialized once enabled for the first time so subsequent
+    // enable/disable cycles preserve the user's chosen configuration.
+    ...(isFirstEnable ? { initialized: true } : {}),
   });
 
   log.info({ enabled: updated.enabled }, 'Parental control settings updated');

--- a/assistant/src/security/parental-control-store.ts
+++ b/assistant/src/security/parental-control-store.ts
@@ -32,6 +32,13 @@ export interface ParentalControlSettings {
   contentRestrictions: ParentalContentTopic[];
   blockedToolCategories: ParentalToolCategory[];
   activeProfile: 'parental' | 'child';
+  /**
+   * Set to `true` the first time parental controls are enabled and defaults
+   * have been applied. Used to distinguish "never configured" from "user
+   * explicitly chose empty restrictions", so that re-enabling after the user
+   * set both sections to None does not silently re-apply defaults.
+   */
+  initialized: boolean;
 }
 
 const DEFAULT_SETTINGS: ParentalControlSettings = {
@@ -39,6 +46,7 @@ const DEFAULT_SETTINGS: ParentalControlSettings = {
   contentRestrictions: [],
   blockedToolCategories: [],
   activeProfile: 'parental',
+  initialized: false,
 };
 
 function getSettingsPath(): string {
@@ -61,6 +69,12 @@ export function getParentalControlSettings(): ParentalControlSettings {
       blockedToolCategories: Array.isArray(parsed.blockedToolCategories) ? parsed.blockedToolCategories : [],
       // Default to "parental" for existing settings files that predate this field.
       activeProfile: parsed.activeProfile === 'child' ? 'child' : 'parental',
+      // Default to false for existing settings files that predate this field.
+      // If parental controls were already enabled, treat them as initialized so
+      // that re-enabling does not silently re-apply defaults.
+      initialized: typeof parsed.initialized === 'boolean'
+        ? parsed.initialized
+        : (typeof parsed.enabled === 'boolean' && parsed.enabled),
     };
   } catch {
     return { ...DEFAULT_SETTINGS };
@@ -86,6 +100,7 @@ export function updateParentalControlSettings(
       ? patch.blockedToolCategories
       : current.blockedToolCategories,
     activeProfile: patch.activeProfile !== undefined ? patch.activeProfile : current.activeProfile,
+    initialized: patch.initialized !== undefined ? patch.initialized : current.initialized,
   };
   saveSettings(next);
   return next;

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
@@ -197,9 +197,26 @@ struct SettingsParentalTab: View {
 
     private var contentRestrictionsSection: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            Text("Content Restrictions")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.textPrimary)
+            HStack {
+                Text("Content Restrictions")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+                Spacer()
+                Button("All") {
+                    updateContentRestrictions(ContentTopic.allCases.map { $0.rawValue })
+                }
+                .buttonStyle(.plain)
+                .font(VFont.caption)
+                .foregroundColor(VColor.accent)
+                .accessibilityLabel("Select all content restrictions")
+                Button("None") {
+                    updateContentRestrictions([])
+                }
+                .buttonStyle(.plain)
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .accessibilityLabel("Deselect all content restrictions")
+            }
 
             Text("Block responses on these topics.")
                 .font(VFont.caption)
@@ -233,9 +250,26 @@ struct SettingsParentalTab: View {
 
     private var toolCategorySection: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            Text("Tool Restrictions")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.textPrimary)
+            HStack {
+                Text("Tool Restrictions")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+                Spacer()
+                Button("All") {
+                    updateToolCategories(ToolCategory.allCases.map { $0.rawValue })
+                }
+                .buttonStyle(.plain)
+                .font(VFont.caption)
+                .foregroundColor(VColor.accent)
+                .accessibilityLabel("Select all tool restrictions")
+                Button("None") {
+                    updateToolCategories([])
+                }
+                .buttonStyle(.plain)
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .accessibilityLabel("Deselect all tool restrictions")
+            }
 
             Text("Prevent the assistant from using these tool categories.")
                 .font(VFont.caption)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
@@ -209,6 +209,7 @@ struct SettingsParentalTab: View {
                 .font(VFont.caption)
                 .foregroundColor(VColor.accent)
                 .accessibilityLabel("Select all content restrictions")
+                .disabled(isLoading)
                 Button("None") {
                     updateContentRestrictions([])
                 }
@@ -216,6 +217,7 @@ struct SettingsParentalTab: View {
                 .font(VFont.caption)
                 .foregroundColor(VColor.textMuted)
                 .accessibilityLabel("Deselect all content restrictions")
+                .disabled(isLoading)
             }
 
             Text("Block responses on these topics.")
@@ -262,6 +264,7 @@ struct SettingsParentalTab: View {
                 .font(VFont.caption)
                 .foregroundColor(VColor.accent)
                 .accessibilityLabel("Select all tool restrictions")
+                .disabled(isLoading)
                 Button("None") {
                     updateToolCategories([])
                 }
@@ -269,6 +272,7 @@ struct SettingsParentalTab: View {
                 .font(VFont.caption)
                 .foregroundColor(VColor.textMuted)
                 .accessibilityLabel("Deselect all tool restrictions")
+                .disabled(isLoading)
             }
 
             Text("Prevent the assistant from using these tool categories.")


### PR DESCRIPTION
When parental controls are first enabled, all content and tool restrictions default to ON. Adds Select All / None buttons to each restrictions section in SettingsParentalTab.

Part of #9653
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
