### PR TITLE
fix: use original user text for guardian conversation title generation

### DIFF
--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -144,7 +144,7 @@ export async function runAgentLoopImpl(
   content: string,
   userMessageId: string,
   onEvent: (msg: ServerMessage) => void,
-  options?: { skipPreMessageRollback?: boolean; isInteractive?: boolean },
+  options?: { skipPreMessageRollback?: boolean; isInteractive?: boolean; titleText?: string },
 ): Promise<void> {
   if (!ctx.abortController) {
     throw new Error('runAgentLoop called without prior persistUserMessage');
@@ -702,7 +702,7 @@ export async function runAgentLoopImpl(
       queueGenerateConversationTitle({
         conversationId: ctx.conversationId,
         provider: ctx.provider,
-        userMessage: content,
+        userMessage: options?.titleText ?? content,
         assistantResponse: state.firstAssistantText || undefined,
         onTitleUpdated: (title) => {
           onEvent({

--- a/assistant/src/daemon/session-history.ts
+++ b/assistant/src/daemon/session-history.ts
@@ -263,7 +263,7 @@ export interface HistorySessionContext {
     content: string,
     userMessageId: string,
     onEvent: (msg: ServerMessage) => void,
-    options?: { skipPreMessageRollback?: boolean },
+    options?: { skipPreMessageRollback?: boolean; titleText?: string },
   ): Promise<void>;
 }
 

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -81,7 +81,7 @@ export interface ProcessSessionContext {
     content: string,
     userMessageId: string,
     onEvent: (msg: ServerMessage) => void,
-    options?: { skipPreMessageRollback?: boolean; isInteractive?: boolean },
+    options?: { skipPreMessageRollback?: boolean; isInteractive?: boolean; titleText?: string },
   ): Promise<void>;
   getTurnChannelContext(): TurnChannelContext | null;
   setTurnChannelContext(ctx: TurnChannelContext): void;
@@ -321,8 +321,12 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
   // Fire-and-forget: persistUserMessage set session.processing = true
   // so subsequent messages will still be enqueued.
   // runAgentLoop's finally block will call drainQueue when this run completes.
+  const drainLoopOptions: { isInteractive?: boolean; titleText?: string } = {};
+  if (next.isInteractive !== undefined) drainLoopOptions.isInteractive = next.isInteractive;
+  if (agentLoopContent !== resolvedContent) drainLoopOptions.titleText = resolvedContent;
+
   session.runAgentLoop(agentLoopContent, userMessageId, next.onEvent,
-    next.isInteractive !== undefined ? { isInteractive: next.isInteractive } : undefined,
+    Object.keys(drainLoopOptions).length > 0 ? drainLoopOptions : undefined,
   ).catch((err) => {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, conversationId: session.conversationId, requestId: next.requestId }, 'Error processing queued message');
@@ -527,8 +531,12 @@ export async function processMessage(
       });
   }
 
+  const loopOptions: { isInteractive?: boolean; titleText?: string } = {};
+  if (options?.isInteractive !== undefined) loopOptions.isInteractive = options.isInteractive;
+  if (agentLoopContent !== resolvedContent) loopOptions.titleText = resolvedContent;
+
   await session.runAgentLoop(agentLoopContent, userMessageId, onEvent,
-    options?.isInteractive !== undefined ? { isInteractive: options.isInteractive } : undefined,
+    Object.keys(loopOptions).length > 0 ? loopOptions : undefined,
   );
   return userMessageId;
 }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -506,7 +506,7 @@ export class Session {
     content: string,
     userMessageId: string,
     onEvent: (msg: ServerMessage) => void,
-    options?: { skipPreMessageRollback?: boolean; isInteractive?: boolean },
+    options?: { skipPreMessageRollback?: boolean; isInteractive?: boolean; titleText?: string },
   ): Promise<void> {
     return runAgentLoopImpl(this, content, userMessageId, onEvent, options);
   }


### PR DESCRIPTION
## Summary
- When guardian setup intent is intercepted, the synthetic rewritten content was being used for conversation title generation
- Now passes the original user text to runAgentLoop for title generation while still using the rewritten content for the agent loop instruction
- Addresses Codex P2 feedback on PR #9693

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/9693
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
