### PR TITLE
refactor: migrate console.log to structured Pino logger

### DIFF
--- a/assistant/src/cli/map.ts
+++ b/assistant/src/cli/map.ts
@@ -19,7 +19,10 @@ import {
 } from '../daemon/ipc-protocol.js';
 import { analyzeApiMap, printApiMapTable,saveApiMap } from '../tools/browser/api-map.js';
 import { loadRecording } from '../tools/browser/recording-store.js';
+import { getCliLogger } from '../util/logger.js';
 import { getSocketPath, readSessionToken } from '../util/platform.js';
+
+const log = getCliLogger('cli:map');
 
 /**
  * Extract the registrable base domain from a hostname.
@@ -307,12 +310,12 @@ export function registerMapCommand(program: Command): void {
 
         if (!json) {
           if (manual) {
-            console.log(`Starting manual API map session for ${domain} (${duration}s)...`);
-            console.log('Browse the site manually. Press Ctrl+C or wait for idle detection to stop recording.');
+            log.info(`Starting manual API map session for ${domain} (${duration}s)...`);
+            log.info('Browse the site manually. Press Ctrl+C or wait for idle detection to stop recording.');
           } else if (navigateDomain !== recordDomain) {
-            console.log(`Starting API map session: navigating ${navigateDomain}, recording *.${recordDomain} (${duration}s)...`);
+            log.info(`Starting API map session: navigating ${navigateDomain}, recording *.${recordDomain} (${duration}s)...`);
           } else {
-            console.log(`Starting API map session for ${domain} (${duration}s)...`);
+            log.info(`Starting API map session for ${domain} (${duration}s)...`);
           }
         }
         const result = await startLearnSession(navigateDomain, recordDomain, duration, !manual);
@@ -338,7 +341,7 @@ export function registerMapCommand(program: Command): void {
         // 5. Display results
         if (!json) {
           printApiMapTable(apiMap);
-          console.log(`API map saved to: ${savedPath}`);
+          log.info(`API map saved to: ${savedPath}`);
         }
 
         // 6. Output JSON result

--- a/assistant/src/swarm/plan-validator.ts
+++ b/assistant/src/swarm/plan-validator.ts
@@ -1,7 +1,10 @@
+import { getLogger } from '../util/logger.js';
 import { detectCycles } from './graph-utils.js';
 import type { SwarmLimits } from './limits.js';
 import type { SwarmPlan, SwarmTaskNode } from './types.js';
 import { VALID_SWARM_ROLES } from './types.js';
+
+const log = getLogger('swarm:plan-validator');
 
 export class SwarmPlanValidationError extends Error {
   constructor(
@@ -41,7 +44,7 @@ export function validateAndNormalizePlan(
 
   // --- Task count limit ---
   if (tasks.length > limits.maxTasks) {
-    console.warn(`Plan truncated from ${tasks.length} tasks to ${limits.maxTasks}`);
+    log.warn({ original: tasks.length, max: limits.maxTasks }, 'Plan truncated to task limit');
     tasks = tasks.slice(0, limits.maxTasks);
   }
 

--- a/assistant/src/tools/browser/api-map.ts
+++ b/assistant/src/tools/browser/api-map.ts
@@ -7,8 +7,11 @@
 import { mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
+import { getCliLogger } from '../../util/logger.js';
 import { getDataDir } from '../../util/platform.js';
 import type { NetworkRecordedEntry } from './network-recording-types.js';
+
+const log = getCliLogger('api-map');
 
 // ---------------------------------------------------------------------------
 // Types
@@ -254,7 +257,7 @@ export function printApiMapTable(result: ApiMapResult): void {
   const dataEndpoints = result.endpoints.filter(ep => ep.count <= 15);
   const boilerplate = result.endpoints.filter(ep => ep.count > 15);
 
-  console.log(`\nAPI Map for ${result.domain} — ${result.endpoints.length} endpoints discovered\n`);
+  log.info(`\nAPI Map for ${result.domain} — ${result.endpoints.length} endpoints discovered\n`);
 
   const stripDomain = (pattern: string) => {
     const idx = pattern.indexOf('/');
@@ -263,7 +266,7 @@ export function printApiMapTable(result: ApiMapResult): void {
 
   const printSection = (title: string, eps: ApiEndpoint[]) => {
     if (eps.length === 0) return;
-    console.log(`  ${title} (${eps.length})\n`);
+    log.info(`  ${title} (${eps.length})\n`);
 
     const header = ['Method', 'Endpoint', 'Hits', 'Response Keys'];
     const rows = eps.map((ep) => [
@@ -281,12 +284,12 @@ export function printApiMapTable(result: ApiMapResult): void {
     const fmt = (row: string[]) =>
       row.map((cell, i) => cell.slice(0, widths[i]).padEnd(widths[i])).join(' | ');
 
-    console.log(`  ${fmt(header)}`);
-    console.log(`  ${sep}`);
+    log.info(`  ${fmt(header)}`);
+    log.info(`  ${sep}`);
     for (const row of rows) {
-      console.log(`  ${fmt(row)}`);
+      log.info(`  ${fmt(row)}`);
     }
-    console.log();
+    log.info('');
   };
 
   printSection('DATA ENDPOINTS', dataEndpoints);


### PR DESCRIPTION
Audit and migrate console.log/error/warn usage in core production modules to structured Pino logger for better observability.

Migrated files:
- assistant/src/swarm/plan-validator.ts: console.warn -> logger.warn with structured context
- assistant/src/tools/browser/api-map.ts: console.log -> getCliLogger for CLI display output
- assistant/src/cli/map.ts: console.log -> getCliLogger for CLI user-facing messages

Intentionally skipped:
- daemon/main.ts: console.error is last-resort fallback when logger may not be initialized (comment explains why)
- tools/skills/sandbox-runner.ts: console.log in generated runner script that communicates via stdout JSON in subprocess
- amazon/*.ts: console.warn/error inside CDP eval() scripts that run in Chrome browser context
- gallery/default-gallery.ts: console.error inside inline HTML/JS templates that run in browser
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
