### PR TITLE
fix: address gateway-only guard test feedback from PR #9684

### DIFF
--- a/assistant/src/__tests__/gateway-only-guard.test.ts
+++ b/assistant/src/__tests__/gateway-only-guard.test.ts
@@ -20,7 +20,7 @@ const ALLOWLIST = new Set([
   // --- Test files are always allowed (matched by directory/suffix below) ---
 
   // --- Gateway internals (gateway calls runtime directly) ---
-  // Matched by prefix check below: gateway/src/
+  // Matched by prefix check below: gateway/
 
   // --- Intentional local daemon-control paths ---
   'clients/shared/IPC/DaemonClient.swift',
@@ -30,7 +30,6 @@ const ALLOWLIST = new Set([
 
   // --- Documentation and comments that mention the port for explanatory purposes ---
   'AGENTS.md', // documents the gateway-only rule itself
-  'gateway/ARCHITECTURE.md', // gateway architecture docs referencing runtime proxy target
   'assistant/src/runtime/middleware/twilio-validation.ts', // comment explaining proxy URL rewriting
 ]);
 
@@ -51,7 +50,7 @@ function isTestFile(filePath: string): boolean {
 }
 
 function isGatewayInternal(filePath: string): boolean {
-  return filePath.startsWith('gateway/src/');
+  return filePath.startsWith('gateway/');
 }
 
 describe('gateway-only API consumption guard', () => {


### PR DESCRIPTION
Address reviewer feedback on the gateway-only guard test: broaden isGatewayInternal() to match all gateway/ files (not just gateway/src/), and remove the now-redundant gateway/ARCHITECTURE.md ALLOWLIST entry.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
