### PR TITLE
fix: add deduplication check in notification dispatch

### DIFF
--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -14,7 +14,7 @@ import { v4 as uuid } from 'uuid';
 import { getLogger } from '../util/logger.js';
 import { pairDeliveryWithConversation } from './conversation-pairing.js';
 import { composeFallbackCopy } from './copy-composer.js';
-import { createDelivery, updateDeliveryStatus } from './deliveries-store.js';
+import { createDelivery, findDeliveryByDecisionAndChannel, updateDeliveryStatus } from './deliveries-store.js';
 import { resolveDestinations } from './destination-resolver.js';
 import type { NotificationSignal } from './signal.js';
 import type {
@@ -188,6 +188,24 @@ export class NotificationBroadcaster {
 
       try {
         if (hasPersistedDecision) {
+          const existingDelivery = findDeliveryByDecisionAndChannel(persistedDecisionId, channel);
+          if (existingDelivery) {
+            log.info(
+              { channel, signalId: signal.signalId, existingDeliveryId: existingDelivery.id },
+              'Delivery already exists for this decision+channel — skipping duplicate',
+            );
+            results.push({
+              channel,
+              destination: destinationLabel,
+              status: 'skipped',
+              errorMessage: 'Duplicate delivery skipped',
+              conversationId: existingDelivery.conversationId ?? undefined,
+              messageId: existingDelivery.messageId ?? undefined,
+              conversationStrategy: existingDelivery.conversationStrategy ?? undefined,
+            });
+            continue;
+          }
+
           createDelivery({
             id: deliveryId,
             notificationDecisionId: persistedDecisionId,

--- a/assistant/src/notifications/deliveries-store.ts
+++ b/assistant/src/notifications/deliveries-store.ts
@@ -6,7 +6,7 @@
  * (decision, channel, destination) are tracked via the `attempt` counter.
  */
 
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 
 import { getDb } from '../memory/db.js';
 import { notificationDeliveries } from '../memory/schema.js';
@@ -189,4 +189,23 @@ export function listDeliveries(decisionId: string): NotificationDeliveryRow[] {
     .where(eq(notificationDeliveries.notificationDecisionId, decisionId))
     .all();
   return rows.map(rowToDelivery);
+}
+
+/** Check whether a delivery already exists for a given decision+channel pair. */
+export function findDeliveryByDecisionAndChannel(
+  decisionId: string,
+  channel: NotificationChannel,
+): NotificationDeliveryRow | undefined {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(notificationDeliveries)
+    .where(
+      and(
+        eq(notificationDeliveries.notificationDecisionId, decisionId),
+        eq(notificationDeliveries.channel, channel),
+      ),
+    )
+    .get();
+  return row ? rowToDelivery(row) : undefined;
 }


### PR DESCRIPTION
Add dedup check before creating notification delivery records — skip if a delivery already exists for the same decision+channel combination.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
