### PR TITLE
security: gate auth bypass env vars behind safety confirmation

### DIFF
--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -92,8 +92,23 @@ export function getRuntimeGatewayOriginSecret(): string | undefined {
   return str('RUNTIME_GATEWAY_ORIGIN_SECRET');
 }
 
+/**
+ * True when HTTP API auth is disabled via DISABLE_HTTP_AUTH=true AND the
+ * safety gate VELLUM_UNSAFE_AUTH_BYPASS=1 is also set. Without the safety
+ * gate, the bypass is ignored.
+ */
 export function isHttpAuthDisabled(): boolean {
-  return str('DISABLE_HTTP_AUTH')?.toLowerCase() === 'true';
+  if (str('DISABLE_HTTP_AUTH')?.toLowerCase() !== 'true') return false;
+  return str('VELLUM_UNSAFE_AUTH_BYPASS')?.trim() === '1';
+}
+
+/**
+ * True when DISABLE_HTTP_AUTH is set but the safety gate
+ * VELLUM_UNSAFE_AUTH_BYPASS=1 is missing — used for warning messages.
+ */
+export function hasUngatedHttpAuthDisabled(): boolean {
+  if (str('DISABLE_HTTP_AUTH')?.toLowerCase() !== 'true') return false;
+  return str('VELLUM_UNSAFE_AUTH_BYPASS')?.trim() !== '1';
 }
 
 // ── Twilio ───────────────────────────────────────────────────────────────────

--- a/assistant/src/daemon/connection-policy.ts
+++ b/assistant/src/daemon/connection-policy.ts
@@ -21,10 +21,30 @@ export function hasSocketOverride(env: Record<string, string | undefined> = proc
  * True when the user has explicitly opted into unauthenticated connections
  * via VELLUM_DAEMON_NOAUTH=1. This is separate from the socket override
  * so that using a custom socket path alone does NOT bypass token auth.
+ *
+ * Requires VELLUM_UNSAFE_AUTH_BYPASS=1 as a safety gate to prevent
+ * accidental production use.
  */
 export function hasNoAuthOverride(env: Record<string, string | undefined> = process.env): boolean {
   const value = env.VELLUM_DAEMON_NOAUTH?.trim();
-  return value === '1' || value === 'true';
+  if (value !== '1' && value !== 'true') return false;
+
+  const safetyGate = env.VELLUM_UNSAFE_AUTH_BYPASS?.trim();
+  if (safetyGate !== '1') return false;
+
+  return true;
+}
+
+/**
+ * True when VELLUM_DAEMON_NOAUTH is set but the safety gate
+ * VELLUM_UNSAFE_AUTH_BYPASS=1 is missing — used for warning messages.
+ */
+export function hasUngatedNoAuthOverride(env: Record<string, string | undefined> = process.env): boolean {
+  const value = env.VELLUM_DAEMON_NOAUTH?.trim();
+  if (value !== '1' && value !== 'true') return false;
+
+  const safetyGate = env.VELLUM_UNSAFE_AUTH_BYPASS?.trim();
+  return safetyGate !== '1';
 }
 
 export function shouldAutoStartDaemon(env: Record<string, string | undefined> = process.env): boolean {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -46,7 +46,7 @@ import {
 import { listWorkItems, updateWorkItem } from '../work-items/work-item-store.js';
 import { WorkspaceHeartbeatService } from '../workspace/heartbeat-service.js';
 import { createApprovalConversationGenerator,createApprovalCopyGenerator } from './approval-generators.js';
-import { hasNoAuthOverride } from './connection-policy.js';
+import { hasNoAuthOverride, hasUngatedNoAuthOverride } from './connection-policy.js';
 import { cleanupPidFile,writePid } from './daemon-control.js';
 import { createGuardianActionCopyGenerator } from './guardian-action-generators.js';
 import { initPairingHandlers } from './handlers/pairing.js';
@@ -79,7 +79,9 @@ export async function runDaemon(): Promise<void> {
   loadDotEnv();
   validateEnv();
 
-  if (hasNoAuthOverride()) {
+  if (hasUngatedNoAuthOverride()) {
+    log.warn('VELLUM_DAEMON_NOAUTH is set but VELLUM_UNSAFE_AUTH_BYPASS=1 is not — auth bypass is IGNORED and authentication remains enabled. Set VELLUM_UNSAFE_AUTH_BYPASS=1 to confirm the bypass.');
+  } else if (hasNoAuthOverride()) {
     log.warn('VELLUM_DAEMON_NOAUTH is set — IPC authentication is DISABLED. This should only be used for development or SSH-forwarded sockets. Do not use in production.');
   }
 

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -25,6 +25,7 @@ import { parseChannelId } from '../channels/types.js';
 import {
   getGatewayInternalBaseUrl,
   getRuntimeGatewayOriginSecret,
+  hasUngatedHttpAuthDisabled,
   isHttpAuthDisabled,
 } from '../config/env.js';
 import type { ServerMessage } from '../daemon/ipc-contract.js';
@@ -303,7 +304,9 @@ export class RuntimeHttpServer {
 
     this.pairingStore.start();
 
-    if (isHttpAuthDisabled()) {
+    if (hasUngatedHttpAuthDisabled()) {
+      log.warn('DISABLE_HTTP_AUTH is set but VELLUM_UNSAFE_AUTH_BYPASS=1 is not — auth bypass is IGNORED and HTTP authentication remains enabled. Set VELLUM_UNSAFE_AUTH_BYPASS=1 to confirm the bypass.');
+    } else if (isHttpAuthDisabled()) {
       log.warn('DISABLE_HTTP_AUTH is set — HTTP API authentication is DISABLED. All API endpoints are accessible without a bearer token. Do not use in production.');
     }
 
@@ -448,7 +451,7 @@ export class RuntimeHttpServer {
       );
     }
 
-    if ((process.env.DISABLE_HTTP_AUTH ?? '').toLowerCase() !== 'true' && this.bearerToken) {
+    if (!isHttpAuthDisabled() && this.bearerToken) {
       const wsUrl = new URL(req.url);
       const token = wsUrl.searchParams.get('token');
       if (!token || !verifyBearerToken(token, this.bearerToken)) {


### PR DESCRIPTION
VELLUM_DAEMON_NOAUTH and DISABLE_HTTP_AUTH now require VELLUM_UNSAFE_AUTH_BYPASS=1 to also be set. Without the safety gate, auth bypass is ignored with a warning. Prevents accidental production auth disable.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
