### PR TITLE
fix: await async addMessage calls in tests

### DIFF
--- a/assistant/src/__tests__/asset-materialize-tool.test.ts
+++ b/assistant/src/__tests__/asset-materialize-tool.test.ts
@@ -311,7 +311,7 @@ describe('AssetMaterializeTool visibility policy', () => {
     const standardConv = createConversation({ title: 'standard-conv' });
     const base64Content = Buffer.from('standard content').toString('base64');
     const attachment = uploadAttachment('public.txt', 'text/plain', base64Content);
-    const msg = addMessage(standardConv.id, 'user', 'standard message');
+    const msg = await addMessage(standardConv.id, 'user', 'standard message');
     linkAttachmentToMessage(msg.id, attachment.id, 0);
 
     // Materialize from a different standard conversation
@@ -334,7 +334,7 @@ describe('AssetMaterializeTool visibility policy', () => {
     const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
     const base64Content = Buffer.from('private content').toString('base64');
     const attachment = uploadAttachment('secret.txt', 'text/plain', base64Content);
-    const msg = addMessage(privateConv.id, 'user', 'private message');
+    const msg = await addMessage(privateConv.id, 'user', 'private message');
     linkAttachmentToMessage(msg.id, attachment.id, 0);
 
     // Materialize from the same private conversation
@@ -356,7 +356,7 @@ describe('AssetMaterializeTool visibility policy', () => {
     const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
     const base64Content = Buffer.from('private content').toString('base64');
     const attachment = uploadAttachment('secret.txt', 'text/plain', base64Content);
-    const msg = addMessage(privateConv.id, 'user', 'private message');
+    const msg = await addMessage(privateConv.id, 'user', 'private message');
     linkAttachmentToMessage(msg.id, attachment.id, 0);
 
     // Attempt to materialize from a different conversation
@@ -380,7 +380,7 @@ describe('AssetMaterializeTool visibility policy', () => {
     const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
     const base64Content = Buffer.from('private content').toString('base64');
     const attachment = uploadAttachment('confidential.pdf', 'application/pdf', base64Content);
-    const msg = addMessage(privateConv.id, 'user', 'private message');
+    const msg = await addMessage(privateConv.id, 'user', 'private message');
     linkAttachmentToMessage(msg.id, attachment.id, 0);
 
     // From a standard conversation
@@ -406,7 +406,7 @@ describe('AssetMaterializeTool visibility policy', () => {
     const privateConv1 = createConversation({ title: 'private-conv-1', threadType: 'private' });
     const base64Content = Buffer.from('private content').toString('base64');
     const attachment = uploadAttachment('secret.txt', 'text/plain', base64Content);
-    const msg = addMessage(privateConv1.id, 'user', 'private message');
+    const msg = await addMessage(privateConv1.id, 'user', 'private message');
     linkAttachmentToMessage(msg.id, attachment.id, 0);
 
     // Attempt from a different private conversation
@@ -431,8 +431,8 @@ describe('AssetMaterializeTool visibility policy', () => {
     const base64Content = Buffer.from('shared content').toString('base64');
     const attachment = uploadAttachment('shared.txt', 'text/plain', base64Content);
 
-    const msg1 = addMessage(privateConv.id, 'user', 'private message');
-    const msg2 = addMessage(standardConv.id, 'user', 'standard message');
+    const msg1 = await addMessage(privateConv.id, 'user', 'private message');
+    const msg2 = await addMessage(standardConv.id, 'user', 'standard message');
     linkAttachmentToMessage(msg1.id, attachment.id, 0);
     linkAttachmentToMessage(msg2.id, attachment.id, 0);
 

--- a/assistant/src/__tests__/asset-search-tool.test.ts
+++ b/assistant/src/__tests__/asset-search-tool.test.ts
@@ -219,14 +219,14 @@ describe('searchAttachments', () => {
 describe('searchAttachments with conversation_id', () => {
   beforeEach(resetTables);
 
-  test('returns only attachments linked to the specified conversation', () => {
+  test('returns only attachments linked to the specified conversation', async () => {
     const png1 = uploadAttachment('in-conv.png', 'image/png', 'AAAA');
     const png2 = uploadAttachment('other-conv.png', 'image/png', 'BBBB');
 
     const conv1 = createConversation();
     const conv2 = createConversation();
-    const msg1 = addMessage(conv1.id, 'user', 'First conv');
-    const msg2 = addMessage(conv2.id, 'user', 'Second conv');
+    const msg1 = await addMessage(conv1.id, 'user', 'First conv');
+    const msg2 = await addMessage(conv2.id, 'user', 'Second conv');
 
     linkAttachmentToMessage(msg1.id, png1.id, 0);
     linkAttachmentToMessage(msg2.id, png2.id, 0);
@@ -236,10 +236,10 @@ describe('searchAttachments with conversation_id', () => {
     expect(results[0].id).toBe(png1.id);
   });
 
-  test('returns empty when conversation has no attachments', () => {
+  test('returns empty when conversation has no attachments', async () => {
     uploadAttachment('orphan.png', 'image/png', 'AAAA');
     const conv = createConversation();
-    addMessage(conv.id, 'user', 'No attachments here');
+    await addMessage(conv.id, 'user', 'No attachments here');
 
     const results = searchAttachments({ conversation_id: conv.id });
     expect(results.length).toBe(0);
@@ -251,12 +251,12 @@ describe('searchAttachments with conversation_id', () => {
     expect(results.length).toBe(0);
   });
 
-  test('combines conversation_id with mime_type filter', () => {
+  test('combines conversation_id with mime_type filter', async () => {
     const png = uploadAttachment('image.png', 'image/png', 'AAAA');
     const pdf = uploadAttachment('doc.pdf', 'application/pdf', 'BBBB');
 
     const conv = createConversation();
-    const msg = addMessage(conv.id, 'user', 'Both types');
+    const msg = await addMessage(conv.id, 'user', 'Both types');
 
     linkAttachmentToMessage(msg.id, png.id, 0);
     linkAttachmentToMessage(msg.id, pdf.id, 1);
@@ -266,12 +266,12 @@ describe('searchAttachments with conversation_id', () => {
     expect(results[0].mimeType).toBe('image/png');
   });
 
-  test('combines conversation_id with filename filter', () => {
+  test('combines conversation_id with filename filter', async () => {
     const a = uploadAttachment('target.png', 'image/png', 'AAAA');
     const b = uploadAttachment('other.png', 'image/png', 'BBBB');
 
     const conv = createConversation();
-    const msg = addMessage(conv.id, 'user', 'Both');
+    const msg = await addMessage(conv.id, 'user', 'Both');
 
     linkAttachmentToMessage(msg.id, a.id, 0);
     linkAttachmentToMessage(msg.id, b.id, 1);
@@ -367,7 +367,7 @@ describe('AssetSearchTool visibility policy', () => {
   test('attachments from standard threads are visible from any context', async () => {
     const standardConv = createConversation({ title: 'standard-conv' });
     const attachment = uploadAttachment('public.png', 'image/png', 'AAAA');
-    const msg = addMessage(standardConv.id, 'user', 'standard message');
+    const msg = await addMessage(standardConv.id, 'user', 'standard message');
     linkAttachmentToMessage(msg.id, attachment.id, 0);
 
     // Search from a different standard conversation
@@ -386,7 +386,7 @@ describe('AssetSearchTool visibility policy', () => {
   test('attachments from private threads are visible within the same private thread', async () => {
     const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
     const attachment = uploadAttachment('secret.png', 'image/png', 'AAAA');
-    const msg = addMessage(privateConv.id, 'user', 'private message');
+    const msg = await addMessage(privateConv.id, 'user', 'private message');
     linkAttachmentToMessage(msg.id, attachment.id, 0);
 
     // Search from the same private conversation
@@ -404,7 +404,7 @@ describe('AssetSearchTool visibility policy', () => {
   test('attachments from private threads are NOT visible from a different conversation', async () => {
     const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
     const attachment = uploadAttachment('secret.png', 'image/png', 'AAAA');
-    const msg = addMessage(privateConv.id, 'user', 'private message');
+    const msg = await addMessage(privateConv.id, 'user', 'private message');
     linkAttachmentToMessage(msg.id, attachment.id, 0);
 
     // Search from a different private conversation
@@ -423,7 +423,7 @@ describe('AssetSearchTool visibility policy', () => {
   test('attachments from private threads are NOT visible from standard threads', async () => {
     const privateConv = createConversation({ title: 'private-conv', threadType: 'private' });
     const attachment = uploadAttachment('secret.png', 'image/png', 'AAAA');
-    const msg = addMessage(privateConv.id, 'user', 'private message');
+    const msg = await addMessage(privateConv.id, 'user', 'private message');
     linkAttachmentToMessage(msg.id, attachment.id, 0);
 
     // Search from a standard conversation
@@ -444,8 +444,8 @@ describe('AssetSearchTool visibility policy', () => {
     const standardConv = createConversation({ title: 'standard-conv' });
     const attachment = uploadAttachment('shared.png', 'image/png', 'AAAA');
 
-    const msg1 = addMessage(privateConv.id, 'user', 'private message');
-    const msg2 = addMessage(standardConv.id, 'user', 'standard message');
+    const msg1 = await addMessage(privateConv.id, 'user', 'private message');
+    const msg2 = await addMessage(standardConv.id, 'user', 'standard message');
     linkAttachmentToMessage(msg1.id, attachment.id, 0);
     linkAttachmentToMessage(msg2.id, attachment.id, 0);
 

--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -206,10 +206,10 @@ describe('deleteAttachment', () => {
     expect(result).toBe('not_found');
   });
 
-  test('returns still_referenced when messages reference the attachment', () => {
+  test('returns still_referenced when messages reference the attachment', async () => {
     const conv = createConversation();
-    const msg1 = addMessage(conv.id, 'user', 'First upload');
-    const msg2 = addMessage(conv.id, 'user', 'Duplicate upload');
+    const msg1 = await addMessage(conv.id, 'user', 'First upload');
+    const msg2 = await addMessage(conv.id, 'user', 'Duplicate upload');
 
     // Dedup: both uploads return the same attachment row
     const first = uploadAttachment('photo.png', 'image/png', 'SHAREDCONTENT1');
@@ -304,9 +304,9 @@ describe('getAttachmentById', () => {
 describe('linkAttachmentToMessage + getAttachmentsForMessage', () => {
   beforeEach(resetTables);
 
-  test('links attachment and retrieves it by message', () => {
+  test('links attachment and retrieves it by message', async () => {
     const conv = createConversation();
-    const msg = addMessage(conv.id, 'assistant', 'Here is a chart');
+    const msg = await addMessage(conv.id, 'assistant', 'Here is a chart');
     const stored = uploadAttachment('chart.png', 'image/png', 'iVBORw0K');
 
     linkAttachmentToMessage(msg.id, stored.id, 0);
@@ -318,9 +318,9 @@ describe('linkAttachmentToMessage + getAttachmentsForMessage', () => {
     expect(linked[0].dataBase64).toBe('iVBORw0K');
   });
 
-  test('returns attachments in position order', () => {
+  test('returns attachments in position order', async () => {
     const conv = createConversation();
-    const msg = addMessage(conv.id, 'assistant', 'Multiple files');
+    const msg = await addMessage(conv.id, 'assistant', 'Multiple files');
     const a = uploadAttachment('first.txt', 'text/plain', 'AAAA');
     const b = uploadAttachment('second.txt', 'text/plain', 'BBBB');
 
@@ -334,9 +334,9 @@ describe('linkAttachmentToMessage + getAttachmentsForMessage', () => {
     expect(linked[1].originalFilename).toBe('second.txt');
   });
 
-  test('returns empty for message with no attachments', () => {
+  test('returns empty for message with no attachments', async () => {
     const conv = createConversation();
-    const msg = addMessage(conv.id, 'assistant', 'No attachments');
+    const msg = await addMessage(conv.id, 'assistant', 'No attachments');
 
     const linked = getAttachmentsForMessage(msg.id);
     expect(linked).toHaveLength(0);
@@ -357,9 +357,9 @@ describe('deleteOrphanAttachments', () => {
     expect(removed).toBe(1);
   });
 
-  test('preserves attachments that are still linked', () => {
+  test('preserves attachments that are still linked', async () => {
     const conv = createConversation();
-    const msg = addMessage(conv.id, 'assistant', 'With attachment');
+    const msg = await addMessage(conv.id, 'assistant', 'With attachment');
     const stored = uploadAttachment('linked.txt', 'text/plain', 'ZGF0YQ==');
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
@@ -370,9 +370,9 @@ describe('deleteOrphanAttachments', () => {
     expect(fetched).not.toBeNull();
   });
 
-  test('removes only orphans when mixed candidates provided', () => {
+  test('removes only orphans when mixed candidates provided', async () => {
     const conv = createConversation();
-    const msg = addMessage(conv.id, 'assistant', 'Mixed');
+    const msg = await addMessage(conv.id, 'assistant', 'Mixed');
     const linked = uploadAttachment('linked.txt', 'text/plain', 'AAAA');
     const orphan = uploadAttachment('orphan.txt', 'text/plain', 'BBBB');
     linkAttachmentToMessage(msg.id, linked.id, 0);

--- a/assistant/src/__tests__/call-conversation-messages.test.ts
+++ b/assistant/src/__tests__/call-conversation-messages.test.ts
@@ -111,7 +111,7 @@ describe('call-conversation-messages', () => {
     expect(buildCallCompletionMessage(session.id)).toBe('**Call cancelled** (3s). 2 event(s) recorded.');
   });
 
-  test('persistCallCompletionMessage keeps completed label when status is completed', () => {
+  test('persistCallCompletionMessage keeps completed label when status is completed', async () => {
     const conversationId = 'conv-call-msg-completed';
     ensureConversation(conversationId);
     const session = createCallSession({
@@ -124,7 +124,7 @@ describe('call-conversation-messages', () => {
     updateCallSession(session.id, { status: 'completed' });
     recordCallEvent(session.id, 'call_ended');
 
-    const summary = persistCallCompletionMessage(conversationId, session.id);
+    const summary = await persistCallCompletionMessage(conversationId, session.id);
     expect(summary).toBe('**Call completed**. 1 event(s) recorded.');
     expect(getLatestAssistantText(conversationId)).toBe('**Call completed**. 1 event(s) recorded.');
   });

--- a/assistant/src/__tests__/conversation-pairing.test.ts
+++ b/assistant/src/__tests__/conversation-pairing.test.ts
@@ -90,11 +90,11 @@ describe('pairDeliveryWithConversation', () => {
 
   // ── start_new_conversation (vellum) ─────────────────────────────────
 
-  test('creates a conversation and message for start_new_conversation strategy', () => {
+  test('creates a conversation and message for start_new_conversation strategy', async () => {
     const signal = makeSignal();
     const copy = makeCopy({ threadTitle: 'Alert Thread' });
 
-    const result = pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
+    const result = await pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
 
     expect(result.conversationId).toBe('conv-001');
     expect(result.messageId).toBe('msg-001');
@@ -105,39 +105,39 @@ describe('pairDeliveryWithConversation', () => {
     expect(callArgs.threadType).toBe('standard');
   });
 
-  test('uses threadTitle for conversation title when available', () => {
+  test('uses threadTitle for conversation title when available', async () => {
     const signal = makeSignal();
     const copy = makeCopy({ threadTitle: 'Custom Thread Title' });
 
-    pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
+    await pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
 
     // Verify createConversation was called with the thread title
     const callArgs = createConversationMock.mock.calls[0]![0] as Record<string, unknown>;
     expect(callArgs.title).toBe('Custom Thread Title');
   });
 
-  test('falls back to copy title when threadTitle is absent', () => {
+  test('falls back to copy title when threadTitle is absent', async () => {
     const signal = makeSignal();
     const copy = makeCopy({ title: 'Notification Title' });
 
-    pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
+    await pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
 
     const callArgs = createConversationMock.mock.calls[0]![0] as Record<string, unknown>;
     expect(callArgs.title).toBe('Notification Title');
   });
 
-  test('uses threadSeedMessage for message content when present and sane', () => {
+  test('uses threadSeedMessage for message content when present and sane', async () => {
     const signal = makeSignal();
     const copy = makeCopy({ threadSeedMessage: 'Custom seed message with enough length' });
 
-    pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
+    await pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
 
     // addMessage second arg is role, third is content
     const contentArg = addMessageMock.mock.calls[0]![2];
     expect(contentArg).toBe('Custom seed message with enough length');
   });
 
-  test('rejects threadSeedMessage that is a JSON dump and uses runtime composer', () => {
+  test('rejects threadSeedMessage that is a JSON dump and uses runtime composer', async () => {
     const signal = makeSignal({
       sourceEventName: 'reminder.fired',
       contextPayload: { message: 'Daily standup' },
@@ -148,7 +148,7 @@ describe('pairDeliveryWithConversation', () => {
       threadSeedMessage: '{"raw": "json dump payload"}',
     });
 
-    pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
+    await pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
 
     const contentArg = addMessageMock.mock.calls[0]![2] as string;
     // Should NOT be the JSON dump
@@ -157,14 +157,14 @@ describe('pairDeliveryWithConversation', () => {
     expect(contentArg).toContain('Reminder');
   });
 
-  test('rejects very short threadSeedMessage and uses runtime composer', () => {
+  test('rejects very short threadSeedMessage and uses runtime composer', async () => {
     const signal = makeSignal({
       sourceEventName: 'reminder.fired',
       contextPayload: { message: 'Test' },
     });
     const copy = makeCopy({ title: 'Reminder', body: 'Test reminder', threadSeedMessage: 'Hi' });
 
-    pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
+    await pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
 
     const contentArg = addMessageMock.mock.calls[0]![2] as string;
     expect(contentArg).not.toBe('Hi');
@@ -172,11 +172,11 @@ describe('pairDeliveryWithConversation', () => {
     expect(contentArg).toContain('Reminder');
   });
 
-  test('passes skipIndexing option to addMessage', () => {
+  test('passes skipIndexing option to addMessage', async () => {
     const signal = makeSignal();
     const copy = makeCopy();
 
-    pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
+    await pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
 
     const optsArg = addMessageMock.mock.calls[0]![4] as Record<string, unknown>;
     expect(optsArg.skipIndexing).toBe(true);
@@ -184,11 +184,11 @@ describe('pairDeliveryWithConversation', () => {
 
   // ── continue_existing_conversation (telegram) ─────────────────────
 
-  test('creates a conversation for continue_existing_conversation strategy', () => {
+  test('creates a conversation for continue_existing_conversation strategy', async () => {
     const signal = makeSignal();
     const copy = makeCopy();
 
-    const result = pairDeliveryWithConversation(signal, 'telegram' as NotificationChannel, copy);
+    const result = await pairDeliveryWithConversation(signal, 'telegram' as NotificationChannel, copy);
 
     // Currently creates a new conversation even for continue_existing_conversation
     // (true continuation is planned for a future PR)
@@ -202,14 +202,14 @@ describe('pairDeliveryWithConversation', () => {
 
   // ── not_deliverable (voice) ───────────────────────────────────────
 
-  test('returns null conversationId and messageId for not_deliverable strategy', () => {
+  test('returns null conversationId and messageId for not_deliverable strategy', async () => {
     const signal = makeSignal();
     const copy = makeCopy();
 
     // voice has not_deliverable strategy — need to cast since voice is
     // not a NotificationChannel (deliveryEnabled: false), but the function
     // accepts NotificationChannel which is then cast internally to ChannelId.
-    const result = pairDeliveryWithConversation(
+    const result = await pairDeliveryWithConversation(
       signal,
       'voice' as NotificationChannel,
       copy,
@@ -224,13 +224,13 @@ describe('pairDeliveryWithConversation', () => {
 
   // ── Error resilience ──────────────────────────────────────────────
 
-  test('catches createConversation errors and returns null IDs without throwing', () => {
+  test('catches createConversation errors and returns null IDs without throwing', async () => {
     createConversationShouldThrow = true;
     const signal = makeSignal();
     const copy = makeCopy();
 
     // Should not throw
-    const result = pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
+    const result = await pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
 
     expect(result.conversationId).toBeNull();
     expect(result.messageId).toBeNull();
@@ -238,24 +238,24 @@ describe('pairDeliveryWithConversation', () => {
     expect(result.strategy).toBe('start_new_conversation');
   });
 
-  test('catches addMessage errors and returns null IDs without throwing', () => {
+  test('catches addMessage errors and returns null IDs without throwing', async () => {
     addMessageShouldThrow = true;
     const signal = makeSignal();
     const copy = makeCopy();
 
-    const result = pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
+    const result = await pairDeliveryWithConversation(signal, 'vellum' as NotificationChannel, copy);
 
     expect(result.conversationId).toBeNull();
     expect(result.messageId).toBeNull();
     expect(result.strategy).toBe('start_new_conversation');
   });
 
-  test('error in pairing does not break the pipeline (no throw)', () => {
+  test('error in pairing does not break the pipeline (no throw)', async () => {
     createConversationShouldThrow = true;
 
     // Calling multiple times should all succeed without throwing
     for (let i = 0; i < 3; i++) {
-      const result = pairDeliveryWithConversation(
+      const result = await pairDeliveryWithConversation(
         makeSignal({ signalId: `sig-${i}` }),
         'vellum' as NotificationChannel,
         makeCopy(),

--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -232,10 +232,10 @@ describe('attachment orphan cleanup', () => {
     db.run('DELETE FROM conversations');
   });
 
-  test('deleteLastExchange cleans up orphaned attachments', () => {
+  test('deleteLastExchange cleans up orphaned attachments', async () => {
     const conv = createConversation('test');
-    addMessage(conv.id, 'user', 'hello');
-    const assistantMsg = addMessage(conv.id, 'assistant', 'Here is a file');
+    await addMessage(conv.id, 'user', 'hello');
+    const assistantMsg = await addMessage(conv.id, 'assistant', 'Here is a file');
 
     const stored = uploadAttachment('chart.png', 'image/png', 'iVBOR');
     linkAttachmentToMessage(assistantMsg.id, stored.id, 0);
@@ -252,11 +252,11 @@ describe('attachment orphan cleanup', () => {
     expect(remaining.c).toBe(0);
   });
 
-  test('deleteLastExchange preserves attachments still linked to other messages', () => {
+  test('deleteLastExchange preserves attachments still linked to other messages', async () => {
     const conv = createConversation('test');
-    const msg1 = addMessage(conv.id, 'assistant', 'first');
-    addMessage(conv.id, 'user', 'question');
-    const msg2 = addMessage(conv.id, 'assistant', 'second');
+    const msg1 = await addMessage(conv.id, 'assistant', 'first');
+    await addMessage(conv.id, 'user', 'question');
+    const msg2 = await addMessage(conv.id, 'assistant', 'second');
 
     const shared = uploadAttachment('shared.png', 'image/png', 'AAAA');
     linkAttachmentToMessage(msg1.id, shared.id, 0);
@@ -271,9 +271,9 @@ describe('attachment orphan cleanup', () => {
     expect(remaining.c).toBe(1);
   });
 
-  test('clearAll removes all attachments', () => {
+  test('clearAll removes all attachments', async () => {
     const conv = createConversation('test');
-    const msg = addMessage(conv.id, 'assistant', 'file');
+    const msg = await addMessage(conv.id, 'assistant', 'file');
     const stored = uploadAttachment('doc.pdf', 'application/pdf', 'JVBER');
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
@@ -286,10 +286,10 @@ describe('attachment orphan cleanup', () => {
     expect(linkCount.c).toBe(0);
   });
 
-  test('deleteLastExchange does not delete unlinked user uploads', () => {
+  test('deleteLastExchange does not delete unlinked user uploads', async () => {
     const conv = createConversation('test');
-    addMessage(conv.id, 'user', 'hello');
-    const assistantMsg = addMessage(conv.id, 'assistant', 'Here is a file');
+    await addMessage(conv.id, 'user', 'hello');
+    const assistantMsg = await addMessage(conv.id, 'assistant', 'Here is a file');
 
     // An attachment linked to the assistant message (should be cleaned up)
     const linked = uploadAttachment('chart.png', 'image/png', 'iVBOR');
@@ -438,15 +438,15 @@ describe('attachment reuse across thread lifecycles', () => {
     db.run('DELETE FROM conversations');
   });
 
-  test('attachment uploaded in conversation A is retrievable by ID without any conversation reference', () => {
+  test('attachment uploaded in conversation A is retrievable by ID without any conversation reference', async () => {
     const convA = createConversation('Thread A');
-    const msgA = addMessage(convA.id, 'assistant', 'Here is a file');
+    const msgA = await addMessage(convA.id, 'assistant', 'Here is a file');
     const stored = uploadAttachment('report.pdf', 'application/pdf', 'JVBER');
     linkAttachmentToMessage(msgA.id, stored.id, 0);
 
     // Create a completely separate conversation
     const convB = createConversation('Thread B');
-    addMessage(convB.id, 'user', 'hello');
+    await addMessage(convB.id, 'user', 'hello');
 
     // The attachment is retrievable by ID regardless of which conversation is active.
     const fetched = getAttachmentById(stored.id);
@@ -456,12 +456,12 @@ describe('attachment reuse across thread lifecycles', () => {
     expect(fetched!.dataBase64).toBe('JVBER');
   });
 
-  test('attachment can be linked to messages in different conversations', () => {
+  test('attachment can be linked to messages in different conversations', async () => {
     const convA = createConversation('Thread A');
     const convB = createConversation('Thread B');
 
-    const msgA = addMessage(convA.id, 'assistant', 'Original file');
-    const msgB = addMessage(convB.id, 'assistant', 'Reused file');
+    const msgA = await addMessage(convA.id, 'assistant', 'Original file');
+    const msgB = await addMessage(convB.id, 'assistant', 'Reused file');
 
     // Upload once, link to both conversations
     const stored = uploadAttachment('shared.png', 'image/png', 'iVBORw0K');
@@ -478,16 +478,16 @@ describe('attachment reuse across thread lifecycles', () => {
     expect(linkedB[0].id).toBe(stored.id);
   });
 
-  test('deleting conversation A does not orphan attachment reused in conversation B', () => {
+  test('deleting conversation A does not orphan attachment reused in conversation B', async () => {
     const convA = createConversation('Thread A');
     const convB = createConversation('Thread B');
 
     // deleteLastExchange deletes from the last user message onward,
     // so we need a user message before the assistant message that carries the attachment.
-    addMessage(convA.id, 'user', 'Please generate a chart');
-    const msgA = addMessage(convA.id, 'assistant', 'Original');
-    addMessage(convB.id, 'user', 'Show me the chart');
-    const msgB = addMessage(convB.id, 'assistant', 'Reused');
+    await addMessage(convA.id, 'user', 'Please generate a chart');
+    const msgA = await addMessage(convA.id, 'assistant', 'Original');
+    await addMessage(convB.id, 'user', 'Show me the chart');
+    const msgB = await addMessage(convB.id, 'assistant', 'Reused');
 
     const stored = uploadAttachment('chart.png', 'image/png', 'AAAA');
     linkAttachmentToMessage(msgA.id, stored.id, 0);
@@ -506,12 +506,12 @@ describe('attachment reuse across thread lifecycles', () => {
     expect(linkedB[0].id).toBe(stored.id);
   });
 
-  test('content-hash dedup works across conversations', () => {
+  test('content-hash dedup works across conversations', async () => {
     const convA = createConversation('Thread A');
     const convB = createConversation('Thread B');
 
-    addMessage(convA.id, 'user', 'upload in A');
-    addMessage(convB.id, 'user', 'upload in B');
+    await addMessage(convA.id, 'user', 'upload in A');
+    await addMessage(convB.id, 'user', 'upload in B');
 
     // Same content uploaded in two different conversation contexts
     const first = uploadAttachment('photo.png', 'image/png', 'DEDUPCROSS');
@@ -535,11 +535,11 @@ describe('no private-thread attachment visibility boundary', () => {
     db.run('DELETE FROM conversations');
   });
 
-  test('attachment from a private thread is visible via getAttachmentById (no thread scoping)', () => {
+  test('attachment from a private thread is visible via getAttachmentById (no thread scoping)', async () => {
     const privateConv = createConversation({ title: 'Secret', threadType: 'private' });
     expect(privateConv.threadType).toBe('private');
 
-    const msg = addMessage(privateConv.id, 'assistant', 'Private content');
+    const msg = await addMessage(privateConv.id, 'assistant', 'Private content');
     const stored = uploadAttachment('secret.pdf', 'application/pdf', 'JVBER');
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
@@ -549,12 +549,12 @@ describe('no private-thread attachment visibility boundary', () => {
     expect(fetched!.originalFilename).toBe('secret.pdf');
   });
 
-  test('attachment from private thread can be linked to a standard thread message', () => {
+  test('attachment from private thread can be linked to a standard thread message', async () => {
     const privateConv = createConversation({ title: 'Private', threadType: 'private' });
     const standardConv = createConversation({ title: 'Standard', threadType: 'standard' });
 
-    const privateMsg = addMessage(privateConv.id, 'assistant', 'Private file');
-    const standardMsg = addMessage(standardConv.id, 'assistant', 'Reusing private file');
+    const privateMsg = await addMessage(privateConv.id, 'assistant', 'Private file');
+    const standardMsg = await addMessage(standardConv.id, 'assistant', 'Reusing private file');
 
     const stored = uploadAttachment('private-doc.png', 'image/png', 'PRIVDATA');
     linkAttachmentToMessage(privateMsg.id, stored.id, 0);
@@ -569,9 +569,9 @@ describe('no private-thread attachment visibility boundary', () => {
     expect(linkedStandard[0].id).toBe(stored.id);
   });
 
-  test('getAttachmentsForMessage returns private thread attachments', () => {
+  test('getAttachmentsForMessage returns private thread attachments', async () => {
     const privateConv = createConversation({ title: 'Private', threadType: 'private' });
-    const msg = addMessage(privateConv.id, 'assistant', 'Private media');
+    const msg = await addMessage(privateConv.id, 'assistant', 'Private media');
     const stored = uploadAttachment('photo.jpg', 'image/jpeg', 'AAAA');
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
@@ -592,12 +592,12 @@ describe('no private-thread attachment visibility boundary', () => {
     expect(fromStandard.id).toBe(fromPrivate.id);
   });
 
-  test('clearAll removes attachments from both private and standard threads', () => {
+  test('clearAll removes attachments from both private and standard threads', async () => {
     const privateConv = createConversation({ title: 'Private', threadType: 'private' });
     const standardConv = createConversation({ title: 'Standard', threadType: 'standard' });
 
-    const privateMsg = addMessage(privateConv.id, 'assistant', 'Private file');
-    const standardMsg = addMessage(standardConv.id, 'assistant', 'Standard file');
+    const privateMsg = await addMessage(privateConv.id, 'assistant', 'Private file');
+    const standardMsg = await addMessage(standardConv.id, 'assistant', 'Standard file');
 
     const att1 = uploadAttachment('private.png', 'image/png', 'PRIV');
     const att2 = uploadAttachment('standard.png', 'image/png', 'STD');

--- a/assistant/src/__tests__/media-reuse-story.e2e.test.ts
+++ b/assistant/src/__tests__/media-reuse-story.e2e.test.ts
@@ -188,7 +188,7 @@ describe('Story E2E: selfie yesterday -> generated image today', () => {
   let selfieId: string;
   let selfieAttachment: ReturnType<typeof uploadAttachment>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetTables();
     // Clear sandbox so stale files from prior tests don't mask regressions
     rmSync(sandboxDir, { recursive: true, force: true });
@@ -216,7 +216,7 @@ describe('Story E2E: selfie yesterday -> generated image today', () => {
     selfieAttachment = uploadAttachment('selfie.png', 'image/png', TINY_PNG_BASE64);
     selfieId = selfieAttachment.id;
 
-    const msgA = addMessage(threadA.id, 'user', 'Here is my selfie from yesterday');
+    const msgA = await addMessage(threadA.id, 'user', 'Here is my selfie from yesterday');
     linkAttachmentToMessage(msgA.id, selfieId, 0);
 
     // Backdate the selfie to "yesterday" for realism


### PR DESCRIPTION
## Summary
- Add missing `await` to `addMessage` calls across 6 test files to match the now-async signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
