### PR TITLE
feat: add automatic TLS certificate renewal before expiry

### DIFF
--- a/assistant/src/daemon/tls-certs.ts
+++ b/assistant/src/daemon/tls-certs.ts
@@ -76,9 +76,17 @@ async function isExistingCertValid(): Promise<boolean> {
     const x509 = new X509Certificate(certPem);
 
     // Check expiration
+    const now = new Date();
     const notAfter = new Date(x509.validTo);
-    if (notAfter <= new Date()) {
+    if (notAfter <= now) {
       log.info('Existing TLS certificate has expired, will regenerate');
+      return false;
+    }
+
+    // Auto-renew if the certificate expires within 30 days
+    const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
+    if (notAfter.getTime() - now.getTime() < thirtyDaysMs) {
+      log.info('TLS certificate approaching expiry, regenerating...');
       return false;
     }
 


### PR DESCRIPTION
Add auto-renewal logic to regenerate TLS certificates when they are within 30 days of expiry. Runs during daemon startup. Logs when renewal occurs. Ensures certificates stay fresh with the new 1-year validity.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
