### PR TITLE
M3: macOS client migrations to gateway URLs

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -399,10 +399,10 @@ struct InlineVideoAttachmentView: View {
         await playFromFile(fileURL)
     }
 
-    /// Fetch attachment content from the daemon HTTP API with retry logic.
+    /// Fetch attachment content via the gateway's runtime proxy with retry logic.
     ///
-    /// For `port_missing` failures, retries up to 3 times with 1s delays
-    /// because the daemon may be mid-restart and the port will appear shortly.
+    /// Retries up to 3 times with 1s delays because the gateway or daemon
+    /// may be mid-restart.
     private func fetchAndPlay() {
         guard let attachmentId = attachment.id.isEmpty ? nil : attachment.id else {
             failure = .invalid_media
@@ -411,7 +411,7 @@ struct InlineVideoAttachmentView: View {
 
         isLoading = true
         Task {
-            // Retry loop: resolve port at each attempt to pick up daemon restarts.
+            let gatewayBaseUrl = resolveGatewayBaseUrl()
             let maxRetries = 3
             var lastError: VideoPlaybackFailure?
 
@@ -420,14 +420,8 @@ struct InlineVideoAttachmentView: View {
                     try? await Task.sleep(nanoseconds: 1_000_000_000) // 1s between retries
                 }
 
-                guard let port = resolveHttpPort() else {
-                    lastError = .port_missing
-                    log.info("Port missing on attempt \(attempt + 1)/\(maxRetries) for attachment \(attachmentId)")
-                    continue
-                }
-
                 do {
-                    let data = try await fetchAttachmentContent(port: port, attachmentId: attachmentId)
+                    let data = try await fetchAttachmentContent(gatewayBaseUrl: gatewayBaseUrl, attachmentId: attachmentId)
                     let fileURL = safeTempURL()
                     try data.write(to: fileURL)
                     await MainActor.run { isLoading = false }
@@ -436,15 +430,15 @@ struct InlineVideoAttachmentView: View {
                 } catch {
                     log.error("Fetch attempt \(attempt + 1)/\(maxRetries) failed for \(attachmentId): \(error.localizedDescription)")
                     lastError = .fetch_failed(error.localizedDescription)
-                    // Only retry on port_missing; fetch_failed errors are typically
-                    // not transient (4xx/5xx, auth issues) so retrying wastes time.
+                    // fetch_failed errors are typically not transient (4xx/5xx, auth issues)
+                    // so don't retry further.
                     break
                 }
             }
 
             await MainActor.run {
                 isLoading = false
-                failure = lastError ?? .port_missing
+                failure = lastError ?? .fetch_failed("Could not fetch video")
             }
         }
     }
@@ -476,13 +470,14 @@ struct InlineVideoAttachmentView: View {
                 await MainActor.run { isSaving = false }
             }
         } else if attachment.isLazyLoad {
-            guard let port = resolveHttpPort(), let attachmentId = attachment.id.isEmpty ? nil : attachment.id else {
+            guard let attachmentId = attachment.id.isEmpty ? nil : attachment.id else {
                 isSaving = false
                 return
             }
+            let gatewayBaseUrl = resolveGatewayBaseUrl()
             Task {
                 do {
-                    let data = try await fetchAttachmentContent(port: port, attachmentId: attachmentId)
+                    let data = try await fetchAttachmentContent(gatewayBaseUrl: gatewayBaseUrl, attachmentId: attachmentId)
                     try data.write(to: destURL)
                     await MainActor.run { isSaving = false }
                 } catch {
@@ -506,11 +501,12 @@ struct InlineVideoAttachmentView: View {
         if let fileURL = cachedFileURL {
             NSWorkspace.shared.open(fileURL)
         } else if attachment.isLazyLoad {
-            guard let port = resolveHttpPort(), let attachmentId = attachment.id.isEmpty ? nil : attachment.id else { return }
+            guard let attachmentId = attachment.id.isEmpty ? nil : attachment.id else { return }
+            let gatewayBaseUrl = resolveGatewayBaseUrl()
             isLoading = true
             Task {
                 do {
-                    let data = try await fetchAttachmentContent(port: port, attachmentId: attachmentId)
+                    let data = try await fetchAttachmentContent(gatewayBaseUrl: gatewayBaseUrl, attachmentId: attachmentId)
                     let fileURL = safeTempURL()
                     try data.write(to: fileURL)
                     await MainActor.run {
@@ -530,8 +526,16 @@ struct InlineVideoAttachmentView: View {
     }
 }
 
-/// Fetch raw attachment bytes from the daemon HTTP content endpoint.
-private func fetchAttachmentContent(port: Int, attachmentId: String) async throws -> Data {
+/// Resolve the local gateway base URL from the GATEWAY_PORT env var (default 7830).
+private func resolveGatewayBaseUrl() -> String {
+    let envPort = ProcessInfo.processInfo.environment["GATEWAY_PORT"]
+        ?? getenv("GATEWAY_PORT").flatMap({ String(cString: $0) })
+    let port = envPort.flatMap(Int.init) ?? 7830
+    return "http://127.0.0.1:\(port)"
+}
+
+/// Fetch raw attachment bytes via the gateway's runtime proxy.
+private func fetchAttachmentContent(gatewayBaseUrl: String, attachmentId: String) async throws -> Data {
     let tokenBase: String
     if let baseDir = ProcessInfo.processInfo.environment["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines),
        !baseDir.isEmpty {
@@ -545,7 +549,7 @@ private func fetchAttachmentContent(port: Int, attachmentId: String) async throw
           !token.isEmpty else {
         throw URLError(.userAuthenticationRequired)
     }
-    let url = URL(string: "http://localhost:\(port)/v1/attachments/\(attachmentId)/content")!
+    let url = URL(string: "\(gatewayBaseUrl)/v1/attachments/\(attachmentId)/content")!
     var request = URLRequest(url: url)
     request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -129,8 +129,8 @@ struct MainWindowView: View {
     }
 
     private func pageURL(for appId: String) -> URL? {
-        guard let port = daemonClient.httpPort else { return nil }
-        return URL(string: "http://localhost:\(port)/pages/\(appId)")
+        let gatewayBaseUrl = settingsStore.localGatewayTarget
+        return URL(string: "\(gatewayBaseUrl)/pages/\(appId)")
     }
 
     func publishPage(html: String, title: String?, appId: String? = nil) {

--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -180,26 +180,26 @@ struct PairingQRCodeSheet: View {
 
     // MARK: - Registration
 
-    /// Resolve the daemon HTTP port. Prefers the IPC-reported value, falls back
-    /// to `RUNTIME_HTTP_PORT` env var, then the default `7821`.
-    private var resolvedHttpPort: Int {
-        if let port = daemonClient?.httpPort { return port }
-        let envPort = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"]
-            ?? getenv("RUNTIME_HTTP_PORT").flatMap({ String(cString: $0) })
-        return envPort.flatMap(Int.init) ?? 7821
+    /// Resolve the local gateway base URL. Prefers `GATEWAY_PORT` env var,
+    /// falls back to the default gateway port 7830.
+    private var resolvedGatewayBaseUrl: String {
+        let envPort = ProcessInfo.processInfo.environment["GATEWAY_PORT"]
+            ?? getenv("GATEWAY_PORT").flatMap({ String(cString: $0) })
+        let port = envPort.flatMap(Int.init) ?? 7830
+        return "http://127.0.0.1:\(port)"
     }
 
     private func registerWithDaemon() {
         registrationState = .registering
         registrationError = nil
 
-        let port = resolvedHttpPort
+        let baseUrl = resolvedGatewayBaseUrl
 
         let reqId = pairingRequestId
         let secret = pairingSecret
 
         Task {
-            let result = await performRegistrationRequest(port: port, requestId: reqId, secret: secret)
+            let result = await performRegistrationRequest(gatewayBaseUrl: baseUrl, requestId: reqId, secret: secret)
             switch result {
             case .success:
                 registrationState = .registered
@@ -214,9 +214,9 @@ struct PairingQRCodeSheet: View {
     /// Only swaps pairingRequestId, pairingSecret, and registrationState atomically
     /// once the HTTP 200 response comes back. On failure the old QR stays visible.
     private func refreshRegistration(newRequestId: String, newSecret: String) async {
-        let port = resolvedHttpPort
+        let baseUrl = resolvedGatewayBaseUrl
 
-        let result = await performRegistrationRequest(port: port, requestId: newRequestId, secret: newSecret)
+        let result = await performRegistrationRequest(gatewayBaseUrl: baseUrl, requestId: newRequestId, secret: newSecret)
         switch result {
         case .success:
             pairingRequestId = newRequestId
@@ -240,14 +240,14 @@ struct PairingQRCodeSheet: View {
     }
 
     /// Shared HTTP request logic for pairing registration.
-    private func performRegistrationRequest(port: Int, requestId: String, secret: String) async -> Result<Void, RegistrationRequestError> {
+    private func performRegistrationRequest(gatewayBaseUrl: String, requestId: String, secret: String) async -> Result<Void, RegistrationRequestError> {
         let tokenPath = resolveHttpTokenPath()
         let bearerToken: String? = {
             guard let path = tokenPath else { return nil }
             return try? String(contentsOfFile: path, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
         }()
 
-        let url = URL(string: "http://localhost:\(port)/v1/pairing/register")!
+        let url = URL(string: "\(gatewayBaseUrl)/v1/pairing/register")!
 
         var body: [String: Any] = [
             "pairingRequestId": requestId,


### PR DESCRIPTION
Part of #9674. Migrates PairingQRCodeSheet.swift, InlineVideoAttachmentView.swift, and MainWindowView.swift from direct daemon runtime URLs to gateway URLs. Uses the existing gateway port (7830) instead of runtime port (7821).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
