### PR TITLE
feat: define standard HTTP error response format

### DIFF
--- a/assistant/src/runtime/http-errors.ts
+++ b/assistant/src/runtime/http-errors.ts
@@ -1,0 +1,72 @@
+/**
+ * Standard HTTP error response format for all /v1/* endpoints.
+ *
+ * Provides a consistent error shape and helper for building error responses.
+ * Existing routes can be migrated incrementally — this module defines the
+ * canonical format without breaking current behavior.
+ */
+
+// ── Error codes ──────────────────────────────────────────────────────────────
+
+/**
+ * Well-known HTTP error codes for the runtime API.
+ *
+ * These are wire-protocol identifiers (stable, client-facing strings) — not
+ * to be confused with `ErrorCode` from `util/errors.ts`, which is for
+ * internal assistant-layer errors.
+ */
+export type HttpErrorCode =
+  | 'BAD_REQUEST'
+  | 'UNAUTHORIZED'
+  | 'FORBIDDEN'
+  | 'NOT_FOUND'
+  | 'CONFLICT'
+  | 'RATE_LIMITED'
+  | 'UNPROCESSABLE_ENTITY'
+  | 'INTERNAL_ERROR'
+  | 'SERVICE_UNAVAILABLE';
+
+// ── Response type ────────────────────────────────────────────────────────────
+
+/**
+ * The standard error envelope returned by all /v1/* endpoints.
+ *
+ * ```json
+ * {
+ *   "error": {
+ *     "code": "BAD_REQUEST",
+ *     "message": "conversationKey is required",
+ *     "details": { ... }          // optional, endpoint-specific
+ *   }
+ * }
+ * ```
+ */
+export interface HttpErrorResponse {
+  error: {
+    code: HttpErrorCode;
+    message: string;
+    details?: unknown;
+  };
+}
+
+// ── Helper ───────────────────────────────────────────────────────────────────
+
+/**
+ * Build a `Response` with the standard error envelope.
+ *
+ * @param code    A stable, machine-readable error code from `HttpErrorCode`.
+ * @param message A human-readable description of the error.
+ * @param status  The HTTP status code (e.g. 400, 404, 500).
+ * @param details Optional structured payload with endpoint-specific context.
+ */
+export function httpError(
+  code: HttpErrorCode,
+  message: string,
+  status: number,
+  details?: unknown,
+): Response {
+  const body: HttpErrorResponse = {
+    error: { code, message, ...(details !== undefined ? { details } : {}) },
+  };
+  return Response.json(body, { status });
+}


### PR DESCRIPTION
Define a standard HTTP error response format with typed error codes and a helper function for consistent error responses across all /v1/* endpoints.

Adds `assistant/src/runtime/http-errors.ts` with:
- `HttpErrorCode` type union of well-known error codes (BAD_REQUEST, UNAUTHORIZED, etc.)
- `HttpErrorResponse` interface defining the standard `{ error: { code, message, details? } }` envelope
- `httpError()` helper function for building consistent error responses

Existing routes are not migrated yet — that's a separate task. This PR defines the canonical format so new routes and incremental migrations can adopt it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
