### PR TITLE
fix: address PR #9701 review feedback on guardian follow-up executor

### DIFF
--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -521,9 +521,13 @@ export async function processMessage(
         _guardianFollowUpGenerator,
       );
 
-      // Apply the disposition to the follow-up state machine
+      // Apply the disposition to the follow-up state machine.
+      // Capture whether the transition succeeded so we only execute
+      // follow-up actions when this handler won the race.
+      let transitionedToDispatching = false;
       if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
-        progressFollowupState(followupRequest.id, 'dispatching', turnResult.disposition);
+        const transitioned = progressFollowupState(followupRequest.id, 'dispatching', turnResult.disposition);
+        transitionedToDispatching = transitioned !== null;
       } else if (turnResult.disposition === 'decline') {
         finalizeFollowup(followupRequest.id, 'declined');
       }
@@ -541,9 +545,9 @@ export async function processMessage(
       onEvent({ type: 'message_complete', sessionId: session.conversationId });
 
       // Execute the action and send a completion/failure message (fire-and-forget).
-      // The initial reply above acknowledges the guardian's choice; the executor
-      // carries out the actual call_back or message_back and posts a second message.
-      if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
+      // Only proceed if we successfully transitioned to dispatching — this
+      // prevents duplicate side effects under concurrent replies.
+      if (transitionedToDispatching) {
         void (async () => {
           try {
             const execResult = await executeFollowupAction(

--- a/assistant/src/runtime/guardian-action-followup-executor.ts
+++ b/assistant/src/runtime/guardian-action-followup-executor.ts
@@ -55,16 +55,13 @@ export type FollowupExecutionResult =
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve the counterparty (the external person who called in) from the
- * original call session. For inbound calls, the counterparty is fromNumber.
- * For outbound calls initiated by the assistant, the counterparty is toNumber.
+ * Resolve the counterparty (the external person) from the original call
+ * session. For inbound calls the counterparty is fromNumber; for outbound
+ * calls initiated by startCall the counterparty is toNumber.
  *
- * Heuristic: if the call session's assistant owns the toNumber (typical for
- * inbound calls where toNumber = Twilio number), the counterparty is
- * fromNumber. Otherwise (outbound calls), the counterparty is toNumber.
- * Since guardian action requests always originate from inbound voice calls
- * (callers asking questions that need guardian approval), the counterparty
- * is reliably the fromNumber.
+ * Heuristic: outbound calls created via startCall always set
+ * initiatedFromConversationId. When that field is present we treat the
+ * call as outbound and use toNumber. Otherwise (inbound) we use fromNumber.
  */
 export function resolveCounterparty(callSessionId: string): CounterpartyInfo | null {
   const session = getCallSession(callSessionId);
@@ -73,11 +70,13 @@ export function resolveCounterparty(callSessionId: string): CounterpartyInfo | n
     return null;
   }
 
-  // Guardian action requests come from inbound calls where fromNumber is the
-  // external caller. This is the person we want to call back or message.
-  const phoneNumber = session.fromNumber;
+  // Outbound calls (startCall) store the assistant's number in fromNumber
+  // and the callee in toNumber. They always have initiatedFromConversationId.
+  const isOutbound = !!session.initiatedFromConversationId;
+  const phoneNumber = isOutbound ? session.toNumber : session.fromNumber;
+
   if (!phoneNumber) {
-    log.warn({ callSessionId }, 'Cannot resolve counterparty: no fromNumber on call session');
+    log.warn({ callSessionId, isOutbound }, 'Cannot resolve counterparty: no phone number on call session');
     return null;
   }
 

--- a/assistant/src/runtime/guardian-action-message-composer.ts
+++ b/assistant/src/runtime/guardian-action-message-composer.ts
@@ -177,11 +177,17 @@ export function getGuardianActionFallbackMessage(context: GuardianActionMessageC
       return 'That request has already expired. No further action is needed.';
 
     case 'outbound_message_copy':
-      return context.callerIdentifier && context.questionText
-        ? `Hi, ${context.callerIdentifier} tried to reach you earlier and asked: "${context.questionText}". Please reply when you get a chance.`
-        : context.questionText
-          ? `Someone tried to reach you earlier and asked: "${context.questionText}". Please reply when you get a chance.`
-          : 'Someone tried to reach you earlier. Please reply when you get a chance.';
+      // This SMS is sent TO the original caller relaying the guardian's answer.
+      // When lateAnswerText is available, include it — that's the whole point of message_back.
+      if (context.lateAnswerText && context.questionText) {
+        return `Hi! You asked "${context.questionText}" earlier. Here's the answer: ${context.lateAnswerText}`;
+      }
+      if (context.lateAnswerText) {
+        return `Hi! Regarding your earlier question — here's the answer: ${context.lateAnswerText}`;
+      }
+      return context.questionText
+        ? `Hi! You asked "${context.questionText}" earlier. We'll get back to you with an answer soon.`
+        : 'Hi! Thanks for calling earlier. We\'ll get back to you soon.';
 
     case 'followup_message_sent':
       return context.counterpartyPhone

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1042,9 +1042,13 @@ export async function handleChannelInbound(
               guardianFollowUpConversationGenerator,
             );
 
-            // Apply the disposition to the follow-up state machine
+            // Apply the disposition to the follow-up state machine.
+            // Capture whether the transition succeeded so we only execute
+            // follow-up actions when this handler won the race.
+            let transitionedToDispatching = false;
             if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
-              progressFollowupState(followupRequest.id, 'dispatching', turnResult.disposition);
+              const transitioned = progressFollowupState(followupRequest.id, 'dispatching', turnResult.disposition);
+              transitionedToDispatching = transitioned !== null;
             } else if (turnResult.disposition === 'decline') {
               finalizeFollowup(followupRequest.id, 'declined');
             }
@@ -1062,9 +1066,9 @@ export async function handleChannelInbound(
             }
 
             // Execute the action and send a completion/failure reply (fire-and-forget).
-            // The initial reply above acknowledges the guardian's choice; this
-            // follow-up message confirms whether the action succeeded.
-            if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
+            // Only proceed if we successfully transitioned to dispatching — this
+            // prevents duplicate side effects under concurrent replies.
+            if (transitionedToDispatching) {
               void (async () => {
                 try {
                   const execResult = await executeFollowupAction(


### PR DESCRIPTION
## Summary - **Fix outbound_message_copy fallback**: The deterministic fallback template omitted lateAnswerText and used wrong audience framing (told the caller 'someone tried to reach you' instead of relaying the guardian's answer). Now includes the answer when available and frames the SMS correctly as a reply to the caller's question. - **Fix counterparty resolution by call direction**: resolveCounterparty always used fromNumber, but outbound calls (startCall) store the assistant's number in fromNumber and the callee in toNumber. Now uses initiatedFromConversationId as a heuristic to detect outbound calls and pick toNumber. - **Gate execution on state transition**: The fire-and-forget executeFollowupAction was unconditional on disposition, but progressFollowupState can fail (returns null) under concurrent replies. Now only executes when the transition to dispatching succeeds, preventing duplicate SMS/callback dispatch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
