### PR TITLE
M1: Land remote skill policy primitive and enable skills.sh-first baseline

### DIFF
--- a/assistant/src/__tests__/remote-skill-policy.test.ts
+++ b/assistant/src/__tests__/remote-skill-policy.test.ts
@@ -130,6 +130,20 @@ describe('remote skill policy — skills.sh', () => {
     expect(decision).toEqual({ ok: false, reason: 'skillssh_risk_exceeds_threshold' });
   });
 
+  test('prototype property risk label is treated as unknown and blocked', () => {
+    const decision = evaluateRemoteSkillInstall(
+      {
+        provider: 'skillssh',
+        slug: 'proto-risk-skill',
+        // "toString" exists on Object.prototype — must not be treated as a known risk label
+        audit: { risk: 'toString' as never },
+      },
+      policy,
+    );
+
+    expect(decision).toEqual({ ok: false, reason: 'skillssh_risk_exceeds_threshold' });
+  });
+
   test('unrecognized risk string is coerced to unknown and blocked', () => {
     const decision = evaluateRemoteSkillInstall(
       {

--- a/assistant/src/__tests__/remote-skill-policy.test.ts
+++ b/assistant/src/__tests__/remote-skill-policy.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  evaluateRemoteSkillInstall,
+  filterInstallableRemoteSkills,
+  type RemoteSkillPolicy,
+} from '../skills/remote-skill-policy.js';
+
+describe('remote skill policy — clawhub', () => {
+  const policy: RemoteSkillPolicy = {
+    blockSuspicious: true,
+    blockMalware: true,
+    maxSkillsShRisk: 'medium',
+  };
+
+  test('suspicious skills are excluded from installable list', () => {
+    const candidates = [
+      {
+        provider: 'clawhub' as const,
+        slug: 'safe-skill',
+        moderation: { isSuspicious: false, isMalwareBlocked: false },
+      },
+      {
+        provider: 'clawhub' as const,
+        slug: 'suspicious-skill',
+        moderation: { isSuspicious: true, isMalwareBlocked: false },
+      },
+    ];
+
+    const installable = filterInstallableRemoteSkills(candidates, policy);
+    expect(installable.map((skill) => skill.slug)).toEqual(['safe-skill']);
+  });
+
+  test('suspicious skills are not installable when installation is attempted', () => {
+    const decision = evaluateRemoteSkillInstall(
+      {
+        provider: 'clawhub',
+        slug: 'suspicious-skill',
+        moderation: { isSuspicious: true, isMalwareBlocked: false },
+      },
+      policy,
+    );
+
+    expect(decision).toEqual({ ok: false, reason: 'clawhub_suspicious' });
+  });
+
+  test('malware-blocked skills are excluded from installable list and blocked on install', () => {
+    const candidates = [
+      {
+        provider: 'clawhub' as const,
+        slug: 'malware-skill',
+        moderation: { isSuspicious: false, isMalwareBlocked: true },
+      },
+    ];
+
+    expect(filterInstallableRemoteSkills(candidates, policy)).toEqual([]);
+
+    const decision = evaluateRemoteSkillInstall(candidates[0], policy);
+    expect(decision).toEqual({ ok: false, reason: 'clawhub_malware_blocked' });
+  });
+});
+
+describe('remote skill policy — skills.sh', () => {
+  const policy: RemoteSkillPolicy = {
+    blockSuspicious: true,
+    blockMalware: true,
+    maxSkillsShRisk: 'medium',
+  };
+
+  test('high-risk skills are excluded from installable list', () => {
+    const candidates = [
+      {
+        provider: 'skillssh' as const,
+        slug: 'safe-skill',
+        audit: { risk: 'low' as const },
+      },
+      {
+        provider: 'skillssh' as const,
+        slug: 'suspicious-skill',
+        audit: { risk: 'high' as const },
+      },
+    ];
+
+    const installable = filterInstallableRemoteSkills(candidates, policy);
+    expect(installable.map((skill) => skill.slug)).toEqual(['safe-skill']);
+  });
+
+  test('high-risk skills are not installable when installation is attempted', () => {
+    const decision = evaluateRemoteSkillInstall(
+      {
+        provider: 'skillssh',
+        slug: 'suspicious-skill',
+        audit: { risk: 'high' },
+      },
+      policy,
+    );
+
+    expect(decision).toEqual({ ok: false, reason: 'skillssh_risk_exceeds_threshold' });
+  });
+
+  test('unknown risk is treated as suspicious and blocked by default', () => {
+    const decision = evaluateRemoteSkillInstall(
+      {
+        provider: 'skillssh',
+        slug: 'unknown-risk-skill',
+        audit: { risk: 'unknown' },
+      },
+      policy,
+    );
+
+    expect(decision).toEqual({ ok: false, reason: 'skillssh_risk_exceeds_threshold' });
+  });
+});

--- a/assistant/src/__tests__/remote-skill-policy.test.ts
+++ b/assistant/src/__tests__/remote-skill-policy.test.ts
@@ -110,4 +110,37 @@ describe('remote skill policy — skills.sh', () => {
 
     expect(decision).toEqual({ ok: false, reason: 'skillssh_risk_exceeds_threshold' });
   });
+
+  test('risk threshold is enforced even when blockSuspicious is false', () => {
+    const permissivePolicy: RemoteSkillPolicy = {
+      blockSuspicious: false,
+      blockMalware: false,
+      maxSkillsShRisk: 'medium',
+    };
+
+    const decision = evaluateRemoteSkillInstall(
+      {
+        provider: 'skillssh',
+        slug: 'high-risk-skill',
+        audit: { risk: 'high' },
+      },
+      permissivePolicy,
+    );
+
+    expect(decision).toEqual({ ok: false, reason: 'skillssh_risk_exceeds_threshold' });
+  });
+
+  test('unrecognized risk string is coerced to unknown and blocked', () => {
+    const decision = evaluateRemoteSkillInstall(
+      {
+        provider: 'skillssh',
+        slug: 'bogus-risk-skill',
+        // Cast to bypass type checking — simulates a provider returning a novel risk label
+        audit: { risk: 'super-duper-risky' as never },
+      },
+      policy,
+    );
+
+    expect(decision).toEqual({ ok: false, reason: 'skillssh_risk_exceeds_threshold' });
+  });
 });

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -117,12 +117,18 @@ export {
   SandboxConfigSchema,
 } from './sandbox-schema.js';
 export type {
+  RemotePolicyConfig,
+  RemoteProviderConfig,
+  RemoteProvidersConfig,
   SkillEntryConfig,
   SkillsConfig,
   SkillsInstallConfig,
   SkillsLoadConfig,
 } from './skills-schema.js';
 export {
+  RemotePolicyConfigSchema,
+  RemoteProviderConfigSchema,
+  RemoteProvidersConfigSchema,
   SkillEntryConfigSchema,
   SkillsConfigSchema,
   SkillsInstallConfigSchema,

--- a/assistant/src/config/skills-schema.ts
+++ b/assistant/src/config/skills-schema.ts
@@ -29,12 +29,15 @@ export const RemoteProvidersConfigSchema = z.object({
 });
 
 const VALID_SKILLS_SH_RISK_LEVELS = ['safe', 'low', 'medium', 'high', 'critical', 'unknown'] as const;
+// 'unknown' is valid as a risk label on a skill but not as a threshold — setting the threshold
+// to 'unknown' would silently disable fail-closed behavior since nothing can exceed it.
+const VALID_MAX_RISK_LEVELS = ['safe', 'low', 'medium', 'high', 'critical'] as const;
 
 export const RemotePolicyConfigSchema = z.object({
   blockSuspicious: z.boolean({ error: 'skills.remotePolicy.blockSuspicious must be a boolean' }).default(true),
   blockMalware: z.boolean({ error: 'skills.remotePolicy.blockMalware must be a boolean' }).default(true),
-  maxSkillsShRisk: z.enum(VALID_SKILLS_SH_RISK_LEVELS, {
-    error: `skills.remotePolicy.maxSkillsShRisk must be one of: ${VALID_SKILLS_SH_RISK_LEVELS.join(', ')}`,
+  maxSkillsShRisk: z.enum(VALID_MAX_RISK_LEVELS, {
+    error: `skills.remotePolicy.maxSkillsShRisk must be one of: ${VALID_MAX_RISK_LEVELS.join(', ')}`,
   }).default('medium'),
 });
 

--- a/assistant/src/config/skills-schema.ts
+++ b/assistant/src/config/skills-schema.ts
@@ -19,14 +19,38 @@ export const SkillsInstallConfigSchema = z.object({
   }).default('npm'),
 });
 
+export const RemoteProviderConfigSchema = z.object({
+  enabled: z.boolean({ error: 'skills.remoteProviders.<provider>.enabled must be a boolean' }).default(true),
+});
+
+export const RemoteProvidersConfigSchema = z.object({
+  skillssh: RemoteProviderConfigSchema.default({} as any),
+  clawhub: RemoteProviderConfigSchema.default({} as any),
+});
+
+const VALID_SKILLS_SH_RISK_LEVELS = ['safe', 'low', 'medium', 'high', 'critical', 'unknown'] as const;
+
+export const RemotePolicyConfigSchema = z.object({
+  blockSuspicious: z.boolean({ error: 'skills.remotePolicy.blockSuspicious must be a boolean' }).default(true),
+  blockMalware: z.boolean({ error: 'skills.remotePolicy.blockMalware must be a boolean' }).default(true),
+  maxSkillsShRisk: z.enum(VALID_SKILLS_SH_RISK_LEVELS, {
+    error: `skills.remotePolicy.maxSkillsShRisk must be one of: ${VALID_SKILLS_SH_RISK_LEVELS.join(', ')}`,
+  }).default('medium'),
+});
+
 export const SkillsConfigSchema = z.object({
   entries: z.record(z.string(), SkillEntryConfigSchema).default({} as any),
   load: SkillsLoadConfigSchema.default({} as any),
   install: SkillsInstallConfigSchema.default({} as any),
   allowBundled: z.array(z.string()).nullable().default(null),
+  remoteProviders: RemoteProvidersConfigSchema.default({} as any),
+  remotePolicy: RemotePolicyConfigSchema.default({} as any),
 });
 
 export type SkillEntryConfig = z.infer<typeof SkillEntryConfigSchema>;
 export type SkillsLoadConfig = z.infer<typeof SkillsLoadConfigSchema>;
 export type SkillsInstallConfig = z.infer<typeof SkillsInstallConfigSchema>;
+export type RemoteProviderConfig = z.infer<typeof RemoteProviderConfigSchema>;
+export type RemoteProvidersConfig = z.infer<typeof RemoteProvidersConfigSchema>;
+export type RemotePolicyConfig = z.infer<typeof RemotePolicyConfigSchema>;
 export type SkillsConfig = z.infer<typeof SkillsConfigSchema>;

--- a/assistant/src/skills/remote-skill-policy.ts
+++ b/assistant/src/skills/remote-skill-policy.ts
@@ -76,7 +76,7 @@ function normalizeSkillsShRisk(audit: SkillsShAuditState | null | undefined): Sk
   const risk = audit?.risk;
   if (risk == null) return 'unknown';
   // Coerce unrecognized risk labels to 'unknown' so we fail closed.
-  if (!(risk in SKILLS_SH_RISK_RANK)) return 'unknown';
+  if (!Object.hasOwn(SKILLS_SH_RISK_RANK, risk)) return 'unknown';
   return risk;
 }
 

--- a/assistant/src/skills/remote-skill-policy.ts
+++ b/assistant/src/skills/remote-skill-policy.ts
@@ -74,7 +74,10 @@ const SKILLS_SH_RISK_RANK: Record<SkillsShRisk, number> = {
 
 function normalizeSkillsShRisk(audit: SkillsShAuditState | null | undefined): SkillsShRisk {
   const risk = audit?.risk;
-  return risk ?? 'unknown';
+  if (risk == null) return 'unknown';
+  // Coerce unrecognized risk labels to 'unknown' so we fail closed.
+  if (!(risk in SKILLS_SH_RISK_RANK)) return 'unknown';
+  return risk;
 }
 
 function exceedsSkillsShRiskThreshold(
@@ -99,10 +102,7 @@ export function evaluateRemoteSkillInstall(
     return { ok: true };
   }
 
-  if (
-    policy.blockSuspicious &&
-    exceedsSkillsShRiskThreshold(candidate.audit, policy.maxSkillsShRisk)
-  ) {
+  if (exceedsSkillsShRiskThreshold(candidate.audit, policy.maxSkillsShRisk)) {
     return { ok: false, reason: 'skillssh_risk_exceeds_threshold' };
   }
 

--- a/assistant/src/skills/remote-skill-policy.ts
+++ b/assistant/src/skills/remote-skill-policy.ts
@@ -1,0 +1,124 @@
+export type RemoteSkillProvider = 'clawhub' | 'skillssh';
+
+export type SkillsShRisk = 'safe' | 'low' | 'medium' | 'high' | 'critical' | 'unknown';
+
+export interface RemoteSkillPolicy {
+  /**
+   * When true, suspicious skills are excluded from installable lists
+   * and blocked from installation.
+   */
+  blockSuspicious: boolean;
+  /**
+   * When true, malware-blocked skills are excluded from installable lists
+   * and blocked from installation.
+   */
+  blockMalware: boolean;
+  /**
+   * Maximum allowed Skills.sh audit risk. Anything above this threshold is blocked.
+   */
+  maxSkillsShRisk: SkillsShRisk;
+}
+
+export interface ClawhubModerationState {
+  isSuspicious?: boolean;
+  isMalwareBlocked?: boolean;
+}
+
+export interface SkillsShAuditState {
+  risk?: SkillsShRisk | null;
+}
+
+interface RemoteSkillCandidateBase {
+  provider: RemoteSkillProvider;
+  slug: string;
+}
+
+export interface ClawhubRemoteSkillCandidate extends RemoteSkillCandidateBase {
+  provider: 'clawhub';
+  moderation?: ClawhubModerationState | null;
+}
+
+export interface SkillsShRemoteSkillCandidate extends RemoteSkillCandidateBase {
+  provider: 'skillssh';
+  audit?: SkillsShAuditState | null;
+}
+
+export type RemoteSkillCandidate =
+  | ClawhubRemoteSkillCandidate
+  | SkillsShRemoteSkillCandidate;
+
+export type RemoteSkillDenyReason =
+  | 'clawhub_suspicious'
+  | 'clawhub_malware_blocked'
+  | 'skillssh_risk_exceeds_threshold';
+
+export type RemoteSkillInstallDecision =
+  | { ok: true }
+  | { ok: false; reason: RemoteSkillDenyReason };
+
+export const DEFAULT_REMOTE_SKILL_POLICY: Readonly<RemoteSkillPolicy> = Object.freeze({
+  blockSuspicious: true,
+  blockMalware: true,
+  maxSkillsShRisk: 'medium',
+});
+
+const SKILLS_SH_RISK_RANK: Record<SkillsShRisk, number> = {
+  safe: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+  // Fail closed when risk is unknown.
+  unknown: 5,
+};
+
+function normalizeSkillsShRisk(audit: SkillsShAuditState | null | undefined): SkillsShRisk {
+  const risk = audit?.risk;
+  return risk ?? 'unknown';
+}
+
+function exceedsSkillsShRiskThreshold(
+  audit: SkillsShAuditState | null | undefined,
+  threshold: SkillsShRisk,
+): boolean {
+  const actualRisk = normalizeSkillsShRisk(audit);
+  return SKILLS_SH_RISK_RANK[actualRisk] > SKILLS_SH_RISK_RANK[threshold];
+}
+
+export function evaluateRemoteSkillInstall(
+  candidate: RemoteSkillCandidate,
+  policy: RemoteSkillPolicy = DEFAULT_REMOTE_SKILL_POLICY,
+): RemoteSkillInstallDecision {
+  if (candidate.provider === 'clawhub') {
+    if (policy.blockMalware && candidate.moderation?.isMalwareBlocked === true) {
+      return { ok: false, reason: 'clawhub_malware_blocked' };
+    }
+    if (policy.blockSuspicious && candidate.moderation?.isSuspicious === true) {
+      return { ok: false, reason: 'clawhub_suspicious' };
+    }
+    return { ok: true };
+  }
+
+  if (
+    policy.blockSuspicious &&
+    exceedsSkillsShRiskThreshold(candidate.audit, policy.maxSkillsShRisk)
+  ) {
+    return { ok: false, reason: 'skillssh_risk_exceeds_threshold' };
+  }
+
+  return { ok: true };
+}
+
+export function isRemoteSkillInstallable(
+  candidate: RemoteSkillCandidate,
+  policy: RemoteSkillPolicy = DEFAULT_REMOTE_SKILL_POLICY,
+): boolean {
+  return evaluateRemoteSkillInstall(candidate, policy).ok;
+}
+
+export function filterInstallableRemoteSkills<T extends RemoteSkillCandidate>(
+  skills: T[],
+  policy: RemoteSkillPolicy = DEFAULT_REMOTE_SKILL_POLICY,
+): T[] {
+  return skills.filter((skill) => isRemoteSkillInstallable(skill, policy));
+}

--- a/assistant/src/skills/remote-skill-policy.ts
+++ b/assistant/src/skills/remote-skill-policy.ts
@@ -1,6 +1,7 @@
 export type RemoteSkillProvider = 'clawhub' | 'skillssh';
 
 export type SkillsShRisk = 'safe' | 'low' | 'medium' | 'high' | 'critical' | 'unknown';
+export type SkillsShRiskThreshold = Exclude<SkillsShRisk, 'unknown'>;
 
 export interface RemoteSkillPolicy {
   /**
@@ -16,7 +17,7 @@ export interface RemoteSkillPolicy {
   /**
    * Maximum allowed Skills.sh audit risk. Anything above this threshold is blocked.
    */
-  maxSkillsShRisk: SkillsShRisk;
+  maxSkillsShRisk: SkillsShRiskThreshold;
 }
 
 export interface ClawhubModerationState {
@@ -82,7 +83,7 @@ function normalizeSkillsShRisk(audit: SkillsShAuditState | null | undefined): Sk
 
 function exceedsSkillsShRiskThreshold(
   audit: SkillsShAuditState | null | undefined,
-  threshold: SkillsShRisk,
+  threshold: SkillsShRiskThreshold,
 ): boolean {
   const actualRisk = normalizeSkillsShRisk(audit);
   return SKILLS_SH_RISK_RANK[actualRisk] > SKILLS_SH_RISK_RANK[threshold];


### PR DESCRIPTION
Land the remote-skill-policy.ts primitive with types and evaluation functions for both Clawhub and skills.sh providers. Add config schema gates for per-provider enablement (remoteProviders) and remote policy settings (remotePolicy). Part of #9776.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
