### PR TITLE
fix: handle stale follow-up transitions before replying (PR #9669 feedback)

### DIFF
--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -521,15 +521,28 @@ export async function processMessage(
         _guardianFollowUpGenerator,
       );
 
-      // Apply the disposition to the follow-up state machine
+      // Apply the disposition to the follow-up state machine.
+      // Both progressFollowupState and finalizeFollowup are compare-and-set:
+      // they return null when the transition was not applied (e.g. a concurrent
+      // reply already advanced the state). In that case we notify the guardian
+      // that the request was already resolved and skip action execution.
+      let stateApplied = true;
       if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
-        progressFollowupState(followupRequest.id, 'dispatching', turnResult.disposition);
+        stateApplied = progressFollowupState(followupRequest.id, 'dispatching', turnResult.disposition) !== null;
       } else if (turnResult.disposition === 'decline') {
-        finalizeFollowup(followupRequest.id, 'declined');
+        stateApplied = finalizeFollowup(followupRequest.id, 'declined') !== null;
       }
       // keep_pending: no state change — guardian can reply again
 
-      const replyMsg = createAssistantMessage(turnResult.replyText);
+      const replyText = stateApplied
+        ? turnResult.replyText
+        : 'This follow-up has already been resolved.';
+
+      if (!stateApplied) {
+        log.warn({ requestId: followupRequest.id, disposition: turnResult.disposition }, 'Follow-up state transition failed (already resolved)');
+      }
+
+      const replyMsg = createAssistantMessage(replyText);
       conversationStore.addMessage(
         session.conversationId,
         'assistant',
@@ -537,13 +550,13 @@ export async function processMessage(
         guardianChannelMeta,
       );
       session.messages.push(replyMsg);
-      onEvent({ type: 'assistant_text_delta', text: turnResult.replyText });
+      onEvent({ type: 'assistant_text_delta', text: replyText });
       onEvent({ type: 'message_complete', sessionId: session.conversationId });
 
       // Execute the action and send a completion/failure message (fire-and-forget).
       // The initial reply above acknowledges the guardian's choice; the executor
       // carries out the actual call_back or message_back and posts a second message.
-      if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
+      if (stateApplied && (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back')) {
         void (async () => {
           try {
             const execResult = await executeFollowupAction(

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1042,13 +1042,37 @@ export async function handleChannelInbound(
               guardianFollowUpConversationGenerator,
             );
 
-            // Apply the disposition to the follow-up state machine
+            // Apply the disposition to the follow-up state machine.
+            // Both progressFollowupState and finalizeFollowup are compare-and-set:
+            // they return null when the transition was not applied (e.g. a concurrent
+            // reply already advanced the state). In that case we notify the guardian
+            // that the request was already resolved and skip action execution.
+            let stateApplied = true;
             if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
-              progressFollowupState(followupRequest.id, 'dispatching', turnResult.disposition);
+              stateApplied = progressFollowupState(followupRequest.id, 'dispatching', turnResult.disposition) !== null;
             } else if (turnResult.disposition === 'decline') {
-              finalizeFollowup(followupRequest.id, 'declined');
+              stateApplied = finalizeFollowup(followupRequest.id, 'declined') !== null;
             }
             // keep_pending: no state change — guardian can reply again
+
+            if (!stateApplied) {
+              log.warn({ requestId: followupRequest.id, disposition: turnResult.disposition }, 'Follow-up state transition failed (already resolved)');
+              try {
+                await deliverChannelReply(replyCallbackUrl, {
+                  chatId: externalChatId,
+                  text: 'This follow-up has already been resolved.',
+                  assistantId,
+                }, bearerToken);
+              } catch (err) {
+                log.error({ err, externalChatId }, 'Failed to deliver stale follow-up notice');
+              }
+              return Response.json({
+                accepted: true,
+                duplicate: false,
+                eventId: result.eventId,
+                guardianFollowUp: 'stale_ignored',
+              });
+            }
 
             // Deliver the generated reply to the guardian
             try {


### PR DESCRIPTION
## Summary
- Check return values of `progressFollowupState` and `finalizeFollowup` in both the channel (Telegram/SMS) and mac/IPC follow-up conversation paths
- When a state transition returns null (concurrent reply already advanced the state), send an "already resolved" notice instead of the success-style reply
- Skip action execution (`executeFollowupAction`) when the transition was not actually applied
- Addresses Codex review feedback on PR #9669 about stale follow-up transition handling

## Test plan
- [ ] Verify that when a guardian reply races with another reply on the same follow-up, the second reply gets an "already resolved" message instead of a misleading success acknowledgment
- [ ] Verify the `stale_ignored` response is returned in the channel path when the transition fails
- [ ] Verify normal (non-racing) follow-up flows still work correctly on both mac and channel paths
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
