### PR TITLE
fix: record last_fix_push_time after re-request comments in blitz

### DIFF
--- a/.claude/commands/blitz.md
+++ b/.claude/commands/blitz.md
@@ -165,7 +165,6 @@ Increment the cycle counter by 1.
    git fetch origin $PR_BRANCH
    LATEST_COMMIT=$(git rev-parse origin/$PR_BRANCH)
    ```
-6. Record the current UTC time as `last_fix_push_time` (e.g., `date -u +%Y-%m-%dT%H:%M:%SZ`).
 
 #### Step 5: Re-request reviews and wait
 
@@ -175,6 +174,8 @@ After fixes are pushed, explicitly tag both reviewers by posting two separate co
 gh pr comment <pr-number> --body "@codex review this PR again — the previous issues have been fixed in commit $LATEST_COMMIT"
 gh pr comment <pr-number> --body "@devin review this PR again — the previous issues have been fixed in commit $LATEST_COMMIT"
 ```
+
+Record the current UTC time as `last_fix_push_time` **after** posting the re-review comments (e.g., `date -u +%Y-%m-%dT%H:%M:%SZ`). This ensures the agent's own comment activity is excluded from the "new activity" check during polling.
 
 Log: `"Re-requested reviews from Codex and Devin on PR #<pr-number> (cycle <cycle-counter>/3, commit $LATEST_COMMIT)."`
 


### PR DESCRIPTION
## Summary
- Moved last_fix_push_time recording to after the @codex/@devin re-review request comments
- This prevents the agent's own comments from being counted as new review activity during polling
- Addresses Codex P2 and Devin feedback on PR #9697

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/9697
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
