### PR TITLE
M6: Execute Callback/Message Actions + Guardian Completion Replies

### DIFF
--- a/assistant/src/__tests__/guardian-action-followup-executor.test.ts
+++ b/assistant/src/__tests__/guardian-action-followup-executor.test.ts
@@ -1,0 +1,353 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'guardian-action-followup-executor-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  readHttpToken: () => 'test-token',
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Track SMS deliveries and call starts for assertions
+const deliveredSms: Array<{ url: string; chatId: string; text: string }> = [];
+const startedCalls: Array<{ phoneNumber: string; task: string; conversationId: string }> = [];
+let mockStartCallResult: { ok: true; session: { id: string }; callSid: string; callerIdentityMode: string } | { ok: false; error: string } = {
+  ok: true, session: { id: 'mock-call-session' }, callSid: 'CA-mock', callerIdentityMode: 'assistant_number',
+};
+
+mock.module('../runtime/gateway-client.js', () => ({
+  deliverChannelReply: async (url: string, payload: { chatId: string; text?: string }) => {
+    deliveredSms.push({ url, chatId: payload.chatId, text: payload.text ?? '' });
+  },
+}));
+
+mock.module('../calls/call-domain.js', () => ({
+  startCall: async (input: { phoneNumber: string; task: string; conversationId: string }) => {
+    startedCalls.push(input);
+    return mockStartCallResult;
+  },
+}));
+
+mock.module('../config/env.js', () => ({
+  getGatewayInternalBaseUrl: () => 'http://127.0.0.1:7830',
+}));
+
+// Mock conversation-key-store for call_back conversation creation
+let conversationCounter = 0;
+mock.module('../memory/conversation-key-store.js', () => ({
+  getOrCreateConversation: () => ({
+    conversationId: `mock-conv-${++conversationCounter}`,
+    created: true,
+  }),
+}));
+
+import { createCallSession, createPendingQuestion } from '../calls/call-store.js';
+import { initializeDb, resetDb } from '../memory/db.js';
+import { getDb } from '../memory/db.js';
+import {
+  createGuardianActionDelivery,
+  createGuardianActionRequest,
+  getGuardianActionRequest,
+  markTimedOutWithReason,
+  progressFollowupState,
+  startFollowupFromExpiredRequest,
+  updateDeliveryStatus,
+} from '../memory/guardian-action-store.js';
+import { executeFollowupAction } from '../runtime/guardian-action-followup-executor.js';
+import { resolveCounterparty } from '../runtime/guardian-action-followup-executor.js';
+import { conversations } from '../memory/schema.js';
+
+initializeDb();
+
+function ensureConversation(id: string): void {
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations).values({
+    id,
+    title: `Conversation ${id}`,
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+}
+
+function resetTables(): void {
+  const db = getDb();
+  db.run('DELETE FROM guardian_action_deliveries');
+  db.run('DELETE FROM guardian_action_requests');
+  db.run('DELETE FROM call_pending_questions');
+  db.run('DELETE FROM call_events');
+  db.run('DELETE FROM call_sessions');
+  db.run('DELETE FROM messages');
+  db.run('DELETE FROM conversations');
+  deliveredSms.length = 0;
+  startedCalls.length = 0;
+  conversationCounter = 0;
+  mockStartCallResult = {
+    ok: true, session: { id: 'mock-call-session' }, callSid: 'CA-mock', callerIdentityMode: 'assistant_number',
+  };
+}
+
+/**
+ * Create a request in `dispatching` state ready for the executor.
+ * The call session has fromNumber='+15550001111' (the counterparty).
+ */
+function createDispatchingRequest(convId: string, action: 'call_back' | 'message_back') {
+  ensureConversation(convId);
+  const session = createCallSession({
+    conversationId: convId,
+    provider: 'twilio',
+    fromNumber: '+15550001111',
+    toNumber: '+15550002222',
+  });
+  const pq = createPendingQuestion(session.id, 'What is the gate code?');
+  const request = createGuardianActionRequest({
+    kind: 'ask_guardian',
+    sourceChannel: 'voice',
+    sourceConversationId: convId,
+    callSessionId: session.id,
+    pendingQuestionId: pq.id,
+    questionText: pq.questionText,
+    expiresAt: Date.now() - 10_000,
+  });
+
+  const deliveryConvId = `delivery-conv-${request.id}`;
+  ensureConversation(deliveryConvId);
+  const delivery = createGuardianActionDelivery({
+    requestId: request.id,
+    destinationChannel: 'telegram',
+    destinationChatId: 'chat-123',
+    destinationExternalUserId: 'user-456',
+    destinationConversationId: deliveryConvId,
+  });
+  updateDeliveryStatus(delivery.id, 'sent');
+
+  // Expire the request
+  markTimedOutWithReason(request.id, 'call_timeout');
+
+  // Start follow-up
+  startFollowupFromExpiredRequest(request.id, 'The gate code is 1234');
+
+  // Progress to dispatching with the given action
+  progressFollowupState(request.id, 'dispatching', action);
+
+  return { request: getGuardianActionRequest(request.id)!, delivery, callSession: session };
+}
+
+describe('guardian-action-followup-executor', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  afterAll(() => {
+    resetDb();
+    try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+  });
+
+  // ── Counterparty resolution ─────────────────────────────────────────
+
+  describe('resolveCounterparty', () => {
+    test('resolves fromNumber as counterparty for inbound call', () => {
+      ensureConversation('cp-test-1');
+      const session = createCallSession({
+        conversationId: 'cp-test-1',
+        provider: 'twilio',
+        fromNumber: '+15550001111',
+        toNumber: '+15550002222',
+      });
+
+      const result = resolveCounterparty(session.id);
+      expect(result).not.toBeNull();
+      expect(result!.phoneNumber).toBe('+15550001111');
+      expect(result!.displayIdentifier).toBe('+15550001111');
+    });
+
+    test('returns null for nonexistent call session', () => {
+      const result = resolveCounterparty('nonexistent-session-id');
+      expect(result).toBeNull();
+    });
+  });
+
+  // ── message_back execution ──────────────────────────────────────────
+
+  describe('message_back', () => {
+    test('sends SMS to counterparty and finalizes as completed', async () => {
+      const { request } = createDispatchingRequest('exec-msg-1', 'message_back');
+
+      const result = await executeFollowupAction(request.id, 'message_back');
+
+      expect(result.ok).toBe(true);
+      expect(result.action).toBe('message_back');
+      expect(result.guardianReplyText.length).toBeGreaterThan(0);
+
+      // Verify SMS was sent to the counterparty
+      expect(deliveredSms.length).toBe(1);
+      expect(deliveredSms[0].chatId).toBe('+15550001111');
+      expect(deliveredSms[0].url).toContain('/deliver/sms');
+      expect(deliveredSms[0].text.length).toBeGreaterThan(0);
+
+      // Verify follow-up state is completed
+      const updated = getGuardianActionRequest(request.id);
+      expect(updated!.followupState).toBe('completed');
+      expect(updated!.followupCompletedAt).toBeGreaterThan(0);
+    });
+
+    test('confirmation text mentions the phone number', async () => {
+      const { request } = createDispatchingRequest('exec-msg-2', 'message_back');
+
+      const result = await executeFollowupAction(request.id, 'message_back');
+
+      expect(result.ok).toBe(true);
+      // The fallback template includes the phone number
+      expect(result.guardianReplyText).toContain('+15550001111');
+    });
+  });
+
+  // ── call_back execution ─────────────────────────────────────────────
+
+  describe('call_back', () => {
+    test('starts outbound call to counterparty and finalizes as completed', async () => {
+      const { request } = createDispatchingRequest('exec-call-1', 'call_back');
+
+      const result = await executeFollowupAction(request.id, 'call_back');
+
+      expect(result.ok).toBe(true);
+      expect(result.action).toBe('call_back');
+      expect(result.guardianReplyText.length).toBeGreaterThan(0);
+
+      // Verify call was started to the counterparty
+      expect(startedCalls.length).toBe(1);
+      expect(startedCalls[0].phoneNumber).toBe('+15550001111');
+      expect(startedCalls[0].task).toContain('gate code');
+
+      // Verify follow-up state is completed
+      const updated = getGuardianActionRequest(request.id);
+      expect(updated!.followupState).toBe('completed');
+      expect(updated!.followupCompletedAt).toBeGreaterThan(0);
+    });
+
+    test('confirmation text mentions calling back', async () => {
+      const { request } = createDispatchingRequest('exec-call-2', 'call_back');
+
+      const result = await executeFollowupAction(request.id, 'call_back');
+
+      expect(result.ok).toBe(true);
+      expect(result.guardianReplyText).toContain('calling');
+    });
+
+    test('failed call start finalizes as failed with error message', async () => {
+      mockStartCallResult = { ok: false, error: 'Twilio account suspended' };
+      const { request } = createDispatchingRequest('exec-call-fail-1', 'call_back');
+
+      const result = await executeFollowupAction(request.id, 'call_back');
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain('Twilio account suspended');
+      }
+      expect(result.guardianReplyText.length).toBeGreaterThan(0);
+
+      // Verify follow-up state is failed
+      const updated = getGuardianActionRequest(request.id);
+      expect(updated!.followupState).toBe('failed');
+      expect(updated!.followupCompletedAt).toBeGreaterThan(0);
+    });
+  });
+
+  // ── Error handling ──────────────────────────────────────────────────
+
+  describe('error handling', () => {
+    test('nonexistent request returns failure with error message', async () => {
+      const result = await executeFollowupAction('nonexistent-id', 'call_back');
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain('not found');
+      }
+      expect(result.guardianReplyText.length).toBeGreaterThan(0);
+    });
+
+    test('request not in dispatching state returns failure', async () => {
+      // Create a request in awaiting_guardian_choice (not dispatching)
+      ensureConversation('exec-wrong-state');
+      const session = createCallSession({
+        conversationId: 'exec-wrong-state',
+        provider: 'twilio',
+        fromNumber: '+15550001111',
+        toNumber: '+15550002222',
+      });
+      const pq = createPendingQuestion(session.id, 'Question?');
+      const request = createGuardianActionRequest({
+        kind: 'ask_guardian',
+        sourceChannel: 'voice',
+        sourceConversationId: 'exec-wrong-state',
+        callSessionId: session.id,
+        pendingQuestionId: pq.id,
+        questionText: pq.questionText,
+        expiresAt: Date.now() - 10_000,
+      });
+      markTimedOutWithReason(request.id, 'call_timeout');
+      startFollowupFromExpiredRequest(request.id, 'Answer');
+      // Still in awaiting_guardian_choice — do NOT progress to dispatching
+
+      const result = await executeFollowupAction(request.id, 'call_back');
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain('Invalid followup state');
+      }
+    });
+
+    test('follow-up states terminate correctly on success', async () => {
+      const { request } = createDispatchingRequest('exec-state-1', 'message_back');
+
+      await executeFollowupAction(request.id, 'message_back');
+
+      const updated = getGuardianActionRequest(request.id);
+      expect(updated!.followupState).toBe('completed');
+      expect(updated!.followupCompletedAt).not.toBeNull();
+    });
+
+    test('follow-up states terminate correctly on failure', async () => {
+      mockStartCallResult = { ok: false, error: 'Provider error' };
+      const { request } = createDispatchingRequest('exec-state-2', 'call_back');
+
+      await executeFollowupAction(request.id, 'call_back');
+
+      const updated = getGuardianActionRequest(request.id);
+      expect(updated!.followupState).toBe('failed');
+      expect(updated!.followupCompletedAt).not.toBeNull();
+    });
+  });
+
+  // ── Outbound SMS content ────────────────────────────────────────────
+
+  describe('outbound SMS content', () => {
+    test('SMS text includes the original question', async () => {
+      const { request } = createDispatchingRequest('exec-sms-content-1', 'message_back');
+
+      await executeFollowupAction(request.id, 'message_back');
+
+      expect(deliveredSms.length).toBe(1);
+      // The deterministic fallback for 'outbound_message_copy' includes the question
+      expect(deliveredSms[0].text).toContain('gate code');
+    });
+  });
+});

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -48,7 +48,7 @@ import { WorkspaceHeartbeatService } from '../workspace/heartbeat-service.js';
 import { createApprovalConversationGenerator,createApprovalCopyGenerator } from './approval-generators.js';
 import { cleanupPidFile,writePid } from './daemon-control.js';
 import { createGuardianActionCopyGenerator, createGuardianFollowUpConversationGenerator } from './guardian-action-generators.js';
-import { setGuardianFollowUpConversationGenerator } from './session-process.js';
+import { setGuardianActionCopyGenerator, setGuardianFollowUpConversationGenerator } from './session-process.js';
 import { initPairingHandlers } from './handlers/pairing.js';
 import { installCliLaunchers } from './install-cli-launchers.js';
 import type { ServerMessage } from './ipc-protocol.js';
@@ -284,7 +284,13 @@ export async function runDaemon(): Promise<void> {
     interfacesDir: getInterfacesDir(),
     approvalCopyGenerator: createApprovalCopyGenerator(),
     approvalConversationGenerator: createApprovalConversationGenerator(),
-    guardianActionCopyGenerator: createGuardianActionCopyGenerator(),
+    guardianActionCopyGenerator: (() => {
+      const gen = createGuardianActionCopyGenerator();
+      // Also inject into the session-process module so the mac/IPC channel
+      // path can generate action copy using the same generator.
+      setGuardianActionCopyGenerator(gen);
+      return gen;
+    })(),
     guardianFollowUpConversationGenerator: (() => {
       const gen = createGuardianFollowUpConversationGenerator();
       // Also inject into the session-process module so the mac/IPC channel

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -24,8 +24,9 @@ import {
   startFollowupFromExpiredRequest,
 } from '../memory/guardian-action-store.js';
 import { processGuardianFollowUpTurn } from '../runtime/guardian-action-conversation-turn.js';
+import { executeFollowupAction } from '../runtime/guardian-action-followup-executor.js';
 import { composeGuardianActionMessageGenerative } from '../runtime/guardian-action-message-composer.js';
-import type { GuardianFollowUpConversationGenerator } from '../runtime/http-types.js';
+import type { GuardianActionCopyGenerator, GuardianFollowUpConversationGenerator } from '../runtime/http-types.js';
 import { extractPreferences } from '../notifications/preference-extractor.js';
 import { createPreference } from '../notifications/preferences-store.js';
 import type { Message } from '../providers/types.js';
@@ -48,10 +49,16 @@ const log = getLogger('session-process');
 // mac/IPC channel path can classify follow-up replies without threading the
 // generator through Session / DaemonServer constructors.
 let _guardianFollowUpGenerator: GuardianFollowUpConversationGenerator | undefined;
+let _guardianActionCopyGenerator: GuardianActionCopyGenerator | undefined;
 
 /** Inject the guardian follow-up conversation generator (called from lifecycle.ts). */
 export function setGuardianFollowUpConversationGenerator(gen: GuardianFollowUpConversationGenerator): void {
   _guardianFollowUpGenerator = gen;
+}
+
+/** Inject the guardian action copy generator (called from lifecycle.ts). */
+export function setGuardianActionCopyGenerator(gen: GuardianActionCopyGenerator): void {
+  _guardianActionCopyGenerator = gen;
 }
 
 /** Build a model_info event with fresh config data. */
@@ -522,6 +529,34 @@ export async function processMessage(
       session.messages.push(replyMsg);
       onEvent({ type: 'assistant_text_delta', text: turnResult.replyText });
       onEvent({ type: 'message_complete', sessionId: session.conversationId });
+
+      // Execute the action and send a completion/failure message (fire-and-forget).
+      // The initial reply above acknowledges the guardian's choice; the executor
+      // carries out the actual call_back or message_back and posts a second message.
+      if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
+        void (async () => {
+          try {
+            const execResult = await executeFollowupAction(
+              followupRequest.id,
+              turnResult.disposition as 'call_back' | 'message_back',
+              _guardianActionCopyGenerator,
+            );
+            const completionMsg = createAssistantMessage(execResult.guardianReplyText);
+            conversationStore.addMessage(
+              session.conversationId,
+              'assistant',
+              JSON.stringify(completionMsg.content),
+              guardianChannelMeta,
+            );
+            session.messages.push(completionMsg);
+            onEvent({ type: 'assistant_text_delta', text: execResult.guardianReplyText });
+            onEvent({ type: 'message_complete', sessionId: session.conversationId });
+          } catch (execErr) {
+            log.error({ err: execErr, requestId: followupRequest.id }, 'Follow-up action execution or completion message failed');
+          }
+        })();
+      }
+
       return persisted.id;
     }
   }

--- a/assistant/src/runtime/guardian-action-followup-executor.ts
+++ b/assistant/src/runtime/guardian-action-followup-executor.ts
@@ -1,0 +1,301 @@
+/**
+ * Guardian action follow-up executor.
+ *
+ * After the conversation engine (M5) classifies the guardian's reply as
+ * `call_back` or `message_back` and transitions the follow-up state to
+ * `dispatching`, this module executes the actual action:
+ *
+ *   - **message_back**: Generates outbound SMS text and sends it to the
+ *     counterparty phone number via the gateway's /deliver/sms endpoint.
+ *   - **call_back**: Starts an outbound call to the counterparty with
+ *     context about the guardian's answer.
+ *
+ * The executor resolves the counterparty from the original call session,
+ * dispatches the appropriate action, and returns a result with generated
+ * reply text for the guardian's confirmation message.
+ *
+ * This module is channel-agnostic: both inbound-message-handler (Telegram,
+ * SMS channels) and session-process (mac/IPC channel) use it.
+ */
+
+import { startCall } from '../calls/call-domain.js';
+import { getCallSession } from '../calls/call-store.js';
+import { getGatewayInternalBaseUrl } from '../config/env.js';
+import { getOrCreateConversation } from '../memory/conversation-key-store.js';
+import {
+  finalizeFollowup,
+  getGuardianActionRequest,
+  type FollowupAction,
+  type GuardianActionRequest,
+} from '../memory/guardian-action-store.js';
+import { getLogger } from '../util/logger.js';
+import { readHttpToken } from '../util/platform.js';
+import { deliverChannelReply } from './gateway-client.js';
+import { composeGuardianActionMessageGenerative } from './guardian-action-message-composer.js';
+import type { GuardianActionCopyGenerator } from './http-types.js';
+
+const log = getLogger('guardian-action-followup-executor');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CounterpartyInfo {
+  phoneNumber: string;
+  /** Human-readable identifier (phone number or name if available). */
+  displayIdentifier: string;
+}
+
+export type FollowupExecutionResult =
+  | { ok: true; action: FollowupAction; guardianReplyText: string }
+  | { ok: false; action: FollowupAction; guardianReplyText: string; error: string };
+
+// ---------------------------------------------------------------------------
+// Counterparty resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the counterparty (the external person who called in) from the
+ * original call session. For inbound calls, the counterparty is fromNumber.
+ * For outbound calls initiated by the assistant, the counterparty is toNumber.
+ *
+ * Heuristic: if the call session's assistant owns the toNumber (typical for
+ * inbound calls where toNumber = Twilio number), the counterparty is
+ * fromNumber. Otherwise (outbound calls), the counterparty is toNumber.
+ * Since guardian action requests always originate from inbound voice calls
+ * (callers asking questions that need guardian approval), the counterparty
+ * is reliably the fromNumber.
+ */
+export function resolveCounterparty(callSessionId: string): CounterpartyInfo | null {
+  const session = getCallSession(callSessionId);
+  if (!session) {
+    log.warn({ callSessionId }, 'Cannot resolve counterparty: call session not found');
+    return null;
+  }
+
+  // Guardian action requests come from inbound calls where fromNumber is the
+  // external caller. This is the person we want to call back or message.
+  const phoneNumber = session.fromNumber;
+  if (!phoneNumber) {
+    log.warn({ callSessionId }, 'Cannot resolve counterparty: no fromNumber on call session');
+    return null;
+  }
+
+  return {
+    phoneNumber,
+    displayIdentifier: phoneNumber,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Action dispatchers
+// ---------------------------------------------------------------------------
+
+/**
+ * Send an SMS to the counterparty with the guardian's answer context.
+ * Uses the gateway's /deliver/sms endpoint (same path as the SMS notification adapter).
+ */
+async function executeMessageBack(
+  request: GuardianActionRequest,
+  counterparty: CounterpartyInfo,
+  generator?: GuardianActionCopyGenerator,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    // Generate the outbound SMS text using the composer
+    const messageText = await composeGuardianActionMessageGenerative(
+      {
+        scenario: 'outbound_message_copy',
+        questionText: request.questionText,
+        lateAnswerText: request.lateAnswerText ?? undefined,
+        callerIdentifier: counterparty.displayIdentifier,
+      },
+      {},
+      generator,
+    );
+
+    const gatewayBase = getGatewayInternalBaseUrl();
+    const deliverUrl = `${gatewayBase}/deliver/sms`;
+    const bearerToken = readHttpToken() ?? undefined;
+
+    await deliverChannelReply(
+      deliverUrl,
+      {
+        chatId: counterparty.phoneNumber,
+        text: messageText,
+        assistantId: request.assistantId,
+      },
+      bearerToken,
+    );
+
+    log.info(
+      { requestId: request.id, counterpartyPhone: counterparty.phoneNumber },
+      'Follow-up message_back SMS sent successfully',
+    );
+
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error(
+      { err, requestId: request.id, counterpartyPhone: counterparty.phoneNumber },
+      'Failed to send follow-up message_back SMS',
+    );
+    return { ok: false, error: message };
+  }
+}
+
+/**
+ * Start an outbound call to the counterparty with context about the
+ * guardian's answer. Uses the existing call start domain flow.
+ */
+async function executeCallBack(
+  request: GuardianActionRequest,
+  counterparty: CounterpartyInfo,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const task = request.lateAnswerText
+      ? `Call back regarding a question that was asked earlier: "${request.questionText}". The guardian has provided an answer: "${request.lateAnswerText}". Relay this answer to the person.`
+      : `Call back regarding a question that was asked earlier: "${request.questionText}". The guardian wants to follow up with them.`;
+
+    const callbackContext = [
+      `This is a follow-up callback. The person called earlier and asked: "${request.questionText}".`,
+      request.lateAnswerText ? `The guardian's answer is: "${request.lateAnswerText}".` : null,
+      'Relay this information naturally and ask if they need anything else.',
+    ].filter(Boolean).join(' ');
+
+    // Create a conversation for the callback call
+    const convKey = `followup-callback:${request.id}`;
+    const { conversationId } = getOrCreateConversation(convKey);
+
+    const result = await startCall({
+      phoneNumber: counterparty.phoneNumber,
+      task,
+      context: callbackContext,
+      conversationId,
+      assistantId: request.assistantId,
+    });
+
+    if (!result.ok) {
+      log.warn(
+        { requestId: request.id, error: result.error },
+        'Failed to start follow-up callback call',
+      );
+      return { ok: false, error: result.error };
+    }
+
+    log.info(
+      { requestId: request.id, callSessionId: result.session.id, counterpartyPhone: counterparty.phoneNumber },
+      'Follow-up call_back initiated successfully',
+    );
+
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error(
+      { err, requestId: request.id, counterpartyPhone: counterparty.phoneNumber },
+      'Failed to start follow-up callback call',
+    );
+    return { ok: false, error: message };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a follow-up action after the conversation engine has classified
+ * the guardian's intent as call_back or message_back and the follow-up
+ * state has been transitioned to `dispatching`.
+ *
+ * On success: finalizes the follow-up to `completed` and returns
+ * generated confirmation text for the guardian.
+ *
+ * On failure: finalizes the follow-up to `failed` and returns
+ * generated error text for the guardian.
+ */
+export async function executeFollowupAction(
+  requestId: string,
+  action: FollowupAction,
+  generator?: GuardianActionCopyGenerator,
+): Promise<FollowupExecutionResult> {
+  const request = getGuardianActionRequest(requestId);
+  if (!request) {
+    const errorText = await composeGuardianActionMessageGenerative(
+      { scenario: 'followup_action_failed', failureReason: 'The follow-up request could not be found.' },
+      {},
+      generator,
+    );
+    return { ok: false, action, guardianReplyText: errorText, error: 'Request not found' };
+  }
+
+  if (request.followupState !== 'dispatching') {
+    const errorText = await composeGuardianActionMessageGenerative(
+      { scenario: 'followup_action_failed', failureReason: 'This follow-up is no longer in a valid state for execution.' },
+      {},
+      generator,
+    );
+    return { ok: false, action, guardianReplyText: errorText, error: `Invalid followup state: ${request.followupState}` };
+  }
+
+  // Resolve the counterparty from the original call session
+  const counterparty = resolveCounterparty(request.callSessionId);
+  if (!counterparty) {
+    finalizeFollowup(requestId, 'failed');
+    const errorText = await composeGuardianActionMessageGenerative(
+      { scenario: 'followup_action_failed', failureReason: "I couldn't find the caller's contact information." },
+      {},
+      generator,
+    );
+    return { ok: false, action, guardianReplyText: errorText, error: 'Counterparty not found' };
+  }
+
+  // Execute the action
+  let actionResult: { ok: true } | { ok: false; error: string };
+
+  if (action === 'message_back') {
+    actionResult = await executeMessageBack(request, counterparty, generator);
+  } else if (action === 'call_back') {
+    actionResult = await executeCallBack(request, counterparty);
+  } else {
+    // decline is already handled in M5 — should not reach the executor
+    finalizeFollowup(requestId, 'failed');
+    const errorText = await composeGuardianActionMessageGenerative(
+      { scenario: 'followup_action_failed', failureReason: 'An unexpected action was requested.' },
+      {},
+      generator,
+    );
+    return { ok: false, action, guardianReplyText: errorText, error: `Unsupported action: ${action}` };
+  }
+
+  if (actionResult.ok) {
+    finalizeFollowup(requestId, 'completed');
+
+    const scenario = action === 'message_back' ? 'followup_message_sent' as const : 'followup_call_started' as const;
+    const confirmText = await composeGuardianActionMessageGenerative(
+      {
+        scenario,
+        counterpartyPhone: counterparty.phoneNumber,
+        questionText: request.questionText,
+        lateAnswerText: request.lateAnswerText ?? undefined,
+      },
+      {},
+      generator,
+    );
+
+    return { ok: true, action, guardianReplyText: confirmText };
+  }
+
+  // Action failed
+  finalizeFollowup(requestId, 'failed');
+  const errorText = await composeGuardianActionMessageGenerative(
+    {
+      scenario: 'followup_action_failed',
+      failureReason: actionResult.error,
+      counterpartyPhone: counterparty.phoneNumber,
+    },
+    {},
+    generator,
+  );
+
+  return { ok: false, action, guardianReplyText: errorText, error: actionResult.error };
+}

--- a/assistant/src/runtime/guardian-action-message-composer.ts
+++ b/assistant/src/runtime/guardian-action-message-composer.ts
@@ -27,7 +27,10 @@ export type GuardianActionMessageScenario =
   | 'guardian_followup_declined_ack'
   | 'guardian_stale_answered'
   | 'guardian_stale_expired'
-  | 'outbound_message_copy';
+  | 'outbound_message_copy'
+  | 'followup_message_sent'
+  | 'followup_call_started'
+  | 'followup_action_failed';
 
 export interface GuardianActionMessageContext {
   scenario: GuardianActionMessageScenario;
@@ -38,6 +41,7 @@ export interface GuardianActionMessageContext {
   lateAnswerText?: string;
   followupAction?: string;
   failureReason?: string;
+  counterpartyPhone?: string;
 }
 
 export interface ComposeGuardianActionMessageOptions {
@@ -178,6 +182,21 @@ export function getGuardianActionFallbackMessage(context: GuardianActionMessageC
         : context.questionText
           ? `Someone tried to reach you earlier and asked: "${context.questionText}". Please reply when you get a chance.`
           : 'Someone tried to reach you earlier. Please reply when you get a chance.';
+
+    case 'followup_message_sent':
+      return context.counterpartyPhone
+        ? `Done! I've sent a text message to ${context.counterpartyPhone} with your answer.`
+        : "Done! I've sent them a text message with your answer.";
+
+    case 'followup_call_started':
+      return context.counterpartyPhone
+        ? `Got it! I'm calling ${context.counterpartyPhone} back now to relay your answer.`
+        : "Got it! I'm calling them back now to relay your answer.";
+
+    case 'followup_action_failed':
+      return context.failureReason
+        ? `I'm sorry, I wasn't able to complete that. ${context.failureReason}`
+        : "I'm sorry, something went wrong and I couldn't complete that action. Please try again later.";
 
     default: {
       const _exhaustive: never = context.scenario;

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -64,6 +64,7 @@ import type {
 } from '../http-types.js';
 import { processGuardianFollowUpTurn } from '../guardian-action-conversation-turn.js';
 import { composeGuardianActionMessageGenerative } from '../guardian-action-message-composer.js';
+import { executeFollowupAction } from '../guardian-action-followup-executor.js';
 import { deliverReplyViaCallback } from './channel-delivery-routes.js';
 import {
   canonicalChannelAssistantId,
@@ -1056,6 +1057,28 @@ export async function handleChannelInbound(
               }, bearerToken);
             } catch (err) {
               log.error({ err, externalChatId }, 'Failed to deliver guardian follow-up conversation reply');
+            }
+
+            // Execute the action and send a completion/failure reply (fire-and-forget).
+            // The initial reply above acknowledges the guardian's choice; this
+            // follow-up message confirms whether the action succeeded.
+            if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
+              void (async () => {
+                try {
+                  const execResult = await executeFollowupAction(
+                    followupRequest.id,
+                    turnResult.disposition as 'call_back' | 'message_back',
+                    guardianActionCopyGenerator,
+                  );
+                  await deliverChannelReply(replyCallbackUrl, {
+                    chatId: externalChatId,
+                    text: execResult.guardianReplyText,
+                    assistantId,
+                  }, bearerToken);
+                } catch (execErr) {
+                  log.error({ err: execErr, requestId: followupRequest.id }, 'Follow-up action execution or completion reply failed');
+                }
+              })();
             }
 
             return Response.json({


### PR DESCRIPTION
Implement the action execution layer for guardian follow-up dispositions. When a guardian chooses to call back or message back, the system resolves the counterparty from the original call session, dispatches the appropriate action (outbound call or SMS), sends generated confirmation to the guardian, and finalizes the follow-up state. Includes failure handling with generated error messages.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
