### PR TITLE
fix: gate follow-up action execution on successful state transition

### DIFF
--- a/assistant/src/__tests__/guardian-action-copy-generator.test.ts
+++ b/assistant/src/__tests__/guardian-action-copy-generator.test.ts
@@ -23,6 +23,7 @@ const ALL_SCENARIOS: GuardianActionMessageScenario[] = [
   'guardian_followup_failed',
   'guardian_followup_declined_ack',
   'guardian_stale_expired',
+  'guardian_stale_followup',
   'outbound_message_copy',
 ];
 

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -521,15 +521,23 @@ export async function processMessage(
         _guardianFollowUpGenerator,
       );
 
-      // Apply the disposition to the follow-up state machine
+      // Apply the disposition to the follow-up state machine.
+      // Both progressFollowupState and finalizeFollowup are compare-and-set:
+      // they return null when the transition fails (e.g. a concurrent message
+      // already advanced the state). In that case, send a stale notice instead
+      // of the disposition-specific reply.
+      let transitionApplied = true;
       if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
-        progressFollowupState(followupRequest.id, 'dispatching', turnResult.disposition);
+        transitionApplied = progressFollowupState(followupRequest.id, 'dispatching', turnResult.disposition) !== null;
       } else if (turnResult.disposition === 'decline') {
-        finalizeFollowup(followupRequest.id, 'declined');
+        transitionApplied = finalizeFollowup(followupRequest.id, 'declined') !== null;
       }
       // keep_pending: no state change — guardian can reply again
 
-      const replyMsg = createAssistantMessage(turnResult.replyText);
+      const replyText = transitionApplied
+        ? turnResult.replyText
+        : await composeGuardianActionMessageGenerative({ scenario: 'guardian_stale_followup' });
+      const replyMsg = createAssistantMessage(replyText);
       conversationStore.addMessage(
         session.conversationId,
         'assistant',
@@ -537,13 +545,13 @@ export async function processMessage(
         guardianChannelMeta,
       );
       session.messages.push(replyMsg);
-      onEvent({ type: 'assistant_text_delta', text: turnResult.replyText });
+      onEvent({ type: 'assistant_text_delta', text: replyText });
       onEvent({ type: 'message_complete', sessionId: session.conversationId });
 
       // Execute the action and send a completion/failure message (fire-and-forget).
       // The initial reply above acknowledges the guardian's choice; the executor
       // carries out the actual call_back or message_back and posts a second message.
-      if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
+      if (transitionApplied && (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back')) {
         void (async () => {
           try {
             const execResult = await executeFollowupAction(

--- a/assistant/src/runtime/guardian-action-message-composer.ts
+++ b/assistant/src/runtime/guardian-action-message-composer.ts
@@ -27,6 +27,7 @@ export type GuardianActionMessageScenario =
   | 'guardian_followup_declined_ack'
   | 'guardian_stale_answered'
   | 'guardian_stale_expired'
+  | 'guardian_stale_followup'
   | 'outbound_message_copy'
   | 'followup_message_sent'
   | 'followup_call_started'
@@ -175,6 +176,9 @@ export function getGuardianActionFallbackMessage(context: GuardianActionMessageC
 
     case 'guardian_stale_expired':
       return 'That request has already expired. No further action is needed.';
+
+    case 'guardian_stale_followup':
+      return 'It looks like this follow-up has already been handled. No further action is needed.';
 
     case 'outbound_message_copy':
       return context.callerIdentifier && context.questionText

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1042,13 +1042,41 @@ export async function handleChannelInbound(
               guardianFollowUpConversationGenerator,
             );
 
-            // Apply the disposition to the follow-up state machine
+            // Apply the disposition to the follow-up state machine.
+            // Both progressFollowupState and finalizeFollowup are compare-and-set:
+            // they return null when the transition fails (e.g. a concurrent message
+            // already advanced the state). In that case, send a stale notice instead
+            // of the disposition-specific reply.
+            let transitionApplied = true;
             if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
-              progressFollowupState(followupRequest.id, 'dispatching', turnResult.disposition);
+              transitionApplied = progressFollowupState(followupRequest.id, 'dispatching', turnResult.disposition) !== null;
             } else if (turnResult.disposition === 'decline') {
-              finalizeFollowup(followupRequest.id, 'declined');
+              transitionApplied = finalizeFollowup(followupRequest.id, 'declined') !== null;
             }
             // keep_pending: no state change — guardian can reply again
+
+            if (!transitionApplied) {
+              const staleText = await composeGuardianActionMessageGenerative(
+                { scenario: 'guardian_stale_followup' as const },
+                {},
+                guardianActionCopyGenerator,
+              );
+              try {
+                await deliverChannelReply(replyCallbackUrl, {
+                  chatId: externalChatId,
+                  text: staleText,
+                  assistantId,
+                }, bearerToken);
+              } catch (err) {
+                log.error({ err, externalChatId }, 'Failed to deliver stale follow-up notice');
+              }
+              return Response.json({
+                accepted: true,
+                duplicate: false,
+                eventId: result.eventId,
+                guardianFollowUp: 'stale_ignored',
+              });
+            }
 
             // Deliver the generated reply to the guardian
             try {


### PR DESCRIPTION
## Summary

- Check return values of `progressFollowupState` and `finalizeFollowup` before sending disposition-specific replies or executing follow-up actions
- When a compare-and-set transition fails (race condition from concurrent messages), deliver a stale notice (`guardian_stale_followup`) instead of the disposition reply
- Skip action execution (`call_back`/`message_back`) when the state transition was not applied
- Add `guardian_stale_followup` scenario to the message composer with appropriate fallback text

Addresses review feedback from Codex on PR #9669 about handling stale follow-up transitions before replying.

## Test plan

- [ ] Verify `guardian_stale_followup` scenario produces non-empty fallback text in existing copy generator tests
- [ ] Confirm channel path (inbound-message-handler) returns `stale_ignored` when state transition fails
- [ ] Confirm mac path (session-process) delivers stale notice text when state transition fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
