### PR TITLE
feat: replace timezone free-text input with searchable picker popover

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -21,14 +21,25 @@ extension ChatBubble {
                 MarkdownSegmentView(segments: segments, isStreaming: streaming)
             } else {
                 let attributed = Self.cachedInlineMarkdown(for: segmentText, isStreaming: streaming)
-                Text(attributed)
-                    .font(.system(size: 13 * conversationZoomScale))
-                    .lineSpacing(3)
-                    .foregroundColor(VColor.textPrimary)
-                    .tint(VColor.accent)
-                    .textSelection(streaming ? .disabled : .enabled)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .frame(maxWidth: 520, alignment: .leading)
+                if streaming {
+                    Text(attributed)
+                        .font(.system(size: 13 * conversationZoomScale))
+                        .lineSpacing(3)
+                        .foregroundColor(VColor.textPrimary)
+                        .tint(VColor.accent)
+                        .textSelection(.disabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: 520, alignment: .leading)
+                } else {
+                    Text(attributed)
+                        .font(.system(size: 13 * conversationZoomScale))
+                        .lineSpacing(3)
+                        .foregroundColor(VColor.textPrimary)
+                        .tint(VColor.accent)
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: 520, alignment: .leading)
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -10,8 +10,7 @@ struct SettingsAppearanceTab: View {
     @State private var isRecordingQuickInputHotkey = false
     @State private var shortcutMonitor: Any?
     @State private var shortcutConflictWarning: String?
-    @State private var timezoneDraft = ""
-    @State private var timezoneValidationError: String?
+    @State private var showTimezonePicker = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
@@ -44,36 +43,39 @@ struct SettingsAppearanceTab: View {
                 Divider()
                     .background(VColor.surfaceBorder)
 
-                HStack(alignment: .top, spacing: VSpacing.sm) {
+                HStack(alignment: .center, spacing: VSpacing.sm) {
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         Text("User timezone")
                             .font(VFont.body)
                             .foregroundColor(VColor.textSecondary)
-                        Text("IANA identifier (e.g. America/New_York). Leave empty to use profile memory, then assistant host timezone.")
+                        Text("Timezone used for time-aware responses.")
                             .font(VFont.caption)
                             .foregroundColor(VColor.textMuted)
                     }
                     Spacer()
-                    TextField("America/New_York", text: $timezoneDraft)
-                        .vInputStyle()
-                        .frame(width: 220)
-                        .onSubmit {
-                            saveTimezone()
+                    if let tz = store.userTimezone {
+                        Text(tz)
+                            .font(VFont.mono)
+                            .foregroundColor(VColor.textPrimary)
+                    } else {
+                        Text("Not set")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    VButton(label: store.userTimezone != nil ? "Change" : "Set", style: .tertiary) {
+                        showTimezonePicker = true
+                    }
+                    .popover(isPresented: $showTimezonePicker, arrowEdge: .bottom) {
+                        TimezonePicker { selected in
+                            store.saveUserTimezone(selected)
+                            showTimezonePicker = false
                         }
-                    VButton(label: "Save", style: .tertiary) {
-                        saveTimezone()
                     }
-                    VButton(label: "Clear", style: .tertiary) {
-                        store.clearUserTimezone()
-                        timezoneDraft = ""
-                        timezoneValidationError = nil
+                    if store.userTimezone != nil {
+                        VButton(label: "Clear", style: .tertiary) {
+                            store.clearUserTimezone()
+                        }
                     }
-                }
-
-                if let timezoneValidationError {
-                    Text(timezoneValidationError)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.warning)
                 }
 
             }
@@ -235,22 +237,9 @@ struct SettingsAppearanceTab: View {
             .padding(VSpacing.lg)
             .vCard(background: VColor.surfaceSubtle)
         }
-        .onAppear {
-            timezoneDraft = store.userTimezone ?? ""
-        }
-        .onChange(of: store.userTimezone) { updated in
-            timezoneDraft = updated ?? ""
-        }
     }
 
     // MARK: - Shortcut Recording
-
-    private func saveTimezone() {
-        timezoneValidationError = store.saveUserTimezone(timezoneDraft)
-        if timezoneValidationError == nil {
-            timezoneDraft = store.userTimezone ?? ""
-        }
-    }
 
     private func startRecording() {
         startRecordingShortcut { shortcut, _ in

--- a/clients/macos/vellum-assistant/Features/Settings/TimezonePicker.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TimezonePicker.swift
@@ -1,0 +1,186 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// A popover-based timezone picker that shows a searchable list of IANA timezones
+/// with a one-click "Use system timezone" option.
+struct TimezonePicker: View {
+    let onSelect: (String) -> Void
+    @State private var searchText = ""
+
+    private static let timezoneEntries: [TimezoneEntry] = {
+        TimeZone.knownTimeZoneIdentifiers.sorted().map { identifier in
+            let tz = TimeZone(identifier: identifier)!
+            let abbreviation = tz.abbreviation() ?? ""
+            let offset = tz.formattedUTCOffset()
+            let friendlyName = tz.friendlyName()
+            return TimezoneEntry(
+                identifier: identifier,
+                friendlyName: friendlyName,
+                abbreviation: abbreviation,
+                offset: offset,
+                searchText: "\(identifier) \(friendlyName) \(abbreviation)".lowercased()
+            )
+        }
+    }()
+
+    private var filteredEntries: [TimezoneEntry] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if query.isEmpty {
+            return Self.timezoneEntries
+        }
+        return Self.timezoneEntries.filter { $0.searchText.contains(query) }
+    }
+
+    private var systemTimezoneIdentifier: String {
+        TimeZone.current.identifier
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Search field
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundColor(VColor.textMuted)
+                    .font(.system(size: 12))
+                TextField("Search timezones...", text: $searchText)
+                    .textFieldStyle(.plain)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                if !searchText.isEmpty {
+                    Button {
+                        searchText = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(VColor.textMuted)
+                            .font(.system(size: 12))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+            .background(VColor.inputBackground)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+            )
+            .padding(.horizontal, VSpacing.md)
+            .padding(.top, VSpacing.md)
+            .padding(.bottom, VSpacing.sm)
+
+            // "Use system timezone" button
+            Button {
+                onSelect(systemTimezoneIdentifier)
+            } label: {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "desktopcomputer")
+                        .foregroundColor(VColor.accent)
+                        .font(.system(size: 12))
+                    Text("Use system: \(systemTimezoneIdentifier)")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.accent)
+                    Spacer()
+                }
+                .padding(.horizontal, VSpacing.md)
+                .padding(.vertical, VSpacing.sm)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .background(Color.clear)
+            .onHover { hovering in
+                if hovering {
+                    NSCursor.pointingHand.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
+
+            Divider()
+                .background(VColor.surfaceBorder)
+                .padding(.horizontal, VSpacing.md)
+
+            // Scrollable timezone list
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(filteredEntries, id: \.identifier) { entry in
+                        Button {
+                            onSelect(entry.identifier)
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(entry.identifier)
+                                        .font(VFont.body)
+                                        .foregroundColor(VColor.textPrimary)
+                                    if !entry.friendlyName.isEmpty {
+                                        Text("\(entry.friendlyName) (\(entry.offset))")
+                                            .font(VFont.caption)
+                                            .foregroundColor(VColor.textMuted)
+                                    }
+                                }
+                                Spacer()
+                            }
+                            .padding(.horizontal, VSpacing.md)
+                            .padding(.vertical, VSpacing.xs)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .onHover { hovering in
+                            if hovering {
+                                NSCursor.pointingHand.push()
+                            } else {
+                                NSCursor.pop()
+                            }
+                        }
+                    }
+
+                    if filteredEntries.isEmpty {
+                        Text("No matching timezones")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                            .padding(.horizontal, VSpacing.md)
+                            .padding(.vertical, VSpacing.md)
+                    }
+                }
+            }
+            .frame(maxHeight: 300)
+        }
+        .frame(width: 320)
+        .background(VColor.surface)
+    }
+}
+
+// MARK: - Supporting Types
+
+private struct TimezoneEntry {
+    let identifier: String
+    let friendlyName: String
+    let abbreviation: String
+    let offset: String
+    let searchText: String
+}
+
+// MARK: - TimeZone Helpers
+
+private extension TimeZone {
+    /// Returns a human-readable name derived from the IANA identifier.
+    /// e.g. "America/New_York" → "New York", "Europe/London" → "London"
+    func friendlyName() -> String {
+        let parts = identifier.split(separator: "/")
+        guard let city = parts.last else { return "" }
+        return city.replacingOccurrences(of: "_", with: " ")
+    }
+
+    /// Returns a formatted UTC offset string like "UTC-5" or "UTC+5:30".
+    func formattedUTCOffset() -> String {
+        let seconds = secondsFromGMT()
+        if seconds == 0 { return "UTC" }
+        let hours = seconds / 3600
+        let minutes = abs(seconds) % 3600 / 60
+        let sign = hours >= 0 ? "+" : ""
+        if minutes == 0 {
+            return "UTC\(sign)\(hours)"
+        }
+        return "UTC\(sign)\(hours):\(String(format: "%02d", minutes))"
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the free-text timezone input + Save/Clear buttons with a clean display row showing current value (or "Not set") and Set/Change/Clear buttons
- "Set" or "Change" opens a popover with a searchable list of all IANA timezones and a one-click "Use system" button that populates from the Mac's timezone
- Selecting any timezone saves immediately and dismisses the popover — invalid input is impossible since all options come from `TimeZone.knownTimeZoneIdentifiers`
- Also fixes a pre-existing Swift build error where a ternary mixed `DisabledTextSelectability` and `EnabledTextSelectability` types

## Original prompt
Implement the timezone picker UX redesign in the macOS settings — replace the free-text IANA timezone input with a popover-based searchable picker with a "Use system timezone" shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
