### PR TITLE
perf: parallelize independent memory retrieval sources

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -139,6 +139,22 @@ async function collectAndMergeCandidates(
   // A per-call scopePolicyOverride takes precedence over the global policy.
   const scopeIds = buildScopeFilter(scopeId, scopePolicy, opts?.scopePolicyOverride);
 
+  // -- Start async semantic search early so the network round-trip overlaps
+  // with all synchronous work (lexical, recency, direct item, entity). --
+  let semanticSearchFailed = false;
+  const semanticPromise = queryVector
+    ? semanticSearch(queryVector, opts?.provider ?? 'unknown', opts?.model ?? 'unknown', config.memory.retrieval.semanticTopK, excludeMessageIds, scopeIds)
+        .catch((err): Candidate[] => {
+          semanticSearchFailed = true;
+          if (isQdrantConnectionError(err)) {
+            log.warn({ err }, 'Qdrant is unavailable — semantic search disabled, memory recall will be degraded');
+          } else {
+            log.warn({ err }, 'Semantic search failed, continuing with other retrieval methods');
+          }
+          return [];
+        })
+    : null;
+
   // -- Phase 1: cheap local searches (always run) --
   const lexical = lexicalSearch(query, config.memory.retrieval.lexicalTopK, excludeMessageIds, scopeIds);
 
@@ -220,8 +236,8 @@ async function collectAndMergeCandidates(
 
   // -- Early termination check --
   // If cheap sources already produced enough high-relevance candidates,
-  // skip the expensive semantic search (Qdrant network call) and entity
-  // relation traversal to reduce recall latency.
+  // skip entity search. The semantic promise (if started) will resolve
+  // on its own via .catch() — we just ignore its results.
   //
   // Deduplicate before counting: lexical and recency can return the same
   // segment (common when recent messages match the query), so checking raw
@@ -248,12 +264,8 @@ async function collectAndMergeCandidates(
     && cheapCandidates.length >= etConfig.minCandidates
     && cheapCandidates.filter((c) => c.lexical >= etConfig.confidenceThreshold).length >= etConfig.minHighConfidence;
 
-  // -- Phase 2: expensive searches (skipped on early termination) --
-  // Semantic search (async Qdrant network call) and entity search (sync
-  // SQLite graph traversal) are independent. Start the network call first,
-  // run the sync work while it's in flight, then await the result.
+  // -- Phase 2: entity search + await semantic (skipped on early termination) --
   let semantic: Candidate[] = [];
-  let semanticSearchFailed = false;
   let entity: Candidate[] = [];
   let candidateDepths: Map<string, number> | undefined;
   let relationSeedEntityCount = 0;
@@ -262,19 +274,8 @@ async function collectAndMergeCandidates(
   let relationExpandedItemCount = 0;
 
   if (!canTerminateEarly) {
-    const semanticPromise = queryVector
-      ? semanticSearch(queryVector, opts?.provider ?? 'unknown', opts?.model ?? 'unknown', config.memory.retrieval.semanticTopK, excludeMessageIds, scopeIds)
-          .catch((err): Candidate[] => {
-            semanticSearchFailed = true;
-            if (isQdrantConnectionError(err)) {
-              log.warn({ err }, 'Qdrant is unavailable — semantic search disabled, memory recall will be degraded');
-            } else {
-              log.warn({ err }, 'Semantic search failed, continuing with other retrieval methods');
-            }
-            return [];
-          })
-      : null;
-
+    // Entity search is synchronous — run it while the semantic promise
+    // (started above) is still in flight.
     if (config.memory.entity.enabled) {
       const entitySearchResult = entitySearch(
         query,


### PR DESCRIPTION
Run independent memory retrieval sources (lexical, semantic, recency, entity) in parallel via Promise.allSettled instead of sequentially. Graceful error handling ensures partial failures don't block other sources. Should improve retrieval latency.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
