### PR TITLE
M2: CLI + assistant TS migrations to gateway URLs

### DIFF
--- a/assistant/src/amazon/client.ts
+++ b/assistant/src/amazon/client.ts
@@ -50,7 +50,7 @@
 
 import type { ExtensionCommand, ExtensionResponse } from '../browser-extension-relay/protocol.js';
 import { extensionRelayServer } from '../browser-extension-relay/server.js';
-import { getRuntimeHttpPort } from '../config/env.js';
+import { getGatewayInternalBaseUrl } from '../config/env.js';
 import type { ExtractedCredential } from '../tools/browser/network-recording-types.js';
 import { readHttpToken } from '../util/platform.js';
 import {
@@ -81,8 +81,7 @@ export async function sendRelayCommand(command: Record<string, unknown>): Promis
     throw new Error('Browser extension relay is not connected and no HTTP token found. Is the daemon running?');
   }
 
-  const port = getRuntimeHttpPort() ?? 7821;
-  const resp = await fetch(`http://127.0.0.1:${port}/v1/browser-relay/command`, {
+  const resp = await fetch(`${getGatewayInternalBaseUrl()}/v1/browser-relay/command`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/assistant/src/influencer/client.ts
+++ b/assistant/src/influencer/client.ts
@@ -47,6 +47,7 @@
 
 import type { ExtensionCommand, ExtensionResponse } from '../browser-extension-relay/protocol.js';
 import { extensionRelayServer } from '../browser-extension-relay/server.js';
+import { getGatewayInternalBaseUrl } from '../config/env.js';
 import { readHttpToken } from '../util/platform.js';
 
 // ---------------------------------------------------------------------------
@@ -133,7 +134,7 @@ async function sendRelayCommand(command: Record<string, unknown>): Promise<Exten
     );
   }
 
-  const resp = await fetch('http://127.0.0.1:7821/v1/browser-relay/command', {
+  const resp = await fetch(`${getGatewayInternalBaseUrl()}/v1/browser-relay/command`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/cli/src/commands/contacts.ts
+++ b/cli/src/commands/contacts.ts
@@ -3,15 +3,16 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 import { loadLatestAssistant } from "../lib/assistant-config";
+import { GATEWAY_PORT } from "../lib/constants.js";
 
 // ---------------------------------------------------------------------------
-// Runtime API client
+// Gateway API client
 // ---------------------------------------------------------------------------
 
-function getRuntimeUrl(): string {
+function getGatewayUrl(): string {
   const entry = loadLatestAssistant();
   if (entry?.runtimeUrl) return entry.runtimeUrl;
-  return "http://localhost:7821";
+  return `http://localhost:${GATEWAY_PORT}`;
 }
 
 function getBearerToken(): string | undefined {
@@ -45,7 +46,7 @@ function buildHeaders(): Record<string, string> {
 }
 
 async function apiGet(path: string): Promise<unknown> {
-  const url = `${getRuntimeUrl()}/v1/${path}`;
+  const url = `${getGatewayUrl()}/v1/${path}`;
   const response = await fetch(url, { headers: buildHeaders() });
   if (!response.ok) {
     const text = await response.text();
@@ -58,7 +59,7 @@ async function apiPost(
   path: string,
   body: unknown,
 ): Promise<unknown> {
-  const url = `${getRuntimeUrl()}/v1/${path}`;
+  const url = `${getGatewayUrl()}/v1/${path}`;
   const response = await fetch(url, {
     method: "POST",
     headers: buildHeaders(),


### PR DESCRIPTION
Part of #9674. Migrates contacts.ts, influencer/client.ts, and amazon/client.ts from direct daemon runtime URLs (localhost:7821) to gateway URLs (port 7830). The /v1/* paths are already proxied by gateway runtime-proxy.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
