### PR TITLE
fix: re-trigger reviews after safe-do rebase

### DIFF
--- a/.claude/commands/safe-do.md
+++ b/.claude/commands/safe-do.md
@@ -226,6 +226,37 @@ git merge-tree --write-tree origin/$PR_BRANCH origin/main > /dev/null 2>&1
 
 Log: `"Rebased PR branch on latest main to resolve merge conflicts."`
 
+**Step 3: Re-trigger reviews after rebase.**
+
+Since the rebase rewrites commits (and conflict resolution may change logic), previously approved reviews may no longer reflect the actual diff. Re-request reviews before proceeding:
+
+1. Post review request comments:
+   ```bash
+   gh pr comment $PR_NUMBER --body "@codex review this PR again — it was rebased onto main to resolve merge conflicts"
+   gh pr comment $PR_NUMBER --body "@devin review this PR again — it was rebased onto main to resolve merge conflicts"
+   ```
+   Log: `"Re-requested reviews from Codex and Devin after rebase on PR #$PR_NUMBER."`
+
+2. Record the current UTC time as `last_fix_push_time` (e.g., `date -u +%Y-%m-%dT%H:%M:%SZ`).
+
+3. Wait for fresh reviews: Poll for **new** reviews posted after `last_fix_push_time`:
+   - Poll every 60 seconds for up to **10 minutes**.
+   - On each poll, use `gh api` to check for reviews and inline comments posted after `last_fix_push_time`:
+     ```bash
+     gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/reviews" \
+       --jq '[.[] | select(.submitted_at > "'$last_fix_push_time'")] | length'
+     gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/comments" \
+       --jq '[.[] | select(.created_at > "'$last_fix_push_time'")] | length'
+     ```
+   - If new reviews exist, run `.claude/check-pr-reviews $PR_NUMBER` and derive the aggregate status:
+     - If aggregate status is `approved`, proceed to Step 6.
+     - If aggregate status is `changes_requested`, return to the feedback loop (Step 5b, step 2 — which checks the cycle limit).
+     - If aggregate status is `pending` or `rate_limited`, continue polling.
+   - If no new reviews/comments exist yet, run `.claude/check-pr-reviews $PR_NUMBER` to check per-reviewer statuses:
+     - If **both** `codex.status` and `devin.status` have responded (i.e., neither is `pending`), proceed to Step 6.
+     - If **either** reviewer is still `pending`, **continue polling**.
+   - If **10 minutes** pass with no new reviews and at least one reviewer is still pending, proceed to Step 6. Log: `"Timed out after 10 minutes waiting for post-rebase reviews. Proceeding with pending reviews."`
+
 Proceed to Step 6.
 
 #### Feedback agent prompt


### PR DESCRIPTION
## Summary
- After conflict resolution rebase + force-push, re-trigger reviews via @codex review comment
- Wait for fresh reviews before proceeding to merge step
- Ensures post-rebase changes are reviewed rather than relying on stale pre-rebase approvals

Addresses review feedback from #9651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
