### PR TITLE
fix: order pending guardian requests by recency

### DIFF
--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -7,7 +7,7 @@
  * answer resolves the request and all other deliveries are marked answered.
  */
 
-import { and, eq, inArray, lt } from 'drizzle-orm';
+import { and, desc, eq, inArray, lt } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
 import { getLogger } from '../util/logger.js';
@@ -207,6 +207,7 @@ export function getPendingRequestByCallSessionId(callSessionId: string): Guardia
         eq(guardianActionRequests.status, 'pending'),
       ),
     )
+    .orderBy(desc(guardianActionRequests.createdAt))
     .get();
   return row ? rowToRequest(row) : null;
 }


### PR DESCRIPTION
## Summary
- Add ORDER BY created_at DESC to getPendingRequestByCallSessionId query
- Ensures the most recent pending request is returned when multiple exist for the same call session
- Prevents the timeout path from expiring the wrong request

Addresses review feedback from #9621.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
