### PR TITLE
feat: add support for custom secret scanner patterns via config

### DIFF
--- a/assistant/src/config/core-schema.ts
+++ b/assistant/src/config/core-schema.ts
@@ -45,6 +45,11 @@ export const RateLimitConfigSchema = z.object({
     .default(0),
 });
 
+export const CustomSecretPatternSchema = z.object({
+  label: z.string({ error: 'secretDetection.customPatterns[].label must be a string' }),
+  pattern: z.string({ error: 'secretDetection.customPatterns[].pattern must be a string' }),
+});
+
 export const SecretDetectionConfigSchema = z.object({
   enabled: z
     .boolean({ error: 'secretDetection.enabled must be a boolean' })
@@ -65,6 +70,9 @@ export const SecretDetectionConfigSchema = z.object({
   blockIngress: z
     .boolean({ error: 'secretDetection.blockIngress must be a boolean' })
     .default(true),
+  customPatterns: z
+    .array(CustomSecretPatternSchema)
+    .optional(),
 });
 
 export const PermissionsConfigSchema = z.object({
@@ -293,6 +301,7 @@ export const UiConfigSchema = z.object({
 
 export type TimeoutConfig = z.infer<typeof TimeoutConfigSchema>;
 export type RateLimitConfig = z.infer<typeof RateLimitConfigSchema>;
+export type CustomSecretPattern = z.infer<typeof CustomSecretPatternSchema>;
 export type SecretDetectionConfig = z.infer<typeof SecretDetectionConfigSchema>;
 export type PermissionsConfig = z.infer<typeof PermissionsConfigSchema>;
 export type AuditLogConfig = z.infer<typeof AuditLogConfigSchema>;

--- a/assistant/src/security/secret-ingress.ts
+++ b/assistant/src/security/secret-ingress.ts
@@ -1,6 +1,6 @@
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
-import { scanText } from './secret-scanner.js';
+import { compileCustomPatterns, scanText } from './secret-scanner.js';
 
 const log = getLogger('secret-ingress');
 
@@ -37,7 +37,10 @@ export function checkIngressForSecrets(content: string): IngressCheckResult {
   }
 
   const entropyConfig = { enabled: true, base64Threshold: config.secretDetection.entropyThreshold };
-  const matches = scanText(content, entropyConfig);
+  const compiledCustom = config.secretDetection.customPatterns?.length
+    ? compileCustomPatterns(config.secretDetection.customPatterns)
+    : undefined;
+  const matches = scanText(content, entropyConfig, compiledCustom);
 
   if (matches.length === 0) {
     return { blocked: false, detectedTypes: [] };

--- a/assistant/src/security/secret-scanner.ts
+++ b/assistant/src/security/secret-scanner.ts
@@ -4,7 +4,10 @@
  * from gitleaks and detect-secrets.
  */
 
+import { getLogger } from '../util/logger.js';
 import { isAllowlisted } from './secret-allowlist.js';
+
+const log = getLogger('secret-scanner');
 
 export interface SecretMatch {
   /** Human-readable type label, e.g. "AWS Access Key" */
@@ -589,8 +592,10 @@ function overlapsExisting(start: number, end: number, ranges: Set<string>): bool
 function scanEncoded(
   text: string,
   existingRanges: Set<string>,
+  customPatterns?: SecretPattern[],
 ): SecretMatch[] {
   const matches: SecretMatch[] = [];
+  const allPatterns = customPatterns?.length ? [...PATTERNS, ...customPatterns] : PATTERNS;
 
   // Helper: try to match decoded content against known secret patterns
   const tryMatchDecoded = (
@@ -600,7 +605,7 @@ function scanEncoded(
     endIndex: number,
     encoding: string,
   ) => {
-    for (const pattern of PATTERNS) {
+    for (const pattern of allPatterns) {
       pattern.regex.lastIndex = 0;
       let pm: RegExpExecArray | null;
       while ((pm = pattern.regex.exec(decoded)) != null) {
@@ -668,6 +673,31 @@ function scanEncoded(
 }
 
 // ---------------------------------------------------------------------------
+// Custom pattern support
+// ---------------------------------------------------------------------------
+
+export interface CustomPatternInput {
+  label: string;
+  pattern: string;
+}
+
+/**
+ * Compile user-provided custom patterns into SecretPattern objects.
+ * Invalid regex patterns are logged and skipped.
+ */
+export function compileCustomPatterns(inputs: CustomPatternInput[]): SecretPattern[] {
+  const compiled: SecretPattern[] = [];
+  for (const { label, pattern } of inputs) {
+    try {
+      compiled.push({ type: label, regex: new RegExp(pattern, 'g') });
+    } catch (err) {
+      log.warn({ label, pattern, error: String(err) }, 'Skipping invalid custom secret pattern');
+    }
+  }
+  return compiled;
+}
+
+// ---------------------------------------------------------------------------
 // Scan function
 // ---------------------------------------------------------------------------
 
@@ -678,13 +708,20 @@ function scanEncoded(
  *
  * @param entropyConfig — optional config for entropy-based scanning.
  *   Pass `{ enabled: false }` to disable. Defaults to DEFAULT_ENTROPY_CONFIG.
+ * @param customPatterns — optional user-defined patterns to apply alongside built-in ones.
  */
-export function scanText(text: string, entropyConfig?: Partial<EntropyConfig>): SecretMatch[] {
+export function scanText(
+  text: string,
+  entropyConfig?: Partial<EntropyConfig>,
+  customPatterns?: SecretPattern[],
+): SecretMatch[] {
   const matches: SecretMatch[] = [];
   // De-duplicate overlapping ranges (a match can fire on multiple patterns)
   const seen = new Set<string>();
 
-  for (const pattern of PATTERNS) {
+  const allPatterns = customPatterns?.length ? [...PATTERNS, ...customPatterns] : PATTERNS;
+
+  for (const pattern of allPatterns) {
     // Reset lastIndex for global regexes
     pattern.regex.lastIndex = 0;
     let m: RegExpExecArray | null;
@@ -719,7 +756,7 @@ export function scanText(text: string, entropyConfig?: Partial<EntropyConfig>): 
   matches.push(...entropyMatches);
 
   // Encoded secret detection — decode candidate segments and re-scan
-  const encodedMatches = scanEncoded(text, seen);
+  const encodedMatches = scanEncoded(text, seen, customPatterns);
   matches.push(...encodedMatches);
 
   // Sort by position; at same start, wider match first so redaction covers the full span
@@ -731,8 +768,12 @@ export function scanText(text: string, entropyConfig?: Partial<EntropyConfig>): 
  * Replace detected secrets in text with redaction markers.
  * Returns the modified text.
  */
-export function redactSecrets(text: string, entropyConfig?: Partial<EntropyConfig>): string {
-  const matches = scanText(text, entropyConfig);
+export function redactSecrets(
+  text: string,
+  entropyConfig?: Partial<EntropyConfig>,
+  customPatterns?: SecretPattern[],
+): string {
+  const matches = scanText(text, entropyConfig, customPatterns);
   if (matches.length === 0) return text;
 
   let result = '';

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -8,7 +8,7 @@ import { addRule } from '../permissions/trust-store.js';
 import { RiskLevel } from '../permissions/types.js';
 import { isToolBlocked } from '../security/parental-control-store.js';
 import { redactSensitiveFields } from '../security/redaction.js';
-import { redactSecrets,scanText } from '../security/secret-scanner.js';
+import { compileCustomPatterns,redactSecrets,scanText } from '../security/secret-scanner.js';
 import { TokenExpiredError } from '../security/token-manager.js';
 import { getTaskRunRules } from '../tasks/ephemeral-permissions.js';
 import { PermissionDeniedError,ToolError } from '../util/errors.js';
@@ -526,13 +526,16 @@ export class ToolExecutor {
       const sdConfig = getConfig().secretDetection;
       if (sdConfig.enabled && !execResult.isError) {
         const entropyConfig = { enabled: true, base64Threshold: sdConfig.entropyThreshold };
-        const contentMatches = scanText(execResult.content, entropyConfig);
+        const compiledCustom = sdConfig.customPatterns?.length
+          ? compileCustomPatterns(sdConfig.customPatterns)
+          : undefined;
+        const contentMatches = scanText(execResult.content, entropyConfig, compiledCustom);
         const diffMatches = execResult.diff
-          ? scanText(execResult.diff.newContent, entropyConfig)
+          ? scanText(execResult.diff.newContent, entropyConfig, compiledCustom)
           : [];
         const blockMatches = (execResult.contentBlocks ?? []).flatMap((block) => {
-          if (block.type === 'text') return scanText(block.text, entropyConfig);
-          if (block.type === 'file' && block.extracted_text) return scanText(block.extracted_text, entropyConfig);
+          if (block.type === 'text') return scanText(block.text, entropyConfig, compiledCustom);
+          if (block.type === 'file' && block.extracted_text) return scanText(block.extracted_text, entropyConfig, compiledCustom);
           return [];
         });
         const allMatches = [...contentMatches, ...diffMatches, ...blockMatches];
@@ -558,20 +561,20 @@ export class ToolExecutor {
           });
 
           if (sdConfig.action === 'redact') {
-            execResult.content = redactSecrets(execResult.content, entropyConfig);
+            execResult.content = redactSecrets(execResult.content, entropyConfig, compiledCustom);
             if (execResult.diff) {
               execResult.diff = {
                 ...execResult.diff,
-                newContent: redactSecrets(execResult.diff.newContent, entropyConfig),
+                newContent: redactSecrets(execResult.diff.newContent, entropyConfig, compiledCustom),
               };
             }
             if (execResult.contentBlocks) {
               execResult.contentBlocks = execResult.contentBlocks.map((block) => {
                 if (block.type === 'text') {
-                  return { ...block, text: redactSecrets(block.text, entropyConfig) };
+                  return { ...block, text: redactSecrets(block.text, entropyConfig, compiledCustom) };
                 }
                 if (block.type === 'file' && block.extracted_text) {
-                  return { ...block, extracted_text: redactSecrets(block.extracted_text, entropyConfig) };
+                  return { ...block, extracted_text: redactSecrets(block.extracted_text, entropyConfig, compiledCustom) };
                 }
                 return block;
               });


### PR DESCRIPTION
Add secretDetection.customPatterns config field and extend secret-scanner.ts to load, validate, and apply user-defined regex patterns alongside built-in ones. Invalid patterns are logged and skipped.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
