### PR TITLE
feat: add per-bearer-token rate limiting for HTTP API

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -48,6 +48,11 @@ import {
 } from './middleware/auth.js';
 import { withErrorHandling } from './middleware/error-handler.js';
 import {
+  apiRateLimiter,
+  rateLimitHeaders,
+  rateLimitResponse,
+} from './middleware/rate-limiter.js';
+import {
   cloneRequestWithBody,
   GATEWAY_ONLY_BLOCKED_SUBPATHS,
   GATEWAY_SUBPATH_MAP,
@@ -368,6 +373,33 @@ export class RuntimeHttpServer {
       }
     }
 
+    // Per-bearer-token rate limiting for /v1/* endpoints
+    if (path.startsWith('/v1/')) {
+      const token = extractBearerToken(req) ?? '__anonymous__';
+      const result = apiRateLimiter.check(token);
+      if (!result.allowed) {
+        return rateLimitResponse(result);
+      }
+      // Attach rate limit headers to the eventual response
+      const originalResponse = await this.handleAuthenticatedRequest(req, url, path);
+      const headers = new Headers(originalResponse.headers);
+      for (const [k, v] of Object.entries(rateLimitHeaders(result))) {
+        headers.set(k, v);
+      }
+      return new Response(originalResponse.body, {
+        status: originalResponse.status,
+        statusText: originalResponse.statusText,
+        headers,
+      });
+    }
+
+    return this.handleAuthenticatedRequest(req, url, path);
+  }
+
+  /**
+   * Handle requests that have already passed auth and rate limiting.
+   */
+  private async handleAuthenticatedRequest(req: Request, url: URL, path: string): Promise<Response> {
     // Pairing registration (bearer-authenticated)
     if (path === '/v1/pairing/register' && req.method === 'POST') {
       return await handlePairingRegister(req, this.pairingContext);

--- a/assistant/src/runtime/middleware/rate-limiter.ts
+++ b/assistant/src/runtime/middleware/rate-limiter.ts
@@ -1,0 +1,119 @@
+// Per-bearer-token sliding-window rate limiter for /v1/* API endpoints.
+// Tracks request counts per token and returns 429 when the limit is exceeded.
+// Follows the same sliding-window pattern as gateway/src/auth-rate-limiter.ts.
+
+const DEFAULT_MAX_REQUESTS = 60;
+const DEFAULT_WINDOW_MS = 60_000; // 60 seconds
+const MAX_TRACKED_TOKENS = 10_000;
+
+export class TokenRateLimiter {
+  private requests = new Map<string, number[]>();
+  private readonly maxRequests: number;
+  private readonly windowMs: number;
+
+  constructor(
+    maxRequests = DEFAULT_MAX_REQUESTS,
+    windowMs = DEFAULT_WINDOW_MS,
+  ) {
+    this.maxRequests = maxRequests;
+    this.windowMs = windowMs;
+  }
+
+  /**
+   * Check whether the request should be allowed and record it.
+   * Returns rate limit metadata for response headers.
+   */
+  check(token: string): RateLimitResult {
+    const now = Date.now();
+    let timestamps = this.requests.get(token);
+
+    if (!timestamps) {
+      if (this.requests.size >= MAX_TRACKED_TOKENS) {
+        this.evictStale(now);
+        if (this.requests.size >= MAX_TRACKED_TOKENS) {
+          const oldest = this.requests.keys().next().value;
+          if (oldest !== undefined) this.requests.delete(oldest);
+        }
+      }
+      timestamps = [];
+      this.requests.set(token, timestamps);
+    }
+
+    const cutoff = now - this.windowMs;
+
+    // Remove expired timestamps from the front
+    while (timestamps.length > 0 && timestamps[0] <= cutoff) {
+      timestamps.shift();
+    }
+
+    const remaining = Math.max(0, this.maxRequests - timestamps.length);
+    const resetAt = timestamps.length > 0
+      ? Math.ceil((timestamps[0] + this.windowMs) / 1000)
+      : Math.ceil((now + this.windowMs) / 1000);
+
+    if (timestamps.length >= this.maxRequests) {
+      return {
+        allowed: false,
+        limit: this.maxRequests,
+        remaining: 0,
+        resetAt,
+      };
+    }
+
+    timestamps.push(now);
+
+    return {
+      allowed: true,
+      limit: this.maxRequests,
+      remaining: remaining - 1,
+      resetAt,
+    };
+  }
+
+  private evictStale(now: number): void {
+    const cutoff = now - this.windowMs;
+    for (const [token, timestamps] of this.requests) {
+      while (timestamps.length > 0 && timestamps[0] <= cutoff) {
+        timestamps.shift();
+      }
+      if (timestamps.length === 0) {
+        this.requests.delete(token);
+      }
+    }
+  }
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  /** Unix timestamp (seconds) when the window resets. */
+  resetAt: number;
+}
+
+/** Build standard rate limit headers from a check result. */
+export function rateLimitHeaders(result: RateLimitResult): Record<string, string> {
+  return {
+    'X-RateLimit-Limit': String(result.limit),
+    'X-RateLimit-Remaining': String(result.remaining),
+    'X-RateLimit-Reset': String(result.resetAt),
+  };
+}
+
+/** Return a 429 response with rate limit headers and a Retry-After hint. */
+export function rateLimitResponse(result: RateLimitResult): Response {
+  const retryAfter = Math.max(1, result.resetAt - Math.ceil(Date.now() / 1000));
+  return Response.json(
+    { error: 'Too Many Requests' },
+    {
+      status: 429,
+      headers: {
+        ...rateLimitHeaders(result),
+        'Retry-After': String(retryAfter),
+      },
+    },
+  );
+}
+
+/** Singleton rate limiter for the runtime HTTP API. */
+export const apiRateLimiter = new TokenRateLimiter();


### PR DESCRIPTION
Add rate limiting middleware for /v1/* API endpoints with per-bearer-token tracking, sliding window algorithm, and standard rate limit headers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
