### PR TITLE
feat: add FTS index reconciliation mechanism

### DIFF
--- a/assistant/src/memory/fts-reconciler.ts
+++ b/assistant/src/memory/fts-reconciler.ts
@@ -1,0 +1,106 @@
+import { getLogger } from '../util/logger.js';
+import { rawGet, rawRun } from './db.js';
+
+const log = getLogger('fts-reconciler');
+
+export interface FtsReconciliationResult {
+  table: string;
+  baseCount: number;
+  ftsCount: number;
+  missingInserted: number;
+  orphansRemoved: number;
+}
+
+/**
+ * Reconcile a single FTS index against its base table. Detects missing entries
+ * (rows in the base table with no corresponding FTS row) and orphaned entries
+ * (FTS rows whose base table row no longer exists), then repairs both.
+ *
+ * This is lighter than a full rebuild — it only touches the delta rather than
+ * wiping and re-inserting the entire index.
+ */
+function reconcileTable(opts: {
+  ftsTable: string;
+  ftsIdColumn: string;
+  ftsContentColumn: string;
+  baseTable: string;
+  baseIdColumn: string;
+  baseContentColumn: string;
+}): FtsReconciliationResult {
+  const { ftsTable, ftsIdColumn, ftsContentColumn, baseTable, baseIdColumn, baseContentColumn } = opts;
+
+  const baseCount = (rawGet<{ c: number }>(`SELECT COUNT(*) AS c FROM ${baseTable}`) ?? { c: 0 }).c;
+  const ftsCount = (rawGet<{ c: number }>(`SELECT COUNT(*) AS c FROM ${ftsTable}`) ?? { c: 0 }).c;
+
+  // Find base table rows missing from the FTS index
+  const missingInserted = rawRun(/*sql*/ `
+    INSERT INTO ${ftsTable}(${ftsIdColumn}, ${ftsContentColumn})
+    SELECT b.${baseIdColumn}, b.${baseContentColumn}
+    FROM ${baseTable} b
+    LEFT JOIN ${ftsTable} f ON f.${ftsIdColumn} = b.${baseIdColumn}
+    WHERE f.${ftsIdColumn} IS NULL
+  `);
+
+  // Find FTS rows whose base table row no longer exists
+  const orphansRemoved = rawRun(/*sql*/ `
+    DELETE FROM ${ftsTable}
+    WHERE ${ftsIdColumn} IN (
+      SELECT f.${ftsIdColumn}
+      FROM ${ftsTable} f
+      LEFT JOIN ${baseTable} b ON b.${baseIdColumn} = f.${ftsIdColumn}
+      WHERE b.${baseIdColumn} IS NULL
+    )
+  `);
+
+  return { table: ftsTable, baseCount, ftsCount, missingInserted, orphansRemoved };
+}
+
+/**
+ * Reconcile all FTS indexes. Returns results for each table so callers can
+ * inspect what was repaired.
+ */
+export function reconcileFtsIndexes(): FtsReconciliationResult[] {
+  const results: FtsReconciliationResult[] = [];
+
+  // memory_segment_fts tracks memory_segments
+  try {
+    const result = reconcileTable({
+      ftsTable: 'memory_segment_fts',
+      ftsIdColumn: 'segment_id',
+      ftsContentColumn: 'text',
+      baseTable: 'memory_segments',
+      baseIdColumn: 'id',
+      baseContentColumn: 'text',
+    });
+    results.push(result);
+    if (result.missingInserted > 0 || result.orphansRemoved > 0) {
+      log.info(result, 'Reconciled memory_segment_fts');
+    } else {
+      log.debug(result, 'memory_segment_fts is in sync');
+    }
+  } catch (err) {
+    log.error({ err }, 'Failed to reconcile memory_segment_fts');
+  }
+
+  // messages_fts tracks messages
+  try {
+    const result = reconcileTable({
+      ftsTable: 'messages_fts',
+      ftsIdColumn: 'message_id',
+      ftsContentColumn: 'content',
+      baseTable: 'messages',
+      baseIdColumn: 'id',
+      baseContentColumn: 'content',
+    });
+    results.push(result);
+    if (result.missingInserted > 0 || result.orphansRemoved > 0) {
+      log.info(result, 'Reconciled messages_fts');
+    } else {
+      log.debug(result, 'messages_fts is in sync');
+    }
+  } catch (err) {
+    log.error({ err }, 'Failed to reconcile messages_fts');
+  }
+
+  return results;
+}

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -25,6 +25,7 @@ export type MemoryJobType =
   | 'build_conversation_summary'
   | 'backfill'
   | 'rebuild_index'
+  | 'reconcile_fts'
   | 'delete_qdrant_vectors'
   | 'media_processing';
 
@@ -245,6 +246,21 @@ export function enqueuePruneOldConversationsJob(retentionDays?: number): string 
     ? { retentionDays }
     : {};
   return enqueueMemoryJob('prune_old_conversations', payload);
+}
+
+export function enqueueReconcileFtsJob(): string {
+  const db = getDb();
+  const existing = db
+    .select()
+    .from(memoryJobs)
+    .where(and(
+      eq(memoryJobs.type, 'reconcile_fts'),
+      inArray(memoryJobs.status, ['pending', 'running']),
+    ))
+    .orderBy(asc(memoryJobs.createdAt))
+    .get();
+  if (existing) return existing.id;
+  return enqueueMemoryJob('reconcile_fts', {});
 }
 
 export function claimMemoryJobs(limit: number): MemoryJob[] {

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -9,6 +9,7 @@ import { cleanupResolvedConflictsJob,resolvePendingConflictsForMessageJob } from
 import { embedItemJob, embedSegmentJob, embedSummaryJob } from './job-handlers/embedding.js';
 import { extractEntitiesJob,extractItemsJob } from './job-handlers/extraction.js';
 import { deleteQdrantVectorsJob,rebuildIndexJob } from './job-handlers/index-maintenance.js';
+import { reconcileFtsIndexes } from './fts-reconciler.js';
 import { mediaProcessingJob } from './job-handlers/media-processing.js';
 import { buildConversationSummaryJob, buildGlobalSummaryJob } from './job-handlers/summarization.js';
 import {
@@ -24,6 +25,7 @@ import {
   enqueueCleanupResolvedConflictsJob,
   enqueueCleanupStaleSupersededItemsJob,
   enqueuePruneOldConversationsJob,
+  enqueueReconcileFtsJob,
   failMemoryJob,
   type MemoryJob,
   resetRunningJobsToPending,
@@ -247,6 +249,9 @@ async function processJob(job: MemoryJob, config: AssistantConfig): Promise<void
     case 'rebuild_index':
       rebuildIndexJob();
       return;
+    case 'reconcile_fts':
+      reconcileFtsIndexes();
+      return;
     case 'delete_qdrant_vectors':
       await deleteQdrantVectorsJob(job);
       return;
@@ -281,11 +286,13 @@ export function maybeEnqueueScheduledCleanupJobs(config: AssistantConfig, nowMs 
   const pruneConversationsJobId = cleanup.conversationRetentionDays > 0
     ? enqueuePruneOldConversationsJob(cleanup.conversationRetentionDays)
     : null;
+  const reconcileFtsJobId = enqueueReconcileFtsJob();
   lastScheduledCleanupEnqueueMs = nowMs;
   log.debug({
     resolvedConflictsJobId,
     staleSupersededItemsJobId,
     pruneConversationsJobId,
+    reconcileFtsJobId,
     enqueueIntervalMs: cleanup.enqueueIntervalMs,
     resolvedConflictRetentionMs: cleanup.resolvedConflictRetentionMs,
     supersededItemRetentionMs: cleanup.supersededItemRetentionMs,


### PR DESCRIPTION
Add reconciliation/repair mechanism to detect and fix FTS index drift — identifies missing and orphaned entries, re-indexes missing entries, and removes orphans.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
