### PR TITLE
feat: add database index on conversations(threadType)

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -18,6 +18,7 @@ import {
   createWatchersAndLogsTables,
   migrateCallSessionMode,
   migrateChannelInboundDeliveredSegments,
+  migrateConversationsThreadTypeIndex,
   migrateGuardianActionFollowup,
   migrateGuardianBootstrapToken,
   migrateGuardianVerificationSessions,
@@ -87,6 +88,9 @@ export function initializeDb(): void {
 
   // 14c. Guardian action follow-up lifecycle columns (timeout reason, late answers)
   migrateGuardianActionFollowup(database);
+
+  // 14d. Index on conversations.thread_type for frequent WHERE filters
+  migrateConversationsThreadTypeIndex(database);
 
   // 15. Notification system
   createNotificationTables(database);

--- a/assistant/src/memory/migrations/031-conversations-thread-type-index.ts
+++ b/assistant/src/memory/migrations/031-conversations-thread-type-index.ts
@@ -1,0 +1,5 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+export function migrateConversationsThreadTypeIndex(database: DrizzleDb): void {
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_conversations_thread_type ON conversations(thread_type)`);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -30,6 +30,7 @@ export { migrateNotificationDeliveryPairingColumns } from './027-notification-de
 export { migrateCallSessionMode } from './028-call-session-mode.js';
 export { migrateChannelInboundDeliveredSegments } from './029-channel-inbound-delivered-segments.js';
 export { migrateGuardianActionFollowup } from './030-guardian-action-followup.js';
+export { migrateConversationsThreadTypeIndex } from './031-conversations-thread-type-index.js';
 export { createCoreTables } from './100-core-tables.js';
 export { createWatchersAndLogsTables } from './101-watchers-and-logs.js';
 export { addCoreColumns } from './102-alter-table-columns.js';

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -19,6 +19,7 @@ export const conversations = sqliteTable('conversations', {
   isAutoTitle: integer('is_auto_title').notNull().default(1),
 }, (table) => [
   index('idx_conversations_updated_at').on(table.updatedAt),
+  index('idx_conversations_thread_type').on(table.threadType),
 ]);
 
 export const messages = sqliteTable('messages', {


### PR DESCRIPTION
Add index on conversations.threadType column to improve performance of queries that filter by thread type.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
