### PR TITLE
fix: replace as-unknown-as casts with proper types

### DIFF
--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -312,10 +312,10 @@ export async function startVoiceTurn(opts: VoiceTurnOptions): Promise<VoiceTurnH
   // Serialized publish chain so hub subscribers observe events in order.
   let hubChain: Promise<void> = Promise.resolve();
   const publishToHub = (msg: ServerMessage): void => {
-    const msgRecord = msg as unknown as Record<string, unknown>;
+    // ServerMessage is a large union; sessionId exists on most but not all variants.
     const msgSessionId =
-      'sessionId' in msg && typeof msgRecord.sessionId === 'string'
-        ? (msgRecord.sessionId as string)
+      'sessionId' in msg && typeof (msg as { sessionId?: unknown }).sessionId === 'string'
+        ? (msg as { sessionId: string }).sessionId
         : undefined;
     const resolvedSessionId = msgSessionId ?? opts.conversationId;
     const event = buildAssistantEvent('self', msg, resolvedSessionId);

--- a/assistant/src/daemon/handlers/config-heartbeat.ts
+++ b/assistant/src/daemon/handlers/config-heartbeat.ts
@@ -85,7 +85,7 @@ export function handleHeartbeatConfig(
         activeHoursEnd: null,
         nextRunAt: null,
         success: false,
-        error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}`,
+        error: `Unknown action: ${String(msg.action)}`,
       });
     }
   } catch (err) {

--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -153,7 +153,7 @@ export function handleIngressInvite(
       }
 
       default: {
-        ctx.send(socket, { type: 'ingress_invite_response', success: false, error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}` });
+        ctx.send(socket, { type: 'ingress_invite_response', success: false, error: `Unknown action: ${String(msg.action)}` });
       }
     }
   } catch (err) {
@@ -264,7 +264,7 @@ export function handleIngressMember(
       }
 
       default: {
-        ctx.send(socket, { type: 'ingress_member_response', success: false, error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}` });
+        ctx.send(socket, { type: 'ingress_member_response', success: false, error: `Unknown action: ${String(msg.action)}` });
       }
     }
   } catch (err) {
@@ -342,7 +342,7 @@ export function handleInboxEscalation(
       }
 
       default: {
-        ctx.send(socket, { type: 'assistant_inbox_escalation_response', success: false, error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}` });
+        ctx.send(socket, { type: 'assistant_inbox_escalation_response', success: false, error: `Unknown action: ${String(msg.action)}` });
       }
     }
   } catch (err) {

--- a/assistant/src/daemon/handlers/config-ingress.ts
+++ b/assistant/src/daemon/handlers/config-ingress.ts
@@ -219,7 +219,7 @@ export async function handleIngressConfig(
         }
       }
     } else {
-      ctx.send(socket, { type: 'ingress_config_response', enabled: false, publicBaseUrl: '', localGatewayTarget, success: false, error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}` });
+      ctx.send(socket, { type: 'ingress_config_response', enabled: false, publicBaseUrl: '', localGatewayTarget, success: false, error: `Unknown action: ${String(msg.action)}` });
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/handlers/config-integrations.ts
+++ b/assistant/src/daemon/handlers/config-integrations.ts
@@ -258,7 +258,7 @@ export function handleTwitterIntegrationConfig(
         managedAvailable: false,
         localClientConfigured: false,
         connected: false,
-        error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}`,
+        error: `Unknown action: ${String(msg.action)}`,
       });
     }
   } catch (err) {

--- a/assistant/src/daemon/handlers/config-platform.ts
+++ b/assistant/src/daemon/handlers/config-platform.ts
@@ -38,7 +38,7 @@ export async function handlePlatformConfig(
         type: 'platform_config_response',
         baseUrl: '',
         success: false,
-        error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}`,
+        error: `Unknown action: ${String(msg.action)}`,
       });
     }
   } catch (err) {

--- a/assistant/src/daemon/handlers/config-scheduling.ts
+++ b/assistant/src/daemon/handlers/config-scheduling.ts
@@ -87,7 +87,7 @@ export async function handleScheduleRunNow(
         { taskId, workingDir: process.cwd(), source: 'schedule' },
         async (conversationId, message, taskRunId) => {
           const session = await ctx.getOrCreateSession(conversationId, socket, true);
-          (session as unknown as { taskRunId?: string }).taskRunId = taskRunId;
+          session.taskRunId = taskRunId;
           await session.processMessage(message, [], (event) => {
             ctx.send(socket, event);
           }, undefined, undefined, undefined, { isInteractive: false });

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -319,7 +319,7 @@ export async function handleTelegramConfig(
         hasBotToken: false,
         connected: false,
         hasWebhookSecret: false,
-        error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}`,
+        error: `Unknown action: ${String(msg.action)}`,
       };
     }
 

--- a/assistant/src/daemon/handlers/config-twilio.ts
+++ b/assistant/src/daemon/handlers/config-twilio.ts
@@ -1062,7 +1062,7 @@ export async function handleTwilioConfig(
         type: 'twilio_config_response',
         success: false,
         hasCredentials: hasTwilioCredentials(),
-        error: `Unknown action: ${String((msg as unknown as Record<string, unknown>).action)}`,
+        error: `Unknown action: ${String(msg.action)}`,
       });
     }
   } catch (err) {

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -683,7 +683,7 @@ export async function handleSessionSwitch(
   // If the target session is headless-locked (actively executing a task run),
   // skip rebinding the socket so tool confirmations stay suppressed.
   const existingSession = ctx.sessions.get(msg.sessionId);
-  const isHeadlessLocked = existingSession && (existingSession as unknown as { headlessLock?: boolean }).headlessLock;
+  const isHeadlessLocked = existingSession?.headlessLock;
 
   ctx.socketToSession.set(socket, msg.sessionId);
 

--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -454,9 +454,9 @@ export async function handleWorkItemRunTask(
             title: workItem.title,
           });
           // Wire the taskRunId so the executor can retrieve ephemeral permission rules
-          (session as unknown as { taskRunId?: string }).taskRunId = taskRunId;
+          session.taskRunId = taskRunId;
           // Prevent interactive clients from rebinding to this session mid-run
-          (session as unknown as { headlessLock: boolean }).headlessLock = true;
+          session.headlessLock = true;
         }
         await session.processMessage(message, [], (event) => {
           ctx.broadcast(event);
@@ -466,7 +466,7 @@ export async function handleWorkItemRunTask(
 
     // Release the headless lock now that the task run is done
     if (session) {
-      (session as unknown as { headlessLock: boolean }).headlessLock = false;
+      session.headlessLock = false;
     }
 
     // Don't overwrite cancelled status — the cancel handler already set it
@@ -486,7 +486,7 @@ export async function handleWorkItemRunTask(
   } catch (err) {
     // Release the headless lock on failure
     if (session) {
-      (session as unknown as { headlessLock: boolean }).headlessLock = false;
+      session.headlessLock = false;
     }
     log.error({ err, workItemId: msg.id }, 'work_item_run_task failed');
     updateWorkItem(msg.id, {
@@ -610,7 +610,7 @@ export function handleWorkItemCancel(
   if (conversationId) {
     const session = ctx.sessions.get(conversationId);
     if (session) {
-      (session as unknown as { headlessLock: boolean }).headlessLock = false;
+      session.headlessLock = false;
       session.abort();
       getSubagentManager().abortAllForParent(conversationId);
     }

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -117,12 +117,11 @@ export function createToolExecutor(
       forcePromptSideEffects: ctx.memoryPolicy.strictSideEffects,
       onToolLifecycleEvent: handleToolLifecycleEvent,
       sendToClient: (msg) => {
-        const serverMsg = msg as unknown as ServerMessage;
-        ctx.sendToClient(serverMsg);
-        // Auto-track ui_surface_show for history persistence, mirroring what
-        // session-surfaces.ts does when sending surfaces through its own path.
-        if (serverMsg.type === 'ui_surface_show') {
-          const s = serverMsg as unknown as UiSurfaceShow;
+        // Tool context's sendToClient uses a loose { type: string; [key: string]: unknown }
+        // signature, but at runtime these are always ServerMessage instances.
+        ctx.sendToClient(msg as ServerMessage);
+        if (msg.type === 'ui_surface_show') {
+          const s = msg as unknown as UiSurfaceShow;
           ctx.currentTurnSurfaces.push({
             surfaceId: s.surfaceId,
             surfaceType: s.surfaceType,

--- a/assistant/src/memory/conflict-store.ts
+++ b/assistant/src/memory/conflict-store.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
-import { getDb, getSqlite, rawAll } from './db.js';
+import { getDb, getSqlite, rawAll, rawChanges } from './db.js';
 import { enqueueMemoryJob } from './jobs-store.js';
 import { memoryItemConflicts, memoryItems } from './schema.js';
 import { clampUnitInterval } from './validation.js';
@@ -241,15 +241,15 @@ export function listPendingConflictDetails(
 
 export function markConflictAsked(conflictId: string, askedAt = Date.now()): boolean {
   const db = getDb();
-  const result = db.update(memoryItemConflicts)
+  db.update(memoryItemConflicts)
     .set({
       lastAskedAt: askedAt,
       updatedAt: askedAt,
     })
     .where(eq(memoryItemConflicts.id, conflictId))
-    .run() as unknown as { changes?: number };
+    .run();
 
-  return (result.changes ?? 0) > 0;
+  return rawChanges() > 0;
 }
 
 export function resolveConflict(conflictId: string, input: ResolveConflictInput): MemoryItemConflict | null {

--- a/assistant/src/memory/db-connection.ts
+++ b/assistant/src/memory/db-connection.ts
@@ -40,6 +40,9 @@ export function getSqlite(): Database {
  * Useful in migrations and tests that receive the Drizzle instance as a parameter.
  */
 export function getSqliteFrom(drizzleDb: DrizzleDb): Database {
+  // Drizzle's bun:sqlite adapter stores the raw Database as $client but
+  // doesn't expose it in its public type. This is the single canonical
+  // location for this cast — all callers should use getSqlite/getSqliteFrom.
   return (drizzleDb as unknown as { $client: Database }).$client;
 }
 

--- a/assistant/src/memory/entity-extractor.ts
+++ b/assistant/src/memory/entity-extractor.ts
@@ -4,7 +4,7 @@ import type { MemoryEntityConfig } from '../config/types.js';
 import { createTimeout, extractToolUse, getConfiguredProvider, userMessage } from '../providers/provider-send-message.js';
 import { getLogger } from '../util/logger.js';
 import { truncate } from '../util/truncate.js';
-import { getDb } from './db.js';
+import { getDb, rawAll } from './db.js';
 import { memoryEntities, memoryEntityRelations, memoryItemEntities } from './schema.js';
 
 const log = getLogger('memory-entity-extractor');
@@ -426,20 +426,15 @@ function parseExtractedRelations(
 function findEntityCandidates(nameOrAlias: string): Array<typeof memoryEntities.$inferSelect> {
   const normalized = normalizeEntityName(nameOrAlias);
   if (!normalized) return [];
-  const db = getDb();
   const nameLower = normalized.toLowerCase();
 
-  const raw = (db as unknown as {
-    $client: { query: (q: string) => { all: (...params: unknown[]) => unknown[] } };
-  }).$client;
-
-  return raw.query(`
+  return rawAll<typeof memoryEntities.$inferSelect>(`
     SELECT DISTINCT me.* FROM memory_entities me
     WHERE LOWER(me.name) = ?
     UNION
     SELECT DISTINCT me.* FROM memory_entities me, json_each(me.aliases) je
     WHERE me.aliases IS NOT NULL AND LOWER(je.value) = ?
-  `).all(nameLower, nameLower) as Array<typeof memoryEntities.$inferSelect>;
+  `, nameLower, nameLower);
 }
 
 /**

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -3,7 +3,7 @@ import { v4 as uuid } from 'uuid';
 
 import { getLogger } from '../util/logger.js';
 import { truncate } from '../util/truncate.js';
-import { getDb, rawAll,rawGet } from './db.js';
+import { getDb, rawAll, rawChanges, rawGet } from './db.js';
 import { memoryJobs } from './schema.js';
 
 const log = getLogger('memory-jobs-store');
@@ -294,11 +294,11 @@ export function claimMemoryJobs(limit: number): MemoryJob[] {
 
   const claimed: MemoryJob[] = [];
   for (const row of candidates) {
-    const result = db.update(memoryJobs)
+    db.update(memoryJobs)
       .set({ status: 'running', updatedAt: now })
       .where(and(eq(memoryJobs.id, row.id), eq(memoryJobs.status, 'pending')))
-      .run() as unknown as { changes?: number };
-    if ((result.changes ?? 0) === 0) continue;
+      .run();
+    if (rawChanges() === 0) continue;
     claimed.push(parseRow({
       ...row,
       status: 'running',

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -721,14 +721,17 @@ export function injectMemoryRecallAsSeparateMessage<T extends { role: 'user' | '
 ): T[] {
   if (memoryRecallText.trim().length === 0) return messages;
   if (messages.length === 0) return messages;
+  // These synthetic messages satisfy the structural constraint T extends { role; content }
+  // but may lack extra fields present on T. In practice T is always Message which has
+  // only role and content, so the cast is safe.
   const contextMessage = {
     role: 'user' as const,
-    content: [{ type: 'text', text: memoryRecallText }],
-  } as unknown as T;
+    content: [{ type: 'text' as const, text: memoryRecallText }],
+  } as T;
   const ackMessage = {
     role: 'assistant' as const,
-    content: [{ type: 'text', text: MEMORY_CONTEXT_ACK }],
-  } as unknown as T;
+    content: [{ type: 'text' as const, text: MEMORY_CONTEXT_ACK }],
+  } as T;
   return [
     ...messages.slice(0, -1),
     contextMessage,

--- a/assistant/src/notifications/deliveries-store.ts
+++ b/assistant/src/notifications/deliveries-store.ts
@@ -8,7 +8,7 @@
 
 import { and, eq } from 'drizzle-orm';
 
-import { getDb } from '../memory/db.js';
+import { getDb, rawChanges } from '../memory/db.js';
 import { notificationDeliveries } from '../memory/schema.js';
 import type { NotificationChannel, NotificationDeliveryStatus } from './types.js';
 
@@ -131,13 +131,13 @@ export function updateDeliveryStatus(
     updates.errorMessage = error.message;
   }
 
-  const result = db
+  db
     .update(notificationDeliveries)
     .set(updates)
     .where(eq(notificationDeliveries.id, id))
-    .run() as unknown as { changes?: number };
+    .run();
 
-  return (result.changes ?? 0) > 0;
+  return rawChanges() > 0;
 }
 
 /**
@@ -171,13 +171,13 @@ export function updateDeliveryClientOutcome(
     updates.clientDeliveryError = error.code;
   }
 
-  const result = db
+  db
     .update(notificationDeliveries)
     .set(updates)
     .where(eq(notificationDeliveries.id, deliveryId))
-    .run() as unknown as { changes?: number };
+    .run();
 
-  return (result.changes ?? 0) > 0;
+  return rawChanges() > 0;
 }
 
 /** List all delivery records for a given notification decision. */

--- a/assistant/src/notifications/preferences-store.ts
+++ b/assistant/src/notifications/preferences-store.ts
@@ -10,7 +10,7 @@
 import { desc, eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
-import { getDb } from '../memory/db.js';
+import { getDb, rawChanges } from '../memory/db.js';
 import { notificationPreferences } from '../memory/schema.js';
 
 // ── Row type ────────────────────────────────────────────────────────────
@@ -107,13 +107,13 @@ export function updatePreference(id: string, params: UpdatePreferenceParams): bo
   if (params.appliesWhen !== undefined) updates.appliesWhenJson = JSON.stringify(params.appliesWhen);
   if (params.priority !== undefined) updates.priority = params.priority;
 
-  const result = db
+  db
     .update(notificationPreferences)
     .set(updates)
     .where(eq(notificationPreferences.id, id))
-    .run() as unknown as { changes?: number };
+    .run();
 
-  return (result.changes ?? 0) > 0;
+  return rawChanges() > 0;
 }
 
 // ── Delete ──────────────────────────────────────────────────────────────
@@ -121,12 +121,12 @@ export function updatePreference(id: string, params: UpdatePreferenceParams): bo
 export function deletePreference(id: string): boolean {
   const db = getDb();
 
-  const result = db
+  db
     .delete(notificationPreferences)
     .where(eq(notificationPreferences.id, id))
-    .run() as unknown as { changes?: number };
+    .run();
 
-  return (result.changes ?? 0) > 0;
+  return rawChanges() > 0;
 }
 
 // ── Get by ID ───────────────────────────────────────────────────────────

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -276,7 +276,9 @@ function loadFromDisk(): TrustRule[] {
         // on loaded rules would silently widen their scope to global
         // wildcards. Stripping them and re-saving prevents scope escalation.
         for (const rule of rules) {
-          const r = rule as unknown as Record<string, unknown>;
+          // Legacy v3 rules may carry principal-scoped fields that no longer
+          // exist in the TrustRule interface — cast to strip them at runtime.
+          const r = rule as Record<string, unknown>;
           if ('principalKind' in r || 'principalId' in r || 'principalVersion' in r) {
             delete r.principalKind;
             delete r.principalId;

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -498,7 +498,8 @@ export class RuntimeHttpServer {
     if (!upgraded) {
       return new Response('WebSocket upgrade failed', { status: 500 });
     }
-    return undefined as unknown as Response;
+    // Bun's WebSocket upgrade consumes the request — no Response is sent.
+    return undefined!;
   }
 
   private handleRelayUpgrade(req: Request, server: ReturnType<typeof Bun.serve>): Response {
@@ -518,7 +519,8 @@ export class RuntimeHttpServer {
     if (!upgraded) {
       return new Response('WebSocket upgrade failed', { status: 500 });
     }
-    return undefined as unknown as Response;
+    // Bun's WebSocket upgrade consumes the request — no Response is sent.
+    return undefined!;
   }
 
   private async handleTwilioWebhook(req: Request, path: string): Promise<Response | null> {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -181,10 +181,10 @@ function makeHubPublisher(
       });
     }
 
-    const msgRecord = msg as unknown as Record<string, unknown>;
+    // ServerMessage is a large union; sessionId exists on most but not all variants.
     const msgSessionId =
-      'sessionId' in msg && typeof msgRecord.sessionId === 'string'
-        ? (msgRecord.sessionId as string)
+      'sessionId' in msg && typeof (msg as { sessionId?: unknown }).sessionId === 'string'
+        ? (msg as { sessionId: string }).sessionId
         : undefined;
     const resolvedSessionId = msgSessionId ?? conversationId;
     const event = buildAssistantEvent('self', msg, resolvedSessionId);

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -152,7 +152,9 @@ export class SubagentManager {
     // Store the managed subagent early so the wrapper can read the mutable
     // parentSendToClient reference — this ensures reconnects are picked up.
     const managed: ManagedSubagent = {
-      session: undefined as unknown as Session,
+      // Placeholder — replaced with the real Session a few lines below, before
+      // any code reads this field. Using null! avoids the `as unknown as` cast.
+      session: null! as Session,
       state,
       parentSendToClient,
     };

--- a/assistant/src/tools/reminder/reminder-store.ts
+++ b/assistant/src/tools/reminder/reminder-store.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq, lte } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
-import { getDb } from '../../memory/db.js';
+import { getDb, rawChanges } from '../../memory/db.js';
 import { reminders } from '../../memory/schema.js';
 import { cast,createRowMapper, parseJson } from '../../util/row-mapper.js';
 
@@ -107,12 +107,12 @@ export function listReminders(options?: { pendingOnly?: boolean }): ReminderRow[
 export function cancelReminder(id: string): boolean {
   const db = getDb();
   const now = Date.now();
-  const result = db
+  db
     .update(reminders)
     .set({ status: 'cancelled', updatedAt: now })
     .where(and(eq(reminders.id, id), eq(reminders.status, 'pending')))
-    .run() as unknown as { changes?: number };
-  return (result.changes ?? 0) > 0;
+    .run();
+  return rawChanges() > 0;
 }
 
 /**
@@ -132,13 +132,13 @@ export function claimDueReminders(now: number): ReminderRow[] {
 
   const claimed: ReminderRow[] = [];
   for (const row of candidates) {
-    const result = db
+    db
       .update(reminders)
       .set({ status: 'firing', firedAt: now, updatedAt: now })
       .where(and(eq(reminders.id, row.id), eq(reminders.status, 'pending')))
-      .run() as unknown as { changes?: number };
+      .run();
 
-    if ((result.changes ?? 0) === 0) continue;
+    if (rawChanges() === 0) continue;
 
     claimed.push(parseRow({
       ...row,

--- a/assistant/src/watcher/watcher-store.ts
+++ b/assistant/src/watcher/watcher-store.ts
@@ -1,7 +1,7 @@
 import { and, asc, desc, eq, gte, lte } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
-import { getDb } from '../memory/db.js';
+import { getDb, rawChanges } from '../memory/db.js';
 import { watcherEvents,watchers } from '../memory/schema.js';
 import { truncate } from '../util/truncate.js';
 import { DEFAULT_POLL_INTERVAL_MS } from './constants.js';
@@ -142,8 +142,8 @@ export function updateWatcher(
 
 export function deleteWatcher(id: string): boolean {
   const db = getDb();
-  const result = db.delete(watchers).where(eq(watchers.id, id)).run() as unknown as { changes?: number };
-  return (result.changes ?? 0) > 0;
+  db.delete(watchers).where(eq(watchers.id, id)).run();
+  return rawChanges() > 0;
 }
 
 // ── Claim / Complete ────────────────────────────────────────────────
@@ -167,7 +167,7 @@ export function claimDueWatchers(now: number): Watcher[] {
 
   const claimed: Watcher[] = [];
   for (const row of candidates) {
-    const result = db
+    db
       .update(watchers)
       .set({ status: 'polling', updatedAt: now })
       .where(and(
@@ -175,9 +175,9 @@ export function claimDueWatchers(now: number): Watcher[] {
         eq(watchers.nextPollAt, row.nextPollAt),
         eq(watchers.status, 'idle'),
       ))
-      .run() as unknown as { changes?: number };
+      .run();
 
-    if ((result.changes ?? 0) === 0) continue;
+    if (rawChanges() === 0) continue;
     claimed.push(parseWatcherRow({ ...row, status: 'polling', updatedAt: now }));
   }
   return claimed;
@@ -271,12 +271,12 @@ export function setWatcherConversationId(id: string, conversationId: string): vo
  */
 export function resetStuckWatchers(): number {
   const db = getDb();
-  const result = db
+  db
     .update(watchers)
     .set({ status: 'idle', updatedAt: Date.now() })
     .where(eq(watchers.status, 'polling'))
-    .run() as unknown as { changes?: number };
-  return result.changes ?? 0;
+    .run();
+  return rawChanges();
 }
 
 // ── Watcher Events ──────────────────────────────────────────────────

--- a/assistant/src/work-items/work-item-runner.ts
+++ b/assistant/src/work-items/work-item-runner.ts
@@ -127,8 +127,8 @@ export function runWorkItemInBackground(workItemId: string): RunWorkItemResult {
               workItemId,
               title: workItem.title,
             } as ServerMessage);
-            (session as unknown as { taskRunId?: string }).taskRunId = taskRunId;
-            (session as unknown as { headlessLock: boolean }).headlessLock = true;
+            session.taskRunId = taskRunId;
+            session.headlessLock = true;
           }
           await session.processMessage(message, [], (event) => {
             broadcast(event);
@@ -137,7 +137,7 @@ export function runWorkItemInBackground(workItemId: string): RunWorkItemResult {
       );
 
       if (session) {
-        (session as unknown as { headlessLock: boolean }).headlessLock = false;
+        session.headlessLock = false;
       }
 
       const current = getWorkItem(workItemId);
@@ -155,7 +155,7 @@ export function runWorkItemInBackground(workItemId: string): RunWorkItemResult {
       broadcast({ type: 'tasks_changed' } as ServerMessage);
     } catch (err) {
       if (session) {
-        (session as unknown as { headlessLock: boolean }).headlessLock = false;
+        session.headlessLock = false;
       }
       log.error({ err, workItemId }, 'work item background run failed');
       updateWorkItem(workItemId, {


### PR DESCRIPTION
Audit and fix `as unknown as` type casts in core production modules, replacing with proper type narrowing, generics, or interface updates where possible.

Changes by category:
- **Drizzle .run() casts** (6 files): Replaced with `rawChanges()` helper from `memory/raw-query.ts`
- **Session property casts** (4 files): Removed unnecessary casts — `headlessLock` and `taskRunId` are public properties
- **Config handler .action casts** (7 files): Replaced `msg as unknown as Record<string, unknown>` with direct `String(msg.action)`
- **ServerMessage sessionId casts** (2 files): Replaced with safer single-step narrowing
- **Bun WebSocket undefined casts** (1 file): Replaced `undefined as unknown as Response` with `undefined!`
- **Entity-extractor $client cast** (1 file): Replaced with `rawAll` helper
- **Subagent manager placeholder** (1 file): Replaced `undefined as unknown as Session` with `null!`
- **Trust-store, session-tool-setup, retriever, db-connection**: Simplified or commented remaining casts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
