### PR TITLE
feat: add TTS feedback during computer use escalation in voice mode

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -84,7 +84,29 @@ extension AppDelegate {
                 self.mainWindow?.hide()
             }
 
+            // Announce CU escalation via voice if voice mode is active
+            let voiceManager = self.mainWindow?.voiceModeManager
+            let voiceModeWasActive = voiceManager?.state != .off && voiceManager?.state != nil
+            if voiceModeWasActive {
+                voiceManager?.speakTransient("Let me take over the screen for a moment.")
+                voiceManager?.pauseConversationTimeout()
+            }
+
             await session.run()
+
+            // Announce CU completion via voice if voice mode is still active
+            if voiceModeWasActive, let voiceManager, voiceManager.state != .off {
+                let summary: String
+                switch session.state {
+                case .completed(let s, _), .responded(let s, _):
+                    summary = s
+                default:
+                    summary = "All done with the screen."
+                }
+                voiceManager.speakTransient(summary)
+                voiceManager.resumeConversationTimeout()
+            }
+
             try? await Task.sleep(nanoseconds: 10_000_000_000)
             overlay.close()
             self.overlayWindow = nil

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -547,6 +547,64 @@ final class VoiceModeManager: ObservableObject {
         conversationTimeoutTask = nil
     }
 
+    // MARK: - Transient Speech & Timeout Control
+
+    /// Speak a one-off message using the TTS system without affecting the voice
+    /// mode state machine. The message is spoken and then the state returns to
+    /// whatever it was before. Callers can use this to provide audible feedback
+    /// (e.g., announcing a computer use escalation) without disrupting the
+    /// conversation flow.
+    func speakTransient(_ message: String) {
+        guard state != .off else { return }
+        log.info("Voice mode: transient speech — \(message, privacy: .public)")
+
+        // Stop any in-progress recording so the TTS output isn't picked up
+        // by the microphone as input.
+        if state == .listening {
+            voiceService.cancelRecording()
+        }
+
+        let previousState = state
+        state = .speaking
+        voiceService.resetStreamingTTS()
+        voiceService.feedTextDelta(message)
+
+        ttsTimeoutTask?.cancel()
+        ttsTimeoutTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 15_000_000_000)
+            guard let self, !Task.isCancelled, self.state == .speaking else { return }
+            log.warning("Voice mode: transient speech timeout, recovering")
+            self.voiceService.stopSpeaking()
+            self.state = previousState == .listening ? .idle : previousState
+        }
+
+        voiceService.finishTextStream { [weak self] in
+            guard let self, self.state == .speaking else { return }
+            self.ttsTimeoutTask?.cancel()
+            self.ttsTimeoutTask = nil
+            self.voiceService.stopBargeInMonitor()
+            // Return to idle rather than the previous state so the conversation
+            // timeout logic is properly re-engaged via handleStateTransition.
+            self.state = .idle
+        }
+    }
+
+    /// Pause the conversation timeout timer. Use this when the assistant is
+    /// performing a long-running operation (e.g., computer use) and the
+    /// conversation should not auto-deactivate.
+    func pauseConversationTimeout() {
+        log.info("Voice mode: conversation timeout paused")
+        cancelConversationTimeout()
+    }
+
+    /// Resume the conversation timeout timer. Call this after a long-running
+    /// operation completes so idle auto-deactivation can kick in again.
+    func resumeConversationTimeout() {
+        log.info("Voice mode: conversation timeout resumed")
+        guard state == .idle else { return }
+        startConversationTimeout()
+    }
+
     // MARK: - Barge-in (interrupt TTS)
 
     private func handleBargeIn() {


### PR DESCRIPTION
When voice mode is active and the agent escalates to foreground computer use, speak a transient announcement ('Let me take over the screen for a moment') and pause the conversation timeout. After CU completes, speak the completion summary and resume the timeout. Adds speakTransient(), pauseConversationTimeout(), and resumeConversationTimeout() to VoiceModeManager. Part of the Voice Mode Actions feature.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
