### PR TITLE
security: add rate limiting on guardian verification attempts

### DIFF
--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -33,6 +33,7 @@ import {
   resendOutbound,
   startOutbound,
 } from '../guardian-outbound-actions.js';
+import { guardianVerificationLimiter } from '../verification-rate-limiter.js';
 
 /**
  * GET /v1/integrations/telegram/config
@@ -147,6 +148,15 @@ export async function handleStartOutbound(req: Request): Promise<Response> {
       { status: 400 },
     );
   }
+
+  // Rate-limit by destination identity before processing
+  if (body.destination && guardianVerificationLimiter.isBlocked(body.destination)) {
+    return Response.json(
+      { success: false, error: 'rate_limited', message: 'Too many verification attempts for this identity. Please try again later.' },
+      { status: 429 },
+    );
+  }
+
   const result = startOutbound({
     channel: body.channel,
     destination: body.destination,
@@ -154,7 +164,12 @@ export async function handleStartOutbound(req: Request): Promise<Response> {
     rebind: body.rebind,
     originConversationId: body.originConversationId,
   });
-  const status = result.success ? 200 : 400;
+
+  if (!result.success && body.destination) {
+    guardianVerificationLimiter.recordFailure(body.destination);
+  }
+
+  const status = result.success ? 200 : (result.error === 'rate_limited' ? 429 : 400);
   return Response.json(result, { status });
 }
 
@@ -180,7 +195,7 @@ export async function handleResendOutbound(req: Request): Promise<Response> {
     assistantId: body.assistantId,
     originConversationId: body.originConversationId,
   });
-  const status = result.success ? 200 : 400;
+  const status = result.success ? 200 : (result.error === 'rate_limited' ? 429 : 400);
   return Response.json(result, { status });
 }
 

--- a/assistant/src/runtime/verification-rate-limiter.ts
+++ b/assistant/src/runtime/verification-rate-limiter.ts
@@ -1,0 +1,83 @@
+// Sliding-window rate limiter for guardian verification attempts.
+// Tracks failed verification initiations per identity (phone number, Telegram
+// user ID, etc.) and blocks identities that exceed the threshold.
+// Modeled after gateway/src/auth-rate-limiter.ts.
+
+const DEFAULT_MAX_FAILURES = 3;
+const DEFAULT_WINDOW_MS = 5 * 60_000; // 5 minutes
+const MAX_TRACKED_IDENTITIES = 10_000;
+
+export class VerificationRateLimiter {
+  private failures = new Map<string, number[]>();
+  private readonly maxFailures: number;
+  private readonly windowMs: number;
+
+  constructor(
+    maxFailures = DEFAULT_MAX_FAILURES,
+    windowMs = DEFAULT_WINDOW_MS,
+  ) {
+    this.maxFailures = maxFailures;
+    this.windowMs = windowMs;
+  }
+
+  /** Record a failed verification attempt for the given identity. */
+  recordFailure(identity: string): void {
+    const now = Date.now();
+    let timestamps = this.failures.get(identity);
+
+    if (!timestamps) {
+      if (this.failures.size >= MAX_TRACKED_IDENTITIES) {
+        this.evictStale(now);
+        if (this.failures.size >= MAX_TRACKED_IDENTITIES) {
+          const oldest = this.failures.keys().next().value;
+          if (oldest !== undefined) this.failures.delete(oldest);
+        }
+      }
+      timestamps = [];
+      this.failures.set(identity, timestamps);
+    }
+
+    timestamps.push(now);
+  }
+
+  /** Returns true if the identity has exceeded the failure threshold. */
+  isBlocked(identity: string): boolean {
+    const timestamps = this.failures.get(identity);
+    if (!timestamps) return false;
+
+    const now = Date.now();
+    const cutoff = now - this.windowMs;
+
+    // Remove expired timestamps from the front
+    while (timestamps.length > 0 && timestamps[0] <= cutoff) {
+      timestamps.shift();
+    }
+
+    if (timestamps.length === 0) {
+      this.failures.delete(identity);
+      return false;
+    }
+
+    return timestamps.length >= this.maxFailures;
+  }
+
+  /** Clear state for an identity on successful verification. */
+  clearIdentity(identity: string): void {
+    this.failures.delete(identity);
+  }
+
+  private evictStale(now: number): void {
+    const cutoff = now - this.windowMs;
+    for (const [identity, timestamps] of this.failures) {
+      while (timestamps.length > 0 && timestamps[0] <= cutoff) {
+        timestamps.shift();
+      }
+      if (timestamps.length === 0) {
+        this.failures.delete(identity);
+      }
+    }
+  }
+}
+
+/** Singleton rate limiter for guardian verification endpoint failures. */
+export const guardianVerificationLimiter = new VerificationRateLimiter();


### PR DESCRIPTION
Add per-identity rate limiting for guardian verification failures. Max 3 failed attempts per identity per 5 minutes. Returns 429 when exceeded. Prevents brute-force attacks on verification codes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
