### PR TITLE
feat: add periodic background cleanup for gateway dedup caches

### DIFF
--- a/gateway/src/dedup-cache.ts
+++ b/gateway/src/dedup-cache.ts
@@ -29,6 +29,7 @@ export class DedupCache {
    * the TTL cache.
    */
   private highWaterMark = -Infinity;
+  private cleanupTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(ttlMs = 5 * 60_000, maxSize = 10_000) {
     this.ttlMs = ttlMs;
@@ -141,6 +142,20 @@ export class DedupCache {
     return this.cache.size;
   }
 
+  /** Start a periodic background sweep of expired entries. */
+  startCleanup(intervalMs = 60_000): void {
+    this.stopCleanup();
+    this.cleanupTimer = setInterval(() => this.evictExpired(), intervalMs);
+  }
+
+  /** Stop the periodic background sweep. */
+  stopCleanup(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
+  }
+
   private evictExpired(): void {
     const now = Date.now();
     let evicted = 0;
@@ -171,6 +186,7 @@ export class StringDedupCache {
   private processing = new Set<string>();
   private readonly ttlMs: number;
   private readonly maxSize: number;
+  private cleanupTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(ttlMs = 5 * 60_000, maxSize = 10_000) {
     this.ttlMs = ttlMs;
@@ -250,6 +266,20 @@ export class StringDedupCache {
 
   get size(): number {
     return this.cache.size;
+  }
+
+  /** Start a periodic background sweep of expired entries. */
+  startCleanup(intervalMs = 60_000): void {
+    this.stopCleanup();
+    this.cleanupTimer = setInterval(() => this.evictExpired(Date.now()), intervalMs);
+  }
+
+  /** Stop the periodic background sweep. */
+  stopCleanup(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
   }
 
   private evictExpired(now: number): void {

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -32,7 +32,7 @@ const START_COMMAND_ACK_TEXT = "Starting up... you'll get my first message in a 
 export function createTelegramWebhookHandler(config: GatewayConfig) {
   const dedupCache = new DedupCache();
 
-  return async (req: Request): Promise<Response> => {
+  const handler = async (req: Request): Promise<Response> => {
     const traceId = req.headers.get("x-trace-id") ?? undefined;
     const tlog = traceId ? log.child({ traceId }) : log;
 
@@ -505,4 +505,6 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
 
     return respond({ ok: true });
   };
+
+  return { handler, dedupCache };
 }

--- a/gateway/src/http/routes/twilio-sms-webhook.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.ts
@@ -50,7 +50,7 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
   // longer window hardens replay prevention beyond the default 5 minutes.
   const dedupCache = new StringDedupCache(24 * 60 * 60_000);
 
-  return async (req: Request): Promise<Response> => {
+  const handler = async (req: Request): Promise<Response> => {
     const traceId = req.headers.get("x-trace-id") ?? undefined;
     const tlog = traceId ? log.child({ traceId }) : log;
 
@@ -230,4 +230,6 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
 
     return Response.json({ ok: true });
   };
+
+  return { handler, dedupCache };
 }

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -20,7 +20,7 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
   // 24-hour TTL — WhatsApp message IDs are globally unique and never reused
   const dedupCache = new StringDedupCache(24 * 60 * 60_000);
 
-  return async (req: Request): Promise<Response> => {
+  const handler = async (req: Request): Promise<Response> => {
     const traceId = req.headers.get("x-trace-id") ?? undefined;
     const tlog = traceId ? log.child({ traceId }) : log;
 
@@ -248,4 +248,6 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
 
     return Response.json({ ok: true });
   };
+
+  return { handler, dedupCache };
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -109,7 +109,7 @@ function main() {
 
   log.info("Starting Vellum Gateway...");
 
-  const handleTelegramWebhook = createTelegramWebhookHandler(config);
+  const { handler: handleTelegramWebhook, dedupCache: telegramDedupCache } = createTelegramWebhookHandler(config);
   const handleTelegramDeliver = createTelegramDeliverHandler(config);
   const handleTelegramReconcile = createTelegramReconcileHandler(config);
 
@@ -123,9 +123,9 @@ function main() {
   const handleTwilioStatusWebhook = createTwilioStatusWebhookHandler(config);
   const handleTwilioConnectActionWebhook = createTwilioConnectActionWebhookHandler(config);
   const handleTwilioRelayWs = createTwilioRelayWebsocketHandler(config);
-  const handleTwilioSmsWebhook = createTwilioSmsWebhookHandler(config);
+  const { handler: handleTwilioSmsWebhook, dedupCache: smsDedupCache } = createTwilioSmsWebhookHandler(config);
   const handleSmsDeliver = createSmsDeliverHandler(config);
-  const handleWhatsAppWebhook = createWhatsAppWebhookHandler(config);
+  const { handler: handleWhatsAppWebhook, dedupCache: whatsappDedupCache } = createWhatsAppWebhookHandler(config);
   const handleWhatsAppDeliver = createWhatsAppDeliverHandler(config);
   const handleOAuthCallback = createOAuthCallbackHandler(config);
   const pairingProxy = createPairingProxyHandler(config);
@@ -350,6 +350,11 @@ function main() {
 
   log.info({ port: server.port }, "Gateway HTTP server listening");
 
+  // Start periodic background cleanup for dedup caches
+  telegramDedupCache.startCleanup();
+  smsDedupCache.startCleanup();
+  whatsappDedupCache.startCleanup();
+
   function registerTelegramCommands(): void {
     callTelegramApi(config, "setMyCommands", {
       commands: [
@@ -453,6 +458,9 @@ function main() {
     credentialWatcher.stop();
     configFileWatcher.stop();
     httpTokenWatcher?.close();
+    telegramDedupCache.stopCleanup();
+    smsDedupCache.stopCleanup();
+    whatsappDedupCache.stopCleanup();
     setTimeout(() => {
       log.info("Drain window elapsed, stopping server");
       server.stop(true);


### PR DESCRIPTION
Add startCleanup()/stopCleanup() methods to DedupCache and StringDedupCache that periodically sweep expired entries (every 60s). Integrated into gateway startup and graceful shutdown. Prevents memory growth from accumulated expired entries.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
