### PR TITLE
fix: voice context prefix display leak, input sanitization, and timing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -235,6 +235,11 @@ final class VoiceModeManager: ObservableObject {
         voiceService.resetStreamingTTS()
 
         Task {
+            // Capture frontmost app context BEFORE awaiting transcription so we
+            // capture the app the user was looking at when they spoke, not after
+            // potential app switches during transcription finalization.
+            let ctx = DictationContextCapture.capture()
+
             let text = await voiceService.stopRecordingAndGetTranscription()
             let trimmed = (text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -252,27 +257,48 @@ final class VoiceModeManager: ObservableObject {
 
             partialTranscription = trimmed
 
-            // Capture frontmost app context so the daemon knows what the user
-            // is looking at during voice conversations (matches PTT behavior).
-            let ctx = DictationContextCapture.capture()
+            // Build the context prefix from captured app context. Sanitize
+            // attacker-controlled values (window titles, selected text) to
+            // prevent prompt injection and excessive length.
             var contextPrefix = ""
             if !ctx.appName.isEmpty {
                 var parts: [String] = ["app: \(ctx.appName)"]
                 if !ctx.windowTitle.isEmpty {
-                    parts.append("window: \"\(ctx.windowTitle)\"")
+                    let sanitizedTitle = Self.sanitize(ctx.windowTitle, maxLength: 200)
+                    parts.append("window: \"\(sanitizedTitle)\"")
                 }
                 if let selected = ctx.selectedText, !selected.isEmpty {
-                    parts.append("selected text: \"\(selected)\"")
+                    let sanitizedSelected = Self.sanitize(selected, maxLength: 500)
+                    parts.append("selected text: \"\(sanitizedSelected)\"")
                 }
                 contextPrefix = "[User's current \(parts.joined(separator: ", "))]\n"
             }
 
-            // Send the transcribed message through the daemon (full context)
+            // Pass context via pendingVoiceContextPrefix so it's injected into
+            // the daemon-bound text only — not into inputText, which is used for
+            // chat bubble display and thread auto-titling.
             chatViewModel.pendingVoiceMessage = true
-            chatViewModel.inputText = contextPrefix + trimmed
+            if !contextPrefix.isEmpty {
+                chatViewModel.pendingVoiceContextPrefix = contextPrefix
+            }
+            chatViewModel.inputText = trimmed
             chatViewModel.sendMessage()
             log.info("Voice mode: sent transcription to chat via daemon")
         }
+    }
+
+    /// Sanitize attacker-controlled text (window titles, selected text) by
+    /// truncating to a maximum length and stripping bracket patterns like
+    /// `[...]` that could be confused with instruction markers.
+    private static func sanitize(_ input: String, maxLength: Int) -> String {
+        var result = String(input.prefix(maxLength))
+        // Strip bracket patterns that could look like instruction markers
+        result = result.replacingOccurrences(
+            of: "\\[.*?\\]",
+            with: "",
+            options: .regularExpression
+        )
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     // MARK: - Streaming TTS from daemon response

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -321,6 +321,11 @@ public final class ChatViewModel: ObservableObject {
     public var onVoiceTextDelta: ((String) -> Void)?
     /// When true, messages are prefixed with a concise-response instruction for voice conversations.
     public var isVoiceModeActive: Bool = false
+    /// Context prefix captured by VoiceModeManager describing the user's frontmost app.
+    /// Injected into the daemon-bound text (not rawText) alongside the voice instruction
+    /// prefix, then cleared after send. This avoids leaking context into chat bubbles
+    /// and thread auto-titles.
+    public var pendingVoiceContextPrefix: String?
     var pendingUserAttachments: [IPCAttachment]?
     /// Stores the last user message that failed to send, enabling retry.
     private(set) var lastFailedMessageText: String?
@@ -813,8 +818,10 @@ public final class ChatViewModel: ObservableObject {
 
     public func sendMessage() {
         let rawText = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let voiceContextPrefix = pendingVoiceContextPrefix ?? ""
+        pendingVoiceContextPrefix = nil
         let text = isVoiceModeActive
-            ? "[Voice conversation — keep spoken responses brief (2-3 sentences) but fully complete the task using any tools needed. Do not give up early. Proactively use tools to fulfill requests rather than describing how. When interacting with macOS apps (Messages, Contacts, Calendar, Reminders, Notes, Mail, etc.), always use osascript with AppleScript — never query databases directly or use sqlite3. Prefer CLI tools and background automation (osascript/AppleScript) over foreground computer use, which takes over the user's screen.]\n\n\(rawText)"
+            ? "[Voice conversation — keep spoken responses brief (2-3 sentences) but fully complete the task using any tools needed. Do not give up early. Proactively use tools to fulfill requests rather than describing how. When interacting with macOS apps (Messages, Contacts, Calendar, Reminders, Notes, Mail, etc.), always use osascript with AppleScript — never query databases directly or use sqlite3. Prefer CLI tools and background automation (osascript/AppleScript) over foreground computer use, which takes over the user's screen.]\n\n\(voiceContextPrefix)\(rawText)"
             : rawText
         let hasAttachments = !pendingAttachments.isEmpty
         let hasSkillInvocation = pendingSkillInvocation != nil


### PR DESCRIPTION
Fixes three issues from review of #9786: (1) Context prefix no longer leaks into chat message bubbles and thread titles — moved from inputText to a dedicated pendingVoiceContextPrefix property that's injected into the daemon-bound text only, matching the voice instruction prefix pattern. (2) Window titles and selected text are now truncated and sanitized to prevent prompt injection. (3) App context is captured before awaiting transcription finalization to avoid stale context from app switches.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
