### PR TITLE
M1: AGENTS.md policy update + CI guard test scaffolding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,19 @@ Concretely:
 
 Why: the gateway is the single point of ingress, handling TLS termination, auth, rate limiting, and routing. Exposing the daemon directly bypasses these protections and breaks the deployment model.
 
+### Gateway-Only API Consumption
+
+All assistant API requests from clients, CLI, skills, and user-facing tooling **MUST** target gateway URLs. Never construct URLs using the daemon runtime port (`7821`) or `RUNTIME_HTTP_PORT` for external API consumption.
+
+**Exception boundary:** The gateway service itself may call the runtime internally. Tests may use direct runtime URLs for isolated unit/integration scenarios. Intentional local daemon-control paths are exempt:
+- `clients/shared/IPC/DaemonClient.swift`
+- `clients/macos/vellum-assistant/App/AppDelegate.swift` (`localHttpEnabled`)
+- `clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift` (health probe)
+
+**Migration rule:** If a needed endpoint is not available at the gateway, add a gateway route/proxy first, then consume it. Do not work around a missing gateway endpoint by hitting the runtime directly.
+
+**Ban on hardcoded runtime hosts/ports:** Do not embed `localhost:7821`, `127.0.0.1:7821`, or runtime-port-derived URLs in docs, skills, or user-facing guidance. Always reference gateway URLs instead. A CI guard test (`gateway-only-guard.test.ts`) enforces this — any new direct runtime URL reference in production code or skills will fail CI.
+
 ## LLM Provider Abstraction
 
 All LLM calls in production code **MUST** go through the provider abstraction layer — never import `@anthropic-ai/sdk` (or any other provider SDK) directly.

--- a/assistant/src/__tests__/gateway-only-guard.test.ts
+++ b/assistant/src/__tests__/gateway-only-guard.test.ts
@@ -1,0 +1,107 @@
+import { execSync } from 'node:child_process';
+
+import { describe, expect, test } from 'bun:test';
+
+/**
+ * Guard test: production files and skills must not reference direct runtime
+ * URLs (localhost:7821, 127.0.0.1:7821, or RUNTIME_HTTP_PORT-derived URLs
+ * used for external API consumption).
+ *
+ * The gateway is the single point of API ingress for clients, CLI, skills,
+ * and user-facing tooling. See AGENTS.md "Gateway-Only API Consumption".
+ *
+ * Allowlist entries should be kept minimal — add a path here only if the
+ * file genuinely needs to reference the runtime port directly (e.g., gateway
+ * internals, daemon-control paths, or tests).
+ */
+
+/** Files that are permitted to contain direct runtime URL patterns. */
+const ALLOWLIST = new Set([
+  // --- Test files are always allowed (matched by directory/suffix below) ---
+
+  // --- Gateway internals (gateway calls runtime directly) ---
+  // Matched by prefix check below: gateway/src/
+
+  // --- Intentional local daemon-control paths ---
+  'clients/shared/IPC/DaemonClient.swift',
+  'clients/macos/vellum-assistant/App/AppDelegate.swift',
+  'clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift',
+
+  // --- TEMPORARY allowlist — violators to be migrated in M6 ---
+  'cli/src/commands/contacts.ts',
+  'assistant/src/influencer/client.ts',
+  'assistant/src/amazon/client.ts',
+  'clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift',
+  'clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift',
+  'clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift',
+  'skills/guardian-verify-setup/SKILL.md',
+  'skills/telegram-setup/SKILL.md',
+  'skills/twilio-setup/SKILL.md',
+  'assistant/src/config/vellum-skills/guardian-verify-setup/SKILL.md',
+  'assistant/src/config/vellum-skills/telegram-setup/SKILL.md',
+  'assistant/src/config/vellum-skills/twilio-setup/SKILL.md',
+]);
+
+/** Patterns that indicate a direct runtime URL reference. */
+const RUNTIME_URL_PATTERNS = [
+  'localhost:7821',
+  '127\\.0\\.0\\.1:7821',
+];
+
+function isTestFile(filePath: string): boolean {
+  return (
+    filePath.includes('/__tests__/') ||
+    filePath.endsWith('.test.ts') ||
+    filePath.endsWith('.test.js') ||
+    filePath.endsWith('.spec.ts') ||
+    filePath.endsWith('.spec.js')
+  );
+}
+
+function isGatewayInternal(filePath: string): boolean {
+  return filePath.startsWith('gateway/src/');
+}
+
+describe('gateway-only API consumption guard', () => {
+  test('no non-allowlisted files reference direct runtime URLs (port 7821)', () => {
+    const grepPattern = RUNTIME_URL_PATTERNS.join('|');
+
+    let grepOutput = '';
+    try {
+      grepOutput = execSync(
+        `git grep -lE "${grepPattern}" -- '*.ts' '*.js' '*.swift' '*.md'`,
+        { encoding: 'utf-8', cwd: process.cwd() + '/..' },
+      ).trim();
+    } catch (err) {
+      // Exit code 1 means no matches — that's the happy path
+      if ((err as { status?: number }).status === 1) {
+        return;
+      }
+      throw err;
+    }
+
+    const files = grepOutput.split('\n').filter((f) => f.length > 0);
+
+    const violations = files.filter((f) => {
+      if (isTestFile(f)) return false;
+      if (isGatewayInternal(f)) return false;
+      if (ALLOWLIST.has(f)) return false;
+      return true;
+    });
+
+    if (violations.length > 0) {
+      const message = [
+        'Found non-allowlisted files referencing direct runtime URLs (port 7821).',
+        'All API requests must target gateway URLs — see AGENTS.md "Gateway-Only API Consumption".',
+        '',
+        'Violations:',
+        ...violations.map((f) => `  - ${f}`),
+        '',
+        'To fix: migrate the reference to use gateway URLs.',
+        'If this is an intentional exception, add it to the ALLOWLIST in gateway-only-guard.test.ts.',
+      ].join('\n');
+
+      expect(violations, message).toEqual([]);
+    }
+  });
+});


### PR DESCRIPTION
Part of #9674. Adds gateway-only API consumption policy to AGENTS.md and creates a CI guard test that fails on direct runtime URL patterns in production code/skills. The guard test has a temporary allowlist for known violators that will be tightened in M6.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
