### PR TITLE
fix: durable conversation timeout pause during CU escalation, failure handling

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -100,6 +100,10 @@ extension AppDelegate {
                 switch session.state {
                 case .completed(let s, _), .responded(let s, _):
                     summary = s
+                case .failed:
+                    summary = "Something went wrong while controlling the screen."
+                case .cancelled:
+                    summary = "Screen control was cancelled."
                 default:
                     summary = "All done with the screen."
                 }

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -36,6 +36,11 @@ final class VoiceModeManager: ObservableObject {
     private var ttsTimeoutTask: Task<Void, Never>?
     /// Timer that fires when the conversation has been idle too long.
     private var conversationTimeoutTask: Task<Void, Never>?
+    /// When true, `handleStateTransition` will not re-arm the conversation
+    /// timeout on transitions to `.idle`. Used during CU escalation so that
+    /// `speakTransient`'s completion (which sets state to `.idle`) does not
+    /// prematurely restart the 30s timer while the CU session is still running.
+    private var conversationTimeoutPaused = false
     /// Permission request IDs currently being handled via voice.
     private var pendingPermissionIds: [String] = []
     /// Combine subscription to detect new confirmations in chat messages.
@@ -156,6 +161,7 @@ final class VoiceModeManager: ObservableObject {
 
         // Cancel conversation timeout before setting state to .off
         // (didSet would cancel it too, but be explicit for clarity).
+        conversationTimeoutPaused = false
         cancelConversationTimeout()
 
         // Set state to .off BEFORE shutdown so that any synchronous
@@ -545,7 +551,8 @@ final class VoiceModeManager: ObservableObject {
         if newState == .idle {
             // Don't start the timeout if the agent is currently executing tools —
             // the isThinking observer will restart it when thinking completes.
-            if chatViewModel?.isThinking != true {
+            // Also skip if the timeout is paused (e.g., during CU escalation).
+            if !conversationTimeoutPaused && chatViewModel?.isThinking != true {
                 startConversationTimeout()
             }
         } else {
@@ -620,6 +627,7 @@ final class VoiceModeManager: ObservableObject {
     /// conversation should not auto-deactivate.
     func pauseConversationTimeout() {
         log.info("Voice mode: conversation timeout paused")
+        conversationTimeoutPaused = true
         cancelConversationTimeout()
     }
 
@@ -627,6 +635,10 @@ final class VoiceModeManager: ObservableObject {
     /// operation completes so idle auto-deactivation can kick in again.
     func resumeConversationTimeout() {
         log.info("Voice mode: conversation timeout resumed")
+        // Clear the paused flag BEFORE the state guard so that when
+        // speakTransient finishes and transitions to .idle,
+        // handleStateTransition will properly restart the timeout.
+        conversationTimeoutPaused = false
         guard state == .idle else { return }
         startConversationTimeout()
     }


### PR DESCRIPTION
Fixes three issues from review of #9787: (1) Added conversationTimeoutPaused flag to prevent speakTransient's idle transition from re-arming the conversation timeout while a CU session is running. (2) resumeConversationTimeout now clears the flag before the state guard so the timeout restarts when speech finishes. (3) Failed/cancelled CU session states now get appropriate spoken feedback instead of a misleading success message.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
