### PR TITLE
fix: use selectableText modifier in ChatBubbleTextContent

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -21,25 +21,14 @@ extension ChatBubble {
                 MarkdownSegmentView(segments: segments, isStreaming: streaming)
             } else {
                 let attributed = Self.cachedInlineMarkdown(for: segmentText, isStreaming: streaming)
-                if streaming {
-                    Text(attributed)
-                        .font(.system(size: 13 * conversationZoomScale))
-                        .lineSpacing(3)
-                        .foregroundColor(VColor.textPrimary)
-                        .tint(VColor.accent)
-                        .textSelection(.disabled)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxWidth: 520, alignment: .leading)
-                } else {
-                    Text(attributed)
-                        .font(.system(size: 13 * conversationZoomScale))
-                        .lineSpacing(3)
-                        .foregroundColor(VColor.textPrimary)
-                        .tint(VColor.accent)
-                        .textSelection(.enabled)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxWidth: 520, alignment: .leading)
-                }
+                Text(attributed)
+                    .font(.system(size: 13 * conversationZoomScale))
+                    .lineSpacing(3)
+                    .foregroundColor(VColor.textPrimary)
+                    .tint(VColor.accent)
+                    .selectableText(!streaming)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: 520, alignment: .leading)
             }
         }
     }


### PR DESCRIPTION
Address review feedback from PR #9671: update ChatBubbleTextContent.swift to use .selectableText(!streaming) instead of separate .textSelection(.disabled)/.textSelection(.enabled) branches. Also collapses the redundant if/else into a single code path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
