### PR TITLE
M4: Tests & snapshots

### DIFF
--- a/assistant/src/__tests__/task-tools.test.ts
+++ b/assistant/src/__tests__/task-tools.test.ts
@@ -384,14 +384,14 @@ describe('task_list_show tool', () => {
     const result = await executeTaskListShow({}, stubContext);
 
     expect(result.isError).toBe(false);
-    expect(result.content).toContain('Opened Tasks window (2 items)');
+    expect(result.content).toContain('Task queue (2 items)');
   });
 
   test('returns empty message when no work items', async () => {
     const result = await executeTaskListShow({}, stubContext);
 
     expect(result.isError).toBe(false);
-    expect(result.content).toContain('no tasks queued');
+    expect(result.content).toContain('No tasks queued');
   });
 
   test('filters by status when status param is provided', async () => {
@@ -510,7 +510,7 @@ describe('task_list_add tool', () => {
     const listResult = await executeTaskListShow({}, stubContext);
 
     expect(listResult.isError).toBe(false);
-    expect(listResult.content).toContain('Opened Tasks window (1 item)');
+    expect(listResult.content).toContain('Task queue (1 item)');
   });
 
   test('applies optional overrides (title, notes, priority_tier)', async () => {


### PR DESCRIPTION
Part of #9715. Updates test assertions in task-tools.test.ts to match the new conversation-only output format (no more 'Opened Tasks window' references).\n\nCloses #9719
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
