### PR TITLE
Fix counterparty resolution and outbound SMS fallback for guardian follow-up

### DIFF
--- a/assistant/src/__tests__/guardian-action-followup-executor.test.ts
+++ b/assistant/src/__tests__/guardian-action-followup-executor.test.ts
@@ -179,6 +179,22 @@ describe('guardian-action-followup-executor', () => {
       expect(result!.displayIdentifier).toBe('+15550001111');
     });
 
+    test('resolves toNumber as counterparty for outbound call', () => {
+      ensureConversation('cp-test-outbound');
+      const session = createCallSession({
+        conversationId: 'cp-test-outbound',
+        provider: 'twilio',
+        fromNumber: '+15550002222', // assistant's number
+        toNumber: '+15550001111',   // callee (the counterparty)
+        initiatedFromConversationId: 'cp-test-outbound', // signals outbound
+      });
+
+      const result = resolveCounterparty(session.id);
+      expect(result).not.toBeNull();
+      expect(result!.phoneNumber).toBe('+15550001111');
+      expect(result!.displayIdentifier).toBe('+15550001111');
+    });
+
     test('returns null for nonexistent call session', () => {
       const result = resolveCounterparty('nonexistent-session-id');
       expect(result).toBeNull();
@@ -348,6 +364,16 @@ describe('guardian-action-followup-executor', () => {
       expect(deliveredSms.length).toBe(1);
       // The deterministic fallback for 'outbound_message_copy' includes the question
       expect(deliveredSms[0].text).toContain('gate code');
+    });
+
+    test('SMS text includes the guardian late answer', async () => {
+      const { request } = createDispatchingRequest('exec-sms-content-2', 'message_back');
+
+      await executeFollowupAction(request.id, 'message_back');
+
+      expect(deliveredSms.length).toBe(1);
+      // The fallback must relay the guardian's answer to the caller
+      expect(deliveredSms[0].text).toContain('1234');
     });
   });
 });

--- a/assistant/src/runtime/guardian-action-followup-executor.ts
+++ b/assistant/src/runtime/guardian-action-followup-executor.ts
@@ -55,16 +55,14 @@ export type FollowupExecutionResult =
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve the counterparty (the external person who called in) from the
- * original call session. For inbound calls, the counterparty is fromNumber.
- * For outbound calls initiated by the assistant, the counterparty is toNumber.
+ * Resolve the counterparty (the external person) from the original call
+ * session by call direction.
  *
- * Heuristic: if the call session's assistant owns the toNumber (typical for
- * inbound calls where toNumber = Twilio number), the counterparty is
- * fromNumber. Otherwise (outbound calls), the counterparty is toNumber.
- * Since guardian action requests always originate from inbound voice calls
- * (callers asking questions that need guardian approval), the counterparty
- * is reliably the fromNumber.
+ * - **Inbound calls** (`initiatedFromConversationId` is null): the external
+ *   caller is `fromNumber`, the assistant's Twilio number is `toNumber`.
+ * - **Outbound calls** (`initiatedFromConversationId` is set): the assistant
+ *   placed the call so `fromNumber` is the assistant's number and `toNumber`
+ *   is the external callee.
  */
 export function resolveCounterparty(callSessionId: string): CounterpartyInfo | null {
   const session = getCallSession(callSessionId);
@@ -73,11 +71,12 @@ export function resolveCounterparty(callSessionId: string): CounterpartyInfo | n
     return null;
   }
 
-  // Guardian action requests come from inbound calls where fromNumber is the
-  // external caller. This is the person we want to call back or message.
-  const phoneNumber = session.fromNumber;
+  // Outbound calls set initiatedFromConversationId; inbound calls do not.
+  const isOutbound = !!session.initiatedFromConversationId;
+  const phoneNumber = isOutbound ? session.toNumber : session.fromNumber;
+
   if (!phoneNumber) {
-    log.warn({ callSessionId }, 'Cannot resolve counterparty: no fromNumber on call session');
+    log.warn({ callSessionId, isOutbound }, 'Cannot resolve counterparty: no phone number on call session');
     return null;
   }
 

--- a/assistant/src/runtime/guardian-action-message-composer.ts
+++ b/assistant/src/runtime/guardian-action-message-composer.ts
@@ -177,11 +177,18 @@ export function getGuardianActionFallbackMessage(context: GuardianActionMessageC
       return 'That request has already expired. No further action is needed.';
 
     case 'outbound_message_copy':
-      return context.callerIdentifier && context.questionText
-        ? `Hi, ${context.callerIdentifier} tried to reach you earlier and asked: "${context.questionText}". Please reply when you get a chance.`
-        : context.questionText
-          ? `Someone tried to reach you earlier and asked: "${context.questionText}". Please reply when you get a chance.`
-          : 'Someone tried to reach you earlier. Please reply when you get a chance.';
+      // This SMS is sent TO the original caller who asked a question.
+      // It should relay the guardian's late answer back to them.
+      if (context.lateAnswerText && context.questionText) {
+        return `Hi! You asked earlier: "${context.questionText}". Here's the answer: ${context.lateAnswerText}`;
+      }
+      if (context.lateAnswerText) {
+        return `Hi! Regarding your earlier question — here's the answer: ${context.lateAnswerText}`;
+      }
+      if (context.questionText) {
+        return `Hi! You asked earlier: "${context.questionText}". We'll get back to you with an answer shortly.`;
+      }
+      return 'Hi! We received your question and will get back to you shortly.';
 
     case 'followup_message_sent':
       return context.counterpartyPhone


### PR DESCRIPTION
Addresses review feedback from PR #9701:

1. **resolveCounterparty now uses call direction**: Uses `initiatedFromConversationId` as the outbound signal — inbound calls resolve the counterparty from `fromNumber`, outbound calls from `toNumber`. Previously always used `fromNumber`, which would target the assistant's own number for outbound calls.

2. **outbound_message_copy fallback includes late answer**: The deterministic fallback template now relays the guardian's `lateAnswerText` to the caller and uses correct audience framing ("You asked earlier" instead of "Someone tried to reach you"). Previously the answer was completely omitted and the framing was inverted.

3. **State gating (P2)** was already addressed in a prior push to the feature branch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
