### PR TITLE
feat(parental): deny-by-default for apps/widgets and improve allowlist UI

### DIFF
--- a/assistant/src/security/parental-control-store.ts
+++ b/assistant/src/security/parental-control-store.ts
@@ -193,28 +193,28 @@ export function clearPIN(): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Returns true if the given app name is in the allowlist, or if no apps have
- * been explicitly restricted (empty allowlist means all apps are allowed).
+ * Returns true if the given app name is in the allowlist.
+ * Deny-by-default: an empty allowlist blocks all apps for the child profile,
+ * because "not on the allowlist" means blocked.
  * Always returns true when parental controls are disabled or the parental
  * profile is active, consistent with isToolBlocked.
  */
 export function isAppAllowed(appName: string): boolean {
   const { enabled, activeProfile, allowedApps } = getParentalControlSettings();
   if (!enabled || activeProfile !== 'child') return true;
-  if (allowedApps.length === 0) return true;
   return allowedApps.includes(appName);
 }
 
 /**
- * Returns true if the given widget name is in the allowlist, or if no widgets
- * have been explicitly restricted (empty allowlist means all widgets are allowed).
+ * Returns true if the given widget name is in the allowlist.
+ * Deny-by-default: an empty allowlist blocks all widgets for the child profile,
+ * because "not on the allowlist" means blocked.
  * Always returns true when parental controls are disabled or the parental
  * profile is active, consistent with isToolBlocked.
  */
 export function isWidgetAllowed(widgetName: string): boolean {
   const { enabled, activeProfile, allowedWidgets } = getParentalControlSettings();
   if (!enabled || activeProfile !== 'child') return true;
-  if (allowedWidgets.length === 0) return true;
   return allowedWidgets.includes(widgetName);
 }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
@@ -460,7 +460,7 @@ struct SettingsParentalTab: View {
                 .font(VFont.sectionTitle)
                 .foregroundColor(VColor.textPrimary)
 
-            Text("When non-empty, only listed apps can be used in child mode. Leave empty to allow all apps.")
+            Text("Apps not on this list are blocked for the Child profile.")
                 .font(VFont.caption)
                 .foregroundColor(VColor.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -481,7 +481,7 @@ struct SettingsParentalTab: View {
             }
 
             if allowedApps.isEmpty {
-                Text("No apps restricted — all apps allowed.")
+                Text("No apps allowed — all apps are blocked for the Child profile.")
                     .font(VFont.caption)
                     .foregroundColor(VColor.textMuted)
                     .textSelection(.enabled)
@@ -493,10 +493,16 @@ struct SettingsParentalTab: View {
                             .foregroundColor(VColor.textSecondary)
                             .textSelection(.enabled)
                         Spacer()
-                        VButton(label: "Remove", style: .danger) {
+                        // "×" button removes the app from the allowlist, effectively disallowing it
+                        Button {
                             let updated = allowedApps.filter { $0 != app }
                             updateAllowlist(apps: updated, widgets: nil)
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(VColor.textMuted)
                         }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Remove \(app) from allowlist")
                         .disabled(isLoading)
                     }
                 }
@@ -514,7 +520,7 @@ struct SettingsParentalTab: View {
                 .font(VFont.sectionTitle)
                 .foregroundColor(VColor.textPrimary)
 
-            Text("When non-empty, only listed widgets can be used in child mode. Leave empty to allow all widgets.")
+            Text("Widgets not on this list are blocked for the Child profile.")
                 .font(VFont.caption)
                 .foregroundColor(VColor.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -535,7 +541,7 @@ struct SettingsParentalTab: View {
             }
 
             if allowedWidgets.isEmpty {
-                Text("No widgets restricted — all widgets allowed.")
+                Text("No widgets allowed — all widgets are blocked for the Child profile.")
                     .font(VFont.caption)
                     .foregroundColor(VColor.textMuted)
                     .textSelection(.enabled)
@@ -547,10 +553,16 @@ struct SettingsParentalTab: View {
                             .foregroundColor(VColor.textSecondary)
                             .textSelection(.enabled)
                         Spacer()
-                        VButton(label: "Remove", style: .danger) {
+                        // "×" button removes the widget from the allowlist, effectively disallowing it
+                        Button {
                             let updated = allowedWidgets.filter { $0 != widget }
                             updateAllowlist(apps: nil, widgets: updated)
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(VColor.textMuted)
                         }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Remove \(widget) from allowlist")
                         .disabled(isLoading)
                     }
                 }


### PR DESCRIPTION
## Summary
- Change app/widget allowlist to deny-by-default: child profile cannot access any apps or widgets unless explicitly added to the allowlist
- Add descriptive caption to allowlist sections explaining the deny-by-default behavior
- Improve allowlist item UI to make allow/disallow action clearer

## Original prompt
- Should allow/disallow to share app in apps view and when app is opened
- By default widgets/apps are not available for child profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
