### PR TITLE
fix: add accessibility label to timezone picker clear button

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TimezonePicker.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TimezonePicker.swift
@@ -55,6 +55,7 @@ struct TimezonePicker: View {
                             .font(.system(size: 12))
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Clear search")
                 }
             }
             .padding(.horizontal, VSpacing.md)


### PR DESCRIPTION
## Summary
- Added .accessibilityLabel("Clear search") to the icon-only clear button in TimezonePicker
- Addresses Codex P1 accessibility feedback on PR #9696

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/9696
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
