### PR TITLE
chore: remove dead voice source classifier branch

### DIFF
--- a/assistant/src/daemon/classifier.ts
+++ b/assistant/src/daemon/classifier.ts
@@ -11,12 +11,7 @@ export type InteractionType = 'computer_use' | 'text_qa';
  * Classify a user task as computer_use or text_qa using an LLM tool-use call,
  * falling back to a heuristic if the API call fails or no API key is available.
  */
-export async function classifyInteraction(task: string, source?: 'voice' | 'text'): Promise<InteractionType> {
-  if (source === 'voice') {
-    log.info({ source }, 'Voice source detected, skipping classification — routing to text_qa');
-    return 'text_qa';
-  }
-
+export async function classifyInteraction(task: string): Promise<InteractionType> {
   const provider = getConfiguredProvider();
   if (!provider) {
     log.warn('No configured provider available, falling back to heuristic classification');

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -413,7 +413,7 @@ export async function handleTaskSubmit(
     const slashCandidate = parseSlashCandidate(msg.task);
     const interactionType = slashCandidate.kind === 'candidate'
       ? 'text_qa' as const
-      : await classifyInteraction(msg.task, msg.source);
+      : await classifyInteraction(msg.task);
     rlog.info({ interactionType, slashBypass: slashCandidate.kind === 'candidate', taskLength: msg.task.length }, 'Task classified');
 
     if (interactionType === 'computer_use') {


### PR DESCRIPTION
Remove the `source === 'voice'` → `text_qa` block in classifier.ts — PTT sends 'voice_action' as source, not 'voice', so this branch is never hit. Part of the Voice Mode Actions cleanup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
