### PR TITLE
feat: capture app context for voice mode messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -235,9 +235,24 @@ final class VoiceModeManager: ObservableObject {
 
             partialTranscription = trimmed
 
+            // Capture frontmost app context so the daemon knows what the user
+            // is looking at during voice conversations (matches PTT behavior).
+            let ctx = DictationContextCapture.capture()
+            var contextPrefix = ""
+            if !ctx.appName.isEmpty {
+                var parts: [String] = ["app: \(ctx.appName)"]
+                if !ctx.windowTitle.isEmpty {
+                    parts.append("window: \"\(ctx.windowTitle)\"")
+                }
+                if let selected = ctx.selectedText, !selected.isEmpty {
+                    parts.append("selected text: \"\(selected)\"")
+                }
+                contextPrefix = "[User's current \(parts.joined(separator: ", "))]\n"
+            }
+
             // Send the transcribed message through the daemon (full context)
             chatViewModel.pendingVoiceMessage = true
-            chatViewModel.inputText = trimmed
+            chatViewModel.inputText = contextPrefix + trimmed
             chatViewModel.sendMessage()
             log.info("Voice mode: sent transcription to chat via daemon")
         }


### PR DESCRIPTION
In VoiceModeManager.handleSilenceDetected(), capture frontmost app context (app name, window title, selected text) via DictationContextCapture before sending the message. This gives the daemon awareness of what the user is looking at during voice conversations, matching PTT behavior. Part of the Voice Mode Actions feature.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
