### PR TITLE
fix: guard against vacuous voice bullet regression test

### DIFF
--- a/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
+++ b/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
@@ -134,6 +134,7 @@ describe('guardian-verify-setup skill — voice auto-followup', () => {
       .split('\n')
       .filter((line) => /^\s*-\s+\*\*Voice\*\*/.test(line))
       .join('\n');
+    expect(voiceBullet).not.toHaveLength(0);
     expect(voiceBullet).not.toContain('wait for the user to confirm');
     expect(voiceBullet).not.toContain('ask the user if it worked');
   });


### PR DESCRIPTION
## Summary
- Add positive assertion that voiceBullet is non-empty before negative assertions
- Prevents the regression test from silently passing when no Voice bullet line matches the filter

Addresses review feedback from #9619.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
