### PR TITLE
fix: use const for resolvedContent in session-process.ts

### DIFF
--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -248,7 +248,7 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
     return;
   }
 
-  let resolvedContent = slashResult.content;
+  const resolvedContent = slashResult.content;
 
   // Preactivate skill tools when slash resolution identifies a known skill
   if (slashResult.kind === 'rewritten') {
@@ -470,7 +470,7 @@ export async function processMessage(
     return persisted.id;
   }
 
-  let resolvedContent = slashResult.content;
+  const resolvedContent = slashResult.content;
 
   // Preactivate skill tools when slash resolution identifies a known skill
   if (slashResult.kind === 'rewritten') {


### PR DESCRIPTION
## Summary
- Change `let` to `const` for `resolvedContent` in both `drainQueue` and `processMessage` functions
- The variable is no longer reassigned after the guardian intent refactoring introduced `agentLoopContent`
- Fixes CI lint failure (`prefer-const` rule)

## Original prompt
fix: change `let` to `const` for `resolvedContent` in session-process.ts — the variable is no longer reassigned after the guardian intent refactoring introduced `agentLoopContent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
