### PR TITLE
fix: resolve Swift textSelection type mismatch causing CI build failure

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -317,7 +317,7 @@ struct ChatBubble: View {
                             .font(.system(size: 13 * conversationZoomScale))
                             .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
                             .tint(isUser ? VColor.userBubbleText : VColor.accent)
-                            .textSelection(message.isStreaming ? .disabled : .enabled)
+                            .selectableText(!message.isStreaming)
                             .fixedSize(horizontal: false, vertical: true)
                     }
                 } else if !message.attachments.isEmpty {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -275,7 +275,7 @@ struct MarkdownTableView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.sm)
-                        .textSelection(isStreaming ? .disabled : .enabled)
+                        .selectableText(!isStreaming)
                 }
             }
 
@@ -314,6 +314,6 @@ struct MarkdownTableView: View {
         return Text(attributed)
             .font(.custom("Inter", size: 13 * zoomScale))
             .foregroundColor(VColor.textPrimary)
-            .textSelection(isStreaming ? .disabled : .enabled)
+            .selectableText(!isStreaming)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -32,7 +32,7 @@ struct MarkdownSegmentView: View {
                         .lineSpacing(4)
                         .foregroundColor(textColor)
                         .tint(tintColor)
-                        .textSelection(isStreaming ? .disabled : .enabled)
+                        .selectableText(!isStreaming)
                         .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: maxContentWidth ?? .infinity, alignment: .leading)
 
@@ -49,7 +49,7 @@ struct MarkdownSegmentView: View {
                             Text(code)
                                 .font(.custom("DMMono-Regular", size: 13 * zoomScale))
                                 .foregroundColor(textColor)
-                                .textSelection(isStreaming ? .disabled : .enabled)
+                                .selectableText(!isStreaming)
                                 .fixedSize(horizontal: true, vertical: true)
                                 .padding(VSpacing.sm)
                         }
@@ -290,6 +290,21 @@ struct MarkdownSegmentView: View {
         }
 
         return result
+    }
+}
+
+// MARK: - Conditional text selection
+
+extension View {
+    /// Wraps `.textSelection(.enabled)` / `.textSelection(.disabled)` behind a
+    /// `@ViewBuilder` branch so the compiler doesn't try to unify the two
+    /// distinct `TextSelectability` conformances in a single ternary expression.
+    @ViewBuilder func selectableText(_ enabled: Bool) -> some View {
+        if enabled {
+            self.textSelection(.enabled)
+        } else {
+            self.textSelection(.disabled)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- `.textSelection(isStreaming ? .disabled : .enabled)` fails to compile because `.disabled` (`DisabledTextSelectability`) and `.enabled` (`EnabledTextSelectability`) are incompatible types in a ternary
- Added `selectableText(_:)` View extension using `@ViewBuilder` to branch between the two types correctly
- Replaced all 5 call sites across `ChatBubble.swift`, `ChatMarkdownParser.swift`, and `MarkdownSegmentView.swift`

## Original prompt
fix: resolve Swift textSelection type mismatch causing CI build failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
