### PR TITLE
fix: correct async return types and build.sh local keyword error

### DIFF
--- a/assistant/src/calls/call-pointer-messages.ts
+++ b/assistant/src/calls/call-pointer-messages.ts
@@ -13,7 +13,7 @@ export async function addPointerMessage(
   event: PointerEvent,
   phoneNumber: string,
   extra?: { duration?: string; reason?: string; verificationCode?: string; channel?: string },
-): void {
+): Promise<void> {
   let text: string;
   switch (event) {
     case 'started':

--- a/assistant/src/daemon/handlers/subagents.ts
+++ b/assistant/src/daemon/handlers/subagents.ts
@@ -84,7 +84,7 @@ export async function handleSubagentMessage(
   msg: SubagentMessageRequest,
   socket: net.Socket,
   ctx: HandlerContext,
-): void {
+): Promise<void> {
   const callerSessionId = ctx.socketToSession.get(socket);
   if (!callerSessionId) {
     log.warn({ subagentId: msg.subagentId }, 'Message rejected: socket has no bound session');

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -132,7 +132,7 @@ export interface AgentLoopSessionContext {
   getQueueDepth(): number;
   hasQueuedMessages(): boolean;
   canHandoffAtCheckpoint(): boolean;
-  drainQueue(reason: QueueDrainReason): void;
+  drainQueue(reason: QueueDrainReason): Promise<void>;
   getTurnChannelContext(): TurnChannelContext | null;
   getTurnInterfaceContext(): TurnInterfaceContext | null;
 }

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -147,7 +147,7 @@ function buildSlashContext(session: ProcessSessionContext): SlashContext {
  * block, we must explicitly continue draining on failure — otherwise
  * remaining queued messages would be stranded.
  */
-export function drainQueue(session: ProcessSessionContext, reason: QueueDrainReason = 'loop_complete'): void {
+export async function drainQueue(session: ProcessSessionContext, reason: QueueDrainReason = 'loop_complete'): Promise<void> {
   const next = session.queue.shift();
   if (!next) return;
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -512,8 +512,8 @@ export class Session {
   }
 
 
-  drainQueue(reason: QueueDrainReason = 'loop_complete'): void {
-    drainQueueImpl(this as ProcessSessionContext, reason);
+  drainQueue(reason: QueueDrainReason = 'loop_complete'): Promise<void> {
+    return drainQueueImpl(this as ProcessSessionContext, reason);
   }
 
   async processMessage(

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -308,7 +308,7 @@ if [ "$DAEMON_BIN_NEEDS_BUILD" = true ]; then
     mkdir -p "$SCRIPT_DIR/daemon-bin/node_modules"
     cp -R "$ASSISTANT_SRC_DIR/node_modules/onnxruntime-node" "$SCRIPT_DIR/daemon-bin/node_modules/"
     cp -R "$ASSISTANT_SRC_DIR/node_modules/onnxruntime-common" "$SCRIPT_DIR/daemon-bin/node_modules/"
-    local onnx_bin="$SCRIPT_DIR/daemon-bin/node_modules/onnxruntime-node/bin/napi-v3"
+    onnx_bin="$SCRIPT_DIR/daemon-bin/node_modules/onnxruntime-node/bin/napi-v3"
     if [ -d "$onnx_bin" ]; then
         find "$onnx_bin" -mindepth 1 -maxdepth 1 -not -name darwin -exec rm -rf {} +
         if [ -d "$onnx_bin/darwin" ]; then


### PR DESCRIPTION
## Summary
- Fix several async functions that declared `void` return types instead of `Promise<void>` (`addPointerMessage`, `handleSubagentMessage`, `drainQueue`, and the `AgentLoopSessionContext` interface)
- Remove invalid `local` keyword in `clients/macos/build.sh` line 311 that caused a shell error (`local: can only be used in a function`) because it was in top-level script scope, not inside a function

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
