### PR TITLE
refactor: extract PermissionChecker class from executor.ts

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -2,9 +2,7 @@ import { readFileSync } from 'node:fs';
 
 import { getConfig } from '../config/loader.js';
 import { getHookManager } from '../hooks/manager.js';
-import { check, classifyRisk, generateAllowlistOptions, generateScopeOptions } from '../permissions/checker.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
-import { addRule } from '../permissions/trust-store.js';
 import { RiskLevel } from '../permissions/types.js';
 import { isToolBlocked } from '../security/parental-control-store.js';
 import { redactSensitiveFields } from '../security/redaction.js';
@@ -17,22 +15,22 @@ import { getLogger } from '../util/logger.js';
 import { resolveExecutionTarget } from './execution-target.js';
 import { executeWithTimeout,safeTimeoutMs } from './execution-timeout.js';
 import { enforceGuardianOnlyPolicy } from './guardian-control-plane-policy.js';
-import { buildPolicyContext } from './policy-context.js';
+import { PermissionChecker } from './permission-checker.js';
 import { getAllTools,getTool } from './registry.js';
 import { applyEdit } from './shared/filesystem/edit-engine.js';
 import { sandboxPolicy } from './shared/filesystem/path-policy.js';
 import { MAX_FILE_SIZE_BYTES } from './shared/filesystem/size-guard.js';
-import { isSideEffectTool } from './side-effects.js';
-import { wrapCommand } from './terminal/sandbox.js';
 import type { ToolContext, ToolExecutionResult, ToolLifecycleEvent } from './types.js';
 
 const log = getLogger('tool-executor');
 
 export class ToolExecutor {
   private prompter: PermissionPrompter;
+  private permissionChecker: PermissionChecker;
 
   constructor(prompter: PermissionPrompter) {
     this.prompter = prompter;
+    this.permissionChecker = new PermissionChecker(prompter);
   }
 
   async execute(
@@ -216,223 +214,24 @@ export class ToolExecutor {
     }
 
     try {
-      // Check permissions
-      const risk = await classifyRisk(name, input, context.workingDir, undefined, undefined, context.signal);
-      riskLevel = risk;
+      // Check permissions via the extracted PermissionChecker
+      const permResult = await this.permissionChecker.checkPermission(
+        name,
+        input,
+        tool,
+        context,
+        executionTarget,
+        (event) => emitLifecycleEvent(context, event),
+        sanitizeToolInput,
+        startTime,
+        computePreviewDiff,
+      );
 
-      // Build principal context from tool metadata so policy rules can
-      // distinguish skill-provided tools from core built-ins. Also includes
-      // ephemeral rules when executing within a task run.
-      const policyContext = buildPolicyContext(tool, context);
-      const result = await check(name, input, context.workingDir, policyContext, undefined, context.signal);
+      riskLevel = permResult.riskLevel;
+      decision = permResult.decision;
 
-      // Private threads force prompting for side-effect tools even when a
-      // trust/allow rule would auto-allow. Deny decisions are preserved —
-      // only allow → prompt promotion happens here.
-      if (
-        context.forcePromptSideEffects
-        && result.decision === 'allow'
-        && isSideEffectTool(name, input)
-      ) {
-        result.decision = 'prompt';
-        result.reason = 'Private thread: side-effect tools require explicit approval';
-      }
-
-      if (result.decision === 'deny') {
-        decision = 'denied';
-        const durationMs = Date.now() - startTime;
-        emitLifecycleEvent(context, {
-          type: 'permission_denied',
-          toolName: name,
-          executionTarget,
-          input,
-          workingDir: context.workingDir,
-          sessionId: context.sessionId,
-          conversationId: context.conversationId,
-          requestId: context.requestId,
-          riskLevel,
-          decision: 'deny',
-          reason: result.reason,
-          durationMs,
-        });
-        return { content: result.reason, isError: true };
-      }
-
-      if (result.decision === 'prompt') {
-        // Non-interactive sessions have no client to respond to prompts —
-        // deny immediately instead of blocking for the full permission timeout.
-        if (context.isInteractive === false) {
-          decision = 'denied';
-          const durationMs = Date.now() - startTime;
-          log.info({ toolName: name, riskLevel }, 'Auto-denying prompt for non-interactive session');
-          emitLifecycleEvent(context, {
-            type: 'permission_denied',
-            toolName: name,
-            executionTarget,
-            input,
-            workingDir: context.workingDir,
-            sessionId: context.sessionId,
-            conversationId: context.conversationId,
-            requestId: context.requestId,
-            riskLevel,
-            decision: 'deny',
-            reason: 'Non-interactive session: no client to approve prompt',
-            durationMs,
-          });
-          return {
-            content: `Permission denied: tool "${name}" requires user approval but no interactive client is connected. The tool was not executed. To allow this tool in non-interactive sessions, add a trust rule via permission settings.`,
-            isError: true,
-          };
-        }
-
-        // Need user approval
-        const allowlistOptions = await generateAllowlistOptions(name, input, context.signal);
-        const scopeOptions = generateScopeOptions(context.workingDir, name);
-
-        // Compute preview diff for file tools so the user sees what will change
-        const previewDiff = computePreviewDiff(name, input, context.workingDir);
-
-        let sandboxed: boolean | undefined;
-        if (name === 'bash' && typeof input.command === 'string') {
-          const cfg = getConfig();
-          const sandboxConfig = context.sandboxOverride != null
-            ? { ...cfg.sandbox, enabled: context.sandboxOverride }
-            : cfg.sandbox;
-          const wrapped = wrapCommand(input.command, context.workingDir, sandboxConfig);
-          sandboxed = wrapped.sandboxed;
-        }
-
-        // Proxied bash prompts are non-persistent — no trust rule saving allowed
-        const persistentDecisionsAllowed = !(
-          name === 'bash'
-          && input.network_mode === 'proxied'
-        );
-
-        emitLifecycleEvent(context, {
-          type: 'permission_prompt',
-          toolName: name,
-          executionTarget,
-          input,
-          workingDir: context.workingDir,
-          sessionId: context.sessionId,
-          conversationId: context.conversationId,
-          requestId: context.requestId,
-          riskLevel,
-          reason: result.reason,
-          allowlistOptions,
-          scopeOptions,
-          diff: previewDiff,
-          sandboxed,
-          persistentDecisionsAllowed,
-        });
-
-        await getHookManager().trigger('permission-request', {
-          toolName: name,
-          input: sanitizeToolInput(name, input),
-          riskLevel,
-          sessionId: context.sessionId,
-        });
-
-        const response = await this.prompter.prompt(
-          name,
-          input,
-          riskLevel,
-          allowlistOptions,
-          scopeOptions,
-          previewDiff,
-          sandboxed,
-          context.conversationId,
-          executionTarget,
-          persistentDecisionsAllowed,
-          context.signal,
-        );
-
-        decision = response.decision;
-
-        await getHookManager().trigger('permission-resolve', {
-          toolName: name,
-          decision: response.decision,
-          riskLevel,
-          sessionId: context.sessionId,
-        });
-
-        if (response.decision === 'deny') {
-          const contextualDenial = typeof response.decisionContext === 'string'
-            ? response.decisionContext.trim()
-            : '';
-          const denialMessage = contextualDenial.length > 0
-            ? contextualDenial
-            : `Permission denied by user. The user chose not to allow the "${name}" tool. Do NOT retry this tool call immediately. Instead, tell the user that the action was not performed because they denied permission, and ask if they would like you to try again or take a different approach. Wait for the user to explicitly respond before retrying.`;
-          const denialReason = contextualDenial.length > 0
-            ? `Permission denied (${name}): contextual policy`
-            : 'Permission denied by user';
-          const durationMs = Date.now() - startTime;
-          emitLifecycleEvent(context, {
-            type: 'permission_denied',
-            toolName: name,
-            executionTarget,
-            input,
-            workingDir: context.workingDir,
-            sessionId: context.sessionId,
-            conversationId: context.conversationId,
-            requestId: context.requestId,
-            riskLevel,
-            decision: 'deny',
-            reason: denialReason,
-            durationMs,
-          });
-          return { content: denialMessage, isError: true };
-        }
-
-        if (response.decision === 'always_deny') {
-          const ruleSaved = !!(persistentDecisionsAllowed && response.selectedPattern && response.selectedScope);
-          if (ruleSaved) {
-            addRule(name, response.selectedPattern!, response.selectedScope!, 'deny');
-          }
-          const denialReason = ruleSaved ? 'Permission denied by user (rule saved)' : 'Permission denied by user';
-          const denialMessage = ruleSaved
-            ? `Permission denied by user, and a rule was saved to always deny the "${name}" tool for this pattern. Do NOT retry this tool call. Inform the user that this action has been permanently blocked by their preference. If the user wants to allow it in the future, they can update their permission rules.`
-            : `Permission denied by user. The user chose not to allow the "${name}" tool. Do NOT retry this tool call immediately. Instead, tell the user that the action was not performed because they denied permission, and ask if they would like you to try again or take a different approach. Wait for the user to explicitly respond before retrying.`;
-          const durationMs = Date.now() - startTime;
-          emitLifecycleEvent(context, {
-            type: 'permission_denied',
-            toolName: name,
-            executionTarget,
-            input,
-            workingDir: context.workingDir,
-            sessionId: context.sessionId,
-            conversationId: context.conversationId,
-            requestId: context.requestId,
-            riskLevel,
-            decision: 'always_deny',
-            reason: denialReason,
-            durationMs,
-          });
-          return { content: denialMessage, isError: true };
-        }
-
-        if (
-          persistentDecisionsAllowed
-          && (response.decision === 'always_allow' || response.decision === 'always_allow_high_risk')
-          && response.selectedPattern
-          && response.selectedScope
-        ) {
-          const ruleOptions: {
-            allowHighRisk?: boolean;
-            executionTarget?: string;
-          } = {};
-
-          if (response.decision === 'always_allow_high_risk') {
-            ruleOptions.allowHighRisk = true;
-          }
-
-          if (policyContext?.executionTarget != null) {
-            ruleOptions.executionTarget = policyContext.executionTarget;
-          }
-
-          const hasOptions = Object.keys(ruleOptions).length > 0;
-          addRule(name, response.selectedPattern, response.selectedScope, 'allow', 100, hasOptions ? ruleOptions : undefined);
-        }
+      if (!permResult.allowed) {
+        return { content: permResult.content, isError: true };
       }
 
       const hookResult = await getHookManager().trigger('pre-tool-execute', {
@@ -799,6 +598,9 @@ export class ToolExecutor {
 // Re-export from the canonical source so existing consumers of
 // `executor.ts` continue to work without changing their imports.
 export { isSideEffectTool } from './side-effects.js';
+
+// Re-export PermissionChecker for consumers that need direct access
+export { PermissionChecker } from './permission-checker.js';
 
 /**
  * Sanitize tool inputs before they are emitted in lifecycle events and hooks.

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -1,0 +1,261 @@
+import { getConfig } from '../config/loader.js';
+import { getHookManager } from '../hooks/manager.js';
+import { check, classifyRisk, generateAllowlistOptions, generateScopeOptions } from '../permissions/checker.js';
+import type { PermissionPrompter } from '../permissions/prompter.js';
+import { addRule } from '../permissions/trust-store.js';
+import { RiskLevel } from '../permissions/types.js';
+import { getLogger } from '../util/logger.js';
+import type { ExecutionTarget } from './types.js';
+import { buildPolicyContext } from './policy-context.js';
+import { isSideEffectTool } from './side-effects.js';
+import { wrapCommand } from './terminal/sandbox.js';
+import type { Tool, ToolContext, ToolLifecycleEvent } from './types.js';
+
+const log = getLogger('permission-checker');
+
+export type PermissionDecision =
+  | { allowed: true; decision: string; riskLevel: string }
+  | { allowed: false; decision: string; riskLevel: string; content: string };
+
+export class PermissionChecker {
+  private prompter: PermissionPrompter;
+
+  constructor(prompter: PermissionPrompter) {
+    this.prompter = prompter;
+  }
+
+  /**
+   * Run risk classification, trust rule evaluation, and (if needed) user
+   * prompting for a tool invocation. Returns whether the tool is allowed
+   * to execute, along with the decision string and risk level for lifecycle
+   * event reporting.
+   */
+  async checkPermission(
+    name: string,
+    input: Record<string, unknown>,
+    tool: Tool,
+    context: ToolContext,
+    executionTarget: ExecutionTarget,
+    emitLifecycleEvent: (event: ToolLifecycleEvent) => void,
+    sanitizeToolInput: (toolName: string, input: Record<string, unknown>) => Record<string, unknown>,
+    startTime: number,
+    computePreviewDiff: (toolName: string, input: Record<string, unknown>, workingDir: string) => { filePath: string; oldContent: string; newContent: string; isNewFile: boolean } | undefined,
+  ): Promise<PermissionDecision> {
+    const risk = await classifyRisk(name, input, context.workingDir, undefined, undefined, context.signal);
+    const riskLevel: string = risk;
+
+    const policyContext = buildPolicyContext(tool, context);
+    const result = await check(name, input, context.workingDir, policyContext, undefined, context.signal);
+
+    // Private threads force prompting for side-effect tools even when a
+    // trust/allow rule would auto-allow. Deny decisions are preserved —
+    // only allow → prompt promotion happens here.
+    if (
+      context.forcePromptSideEffects
+      && result.decision === 'allow'
+      && isSideEffectTool(name, input)
+    ) {
+      result.decision = 'prompt';
+      result.reason = 'Private thread: side-effect tools require explicit approval';
+    }
+
+    if (result.decision === 'deny') {
+      const durationMs = Date.now() - startTime;
+      emitLifecycleEvent({
+        type: 'permission_denied',
+        toolName: name,
+        executionTarget,
+        input,
+        workingDir: context.workingDir,
+        sessionId: context.sessionId,
+        conversationId: context.conversationId,
+        requestId: context.requestId,
+        riskLevel,
+        decision: 'deny',
+        reason: result.reason,
+        durationMs,
+      });
+      return { allowed: false, decision: 'denied', riskLevel, content: result.reason };
+    }
+
+    if (result.decision === 'prompt') {
+      // Non-interactive sessions have no client to respond to prompts —
+      // deny immediately instead of blocking for the full permission timeout.
+      if (context.isInteractive === false) {
+        const durationMs = Date.now() - startTime;
+        log.info({ toolName: name, riskLevel }, 'Auto-denying prompt for non-interactive session');
+        emitLifecycleEvent({
+          type: 'permission_denied',
+          toolName: name,
+          executionTarget,
+          input,
+          workingDir: context.workingDir,
+          sessionId: context.sessionId,
+          conversationId: context.conversationId,
+          requestId: context.requestId,
+          riskLevel,
+          decision: 'deny',
+          reason: 'Non-interactive session: no client to approve prompt',
+          durationMs,
+        });
+        return {
+          allowed: false,
+          decision: 'denied',
+          riskLevel,
+          content: `Permission denied: tool "${name}" requires user approval but no interactive client is connected. The tool was not executed. To allow this tool in non-interactive sessions, add a trust rule via permission settings.`,
+        };
+      }
+
+      const allowlistOptions = await generateAllowlistOptions(name, input, context.signal);
+      const scopeOptions = generateScopeOptions(context.workingDir, name);
+      const previewDiff = computePreviewDiff(name, input, context.workingDir);
+
+      let sandboxed: boolean | undefined;
+      if (name === 'bash' && typeof input.command === 'string') {
+        const cfg = getConfig();
+        const sandboxConfig = context.sandboxOverride != null
+          ? { ...cfg.sandbox, enabled: context.sandboxOverride }
+          : cfg.sandbox;
+        const wrapped = wrapCommand(input.command, context.workingDir, sandboxConfig);
+        sandboxed = wrapped.sandboxed;
+      }
+
+      // Proxied bash prompts are non-persistent — no trust rule saving allowed
+      const persistentDecisionsAllowed = !(
+        name === 'bash'
+        && input.network_mode === 'proxied'
+      );
+
+      emitLifecycleEvent({
+        type: 'permission_prompt',
+        toolName: name,
+        executionTarget,
+        input,
+        workingDir: context.workingDir,
+        sessionId: context.sessionId,
+        conversationId: context.conversationId,
+        requestId: context.requestId,
+        riskLevel,
+        reason: result.reason,
+        allowlistOptions,
+        scopeOptions,
+        diff: previewDiff,
+        sandboxed,
+        persistentDecisionsAllowed,
+      });
+
+      await getHookManager().trigger('permission-request', {
+        toolName: name,
+        input: sanitizeToolInput(name, input),
+        riskLevel,
+        sessionId: context.sessionId,
+      });
+
+      const response = await this.prompter.prompt(
+        name,
+        input,
+        riskLevel,
+        allowlistOptions,
+        scopeOptions,
+        previewDiff,
+        sandboxed,
+        context.conversationId,
+        executionTarget,
+        persistentDecisionsAllowed,
+        context.signal,
+      );
+
+      const decision = response.decision;
+
+      await getHookManager().trigger('permission-resolve', {
+        toolName: name,
+        decision: response.decision,
+        riskLevel,
+        sessionId: context.sessionId,
+      });
+
+      if (response.decision === 'deny') {
+        const contextualDenial = typeof response.decisionContext === 'string'
+          ? response.decisionContext.trim()
+          : '';
+        const denialMessage = contextualDenial.length > 0
+          ? contextualDenial
+          : `Permission denied by user. The user chose not to allow the "${name}" tool. Do NOT retry this tool call immediately. Instead, tell the user that the action was not performed because they denied permission, and ask if they would like you to try again or take a different approach. Wait for the user to explicitly respond before retrying.`;
+        const denialReason = contextualDenial.length > 0
+          ? `Permission denied (${name}): contextual policy`
+          : 'Permission denied by user';
+        const durationMs = Date.now() - startTime;
+        emitLifecycleEvent({
+          type: 'permission_denied',
+          toolName: name,
+          executionTarget,
+          input,
+          workingDir: context.workingDir,
+          sessionId: context.sessionId,
+          conversationId: context.conversationId,
+          requestId: context.requestId,
+          riskLevel,
+          decision: 'deny',
+          reason: denialReason,
+          durationMs,
+        });
+        return { allowed: false, decision, riskLevel, content: denialMessage };
+      }
+
+      if (response.decision === 'always_deny') {
+        const ruleSaved = !!(persistentDecisionsAllowed && response.selectedPattern && response.selectedScope);
+        if (ruleSaved) {
+          addRule(name, response.selectedPattern!, response.selectedScope!, 'deny');
+        }
+        const denialReason = ruleSaved ? 'Permission denied by user (rule saved)' : 'Permission denied by user';
+        const denialMessage = ruleSaved
+          ? `Permission denied by user, and a rule was saved to always deny the "${name}" tool for this pattern. Do NOT retry this tool call. Inform the user that this action has been permanently blocked by their preference. If the user wants to allow it in the future, they can update their permission rules.`
+          : `Permission denied by user. The user chose not to allow the "${name}" tool. Do NOT retry this tool call immediately. Instead, tell the user that the action was not performed because they denied permission, and ask if they would like you to try again or take a different approach. Wait for the user to explicitly respond before retrying.`;
+        const durationMs = Date.now() - startTime;
+        emitLifecycleEvent({
+          type: 'permission_denied',
+          toolName: name,
+          executionTarget,
+          input,
+          workingDir: context.workingDir,
+          sessionId: context.sessionId,
+          conversationId: context.conversationId,
+          requestId: context.requestId,
+          riskLevel,
+          decision: 'always_deny',
+          reason: denialReason,
+          durationMs,
+        });
+        return { allowed: false, decision, riskLevel, content: denialMessage };
+      }
+
+      if (
+        persistentDecisionsAllowed
+        && (response.decision === 'always_allow' || response.decision === 'always_allow_high_risk')
+        && response.selectedPattern
+        && response.selectedScope
+      ) {
+        const ruleOptions: {
+          allowHighRisk?: boolean;
+          executionTarget?: string;
+        } = {};
+
+        if (response.decision === 'always_allow_high_risk') {
+          ruleOptions.allowHighRisk = true;
+        }
+
+        if (policyContext?.executionTarget != null) {
+          ruleOptions.executionTarget = policyContext.executionTarget;
+        }
+
+        const hasOptions = Object.keys(ruleOptions).length > 0;
+        addRule(name, response.selectedPattern, response.selectedScope, 'allow', 100, hasOptions ? ruleOptions : undefined);
+      }
+
+      return { allowed: true, decision, riskLevel };
+    }
+
+    // result.decision === 'allow'
+    return { allowed: true, decision: 'allow', riskLevel };
+  }
+}


### PR DESCRIPTION
Extract risk classification, trust rule evaluation, and permission decision logic into a dedicated PermissionChecker class.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
