### PR TITLE
fix: context capture timing and post-sanitization emptiness check

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -241,12 +241,15 @@ final class VoiceModeManager: ObservableObject {
         voiceService.resetStreamingTTS()
 
         Task {
-            // Capture frontmost app context BEFORE awaiting transcription so we
-            // capture the app the user was looking at when they spoke, not after
-            // potential app switches during transcription finalization.
-            let ctx = DictationContextCapture.capture()
+            // Run context capture concurrently with transcription finalization.
+            // Both start after silence is detected (recording stops inside
+            // stopRecordingAndGetTranscription), so context captures the app
+            // the user was looking at when they spoke, and any AX query delay
+            // in capture() doesn't extend the recording window.
+            async let ctx = DictationContextCapture.capture()
+            async let transcription = voiceService.stopRecordingAndGetTranscription()
 
-            let text = await voiceService.stopRecordingAndGetTranscription()
+            let text = await transcription
             let trimmed = (text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
 
             guard !trimmed.isEmpty, let chatViewModel else {
@@ -266,16 +269,21 @@ final class VoiceModeManager: ObservableObject {
             // Build the context prefix from captured app context. Sanitize
             // attacker-controlled values (window titles, selected text) to
             // prevent prompt injection and excessive length.
+            let capturedCtx = await ctx
             var contextPrefix = ""
-            if !ctx.appName.isEmpty {
-                var parts: [String] = ["app: \(ctx.appName)"]
-                if !ctx.windowTitle.isEmpty {
-                    let sanitizedTitle = Self.sanitize(ctx.windowTitle, maxLength: 200)
-                    parts.append("window: \"\(sanitizedTitle)\"")
+            if !capturedCtx.appName.isEmpty {
+                var parts: [String] = ["app: \(capturedCtx.appName)"]
+                if !capturedCtx.windowTitle.isEmpty {
+                    let sanitizedTitle = Self.sanitize(capturedCtx.windowTitle, maxLength: 200)
+                    if !sanitizedTitle.isEmpty {
+                        parts.append("window: \"\(sanitizedTitle)\"")
+                    }
                 }
-                if let selected = ctx.selectedText, !selected.isEmpty {
+                if let selected = capturedCtx.selectedText, !selected.isEmpty {
                     let sanitizedSelected = Self.sanitize(selected, maxLength: 500)
-                    parts.append("selected text: \"\(sanitizedSelected)\"")
+                    if !sanitizedSelected.isEmpty {
+                        parts.append("selected text: \"\(sanitizedSelected)\"")
+                    }
                 }
                 contextPrefix = "[User's current \(parts.joined(separator: ", "))]\n"
             }


### PR DESCRIPTION
Fixes two issues from review of #9815: (1) App context capture now runs concurrently with transcription finalization (using async let) instead of before recording stops, preventing extra noise pickup during AX queries. (2) Added emptiness checks after sanitization to avoid appending empty window titles or selected text when bracket stripping removes all content.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
