### PR TITLE
feat: add /v1/debug introspection endpoint

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -79,6 +79,7 @@ import {
   handleGetAttachmentContent,
   handleUploadAttachment,
 } from './routes/attachment-routes.js';
+import { handleDebug } from './routes/debug-routes.js';
 import {
   handleAnswerCall,
   handleCancelCall,
@@ -563,6 +564,7 @@ export class RuntimeHttpServer {
   ): Promise<Response> {
     return withErrorHandling(endpoint, async () => {
       if (endpoint === 'health' && req.method === 'GET') return handleHealth();
+      if (endpoint === 'debug' && req.method === 'GET') return handleDebug();
 
       if (endpoint === 'browser-relay/status' && req.method === 'GET') {
         return Response.json(extensionRelayServer.getStatus());

--- a/assistant/src/runtime/routes/debug-routes.ts
+++ b/assistant/src/runtime/routes/debug-routes.ts
@@ -1,0 +1,65 @@
+/**
+ * Debug introspection endpoint for monitoring and troubleshooting.
+ */
+
+import { statSync } from 'node:fs';
+
+import { getDbPath } from '../../util/platform.js';
+import { countConversations } from '../../memory/conversation-store.js';
+import { getMemoryJobCounts } from '../../memory/jobs-store.js';
+import { listSchedules } from '../../schedule/schedule-store.js';
+import { rawAll } from '../../memory/db.js';
+
+/** Process start time — used to calculate uptime. */
+const startedAt = Date.now();
+
+function getDatabaseSizeBytes(): number | null {
+  try {
+    return statSync(getDbPath()).size;
+  } catch {
+    return null;
+  }
+}
+
+function getMemoryItemCount(): number {
+  try {
+    const rows = rawAll<{ c: number }>('SELECT COUNT(*) AS c FROM memory_items');
+    return rows[0]?.c ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function handleDebug(): Response {
+  const now = Date.now();
+  const uptimeSeconds = Math.floor((now - startedAt) / 1000);
+
+  const conversationCount = countConversations();
+  const memoryItemCount = getMemoryItemCount();
+  const dbSizeBytes = getDatabaseSizeBytes();
+
+  const memoryJobCounts = getMemoryJobCounts();
+
+  const schedules = listSchedules();
+  const enabledSchedules = schedules.filter((s) => s.enabled).length;
+
+  return Response.json({
+    session: {
+      uptimeSeconds,
+      startedAt: new Date(startedAt).toISOString(),
+    },
+    memory: {
+      conversationCount,
+      memoryItemCount,
+      ...(dbSizeBytes != null ? { databaseSizeBytes: dbSizeBytes } : {}),
+    },
+    jobs: {
+      memory: memoryJobCounts,
+    },
+    schedules: {
+      total: schedules.length,
+      enabled: enabledSchedules,
+    },
+    timestamp: new Date(now).toISOString(),
+  });
+}


### PR DESCRIPTION
Add GET /v1/debug endpoint returning session state summary, memory stats, and job queue health for debugging and monitoring.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
