### PR TITLE
fix: address review feedback from PR #9690

### DIFF
--- a/assistant/src/__tests__/gateway-only-guard.test.ts
+++ b/assistant/src/__tests__/gateway-only-guard.test.ts
@@ -30,7 +30,6 @@ const ALLOWLIST = new Set([
 
   // --- Documentation and comments that mention the port for explanatory purposes ---
   'AGENTS.md', // documents the gateway-only rule itself
-  'assistant/src/runtime/middleware/twilio-validation.ts', // comment explaining proxy URL rewriting
 ]);
 
 /** Patterns that indicate a direct runtime URL reference. */

--- a/assistant/src/runtime/middleware/twilio-validation.ts
+++ b/assistant/src/runtime/middleware/twilio-validation.ts
@@ -85,9 +85,9 @@ export async function validateTwilioWebhook(
   }
 
   // Reconstruct the public-facing URL that Twilio signed against.
-  // Behind proxies/gateways, req.url is the local server URL (e.g.
-  // http://127.0.0.1:7821/...) which differs from the public URL Twilio
-  // used to compute the HMAC-SHA1 signature.
+  // Behind proxies/gateways, req.url is the local runtime URL which
+  // differs from the public URL Twilio used to compute the HMAC-SHA1
+  // signature.
   let publicBaseUrl: string | undefined;
   try {
     publicBaseUrl = getPublicBaseUrl(loadConfig());


### PR DESCRIPTION
Addresses Codex review feedback on PR #9690 (M6: Tighten CI guard and final cleanup):

- Removed `assistant/src/runtime/middleware/twilio-validation.ts` from the gateway-only guard allowlist, as flagged by Codex. Allowlisting an executable runtime middleware module weakens the policy enforcement — any future hardcoded runtime URL added to that file would silently bypass CI.
- Rewrote the comment in `twilio-validation.ts` (line 89) to avoid the literal `127.0.0.1:7821` string that triggered the guard match. The comment now says "local runtime URL" instead of including the actual host:port.

This tightens the CI guard without changing any runtime behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
