### PR TITLE
feat: add startup warning when VELLUM_DAEMON_NOAUTH is set

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -46,6 +46,7 @@ import {
 import { listWorkItems, updateWorkItem } from '../work-items/work-item-store.js';
 import { WorkspaceHeartbeatService } from '../workspace/heartbeat-service.js';
 import { createApprovalConversationGenerator,createApprovalCopyGenerator } from './approval-generators.js';
+import { hasNoAuthOverride } from './connection-policy.js';
 import { cleanupPidFile,writePid } from './daemon-control.js';
 import { createGuardianActionCopyGenerator } from './guardian-action-generators.js';
 import { initPairingHandlers } from './handlers/pairing.js';
@@ -77,6 +78,11 @@ function loadDotEnv(): void {
 export async function runDaemon(): Promise<void> {
   loadDotEnv();
   validateEnv();
+
+  if (hasNoAuthOverride()) {
+    log.warn('VELLUM_DAEMON_NOAUTH is set — IPC authentication is DISABLED. This should only be used for development or SSH-forwarded sockets. Do not use in production.');
+  }
+
   initSentry();
   await initLogfire();
 


### PR DESCRIPTION
Log a prominent warning during daemon startup when VELLUM_DAEMON_NOAUTH=1 is set, making it clear that IPC authentication is disabled and this should only be used for development.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
