### PR TITLE
fix: restore voice source classifier bypass for Fn-hold dictation

### DIFF
--- a/assistant/src/daemon/classifier.ts
+++ b/assistant/src/daemon/classifier.ts
@@ -11,7 +11,12 @@ export type InteractionType = 'computer_use' | 'text_qa';
  * Classify a user task as computer_use or text_qa using an LLM tool-use call,
  * falling back to a heuristic if the API call fails or no API key is available.
  */
-export async function classifyInteraction(task: string): Promise<InteractionType> {
+export async function classifyInteraction(task: string, source?: 'voice' | 'text'): Promise<InteractionType> {
+  if (source === 'voice') {
+    log.info({ source }, 'Voice source detected, skipping classification — routing to text_qa');
+    return 'text_qa';
+  }
+
   const provider = getConfiguredProvider();
   if (!provider) {
     log.warn('No configured provider available, falling back to heuristic classification');

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -413,7 +413,7 @@ export async function handleTaskSubmit(
     const slashCandidate = parseSlashCandidate(msg.task);
     const interactionType = slashCandidate.kind === 'candidate'
       ? 'text_qa' as const
-      : await classifyInteraction(msg.task);
+      : await classifyInteraction(msg.task, msg.source);
     rlog.info({ interactionType, slashBypass: slashCandidate.kind === 'candidate', taskLength: msg.task.length }, 'Task classified');
 
     if (interactionType === 'computer_use') {


### PR DESCRIPTION
Restores the source === 'voice' → text_qa bypass in the classifier that was incorrectly removed in #9775. The VoiceInputManager's Fn-hold dictation fallback path (AppDelegate.swift:1807) sends source: 'voice', so this branch IS reachable and provides deterministic routing without LLM classification latency.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
