### PR TITLE
feat: add skill tool name collision detection

### DIFF
--- a/assistant/src/__tests__/computer-use-skill-manifest-regression.test.ts
+++ b/assistant/src/__tests__/computer-use-skill-manifest-regression.test.ts
@@ -77,8 +77,8 @@ describe('computer-use skill manifest regression', () => {
     await initializeTools();
 
     // The 12 computer_use_* action tools must NOT be in the global registry
-    // after initializeTools(). If they were, registerSkillTools() would throw
-    // a "collides with core tool" error when the computer-use skill is activated.
+    // after initializeTools(). If they were, registerSkillTools() would skip
+    // them as core tool collisions when the computer-use skill is activated.
     for (const name of COMPUTER_USE_TOOL_NAMES) {
       expect(getTool(name)).toBeUndefined();
     }

--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -334,14 +334,18 @@ describe('dynamic skill tool registry', () => {
     expect(getTool('sk_tool_b')?.origin).toBe('skill');
   });
 
-  test('rejects skill tool that collides with a core tool', async () => {
+  test('skips skill tool that collides with a core tool without throwing', async () => {
     await initializeTools();
 
     // host_file_read is a core tool registered during init
     const colliding = makeSkillTool('host_file_read', 'rogue-skill');
-    expect(() => registerSkillTools([colliding])).toThrow(
-      'collides with core tool',
-    );
+    const accepted = registerSkillTools([colliding]);
+
+    // The colliding tool should be silently skipped
+    expect(accepted).toHaveLength(0);
+    // The core tool should still be in place (not overwritten)
+    const retrieved = getTool('host_file_read');
+    expect(retrieved?.origin).toBeUndefined(); // core tools have no origin
   });
 
   test('allows replacement within the same owning skill', () => {
@@ -410,7 +414,7 @@ describe('dynamic skill tool registry', () => {
     expect(skillNames).not.toContain('bash');
   });
 
-  test('registerSkillTools is atomic — no partial registration on collision', async () => {
+  test('registerSkillTools skips core-colliding tools but registers the rest', async () => {
     await initializeTools();
 
     const tools = [
@@ -418,9 +422,14 @@ describe('dynamic skill tool registry', () => {
       makeSkillTool('host_file_read', 'atomic-skill'), // collides with core
     ];
 
-    expect(() => registerSkillTools(tools)).toThrow('collides with core tool');
-    // The first tool should NOT have been registered either
-    expect(getTool('sk_atomic_ok')).toBeUndefined();
+    const accepted = registerSkillTools(tools);
+    // Only the non-colliding tool should be accepted
+    expect(accepted).toHaveLength(1);
+    expect(accepted[0].name).toBe('sk_atomic_ok');
+    // The non-colliding tool should be registered
+    expect(getTool('sk_atomic_ok')).toBeDefined();
+    // The core tool should be untouched
+    expect(getTool('host_file_read')?.origin).toBeUndefined();
   });
 });
 

--- a/assistant/src/daemon/session-skill-tools.ts
+++ b/assistant/src/daemon/session-skill-tools.ts
@@ -282,17 +282,18 @@ export function projectSkillTools(
     );
 
     if (tools.length > 0) {
+      let accepted = tools;
       const prevHash = prevActive.get(skillId);
       if (prevHash === undefined) {
         // Newly active skill — register for the first time
-        registerSkillTools(tools);
+        accepted = registerSkillTools(tools);
       } else if (prevHash !== currentHash) {
         // Hash changed — unregister stale tools, then re-register with new definitions
         log.info({ skillId, prevHash, currentHash }, 'Skill version changed, re-registering tools');
         unregisterSkillTools(skillId);
         alreadyUnregistered.add(skillId);
         try {
-          registerSkillTools(tools);
+          accepted = registerSkillTools(tools);
         } catch (err) {
           log.error({ err, skillId }, 'Failed to re-register skill tools after version change');
           // Don't add to successfulEntries — will be cleaned up as transiently-failed
@@ -306,12 +307,12 @@ export function projectSkillTools(
         if (existing && existing.ownerSkillBundled !== (skill.bundled ?? undefined)) {
           log.info({ skillId, bundled: skill.bundled }, 'Skill bundled status changed, re-registering tools');
           unregisterSkillTools(skillId);
-          registerSkillTools(tools);
+          accepted = registerSkillTools(tools);
         }
       }
 
       successfulEntries.set(skillId, currentHash);
-      for (const tool of tools) {
+      for (const tool of accepted) {
         allToolDefinitions.push(tool.getDefinition());
         allToolNames.add(tool.name);
       }

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -109,20 +109,25 @@ export function getAllTools(): Tool[] {
 
 /**
  * Register multiple skill-origin tools at once.
- * Throws if any tool name collides with a core tool (origin !== 'skill' or undefined origin).
+ * Skips any tool whose name collides with a core tool (logs a warning instead
+ * of throwing so the remaining tools in the batch still get registered).
+ * Throws if a tool name collides with a skill tool owned by a different skill.
  * Allows replacement when the incoming tool has the same ownerSkillId as the existing one,
  * which supports hot-reloading a skill without tearing down first.
  */
-export function registerSkillTools(newTools: Tool[]): void {
-  // Validate all tools before mutating the registry so we get atomic-or-nothing behavior.
+export function registerSkillTools(newTools: Tool[]): Tool[] {
+  // Filter out tools that collide with core tools, and validate the rest.
+  const accepted: Tool[] = [];
   for (const tool of newTools) {
     const existing = tools.get(tool.name);
     if (existing) {
       const existingIsCore = existing.origin !== 'skill';
       if (existingIsCore) {
-        throw new Error(
-          `Skill tool "${tool.name}" collides with core tool of the same name`,
+        log.warn(
+          { toolName: tool.name, skillId: tool.ownerSkillId },
+          `Skill "${tool.ownerSkillId}" tried to register tool "${tool.name}" which conflicts with a core tool. Skipping.`,
         );
+        continue;
       }
       // Existing is also a skill tool — only allow replacement from the same owner.
       if (existing.ownerSkillId !== tool.ownerSkillId) {
@@ -131,11 +136,12 @@ export function registerSkillTools(newTools: Tool[]): void {
         );
       }
     }
+    accepted.push(tool);
   }
 
   // Collect unique skill IDs from the batch to bump ref counts
   const skillIds = new Set<string>();
-  for (const tool of newTools) {
+  for (const tool of accepted) {
     tools.set(tool.name, tool);
     if (tool.ownerSkillId) skillIds.add(tool.ownerSkillId);
     log.info({ name: tool.name, ownerSkillId: tool.ownerSkillId }, 'Skill tool registered');
@@ -144,6 +150,8 @@ export function registerSkillTools(newTools: Tool[]): void {
   for (const id of skillIds) {
     skillRefCount.set(id, (skillRefCount.get(id) ?? 0) + 1);
   }
+
+  return accepted;
 }
 
 /**


### PR DESCRIPTION
Validate on skill load that no skill-provided tool name shadows a core tool name. When a collision is detected, log a warning and skip the conflicting skill tool to prevent core functionality from being accidentally overridden.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
