### PR TITLE
security: reduce TLS certificate validity from 10 years to 1 year

### DIFF
--- a/assistant/src/daemon/tls-certs.ts
+++ b/assistant/src/daemon/tls-certs.ts
@@ -151,13 +151,13 @@ export async function ensureTlsCert(): Promise<{ cert: string; key: string; fing
     throw new Error(`Failed to generate TLS key: ${stderr}`);
   }
 
-  // Generate self-signed cert (10-year validity)
+  // Generate self-signed cert (1-year validity)
   const certProc = Bun.spawn(
     [
       'openssl', 'req', '-new', '-x509',
       '-key', keyPath,
       '-out', certPath,
-      '-days', '3650',
+      '-days', '365',
       '-subj', '/CN=Vellum Daemon',
     ],
     { stdout: 'pipe', stderr: 'pipe' },


### PR DESCRIPTION
Reduce self-signed TLS certificate validity from 3650 days (10 years) to 365 days (1 year). Shorter-lived certificates limit the window of exposure if a certificate is compromised.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
