### PR TITLE
fix: reject non-IANA timezone abbreviations in timezone override

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -255,10 +255,7 @@ public final class SettingsStore: ObservableObject {
     }()
 
     private static func canonicalizeTimeZoneIdentifier(_ raw: String) -> String? {
-        if let tz = TimeZone(identifier: raw) {
-            return tz.identifier
-        }
-        return allKnownTimeZoneIdentifiersByLowercase[raw.lowercased()]
+        allKnownTimeZoneIdentifiersByLowercase[raw.lowercased()]
     }
 
     init(


### PR DESCRIPTION
## Summary
- Remove the `TimeZone(identifier:)` fallback in `canonicalizeTimeZoneIdentifier` that accepted abbreviations like `EST`/`PST`
- These abbreviations are fixed-offset aliases that cause incorrect local-date grounding around DST transitions
- Now only accepts IANA identifiers from `TimeZone.knownTimeZoneIdentifiers` (case-insensitive lookup)

## Original prompt
address the feedback here: https://github.com/vellum-ai/vellum-assistant/pull/9615#discussion_r2860815425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
