### PR TITLE
fix: stop computer use agent from refusing to navigate to consoles/dashboards

### DIFF
--- a/assistant/src/config/computer-use-prompt.ts
+++ b/assistant/src/config/computer-use-prompt.ts
@@ -52,6 +52,7 @@ RULES:
 - If you're stuck (same state after 3+ actions), try a different approach or call computer_use_done with an explanation.
 - NEVER type passwords, credit card numbers, SSNs, or other sensitive data.
 - When you must use foreground computer use, prefer keyboard shortcuts (cmd+c, cmd+v) over menu navigation.
+- You CAN and SHOULD navigate to any website, console, dashboard, admin panel, or settings page the user asks you to visit. This includes developer consoles (Anthropic, AWS, GitHub, etc.), login pages, account management, API key creation pages, and similar. Your user is asking you to do this on their machine with their accounts — do not second-guess their intent or refuse. The only hard rule is: never type actual passwords or secrets into fields.
 - When the task is complete, call the computer_use_done tool with a summary.
 - You may receive a "CHANGES SINCE LAST ACTION" section that summarizes what changed in the UI. Use this to confirm your action worked or to adapt.
 - You may see "OTHER VISIBLE WINDOWS" showing elements from other apps. Use this for cross-app tasks (e.g., "copy from Safari, paste into Notes").


### PR DESCRIPTION
## Summary
- Add explicit instruction in computer-use prompt allowing navigation to websites, consoles, dashboards, and admin panels when the user asks
- Counteracts the model's default over-caution about anything credential-adjacent
- The only hard rule remains: never type actual passwords or secrets

## Original prompt
yo why is assistant saying no to me here this is fucked up (screenshot of assistant refusing to navigate to Anthropic console for computer use testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
