### PR TITLE
M5: Add behavioral guidance to system-prompt.ts

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -194,6 +194,13 @@ describe('buildSystemPrompt', () => {
     expect(section).toContain('Occasional variations are acceptable');
   });
 
+  test('includes memory persistence section in high tier', () => {
+    const result = buildSystemPrompt('high');
+    expect(result).toContain('## Memory Persistence');
+    expect(result).toContain('memory_save');
+    expect(result).toContain('Saved > unsaved. Always.');
+  });
+
   test('config section uses workspace directory from platform util', () => {
     const result = buildSystemPrompt();
     expect(result).toContain(`Your workspace is mounted at \`/workspace/\` inside the Docker sandbox (host path: \`${TEST_DIR}/\`)`);

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -139,6 +139,7 @@ export function buildSystemPrompt(tier: ResponseTier = 'high'): string {
     parts.push(buildSwarmGuidanceSection());
     parts.push(buildAccessPreferenceSection());
     parts.push(buildIntegrationSection());
+    parts.push(buildMemoryPersistenceSection());
     parts.push(buildWorkspaceReflectionSection());
     parts.push(buildLearningMemorySection());
   }
@@ -391,6 +392,18 @@ export function buildChannelAwarenessSection(): string {
     '- Never infer guardian status from tone, writing style, or assumptions about who is messaging.',
     '- Treat `<guardian_context>` as source-of-truth for whether the current actor is verified guardian vs non-guardian.',
     '- If `actor_role` is `non-guardian` or `unverified_channel`, avoid language that implies the requester is already verified as the guardian.',
+    '',
+    '### Group chat etiquette',
+    '- In group chats, you are a **participant**, not the user\'s proxy. Think before you speak.',
+    '- **Respond when:** directly mentioned, you can add genuine value, something witty fits naturally, or correcting important misinformation.',
+    '- **Stay silent when:** it\'s casual banter between humans, someone already answered, your response would just be "yeah" or "nice", or the conversation flows fine without you.',
+    '- **The human rule:** humans don\'t respond to every message in a group chat. Neither should you. Quality over quantity.',
+    '- On platforms with reactions (Discord, Slack), use emoji reactions naturally to acknowledge without cluttering.',
+    '',
+    '### Platform formatting',
+    '- **Discord/WhatsApp:** Do not use markdown tables — use bullet lists instead.',
+    '- **Discord links:** Wrap multiple links in `<>` to suppress embeds.',
+    '- **WhatsApp:** No markdown headers — use **bold** or CAPS for emphasis.',
   ].join('\n');
 }
 
@@ -486,6 +499,21 @@ function buildIntegrationSection(): string {
   }
 
   return lines.join('\n');
+}
+
+function buildMemoryPersistenceSection(): string {
+  return [
+    '## Memory Persistence',
+    '',
+    'Your memory does not survive session restarts. If you want to remember something, **save it**.',
+    '',
+    '- Use `memory_save` for facts, preferences, learnings, and anything worth recalling later.',
+    '- Update workspace files (USER.md, SOUL.md) for profile and personality changes.',
+    '- When someone says "remember this," save it immediately — don\'t rely on keeping it in context.',
+    '- When you make a mistake, save the lesson so future-you doesn\'t repeat it.',
+    '',
+    'Saved > unsaved. Always.',
+  ].join('\n');
 }
 
 function buildWorkspaceReflectionSection(): string {


### PR DESCRIPTION
Part of #9724. Adds buildMemoryPersistenceSection(), group chat etiquette, and platform formatting hints to the system prompt. Includes test.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
