### PR TITLE
fix: sign all bundled node_modules files to fix codesign failure

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -162,6 +162,13 @@ build_binaries() {
     mkdir -p "$SCRIPT_DIR/daemon-bin/node_modules"
     cp -R "$ASSISTANT_SRC_DIR/node_modules/onnxruntime-node" "$SCRIPT_DIR/daemon-bin/node_modules/"
     cp -R "$ASSISTANT_SRC_DIR/node_modules/onnxruntime-common" "$SCRIPT_DIR/daemon-bin/node_modules/"
+    # Strip non-runtime files to reduce bundle size (source, docs, sourcemaps, type declarations)
+    rm -rf "$SCRIPT_DIR/daemon-bin/node_modules/onnxruntime-node/script"
+    rm -rf "$SCRIPT_DIR/daemon-bin/node_modules/onnxruntime-node/lib"
+    rm -f  "$SCRIPT_DIR/daemon-bin/node_modules/onnxruntime-node/README.md"
+    rm -rf "$SCRIPT_DIR/daemon-bin/node_modules/onnxruntime-common/lib"
+    rm -f  "$SCRIPT_DIR/daemon-bin/node_modules/onnxruntime-common/README.md"
+    find "$SCRIPT_DIR/daemon-bin/node_modules" \( -name "*.ts" -o -name "*.map" -o -name "*.d.ts" \) -delete 2>/dev/null || true
     # Strip non-native-platform binaries to save space
     local onnx_bin="$SCRIPT_DIR/daemon-bin/node_modules/onnxruntime-node/bin/napi-v3"
     if [ -d "$onnx_bin" ]; then
@@ -308,6 +315,13 @@ if [ "$DAEMON_BIN_NEEDS_BUILD" = true ]; then
     mkdir -p "$SCRIPT_DIR/daemon-bin/node_modules"
     cp -R "$ASSISTANT_SRC_DIR/node_modules/onnxruntime-node" "$SCRIPT_DIR/daemon-bin/node_modules/"
     cp -R "$ASSISTANT_SRC_DIR/node_modules/onnxruntime-common" "$SCRIPT_DIR/daemon-bin/node_modules/"
+    # Strip non-runtime files to reduce bundle size (source, docs, sourcemaps, type declarations)
+    rm -rf "$SCRIPT_DIR/daemon-bin/node_modules/onnxruntime-node/script"
+    rm -rf "$SCRIPT_DIR/daemon-bin/node_modules/onnxruntime-node/lib"
+    rm -f  "$SCRIPT_DIR/daemon-bin/node_modules/onnxruntime-node/README.md"
+    rm -rf "$SCRIPT_DIR/daemon-bin/node_modules/onnxruntime-common/lib"
+    rm -f  "$SCRIPT_DIR/daemon-bin/node_modules/onnxruntime-common/README.md"
+    find "$SCRIPT_DIR/daemon-bin/node_modules" \( -name "*.ts" -o -name "*.map" -o -name "*.d.ts" \) -delete 2>/dev/null || true
     onnx_bin="$SCRIPT_DIR/daemon-bin/node_modules/onnxruntime-node/bin/napi-v3"
     if [ -d "$onnx_bin" ]; then
         find "$onnx_bin" -mindepth 1 -maxdepth 1 -not -name darwin -exec rm -rf {} +
@@ -664,15 +678,17 @@ if [ -f "$MACOS_DIR/vellum-gateway" ]; then
     echo "Gateway binary signed"
 fi
 
-# Sign onnxruntime native libraries (must sign before daemon binary)
-if [ -d "$MACOS_DIR/node_modules/onnxruntime-node/bin" ]; then
+# Sign all files in bundled node_modules (must sign before daemon binary).
+# codesign treats everything under Contents/MacOS/ as code objects, so all
+# files — native binaries, JS, JSON, etc. — must carry a valid signature.
+if [ -d "$MACOS_DIR/node_modules" ]; then
     NATIVE_SIGN_FLAGS=(--force --sign "$SIGN_IDENTITY")
     if [ "$CONFIG" = "release" ] && [ "$SIGN_IDENTITY" != "-" ]; then
         NATIVE_SIGN_FLAGS+=(--timestamp --options runtime)
     fi
-    find "$MACOS_DIR/node_modules/onnxruntime-node/bin" \( -name "*.node" -o -name "*.dylib" \) -exec \
+    find "$MACOS_DIR/node_modules" -type f -exec \
         codesign "${NATIVE_SIGN_FLAGS[@]}" {} \;
-    echo "ONNX Runtime native libraries signed"
+    echo "Bundled node_modules signed"
 fi
 
 # Sign daemon binary with its own entitlements (JIT, network)


### PR DESCRIPTION
## Summary
- Sign all files in `Contents/MacOS/node_modules/` (not just `.node` and `.dylib`) — codesign treats everything under `Contents/MacOS/` as code objects
- Strip non-runtime files from the onnxruntime node_modules copy: `script/`, `lib/`, `README.md`, `*.ts`, `*.d.ts`, `*.map` — reduces bundle size and signing surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
