### PR TITLE
feat: use local file path for recording playback & thumbnails

### DIFF
--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -4,10 +4,9 @@ import * as path from 'node:path';
 
 import { v4 as uuid } from 'uuid';
 
-import { linkAttachmentToMessage, setAttachmentThumbnail,uploadFileBackedAttachment } from '../../memory/attachments-store.js';
+import { linkAttachmentToMessage, uploadFileBackedAttachment } from '../../memory/attachments-store.js';
 import * as conversationStore from '../../memory/conversation-store.js';
 import type { RecordingOptions,RecordingStatus } from '../ipc-protocol.js';
-import { generateVideoThumbnailFromPath } from '../video-thumbnail.js';
 import { defineHandlers, findSocketForSession, type HandlerContext,log } from './shared.js';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -575,19 +574,10 @@ export async function finalizeAndPublishRecording(params: {
     linkAttachmentToMessage(messageId, attachment.id, 0);
     log.info({ recordingId, messageId, attachmentId: attachment.id }, 'Linked recording attachment to assistant message');
 
-    // Generate thumbnail before notifying the client so it's included
-    // in the message_complete payload (fire-and-forget would race).
-    let thumbnailData: string | undefined;
-    try {
-      const thumb = await generateVideoThumbnailFromPath(resolvedPath);
-      if (thumb) {
-        setAttachmentThumbnail(attachment.id, thumb);
-        thumbnailData = thumb;
-        log.info({ recordingId, attachmentId: attachment.id }, 'Thumbnail generated for recording');
-      }
-    } catch (err) {
-      log.warn({ err, recordingId }, 'Thumbnail generation failed — continuing without thumbnail');
-    }
+    // Skip server-side thumbnail generation for recordings — the client
+    // generates thumbnails natively from the local file path using
+    // AVAssetImageGenerator, which is faster and doesn't depend on ffmpeg.
+    const thumbnailData: string | undefined = undefined;
 
     // Notify the client via the reporting socket
     ctx.send(notifySocket, {
@@ -605,6 +595,7 @@ export async function finalizeAndPublishRecording(params: {
         data: '',  // empty for file-backed; client uses content endpoint
         sizeBytes: attachment.sizeBytes,
         thumbnailData,
+        filePath: resolvedPath,
       }],
     });
 

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -4,7 +4,7 @@ import { v4 as uuid } from 'uuid';
 
 import { type InterfaceId,isChannelId, parseChannelId, parseInterfaceId } from '../../channels/types.js';
 import { getConfig } from '../../config/loader.js';
-import { getAttachmentsForMessage, setAttachmentThumbnail } from '../../memory/attachments-store.js';
+import { getAttachmentsForMessage, getFilePathForAttachment, setAttachmentThumbnail } from '../../memory/attachments-store.js';
 import { getAttentionStateByConversationIds } from '../../memory/conversation-attention-store.js';
 import * as conversationStore from '../../memory/conversation-store.js';
 import { GENERATING_TITLE, queueGenerateConversationTitle, UNTITLED_FALLBACK } from '../../memory/conversation-title-service.js';
@@ -830,6 +830,7 @@ export function handleHistoryRequest(
               );
             }
 
+            const fp = getFilePathForAttachment(a.id);
             return {
               id: a.id,
               filename: a.originalFilename,
@@ -837,18 +838,23 @@ export function handleHistoryRequest(
               data: omit ? '' : a.dataBase64,
               ...(omit ? { sizeBytes: a.sizeBytes } : {}),
               ...(a.thumbnailBase64 ? { thumbnailData: a.thumbnailBase64 } : {}),
+              ...(fp ? { filePath: fp } : {}),
             };
           });
         } else {
           // Light mode: metadata only, strip base64 data
-          attachments = linked.map((a) => ({
-            id: a.id,
-            filename: a.originalFilename,
-            mimeType: a.mimeType,
-            data: '',
-            sizeBytes: a.sizeBytes,
-            ...(a.thumbnailBase64 ? { thumbnailData: a.thumbnailBase64 } : {}),
-          }));
+          attachments = linked.map((a) => {
+            const fp = getFilePathForAttachment(a.id);
+            return {
+              id: a.id,
+              filename: a.originalFilename,
+              mimeType: a.mimeType,
+              data: '',
+              sizeBytes: a.sizeBytes,
+              ...(a.thumbnailBase64 ? { thumbnailData: a.thumbnailBase64 } : {}),
+              ...(fp ? { filePath: fp } : {}),
+            };
+          });
         }
       }
     }

--- a/assistant/src/daemon/ipc-contract/shared.ts
+++ b/assistant/src/daemon/ipc-contract/shared.ts
@@ -45,4 +45,6 @@ export interface UserMessageAttachment {
   sizeBytes?: number;
   /** Base64-encoded JPEG thumbnail. Generated server-side for video attachments. */
   thumbnailData?: string;
+  /** Absolute path to the local file on disk. Present for file-backed attachments (e.g. recordings). */
+  filePath?: string;
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -295,21 +295,32 @@ struct InlineVideoAttachmentView: View {
         return FileManager.default.temporaryDirectory.appendingPathComponent(uniqueName)
     }
 
+    /// Returns a file URL for the local file path if set and the file exists on disk.
+    private var localFileURL: URL? {
+        guard let path = attachment.filePath, !path.isEmpty else { return nil }
+        let url = URL(fileURLWithPath: path)
+        return FileManager.default.fileExists(atPath: url.path) ? url : nil
+    }
+
     private func generateThumbnail() async {
         // Server thumbnail and aspect ratio are set eagerly in init.
         if thumbnailImage != nil { return }
 
         let fileURL: URL
-        if !attachment.data.isEmpty, let data = Data(base64Encoded: attachment.data) {
+        if let localURL = localFileURL {
+            // Local file-backed attachment (e.g. recording): generate thumbnail
+            // directly from the on-disk file — no download or base64 decode needed.
+            fileURL = localURL
+        } else if !attachment.data.isEmpty, let data = Data(base64Encoded: attachment.data) {
             // Inline attachment: decode base64 to temp file.
             let url = safeTempURL()
             do { try data.write(to: url) } catch { return }
             fileURL = url
         } else {
-            // For lazy (file-backed) attachments, don't download the full video
-            // just for a thumbnail — large recordings (100MB+) cause unnecessary
-            // network traffic and memory pressure. The view already shows a
-            // play-button placeholder when thumbnailImage is nil.
+            // For lazy (file-backed) attachments without a local path, don't
+            // download the full video just for a thumbnail — large recordings
+            // (100MB+) cause unnecessary network traffic and memory pressure.
+            // The view already shows a play-button placeholder when thumbnailImage is nil.
             return
         }
 
@@ -343,8 +354,11 @@ struct InlineVideoAttachmentView: View {
     }
 
     private func prepareAndPlay() {
-        // Reuse the temp file written by generateThumbnail() if available.
-        if let fileURL = cachedFileURL {
+        // Prefer the local file path (recordings on the same Mac).
+        if let localURL = localFileURL {
+            Task { await playFromFile(localURL) }
+        } else if let fileURL = cachedFileURL {
+            // Reuse the temp file written by generateThumbnail() if available.
             Task { await playFromFile(fileURL) }
         } else if attachment.isLazyLoad {
             fetchAndPlay()
@@ -472,7 +486,7 @@ struct InlineVideoAttachmentView: View {
         guard panel.runModal() == .OK, let destURL = panel.url else { return }
 
         isSaving = true
-        if let sourceURL = cachedFileURL {
+        if let sourceURL = localFileURL ?? cachedFileURL {
             Task.detached {
                 do {
                     // Copy to a temp location first, then atomically replace the destination so the
@@ -520,7 +534,7 @@ struct InlineVideoAttachmentView: View {
     }
 
     private func openInExternalPlayer() {
-        if let fileURL = cachedFileURL {
+        if let fileURL = localFileURL ?? cachedFileURL {
             NSWorkspace.shared.open(fileURL)
         } else if attachment.isLazyLoad {
             guard let attachmentId = attachment.id.isEmpty ? nil : attachment.id else { return }
@@ -577,6 +591,8 @@ private func fetchAttachmentContent(gatewayBaseUrl: String, attachmentId: String
 
     let (data, response) = try await URLSession.shared.data(for: request)
     guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+        log.error("Attachment fetch failed with HTTP \(statusCode) for \(attachmentId)")
         throw URLError(.badServerResponse)
     }
 

--- a/clients/macos/vellum-assistant/Recording/RecordingHUDWindow.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingHUDWindow.swift
@@ -196,7 +196,7 @@ struct RecordingHUDView: View {
                         .foregroundColor(.white)
                         .frame(width: 24, height: 24)
                         .background(
-                            RoundedRectangle(cornerRadius: VRadius.sm)
+                            RoundedRectangle(cornerRadius: VRadius.md)
                                 .fill(VColor.accent)
                         )
                 }
@@ -210,7 +210,7 @@ struct RecordingHUDView: View {
                         .foregroundColor(.white)
                         .frame(width: 24, height: 24)
                         .background(
-                            RoundedRectangle(cornerRadius: VRadius.sm)
+                            RoundedRectangle(cornerRadius: VRadius.md)
                                 .fill(VColor.error)
                         )
                 }
@@ -218,7 +218,7 @@ struct RecordingHUDView: View {
                 .accessibilityLabel("Stop recording")
             }
         }
-        .padding(.horizontal, VSpacing.md)
+        .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.sm)
         .background(
             RoundedRectangle(cornerRadius: VRadius.lg)

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -21,7 +21,7 @@ struct RecordingSourcePickerView: View {
             Text("Screen Recording")
                 .font(VFont.title)
                 .foregroundColor(VColor.textPrimary)
-                .padding(.top, VSpacing.xl)
+                .padding(.top, VSpacing.md)
                 .padding(.bottom, VSpacing.sm)
 
             Text("Choose what to record")
@@ -38,7 +38,7 @@ struct RecordingSourcePickerView: View {
             .pickerStyle(.segmented)
             .labelsHidden()
             .controlSize(.large)
-            .padding(.horizontal, VSpacing.xl)
+            .padding(.horizontal, VSpacing.lg)
             .padding(.bottom, VSpacing.sm)
 
             // Preview pane
@@ -108,7 +108,7 @@ struct RecordingSourcePickerView: View {
     /// The rows of source items (display or window) without a scroll wrapper.
     @ViewBuilder
     private var sourceListContent: some View {
-        VStack(spacing: VSpacing.xs) {
+        VStack(spacing: VSpacing.sm) {
             switch viewModel.captureScope {
             case .display:
                 ForEach(viewModel.displays) { display in
@@ -179,16 +179,19 @@ struct RecordingSourcePickerView: View {
                         .font(VFont.bodyMedium)
                         .foregroundColor(VColor.textPrimary)
                         .lineLimit(1)
-                    Text(window.appName)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                        .lineLimit(1)
+                    if !window.appName.isEmpty {
+                        Text(window.appName)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                            .lineLimit(1)
+                    }
                 }
 
                 Spacer()
 
                 if isSelected {
                     Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 18))
                         .foregroundColor(VColor.accent)
                 }
             }
@@ -223,11 +226,6 @@ struct RecordingSourcePickerView: View {
                     size: rowThumbnailSize
                 )
 
-                Image(systemName: "display")
-                    .font(.system(size: 16))
-                    .foregroundColor(isSelected ? VColor.accent : VColor.textSecondary)
-                    .frame(width: 24)
-
                 VStack(alignment: .leading, spacing: 2) {
                     HStack(spacing: VSpacing.sm) {
                         Text(display.name)
@@ -248,6 +246,7 @@ struct RecordingSourcePickerView: View {
 
                 if isSelected {
                     Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 18))
                         .foregroundColor(VColor.accent)
                 }
             }
@@ -326,6 +325,7 @@ struct RecordingSourcePickerView: View {
                     onStart(viewModel.selectedRecordingOptions)
                 }
             }
+            .padding(.top, VSpacing.xs)
             .padding(.horizontal, VSpacing.xl)
             .background {
                 // Hidden buttons for keyboard shortcuts

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1214,12 +1214,16 @@ public struct ChatAttachment: Identifiable {
     #error("Unsupported platform")
     #endif
 
+    /// Absolute path to the local file on disk. Present for file-backed attachments
+    /// (e.g. recordings) where the file lives on the same Mac as the client.
+    public let filePath: String?
+
     /// Whether this attachment's binary data was omitted to keep the IPC payload small.
     /// The client should fetch it lazily via the HTTP endpoint when the user interacts.
     public var isLazyLoad: Bool { data.isEmpty && sizeBytes != nil }
 
     #if os(macOS)
-    public init(id: String, filename: String, mimeType: String, data: String, thumbnailData: Data?, dataLength: Int, sizeBytes: Int? = nil, thumbnailImage: NSImage?) {
+    public init(id: String, filename: String, mimeType: String, data: String, thumbnailData: Data?, dataLength: Int, sizeBytes: Int? = nil, thumbnailImage: NSImage?, filePath: String? = nil) {
         self.id = id
         self.filename = filename
         self.mimeType = mimeType
@@ -1228,9 +1232,10 @@ public struct ChatAttachment: Identifiable {
         self.dataLength = dataLength
         self.sizeBytes = sizeBytes
         self.thumbnailImage = thumbnailImage
+        self.filePath = filePath
     }
     #elseif os(iOS)
-    public init(id: String, filename: String, mimeType: String, data: String, thumbnailData: Data?, dataLength: Int, sizeBytes: Int? = nil, thumbnailImage: UIImage?) {
+    public init(id: String, filename: String, mimeType: String, data: String, thumbnailData: Data?, dataLength: Int, sizeBytes: Int? = nil, thumbnailImage: UIImage?, filePath: String? = nil) {
         self.id = id
         self.filename = filename
         self.mimeType = mimeType
@@ -1239,6 +1244,7 @@ public struct ChatAttachment: Identifiable {
         self.dataLength = dataLength
         self.sizeBytes = sizeBytes
         self.thumbnailImage = thumbnailImage
+        self.filePath = filePath
     }
     #else
     #error("Unsupported platform")

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -321,7 +321,8 @@ extension ChatViewModel {
                 thumbnailData: thumbnailData,
                 dataLength: dataLength,
                 sizeBytes: sizeBytes,
-                thumbnailImage: thumbnailImage
+                thumbnailImage: thumbnailImage,
+                filePath: ipc.filePath
             )
         }
     }

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -5739,8 +5739,10 @@ public struct IPCUserMessageAttachment: Codable, Sendable {
     public let sizeBytes: Int?
     /// Base64-encoded JPEG thumbnail. Generated server-side for video attachments.
     public let thumbnailData: String?
+    /// Absolute path to the local file on disk. Present for file-backed attachments (e.g. recordings).
+    public let filePath: String?
 
-    public init(id: String? = nil, filename: String, mimeType: String, data: String, extractedText: String? = nil, sizeBytes: Int? = nil, thumbnailData: String? = nil) {
+    public init(id: String? = nil, filename: String, mimeType: String, data: String, extractedText: String? = nil, sizeBytes: Int? = nil, thumbnailData: String? = nil, filePath: String? = nil) {
         self.id = id
         self.filename = filename
         self.mimeType = mimeType
@@ -5748,6 +5750,7 @@ public struct IPCUserMessageAttachment: Codable, Sendable {
         self.extractedText = extractedText
         self.sizeBytes = sizeBytes
         self.thumbnailData = thumbnailData
+        self.filePath = filePath
     }
 }
 


### PR DESCRIPTION
## Summary
- Pass the on-disk file path from daemon to client via IPC (`filePath` field on `UserMessageAttachment`) so screen recordings play directly from the local file — no HTTP roundtrip needed
- Client generates thumbnails natively with `AVAssetImageGenerator`, eliminating the ffmpeg dependency (which wasn't on PATH when launched from the app bundle)
- Fixes the 3:4 portrait aspect ratio fallback by deriving real dimensions from the local video file
- Includes `filePath` in `history_response` so recordings still work when reopening a conversation

### Recording UI polish
- **Display/Window switch**: Match width to preview pane (horizontal padding `xl` → `lg`); border/radius unchanged (native segmented control)
- **Display rows**: Remove monitor icon from each row
- **Row spacing**: Increase from 4px (`xs`) to 8px (`sm`) between source rows
- **Check icon**: Increase size to 18pt (+4px)
- **Mic ↔ buttons spacing**: Add 4px (`xs`) extra top padding above Cancel/Start buttons
- **"Screen Recording" title**: Reduce top margin from 24px (`xl`) to 12px (`md`)
- **Recording bar buttons**: Update border radius from 4px (`sm`) to 8px (`md`) to better match outer bar
- **Recording bar padding**: Match horizontal padding to vertical (both 8px / `sm`)
- **Window list items**: Conditionally hide subtitle when empty so title centers vertically

## Test plan
- [x] `bun test recording-handler` — 19/19 pass
- [x] `./build.sh` — Swift build succeeds
- [x] `./build.sh test` — 70/70 Swift tests pass
- [x] `bun run check:ipc-generated` — in sync
- [x] `bun run ipc:inventory` — in sync
- [ ] Manual: record screen, stop — video plays immediately with landscape thumbnail
- [ ] Manual: close and reopen conversation — recording still plays (history_response path)
- [ ] Manual: user-uploaded video attachments still work (ffmpeg path unchanged)
- [ ] Manual: delete recording file from disk, reopen — falls back to HTTP gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)