### PR TITLE
M1: Prompting, tool copy & conversation lifecycle cleanup

### DIFF
--- a/assistant/src/config/bundled-skills/tasks/SKILL.md
+++ b/assistant/src/config/bundled-skills/tasks/SKILL.md
@@ -12,7 +12,7 @@ Templates are reusable definitions saved from conversations via `task_save`. The
 
 ## Work Items (Task Queue)
 
-Work items are the user-facing "Tasks" shown in the Tasks panel. They track status and priority:
+Work items are the user-facing "Tasks" managed through conversation. They track status and priority:
 
 - **Priority tiers**: 0 = high, 1 = medium (default), 2 = low
 - **Status flow**: queued -> running -> awaiting_review -> done

--- a/assistant/src/config/bundled-skills/tasks/TOOLS.json
+++ b/assistant/src/config/bundled-skills/tasks/TOOLS.json
@@ -82,7 +82,7 @@
     },
     {
       "name": "task_list_show",
-      "description": "List the user's Task Queue (work items) with their status, priority, and last run info. Use this when the user says \"show my tasks\", \"what's in my queue\", \"what's on my task list\", or similar.",
+      "description": "List the user's Task Queue (work items) with their status, priority, and last run info. Use this when the user says \"show my tasks\", \"what's in my queue\", \"what's on my task list\", or similar. Present the results as a summary in the conversation.",
       "category": "tasks",
       "risk": "low",
       "input_schema": {
@@ -153,7 +153,7 @@
     },
     {
       "name": "task_list_update",
-      "description": "Update an existing task in the Task Queue. Can change priority, notes, status, or sort order. Identifies the task by work item ID, task ID, task name, or title.",
+      "description": "Update an existing task in the Task Queue. Can change priority, notes, status (including marking as done), or sort order. Identifies the task by work item ID, task ID, task name, or title.",
       "category": "tasks",
       "risk": "low",
       "input_schema": {
@@ -185,8 +185,8 @@
           },
           "status": {
             "type": "string",
-            "enum": ["queued", "running", "awaiting_review", "failed", "cancelled", "archived"],
-            "description": "New status for the work item"
+            "enum": ["queued", "running", "awaiting_review", "done", "failed", "cancelled", "archived"],
+            "description": "New status for the work item. To mark a task as done, it must currently be in 'awaiting_review' status."
           },
           "sort_index": {
             "type": "number",

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -182,8 +182,6 @@ function buildTaskScheduleReminderRoutingSection(): string {
     '',
     'If an error says "entity mismatch", read the corrective action and selector fields it provides to pick the right tool.',
     '',
-    '### task_list_show UI note',
-    'When you call `task_list_show`, the Tasks window opens automatically. Present a brief summary in chat — do NOT also create a separate surface/UI (`ui_show` or `app_create`) to display the task queue.',
   ].join('\n');
 }
 

--- a/assistant/src/tools/tasks/index.ts
+++ b/assistant/src/tools/tasks/index.ts
@@ -2,9 +2,9 @@
  * UX Terminology Glossary
  * ──────────────────────────────────────────────────────────────────────
  *
- * "Task" (user-facing) — A work item in the Tasks panel (backed by the
- *   `work_items` table). This is what users see, create, run, and track.
- *   The user-facing surface is simply called "Tasks".
+ * "Task" (user-facing) — A work item in the task queue (backed by the
+ *   `work_items` table). This is what users create, run, and track
+ *   through conversation.
  *
  * "Task template" / "task definition" (internal) — A reusable template
  *   saved from a conversation (backed by the `tasks` table). Templates

--- a/assistant/src/tools/tasks/work-item-list.ts
+++ b/assistant/src/tools/tasks/work-item-list.ts
@@ -37,8 +37,8 @@ export async function executeTaskListShow(
     const filtered = statusFilter !== undefined;
 
     if (count === 0) {
-      const suffix = filtered ? 'no items matching filter.' : 'no tasks queued.';
-      return { content: `Opened Tasks window \u2014 ${suffix}`, isError: false };
+      const suffix = filtered ? 'No items matching that filter.' : 'No tasks queued.';
+      return { content: suffix, isError: false };
     }
 
     const label = filtered
@@ -47,7 +47,7 @@ export async function executeTaskListShow(
 
     const taskList = formatTaskList(items);
 
-    return { content: `Opened Tasks window (${label}).\n\nCurrent tasks:\n${taskList}`, isError: false };
+    return { content: `Task queue (${label}):\n${taskList}`, isError: false };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return { content: `Error: ${msg}`, isError: true };

--- a/assistant/src/tools/tasks/work-item-update.ts
+++ b/assistant/src/tools/tasks/work-item-update.ts
@@ -53,12 +53,11 @@ export async function executeTaskListUpdate(
 
     const item = result.workItem;
 
-    // Block direct transitions to 'done' — the only path to done is
-    // through the Review action (handleWorkItemComplete in the daemon).
-    if (input.status === 'done') {
-      log.warn({ selectorType, resolvedWorkItemId: item.id }, 'rejected attempt to set status to done directly');
+    // Allow direct transitions to 'done' only from 'awaiting_review'
+    if (input.status === 'done' && item.status !== 'awaiting_review') {
+      log.warn({ selectorType, resolvedWorkItemId: item.id, currentStatus: item.status }, 'rejected attempt to set status to done from non-review state');
       return {
-        content: 'Error: Cannot set status to \'done\' directly. Use the Review action in the Tasks window.',
+        content: `Error: Cannot mark as done from '${item.status}'. Tasks must reach 'awaiting_review' status first (typically after a task run completes). You can set the status to 'awaiting_review' if the task is ready to be completed.`,
         isError: true,
       };
     }


### PR DESCRIPTION
Part of #9715. Removes all references to the Tasks window from model instructions, tool descriptions, and tool outputs. Task management now happens entirely through conversation.\n\nCloses #9716
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
