### PR TITLE
feat: add migration crash recovery for stalled migrations

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -24,6 +24,7 @@ import {
   migrateGuardianVerificationSessions,
   migrateMessagesFtsBackfill,
   migrateReminderRoutingIntent,
+  recoverCrashedMigrations,
   runComplexMigrations,
   runLateMigrations,
   validateMigrationState,
@@ -34,6 +35,10 @@ export function initializeDb(): void {
 
   // 1. Create core tables (conversations, messages, memory, etc.)
   createCoreTables(database);
+
+  // 1b. Clear any stalled 'started' checkpoints left by previous crashes
+  // so the affected migrations can re-run from scratch.
+  recoverCrashedMigrations(database);
 
   // 2. Create watchers, logs, entities, FTS, and conversation keys
   createWatchersAndLogsTables(database);

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -55,4 +55,4 @@ export {
   type MigrationRegistryEntry,
   type MigrationValidationResult,
 } from './registry.js';
-export { validateMigrationState } from './validate-migration-state.js';
+export { recoverCrashedMigrations, validateMigrationState, withCrashRecovery } from './validate-migration-state.js';

--- a/assistant/src/memory/migrations/validate-migration-state.ts
+++ b/assistant/src/memory/migrations/validate-migration-state.ts
@@ -6,6 +6,88 @@ import { MIGRATION_REGISTRY, type MigrationValidationResult } from './registry.j
 const log = getLogger('memory-db');
 
 /**
+ * Recover from crashed migrations before the migration runner executes.
+ *
+ * Scans memory_checkpoints for entries with value 'started' — these represent
+ * migrations that began but never completed (e.g., due to a process crash).
+ * Deletes the stalled checkpoint so the migration can re-run from scratch on
+ * this startup. Each migration's own idempotency guards (DDL IF NOT EXISTS,
+ * transactional rollback) ensure re-running is safe.
+ *
+ * Call this BEFORE running migrations so that stalled checkpoints don't block
+ * re-execution.
+ */
+export function recoverCrashedMigrations(database: DrizzleDb): string[] {
+  const raw = getSqliteFrom(database);
+
+  let rows: Array<{ key: string; value: string }>;
+  try {
+    rows = raw.query(`SELECT key, value FROM memory_checkpoints`).all() as Array<{ key: string; value: string }>;
+  } catch {
+    return [];
+  }
+
+  const crashed = rows.filter((r) => r.value === 'started').map((r) => r.key);
+  if (crashed.length === 0) return [];
+
+  log.error(
+    { crashed },
+    [
+      '╔══════════════════════════════════════════════════════════════╗',
+      '║  CRASHED MIGRATIONS DETECTED — AUTO-RECOVERING             ║',
+      '╚══════════════════════════════════════════════════════════════╝',
+      '',
+      `The following migrations started but never completed: ${crashed.join(', ')}`,
+      '',
+      'Clearing stalled checkpoints so they can be retried on this startup.',
+      'If retries continue to fail, manually inspect the database:',
+      '  sqlite3 ~/.vellum/data/assistant.db "SELECT * FROM memory_checkpoints"',
+    ].join('\n'),
+  );
+
+  for (const key of crashed) {
+    raw.query(`DELETE FROM memory_checkpoints WHERE key = ?`).run(key);
+    log.info({ key }, `Cleared stalled checkpoint "${key}" — migration will re-run`);
+  }
+
+  return crashed;
+}
+
+/**
+ * Wrap a migration function with crash-recovery bookkeeping.
+ *
+ * Writes a 'started' checkpoint before executing the migration body, then
+ * overwrites it with the completion value on success. If the process crashes
+ * between the start marker and completion, recoverCrashedMigrations (which
+ * runs before all migrations) will detect and clear it on the next startup.
+ *
+ * The migrationFn receives the raw SQLite database and should perform its
+ * own transaction management internally.
+ */
+export function withCrashRecovery(
+  database: DrizzleDb,
+  checkpointKey: string,
+  migrationFn: () => void,
+): void {
+  const raw = getSqliteFrom(database);
+
+  const existing = raw.query(
+    `SELECT value FROM memory_checkpoints WHERE key = ?`,
+  ).get(checkpointKey) as { value: string } | null;
+  if (existing && existing.value !== 'started') return;
+
+  raw.query(
+    `INSERT OR REPLACE INTO memory_checkpoints (key, value, updated_at) VALUES (?, 'started', ?)`,
+  ).run(checkpointKey, Date.now());
+
+  migrationFn();
+
+  raw.query(
+    `UPDATE memory_checkpoints SET value = '1', updated_at = ? WHERE key = ?`,
+  ).run(Date.now(), checkpointKey);
+}
+
+/**
  * Validate the applied migration state against the registry at startup.
  *
  * Logs a prominent error when a migration started but never completed (crash
@@ -30,23 +112,20 @@ export function validateMigrationState(database: DrizzleDb): MigrationValidation
     return { crashed: [], dependencyViolations: [] };
   }
 
-  // Detect crashed migrations: a checkpoint value of 'started' means the
-  // migration wrote its start marker but never reached the completion INSERT.
-  // The migration will re-run on the next startup (its own idempotency guard
-  // will determine safety), but we surface a warning for visibility.
+  // Any remaining 'started' checkpoints after recovery + migration execution
+  // indicate a migration that was retried but failed again.
   const crashed = rows.filter((r) => r.value === 'started').map((r) => r.key);
   if (crashed.length > 0) {
     log.error(
       { crashed },
       [
         '╔══════════════════════════════════════════════════════════════╗',
-        '║  CRASHED MIGRATIONS DETECTED                               ║',
+        '║  MIGRATIONS STILL INCOMPLETE AFTER RETRY                   ║',
         '╚══════════════════════════════════════════════════════════════╝',
         '',
-        `The following migrations started but never completed: ${crashed.join(', ')}`,
+        `The following migrations were retried but still did not complete: ${crashed.join(', ')}`,
         '',
-        'These will be retried automatically on this startup.',
-        'If retries continue to fail, manually update the checkpoint:',
+        'Manual intervention is required. Inspect the database and resolve:',
         '  sqlite3 ~/.vellum/data/assistant.db "DELETE FROM memory_checkpoints WHERE key = \'<migration_key>\'"',
         'Then restart the daemon.',
       ].join('\n'),

--- a/assistant/src/memory/schema-migration.ts
+++ b/assistant/src/memory/schema-migration.ts
@@ -28,5 +28,7 @@ export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,
   type MigrationValidationResult,
+  recoverCrashedMigrations,
   validateMigrationState,
+  withCrashRecovery,
 } from './migrations/index.js';


### PR DESCRIPTION
Detect migrations that were started but never completed (e.g., due to a crash) and provide clear error messaging with auto-repair capability.

## Changes

- **`recoverCrashedMigrations()`**: Runs before all migrations at startup. Scans `memory_checkpoints` for entries with value `'started'` (indicating a migration that began but never completed), deletes them so the migration can re-run from scratch.

- **`withCrashRecovery()`**: A wrapper utility that future migrations can use to bracket their work with a `started` -> `completed` checkpoint lifecycle. Writes a `'started'` marker before execution, then overwrites with `'1'` on success.

- **Updated `validateMigrationState()`**: Post-migration validation now distinguishes between first-time crash detection (handled by recovery) and persistent failures (migrations retried but still incomplete). The latter surfaces actionable manual intervention instructions.

- **`db-init.ts`**: Wired `recoverCrashedMigrations()` to run right after core tables are created (so `memory_checkpoints` exists) but before any checkpoint-guarded migrations execute.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
