### PR TITLE
M5: Skills/docs migration to gateway-only usage

### DIFF
--- a/assistant/src/config/vellum-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/guardian-verify-setup/SKILL.md
@@ -5,11 +5,11 @@ user-invocable: true
 metadata: {"vellum": {"emoji": "\ud83d\udd10"}}
 ---
 
-You are helping your user set up guardian verification for a messaging channel (SMS, voice, or Telegram). This links their identity as the trusted guardian for the chosen channel. All API calls go through the runtime HTTP API using `curl` with bearer auth.
+You are helping your user set up guardian verification for a messaging channel (SMS, voice, or Telegram). This links their identity as the trusted guardian for the chosen channel. All API calls go through the gateway HTTP API using `curl` with bearer auth.
 
 ## Prerequisites
 
-- The runtime HTTP API is available at `http://localhost:7821` (or the configured `RUNTIME_HTTP_PORT`).
+- The gateway API is available at `http://localhost:7830` (or the configured gateway port).
 - The bearer token is stored at `~/.vellum/http-token`. Read it with: `TOKEN=$(cat ~/.vellum/http-token)`.
 - Run shell commands for this skill with `host_bash` (not sandbox `bash`) so host auth/token and localhost routing are reliable.
 - Keep narration minimal: execute required calls first, then provide a concise status update. Do not narrate internal install/check/load chatter unless something fails.
@@ -39,7 +39,7 @@ Execute the outbound start request:
 
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
-curl -s -X POST http://localhost:7821/v1/integrations/guardian/outbound/start \
+curl -s -X POST http://localhost:7830/v1/integrations/guardian/outbound/start \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{"channel": "<channel>", "destination": "<destination>"}'
@@ -77,7 +77,7 @@ If the user says they did not receive the code or asks to resend:
 
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
-curl -s -X POST http://localhost:7821/v1/integrations/guardian/outbound/resend \
+curl -s -X POST http://localhost:7830/v1/integrations/guardian/outbound/resend \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{"channel": "<channel>"}'
@@ -107,7 +107,7 @@ If the user wants to cancel the verification:
 
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
-curl -s -X POST http://localhost:7821/v1/integrations/guardian/outbound/cancel \
+curl -s -X POST http://localhost:7830/v1/integrations/guardian/outbound/cancel \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{"channel": "<channel>"}'
@@ -126,7 +126,7 @@ For **voice** verification only: after telling the user their code and instructi
 
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
-curl -s http://localhost:7821/v1/integrations/guardian/status?channel=voice \
+curl -s http://localhost:7830/v1/integrations/guardian/status?channel=voice \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -153,7 +153,7 @@ After the user reports entering the code, verify the binding was created:
 
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
-curl -s http://localhost:7821/v1/integrations/guardian/status?channel=<channel> \
+curl -s http://localhost:7830/v1/integrations/guardian/status?channel=<channel> \
   -H "Authorization: Bearer $TOKEN"
 ```
 

--- a/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/telegram-setup/SKILL.md
@@ -12,7 +12,7 @@ You are helping your user connect a Telegram bot to the Vellum Assistant gateway
 
 Before beginning setup, verify these conditions are met:
 
-1. **Daemon is running:** Run `curl -sf http://localhost:7821/healthz` — it should return OK. If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
+1. **Gateway is running:** Run `curl -sf http://localhost:7830/healthz` — it should return OK. If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
 2. **Public ingress URL is configured.** The gateway webhook URL is derived from `${ingress.publicBaseUrl}/webhooks/telegram`. If the ingress URL is not configured, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the URL before continuing.
 
 ## What You Need
@@ -36,7 +36,7 @@ The token is collected securely via a system-level prompt and is never exposed i
 After the token is collected, call the composite setup endpoint which validates the token, stores credentials, and registers bot commands in a single request:
 
 ```bash
-curl -sf -X POST http://localhost:7821/v1/integrations/telegram/setup \
+curl -sf -X POST http://localhost:7830/v1/integrations/telegram/setup \
   -H "Authorization: Bearer $(cat ~/.vellum/http-token)" \
   -H "Content-Type: application/json" \
   -d '{}'
@@ -97,7 +97,7 @@ If routing is misconfigured, inbound Telegram messages will be rejected and the 
 Before reporting success, confirm the guardian binding was actually created. Check the guardian binding status:
 
 ```bash
-curl -sf http://localhost:7821/v1/integrations/guardian/status?channel=telegram \
+curl -sf http://localhost:7830/v1/integrations/guardian/status?channel=telegram \
   -H "Authorization: Bearer $(cat ~/.vellum/http-token)"
 ```
 
@@ -116,7 +116,7 @@ Summarize what was done:
 - Guardian identity: {verified | not configured}
 - Guardian verification status: {verified via outbound flow | skipped}
 - Routing configuration validated
-- To re-check guardian status later, use: `curl -sf http://localhost:7821/v1/integrations/guardian/status?channel=telegram -H "Authorization: Bearer $(cat ~/.vellum/http-token)"`
+- To re-check guardian status later, use: `curl -sf http://localhost:7830/v1/integrations/guardian/status?channel=telegram -H "Authorization: Bearer $(cat ~/.vellum/http-token)"`
 
 The gateway automatically detects credentials from the vault, reconciles the Telegram webhook registration, and begins accepting Telegram webhooks shortly. In single-assistant mode, routing is automatically configured — no manual environment variable configuration or webhook registration is needed. If the webhook secret changes later, the gateway's credential watcher will automatically re-register the webhook. If the ingress URL changes (e.g., tunnel restart), the assistant daemon triggers an immediate internal reconcile so the webhook re-registers automatically without a gateway restart.
 

--- a/assistant/src/config/vellum-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/vellum-skills/twilio-setup/SKILL.md
@@ -228,10 +228,10 @@ To re-check guardian status later, query the channel(s) that were verified:
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
 # Check SMS guardian status
-curl -s http://localhost:7821/v1/integrations/guardian/status?channel=sms \
+curl -s http://localhost:7830/v1/integrations/guardian/status?channel=sms \
   -H "Authorization: Bearer $TOKEN"
 # Check voice guardian status
-curl -s http://localhost:7821/v1/integrations/guardian/status?channel=voice \
+curl -s http://localhost:7830/v1/integrations/guardian/status?channel=voice \
   -H "Authorization: Bearer $TOKEN"
 ```
 

--- a/skills/guardian-verify-setup/SKILL.md
+++ b/skills/guardian-verify-setup/SKILL.md
@@ -5,11 +5,11 @@ user-invocable: true
 metadata: {"vellum": {"emoji": "\ud83d\udd10"}}
 ---
 
-You are helping your user set up guardian verification for a messaging channel (SMS, voice, or Telegram). This links their identity as the trusted guardian for the chosen channel. All API calls go through the runtime HTTP API using `curl` with bearer auth.
+You are helping your user set up guardian verification for a messaging channel (SMS, voice, or Telegram). This links their identity as the trusted guardian for the chosen channel. All API calls go through the gateway HTTP API using `curl` with bearer auth.
 
 ## Prerequisites
 
-- The runtime HTTP API is available at `http://localhost:7821` (or the configured `RUNTIME_HTTP_PORT`).
+- The gateway API is available at `http://localhost:7830` (or the configured gateway port).
 - The bearer token is stored at `~/.vellum/http-token`. Read it with: `TOKEN=$(cat ~/.vellum/http-token)`.
 - Run shell commands for this skill with `host_bash` (not sandbox `bash`) so host auth/token and localhost routing are reliable.
 - Keep narration minimal: execute required calls first, then provide a concise status update. Do not narrate internal install/check/load chatter unless something fails.
@@ -39,7 +39,7 @@ Execute the outbound start request:
 
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
-curl -s -X POST http://localhost:7821/v1/integrations/guardian/outbound/start \
+curl -s -X POST http://localhost:7830/v1/integrations/guardian/outbound/start \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{"channel": "<channel>", "destination": "<destination>"}'
@@ -77,7 +77,7 @@ If the user says they did not receive the code or asks to resend:
 
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
-curl -s -X POST http://localhost:7821/v1/integrations/guardian/outbound/resend \
+curl -s -X POST http://localhost:7830/v1/integrations/guardian/outbound/resend \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{"channel": "<channel>"}'
@@ -107,7 +107,7 @@ If the user wants to cancel the verification:
 
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
-curl -s -X POST http://localhost:7821/v1/integrations/guardian/outbound/cancel \
+curl -s -X POST http://localhost:7830/v1/integrations/guardian/outbound/cancel \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{"channel": "<channel>"}'
@@ -126,7 +126,7 @@ For **voice** verification only: after telling the user their code and instructi
 
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
-curl -s http://localhost:7821/v1/integrations/guardian/status?channel=voice \
+curl -s http://localhost:7830/v1/integrations/guardian/status?channel=voice \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -153,7 +153,7 @@ After the user reports entering the code, verify the binding was created:
 
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
-curl -s http://localhost:7821/v1/integrations/guardian/status?channel=<channel> \
+curl -s http://localhost:7830/v1/integrations/guardian/status?channel=<channel> \
   -H "Authorization: Bearer $TOKEN"
 ```
 

--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -12,7 +12,7 @@ You are helping your user connect a Telegram bot to the Vellum Assistant gateway
 
 Before beginning setup, verify these conditions are met:
 
-1. **Daemon is running:** Run `curl -sf http://localhost:7821/healthz` — it should return OK. If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
+1. **Gateway is running:** Run `curl -sf http://localhost:7830/healthz` — it should return OK. If it fails, tell the user to start the daemon with `vellum daemon start` and wait for it to become healthy before continuing.
 2. **Public ingress URL is configured.** The gateway webhook URL is derived from `${ingress.publicBaseUrl}/webhooks/telegram`. If the ingress URL is not configured, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the URL before continuing.
 
 ## What You Need
@@ -36,7 +36,7 @@ The token is collected securely via a system-level prompt and is never exposed i
 After the token is collected, call the composite setup endpoint which validates the token, stores credentials, and registers bot commands in a single request:
 
 ```bash
-curl -sf -X POST http://localhost:7821/v1/integrations/telegram/setup \
+curl -sf -X POST http://localhost:7830/v1/integrations/telegram/setup \
   -H "Authorization: Bearer $(cat ~/.vellum/http-token)" \
   -H "Content-Type: application/json" \
   -d '{}'
@@ -97,7 +97,7 @@ If routing is misconfigured, inbound Telegram messages will be rejected and the 
 Before reporting success, confirm the guardian binding was actually created. Check the guardian binding status:
 
 ```bash
-curl -sf http://localhost:7821/v1/integrations/guardian/status?channel=telegram \
+curl -sf http://localhost:7830/v1/integrations/guardian/status?channel=telegram \
   -H "Authorization: Bearer $(cat ~/.vellum/http-token)"
 ```
 
@@ -116,7 +116,7 @@ Summarize what was done:
 - Guardian identity: {verified | not configured}
 - Guardian verification status: {verified via outbound flow | skipped}
 - Routing configuration validated
-- To re-check guardian status later, use: `curl -sf http://localhost:7821/v1/integrations/guardian/status?channel=telegram -H "Authorization: Bearer $(cat ~/.vellum/http-token)"`
+- To re-check guardian status later, use: `curl -sf http://localhost:7830/v1/integrations/guardian/status?channel=telegram -H "Authorization: Bearer $(cat ~/.vellum/http-token)"`
 
 The gateway automatically detects credentials from the vault, reconciles the Telegram webhook registration, and begins accepting Telegram webhooks shortly. In single-assistant mode, routing is automatically configured — no manual environment variable configuration or webhook registration is needed. If the webhook secret changes later, the gateway's credential watcher will automatically re-register the webhook. If the ingress URL changes (e.g., tunnel restart), the assistant daemon triggers an immediate internal reconcile so the webhook re-registers automatically without a gateway restart.
 

--- a/skills/twilio-setup/SKILL.md
+++ b/skills/twilio-setup/SKILL.md
@@ -228,10 +228,10 @@ To re-check guardian status later, query the channel(s) that were verified:
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
 # Check SMS guardian status
-curl -s http://localhost:7821/v1/integrations/guardian/status?channel=sms \
+curl -s http://localhost:7830/v1/integrations/guardian/status?channel=sms \
   -H "Authorization: Bearer $TOKEN"
 # Check voice guardian status
-curl -s http://localhost:7821/v1/integrations/guardian/status?channel=voice \
+curl -s http://localhost:7830/v1/integrations/guardian/status?channel=voice \
   -H "Authorization: Bearer $TOKEN"
 ```
 


### PR DESCRIPTION
Part of #9674. Updates all 6 skill documentation files (guardian-verify-setup, telegram-setup, twilio-setup × 2 locations) to use gateway port (7830) instead of daemon runtime port (7821) for API examples.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
