### PR TITLE
fix: resolve macOS build warnings

### DIFF
--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
             name: "VellumAssistantShared",
             dependencies: [],
             path: "shared",
-            exclude: ["Tests"],
+            exclude: ["Tests", "PERF_NOTES.md"],
             swiftSettings: [
                 .enableUpcomingFeature("BareSlashRegexLiterals")
             ],

--- a/clients/macos/vellum-assistant/App/PermissionManager.swift
+++ b/clients/macos/vellum-assistant/App/PermissionManager.swift
@@ -136,7 +136,7 @@ enum PermissionManager {
             let settings = await UNUserNotificationCenter.current().notificationSettings()
             switch settings.authorizationStatus {
             case .notDetermined:
-                try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
+                _ = try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
             case .authorized, .provisional, .ephemeral:
                 return
             case .denied:
@@ -152,7 +152,7 @@ enum PermissionManager {
             let settings = await UNUserNotificationCenter.current().notificationSettings()
             switch settings.authorizationStatus {
             case .notDetermined:
-                try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
+                _ = try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
             case .authorized, .provisional, .ephemeral:
                 if settings.badgeSetting != .enabled {
                     _ = openNotificationSettings()


### PR DESCRIPTION
## Summary
- Exclude `PERF_NOTES.md` from the `VellumAssistantShared` SPM target to silence the unhandled file warning
- Assign unused `try?` result to `_` in `PermissionManager.swift` to silence the no-usage warning

## Original prompt
fix: ~v/clients/macos git:(main❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
Building (debug)...
warning: 'clients': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/sidd/vocify/vellum-assistant/clients/shared/PERF_NOTES.md
[1/1] Planning build
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/App/PermissionManager.swift:139:17: warning: result of 'try?' is unused [#no-usage]
137 |             switch settings.authorizationStatus {
138 |             case .notDetermined:
139 |                 try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
    |                 `- warning: result of 'try?' is unused [#no-usage]
140 |             case .authorized, .provisional, .ephemeral:
141 |                 return

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
