### PR TITLE
fix: remove twilio-validation.ts from guard allowlist by rewording comment

### DIFF
--- a/assistant/src/__tests__/gateway-only-guard.test.ts
+++ b/assistant/src/__tests__/gateway-only-guard.test.ts
@@ -30,7 +30,6 @@ const ALLOWLIST = new Set([
 
   // --- Documentation and comments that mention the port for explanatory purposes ---
   'AGENTS.md', // documents the gateway-only rule itself
-  'assistant/src/runtime/middleware/twilio-validation.ts', // comment explaining proxy URL rewriting
 ]);
 
 /** Patterns that indicate a direct runtime URL reference via hardcoded port. */

--- a/assistant/src/runtime/middleware/twilio-validation.ts
+++ b/assistant/src/runtime/middleware/twilio-validation.ts
@@ -85,9 +85,9 @@ export async function validateTwilioWebhook(
   }
 
   // Reconstruct the public-facing URL that Twilio signed against.
-  // Behind proxies/gateways, req.url is the local server URL (e.g.
-  // http://127.0.0.1:7821/...) which differs from the public URL Twilio
-  // used to compute the HMAC-SHA1 signature.
+  // Behind proxies/gateways, req.url is the daemon runtime's local HTTP
+  // endpoint which differs from the public URL Twilio used to compute
+  // the HMAC-SHA1 signature.
   let publicBaseUrl: string | undefined;
   try {
     publicBaseUrl = getPublicBaseUrl(loadConfig());


### PR DESCRIPTION
Addresses Codex feedback from #9690. Instead of allowlisting the entire twilio-validation.ts middleware file (which would silently exempt future violations), rewords the comment that mentioned the literal runtime port to avoid triggering the guard.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
