### PR TITLE
feat: add circuit breaker for Qdrant client

### DIFF
--- a/assistant/src/daemon/session-history.ts
+++ b/assistant/src/daemon/session-history.ts
@@ -3,6 +3,7 @@ import { v4 as uuid } from 'uuid';
 import { getSummaryFromContextMessage } from '../context/window-manager.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { enqueueMemoryJob } from '../memory/jobs-store.js';
+import { withQdrantBreaker } from '../memory/qdrant-circuit-breaker.js';
 import { getQdrantClient } from '../memory/qdrant-client.js';
 import type { ContentBlock,Message } from '../providers/types.js';
 import { getLogger } from '../util/logger.js';
@@ -67,7 +68,7 @@ export async function cleanupQdrantVectors(
   }
 
   const results = await Promise.allSettled(
-    targets.map((t) => qdrant.deleteByTarget(t.targetType, t.targetId)),
+    targets.map((t) => withQdrantBreaker(() => qdrant.deleteByTarget(t.targetType, t.targetId))),
   );
 
   let succeeded = 0;

--- a/assistant/src/memory/job-handlers/index-maintenance.ts
+++ b/assistant/src/memory/job-handlers/index-maintenance.ts
@@ -4,6 +4,7 @@ import { getLogger } from '../../util/logger.js';
 import { getDb, rawExec } from '../db.js';
 import { asString, BackendUnavailableError } from '../job-utils.js';
 import { enqueueMemoryJob, type MemoryJob } from '../jobs-store.js';
+import { withQdrantBreaker } from '../qdrant-circuit-breaker.js';
 import { getQdrantClient } from '../qdrant-client.js';
 import { memoryEmbeddings, memoryItems, memorySegments, memorySummaries } from '../schema.js';
 
@@ -50,6 +51,6 @@ export async function deleteQdrantVectorsJob(job: MemoryJob): Promise<void> {
     throw new BackendUnavailableError('Qdrant client not initialized');
   }
 
-  await qdrant.deleteByTarget(targetType, targetId);
+  await withQdrantBreaker(() => qdrant.deleteByTarget(targetType, targetId));
   log.info({ targetType, targetId }, 'Retried Qdrant vector deletion succeeded');
 }

--- a/assistant/src/memory/job-utils.ts
+++ b/assistant/src/memory/job-utils.ts
@@ -7,6 +7,7 @@ import { BackendUnavailableError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
 import { getDb } from './db.js';
 import { embedWithBackend, getMemoryBackendStatus } from './embedding-backend.js';
+import { withQdrantBreaker } from './qdrant-circuit-breaker.js';
 import { getQdrantClient } from './qdrant-client.js';
 import { memoryEmbeddings } from './schema.js';
 
@@ -213,11 +214,13 @@ export async function embedAndUpsert(
   }
 
   try {
-    await qdrant.upsert(targetType, targetId, vector, {
-      text,
-      created_at: (extraPayload?.created_at as number) ?? now,
-      ...(extraPayload as Record<string, unknown> | undefined),
-    });
+    await withQdrantBreaker(() =>
+      qdrant.upsert(targetType, targetId, vector, {
+        text,
+        created_at: (extraPayload?.created_at as number) ?? now,
+        ...(extraPayload as Record<string, unknown> | undefined),
+      }),
+    );
   } catch (err) {
     log.warn({ err, targetType, targetId }, 'Failed to upsert embedding to Qdrant');
     throw err;

--- a/assistant/src/memory/qdrant-circuit-breaker.ts
+++ b/assistant/src/memory/qdrant-circuit-breaker.ts
@@ -1,0 +1,105 @@
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('qdrant-circuit-breaker');
+
+/**
+ * Circuit breaker for Qdrant operations.
+ *
+ * After FAILURE_THRESHOLD consecutive failures, the circuit opens and
+ * all calls fail-fast without hitting Qdrant. After COOLDOWN_MS, one
+ * probe request is allowed through (half-open). If the probe succeeds,
+ * the circuit closes; if it fails, the circuit re-opens.
+ */
+
+const FAILURE_THRESHOLD = 5;
+const COOLDOWN_MS = 30_000;
+
+type BreakerState = 'closed' | 'open' | 'half-open';
+
+let breakerState: BreakerState = 'closed';
+let consecutiveFailures = 0;
+let openedAt = 0;
+let halfOpenProbeInFlight = false;
+
+export class QdrantCircuitOpenError extends Error {
+  constructor() {
+    super('Qdrant circuit breaker open');
+    this.name = 'QdrantCircuitOpenError';
+  }
+}
+
+function allows(): boolean {
+  if (breakerState === 'closed') return true;
+  if (breakerState === 'open') {
+    if (Date.now() - openedAt >= COOLDOWN_MS) {
+      breakerState = 'half-open';
+      halfOpenProbeInFlight = true;
+      log.info('Qdrant circuit breaker entering half-open state — allowing probe request');
+      return true;
+    }
+    return false;
+  }
+  // half-open: only allow through if no probe is already in flight
+  if (halfOpenProbeInFlight) return false;
+  halfOpenProbeInFlight = true;
+  return true;
+}
+
+function recordSuccess(): void {
+  if (breakerState !== 'closed') {
+    log.info({ previousFailures: consecutiveFailures }, 'Qdrant circuit breaker closed — operation succeeded');
+  }
+  consecutiveFailures = 0;
+  breakerState = 'closed';
+  openedAt = 0;
+  halfOpenProbeInFlight = false;
+}
+
+function recordFailure(): void {
+  consecutiveFailures++;
+  halfOpenProbeInFlight = false;
+  if (consecutiveFailures >= FAILURE_THRESHOLD) {
+    breakerState = 'open';
+    openedAt = Date.now();
+    log.warn(
+      { consecutiveFailures, cooldownMs: COOLDOWN_MS },
+      'Qdrant circuit breaker opened — Qdrant operations disabled until probe succeeds',
+    );
+  } else if (breakerState === 'half-open') {
+    breakerState = 'open';
+    openedAt = Date.now();
+    log.warn('Qdrant circuit breaker re-opened — half-open probe failed');
+  }
+}
+
+/**
+ * Execute a Qdrant operation through the circuit breaker.
+ * Throws QdrantCircuitOpenError if the circuit is open.
+ * Re-throws the original error on failure after recording it.
+ */
+export async function withQdrantBreaker<T>(fn: () => Promise<T>): Promise<T> {
+  if (!allows()) {
+    throw new QdrantCircuitOpenError();
+  }
+  try {
+    const result = await fn();
+    recordSuccess();
+    return result;
+  } catch (err) {
+    recordFailure();
+    throw err;
+  }
+}
+
+/** @internal Test-only: reset circuit breaker state */
+export function _resetQdrantBreaker(): void {
+  breakerState = 'closed';
+  consecutiveFailures = 0;
+  openedAt = 0;
+  halfOpenProbeInFlight = false;
+}
+
+/** @internal Test-only: get breaker state */
+export function _getQdrantBreakerState(): { state: BreakerState; consecutiveFailures: number } {
+  return { state: breakerState, consecutiveFailures };
+}

--- a/assistant/src/memory/search/semantic.ts
+++ b/assistant/src/memory/search/semantic.ts
@@ -2,6 +2,7 @@ import { inArray } from 'drizzle-orm';
 
 import { getLogger } from '../../util/logger.js';
 import { getDb } from '../db.js';
+import { withQdrantBreaker, _resetQdrantBreaker, _getQdrantBreakerState } from '../qdrant-circuit-breaker.js';
 import type { QdrantSearchResult } from '../qdrant-client.js';
 import { getQdrantClient } from '../qdrant-client.js';
 import {
@@ -13,82 +14,10 @@ import {
 import { computeRecencyScore } from './ranking.js';
 import type { Candidate } from './types.js';
 
-const log = getLogger('qdrant-circuit-breaker');
+const log = getLogger('semantic-search');
 
-// ── Qdrant circuit breaker ───────────────────────────────────────────
-// After FAILURE_THRESHOLD consecutive Qdrant failures, stop sending
-// requests (open state). After COOLDOWN_MS, allow a single probe
-// request (half-open). If the probe succeeds, close the circuit; if it
-// fails, re-open and restart the cooldown.
-
-const FAILURE_THRESHOLD = 5;
-const COOLDOWN_MS = 60_000;
-
-type BreakerState = 'closed' | 'open' | 'half-open';
-
-let breakerState: BreakerState = 'closed';
-let consecutiveFailures = 0;
-let openedAt = 0;
-// Ensures only one request passes through during half-open state
-let halfOpenProbeInFlight = false;
-
-function qdrantBreakerAllows(): boolean {
-  if (breakerState === 'closed') return true;
-  if (breakerState === 'open') {
-    if (Date.now() - openedAt >= COOLDOWN_MS) {
-      breakerState = 'half-open';
-      halfOpenProbeInFlight = true;
-      log.info('Qdrant circuit breaker entering half-open state — allowing probe request');
-      return true;
-    }
-    return false;
-  }
-  // half-open: only allow through if no probe is already in flight
-  if (halfOpenProbeInFlight) return false;
-  halfOpenProbeInFlight = true;
-  return true;
-}
-
-function qdrantBreakerRecordSuccess(): void {
-  if (breakerState !== 'closed') {
-    log.info({ previousFailures: consecutiveFailures }, 'Qdrant circuit breaker closed — search succeeded');
-  }
-  consecutiveFailures = 0;
-  breakerState = 'closed';
-  openedAt = 0;
-  halfOpenProbeInFlight = false;
-}
-
-function qdrantBreakerRecordFailure(): void {
-  consecutiveFailures++;
-  halfOpenProbeInFlight = false;
-  if (consecutiveFailures >= FAILURE_THRESHOLD) {
-    breakerState = 'open';
-    openedAt = Date.now();
-    log.warn(
-      { consecutiveFailures, cooldownMs: COOLDOWN_MS },
-      'Qdrant circuit breaker opened — semantic search disabled until probe succeeds',
-    );
-  } else if (breakerState === 'half-open') {
-    // Probe failed — re-open
-    breakerState = 'open';
-    openedAt = Date.now();
-    log.warn('Qdrant circuit breaker re-opened — half-open probe failed');
-  }
-}
-
-/** @internal Test-only: reset circuit breaker state */
-export function _resetQdrantBreaker(): void {
-  breakerState = 'closed';
-  consecutiveFailures = 0;
-  openedAt = 0;
-  halfOpenProbeInFlight = false;
-}
-
-/** @internal Test-only: get breaker state */
-export function _getQdrantBreakerState(): { state: BreakerState; consecutiveFailures: number } {
-  return { state: breakerState, consecutiveFailures };
-}
+// Re-export for tests that depend on these from this module
+export { _resetQdrantBreaker, _getQdrantBreakerState };
 
 export async function semanticSearch(
   queryVector: number[],
@@ -100,31 +29,20 @@ export async function semanticSearch(
 ): Promise<Candidate[]> {
   if (limit <= 0) return [];
 
-  // Circuit breaker: throw so the caller's .catch() marks the result as degraded
-  if (!qdrantBreakerAllows()) {
-    log.debug('Qdrant circuit breaker open — skipping semantic search');
-    throw new Error('Qdrant circuit breaker open');
-  }
-
   const qdrant = getQdrantClient();
 
   // Overfetch to account for items filtered out post-query (invalidated, excluded, etc.)
   // Use 3x when exclusions are active to ensure enough results survive filtering
   const overfetchMultiplier = excludedMessageIds.length > 0 ? 3 : 2;
   const fetchLimit = limit * overfetchMultiplier;
-  let results: QdrantSearchResult[];
-  try {
-    results = await qdrant.searchWithFilter(
+  const results: QdrantSearchResult[] = await withQdrantBreaker(() =>
+    qdrant.searchWithFilter(
       queryVector,
       fetchLimit,
       ['item', 'summary', 'segment'],
       excludedMessageIds,
-    );
-    qdrantBreakerRecordSuccess();
-  } catch (err) {
-    qdrantBreakerRecordFailure();
-    throw err;
-  }
+    ),
+  );
 
   const db = getDb();
 


### PR DESCRIPTION
Add circuit breaker pattern for Qdrant client to track consecutive failures, fail-fast after threshold (5 consecutive failures), and periodically probe for recovery (every 30 seconds).

Extracts the existing inline circuit breaker from semantic.ts into a reusable module (qdrant-circuit-breaker.ts) and integrates it across all Qdrant call sites: search, upsert, and delete operations.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
