### PR TITLE
fix: remove runtime-port URLs from trusted-contact skill docs

### DIFF
--- a/assistant/docs/runbook-trusted-contacts.md
+++ b/assistant/docs/runbook-trusted-contacts.md
@@ -1,6 +1,6 @@
 # Trusted Contacts — Operator Runbook
 
-Operational procedures for inspecting, managing, and debugging the trusted contact access flow. All HTTP commands use the runtime API (default `http://localhost:7821`) with bearer authentication.
+Operational procedures for inspecting, managing, and debugging the trusted contact access flow. All HTTP commands use the gateway API (default `http://localhost:7830`) with bearer authentication.
 
 ## Prerequisites
 
@@ -9,7 +9,7 @@ Operational procedures for inspecting, managing, and debugging the trusted conta
 TOKEN=$(cat ~/.vellum/http-token)
 
 # Base URL (adjust if using a non-default port)
-BASE=http://localhost:7821
+BASE=http://localhost:7830
 ```
 
 ## 1. Inspect Trusted Contacts (Members)

--- a/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
+++ b/assistant/src/config/vellum-skills/trusted-contacts/SKILL.md
@@ -5,11 +5,11 @@ user-invocable: true
 metadata: {"vellum": {"emoji": "\ud83d\udc65"}}
 ---
 
-You are helping your user manage trusted contacts for the Vellum Assistant. Trusted contacts control who is allowed to send messages to the assistant through external channels like Telegram and SMS. All operations go through the runtime HTTP API using `curl` with bearer auth.
+You are helping your user manage trusted contacts for the Vellum Assistant. Trusted contacts control who is allowed to send messages to the assistant through external channels like Telegram and SMS. All operations go through the gateway HTTP API using `curl` with bearer auth.
 
 ## Prerequisites
 
-- The runtime HTTP API is available at `http://localhost:7821` (or the configured `RUNTIME_HTTP_PORT`).
+- The gateway API is available at `http://localhost:7830` (or the configured gateway port).
 - The bearer token is stored at `~/.vellum/http-token`. Read it with: `TOKEN=$(cat ~/.vellum/http-token)`.
 
 ## Concepts
@@ -27,7 +27,7 @@ Use this to show the user who currently has access, or to look up a specific con
 
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
-curl -s http://localhost:7821/v1/ingress/members \
+curl -s http://localhost:7830/v1/ingress/members \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -38,7 +38,7 @@ Optional query parameters for filtering:
 
 Example with filters:
 ```bash
-curl -s "http://localhost:7821/v1/ingress/members?sourceChannel=telegram&status=active" \
+curl -s "http://localhost:7830/v1/ingress/members?sourceChannel=telegram&status=active" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -63,7 +63,7 @@ Ask the user: *"I'll add [name/identifier] on [channel] as an allowed contact. S
 
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
-curl -s -X POST http://localhost:7821/v1/ingress/members \
+curl -s -X POST http://localhost:7830/v1/ingress/members \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{
@@ -95,7 +95,7 @@ First, list members to find the member's `id`, then revoke:
 
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
-curl -s -X DELETE "http://localhost:7821/v1/ingress/members/<member_id>" \
+curl -s -X DELETE "http://localhost:7830/v1/ingress/members/<member_id>" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"reason": "<optional reason>"}'
@@ -111,7 +111,7 @@ Ask the user: *"I'll block [name/identifier]. They will be permanently denied fr
 
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
-curl -s -X POST "http://localhost:7821/v1/ingress/members/<member_id>/block" \
+curl -s -X POST "http://localhost:7830/v1/ingress/members/<member_id>/block" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{"reason": "<optional reason>"}'

--- a/skills/trusted-contacts/SKILL.md
+++ b/skills/trusted-contacts/SKILL.md
@@ -5,11 +5,11 @@ user-invocable: true
 metadata: {"vellum": {"emoji": "\ud83d\udc65"}}
 ---
 
-You are helping your user manage trusted contacts for the Vellum Assistant. Trusted contacts control who is allowed to send messages to the assistant through external channels like Telegram and SMS. All operations go through the runtime HTTP API using `curl` with bearer auth.
+You are helping your user manage trusted contacts for the Vellum Assistant. Trusted contacts control who is allowed to send messages to the assistant through external channels like Telegram and SMS. All operations go through the gateway HTTP API using `curl` with bearer auth.
 
 ## Prerequisites
 
-- The runtime HTTP API is available at `http://localhost:7821` (or the configured `RUNTIME_HTTP_PORT`).
+- The gateway API is available at `http://localhost:7830` (or the configured gateway port).
 - The bearer token is stored at `~/.vellum/http-token`. Read it with: `TOKEN=$(cat ~/.vellum/http-token)`.
 
 ## Concepts
@@ -27,7 +27,7 @@ Use this to show the user who currently has access, or to look up a specific con
 
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
-curl -s http://localhost:7821/v1/ingress/members \
+curl -s http://localhost:7830/v1/ingress/members \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -38,7 +38,7 @@ Optional query parameters for filtering:
 
 Example with filters:
 ```bash
-curl -s "http://localhost:7821/v1/ingress/members?sourceChannel=telegram&status=active" \
+curl -s "http://localhost:7830/v1/ingress/members?sourceChannel=telegram&status=active" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -63,7 +63,7 @@ Ask the user: *"I'll add [name/identifier] on [channel] as an allowed contact. S
 
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
-curl -s -X POST http://localhost:7821/v1/ingress/members \
+curl -s -X POST http://localhost:7830/v1/ingress/members \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{
@@ -95,7 +95,7 @@ First, list members to find the member's `id`, then revoke:
 
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
-curl -s -X DELETE "http://localhost:7821/v1/ingress/members/<member_id>" \
+curl -s -X DELETE "http://localhost:7830/v1/ingress/members/<member_id>" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"reason": "<optional reason>"}'
@@ -111,7 +111,7 @@ Ask the user: *"I'll block [name/identifier]. They will be permanently denied fr
 
 ```bash
 TOKEN=$(cat ~/.vellum/http-token)
-curl -s -X POST "http://localhost:7821/v1/ingress/members/<member_id>/block" \
+curl -s -X POST "http://localhost:7830/v1/ingress/members/<member_id>/block" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{"reason": "<optional reason>"}'


### PR DESCRIPTION
Replaces hardcoded localhost:7821 URLs in the trusted-contacts skill and runbook with gateway URLs, fixing the gateway-only-guard CI test and aligning with the gateway-only API consumption rule.

Part of #9432
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
