### PR TITLE
Fix M6 review feedback: counterparty direction, transition gating, outbound copy

### DIFF
--- a/assistant/src/runtime/guardian-action-followup-executor.ts
+++ b/assistant/src/runtime/guardian-action-followup-executor.ts
@@ -55,16 +55,14 @@ export type FollowupExecutionResult =
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve the counterparty (the external person who called in) from the
- * original call session. For inbound calls, the counterparty is fromNumber.
- * For outbound calls initiated by the assistant, the counterparty is toNumber.
+ * Resolve the counterparty (the external person) from the original call
+ * session. The counterparty depends on call direction:
  *
- * Heuristic: if the call session's assistant owns the toNumber (typical for
- * inbound calls where toNumber = Twilio number), the counterparty is
- * fromNumber. Otherwise (outbound calls), the counterparty is toNumber.
- * Since guardian action requests always originate from inbound voice calls
- * (callers asking questions that need guardian approval), the counterparty
- * is reliably the fromNumber.
+ *   - **Inbound calls** (`initiatedFromConversationId` is null): the
+ *     counterparty is `fromNumber` (the external caller).
+ *   - **Outbound calls** (`initiatedFromConversationId` is set): the
+ *     counterparty is `toNumber` (the callee), because `fromNumber` is
+ *     the assistant's own Twilio number.
  */
 export function resolveCounterparty(callSessionId: string): CounterpartyInfo | null {
   const session = getCallSession(callSessionId);
@@ -73,11 +71,11 @@ export function resolveCounterparty(callSessionId: string): CounterpartyInfo | n
     return null;
   }
 
-  // Guardian action requests come from inbound calls where fromNumber is the
-  // external caller. This is the person we want to call back or message.
-  const phoneNumber = session.fromNumber;
+  // Outbound calls set initiatedFromConversationId; inbound calls leave it null.
+  const isOutbound = session.initiatedFromConversationId != null;
+  const phoneNumber = isOutbound ? session.toNumber : session.fromNumber;
   if (!phoneNumber) {
-    log.warn({ callSessionId }, 'Cannot resolve counterparty: no fromNumber on call session');
+    log.warn({ callSessionId, isOutbound }, 'Cannot resolve counterparty: no phone number on call session');
     return null;
   }
 
@@ -101,13 +99,18 @@ async function executeMessageBack(
   generator?: GuardianActionCopyGenerator,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   try {
-    // Generate the outbound SMS text using the composer
+    // Generate the outbound SMS text using the composer.
+    // callerIdentifier identifies who provided the answer (the guardian),
+    // not the counterparty receiving the SMS.
+    const guardianLabel = request.answeredByChannel
+      ? `the guardian (via ${request.answeredByChannel})`
+      : 'the guardian';
     const messageText = await composeGuardianActionMessageGenerative(
       {
         scenario: 'outbound_message_copy',
         questionText: request.questionText,
         lateAnswerText: request.lateAnswerText ?? undefined,
-        callerIdentifier: counterparty.displayIdentifier,
+        callerIdentifier: guardianLabel,
       },
       {},
       generator,

--- a/assistant/src/runtime/guardian-action-message-composer.ts
+++ b/assistant/src/runtime/guardian-action-message-composer.ts
@@ -177,11 +177,13 @@ export function getGuardianActionFallbackMessage(context: GuardianActionMessageC
       return 'That request has already expired. No further action is needed.';
 
     case 'outbound_message_copy':
-      return context.callerIdentifier && context.questionText
-        ? `Hi, ${context.callerIdentifier} tried to reach you earlier and asked: "${context.questionText}". Please reply when you get a chance.`
-        : context.questionText
-          ? `Someone tried to reach you earlier and asked: "${context.questionText}". Please reply when you get a chance.`
-          : 'Someone tried to reach you earlier. Please reply when you get a chance.';
+      if (context.lateAnswerText && context.questionText) {
+        return `Hi, we have an update regarding your earlier question: "${context.questionText}". The answer is: "${context.lateAnswerText}".`;
+      }
+      if (context.questionText) {
+        return `Hi, we have an update regarding your earlier question: "${context.questionText}". Please reply if you need anything else.`;
+      }
+      return 'Hi, we have an update regarding your earlier inquiry. Please reply if you need anything else.';
 
     case 'followup_message_sent':
       return context.counterpartyPhone

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1088,7 +1088,10 @@ export async function handleChannelInbound(
             // Execute the action and send a completion/failure reply (fire-and-forget).
             // The initial reply above acknowledges the guardian's choice; this
             // follow-up message confirms whether the action succeeded.
-            if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
+            // Only execute if the state transition succeeded — a null return
+            // from progressFollowupState means a concurrent handler already
+            // moved the request, and executing here would cause duplicates.
+            if (stateApplied && (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back')) {
               void (async () => {
                 try {
                   const execResult = await executeFollowupAction(


### PR DESCRIPTION
Address review feedback from PR #9701 that landed after the PR was merged.

Fixes:
1. Resolve counterparty by call direction for outbound calls (Codex P1)
2. Gate follow-up action execution on successful state transition to prevent duplicate side effects (Codex P2)
3. Fix outbound_message_copy fallback to include lateAnswerText and correct framing (Codex P2 + Devin)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
