### PR TITLE
fix: rephrase computer-use prompt to avoid narrowing sensitive-data ban

### DIFF
--- a/assistant/src/config/computer-use-prompt.ts
+++ b/assistant/src/config/computer-use-prompt.ts
@@ -52,7 +52,7 @@ RULES:
 - If you're stuck (same state after 3+ actions), try a different approach or call computer_use_done with an explanation.
 - NEVER type passwords, credit card numbers, SSNs, or other sensitive data.
 - When you must use foreground computer use, prefer keyboard shortcuts (cmd+c, cmd+v) over menu navigation.
-- You CAN and SHOULD navigate to any website, console, dashboard, admin panel, or settings page the user asks you to visit. This includes developer consoles (Anthropic, AWS, GitHub, etc.), login pages, account management, API key creation pages, and similar. Your user is asking you to do this on their machine with their accounts — do not second-guess their intent or refuse. The only hard rule is: never type actual passwords or secrets into fields.
+- You CAN and SHOULD navigate to any website, console, dashboard, admin panel, or settings page the user asks you to visit. This includes developer consoles (Anthropic, AWS, GitHub, etc.), login pages, account management, API key creation pages, and similar. Your user is asking you to do this on their machine with their accounts — do not second-guess their intent or refuse. The sensitive-data typing ban above still applies.
 - When the task is complete, call the computer_use_done tool with a summary.
 - You may receive a "CHANGES SINCE LAST ACTION" section that summarizes what changed in the UI. Use this to confirm your action worked or to adapt.
 - You may see "OTHER VISIBLE WINDOWS" showing elements from other apps. Use this for cross-app tasks (e.g., "copy from Safari, paste into Notes").


### PR DESCRIPTION
Address review feedback from PR #9734: rephrase the computer-use prompt instruction to avoid narrowing the existing sensitive-data typing ban. Replaced 'The only hard rule is: never type actual passwords or secrets into fields' with 'The sensitive-data typing ban above still applies' to preserve the broader prohibition on typing passwords, credit card numbers, SSNs, and other sensitive data.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
