### PR TITLE
fix: guardian intent routing improvements

### DIFF
--- a/assistant/src/daemon/guardian-verification-intent.ts
+++ b/assistant/src/daemon/guardian-verification-intent.ts
@@ -97,7 +97,7 @@ export function resolveGuardianVerificationIntent(text: string): GuardianVerific
   // Strip fillers for pattern matching but keep original for context
   const withoutFillers = trimmed.replace(FILLER_PATTERN, '').replace(/\s{2,}/g, ' ').trim();
 
-  if (!isDirectSetupIntent(trimmed) && !isDirectSetupIntent(withoutFillers)) {
+  if (!isDirectSetupIntent(withoutFillers)) {
     return { kind: 'none' };
   }
 

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -249,12 +249,15 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
     session.preactivatedSkillIds = [slashResult.skillId];
   }
 
-  // Guardian verification intent interception for queued messages
+  // Guardian verification intent interception for queued messages.
+  // Preserve the original user content for persistence; only the agent
+  // loop receives the rewritten instruction.
+  let agentLoopContent = resolvedContent;
   if (slashResult.kind === 'passthrough') {
     const guardianIntent = resolveGuardianVerificationIntent(resolvedContent);
     if (guardianIntent.kind === 'direct_setup') {
       log.info({ conversationId: session.conversationId, channelHint: guardianIntent.channelHint }, 'Guardian verification intent intercepted in queue — forcing skill flow');
-      resolvedContent = guardianIntent.rewrittenContent;
+      agentLoopContent = guardianIntent.rewrittenContent;
       session.preactivatedSkillIds = ['guardian-verify-setup'];
     }
   }
@@ -312,7 +315,7 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
   // Fire-and-forget: persistUserMessage set session.processing = true
   // so subsequent messages will still be enqueued.
   // runAgentLoop's finally block will call drainQueue when this run completes.
-  session.runAgentLoop(resolvedContent, userMessageId, next.onEvent,
+  session.runAgentLoop(agentLoopContent, userMessageId, next.onEvent,
     next.isInteractive !== undefined ? { isInteractive: next.isInteractive } : undefined,
   ).catch((err) => {
     const message = err instanceof Error ? err.message : String(err);
@@ -464,11 +467,14 @@ export async function processMessage(
   // Guardian verification intent interception — force direct guardian
   // verification requests into the guardian-verify-setup skill flow on
   // the first turn, avoiding conceptual preambles from the agent.
+  // We keep the original user content for persistence and use the
+  // rewritten content only for the agent loop instruction.
+  let agentLoopContent = resolvedContent;
   if (slashResult.kind === 'passthrough') {
     const guardianIntent = resolveGuardianVerificationIntent(resolvedContent);
     if (guardianIntent.kind === 'direct_setup') {
       log.info({ conversationId: session.conversationId, channelHint: guardianIntent.channelHint }, 'Guardian verification intent intercepted — forcing skill flow');
-      resolvedContent = guardianIntent.rewrittenContent;
+      agentLoopContent = guardianIntent.rewrittenContent;
       session.preactivatedSkillIds = ['guardian-verify-setup'];
     }
   }
@@ -508,7 +514,7 @@ export async function processMessage(
       });
   }
 
-  await session.runAgentLoop(resolvedContent, userMessageId, onEvent,
+  await session.runAgentLoop(agentLoopContent, userMessageId, onEvent,
     options?.isInteractive !== undefined ? { isInteractive: options.isInteractive } : undefined,
   );
   return userMessageId;


### PR DESCRIPTION
## Summary
- Use normalized (filler-stripped) text for direct guardian pattern matching instead of trimmed
- Fix regex bug: `phone\s+(?:number)?` → `phone(?:\s+number)?` so 'verify my phone' matches
- Preserve original user message content when forcing guardian setup flow instead of overwriting with fixed string

Addresses review feedback from #9616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
