### PR TITLE
fix: schedule-triggered task threads appear in wrong sidebar section

### DIFF
--- a/assistant/src/daemon/handlers/config-scheduling.ts
+++ b/assistant/src/daemon/handlers/config-scheduling.ts
@@ -84,7 +84,7 @@ export async function handleScheduleRunNow(
       log.info({ jobId: schedule.id, name: schedule.name, taskId }, 'Executing scheduled task manually (run now)');
       const { runTask } = await import('../../tasks/task-runner.js');
       const result = await runTask(
-        { taskId, workingDir: process.cwd() },
+        { taskId, workingDir: process.cwd(), source: 'schedule' },
         async (conversationId, message, taskRunId) => {
           const session = await ctx.getOrCreateSession(conversationId, socket, true);
           (session as unknown as { taskRunId?: string }).taskRunId = taskRunId;

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -95,7 +95,7 @@ async function runScheduleOnce(
         log.info({ jobId: job.id, name: job.name, taskId, syntax: job.syntax, expression: job.expression, isRruleSet }, 'Executing scheduled task');
         const { runTask } = await import('../tasks/task-runner.js');
         const result = await runTask(
-          { taskId, workingDir: process.cwd() },
+          { taskId, workingDir: process.cwd(), source: 'schedule' },
           processMessage as (conversationId: string, message: string, taskRunId: string) => Promise<void>,
         );
 

--- a/assistant/src/tasks/task-runner.ts
+++ b/assistant/src/tasks/task-runner.ts
@@ -14,6 +14,8 @@ export interface TaskRunOptions {
   workingDir: string;
   /** Pre-approved tools from the permission preflight flow. When set, only these tools get ephemeral allow rules. */
   approvedTools?: string[];
+  /** Conversation source to propagate to the created conversation (e.g. 'schedule' when triggered by a schedule). */
+  source?: string;
 }
 
 export interface TaskRunResult {
@@ -45,7 +47,7 @@ export async function runTask(
   }
 
   const run = createTaskRun(task.id);
-  const conversation = createConversation({ title: GENERATING_TITLE, threadType: 'background' });
+  const conversation = createConversation({ title: GENERATING_TITLE, threadType: 'background', source: opts.source });
   queueGenerateConversationTitle({
     conversationId: conversation.id,
     context: { origin: 'task', systemHint: `Task: ${task.title}` },


### PR DESCRIPTION
## Summary

- Task runner's `createConversation()` call was missing `source: 'schedule'` when invoked by the scheduler, causing threads to default to `source: 'user'`
- Added optional `source` field to `TaskRunOptions` and propagated it to `createConversation()`
- Both the scheduler tick path and the manual "Run Now" handler now pass `source: 'schedule'`

## Original prompt

Why are these threads showing up in the top section. These are cronjobs and should show up under the "Scheduled" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
