### PR TITLE
M2: Remove window-open side effect & IPC message

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -2790,12 +2790,6 @@ exports[`IPC message snapshots ServerMessage types tasks_changed serializes to e
 }
 `;
 
-exports[`IPC message snapshots ServerMessage types open_tasks_window serializes to expected JSON 1`] = `
-{
-  "type": "open_tasks_window",
-}
-`;
-
 exports[`IPC message snapshots ServerMessage types task_run_thread_created serializes to expected JSON 1`] = `
 {
   "conversationId": "conv-task-run-001",

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -1775,9 +1775,6 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   tasks_changed: {
     type: 'tasks_changed',
   },
-  open_tasks_window: {
-    type: 'open_tasks_window',
-  },
   task_run_thread_created: {
     type: 'task_run_thread_created',
     conversationId: 'conv-task-run-001',

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -263,7 +263,6 @@
     "notification_thread_created",
     "oauth_connect_result",
     "open_bundle_response",
-    "open_tasks_window",
     "open_url",
     "pairing_approval_request",
     "parental_control_get_response",

--- a/assistant/src/daemon/ipc-contract/work-items.ts
+++ b/assistant/src/daemon/ipc-contract/work-items.ts
@@ -181,11 +181,6 @@ export interface WorkItemCancelResponse {
   error?: string;
 }
 
-/** Server push — tells the client to open/focus the tasks window. */
-export interface OpenTasksWindow {
-  type: 'open_tasks_window';
-}
-
 /** Server push — lightweight invalidation signal: the task queue has been mutated, refetch your list. */
 export interface TasksChanged {
   type: 'tasks_changed';
@@ -240,5 +235,4 @@ export type _WorkItemsServerMessages =
   | WorkItemCancelResponse
   | WorkItemStatusChanged
   | TaskRunThreadCreated
-  | TasksChanged
-  | OpenTasksWindow;
+  | TasksChanged;

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -74,11 +74,6 @@ registerHook('app_update', (_name, input, _result, { ctx, broadcastToAllClients 
   }
 });
 
-// Tell the client to open/focus the tasks window when the model lists tasks
-registerHook('task_list_show', (_name, _input, _result, { ctx }) => {
-  ctx.sendToClient({ type: 'open_tasks_window' });
-});
-
 // Broadcast tasks_changed so connected clients (e.g. macOS Tasks window)
 // auto-refresh when the LLM mutates the task queue via tools
 registerHook(

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -989,10 +989,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             }
         }
 
-        daemonClient.onOpenTasksWindow = { [weak self] in
-            self?.showTasksWindow()
-        }
-
         daemonClient.onPairingApprovalRequest = { [weak self] msg in
             guard let self else { return }
             if self.pairingApprovalWindow == nil {

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -440,9 +440,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when a task run creates a conversation so the client can show it as a visible chat thread.
     public var onTaskRunThreadCreated: ((IPCTaskRunThreadCreated) -> Void)?
 
-    /// Called when the daemon wants us to open/focus the tasks window.
-    public var onOpenTasksWindow: (() -> Void)?
-
     /// Called when the daemon requests pairing approval from macOS.
     public var onPairingApprovalRequest: ((PairingApprovalRequestMessage) -> Void)?
 

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -236,8 +236,6 @@ extension DaemonClient {
             onWorkItemCancelResponse?(msg)
         case .taskRunThreadCreated(let msg):
             onTaskRunThreadCreated?(msg)
-        case .openTasksWindow:
-            onOpenTasksWindow?()
         case .subagentSpawned(let msg):
             onSubagentSpawned?(msg)
         case .subagentStatusChanged(let msg):

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -3073,15 +3073,6 @@ public struct IPCOpenBundleResponseSignatureResult: Codable, Sendable {
     }
 }
 
-/// Server push — tells the client to open/focus the tasks window.
-public struct IPCOpenTasksWindow: Codable, Sendable {
-    public let type: String
-
-    public init(type: String) {
-        self.type = type
-    }
-}
-
 public struct IPCOpenUrl: Codable, Sendable {
     public let type: String
     public let url: String

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2309,7 +2309,6 @@ public enum ServerMessage: Decodable, Sendable {
     case workItemApprovePermissionsResponse(IPCWorkItemApprovePermissionsResponse)
     case workItemCancelResponse(IPCWorkItemCancelResponse)
     case taskRunThreadCreated(IPCTaskRunThreadCreated)
-    case openTasksWindow(OpenTasksWindowMessage)
     case subagentSpawned(IPCSubagentSpawned)
     case subagentStatusChanged(IPCSubagentStatusChanged)
     indirect case subagentEvent(SubagentEventMessage)
@@ -2687,9 +2686,6 @@ public enum ServerMessage: Decodable, Sendable {
         case "task_run_thread_created":
             let message = try IPCTaskRunThreadCreated(from: decoder)
             self = .taskRunThreadCreated(message)
-        case "open_tasks_window":
-            let message = try OpenTasksWindowMessage(from: decoder)
-            self = .openTasksWindow(message)
         case "subagent_spawned":
             let message = try IPCSubagentSpawned(from: decoder)
             self = .subagentSpawned(message)
@@ -2802,12 +2798,6 @@ public struct BrowserCDPResponseMessage: Encodable, Sendable {
 // MARK: - App Files Changed
 
 public typealias AppFilesChangedMessage = IPCAppFilesChanged
-
-// MARK: - Open Tasks Window
-
-/// Server push — tells the client to open/focus the tasks window.
-/// Backed by generated `IPCOpenTasksWindow`.
-public typealias OpenTasksWindowMessage = IPCOpenTasksWindow
 
 // MARK: - Parental Control Messages
 


### PR DESCRIPTION
Part of #9715. Removes the open_tasks_window IPC message type and the task_list_show side effect that triggered it. Regenerates IPC artifacts and cleans up Swift routing.

Closes #9717
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
