### PR TITLE
Use Sonnet 4.6 for low-tier responses instead of Haiku

### DIFF
--- a/assistant/src/daemon/response-tier.ts
+++ b/assistant/src/daemon/response-tier.ts
@@ -226,12 +226,12 @@ export function tierMaxTokens(tier: ResponseTier, configuredMax: number): number
 
 /**
  * Map for Anthropic provider: tier → model.
- *   low    → haiku (fastest TTFT)
+ *   low    → sonnet (balanced)
  *   medium → sonnet (balanced)
  *   high   → undefined (use configured default, typically opus)
  */
 const ANTHROPIC_TIER_MODELS: Record<ResponseTier, string | undefined> = {
-  low: 'claude-haiku-4-5-20251001',
+  low: 'claude-sonnet-4-6',
   medium: 'claude-sonnet-4-6',
   high: undefined, // use configured default
 };


### PR DESCRIPTION
## Summary
- Updates the tier-based model routing so low-complexity messages use Sonnet 4.6 instead of Haiku
- Both low and medium tiers now route to Sonnet 4.6, while high tier continues to use the configured default (Opus 4.6)
- The background Haiku classifier for async tier hints remains unchanged

## Test plan
- [ ] Verify low-tier messages (greetings, short acknowledgements) use Sonnet 4.6
- [ ] Verify medium-tier messages continue using Sonnet 4.6
- [ ] Verify high-tier messages continue using the configured default (Opus 4.6)
- [ ] Verify background async tier classification still uses Haiku via latency-optimized intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
