### PR TITLE
fix: replace any types with proper types in http-server WebSocket handlers

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -8,6 +8,8 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
+import type { ServerWebSocket } from 'bun';
+
 import type { BrowserRelayWebSocketData } from '../browser-extension-relay/server.js';
 import { extensionRelayServer } from '../browser-extension-relay/server.js';
 import {
@@ -245,15 +247,13 @@ export class RuntimeHttpServer {
         open(ws) {
           const data = ws.data as AllWebSocketData;
           if ('wsType' in data && data.wsType === 'browser-relay') {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            extensionRelayServer.handleOpen(ws as any);
+            extensionRelayServer.handleOpen(ws as ServerWebSocket<BrowserRelayWebSocketData>);
             return;
           }
           const callSessionId = (data as RelayWebSocketData).callSessionId;
           log.info({ callSessionId }, 'ConversationRelay WebSocket opened');
           if (callSessionId) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const connection = new RelayConnection(ws as any, callSessionId);
+            const connection = new RelayConnection(ws as ServerWebSocket<RelayWebSocketData>, callSessionId);
             activeRelayConnections.set(callSessionId, connection);
           }
         },
@@ -261,8 +261,7 @@ export class RuntimeHttpServer {
           const data = ws.data as AllWebSocketData;
           const raw = typeof message === 'string' ? message : new TextDecoder().decode(message);
           if ('wsType' in data && data.wsType === 'browser-relay') {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            extensionRelayServer.handleMessage(ws as any, raw);
+            extensionRelayServer.handleMessage(ws as ServerWebSocket<BrowserRelayWebSocketData>, raw);
             return;
           }
           const callSessionId = (data as RelayWebSocketData).callSessionId;
@@ -274,8 +273,7 @@ export class RuntimeHttpServer {
         close(ws, code, reason) {
           const data = ws.data as AllWebSocketData;
           if ('wsType' in data && data.wsType === 'browser-relay') {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            extensionRelayServer.handleClose(ws as any, code, reason?.toString());
+            extensionRelayServer.handleClose(ws as ServerWebSocket<BrowserRelayWebSocketData>, code, reason?.toString());
             return;
           }
           const callSessionId = (data as RelayWebSocketData).callSessionId;


### PR DESCRIPTION
Replace `ws as any` casts with properly typed `ServerWebSocket<BrowserRelayWebSocketData>` and `ServerWebSocket<RelayWebSocketData>` assertions in the HTTP server WebSocket handlers. This preserves full type safety on the WebSocket methods while eliminating 4 `any` casts and their eslint-disable comments.

Audit of core modules (agent/, daemon/, tools/, memory/) found the codebase is already very clean — the only remaining `any` in production code is a single Drizzle ORM type workaround in conversation-attention-store.ts (conditional join changes query type) and ~50 Zod v4 `.default({} as any)` workarounds in config schemas (a known Zod v4 limitation where nested defaults require this pattern).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
