### PR TITLE
fix: add error handling for FTS5 trigger sync operations

### DIFF
--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -290,6 +290,21 @@ export function addMessage(conversationId: string, role: string, content: string
   }
   const message = { id: messageId, conversationId, role, content, createdAt: now, ...(metadataStr ? { metadata: metadataStr } : {}) };
 
+  // Verify the FTS trigger fired for this message. The trigger is atomic with
+  // the INSERT (see 116-messages-fts.ts), so a missing FTS row after a
+  // successful transaction indicates the trigger was dropped or the FTS table
+  // was recreated without triggers. Log a warning so the desync is visible.
+  try {
+    const ftsRow = rawGet<{ c: number }>(
+      'SELECT COUNT(*) AS c FROM messages_fts WHERE message_id = ?', messageId,
+    );
+    if (ftsRow && ftsRow.c === 0) {
+      log.warn({ conversationId, messageId }, 'FTS sync missing: messages_fts row not found after INSERT — search index may be stale');
+    }
+  } catch (err) {
+    log.warn({ err, conversationId, messageId }, 'FTS sync check failed — messages_fts may be corrupted or missing');
+  }
+
   if (!opts?.skipIndexing) {
     try {
       const config = getConfig();
@@ -504,7 +519,16 @@ export function clearAll(): { conversations: number; messages: number } {
   // Delete in dependency order. Cascades handle memory_segments,
   // memory_item_sources, and tool_invocations, but we explicitly
   // clear non-cascading memory tables too.
-  rawExec('DELETE FROM memory_segment_fts');
+  //
+  // FTS virtual tables are cleared before their base tables. If an FTS
+  // table is corrupted, the DELETE will fail — we catch and log the error
+  // so that the rest of the cleanup can proceed. The FTS table can be
+  // rebuilt via its backfill migration after the corruption is resolved.
+  try {
+    rawExec('DELETE FROM memory_segment_fts');
+  } catch (err) {
+    log.warn({ err }, 'clearAll: failed to clear memory_segment_fts — FTS index may be corrupted');
+  }
   rawExec('DELETE FROM memory_item_sources');
   rawExec('DELETE FROM memory_segments');
   rawExec('DELETE FROM memory_items');
@@ -517,7 +541,11 @@ export function clearAll(): { conversations: number; messages: number } {
   rawExec('DELETE FROM message_attachments');
   rawExec('DELETE FROM attachments');
   rawExec('DELETE FROM tool_invocations');
-  rawExec('DELETE FROM messages_fts');
+  try {
+    rawExec('DELETE FROM messages_fts');
+  } catch (err) {
+    log.warn({ err }, 'clearAll: failed to clear messages_fts — FTS index may be corrupted');
+  }
   rawExec('DELETE FROM messages');
   rawExec('DELETE FROM conversations');
 
@@ -623,6 +651,20 @@ export function updateMessageContent(messageId: string, newContent: string): voi
     .set({ content: newContent })
     .where(eq(messages.id, messageId))
     .run();
+
+  // Verify FTS trigger synced the content update. The UPDATE trigger
+  // atomically deletes the old FTS row and inserts a new one, so a
+  // missing row here indicates a trigger or FTS table issue.
+  try {
+    const ftsRow = rawGet<{ c: number }>(
+      'SELECT COUNT(*) AS c FROM messages_fts WHERE message_id = ?', messageId,
+    );
+    if (ftsRow && ftsRow.c === 0) {
+      log.warn({ messageId }, 'FTS sync missing after updateMessageContent — search index may be stale');
+    }
+  } catch (err) {
+    log.warn({ err, messageId }, 'FTS sync check failed after updateMessageContent');
+  }
 }
 
 /**
@@ -809,8 +851,8 @@ export function searchConversations(
         LIMIT 1000
       `, ftsMatch);
       for (const row of ftsRows) ftsConvIds.add(row.conversation_id);
-    } catch {
-      // FTS parse failure — fall through, title matches may still produce results.
+    } catch (err) {
+      log.warn({ err, query: query.slice(0, 80) }, 'searchConversations: FTS query failed — falling through to title matches');
     }
   } else if (query.trim()) {
     // FTS tokens were all dropped (non-ASCII, single-char, etc.) — fall back to
@@ -871,8 +913,8 @@ export function searchConversations(
           ORDER BY m.created_at ASC
           LIMIT ?
         `, ftsMatch, conv.id, maxMsgsPerConv);
-      } catch {
-        // FTS parse failure — no matching messages for this conversation.
+      } catch (err) {
+        log.warn({ err, conversationId: conv.id }, 'searchConversations: FTS per-conversation query failed');
       }
     } else if (query.trim()) {
       // LIKE fallback for non-ASCII / short-token queries.

--- a/assistant/src/memory/migrations/101-watchers-and-logs.ts
+++ b/assistant/src/memory/migrations/101-watchers-and-logs.ts
@@ -108,6 +108,10 @@ export function createWatchersAndLogsTables(database: DrizzleDb): void {
   `);
 
   // FTS table for lexical retrieval over memory_segments.text.
+  // Triggers below are atomic with the triggering statement: if the FTS
+  // operation fails, the base table write rolls back too. A corrupted FTS
+  // table will block all memory_segments writes until rebuilt. See the
+  // analogous comment in 116-messages-fts.ts for recovery steps.
   database.run(/*sql*/ `
     CREATE VIRTUAL TABLE IF NOT EXISTS memory_segment_fts USING fts5(
       segment_id UNINDEXED,

--- a/assistant/src/memory/migrations/116-messages-fts.ts
+++ b/assistant/src/memory/migrations/116-messages-fts.ts
@@ -8,6 +8,19 @@ import type { DrizzleDb } from '../db-connection.js';
  * (type, text, tool_use) are short common words that rarely matter as search
  * terms.  The existing buildExcerpt() in conversation-store handles extracting
  * readable text from JSON for display after matching.
+ *
+ * ## Trigger atomicity and failure modes
+ *
+ * SQLite triggers execute atomically within the triggering statement's
+ * transaction. If the FTS trigger fails (e.g., corrupted FTS index), the
+ * entire statement — including the base table INSERT/UPDATE/DELETE — is
+ * rolled back. This means a trigger failure does NOT silently lose FTS
+ * data; instead, it prevents the base operation from succeeding at all.
+ *
+ * The real risk is the reverse: a corrupted FTS virtual table will cause
+ * ALL writes to the messages table to fail until the FTS table is rebuilt.
+ * If this happens, `messages_fts` should be dropped and recreated, then
+ * backfilled via `migrateMessagesFtsBackfill`.
  */
 export function createMessagesFts(database: DrizzleDb): void {
   database.run(/*sql*/ `


### PR DESCRIPTION
Add error handling and logging around FTS5 operations to ensure trigger failures don't silently lose search index data. Document the atomic nature of SQLite triggers and add visibility when FTS sync issues occur.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
