### PR TITLE
feat: surface Qdrant circuit-breaker state in memory retrieval

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -473,7 +473,17 @@ function formatRecallResult(
   const selected = trimToTokenBudget(merged, maxInjectTokens, config.memory.retrieval.injectionFormat);
   markItemUsage(selected);
 
-  const injectedText = buildInjectedText(selected, config.memory.retrieval.injectionFormat);
+  let injectedText = buildInjectedText(selected, config.memory.retrieval.injectionFormat);
+
+  // Surface degradation notice in the injected text so the model knows
+  // semantic search is unavailable and recall quality may be reduced.
+  if (collected.semanticSearchFailed) {
+    const notice = '[Note: Semantic search is currently unavailable. Memory recall is limited to lexical and recency matching — results may be incomplete or miss semantically relevant memories.]';
+    injectedText = injectedText.length > 0
+      ? injectedText + '\n\n' + notice
+      : notice;
+  }
+
   const topCandidates: MemoryRecallCandiateDebug[] = selected.slice(0, 10).map((c) => ({
     key: c.key,
     type: c.type,


### PR DESCRIPTION
When Qdrant circuit breaker is open, include a degradation notice in memory retrieval results so the model knows semantic search quality is reduced.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
