### PR TITLE
refactor: migrate route error responses to standard format

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -38,6 +38,7 @@ import { getLogger } from '../util/logger.js';
 import { buildAssistantEvent } from './assistant-event.js';
 import { assistantEventHub } from './assistant-event-hub.js';
 import { sweepFailedEvents } from './channel-retry-sweep.js';
+import { httpError } from './http-errors.js';
 // Middleware
 import {
   extractBearerToken,
@@ -369,7 +370,7 @@ export class RuntimeHttpServer {
     if (!isHttpAuthDisabled() && this.bearerToken) {
       const token = extractBearerToken(req);
       if (!token || !verifyBearerToken(token, this.bearerToken)) {
-        return Response.json({ error: 'Unauthorized' }, { status: 401 });
+        return httpError('UNAUTHORIZED', 'Unauthorized', 401);
       }
     }
 
@@ -412,7 +413,7 @@ export class RuntimeHttpServer {
         return handleServePage(pagesMatch[1]);
       } catch (err) {
         log.error({ err, appId: pagesMatch[1] }, 'Runtime HTTP handler error serving page');
-        return Response.json({ error: 'Internal server error' }, { status: 500 });
+        return httpError('INTERNAL_ERROR', 'Internal server error', 500);
       }
     }
 
@@ -420,7 +421,7 @@ export class RuntimeHttpServer {
     if (path === '/v1/apps/share' && req.method === 'POST') {
       try { return await handleShareApp(req); } catch (err) {
         log.error({ err }, 'Runtime HTTP handler error sharing app');
-        return Response.json({ error: 'Internal server error' }, { status: 500 });
+        return httpError('INTERNAL_ERROR', 'Internal server error', 500);
       }
     }
 
@@ -430,13 +431,13 @@ export class RuntimeHttpServer {
       if (req.method === 'GET') {
         try { return handleDownloadSharedApp(shareToken); } catch (err) {
           log.error({ err, shareToken }, 'Runtime HTTP handler error downloading shared app');
-          return Response.json({ error: 'Internal server error' }, { status: 500 });
+          return httpError('INTERNAL_ERROR', 'Internal server error', 500);
         }
       }
       if (req.method === 'DELETE') {
         try { return handleDeleteSharedApp(shareToken); } catch (err) {
           log.error({ err, shareToken }, 'Runtime HTTP handler error deleting shared app');
-          return Response.json({ error: 'Internal server error' }, { status: 500 });
+          return httpError('INTERNAL_ERROR', 'Internal server error', 500);
         }
       }
     }
@@ -445,7 +446,7 @@ export class RuntimeHttpServer {
     if (sharedMetadataMatch && req.method === 'GET') {
       try { return handleGetSharedAppMetadata(sharedMetadataMatch[1]); } catch (err) {
         log.error({ err, shareToken: sharedMetadataMatch[1] }, 'Runtime HTTP handler error getting shared app metadata');
-        return Response.json({ error: 'Internal server error' }, { status: 500 });
+        return httpError('INTERNAL_ERROR', 'Internal server error', 500);
       }
     }
 
@@ -453,7 +454,7 @@ export class RuntimeHttpServer {
     if (path === '/v1/secrets' && req.method === 'POST') {
       try { return await handleAddSecret(req); } catch (err) {
         log.error({ err }, 'Runtime HTTP handler error adding secret');
-        return Response.json({ error: 'Internal server error' }, { status: 500 });
+        return httpError('INTERNAL_ERROR', 'Internal server error', 500);
       }
     }
 
@@ -466,7 +467,7 @@ export class RuntimeHttpServer {
     // Legacy: /v1/assistants/:assistantId/<endpoint>
     const match = path.match(/^\/v1\/assistants\/([^/]+)\/(.+)$/);
     if (!match) {
-      return Response.json({ error: 'Not found', source: 'runtime' }, { status: 404 });
+      return httpError('NOT_FOUND', 'Not found', 404);
     }
 
     const assistantId = canonicalChannelAssistantId(match[1]);
@@ -477,17 +478,14 @@ export class RuntimeHttpServer {
 
   private handleBrowserRelayUpgrade(req: Request, server: ReturnType<typeof Bun.serve>): Response {
     if (!isLoopbackHost(new URL(req.url).hostname) && !isPrivateNetworkPeer(server, req)) {
-      return Response.json(
-        { error: 'Browser relay only accepts connections from localhost', code: 'LOCALHOST_ONLY' },
-        { status: 403 },
-      );
+      return httpError('FORBIDDEN', 'Browser relay only accepts connections from localhost', 403);
     }
 
     if (!isHttpAuthDisabled() && this.bearerToken) {
       const wsUrl = new URL(req.url);
       const token = wsUrl.searchParams.get('token');
       if (!token || !verifyBearerToken(token, this.bearerToken)) {
-        return Response.json({ error: 'Unauthorized' }, { status: 401 });
+        return httpError('UNAUTHORIZED', 'Unauthorized', 401);
       }
     }
 
@@ -503,10 +501,7 @@ export class RuntimeHttpServer {
 
   private handleRelayUpgrade(req: Request, server: ReturnType<typeof Bun.serve>): Response {
     if (!isPrivateNetworkPeer(server, req) || !isPrivateNetworkOrigin(req)) {
-      return Response.json(
-        { error: 'Direct relay access disabled — only private network peers allowed', code: 'GATEWAY_ONLY' },
-        { status: 403 },
-      );
+      return httpError('FORBIDDEN', 'Direct relay access disabled — only private network peers allowed', 403);
     }
 
     const wsUrl = new URL(req.url);
@@ -534,10 +529,7 @@ export class RuntimeHttpServer {
     const twilioSubpath = resolvedTwilioSubpath;
 
     if (GATEWAY_ONLY_BLOCKED_SUBPATHS.has(twilioSubpath)) {
-      return Response.json(
-        { error: 'Direct webhook access disabled. Use the gateway.', code: 'GATEWAY_ONLY' },
-        { status: 410 },
-      );
+      return httpError('NOT_FOUND', 'Direct webhook access disabled. Use the gateway.', 410);
     }
 
     const validation = await validateTwilioWebhook(req);
@@ -574,7 +566,7 @@ export class RuntimeHttpServer {
           const resp = await extensionRelayServer.sendCommand(body as Omit<import('../browser-extension-relay/protocol.js').ExtensionCommand, 'id'>);
           return Response.json(resp);
         } catch (err) {
-          return Response.json({ success: false, error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+          return httpError('INTERNAL_ERROR', err instanceof Error ? err.message : String(err), 500);
         }
       }
 
@@ -627,7 +619,7 @@ export class RuntimeHttpServer {
       if (endpoint === 'conversations/seen' && req.method === 'POST') {
         const body = await req.json() as Record<string, unknown>;
         const conversationId = body.conversationId as string | undefined;
-        if (!conversationId) return Response.json({ error: 'Missing conversationId' }, { status: 400 });
+        if (!conversationId) return httpError('BAD_REQUEST', 'Missing conversationId', 400);
         try {
           recordConversationSeenSignal({
             conversationId,
@@ -643,7 +635,7 @@ export class RuntimeHttpServer {
           return Response.json({ ok: true });
         } catch (err) {
           log.error({ err, conversationId }, 'POST /v1/conversations/seen: failed');
-          return Response.json({ error: 'Failed to record seen signal' }, { status: 500 });
+          return httpError('INTERNAL_ERROR', 'Failed to record seen signal', 500);
         }
       }
 
@@ -756,32 +748,32 @@ export class RuntimeHttpServer {
       // Internal OAuth callback endpoint (gateway -> runtime)
       if (endpoint === 'internal/oauth/callback' && req.method === 'POST') {
         const json = await req.json() as { state: string; code?: string; error?: string };
-        if (!json.state) return Response.json({ error: 'Missing state parameter' }, { status: 400 });
+        if (!json.state) return httpError('BAD_REQUEST', 'Missing state parameter', 400);
         if (json.error) {
           const consumed = consumeCallbackError(json.state, json.error);
-          return consumed ? Response.json({ ok: true }) : Response.json({ error: 'Unknown state' }, { status: 404 });
+          return consumed ? Response.json({ ok: true }) : httpError('NOT_FOUND', 'Unknown state', 404);
         }
         if (json.code) {
           const consumed = consumeCallback(json.state, json.code);
-          return consumed ? Response.json({ ok: true }) : Response.json({ error: 'Unknown state' }, { status: 404 });
+          return consumed ? Response.json({ ok: true }) : httpError('NOT_FOUND', 'Unknown state', 404);
         }
-        return Response.json({ error: 'Missing code or error parameter' }, { status: 400 });
+        return httpError('BAD_REQUEST', 'Missing code or error parameter', 400);
       }
 
-      return Response.json({ error: 'Not found', source: 'runtime' }, { status: 404 });
+      return httpError('NOT_FOUND', 'Not found', 404);
     });
   }
 
   private handleGetInterface(interfacePath: string): Response {
     if (!this.interfacesDir) {
-      return Response.json({ error: 'Interface not found' }, { status: 404 });
+      return httpError('NOT_FOUND', 'Interface not found', 404);
     }
     const fullPath = resolve(this.interfacesDir, interfacePath);
     if (
       (fullPath !== this.interfacesDir && !fullPath.startsWith(this.interfacesDir + '/')) ||
       !existsSync(fullPath)
     ) {
-      return Response.json({ error: 'Interface not found' }, { status: 404 });
+      return httpError('NOT_FOUND', 'Interface not found', 404);
     }
     const source = readFileSync(fullPath, 'utf-8');
     return new Response(source, {

--- a/assistant/src/runtime/middleware/error-handler.ts
+++ b/assistant/src/runtime/middleware/error-handler.ts
@@ -4,6 +4,7 @@
 
 import { ConfigError, IngressBlockedError } from '../../util/errors.js';
 import { getLogger } from '../../util/logger.js';
+import { httpError } from '../http-errors.js';
 
 const log = getLogger('runtime-http');
 
@@ -20,14 +21,14 @@ export async function withErrorHandling(
   } catch (err) {
     if (err instanceof IngressBlockedError) {
       log.warn({ endpoint, detectedTypes: err.detectedTypes }, 'Blocked HTTP request containing secrets');
-      return Response.json({ error: err.message, code: err.code }, { status: 422 });
+      return httpError('UNPROCESSABLE_ENTITY', err.message, 422);
     }
     if (err instanceof ConfigError) {
       log.warn({ err, endpoint }, 'Runtime HTTP config error');
-      return Response.json({ error: err.message, code: err.code }, { status: 422 });
+      return httpError('UNPROCESSABLE_ENTITY', err.message, 422);
     }
     log.error({ err, endpoint }, 'Runtime HTTP handler error');
     const message = err instanceof Error ? err.message : 'Internal server error';
-    return Response.json({ error: message }, { status: 500 });
+    return httpError('INTERNAL_ERROR', message, 500);
   }
 }

--- a/assistant/src/runtime/middleware/rate-limiter.ts
+++ b/assistant/src/runtime/middleware/rate-limiter.ts
@@ -2,6 +2,8 @@
 // Tracks request counts per token and returns 429 when the limit is exceeded.
 // Follows the same sliding-window pattern as gateway/src/auth-rate-limiter.ts.
 
+import type { HttpErrorResponse } from '../http-errors.js';
+
 const DEFAULT_MAX_REQUESTS = 60;
 const DEFAULT_WINDOW_MS = 60_000; // 60 seconds
 const MAX_TRACKED_TOKENS = 10_000;
@@ -103,16 +105,16 @@ export function rateLimitHeaders(result: RateLimitResult): Record<string, string
 /** Return a 429 response with rate limit headers and a Retry-After hint. */
 export function rateLimitResponse(result: RateLimitResult): Response {
   const retryAfter = Math.max(1, result.resetAt - Math.ceil(Date.now() / 1000));
-  return Response.json(
-    { error: 'Too Many Requests' },
-    {
-      status: 429,
-      headers: {
-        ...rateLimitHeaders(result),
-        'Retry-After': String(retryAfter),
-      },
+  const body: HttpErrorResponse = {
+    error: { code: 'RATE_LIMITED', message: 'Too Many Requests' },
+  };
+  return Response.json(body, {
+    status: 429,
+    headers: {
+      ...rateLimitHeaders(result),
+      'Retry-After': String(retryAfter),
     },
-  );
+  });
 }
 
 /** Singleton rate limiter for the runtime HTTP API. */

--- a/assistant/src/runtime/middleware/twilio-validation.ts
+++ b/assistant/src/runtime/middleware/twilio-validation.ts
@@ -7,6 +7,7 @@ import { isTwilioWebhookValidationDisabled } from '../../config/env.js';
 import { loadConfig } from '../../config/loader.js';
 import { getPublicBaseUrl } from '../../inbound/public-ingress-urls.js';
 import { getLogger } from '../../util/logger.js';
+import { httpError } from '../http-errors.js';
 
 const log = getLogger('runtime-http');
 
@@ -68,13 +69,13 @@ export async function validateTwilioWebhook(
   // Fail-closed: reject if no auth token is configured
   if (!authToken) {
     log.error('Twilio auth token not configured — rejecting webhook request (fail-closed)');
-    return Response.json({ error: 'Forbidden' }, { status: 403 });
+    return httpError('FORBIDDEN', 'Forbidden', 403);
   }
 
   const signature = req.headers.get('x-twilio-signature');
   if (!signature) {
     log.warn('Twilio webhook request missing X-Twilio-Signature header');
-    return Response.json({ error: 'Forbidden' }, { status: 403 });
+    return httpError('FORBIDDEN', 'Forbidden', 403);
   }
 
   // Parse form-urlencoded body into key-value params for signature computation
@@ -108,7 +109,7 @@ export async function validateTwilioWebhook(
 
   if (!isValid) {
     log.warn('Twilio webhook signature validation failed');
-    return Response.json({ error: 'Forbidden' }, { status: 403 });
+    return httpError('FORBIDDEN', 'Forbidden', 403);
   }
 
   return { body: rawBody };

--- a/assistant/src/runtime/routes/app-routes.ts
+++ b/assistant/src/runtime/routes/app-routes.ts
@@ -11,6 +11,7 @@ import type { AppManifest } from '../../bundler/manifest.js';
 import { getApp } from '../../memory/app-store.js';
 import * as sharedAppLinksStore from '../../memory/shared-app-links-store.js';
 import { getLogger } from '../../util/logger.js';
+import { httpError } from '../http-errors.js';
 
 const log = getLogger('runtime-http');
 
@@ -41,7 +42,7 @@ function loadDesignSystemCss(): string {
 export function handleServePage(appId: string): Response {
   const app = getApp(appId);
   if (!app) {
-    return Response.json({ error: 'App not found' }, { status: 404 });
+    return httpError('NOT_FOUND', 'App not found', 404);
   }
 
   const css = loadDesignSystemCss();
@@ -96,16 +97,13 @@ const MAX_SHARE_BODY_BYTES = 50 * 1024 * 1024;
 export async function handleShareApp(req: Request): Promise<Response> {
   const rawBody = await req.arrayBuffer();
   if (rawBody.byteLength > MAX_SHARE_BODY_BYTES) {
-    return Response.json(
-      { error: `Request body too large (limit: ${MAX_SHARE_BODY_BYTES} bytes)` },
-      { status: 413 },
-    );
+    return httpError('BAD_REQUEST', `Request body too large (limit: ${MAX_SHARE_BODY_BYTES} bytes)`, 413);
   }
 
   const bundleData = Buffer.from(rawBody);
 
   if (bundleData.length === 0) {
-    return Response.json({ error: 'Empty body' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'Empty body', 400);
   }
 
   // Validate it's a valid zip with a manifest.json
@@ -114,16 +112,16 @@ export async function handleShareApp(req: Request): Promise<Response> {
     const zip = await JSZip.loadAsync(bundleData);
     const manifestFile = zip.file('manifest.json');
     if (!manifestFile) {
-      return Response.json({ error: 'Invalid bundle: missing manifest.json' }, { status: 400 });
+      return httpError('BAD_REQUEST', 'Invalid bundle: missing manifest.json', 400);
     }
     const manifestText = await manifestFile.async('text');
     manifest = JSON.parse(manifestText) as AppManifest;
     if (!manifest.name || !manifest.entry) {
-      return Response.json({ error: 'Invalid manifest: missing required fields' }, { status: 400 });
+      return httpError('BAD_REQUEST', 'Invalid manifest: missing required fields', 400);
     }
   } catch (err) {
     if (err instanceof Response) throw err;
-    return Response.json({ error: 'Invalid zip file' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'Invalid zip file', 400);
   }
 
   const { shareToken } = sharedAppLinksStore.createSharedAppLink(bundleData, manifest);
@@ -138,7 +136,7 @@ export async function handleShareApp(req: Request): Promise<Response> {
 export function handleDownloadSharedApp(shareToken: string): Response {
   const record = sharedAppLinksStore.getSharedAppLink(shareToken);
   if (!record) {
-    return Response.json({ error: 'Shared app not found' }, { status: 404 });
+    return httpError('NOT_FOUND', 'Shared app not found', 404);
   }
 
   sharedAppLinksStore.incrementDownloadCount(shareToken);
@@ -154,14 +152,14 @@ export function handleDownloadSharedApp(shareToken: string): Response {
 export function handleGetSharedAppMetadata(shareToken: string): Response {
   const record = sharedAppLinksStore.getSharedAppLink(shareToken);
   if (!record) {
-    return Response.json({ error: 'Shared app not found' }, { status: 404 });
+    return httpError('NOT_FOUND', 'Shared app not found', 404);
   }
 
   let manifest: AppManifest;
   try {
     manifest = JSON.parse(record.manifestJson) as AppManifest;
   } catch {
-    return Response.json({ error: 'Corrupted manifest data' }, { status: 500 });
+    return httpError('INTERNAL_ERROR', 'Corrupted manifest data', 500);
   }
 
   return Response.json({
@@ -175,7 +173,7 @@ export function handleGetSharedAppMetadata(shareToken: string): Response {
 export function handleDeleteSharedApp(shareToken: string): Response {
   const deleted = sharedAppLinksStore.deleteSharedAppLinkByToken(shareToken);
   if (!deleted) {
-    return Response.json({ error: 'Shared app not found' }, { status: 404 });
+    return httpError('NOT_FOUND', 'Shared app not found', 404);
   }
   return Response.json({ success: true });
 }

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -8,6 +8,7 @@ import { getConversationByKey } from '../../memory/conversation-key-store.js';
 import { addRule } from '../../permissions/trust-store.js';
 import { getTool } from '../../tools/registry.js';
 import { getLogger } from '../../util/logger.js';
+import { httpError } from '../http-errors.js';
 import * as pendingInteractions from '../pending-interactions.js';
 
 const log = getLogger('approval-routes');
@@ -24,22 +25,16 @@ export async function handleConfirm(req: Request): Promise<Response> {
   const { requestId, decision } = body;
 
   if (!requestId || typeof requestId !== 'string') {
-    return Response.json({ error: 'requestId is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'requestId is required', 400);
   }
 
   if (decision !== 'allow' && decision !== 'deny') {
-    return Response.json(
-      { error: 'decision must be "allow" or "deny"' },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', 'decision must be "allow" or "deny"', 400);
   }
 
   const interaction = pendingInteractions.resolve(requestId);
   if (!interaction) {
-    return Response.json(
-      { error: 'No pending interaction found for this requestId' },
-      { status: 404 },
-    );
+    return httpError('NOT_FOUND', 'No pending interaction found for this requestId', 404);
   }
 
   interaction.session.handleConfirmationResponse(requestId, decision);
@@ -59,22 +54,16 @@ export async function handleSecret(req: Request): Promise<Response> {
   const { requestId, value, delivery } = body;
 
   if (!requestId || typeof requestId !== 'string') {
-    return Response.json({ error: 'requestId is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'requestId is required', 400);
   }
 
   if (delivery !== undefined && delivery !== 'store' && delivery !== 'transient_send') {
-    return Response.json(
-      { error: 'delivery must be "store" or "transient_send"' },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', 'delivery must be "store" or "transient_send"', 400);
   }
 
   const interaction = pendingInteractions.resolve(requestId);
   if (!interaction) {
-    return Response.json(
-      { error: 'No pending interaction found for this requestId' },
-      { status: 404 },
-    );
+    return httpError('NOT_FOUND', 'No pending interaction found for this requestId', 404);
   }
 
   interaction.session.handleSecretResponse(
@@ -104,62 +93,47 @@ export async function handleTrustRule(req: Request): Promise<Response> {
   const { requestId, pattern, scope, decision } = body;
 
   if (!requestId || typeof requestId !== 'string') {
-    return Response.json({ error: 'requestId is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'requestId is required', 400);
   }
 
   if (!pattern || typeof pattern !== 'string') {
-    return Response.json({ error: 'pattern is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'pattern is required', 400);
   }
 
   if (!scope || typeof scope !== 'string') {
-    return Response.json({ error: 'scope is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'scope is required', 400);
   }
 
   if (decision !== 'allow' && decision !== 'deny') {
-    return Response.json({ error: 'decision must be "allow" or "deny"' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'decision must be "allow" or "deny"', 400);
   }
 
   // Look up without removing — trust rule doesn't resolve the confirmation
   const interaction = pendingInteractions.get(requestId);
   if (!interaction) {
-    return Response.json(
-      { error: 'No pending interaction found for this requestId' },
-      { status: 404 },
-    );
+    return httpError('NOT_FOUND', 'No pending interaction found for this requestId', 404);
   }
 
   if (!interaction.confirmationDetails) {
-    return Response.json(
-      { error: 'No confirmation details available for this request' },
-      { status: 409 },
-    );
+    return httpError('CONFLICT', 'No confirmation details available for this request', 409);
   }
 
   const confirmation = interaction.confirmationDetails;
 
   if (confirmation.persistentDecisionsAllowed === false) {
-    return Response.json(
-      { error: 'Persistent trust rules are not allowed for this tool invocation' },
-      { status: 403 },
-    );
+    return httpError('FORBIDDEN', 'Persistent trust rules are not allowed for this tool invocation', 403);
   }
 
   // Validate pattern against server-provided allowlist options
   const validPatterns = (confirmation.allowlistOptions ?? []).map((o) => o.pattern);
   if (!validPatterns.includes(pattern)) {
-    return Response.json(
-      { error: 'pattern does not match any server-provided allowlist option' },
-      { status: 403 },
-    );
+    return httpError('FORBIDDEN', 'pattern does not match any server-provided allowlist option', 403);
   }
 
   // Validate scope against server-provided scope options
   const validScopes = (confirmation.scopeOptions ?? []).map((o) => o.scope);
   if (!validScopes.includes(scope)) {
-    return Response.json(
-      { error: 'scope does not match any server-provided scope option' },
-      { status: 403 },
-    );
+    return httpError('FORBIDDEN', 'scope does not match any server-provided scope option', 403);
   }
 
   try {
@@ -175,7 +149,7 @@ export async function handleTrustRule(req: Request): Promise<Response> {
     return Response.json({ accepted: true });
   } catch (err) {
     log.error({ err }, 'Failed to add trust rule');
-    return Response.json({ error: 'Failed to add trust rule' }, { status: 500 });
+    return httpError('INTERNAL_ERROR', 'Failed to add trust rule', 500);
   }
 }
 
@@ -197,10 +171,7 @@ export function handleListPendingInteractions(url: URL): Response {
     const mapping = getConversationByKey(conversationKey);
     resolvedConversationId = mapping?.conversationId;
   } else {
-    return Response.json(
-      { error: 'conversationKey or conversationId query parameter is required' },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', 'conversationKey or conversationId query parameter is required', 400);
   }
 
   if (!resolvedConversationId) {

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -5,6 +5,7 @@ import { existsSync } from 'node:fs';
 
 import * as attachmentsStore from '../../memory/attachments-store.js';
 import { AttachmentUploadError, getFilePathForAttachment, validateAttachmentUpload } from '../../memory/attachments-store.js';
+import { httpError } from '../http-errors.js';
 
 /** 30 MB — base64-encoded 20 MB attachment ≈ 27 MB plus JSON wrapper overhead. */
 const MAX_UPLOAD_BODY_BYTES = 30 * 1024 * 1024;
@@ -12,10 +13,7 @@ const MAX_UPLOAD_BODY_BYTES = 30 * 1024 * 1024;
 export async function handleUploadAttachment(req: Request): Promise<Response> {
   const rawBody = await req.arrayBuffer();
   if (rawBody.byteLength > MAX_UPLOAD_BODY_BYTES) {
-    return Response.json(
-      { error: `Request body too large (limit: ${MAX_UPLOAD_BODY_BYTES} bytes)` },
-      { status: 413 },
-    );
+    return httpError('BAD_REQUEST', `Request body too large (limit: ${MAX_UPLOAD_BODY_BYTES} bytes)`, 413);
   }
 
   const body = JSON.parse(new TextDecoder().decode(rawBody)) as {
@@ -27,32 +25,20 @@ export async function handleUploadAttachment(req: Request): Promise<Response> {
   const { filename, mimeType, data } = body;
 
   if (!filename || typeof filename !== 'string') {
-    return Response.json(
-      { error: 'filename is required' },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', 'filename is required', 400);
   }
 
   if (!mimeType || typeof mimeType !== 'string') {
-    return Response.json(
-      { error: 'mimeType is required' },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', 'mimeType is required', 400);
   }
 
   if (!data || typeof data !== 'string') {
-    return Response.json(
-      { error: 'data (base64) is required' },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', 'data (base64) is required', 400);
   }
 
   const validation = validateAttachmentUpload(filename, mimeType);
   if (!validation.ok) {
-    return Response.json(
-      { error: validation.error },
-      { status: 415 },
-    );
+    return httpError('UNPROCESSABLE_ENTITY', validation.error, 415);
   }
 
   let attachment: attachmentsStore.StoredAttachment;
@@ -65,7 +51,7 @@ export async function handleUploadAttachment(req: Request): Promise<Response> {
   } catch (err) {
     if (err instanceof AttachmentUploadError) {
       const status = err.message.startsWith('Attachment too large') ? 413 : 400;
-      return Response.json({ error: err.message }, { status });
+      return httpError('BAD_REQUEST', err.message, status);
     }
     throw err;
   }
@@ -84,35 +70,23 @@ export async function handleDeleteAttachment(req: Request): Promise<Response> {
   try {
     body = await req.json() as { attachmentId?: string };
   } catch {
-    return Response.json(
-      { error: 'Invalid or missing JSON body' },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', 'Invalid or missing JSON body', 400);
   }
 
   const { attachmentId } = body;
 
   if (!attachmentId || typeof attachmentId !== 'string') {
-    return Response.json(
-      { error: 'attachmentId is required' },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', 'attachmentId is required', 400);
   }
 
   const result = attachmentsStore.deleteAttachment(attachmentId);
 
   if (result === 'not_found') {
-    return Response.json(
-      { error: 'Attachment not found' },
-      { status: 404 },
-    );
+    return httpError('NOT_FOUND', 'Attachment not found', 404);
   }
 
   if (result === 'still_referenced') {
-    return Response.json(
-      { error: 'Attachment is still referenced by one or more messages' },
-      { status: 409 },
-    );
+    return httpError('CONFLICT', 'Attachment is still referenced by one or more messages', 409);
   }
 
   return new Response(null, { status: 204 });
@@ -121,7 +95,7 @@ export async function handleDeleteAttachment(req: Request): Promise<Response> {
 export function handleGetAttachment(attachmentId: string): Response {
   const attachment = attachmentsStore.getAttachmentById(attachmentId);
   if (!attachment) {
-    return Response.json({ error: 'Attachment not found' }, { status: 404 });
+    return httpError('NOT_FOUND', 'Attachment not found', 404);
   }
 
   // Use the file_path column to detect file-backed attachments, not string
@@ -148,14 +122,14 @@ export function handleGetAttachment(attachmentId: string): Response {
 export function handleGetAttachmentContent(attachmentId: string, req: Request): Response {
   const attachment = attachmentsStore.getAttachmentById(attachmentId);
   if (!attachment) {
-    return Response.json({ error: 'Attachment not found' }, { status: 404 });
+    return httpError('NOT_FOUND', 'Attachment not found', 404);
   }
 
   // Check for file-backed attachment
   const filePath = getFilePathForAttachment(attachmentId);
   if (filePath) {
     if (!existsSync(filePath)) {
-      return Response.json({ error: 'Recording file not found on disk' }, { status: 404 });
+      return httpError('NOT_FOUND', 'Recording file not found on disk', 404);
     }
 
     const file = Bun.file(filePath);
@@ -223,7 +197,7 @@ export function handleGetAttachmentContent(attachmentId: string, req: Request): 
 
   // Fall back to base64-decoded content for inline attachments
   if (!attachment.dataBase64) {
-    return Response.json({ error: 'No content available' }, { status: 404 });
+    return httpError('NOT_FOUND', 'No content available', 404);
   }
 
   const buffer = Buffer.from(attachment.dataBase64, 'base64');

--- a/assistant/src/runtime/routes/call-routes.ts
+++ b/assistant/src/runtime/routes/call-routes.ts
@@ -11,6 +11,7 @@
 import { answerCall, cancelCall, getCallStatus, relayInstruction,startCall } from '../../calls/call-domain.js';
 import { getConfig } from '../../config/loader.js';
 import { VALID_CALLER_IDENTITY_MODES } from '../../config/schema.js';
+import { httpError } from '../http-errors.js';
 
 // ── Idempotency cache ─────────────────────────────────────────────────────────
 // Stores serialized 201 responses keyed by idempotencyKey for 5 minutes so
@@ -42,10 +43,7 @@ function pruneIdempotencyCache(): void {
  */
 export async function handleStartCall(req: Request, assistantId: string = 'self'): Promise<Response> {
   if (!getConfig().calls.enabled) {
-    return Response.json(
-      { error: 'Calls feature is disabled via configuration. Set calls.enabled to true to use this feature.' },
-      { status: 403 },
-    );
+    return httpError('FORBIDDEN', 'Calls feature is disabled via configuration. Set calls.enabled to true to use this feature.', 403);
   }
 
   let body: {
@@ -59,23 +57,20 @@ export async function handleStartCall(req: Request, assistantId: string = 'self'
   try {
     body = await req.json() as typeof body;
   } catch {
-    return Response.json({ error: 'Invalid JSON in request body' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'Invalid JSON in request body', 400);
   }
 
   if (typeof body !== 'object' || body == null || Array.isArray(body)) {
-    return Response.json({ error: 'Request body must be a JSON object' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'Request body must be a JSON object', 400);
   }
 
   if (!body.conversationId) {
-    return Response.json({ error: 'conversationId is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'conversationId is required', 400);
   }
 
   if (body.callerIdentityMode != null &&
       !(VALID_CALLER_IDENTITY_MODES as readonly string[]).includes(body.callerIdentityMode as string)) {
-    return Response.json(
-      { error: `Invalid callerIdentityMode: "${body.callerIdentityMode}". Must be one of: ${VALID_CALLER_IDENTITY_MODES.join(', ')}` },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', `Invalid callerIdentityMode: "${body.callerIdentityMode}". Must be one of: ${VALID_CALLER_IDENTITY_MODES.join(', ')}`, 400);
   }
 
   // Idempotency check: return cached response for duplicate requests
@@ -101,7 +96,7 @@ export async function handleStartCall(req: Request, assistantId: string = 'self'
   });
 
   if (!result.ok) {
-    return Response.json({ error: result.error }, { status: result.status ?? 500 });
+    return httpError('INTERNAL_ERROR', result.error, result.status ?? 500);
   }
 
   const responseBody = {
@@ -127,7 +122,7 @@ export function handleGetCallStatus(callSessionId: string): Response {
   const result = getCallStatus(callSessionId);
 
   if (!result.ok) {
-    return Response.json({ error: result.error }, { status: result.status ?? 500 });
+    return httpError('INTERNAL_ERROR', result.error, result.status ?? 500);
   }
 
   const { session } = result;
@@ -166,7 +161,7 @@ export async function handleCancelCall(req: Request, callSessionId: string): Pro
   const result = await cancelCall({ callSessionId, reason });
 
   if (!result.ok) {
-    return Response.json({ error: result.error }, { status: result.status ?? 500 });
+    return httpError('INTERNAL_ERROR', result.error, result.status ?? 500);
   }
 
   return Response.json({
@@ -185,11 +180,11 @@ export async function handleAnswerCall(req: Request, callSessionId: string): Pro
   try {
     body = await req.json() as typeof body;
   } catch {
-    return Response.json({ error: 'Invalid JSON in request body' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'Invalid JSON in request body', 400);
   }
 
   if (typeof body !== 'object' || body == null || Array.isArray(body)) {
-    return Response.json({ error: 'Request body must be a JSON object' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'Request body must be a JSON object', 400);
   }
 
   const result = await answerCall({
@@ -198,7 +193,7 @@ export async function handleAnswerCall(req: Request, callSessionId: string): Pro
   });
 
   if (!result.ok) {
-    return Response.json({ error: result.error }, { status: result.status ?? 500 });
+    return httpError('INTERNAL_ERROR', result.error, result.status ?? 500);
   }
 
   return Response.json({ ok: true, questionId: result.questionId });
@@ -214,11 +209,11 @@ export async function handleInstructionCall(req: Request, callSessionId: string)
   try {
     body = await req.json() as typeof body;
   } catch {
-    return Response.json({ error: 'Invalid JSON in request body' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'Invalid JSON in request body', 400);
   }
 
   if (typeof body !== 'object' || body == null || Array.isArray(body)) {
-    return Response.json({ error: 'Request body must be a JSON object' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'Request body must be a JSON object', 400);
   }
 
   const result = await relayInstruction({
@@ -227,7 +222,7 @@ export async function handleInstructionCall(req: Request, callSessionId: string)
   });
 
   if (!result.ok) {
-    return Response.json({ error: result.error }, { status: result.status ?? 500 });
+    return httpError('INTERNAL_ERROR', result.error, result.status ?? 500);
   }
 
   return Response.json({ ok: true });

--- a/assistant/src/runtime/routes/channel-delivery-routes.ts
+++ b/assistant/src/runtime/routes/channel-delivery-routes.ts
@@ -3,6 +3,7 @@
  * and post-decision delivery scheduling.
  */
 import * as channelDeliveryStore from '../../memory/channel-delivery-store.js';
+import { httpError } from '../http-errors.js';
 export { type DeliverReplyOptions,deliverReplyViaCallback } from '../channel-reply-delivery.js';
 
 // ---------------------------------------------------------------------------
@@ -19,7 +20,7 @@ export async function handleReplayDeadLetters(req: Request): Promise<Response> {
   const eventIds = body.eventIds;
 
   if (!Array.isArray(eventIds) || eventIds.length === 0) {
-    return Response.json({ error: 'eventIds array is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'eventIds array is required', 400);
   }
 
   const replayed = channelDeliveryStore.replayDeadLetters(eventIds);
@@ -40,13 +41,13 @@ export async function handleChannelDeliveryAck(req: Request): Promise<Response> 
   const { sourceChannel, externalChatId, externalMessageId } = body;
 
   if (!sourceChannel || typeof sourceChannel !== 'string') {
-    return Response.json({ error: 'sourceChannel is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'sourceChannel is required', 400);
   }
   if (!externalChatId || typeof externalChatId !== 'string') {
-    return Response.json({ error: 'externalChatId is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'externalChatId is required', 400);
   }
   if (!externalMessageId || typeof externalMessageId !== 'string') {
-    return Response.json({ error: 'externalMessageId is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'externalMessageId is required', 400);
   }
 
   const acked = channelDeliveryStore.acknowledgeDelivery(
@@ -56,7 +57,7 @@ export async function handleChannelDeliveryAck(req: Request): Promise<Response> 
   );
 
   if (!acked) {
-    return Response.json({ error: 'Inbound event not found' }, { status: 404 });
+    return httpError('NOT_FOUND', 'Inbound event not found', 404);
   }
 
   return new Response(null, { status: 204 });

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -7,6 +7,7 @@
  */
 
 import { getContact, listContacts, mergeContacts } from '../../contacts/contact-store.js';
+import { httpError } from '../http-errors.js';
 
 /**
  * GET /v1/contacts?limit=50
@@ -23,10 +24,7 @@ export function handleListContacts(url: URL): Response {
 export function handleGetContact(contactId: string): Response {
   const contact = getContact(contactId);
   if (!contact) {
-    return Response.json(
-      { ok: false, error: `Contact "${contactId}" not found` },
-      { status: 404 },
-    );
+    return httpError('NOT_FOUND', `Contact "${contactId}" not found`, 404);
   }
   return Response.json({ ok: true, contact });
 }
@@ -38,10 +36,7 @@ export async function handleMergeContacts(req: Request): Promise<Response> {
   const body = (await req.json()) as { keepId?: string; mergeId?: string };
 
   if (!body.keepId || !body.mergeId) {
-    return Response.json(
-      { ok: false, error: 'keepId and mergeId are required' },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', 'keepId and mergeId are required', 400);
   }
 
   try {
@@ -49,6 +44,6 @@ export async function handleMergeContacts(req: Request): Promise<Response> {
     return Response.json({ ok: true, contact });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    return Response.json({ ok: false, error: message }, { status: 400 });
+    return httpError('BAD_REQUEST', message, 400);
   }
 }

--- a/assistant/src/runtime/routes/conversation-attention-routes.ts
+++ b/assistant/src/runtime/routes/conversation-attention-routes.ts
@@ -10,6 +10,7 @@ import {
 } from '../../memory/conversation-attention-store.js';
 import * as conversationStore from '../../memory/conversation-store.js';
 import { truncate } from '../../util/truncate.js';
+import { httpError } from '../http-errors.js';
 
 export function handleListConversationAttention(url: URL): Response {
   const stateParam = url.searchParams.get('state') ?? 'all';
@@ -22,7 +23,7 @@ export function handleListConversationAttention(url: URL): Response {
   const before = rawBefore !== undefined && Number.isFinite(rawBefore) ? rawBefore : undefined;
 
   if (!['seen', 'unseen', 'all'].includes(stateParam)) {
-    return Response.json({ error: 'Invalid state parameter. Must be seen, unseen, or all.' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'Invalid state parameter. Must be seen, unseen, or all.', 400);
   }
 
   const attentionStates = listConversationAttention({

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -17,6 +17,7 @@ import { getConfiguredProvider } from '../../providers/provider-send-message.js'
 import type { Provider } from '../../providers/types.js';
 import { getLogger } from '../../util/logger.js';
 import { buildAssistantEvent } from '../assistant-event.js';
+import { httpError } from '../http-errors.js';
 import type {
   MessageProcessor,
   NonBlockingMessageProcessor,
@@ -64,10 +65,7 @@ export function handleListMessages(
     const mapping = getConversationByKey(conversationKey);
     resolvedConversationId = mapping?.conversationId;
   } else {
-    return Response.json(
-      { error: 'conversationKey or conversationId query parameter is required' },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', 'conversationKey or conversationId query parameter is required', 400);
   }
 
   if (!resolvedConversationId) {
@@ -217,57 +215,36 @@ export async function handleSendMessage(
 
   const { conversationKey, content, attachmentIds } = body;
   if (!body.sourceChannel || typeof body.sourceChannel !== 'string') {
-    return Response.json(
-      { error: 'sourceChannel is required' },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', 'sourceChannel is required', 400);
   }
   const sourceChannel = parseChannelId(body.sourceChannel);
 
   if (!sourceChannel) {
-    return Response.json(
-      { error: `Invalid sourceChannel: ${body.sourceChannel}. Valid values: ${CHANNEL_IDS.join(', ')}` },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', `Invalid sourceChannel: ${body.sourceChannel}. Valid values: ${CHANNEL_IDS.join(', ')}`, 400);
   }
 
   if (!body.interface || typeof body.interface !== 'string') {
-    return Response.json(
-      { error: 'interface is required' },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', 'interface is required', 400);
   }
   const sourceInterface = parseInterfaceId(body.interface);
   if (!sourceInterface) {
-    return Response.json(
-      { error: `Invalid interface: ${body.interface}. Valid values: ${INTERFACE_IDS.join(', ')}` },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', `Invalid interface: ${body.interface}. Valid values: ${INTERFACE_IDS.join(', ')}`, 400);
   }
 
   if (!conversationKey) {
-    return Response.json(
-      { error: 'conversationKey is required' },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', 'conversationKey is required', 400);
   }
 
   // Reject non-string content values (numbers, objects, etc.)
   if (content != null && typeof content !== 'string') {
-    return Response.json(
-      { error: 'content must be a string' },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', 'content must be a string', 400);
   }
 
   const trimmedContent = typeof content === 'string' ? content.trim() : '';
   const hasAttachments = Array.isArray(attachmentIds) && attachmentIds.length > 0;
 
   if (trimmedContent.length === 0 && !hasAttachments) {
-    return Response.json(
-      { error: 'content or attachmentIds is required' },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', 'content or attachmentIds is required', 400);
   }
 
   // Validate that all attachment IDs resolve
@@ -276,10 +253,7 @@ export async function handleSendMessage(
     if (resolved.length !== attachmentIds.length) {
       const resolvedIds = new Set(resolved.map((a) => a.id));
       const missing = attachmentIds.filter((id) => !resolvedIds.has(id));
-      return Response.json(
-        { error: `Attachment IDs not found: ${missing.join(', ')}` },
-        { status: 400 },
-      );
+      return httpError('BAD_REQUEST', `Attachment IDs not found: ${missing.join(', ')}`, 400);
     }
   }
 
@@ -317,10 +291,7 @@ export async function handleSendMessage(
         { isInteractive: false },
       );
       if (result.rejected) {
-        return Response.json(
-          { error: 'Message queue is full. Please retry later.' },
-          { status: 429 },
-        );
+        return httpError('RATE_LIMITED', 'Message queue is full. Please retry later.', 429);
       }
       return Response.json({ accepted: true, queued: true }, { status: 202 });
     }
@@ -349,7 +320,7 @@ export async function handleSendMessage(
   // ── Legacy path (fallback when sendMessageDeps not wired) ───────────
   const processor = deps.persistAndProcessMessage ?? deps.processMessage;
   if (!processor) {
-    return Response.json({ error: 'Message processing not configured' }, { status: 503 });
+    return httpError('SERVICE_UNAVAILABLE', 'Message processing not configured', 503);
   }
 
   try {
@@ -364,10 +335,7 @@ export async function handleSendMessage(
     return Response.json({ accepted: true, messageId: result.messageId }, { status: 202 });
   } catch (err) {
     if (err instanceof Error && err.message === 'Session is already processing a message') {
-      return Response.json(
-        { error: 'Session is busy processing another message. Please retry.' },
-        { status: 409 },
-      );
+      return httpError('CONFLICT', 'Session is busy processing another message. Please retry.', 409);
     }
     throw err;
   }
@@ -406,10 +374,7 @@ export async function handleGetSuggestion(
 ): Promise<Response> {
   const conversationKey = url.searchParams.get('conversationKey');
   if (!conversationKey) {
-    return Response.json(
-      { error: 'conversationKey query parameter is required' },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', 'conversationKey query parameter is required', 400);
   }
 
   const mapping = getConversationByKey(conversationKey);
@@ -517,10 +482,7 @@ export async function handleGetSuggestion(
 export function handleSearchConversations(url: URL): Response {
   const query = url.searchParams.get('q') ?? '';
   if (!query.trim()) {
-    return Response.json(
-      { error: 'q query parameter is required' },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', 'q query parameter is required', 400);
   }
 
   const limit = url.searchParams.has('limit')

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -11,6 +11,7 @@ import { getOrCreateConversation } from '../../memory/conversation-key-store.js'
 import { formatSseFrame, formatSseHeartbeat } from '../assistant-event.js';
 import type { AssistantEventSubscription } from '../assistant-event-hub.js';
 import { AssistantEventHub,assistantEventHub } from '../assistant-event-hub.js';
+import { httpError } from '../http-errors.js';
 
 /** Keep-alive comment sent to idle clients every 30 s by default. */
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
@@ -35,7 +36,7 @@ export function handleSubscribeAssistantEvents(
 ): Response {
   const conversationKey = url.searchParams.get('conversationKey');
   if (!conversationKey) {
-    return Response.json({ error: 'conversationKey is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'conversationKey is required', 400);
   }
 
   const hub = options?.hub ?? assistantEventHub;
@@ -88,7 +89,7 @@ export function handleSubscribeAssistantEvents(
     );
   } catch (err) {
     if (err instanceof RangeError) {
-      return Response.json({ error: 'Too many concurrent connections' }, { status: 503 });
+      return httpError('SERVICE_UNAVAILABLE', 'Too many concurrent connections', 503);
     }
     throw err;
   }

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url';
 
 import { getBaseDataDir } from '../../config/env-registry.js';
 import { getWorkspacePromptPath, readLockfile } from '../../util/platform.js';
+import { httpError } from '../http-errors.js';
 
 interface DiskSpaceInfo {
   path: string;
@@ -57,7 +58,7 @@ export function handleHealth(): Response {
 export function handleGetIdentity(): Response {
   const identityPath = getWorkspacePromptPath('IDENTITY.md');
   if (!existsSync(identityPath)) {
-    return Response.json({ error: 'IDENTITY.md not found' }, { status: 404 });
+    return httpError('NOT_FOUND', 'IDENTITY.md not found', 404);
   }
 
   const content = readFileSync(identityPath, 'utf-8');

--- a/assistant/src/runtime/routes/inbound-conversation.ts
+++ b/assistant/src/runtime/routes/inbound-conversation.ts
@@ -3,6 +3,7 @@
  */
 import { deleteConversationKey } from '../../memory/conversation-key-store.js';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
+import { httpError } from '../http-errors.js';
 
 export async function handleDeleteConversation(req: Request, assistantId: string = 'self'): Promise<Response> {
   const body = await req.json() as {
@@ -13,10 +14,10 @@ export async function handleDeleteConversation(req: Request, assistantId: string
   const { sourceChannel, externalChatId } = body;
 
   if (!sourceChannel || typeof sourceChannel !== 'string') {
-    return Response.json({ error: 'sourceChannel is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'sourceChannel is required', 400);
   }
   if (!externalChatId || typeof externalChatId !== 'string') {
-    return Response.json({ error: 'externalChatId is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'externalChatId is required', 400);
   }
 
   // Delete the assistant-scoped key unconditionally. The legacy key is

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -56,6 +56,7 @@ import type {
   GuardianActionCopyGenerator,
   MessageProcessor,
 } from '../http-types.js';
+import { httpError } from '../http-errors.js';
 import { deliverReplyViaCallback } from './channel-delivery-routes.js';
 import {
   canonicalChannelAssistantId,
@@ -131,40 +132,34 @@ export async function handleChannelInbound(
   } = body;
 
   if (!body.sourceChannel || typeof body.sourceChannel !== 'string') {
-    return Response.json({ error: 'sourceChannel is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'sourceChannel is required', 400);
   }
   // Validate and narrow to canonical ChannelId at the boundary — the gateway
   // only sends well-known channel strings, so an unknown value is rejected.
   if (!isChannelId(body.sourceChannel)) {
-    return Response.json(
-      { error: `Invalid sourceChannel: ${body.sourceChannel}. Valid values: ${CHANNEL_IDS.join(', ')}` },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', `Invalid sourceChannel: ${body.sourceChannel}. Valid values: ${CHANNEL_IDS.join(', ')}`, 400);
   }
 
   const sourceChannel = body.sourceChannel;
 
   if (!body.interface || typeof body.interface !== 'string') {
-    return Response.json({ error: 'interface is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'interface is required', 400);
   }
   const sourceInterface = parseInterfaceId(body.interface);
   if (!sourceInterface) {
-    return Response.json(
-      { error: `Invalid interface: ${body.interface}. Valid values: ${INTERFACE_IDS.join(', ')}` },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', `Invalid interface: ${body.interface}. Valid values: ${INTERFACE_IDS.join(', ')}`, 400);
   }
 
   if (!externalChatId || typeof externalChatId !== 'string') {
-    return Response.json({ error: 'externalChatId is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'externalChatId is required', 400);
   }
   if (!externalMessageId || typeof externalMessageId !== 'string') {
-    return Response.json({ error: 'externalMessageId is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'externalMessageId is required', 400);
   }
 
   // Reject non-string content regardless of whether attachments are present.
   if (content != null && typeof content !== 'string') {
-    return Response.json({ error: 'content must be a string' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'content must be a string', 400);
   }
 
   const trimmedContent = typeof content === 'string' ? content.trim() : '';
@@ -173,7 +168,7 @@ export async function handleChannelInbound(
   const hasCallbackData = typeof body.callbackData === 'string' && body.callbackData.length > 0;
 
   if (trimmedContent.length === 0 && !hasAttachments && !isEdit && !hasCallbackData) {
-    return Response.json({ error: 'content or attachmentIds is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'content or attachmentIds is required', 400);
   }
 
   // Canonicalize the assistant ID so all DB-facing operations use the
@@ -318,7 +313,7 @@ export async function handleChannelInbound(
     : undefined;
 
   if (isEdit && !sourceMessageId) {
-    return Response.json({ error: 'sourceMetadata.messageId is required for edits' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'sourceMetadata.messageId is required for edits', 400);
   }
 
   // ── Edit path: update existing message content, no new agent loop ──

--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -21,6 +21,7 @@ import {
   createGuardianChallenge,
   getGuardianStatus,
 } from '../../daemon/handlers/config-channels.js';
+import { httpError } from '../http-errors.js';
 import {
   clearTelegramConfig,
   getTelegramConfig,
@@ -143,18 +144,12 @@ export async function handleStartOutbound(req: Request): Promise<Response> {
     originConversationId?: string;
   };
   if (!body.channel) {
-    return Response.json(
-      { success: false, error: 'missing_channel', message: 'The "channel" field is required.' },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', 'The "channel" field is required.', 400);
   }
 
   // Rate-limit by destination identity before processing
   if (body.destination && guardianVerificationLimiter.isBlocked(body.destination)) {
-    return Response.json(
-      { success: false, error: 'rate_limited', message: 'Too many verification attempts for this identity. Please try again later.' },
-      { status: 429 },
-    );
+    return httpError('RATE_LIMITED', 'Too many verification attempts for this identity. Please try again later.', 429);
   }
 
   const result = startOutbound({
@@ -185,10 +180,7 @@ export async function handleResendOutbound(req: Request): Promise<Response> {
     originConversationId?: string;
   };
   if (!body.channel) {
-    return Response.json(
-      { success: false, error: 'missing_channel', message: 'The "channel" field is required.' },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', 'The "channel" field is required.', 400);
   }
   const result = resendOutbound({
     channel: body.channel,
@@ -210,10 +202,7 @@ export async function handleCancelOutbound(req: Request): Promise<Response> {
     assistantId?: string;
   };
   if (!body.channel) {
-    return Response.json(
-      { success: false, error: 'missing_channel', message: 'The "channel" field is required.' },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', 'The "channel" field is required.', 400);
   }
   const result = cancelOutbound({
     channel: body.channel,

--- a/assistant/src/runtime/routes/pairing-routes.ts
+++ b/assistant/src/runtime/routes/pairing-routes.ts
@@ -10,6 +10,7 @@ import {
 import type { ServerMessage } from '../../daemon/ipc-contract.js';
 import { PairingStore } from '../../daemon/pairing-store.js';
 import { getLogger } from '../../util/logger.js';
+import { httpError } from '../http-errors.js';
 
 const log = getLogger('runtime-http');
 
@@ -32,18 +33,18 @@ export async function handlePairingRegister(req: Request, ctx: PairingHandlerCon
     const localLanUrl = typeof body.localLanUrl === 'string' ? body.localLanUrl : null;
 
     if (!pairingRequestId || !pairingSecret || !gatewayUrl) {
-      return Response.json({ error: 'Missing required fields: pairingRequestId, pairingSecret, gatewayUrl' }, { status: 400 });
+      return httpError('BAD_REQUEST', 'Missing required fields: pairingRequestId, pairingSecret, gatewayUrl', 400);
     }
 
     const result = ctx.pairingStore.register({ pairingRequestId, pairingSecret, gatewayUrl, localLanUrl });
     if (!result.ok) {
-      return Response.json({ error: 'Conflict: pairingRequestId exists with different secret' }, { status: 409 });
+      return httpError('CONFLICT', 'Conflict: pairingRequestId exists with different secret', 409);
     }
 
     return Response.json({ ok: true });
   } catch (err) {
     log.error({ err }, 'Failed to register pairing request');
-    return Response.json({ error: 'Internal server error' }, { status: 500 });
+    return httpError('INTERNAL_ERROR', 'Internal server error', 500);
   }
 }
 
@@ -63,17 +64,17 @@ export async function handlePairingRequest(req: Request, ctx: PairingHandlerCont
     log.info({ pairingRequestId, deviceName, hasDeviceId: !!deviceId }, 'Pairing request received');
 
     if (!deviceId || !deviceName) {
-      return Response.json({ error: 'Missing required fields: deviceId, deviceName' }, { status: 400 });
+      return httpError('BAD_REQUEST', 'Missing required fields: deviceId, deviceName', 400);
     }
 
     if (!pairingRequestId || !pairingSecret) {
-      return Response.json({ error: 'Missing required fields: pairingRequestId, pairingSecret' }, { status: 400 });
+      return httpError('BAD_REQUEST', 'Missing required fields: pairingRequestId, pairingSecret', 400);
     }
 
     const result = ctx.pairingStore.beginRequest({ pairingRequestId, pairingSecret, deviceId, deviceName });
     if (!result.ok) {
       const statusCode = result.reason === 'invalid_secret' ? 403 : result.reason === 'not_found' ? 403 : 410;
-      return Response.json({ error: 'Forbidden' }, { status: statusCode });
+      return httpError('FORBIDDEN', 'Forbidden', statusCode);
     }
 
     const entry = result.entry;
@@ -105,7 +106,7 @@ export async function handlePairingRequest(req: Request, ctx: PairingHandlerCont
     return Response.json({ status: 'pending' });
   } catch (err) {
     log.error({ err }, 'Failed to process pairing request');
-    return Response.json({ error: 'Internal server error' }, { status: 500 });
+    return httpError('INTERNAL_ERROR', 'Internal server error', 500);
   }
 }
 
@@ -119,16 +120,16 @@ export function handlePairingStatus(url: URL, ctx: PairingHandlerContext): Respo
   const secret = url.searchParams.get('secret') ?? '';
 
   if (!id || !secret) {
-    return Response.json({ error: 'Missing required params: id, secret' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'Missing required params: id, secret', 400);
   }
 
   if (!ctx.pairingStore.validateSecret(id, secret)) {
-    return Response.json({ error: 'Forbidden' }, { status: 403 });
+    return httpError('FORBIDDEN', 'Forbidden', 403);
   }
 
   const entry = ctx.pairingStore.get(id);
   if (!entry) {
-    return Response.json({ error: 'Not found' }, { status: 404 });
+    return httpError('NOT_FOUND', 'Not found', 404);
   }
 
   if (entry.status === 'approved') {

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -3,6 +3,7 @@ import { initializeProviders } from '../../providers/registry.js';
 import { setSecureKey } from '../../security/secure-keys.js';
 import { assertMetadataWritable, upsertCredentialMetadata } from '../../tools/credentials/metadata-store.js';
 import { getLogger } from '../../util/logger.js';
+import { httpError } from '../http-errors.js';
 
 const log = getLogger('runtime-http');
 
@@ -16,26 +17,23 @@ export async function handleAddSecret(req: Request): Promise<Response> {
   const { type, name, value } = body;
 
   if (!type || typeof type !== 'string') {
-    return Response.json({ error: 'type is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'type is required', 400);
   }
   if (!name || typeof name !== 'string') {
-    return Response.json({ error: 'name is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'name is required', 400);
   }
   if (!value || typeof value !== 'string') {
-    return Response.json({ error: 'value is required' }, { status: 400 });
+    return httpError('BAD_REQUEST', 'value is required', 400);
   }
 
   try {
     if (type === 'api_key') {
       if (!API_KEY_PROVIDERS.includes(name as typeof API_KEY_PROVIDERS[number])) {
-        return Response.json(
-          { error: `Unknown API key provider: ${name}. Valid providers: ${API_KEY_PROVIDERS.join(', ')}` },
-          { status: 400 },
-        );
+        return httpError('BAD_REQUEST', `Unknown API key provider: ${name}. Valid providers: ${API_KEY_PROVIDERS.join(', ')}`, 400);
       }
       const stored = setSecureKey(name, value);
       if (!stored) {
-        return Response.json({ error: 'Failed to store API key in secure storage' }, { status: 500 });
+        return httpError('INTERNAL_ERROR', 'Failed to store API key in secure storage', 500);
       }
       invalidateConfigCache();
       initializeProviders(getConfig());
@@ -46,10 +44,7 @@ export async function handleAddSecret(req: Request): Promise<Response> {
     if (type === 'credential') {
       const colonIdx = name.indexOf(':');
       if (colonIdx < 1 || colonIdx === name.length - 1) {
-        return Response.json(
-          { error: 'For credential type, name must be in "service:field" format (e.g. "github:api_token")' },
-          { status: 400 },
-        );
+        return httpError('BAD_REQUEST', 'For credential type, name must be in "service:field" format (e.g. "github:api_token")', 400);
       }
       assertMetadataWritable();
       const service = name.slice(0, colonIdx);
@@ -57,20 +52,17 @@ export async function handleAddSecret(req: Request): Promise<Response> {
       const key = `credential:${service}:${field}`;
       const stored = setSecureKey(key, value);
       if (!stored) {
-        return Response.json({ error: 'Failed to store credential in secure storage' }, { status: 500 });
+        return httpError('INTERNAL_ERROR', 'Failed to store credential in secure storage', 500);
       }
       upsertCredentialMetadata(service, field, {});
       log.info({ service, field }, 'Credential added via HTTP');
       return Response.json({ success: true, type, name }, { status: 201 });
     }
 
-    return Response.json(
-      { error: `Unknown secret type: ${type}. Valid types: api_key, credential` },
-      { status: 400 },
-    );
+    return httpError('BAD_REQUEST', `Unknown secret type: ${type}. Valid types: api_key, credential`, 400);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, type, name }, 'Failed to add secret via HTTP');
-    return Response.json({ error: message }, { status: 500 });
+    return httpError('INTERNAL_ERROR', message, 500);
   }
 }


### PR DESCRIPTION
Migrate all /v1/* route error responses to use the standard HTTP error response format from http-errors.ts for consistency. All error responses now use the `{ error: { code, message } }` envelope via the `httpError()` helper.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
