### PR TITLE
fix: restore guardian binding on outbound verification success

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -2740,9 +2740,10 @@ describe('outbound SMS verification', () => {
 
     expect(result.success).toBe(true);
     if (result.success) {
-      // Identity-bound outbound sessions produce trusted_contact verification
-      // (no guardian binding created)
-      expect(result.verificationType).toBe('trusted_contact');
+      // Guardian outbound sessions (no verificationPurpose override) create
+      // guardian bindings on success
+      expect(result.verificationType).toBe('guardian');
+      expect(result.bindingId).toBeDefined();
     }
   });
 

--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -388,6 +388,7 @@ describe('trusted contact activated notification signal', () => {
       expectedChatId: 'chat-123',
       identityBindingStatus: 'bound',
       destinationAddress: 'chat-123',
+      verificationPurpose: 'trusted_contact',
     });
 
     // Requester enters the verification code
@@ -460,6 +461,7 @@ describe('trusted contact activated notification signal', () => {
       expectedChatId: 'chat-123',
       identityBindingStatus: 'bound',
       destinationAddress: 'chat-123',
+      verificationPurpose: 'trusted_contact',
     });
 
     const verifyReq = buildInboundRequest({

--- a/assistant/src/__tests__/trusted-contact-multichannel.test.ts
+++ b/assistant/src/__tests__/trusted-contact-multichannel.test.ts
@@ -234,6 +234,7 @@ for (const config of CHANNEL_CONFIGS) {
         expectedChatId: config.externalChatId,
         identityBindingStatus: 'bound',
         destinationAddress: config.externalChatId,
+        verificationPurpose: 'trusted_contact',
       });
 
       const result = validateAndConsumeChallenge(
@@ -324,6 +325,7 @@ describe('SMS identity binding with E.164 phone numbers', () => {
       expectedChatId: phone,
       identityBindingStatus: 'bound',
       destinationAddress: phone,
+      verificationPurpose: 'trusted_contact',
     });
 
     // Verify with matching phone identity

--- a/assistant/src/__tests__/trusted-contact-verification.test.ts
+++ b/assistant/src/__tests__/trusted-contact-verification.test.ts
@@ -95,6 +95,7 @@ describe('trusted contact verification → member activation', () => {
       expectedChatId: 'requester-chat-123',
       identityBindingStatus: 'bound',
       destinationAddress: 'requester-chat-123',
+      verificationPurpose: 'trusted_contact',
     });
 
     // Requester enters the 6-digit code
@@ -152,6 +153,7 @@ describe('trusted contact verification → member activation', () => {
       expectedChatId: 'requester-chat-456',
       identityBindingStatus: 'bound',
       destinationAddress: 'requester-chat-456',
+      verificationPurpose: 'trusted_contact',
     });
 
     validateAndConsumeChallenge(
@@ -192,6 +194,7 @@ describe('trusted contact verification → member activation', () => {
       expectedChatId: 'chat-cross-test',
       identityBindingStatus: 'bound',
       destinationAddress: 'chat-cross-test',
+      verificationPurpose: 'trusted_contact',
     });
 
     validateAndConsumeChallenge(
@@ -260,6 +263,7 @@ describe('trusted contact verification → member activation', () => {
       expectedChatId: 'chat-revoked',
       identityBindingStatus: 'bound',
       destinationAddress: 'chat-revoked',
+      verificationPurpose: 'trusted_contact',
     });
 
     // Requester enters the new code
@@ -312,6 +316,7 @@ describe('trusted contact verification → member activation', () => {
       expectedChatId: 'requester-chat-789',
       identityBindingStatus: 'bound',
       destinationAddress: 'requester-chat-789',
+      verificationPurpose: 'trusted_contact',
     });
 
     const result = validateAndConsumeChallenge(

--- a/assistant/src/memory/channel-guardian-store.ts
+++ b/assistant/src/memory/channel-guardian-store.ts
@@ -28,6 +28,7 @@ export type ChallengeStatus = 'pending' | 'consumed' | 'expired' | 'revoked';
 export type SessionStatus = 'pending' | 'consumed' | 'pending_bootstrap' | 'awaiting_response' | 'verified' | 'expired' | 'revoked' | 'locked';
 export type IdentityBindingStatus = 'pending_bootstrap' | 'bound';
 export type ApprovalRequestStatus = 'pending' | 'approved' | 'denied' | 'expired' | 'cancelled';
+export type VerificationPurpose = 'guardian' | 'trusted_contact';
 
 export interface GuardianBinding {
   id: string;
@@ -66,6 +67,8 @@ export interface VerificationChallenge {
   // Session configuration
   codeDigits: number;
   maxAttempts: number;
+  // Distinguishes guardian verification from trusted contact verification
+  verificationPurpose: VerificationPurpose;
   // Telegram bootstrap deep-link token hash
   bootstrapTokenHash: string | null;
   createdAt: number;
@@ -134,6 +137,7 @@ function rowToChallenge(row: typeof channelGuardianVerificationChallenges.$infer
     nextResendAt: row.nextResendAt ?? null,
     codeDigits: row.codeDigits ?? 6,
     maxAttempts: row.maxAttempts ?? 3,
+    verificationPurpose: (row.verificationPurpose as VerificationPurpose) ?? 'guardian',
     bootstrapTokenHash: row.bootstrapTokenHash ?? null,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
@@ -413,6 +417,7 @@ export function createVerificationSession(params: {
   destinationAddress?: string | null;
   codeDigits?: number;
   maxAttempts?: number;
+  verificationPurpose?: VerificationPurpose;
   bootstrapTokenHash?: string | null;
 }): VerificationChallenge {
   const db = getDb();
@@ -450,6 +455,7 @@ export function createVerificationSession(params: {
     nextResendAt: null,
     codeDigits: params.codeDigits ?? 6,
     maxAttempts: params.maxAttempts ?? 3,
+    verificationPurpose: params.verificationPurpose ?? 'guardian',
     bootstrapTokenHash: params.bootstrapTokenHash ?? null,
     createdAt: now,
     updatedAt: now,

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -19,6 +19,7 @@ import {
   migrateCallSessionMode,
   migrateChannelInboundDeliveredSegments,
   migrateGuardianBootstrapToken,
+  migrateGuardianVerificationPurpose,
   migrateGuardianVerificationSessions,
   migrateMessagesFtsBackfill,
   runComplexMigrations,
@@ -70,6 +71,9 @@ export function initializeDb(): void {
 
   // 11c. Guardian bootstrap token hash column (Telegram deep-link flow)
   migrateGuardianBootstrapToken(database);
+
+  // 11d. Guardian verification purpose discriminator (guardian vs trusted_contact)
+  migrateGuardianVerificationPurpose(database);
 
   // 12. Media assets
   createMediaAssetsTables(database);

--- a/assistant/src/memory/migrations/030-guardian-verification-purpose.ts
+++ b/assistant/src/memory/migrations/030-guardian-verification-purpose.ts
@@ -1,0 +1,17 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Add verification_purpose column to channel_guardian_verification_challenges.
+ * Distinguishes guardian outbound verification from trusted contact verification
+ * so the consume path knows whether to create a guardian binding.
+ *
+ * Uses ALTER TABLE ADD COLUMN which is a no-op if the column already
+ * exists (caught by try/catch).
+ */
+export function migrateGuardianVerificationPurpose(database: DrizzleDb): void {
+  try {
+    database.run(
+      /*sql*/ `ALTER TABLE channel_guardian_verification_challenges ADD COLUMN verification_purpose TEXT DEFAULT 'guardian'`,
+    );
+  } catch { /* already exists */ }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -29,6 +29,7 @@ export { migrateGuardianBootstrapToken } from './027-guardian-bootstrap-token.js
 export { migrateNotificationDeliveryPairingColumns } from './027-notification-delivery-pairing-columns.js';
 export { migrateCallSessionMode } from './028-call-session-mode.js';
 export { migrateChannelInboundDeliveredSegments } from './029-channel-inbound-delivered-segments.js';
+export { migrateGuardianVerificationPurpose } from './030-guardian-verification-purpose.js';
 export { createCoreTables } from './100-core-tables.js';
 export { createWatchersAndLogsTables } from './101-watchers-and-logs.js';
 export { addCoreColumns } from './102-alter-table-columns.js';

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -658,6 +658,8 @@ export const channelGuardianVerificationChallenges = sqliteTable('channel_guardi
   // Session configuration
   codeDigits: integer('code_digits').default(6),
   maxAttempts: integer('max_attempts').default(3),
+  // Distinguishes guardian verification from trusted contact verification
+  verificationPurpose: text('verification_purpose').default('guardian'),
   // Telegram bootstrap deep-link token hash
   bootstrapTokenHash: text('bootstrap_token_hash'),
   createdAt: integer('created_at').notNull(),

--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -9,7 +9,7 @@
 import { createHash,randomBytes } from 'crypto';
 import { v4 as uuid } from 'uuid';
 
-import type { GuardianBinding, IdentityBindingStatus,SessionStatus, VerificationChallenge } from '../memory/channel-guardian-store.js';
+import type { GuardianBinding, IdentityBindingStatus, SessionStatus, VerificationChallenge, VerificationPurpose } from '../memory/channel-guardian-store.js';
 import {
   bindSessionIdentity as storeBindSessionIdentity,
   consumeChallenge,
@@ -273,11 +273,12 @@ export function validateAndConsumeChallenge(
   // Reset the rate-limit counter on success
   resetRateLimit(assistantId, channel, actorExternalUserId, actorChatId);
 
-  // Identity-bound outbound sessions (from the trusted contact access flow)
-  // should NOT create a guardian binding — the requester is becoming a trusted
-  // contact, not a guardian. Only unbound inbound challenges (guardian
-  // verification) create guardian bindings.
-  if (hasExpectedIdentity && challenge.identityBindingStatus === 'bound') {
+  // Trusted contact verification sessions (created by the access request
+  // approval flow) should NOT create a guardian binding — the requester is
+  // becoming a trusted contact, not a guardian. The explicit verificationPurpose
+  // field distinguishes this from guardian outbound verification which also uses
+  // identity-bound sessions.
+  if (challenge.verificationPurpose === 'trusted_contact') {
     return { success: true, verificationType: 'trusted_contact' };
   }
 
@@ -405,6 +406,7 @@ export function createOutboundSession(params: {
   maxAttempts?: number;
   sessionId?: string;
   bootstrapTokenHash?: string;
+  verificationPurpose?: VerificationPurpose;
 }): CreateOutboundSessionResult {
   // Use high-entropy hex for unbound bootstrap sessions to prevent brute-force;
   // 6-digit numeric codes are only safe when identity is already bound.
@@ -430,6 +432,7 @@ export function createOutboundSession(params: {
     destinationAddress: params.destinationAddress,
     codeDigits: params.codeDigits,
     maxAttempts: params.maxAttempts,
+    verificationPurpose: params.verificationPurpose,
     bootstrapTokenHash: params.bootstrapTokenHash,
   });
 

--- a/assistant/src/runtime/routes/access-request-decision.ts
+++ b/assistant/src/runtime/routes/access-request-decision.ts
@@ -77,7 +77,8 @@ export function handleAccessRequestDecision(
 
   // On approve: create an identity-bound outbound verification session.
   // The session is bound to the requester's identity on the same channel
-  // so only the original requester can consume the code.
+  // so only the original requester can consume the code. Mark as
+  // trusted_contact so the consume path skips guardian binding creation.
   const session = createOutboundSession({
     assistantId: approval.assistantId,
     channel: approval.channel,
@@ -85,6 +86,7 @@ export function handleAccessRequestDecision(
     expectedChatId: approval.requesterChatId,
     identityBindingStatus: 'bound',
     destinationAddress: approval.requesterChatId,
+    verificationPurpose: 'trusted_contact',
   });
 
   return {


### PR DESCRIPTION
The M4 trusted contact PR incorrectly classified all identity-bound verification sessions as trusted contact verifications, which broke outbound guardian verification (SMS/Telegram/voice). Adds an explicit `verificationPurpose` discriminator field to the verification session to distinguish trusted contact verification from guardian verification so both flows work correctly.

**Changes:**
- Added `verification_purpose` column to `channel_guardian_verification_challenges` table (defaults to `'guardian'`)
- Updated `createOutboundSession` to accept optional `verificationPurpose` parameter
- Updated `access-request-decision.ts` to set `verificationPurpose: 'trusted_contact'` when creating sessions for the trusted contact flow
- Changed the discriminator in `validateAndConsumeChallenge` from the fragile `hasExpectedIdentity && identityBindingStatus === 'bound'` heuristic to an explicit `challenge.verificationPurpose === 'trusted_contact'` check
- Updated tests to use the explicit discriminator

Part of #9432
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
