### PR TITLE
feat: auto-deny pending tool confirmations in daemon on new user message

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -179,14 +179,6 @@ export async function handleUserMessage(
       });
     };
 
-    // If the session has a pending tool confirmation, auto-deny it so the
-    // agent can process the user's follow-up message instead.  The agent
-    // will see the denial and can re-request the tool if still needed.
-    if (session.hasAnyPendingConfirmation()) {
-      rlog.info('Auto-denying pending confirmation(s) due to new user message');
-      session.denyAllPendingConfirmations();
-    }
-
     const config = getConfig();
     let messageText = msg.content ?? '';
 
@@ -445,6 +437,14 @@ export async function handleUserMessage(
           }
         }
       }
+    }
+
+    // If the session has a pending tool confirmation, auto-deny it so the
+    // agent can process the user's follow-up message instead.  The agent
+    // will see the denial and can re-request the tool if still needed.
+    if (session.hasAnyPendingConfirmation()) {
+      rlog.info('Auto-denying pending confirmation(s) due to new user message');
+      session.denyAllPendingConfirmations();
     }
 
     dispatchUserMessage(

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -179,6 +179,14 @@ export async function handleUserMessage(
       });
     };
 
+    // If the session has a pending tool confirmation, auto-deny it so the
+    // agent can process the user's follow-up message instead.  The agent
+    // will see the denial and can re-request the tool if still needed.
+    if (session.hasAnyPendingConfirmation()) {
+      rlog.info('Auto-denying pending confirmation(s) due to new user message');
+      session.denyAllPendingConfirmations();
+    }
+
     const config = getConfig();
     let messageText = msg.content ?? '';
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -426,6 +426,14 @@ export class Session {
     return this.prompter.hasPendingRequest(requestId);
   }
 
+  hasAnyPendingConfirmation(): boolean {
+    return this.prompter.hasPending;
+  }
+
+  denyAllPendingConfirmations(): void {
+    this.prompter.denyAllPending();
+  }
+
   hasPendingSecret(requestId: string): boolean {
     return this.secretPrompter.hasPendingRequest(requestId);
   }

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -114,6 +114,23 @@ export class PermissionPrompter {
     pending.resolve({ decision, selectedPattern, selectedScope, decisionContext });
   }
 
+  /**
+   * Deny all pending confirmation prompts at once. Used when a new user
+   * message arrives while confirmations are outstanding — the agent will
+   * see the denial and can re-request if still needed.
+   */
+  denyAllPending(): void {
+    for (const [requestId, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      this.pending.delete(requestId);
+      pending.resolve({ decision: 'deny', decisionContext: 'auto_denied_new_user_message' });
+    }
+  }
+
+  get hasPending(): boolean {
+    return this.pending.size > 0;
+  }
+
   dispose(): void {
     for (const [, pending] of this.pending) {
       clearTimeout(pending.timer);

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -67,6 +67,18 @@ export function getByConversation(conversationId: string): Array<{ requestId: st
   return results;
 }
 
+/**
+ * Remove all pending interactions for a given session.
+ * Used when auto-denying all pending confirmations (e.g. new user message).
+ */
+export function removeBySession(session: Session): void {
+  for (const [requestId, interaction] of pending) {
+    if (interaction.session === session) {
+      pending.delete(requestId);
+    }
+  }
+}
+
 /** Clear all pending interactions. Useful for testing. */
 export function clear(): void {
   pending.clear();

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -303,6 +303,7 @@ export async function handleSendMessage(
       // can finish the current turn and process this queued message.
       if (session.hasAnyPendingConfirmation()) {
         session.denyAllPendingConfirmations();
+        pendingInteractions.removeBySession(session);
       }
 
       // Queue the message so it's processed when the current turn completes

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -299,6 +299,12 @@ export async function handleSendMessage(
       : [];
 
     if (session.isProcessing()) {
+      // If a tool confirmation is pending, auto-deny it so the agent
+      // can finish the current turn and process this queued message.
+      if (session.hasAnyPendingConfirmation()) {
+        session.denyAllPendingConfirmations();
+      }
+
       // Queue the message so it's processed when the current turn completes
       const requestId = crypto.randomUUID();
       const result = session.enqueueMessage(

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -820,13 +820,6 @@ public final class ChatViewModel: ObservableObject {
         let hasSkillInvocation = pendingSkillInvocation != nil
         guard !text.isEmpty || hasAttachments || hasSkillInvocation else { return }
 
-        // If there's a pending tool confirmation, auto-deny it so the agent
-        // can process the user's follow-up message instead.
-        if let pendingIndex = messages.firstIndex(where: { $0.confirmation?.state == .pending }),
-           let requestId = messages[pendingIndex].confirmation?.requestId {
-            respondToConfirmation(requestId: requestId, decision: "deny")
-        }
-
         // When "/model" or "/models" is sent, refresh model state so the picker/table has fresh data
         if (text == "/model" || text == "/models") && !hasSkillInvocation {
             do {


### PR DESCRIPTION
## Summary
- Adds `denyAllPending()` to `PermissionPrompter` to resolve all outstanding confirmations with 'deny'
- Adds `hasAnyPendingConfirmation()` and `denyAllPendingConfirmations()` to `Session`
- Calls auto-deny in `handleUserMessage()` before dispatching, so the agent sees the denial and processes the user's follow-up message instead

## Context
Addresses feedback from PR #9683: Aaron asked whether the auto-deny logic should live in the daemon instead of the client. Moving it to the daemon centralizes the behavior so all clients (macOS, iOS, web) get it for free.

## Original prompt
Move the auto-deny pending confirmation logic from the client to the daemon. When the daemon receives a new user message while a tool confirmation is pending, it should automatically deny the pending confirmation before processing the user's message. This centralizes the logic so all clients (macOS, iOS, web) get it for free.

The client-side changes from PR #9683 should be kept for the UI part (showing send button instead of stop button when confirmation is pending), but the auto-deny logic in ChatViewModel.swift's sendMessage() should be removed since the daemon will handle it.

Context from PR #9683 feedback: Aaron asked whether this should be in the daemon instead of the client layer. The answer is yes - the daemon should handle the auto-deny so it works for all clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
