### PR TITLE
perf: replace Bun.sleepSync with async Bun.sleep in retry logic

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -85,7 +85,7 @@ export class AgentLoop {
 
   async run(
     messages: Message[],
-    onEvent: (event: AgentEvent) => void,
+    onEvent: (event: AgentEvent) => void | Promise<void>,
     signal?: AbortSignal,
     requestId?: string,
     onCheckpoint?: (checkpoint: CheckpointInfo) => CheckpointDecision,
@@ -244,7 +244,7 @@ export class AgentLoop {
         };
         history.push(assistantMessage);
 
-        onEvent({ type: 'message_complete', message: assistantMessage });
+        await onEvent({ type: 'message_complete', message: assistantMessage });
 
         // Check for tool use
         toolUseBlocks = response.content.filter(

--- a/assistant/src/calls/call-conversation-messages.ts
+++ b/assistant/src/calls/call-conversation-messages.ts
@@ -21,9 +21,9 @@ export function buildCallCompletionMessage(callSessionId: string): string {
   return `**${statusLabel}**${durationStr}. ${events.length} event(s) recorded.`;
 }
 
-export function persistCallCompletionMessage(conversationId: string, callSessionId: string): string {
+export async function persistCallCompletionMessage(conversationId: string, callSessionId: string): Promise<string> {
   const summaryText = buildCallCompletionMessage(callSessionId);
-  conversationStore.addMessage(
+  await conversationStore.addMessage(
     conversationId,
     'assistant',
     JSON.stringify([{ type: 'text', text: summaryText }]),

--- a/assistant/src/calls/call-pointer-messages.ts
+++ b/assistant/src/calls/call-pointer-messages.ts
@@ -8,7 +8,7 @@ import * as conversationStore from '../memory/conversation-store.js';
 
 export type PointerEvent = 'started' | 'completed' | 'failed' | 'guardian_verification_succeeded' | 'guardian_verification_failed';
 
-export function addPointerMessage(
+export async function addPointerMessage(
   conversationId: string,
   event: PointerEvent,
   phoneNumber: string,
@@ -49,7 +49,7 @@ export function addPointerMessage(
   // desktop thread. Do not set userMessageChannel — doing so would mark the
   // conversation's origin channel as voice, causing it to leak into the
   // desktop thread list as a channel-bound session.
-  conversationStore.addMessage(
+  await conversationStore.addMessage(
     conversationId,
     'assistant',
     JSON.stringify([{ type: 'text', text }]),

--- a/assistant/src/calls/guardian-action-sweep.ts
+++ b/assistant/src/calls/guardian-action-sweep.ts
@@ -28,10 +28,10 @@ let sweepTimer: ReturnType<typeof setInterval> | null = null;
 /**
  * Sweep expired guardian action requests and clean up.
  */
-export function sweepExpiredGuardianActions(
+export async function sweepExpiredGuardianActions(
   gatewayBaseUrl: string,
   bearerToken?: string,
-): void {
+): Promise<void> {
   const expired = getExpiredGuardianActionRequests();
 
   for (const request of expired) {
@@ -55,7 +55,7 @@ export function sweepExpiredGuardianActions(
 
       if ((delivery.destinationChannel === 'vellum' || delivery.destinationChannel === 'macos' || delivery.destinationChannel === 'mac') && delivery.destinationConversationId) {
         // Add expiry message to vellum guardian thread
-        addMessage(
+        await addMessage(
           delivery.destinationConversationId,
           'assistant',
           JSON.stringify([{ type: 'text', text: 'This guardian question has expired without a response.' }]),

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -477,10 +477,10 @@ export class RelayConnection {
   /**
    * Generate a verification code and prompt the callee to enter it via DTMF.
    */
-  private startVerification(
+  private async startVerification(
     session: ReturnType<typeof getCallSession>,
     verificationConfig: { maxAttempts: number; codeLength: number },
-  ): void {
+  ): Promise<void> {
     this.verificationMaxAttempts = verificationConfig.maxAttempts;
     this.verificationCodeLength = verificationConfig.codeLength;
     this.verificationAttempts = 0;
@@ -505,7 +505,7 @@ export class RelayConnection {
     // guardian (user) can share it with the callee.
     if (session?.initiatedFromConversationId) {
       const codeMsg = `\u{1F510} Verification code for call to ${session.toNumber}: ${code}`;
-      conversationStore.addMessage(
+      await conversationStore.addMessage(
         session.initiatedFromConversationId,
         'assistant',
         JSON.stringify([{ type: 'text', text: codeMsg }]),
@@ -889,7 +889,7 @@ export class RelayConnection {
       // this early-utterance path bypasses it entirely.
       if (session) {
         try {
-          conversationStore.addMessage(
+          await conversationStore.addMessage(
             session.conversationId,
             'user',
             JSON.stringify([{ type: 'text', text: msg.voicePrompt }]),

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -307,7 +307,7 @@ export async function startVoiceTurn(opts: VoiceTurnOptions): Promise<VoiceTurnH
 
   const requestId = crypto.randomUUID();
   const turnId = crypto.randomUUID();
-  const messageId = session.persistUserMessage(persistedContent, [], requestId);
+  const messageId = await session.persistUserMessage(persistedContent, [], requestId);
 
   // Serialized publish chain so hub subscribers observe events in order.
   let hubChain: Promise<void> = Promise.resolve();

--- a/assistant/src/config/vellum-skills/chatgpt-import/tools/chatgpt-import.ts
+++ b/assistant/src/config/vellum-skills/chatgpt-import/tools/chatgpt-import.ts
@@ -110,7 +110,7 @@ export async function run(
     } as const;
 
     for (const msg of conv.messages) {
-      addMessage(conversation.id, msg.role, JSON.stringify(msg.content), importChannelMetadata);
+      await addMessage(conversation.id, msg.role, JSON.stringify(msg.content), importChannelMetadata);
     }
 
     // addMessage auto-fills originChannel but not originInterface, so set it explicitly

--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -482,7 +482,7 @@ async function executeDeny(
 
   // Store a system note about the denial in the conversation
   const denialInterface = isInterfaceId(sourceChannel) ? sourceChannel : undefined;
-  addMessage(conversationId, 'assistant', denialText, {
+  await addMessage(conversationId, 'assistant', denialText, {
     provenanceActorRole: 'guardian' as const,
     userMessageChannel: sourceChannel,
     assistantMessageChannel: sourceChannel,

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -89,8 +89,8 @@ export async function handleTaskSubmit(
           sessionId: conversation.id,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
-        conversationStore.addMessage(conversation.id, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
-        conversationStore.addMessage(conversation.id, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        await conversationStore.addMessage(conversation.id, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
+        await conversationStore.addMessage(conversation.id, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         // Sync in-memory session if one exists for this conversation
         const startSession = ctx.sessions.get(conversation.id);
         if (startSession && !startSession.isProcessing()) {
@@ -115,8 +115,8 @@ export async function handleTaskSubmit(
           sessionId: activeSessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
-        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
-        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        await conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
+        await conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         const stopSession = ctx.sessions.get(activeSessionId);
         if (stopSession && !stopSession.isProcessing()) {
           stopSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
@@ -138,8 +138,8 @@ export async function handleTaskSubmit(
           sessionId: activeSessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
-        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
-        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: restartResult.responseText }]));
+        await conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
+        await conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: restartResult.responseText }]));
         const restartSession = ctx.sessions.get(activeSessionId);
         if (restartSession && !restartSession.isProcessing()) {
           restartSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
@@ -162,8 +162,8 @@ export async function handleTaskSubmit(
           sessionId: activeSessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
-        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
-        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        await conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
+        await conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         const pauseSession = ctx.sessions.get(activeSessionId);
         if (pauseSession && !pauseSession.isProcessing()) {
           pauseSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
@@ -186,8 +186,8 @@ export async function handleTaskSubmit(
           sessionId: activeSessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
-        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
-        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        await conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
+        await conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         const resumeSession = ctx.sessions.get(activeSessionId);
         if (resumeSession && !resumeSession.isProcessing()) {
           resumeSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
@@ -225,8 +225,8 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'task_routed', sessionId: conversation.id, interactionType: 'text_qa' });
         ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: conversation.id });
         ctx.send(socket, { type: 'message_complete', sessionId: conversation.id });
-        conversationStore.addMessage(conversation.id, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
-        conversationStore.addMessage(conversation.id, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+        await conversationStore.addMessage(conversation.id, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
+        await conversationStore.addMessage(conversation.id, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
         const startOnlySession = ctx.sessions.get(conversation.id);
         if (startOnlySession && !startOnlySession.isProcessing()) {
           startOnlySession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
@@ -260,8 +260,8 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: activeSessionId });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
-        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
-        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+        await conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
+        await conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
         const stopOnlySession = ctx.sessions.get(activeSessionId);
         if (stopOnlySession && !stopOnlySession.isProcessing()) {
           stopOnlySession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
@@ -288,8 +288,8 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: activeSessionId });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
-        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
-        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+        await conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
+        await conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
         const startStopOnlySession = ctx.sessions.get(activeSessionId);
         if (startStopOnlySession && !startStopOnlySession.isProcessing()) {
           startStopOnlySession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
@@ -317,8 +317,8 @@ export async function handleTaskSubmit(
         ctx.send(socket, { type: 'task_routed', sessionId: activeSessionId, interactionType: 'text_qa' });
         ctx.send(socket, { type: 'assistant_text_delta', text: execResult.responseText!, sessionId: activeSessionId });
         ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
-        conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
-        conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+        await conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
+        await conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
         const handledSession = ctx.sessions.get(activeSessionId);
         if (handledSession && !handledSession.isProcessing()) {
           handledSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });
@@ -389,8 +389,8 @@ export async function handleTaskSubmit(
                 sessionId: activeSessionId,
               });
               ctx.send(socket, { type: 'message_complete', sessionId: activeSessionId });
-              conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
-              conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+              await conversationStore.addMessage(activeSessionId, 'user', JSON.stringify([{ type: 'text', text: msg.task || '' }]));
+              await conversationStore.addMessage(activeSessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
               const fallbackSession = ctx.sessions.get(activeSessionId);
               if (fallbackSession && !fallbackSession.isProcessing()) {
                 fallbackSession.messages.push({ role: 'user', content: [{ type: 'text', text: msg.task || '' }] });

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -446,7 +446,7 @@ export async function finalizeAndPublishRecording(params: {
     log.warn({ recordingId, conversationId }, 'Recording stopped without file path');
     const errorText = 'Recording stopped but no file was produced.';
     try {
-      conversationStore.addMessage(
+      await conversationStore.addMessage(
         conversationId,
         'assistant',
         JSON.stringify([{ type: 'text', text: errorText }]),
@@ -487,7 +487,7 @@ export async function finalizeAndPublishRecording(params: {
     log.warn({ recordingId, filePath, allowedDir, resolvedAllowedDir }, 'Recording file path outside allowed directory — rejecting');
     const errorText = 'Recording file is unavailable or expired.';
     try {
-      conversationStore.addMessage(
+      await conversationStore.addMessage(
         conversationId,
         'assistant',
         JSON.stringify([{ type: 'text', text: errorText }]),
@@ -509,7 +509,7 @@ export async function finalizeAndPublishRecording(params: {
       log.error({ recordingId, filePath }, 'Recording file does not exist');
       const errorText = 'Recording failed to save.';
       try {
-        conversationStore.addMessage(
+        await conversationStore.addMessage(
           conversationId,
           'assistant',
           JSON.stringify([{ type: 'text', text: errorText }]),
@@ -533,7 +533,7 @@ export async function finalizeAndPublishRecording(params: {
       log.error({ recordingId, filePath }, 'Recording file is zero-length — treating as failed');
       const errorText = 'Recording failed to save.';
       try {
-        conversationStore.addMessage(
+        await conversationStore.addMessage(
           conversationId,
           'assistant',
           JSON.stringify([{ type: 'text', text: errorText }]),
@@ -564,7 +564,7 @@ export async function finalizeAndPublishRecording(params: {
     // Reusing the last assistant message would attach the recording to an
     // unrelated older message after reload.
     const msgText = 'Screen recording complete. Your recording has been saved.';
-    const newMsg = conversationStore.addMessage(
+    const newMsg = await conversationStore.addMessage(
       conversationId,
       'assistant',
       JSON.stringify([{ type: 'text', text: msgText }]),
@@ -613,7 +613,7 @@ export async function finalizeAndPublishRecording(params: {
     log.error({ err, recordingId, filePath }, 'Failed to create attachment for standalone recording');
     const errorText = 'Recording saved but failed to attach to conversation.';
     try {
-      conversationStore.addMessage(
+      await conversationStore.addMessage(
         conversationId,
         'assistant',
         JSON.stringify([{ type: 'text', text: errorText }]),

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -245,8 +245,8 @@ export async function handleUserMessage(
           sessionId: msg.sessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
-        conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
-        conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        await conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+        await conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         // Keep in-memory session history aligned with DB so regenerate() and
         // other history operations that rely on session.messages stay consistent.
         // Only push when agent loop is NOT active to avoid corrupting role alternation.
@@ -264,8 +264,8 @@ export async function handleUserMessage(
           sessionId: msg.sessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
-        conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
-        conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        await conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+        await conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         if (!session.isProcessing()) {
           session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
           session.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
@@ -279,8 +279,8 @@ export async function handleUserMessage(
           sessionId: msg.sessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
-        conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
-        conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: restartResult.responseText }]));
+        await conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+        await conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: restartResult.responseText }]));
         if (!session.isProcessing()) {
           session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
           session.messages.push({ role: 'assistant', content: [{ type: 'text', text: restartResult.responseText }] });
@@ -295,8 +295,8 @@ export async function handleUserMessage(
           sessionId: msg.sessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
-        conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
-        conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        await conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+        await conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         if (!session.isProcessing()) {
           session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
           session.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
@@ -311,8 +311,8 @@ export async function handleUserMessage(
           sessionId: msg.sessionId,
         });
         ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
-        conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
-        conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
+        await conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+        await conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: responseText }]));
         if (!session.isProcessing()) {
           session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
           session.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
@@ -349,8 +349,8 @@ export async function handleUserMessage(
             sessionId: msg.sessionId,
           });
           ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
-          conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
-          conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+          await conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+          await conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
           if (!session.isProcessing()) {
             session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
             session.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });
@@ -426,8 +426,8 @@ export async function handleUserMessage(
                 sessionId: msg.sessionId,
               });
               ctx.send(socket, { type: 'message_complete', sessionId: msg.sessionId });
-              conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
-              conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
+              await conversationStore.addMessage(msg.sessionId, 'user', JSON.stringify([{ type: 'text', text: messageText }]));
+              await conversationStore.addMessage(msg.sessionId, 'assistant', JSON.stringify([{ type: 'text', text: execResult.responseText! }]));
               if (!session.isProcessing()) {
                 session.messages.push({ role: 'user', content: [{ type: 'text', text: messageText }] });
                 session.messages.push({ role: 'assistant', content: [{ type: 'text', text: execResult.responseText! }] });

--- a/assistant/src/daemon/handlers/subagents.ts
+++ b/assistant/src/daemon/handlers/subagents.ts
@@ -80,7 +80,7 @@ export function handleSubagentStatus(
   }
 }
 
-export function handleSubagentMessage(
+export async function handleSubagentMessage(
   msg: SubagentMessageRequest,
   socket: net.Socket,
   ctx: HandlerContext,
@@ -110,7 +110,7 @@ export function handleSubagentMessage(
     return;
   }
 
-  const result = manager.sendMessage(msg.subagentId, msg.content);
+  const result = await manager.sendMessage(msg.subagentId, msg.content);
 
   if (result === 'queue_full') {
     log.warn({ subagentId: msg.subagentId }, 'Subagent message rejected — queue full');

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -188,7 +188,7 @@ export class DaemonServer {
       const children = getSubagentManager().getChildrenOf(sessionId);
       return children.some((c) => c.status === 'running' || c.status === 'pending');
     };
-    getSubagentManager().onSubagentFinished = (parentSessionId, message, sendToClient, notification) => {
+    getSubagentManager().onSubagentFinished = async (parentSessionId, message, sendToClient, notification) => {
       const parentSession = this.sessions.get(parentSessionId);
       if (!parentSession) {
         log.warn({ parentSessionId }, 'Subagent finished but parent session not found');
@@ -202,7 +202,7 @@ export class DaemonServer {
         return;
       }
       if (!enqueueResult.queued) {
-        const messageId = parentSession.persistUserMessage(message, [], undefined, metadata);
+        const messageId = await parentSession.persistUserMessage(message, [], undefined, metadata);
         parentSession.runAgentLoop(message, messageId, sendToClient).catch((err) => {
           log.error({ parentSessionId, err }, 'Failed to process subagent notification in parent');
         });
@@ -809,7 +809,7 @@ export class DaemonServer {
     );
 
     const requestId = crypto.randomUUID();
-    const messageId = session.persistUserMessage(content, attachments, requestId);
+    const messageId = await session.persistUserMessage(content, attachments, requestId);
 
     // Register pending interactions so channel approval interception can
     // find the session by requestId when confirmation/secret events fire.
@@ -865,7 +865,7 @@ export class DaemonServer {
           : {}),
       };
       const userMsg = createUserMessage(content, attachments);
-      const persisted = conversationStore.addMessage(
+      const persisted = await conversationStore.addMessage(
         conversationId,
         'user',
         JSON.stringify(userMsg.content),
@@ -889,7 +889,7 @@ export class DaemonServer {
       }
 
       const assistantMsg = createAssistantMessage(slashResult.message);
-      conversationStore.addMessage(
+      await conversationStore.addMessage(
         conversationId,
         'assistant',
         JSON.stringify(assistantMsg.content),
@@ -908,7 +908,7 @@ export class DaemonServer {
     const requestId = crypto.randomUUID();
     let messageId: string;
     try {
-      messageId = session.persistUserMessage(resolvedContent, attachments, requestId);
+      messageId = await session.persistUserMessage(resolvedContent, attachments, requestId);
     } catch (err) {
       session.setPreactivatedSkillIds(undefined);
       throw err;

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -281,11 +281,11 @@ export function handleError(
   }
 }
 
-export function handleMessageComplete(
+export async function handleMessageComplete(
   state: EventHandlerState,
   deps: EventHandlerDeps,
   event: Extract<AgentEvent, { type: 'message_complete' }>,
-): void {
+): Promise<void> {
   // Flush any remaining directive display buffer
   if (state.pendingDirectiveDisplayBuffer.length > 0) {
     deps.onEvent({
@@ -315,7 +315,7 @@ export function handleMessageComplete(
       userMessageInterface: deps.turnInterfaceContext.userMessageInterface,
       assistantMessageInterface: deps.turnInterfaceContext.assistantMessageInterface,
     };
-    conversationStore.addMessage(
+    await conversationStore.addMessage(
       deps.ctx.conversationId,
       'user',
       JSON.stringify(toolResultBlocks),
@@ -360,7 +360,7 @@ export function handleMessageComplete(
     userMessageInterface: deps.turnInterfaceContext.userMessageInterface,
     assistantMessageInterface: deps.turnInterfaceContext.assistantMessageInterface,
   };
-  const assistantMsg = conversationStore.addMessage(
+  const assistantMsg = await conversationStore.addMessage(
     deps.ctx.conversationId,
     'assistant',
     JSON.stringify(contentWithSurfaces),
@@ -424,11 +424,11 @@ export function handleUsage(
 // ── Dispatcher ───────────────────────────────────────────────────────
 
 /** Routes an AgentEvent to the appropriate handler. */
-export function dispatchAgentEvent(
+export async function dispatchAgentEvent(
   state: EventHandlerState,
   deps: EventHandlerDeps,
   event: AgentEvent,
-): void {
+): Promise<void> {
   switch (event.type) {
     case 'text_delta':
       handleTextDelta(state, deps, event);
@@ -452,7 +452,7 @@ export function dispatchAgentEvent(
       handleError(state, deps, event);
       break;
     case 'message_complete':
-      handleMessageComplete(state, deps, event);
+      await handleMessageComplete(state, deps, event);
       break;
     case 'usage':
       handleUsage(state, deps, event);

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -272,7 +272,7 @@ export async function runAgentLoopImpl(
         assistantMessageInterface: capturedTurnInterfaceContext.assistantMessageInterface,
       };
       const assistantMessage = createAssistantMessage(memoryResult.conflictClarification);
-      conversationStore.addMessage(
+      await conversationStore.addMessage(
         ctx.conversationId,
         'assistant',
         JSON.stringify(assistantMessage.content),
@@ -591,7 +591,7 @@ export async function runAgentLoopImpl(
         userMessageInterface: capturedTurnInterfaceContext.userMessageInterface,
         assistantMessageInterface: capturedTurnInterfaceContext.assistantMessageInterface,
       };
-      conversationStore.addMessage(
+      await conversationStore.addMessage(
         ctx.conversationId,
         'user',
         JSON.stringify(toolResultBlocks),
@@ -617,7 +617,7 @@ export async function runAgentLoopImpl(
         assistantMessageInterface: capturedTurnInterfaceContext.assistantMessageInterface,
       };
       const errorAssistantMessage = createAssistantMessage(state.providerErrorUserMessage);
-      conversationStore.addMessage(
+      await conversationStore.addMessage(
         ctx.conversationId,
         'assistant',
         JSON.stringify(errorAssistantMessage.content),

--- a/assistant/src/daemon/session-messaging.ts
+++ b/assistant/src/daemon/session-messaging.ts
@@ -154,14 +154,14 @@ export function enqueueMessage(
 
 // ── persistUserMessage ───────────────────────────────────────────────
 
-export function persistUserMessage(
+export async function persistUserMessage(
   ctx: MessagingSessionContext,
   content: string,
   attachments: UserMessageAttachment[],
   requestId?: string,
   metadata?: Record<string, unknown>,
   displayContent?: string,
-): string {
+): Promise<string> {
   if (ctx.processing) {
     throw new Error('Session is already processing a message');
   }
@@ -214,7 +214,7 @@ export function persistUserMessage(
           id: a.id, filename: a.filename, mimeType: a.mimeType, data: a.data, extractedText: a.extractedText,
         }))).content)
       : JSON.stringify(userMessage.content);
-    const persistedUserMessage = conversationStore.addMessage(
+    const persistedUserMessage = await conversationStore.addMessage(
       ctx.conversationId,
       'user',
       contentToPersist,

--- a/assistant/src/daemon/session-notifiers.ts
+++ b/assistant/src/daemon/session-notifiers.ts
@@ -96,12 +96,12 @@ export function registerSessionNotifiers(
     }
   });
 
-  registerCallQuestionNotifier(conversationId, (callSessionId: string, question: string) => {
+  registerCallQuestionNotifier(conversationId, async (callSessionId: string, question: string) => {
     const callSession = getCallSession(callSessionId);
     const callee = callSession?.toNumber ?? 'the caller';
     const questionText = `**Live call question** (to ${callee}):\n\n${question}\n\n_Use the call answer API to respond._`;
 
-    conversationStore.addMessage(
+    await conversationStore.addMessage(
       conversationId,
       'assistant',
       JSON.stringify([{ type: 'text', text: questionText }]),

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -76,7 +76,7 @@ export interface ProcessSessionContext {
   /** Assistant identity — used for scoping notification preferences. */
   readonly assistantId?: string;
   guardianContext?: GuardianRuntimeContext;
-  persistUserMessage(content: string, attachments: UserMessageAttachment[], requestId?: string, metadata?: Record<string, unknown>, displayContent?: string): string;
+  persistUserMessage(content: string, attachments: UserMessageAttachment[], requestId?: string, metadata?: Record<string, unknown>, displayContent?: string): Promise<string>;
   runAgentLoop(
     content: string,
     userMessageId: string,
@@ -198,7 +198,7 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
       const contentToPersist = next.displayContent
         ? JSON.stringify(createUserMessage(next.displayContent, next.attachments).content)
         : JSON.stringify(userMsg.content);
-      conversationStore.addMessage(
+      await conversationStore.addMessage(
         session.conversationId,
         'user',
         contentToPersist,
@@ -207,7 +207,7 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
       session.messages.push(userMsg);
 
       const assistantMsg = createAssistantMessage(slashResult.message);
-      conversationStore.addMessage(
+      await conversationStore.addMessage(
         session.conversationId,
         'assistant',
         JSON.stringify(assistantMsg.content),
@@ -274,7 +274,7 @@ export function drainQueue(session: ProcessSessionContext, reason: QueueDrainRea
   // resolves early (no runAgentLoop call), so we must continue draining.
   let userMessageId: string;
   try {
-    userMessageId = session.persistUserMessage(resolvedContent, next.attachments, next.requestId, next.metadata, next.displayContent);
+    userMessageId = await session.persistUserMessage(resolvedContent, next.attachments, next.requestId, next.metadata, next.displayContent);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, conversationId: session.conversationId, requestId: next.requestId }, 'Failed to persist queued message');
@@ -360,7 +360,7 @@ export async function processMessage(
       const guardianIfCtx = session.getTurnInterfaceContext();
       const guardianChannelMeta = { userMessageChannel: 'vellum' as const, assistantMessageChannel: 'vellum' as const, userMessageInterface: guardianIfCtx?.userMessageInterface ?? 'vellum', assistantMessageInterface: guardianIfCtx?.assistantMessageInterface ?? 'vellum', provenanceActorRole: 'guardian' as const };
       const userMsg = createUserMessage(content, attachments);
-      const persisted = conversationStore.addMessage(
+      const persisted = await conversationStore.addMessage(
         session.conversationId,
         'user',
         JSON.stringify(userMsg.content),
@@ -380,7 +380,7 @@ export async function processMessage(
           ? 'Your answer has been relayed to the call.'
           : 'This question has already been answered from another channel.';
         const replyMsg = createAssistantMessage(replyText);
-        conversationStore.addMessage(
+        await conversationStore.addMessage(
           session.conversationId,
           'assistant',
           JSON.stringify(replyMsg.content),
@@ -392,7 +392,7 @@ export async function processMessage(
         const errorDetail = 'error' in answerResult ? answerResult.error : 'Unknown error';
         log.warn({ callSessionId: guardianRequest.callSessionId, error: errorDetail }, 'answerCall failed for mac guardian answer');
         const failMsg = createAssistantMessage('Failed to deliver your answer to the call. Please try again.');
-        conversationStore.addMessage(
+        await conversationStore.addMessage(
           session.conversationId,
           'assistant',
           JSON.stringify(failMsg.content),
@@ -432,7 +432,7 @@ export async function processMessage(
     const contentToPersist = displayContent
       ? JSON.stringify(createUserMessage(displayContent, attachments).content)
       : JSON.stringify(userMsg.content);
-    const persisted = conversationStore.addMessage(
+    const persisted = await conversationStore.addMessage(
       session.conversationId,
       'user',
       contentToPersist,
@@ -441,7 +441,7 @@ export async function processMessage(
     session.messages.push(userMsg);
 
     const assistantMsg = createAssistantMessage(slashResult.message);
-    conversationStore.addMessage(
+    await conversationStore.addMessage(
       session.conversationId,
       'assistant',
       JSON.stringify(assistantMsg.content),
@@ -494,7 +494,7 @@ export async function processMessage(
 
   let userMessageId: string;
   try {
-    userMessageId = session.persistUserMessage(resolvedContent, attachments, requestId, undefined, displayContent);
+    userMessageId = await session.persistUserMessage(resolvedContent, attachments, requestId, undefined, displayContent);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     onEvent({ type: 'error', message });

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -490,13 +490,13 @@ export class Session {
     return this.currentTurnInterfaceContext;
   }
 
-  persistUserMessage(
+  async persistUserMessage(
     content: string,
     attachments: UserMessageAttachment[],
     requestId?: string,
     metadata?: Record<string, unknown>,
     displayContent?: string,
-  ): string {
+  ): Promise<string> {
     return persistUserMessageImpl(this, content, attachments, requestId, metadata, displayContent);
   }
 

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -233,7 +233,7 @@ export function getLatestConversation(): ConversationRow | null {
   return row ? parseConversation(row) : null;
 }
 
-export function addMessage(conversationId: string, role: string, content: string, metadata?: Record<string, unknown>, opts?: { skipIndexing?: boolean }) {
+export async function addMessage(conversationId: string, role: string, content: string, metadata?: Record<string, unknown>, opts?: { skipIndexing?: boolean }) {
   const db = getDb();
   const messageId = uuid();
 
@@ -282,7 +282,7 @@ export function addMessage(conversationId: string, role: string, content: string
     } catch (err) {
       if (attempt < MAX_RETRIES && (err as { code?: string }).code === 'SQLITE_BUSY') {
         log.warn({ attempt, conversationId }, 'addMessage: SQLITE_BUSY, retrying');
-        Bun.sleepSync(50 * (attempt + 1));
+        await Bun.sleep(50 * (attempt + 1));
         continue;
       }
       throw err;

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -126,7 +126,7 @@ export class NotificationBroadcaster {
       }
 
       // Pair the delivery with a conversation before sending
-      const pairing = pairDeliveryWithConversation(signal, channel, copy);
+      const pairing = await pairDeliveryWithConversation(signal, channel, copy);
 
       // For the vellum channel, merge the conversationId into deep-link metadata
       // so the macOS/iOS client can navigate directly to the notification thread.

--- a/assistant/src/notifications/conversation-pairing.ts
+++ b/assistant/src/notifications/conversation-pairing.ts
@@ -34,11 +34,11 @@ export interface PairingResult {
  * Errors are caught and logged — this function never throws so the
  * notification pipeline is not disrupted by pairing failures.
  */
-export function pairDeliveryWithConversation(
+export async function pairDeliveryWithConversation(
   signal: NotificationSignal,
   channel: NotificationChannel,
   copy: RenderedChannelCopy,
-): PairingResult {
+): Promise<PairingResult> {
   try {
     const strategy = getConversationStrategy(channel as ChannelId);
 
@@ -78,7 +78,7 @@ export function pairDeliveryWithConversation(
       : composeThreadSeed(signal, channel, copy);
     // Skip memory indexing — notification audit messages are not conversational
     // memory and should not pollute recall or incur embedding/extraction overhead.
-    const message = addMessage(conversation.id, 'assistant', messageContent, undefined, { skipIndexing: true });
+    const message = await addMessage(conversation.id, 'assistant', messageContent, undefined, { skipIndexing: true });
 
     log.info(
       {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -335,7 +335,7 @@ export async function handleSendMessage(
       assistantMessageInterface: sourceInterface,
     });
     const requestId = crypto.randomUUID();
-    const messageId = session.persistUserMessage(content ?? '', attachments, requestId);
+    const messageId = await session.persistUserMessage(content ?? '', attachments, requestId);
 
     // Fire-and-forget the agent loop; events flow to the hub via onEvent.
     // Mark non-interactive so conflict clarification doesn't block the turn.

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -232,7 +232,7 @@ export class SubagentManager {
 
     try {
       // Send the objective as the first user message and process it.
-      const messageId = managed.session.persistUserMessage(objective, []);
+      const messageId = await managed.session.persistUserMessage(objective, []);
       await managed.session.runAgentLoop(objective, messageId, onEvent);
 
       // Agent loop completed successfully.
@@ -349,7 +349,7 @@ export class SubagentManager {
 
   // ── Send message to subagent ──────────────────────────────────────────
 
-  sendMessage(subagentId: string, content: string): 'sent' | 'empty' | 'not_found' | 'terminal' | 'queue_full' {
+  async sendMessage(subagentId: string, content: string): Promise<'sent' | 'empty' | 'not_found' | 'terminal' | 'queue_full'> {
     const trimmed = content?.trim();
     if (!trimmed) return 'empty';
 
@@ -365,7 +365,7 @@ export class SubagentManager {
     if (result.rejected) return 'queue_full';
     if (!result.queued) {
       // Session is idle — send directly.  Fire-and-forget so we don't block.
-      const messageId = managed.session.persistUserMessage(trimmed, []);
+      const messageId = await managed.session.persistUserMessage(trimmed, []);
       managed.session.runAgentLoop(trimmed, messageId, onEvent).catch((err) => {
         log.error({ subagentId, err }, 'Subagent message processing failed');
       });

--- a/assistant/src/tools/subagent/message.ts
+++ b/assistant/src/tools/subagent/message.ts
@@ -23,7 +23,7 @@ export async function executeSubagentMessage(
     };
   }
 
-  const result = manager.sendMessage(subagentId, content);
+  const result = await manager.sendMessage(subagentId, content);
 
   if (result === 'queue_full') {
     return {


### PR DESCRIPTION
Replace synchronous Bun.sleepSync() with async Bun.sleep() in conversation-store.ts SQLite retry logic. The sync version blocks the entire event loop during retry backoff, preventing other work from progressing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
