### PR TITLE
feat: add database index on conversations(updatedAt)

### DIFF
--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -17,7 +17,9 @@ export const conversations = sqliteTable('conversations', {
   originChannel: text('origin_channel'),
   originInterface: text('origin_interface'),
   isAutoTitle: integer('is_auto_title').notNull().default(1),
-});
+}, (table) => [
+  index('idx_conversations_updated_at').on(table.updatedAt),
+]);
 
 export const messages = sqliteTable('messages', {
   id: text('id').primaryKey(),


### PR DESCRIPTION
Add index on conversations.updatedAt column to improve performance of ORDER BY updatedAt queries (e.g., listConversations). Follows existing index patterns in schema.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
