### PR TITLE
fix: safe-do feedback loop should wait for pending reviews

### DIFF
--- a/.claude/commands/safe-do.md
+++ b/.claude/commands/safe-do.md
@@ -131,7 +131,7 @@ The `check-pr-reviews` script reports **cumulative** review status — it counts
    Log: `"Re-requested reviews from Codex and Devin on PR #$PR_NUMBER (cycle <cycle-counter>/3, commit $LATEST_COMMIT)."`
 
 5. **Wait for fresh reviews**: After fixes are pushed, poll for **new** reviews posted after `last_fix_push_time`:
-   - Poll every 60 seconds for up to **3 minutes**.
+   - Poll every 60 seconds for up to **10 minutes**.
    - On each poll, use `gh api` to check for reviews and inline comments posted after `last_fix_push_time`:
      ```bash
      gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/reviews" \
@@ -143,9 +143,12 @@ The `check-pr-reviews` script reports **cumulative** review status — it counts
      - If aggregate status is `approved`, proceed to Step 6.
      - If aggregate status is `changes_requested`, return to step 2 (which checks the cycle limit).
      - If aggregate status is `pending` or `rate_limited`, continue polling.
-   - If **3 minutes** pass with no new reviews (zero new reviews/comments since `last_fix_push_time`), proceed to Step 6. Log: `"No new reviews within 3 minutes after fixes pushed. Proceeding."`
+   - If no new reviews/comments exist yet, run `.claude/check-pr-reviews $PR_NUMBER` to check per-reviewer statuses:
+     - If **both** `codex.status` and `devin.status` have responded (i.e., neither is `pending`), proceed to Step 6.
+     - If **either** reviewer is still `pending`, **continue polling** — do not exit the loop. Review bots can take longer than 3 minutes to respond.
+   - If **10 minutes** pass with no new reviews and at least one reviewer is still pending, proceed to Step 6. Log: `"Timed out after 10 minutes waiting for reviewer responses. Proceeding with pending reviews."`
 
-Repeat steps 1-5 until the exit condition: either `approved` aggregate status, 3-minute timeout with no new reviews after a fix push, or the cycle counter has reached 3.
+Repeat steps 1-5 until the exit condition: either `approved` aggregate status, both reviewers have responded, 10-minute timeout after a fix push, or the cycle counter has reached 3.
 
 #### 5c. Check for and resolve merge conflicts with main
 


### PR DESCRIPTION
## Summary
- Fix safe-do feedback loop to continue polling when reviews are still pending
- Prevent premature exit when review bots take longer than 3 minutes to respond
- Only exit when both reviewers have responded or a longer timeout is reached

Addresses review feedback from #9642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
