### PR TITLE
Screen Picker UI Polish & Button Gallery Sizes

### DIFF
--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -146,7 +146,11 @@ struct RecordingSourcePickerView: View {
     private var sourceList: some View {
         ViewThatFits(in: .vertical) {
             sourceListContent
-            ScrollView { sourceListContent }
+            ScrollView {
+                sourceListContent
+                    .background(ScrollViewScrollerHider())
+            }
+            .scrollIndicators(.hidden)
         }
     }
 
@@ -231,15 +235,7 @@ struct RecordingSourcePickerView: View {
                             .foregroundColor(VColor.textPrimary)
                             .lineLimit(1)
                         if display.isCurrentDisplay {
-                            Text("This display")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.accent)
-                                .padding(.horizontal, VSpacing.xs)
-                                .padding(.vertical, 1)
-                                .background(
-                                    Capsule()
-                                        .fill(VColor.accent.opacity(0.15))
-                                )
+                            VBadge(style: .label("This display"), color: VColor.accent)
                         }
                     }
                     Text(display.subtitle)
@@ -322,11 +318,11 @@ struct RecordingSourcePickerView: View {
 
             // Buttons
             HStack(spacing: VSpacing.md) {
-                VButton(label: "Cancel", style: .secondary, size: .large) {
+                VButton(label: "Cancel", style: .tertiary, size: .medium) {
                     onCancel()
                 }
                 Spacer()
-                VButton(label: "Start Recording", style: .primary, size: .large, isDisabled: !viewModel.canStart) {
+                VButton(label: "Start Recording", style: .primary, size: .medium, isDisabled: !viewModel.canStart) {
                     onStart(viewModel.selectedRecordingOptions)
                 }
             }
@@ -350,6 +346,43 @@ struct RecordingSourcePickerView: View {
             }
         }
         .padding(.vertical, VSpacing.lg)
+    }
+}
+
+// MARK: - Scroll View Helpers
+
+/// Finds the nearest NSScrollView ancestor and hides its scrollers,
+/// overriding the macOS "Show scroll bars: Always" system preference.
+/// Walks the full superview chain as a fallback if `enclosingScrollView`
+/// returns nil (which can happen with SwiftUI's internal hosting layers).
+private struct ScrollViewScrollerHider: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async { hideScrollers(from: view) }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async { hideScrollers(from: nsView) }
+    }
+
+    private func hideScrollers(from view: NSView) {
+        // Try the fast path first
+        if let scrollView = view.enclosingScrollView {
+            scrollView.hasVerticalScroller = false
+            scrollView.hasHorizontalScroller = false
+            return
+        }
+        // Walk the full superview chain looking for any NSScrollView
+        var current: NSView? = view.superview
+        while let ancestor = current {
+            if let scrollView = ancestor as? NSScrollView {
+                scrollView.hasVerticalScroller = false
+                scrollView.hasHorizontalScroller = false
+                return
+            }
+            current = ancestor.superview
+        }
     }
 }
 

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -63,6 +63,28 @@ struct ButtonsGallerySection: View {
                 }
             }
 
+            // All Sizes
+            Text("All Sizes")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textSecondary)
+
+            VCard {
+                HStack(spacing: VSpacing.xl) {
+                    ForEach([VButton.Size.small, .medium, .large], id: \.self) { size in
+                        VStack(spacing: VSpacing.md) {
+                            Text(sizeName(size))
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                            VButton(label: sizeName(size), style: .primary, size: size) {}
+                            VButton(label: sizeName(size), style: .secondary, size: size) {}
+                            VButton(label: sizeName(size), style: .tertiary, size: size) {}
+                            VButton(label: sizeName(size), style: .danger, size: size) {}
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                }
+            }
+
             Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
 
             // MARK: - VIconButton
@@ -151,6 +173,14 @@ struct ButtonsGallerySection: View {
         case .tertiary: return "Tertiary"
         case .secondary: return "Secondary"
         case .danger: return "Danger"
+        }
+    }
+
+    private func sizeName(_ size: VButton.Size) -> String {
+        switch size {
+        case .small: return "Small"
+        case .medium: return "Medium"
+        case .large: return "Large"
         }
     }
 }


### PR DESCRIPTION
## Summary
- Change Cancel button to tertiary style and both action buttons to medium size
- Hide scrollbar in source list by force-disabling NSScrollView scrollers (overrides macOS "Show scroll bars: Always" preference)
- Replace hand-rolled "This display" capsule badge with `VBadge` design system component
- Add "All Sizes" section to `ButtonsGallerySection` showing small/medium/large across all button styles

## Test plan
- [ ] Open screen recording picker — verify Cancel is tertiary style, both buttons are medium size
- [ ] Verify scrollbar is hidden in source list even with "Show scroll bars: Always" in System Preferences
- [ ] Verify "This display" badge renders correctly using VBadge
- [ ] Open Component Gallery — verify "All Sizes" section appears in Buttons tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
