### PR TITLE
fix: fall back to any valid codesigning identity before ad-hoc signing

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -80,6 +80,14 @@ if [ -z "${SIGN_IDENTITY:-}" ]; then
             | sed 's/.*"\(.*\)"/\1/' || true)
     fi
 
+    # Fall back to any valid codesigning identity (e.g. self-signed)
+    if [ -z "$SIGN_IDENTITY" ]; then
+        SIGN_IDENTITY=$(security find-identity -v -p codesigning 2>/dev/null \
+            | grep -v "valid identities found" \
+            | head -1 \
+            | sed 's/.*"\(.*\)"/\1/' || true)
+    fi
+
     # Fall back to adhoc signing (no certificate)
     if [ -z "$SIGN_IDENTITY" ]; then
         SIGN_IDENTITY="-"


### PR DESCRIPTION
## Summary

- Add a generic fallback in `build.sh` that picks any valid codesigning identity from the keychain before falling through to ad-hoc signing (`-`)
- Fixes macOS permissions (Accessibility, Screen Recording, Microphone, etc.) being revoked on every rebuild — ad-hoc signing produces a new code hash each time, so TCC treats it as a different app
- Self-signed certificates (e.g. "Vellum Development") are now auto-detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
