### PR TITLE
feat: add startup warning when DISABLE_HTTP_AUTH is set

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -303,6 +303,10 @@ export class RuntimeHttpServer {
 
     this.pairingStore.start();
 
+    if (isHttpAuthDisabled()) {
+      log.warn('DISABLE_HTTP_AUTH is set — HTTP API authentication is DISABLED. All API endpoints are accessible without a bearer token. Do not use in production.');
+    }
+
     log.info({ port: this.actualPort, hostname: this.hostname, auth: !!this.bearerToken }, 'Runtime HTTP server listening');
   }
 


### PR DESCRIPTION
Log a prominent warning during HTTP server startup when DISABLE_HTTP_AUTH=true is set, making it clear that API authentication is disabled and this should not be used in production.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
