### PR TITLE
feat: extend voice mode timeout during tool execution

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -40,6 +40,8 @@ final class VoiceModeManager: ObservableObject {
     private var pendingPermissionIds: [String] = []
     /// Combine subscription to detect new confirmations in chat messages.
     private var messageCancellable: AnyCancellable?
+    /// Combine subscription to pause/resume conversation timeout during tool execution.
+    private var isThinkingCancellable: AnyCancellable?
 
     nonisolated init() {
         self.voiceService = OpenAIVoiceService()
@@ -112,6 +114,19 @@ final class VoiceModeManager: ObservableObject {
                 self?.checkForConfirmations(in: messages)
             }
 
+        // Pause the conversation timeout while the agent is executing tools,
+        // preventing auto-deactivation during multi-step tool sequences.
+        isThinkingCancellable = chatViewModel.messageManager.$isThinking
+            .removeDuplicates()
+            .sink { [weak self] thinking in
+                guard let self, self.state == .idle else { return }
+                if thinking {
+                    self.cancelConversationTimeout()
+                } else {
+                    self.startConversationTimeout()
+                }
+            }
+
         // Pre-warm audio engine so first recording starts instantly
         voiceService.prewarmEngine()
 
@@ -164,6 +179,8 @@ final class VoiceModeManager: ObservableObject {
         previousOnVoiceTextDelta = nil
         messageCancellable?.cancel()
         messageCancellable = nil
+        isThinkingCancellable?.cancel()
+        isThinkingCancellable = nil
         pendingPermissionIds = []
 
         chatViewModel = nil
@@ -485,7 +502,11 @@ final class VoiceModeManager: ObservableObject {
         guard oldState != newState else { return }
 
         if newState == .idle {
-            startConversationTimeout()
+            // Don't start the timeout if the agent is currently executing tools —
+            // the isThinking observer will restart it when thinking completes.
+            if chatViewModel?.isThinking != true {
+                startConversationTimeout()
+            }
         } else {
             cancelConversationTimeout()
         }


### PR DESCRIPTION
Pause the voice mode conversation timeout when ChatViewModel.isThinking is true, preventing auto-deactivation while the agent runs multi-step tool sequences. Resume timeout when thinking completes. Part of the Voice Mode Actions feature.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
