### PR TITLE
fix: destructure handler from webhook factory return values in gateway tests

### DIFF
--- a/gateway/src/__tests__/load-guards.test.ts
+++ b/gateway/src/__tests__/load-guards.test.ts
@@ -54,7 +54,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
 
 describe("payload size guard", () => {
   test("returns 413 when content-length exceeds limit", async () => {
-    const handler = createTelegramWebhookHandler(makeConfig());
+    const { handler } = createTelegramWebhookHandler(makeConfig());
     const body = JSON.stringify({ data: "x".repeat(300) });
     const req = new Request("http://localhost:7830/webhooks/telegram", {
       method: "POST",
@@ -72,7 +72,7 @@ describe("payload size guard", () => {
   });
 
   test("returns 413 when body exceeds limit even without content-length", async () => {
-    const handler = createTelegramWebhookHandler(makeConfig());
+    const { handler } = createTelegramWebhookHandler(makeConfig());
     const body = JSON.stringify({ data: "x".repeat(300) });
     const req = new Request("http://localhost:7830/webhooks/telegram", {
       method: "POST",
@@ -87,7 +87,7 @@ describe("payload size guard", () => {
   });
 
   test("accepts payload within limit", async () => {
-    const handler = createTelegramWebhookHandler(
+    const { handler } = createTelegramWebhookHandler(
       makeConfig({ maxWebhookPayloadBytes: 10000 }),
     );
     const body = JSON.stringify({ update_id: 1, message: { text: "hi", chat: { id: 1, type: "private" }, from: { id: 1 }, message_id: 1 } });

--- a/gateway/src/__tests__/probes.test.ts
+++ b/gateway/src/__tests__/probes.test.ts
@@ -22,7 +22,7 @@ const { createTelegramWebhookHandler } = await import(
 
 const config = loadConfig();
 
-const handleTelegramWebhook = createTelegramWebhookHandler(config);
+const { handler: handleTelegramWebhook } = createTelegramWebhookHandler(config);
 
 let draining = false;
 

--- a/gateway/src/__tests__/sms-ingress-guard.test.ts
+++ b/gateway/src/__tests__/sms-ingress-guard.test.ts
@@ -81,7 +81,7 @@ function computeSignature(
 
 describe("SMS ingress cannot bypass gateway boundary", () => {
   test("rejects SMS webhook without X-Twilio-Signature header", async () => {
-    const handler = createTwilioSmsWebhookHandler(makeConfig());
+    const { handler } = createTwilioSmsWebhookHandler(makeConfig());
     const req = new Request("http://localhost:7830/webhooks/twilio/sms", {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -92,7 +92,7 @@ describe("SMS ingress cannot bypass gateway boundary", () => {
   });
 
   test("rejects SMS webhook with forged signature", async () => {
-    const handler = createTwilioSmsWebhookHandler(makeConfig());
+    const { handler } = createTwilioSmsWebhookHandler(makeConfig());
     const req = new Request("http://localhost:7830/webhooks/twilio/sms", {
       method: "POST",
       headers: {
@@ -106,7 +106,7 @@ describe("SMS ingress cannot bypass gateway boundary", () => {
   });
 
   test("rejects SMS webhook when auth token is not configured (fail-closed)", async () => {
-    const handler = createTwilioSmsWebhookHandler(
+    const { handler } = createTwilioSmsWebhookHandler(
       makeConfig({ twilioAuthToken: undefined }),
     );
     const req = new Request("http://localhost:7830/webhooks/twilio/sms", {
@@ -119,7 +119,7 @@ describe("SMS ingress cannot bypass gateway boundary", () => {
   });
 
   test("rejects SMS webhook with signature signed by wrong auth token", async () => {
-    const handler = createTwilioSmsWebhookHandler(makeConfig());
+    const { handler } = createTwilioSmsWebhookHandler(makeConfig());
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
       Body: "hello",
@@ -152,7 +152,7 @@ describe("SMS ingress cannot bypass gateway boundary", () => {
   });
 
   test("rejects non-POST methods", async () => {
-    const handler = createTwilioSmsWebhookHandler(makeConfig());
+    const { handler } = createTwilioSmsWebhookHandler(makeConfig());
     const req = new Request("http://localhost:7830/webhooks/twilio/sms", {
       method: "GET",
     });
@@ -161,7 +161,7 @@ describe("SMS ingress cannot bypass gateway boundary", () => {
   });
 
   test("rejects SMS webhook with empty body (no MessageSid)", async () => {
-    const handler = createTwilioSmsWebhookHandler(makeConfig());
+    const { handler } = createTwilioSmsWebhookHandler(makeConfig());
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params: Record<string, string> = {};
     const signature = computeSignature(url, params, AUTH_TOKEN);
@@ -180,7 +180,7 @@ describe("SMS ingress cannot bypass gateway boundary", () => {
   });
 
   test("rejects oversized SMS webhook payload", async () => {
-    const handler = createTwilioSmsWebhookHandler(
+    const { handler } = createTwilioSmsWebhookHandler(
       makeConfig({ maxWebhookPayloadBytes: 50 }),
     );
     const req = new Request("http://localhost:7830/webhooks/twilio/sms", {
@@ -201,7 +201,7 @@ describe("SMS ingress signature validation with INGRESS_PUBLIC_BASE_URL", () => 
   test("validates signature against configured ingress URL as primary candidate", async () => {
     const publicBase = "https://sms-tunnel.example.com";
     const config = makeConfig({ ingressPublicBaseUrl: publicBase });
-    const handler = createTwilioSmsWebhookHandler(config);
+    const { handler } = createTwilioSmsWebhookHandler(config);
 
     // Twilio signs against the public URL
     const publicUrl = `${publicBase}/webhooks/twilio/sms`;
@@ -232,7 +232,7 @@ describe("SMS ingress signature validation with INGRESS_PUBLIC_BASE_URL", () => 
     const config = makeConfig({
       ingressPublicBaseUrl: "https://correct-tunnel.example.com",
     });
-    const handler = createTwilioSmsWebhookHandler(config);
+    const { handler } = createTwilioSmsWebhookHandler(config);
 
     // Attacker signs against a different URL
     const wrongUrl = "https://attacker.example.com/webhooks/twilio/sms";
@@ -259,7 +259,7 @@ describe("SMS ingress signature validation with INGRESS_PUBLIC_BASE_URL", () => 
 
   test("local-dev fallback: signature against local URL validates when no ingress configured", async () => {
     const config = makeConfig({ ingressPublicBaseUrl: undefined });
-    const handler = createTwilioSmsWebhookHandler(config);
+    const { handler } = createTwilioSmsWebhookHandler(config);
 
     // In local dev, Twilio signs against the raw request URL
     const localUrl = "http://localhost:7830/webhooks/twilio/sms";

--- a/gateway/src/__tests__/telegram-only-default.test.ts
+++ b/gateway/src/__tests__/telegram-only-default.test.ts
@@ -38,7 +38,7 @@ const { createRuntimeProxyHandler } = await import(
 
 const config = loadConfig();
 
-const handleTelegramWebhook = createTelegramWebhookHandler(config);
+const { handler: handleTelegramWebhook } = createTelegramWebhookHandler(config);
 
 // Mirror production routing from src/index.ts: only create proxy when enabled
 const handleRuntimeProxy = config.runtimeProxyEnabled

--- a/gateway/src/__tests__/telegram-webhook-handler.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-handler.test.ts
@@ -163,7 +163,7 @@ describe("telegram webhook handler: gatewayInternalBaseUrl", () => {
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
     });
     installFetchMock();
-    const handler = createTelegramWebhookHandler(config);
+    const { handler } = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("hello");
     const req = makeWebhookRequest(payload);
@@ -185,7 +185,7 @@ describe("telegram webhook handler: gatewayInternalBaseUrl", () => {
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
     });
     installFetchMock();
-    const handler = createTelegramWebhookHandler(config);
+    const { handler } = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("hello", 2001);
     const req = makeWebhookRequest(payload);
@@ -207,7 +207,7 @@ describe("telegram webhook handler: /new rejection", () => {
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
     });
     installFetchMock();
-    const handler = createTelegramWebhookHandler(config);
+    const { handler } = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("/start deep-link-token", 2501);
     const req = makeWebhookRequest(payload);
@@ -235,7 +235,7 @@ describe("telegram webhook handler: /new rejection", () => {
   test("/start with routing rejection sends setup notice and does not forward", async () => {
     const config = makeConfig({ unmappedPolicy: "reject" });
     installFetchMock();
-    const handler = createTelegramWebhookHandler(config);
+    const { handler } = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("/start", 2502);
     (payload.message as any).chat.id = 54321;
@@ -258,7 +258,7 @@ describe("telegram webhook handler: /new rejection", () => {
     // No routing entries and unmappedPolicy is "reject" — routing will fail
     const config = makeConfig({ unmappedPolicy: "reject" });
     installFetchMock();
-    const handler = createTelegramWebhookHandler(config);
+    const { handler } = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("/new", 3001);
     const req = makeWebhookRequest(payload);
@@ -282,7 +282,7 @@ describe("telegram webhook handler: /new rejection", () => {
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
     });
     installFetchMock();
-    const handler = createTelegramWebhookHandler(config);
+    const { handler } = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("/new", 4001);
     const req = makeWebhookRequest(payload);
@@ -309,7 +309,7 @@ describe("telegram webhook handler: /new rejection", () => {
   test("/new rejection does not call resetConversation", async () => {
     const config = makeConfig({ unmappedPolicy: "reject" });
     installFetchMock();
-    const handler = createTelegramWebhookHandler(config);
+    const { handler } = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("/new", 5001);
     const req = makeWebhookRequest(payload);
@@ -363,7 +363,7 @@ describe("telegram webhook handler: in-flight dedup", () => {
       return new Response("Not found", { status: 404 });
     });
 
-    const handler = createTelegramWebhookHandler(config);
+    const { handler } = createTelegramWebhookHandler(config);
     const payload = makeTelegramPayload("hello", 9001);
 
     // Fire first request (will block on runtime call)
@@ -424,7 +424,7 @@ describe("telegram webhook handler: in-flight dedup", () => {
       return new Response("Not found", { status: 404 });
     });
 
-    const handler = createTelegramWebhookHandler(config);
+    const { handler } = createTelegramWebhookHandler(config);
     const payload = makeTelegramPayload("hello", 9002);
 
     // First attempt fails — should return 500 and unreserve
@@ -443,7 +443,7 @@ describe("telegram webhook handler: in-flight dedup", () => {
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
     });
     installFetchMock();
-    const handler = createTelegramWebhookHandler(config);
+    const { handler } = createTelegramWebhookHandler(config);
     const payload = makeTelegramPayload("hello", 9003);
 
     // Process successfully
@@ -483,7 +483,7 @@ describe("telegram webhook handler: callback_query forwarding", () => {
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
     });
     installFetchMock();
-    const handler = createTelegramWebhookHandler(config);
+    const { handler } = createTelegramWebhookHandler(config);
 
     const payload = makeCallbackQueryPayload("apr:run-abc:approve", 7001);
     const req = makeWebhookRequest(payload);
@@ -507,7 +507,7 @@ describe("telegram webhook handler: callback_query forwarding", () => {
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
     });
     installFetchMock();
-    const handler = createTelegramWebhookHandler(config);
+    const { handler } = createTelegramWebhookHandler(config);
 
     const payload = makeCallbackQueryPayload("apr:run-xyz:reject", 7002);
     const req = makeWebhookRequest(payload);
@@ -527,7 +527,7 @@ describe("telegram webhook handler: callback_query forwarding", () => {
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
     });
     installFetchMock();
-    const handler = createTelegramWebhookHandler(config);
+    const { handler } = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("hello", 7003);
     const req = makeWebhookRequest(payload);
@@ -546,7 +546,7 @@ describe("telegram webhook handler: callback_query forwarding", () => {
       routingEntries: [{ type: "chat_id", key: "12345", assistantId: "assistant-a" }],
     });
     installFetchMock();
-    const handler = createTelegramWebhookHandler(config);
+    const { handler } = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("hello", 7004);
     const req = makeWebhookRequest(payload);
@@ -568,7 +568,7 @@ describe("telegram webhook handler: gateway-origin marker", () => {
       runtimeBearerToken: bearerToken,
     });
     installFetchMock();
-    const handler = createTelegramWebhookHandler(config);
+    const { handler } = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("hello", 8001);
     const req = makeWebhookRequest(payload);
@@ -587,7 +587,7 @@ describe("telegram webhook handler: gateway-origin marker", () => {
       runtimeBearerToken: undefined,
     });
     installFetchMock();
-    const handler = createTelegramWebhookHandler(config);
+    const { handler } = createTelegramWebhookHandler(config);
 
     const payload = makeTelegramPayload("hello", 8002);
     const req = makeWebhookRequest(payload);

--- a/gateway/src/http/routes/telegram-webhook.test.ts
+++ b/gateway/src/http/routes/telegram-webhook.test.ts
@@ -137,7 +137,7 @@ describe("telegram-webhook callback query acknowledgment", () => {
   });
 
   it("acknowledges callback query after successful forwarding", async () => {
-    const handler = createTelegramWebhookHandler(baseConfig);
+    const { handler } = createTelegramWebhookHandler(baseConfig);
     const body = makeCallbackQueryBody("apr:run1:approve", 300);
     const res = await handler(postRequest(body));
 
@@ -156,7 +156,7 @@ describe("telegram-webhook callback query acknowledgment", () => {
       Promise.resolve({ forwarded: false, rejected: true, rejectionReason: "No route" }),
     );
 
-    const handler = createTelegramWebhookHandler(baseConfig);
+    const { handler } = createTelegramWebhookHandler(baseConfig);
     const body = makeCallbackQueryBody("apr:run1:approve", 301);
     const res = await handler(postRequest(body));
 
@@ -175,7 +175,7 @@ describe("telegram-webhook callback query acknowledgment", () => {
       Promise.resolve({ forwarded: false, rejected: false }),
     );
 
-    const handler = createTelegramWebhookHandler(baseConfig);
+    const { handler } = createTelegramWebhookHandler(baseConfig);
     const body = makeCallbackQueryBody("apr:run1:approve", 304);
     const res = await handler(postRequest(body));
 
@@ -192,7 +192,7 @@ describe("telegram-webhook callback query acknowledgment", () => {
   it("acknowledges callback query when forwarding throws", async () => {
     handleInboundMock.mockImplementation(() => Promise.reject(new Error("boom")));
 
-    const handler = createTelegramWebhookHandler(baseConfig);
+    const { handler } = createTelegramWebhookHandler(baseConfig);
     const body = makeCallbackQueryBody("apr:run1:approve", 305);
     const res = await handler(postRequest(body));
 
@@ -207,7 +207,7 @@ describe("telegram-webhook callback query acknowledgment", () => {
   });
 
   it("acknowledges callback query when /new command is triggered via callback", async () => {
-    const handler = createTelegramWebhookHandler(baseConfig);
+    const { handler } = createTelegramWebhookHandler(baseConfig);
     const body = makeCallbackQueryBody("/new", 302);
     const res = await handler(postRequest(body));
 
@@ -222,7 +222,7 @@ describe("telegram-webhook callback query acknowledgment", () => {
   });
 
   it("acknowledges callback query when /start command is triggered via callback", async () => {
-    const handler = createTelegramWebhookHandler(baseConfig);
+    const { handler } = createTelegramWebhookHandler(baseConfig);
     const body = makeCallbackQueryBody("/start", 313);
     const res = await handler(postRequest(body));
 
@@ -238,7 +238,7 @@ describe("telegram-webhook callback query acknowledgment", () => {
   });
 
   it("forwards /start as channel command-intent metadata and sends start acknowledgement", async () => {
-    const handler = createTelegramWebhookHandler(baseConfig);
+    const { handler } = createTelegramWebhookHandler(baseConfig);
     const body = JSON.stringify({
       update_id: 314,
       message: {
@@ -268,7 +268,7 @@ describe("telegram-webhook callback query acknowledgment", () => {
   });
 
   it("does not call answerCallbackQuery for regular text messages", async () => {
-    const handler = createTelegramWebhookHandler(baseConfig);
+    const { handler } = createTelegramWebhookHandler(baseConfig);
     const body = JSON.stringify({
       update_id: 303,
       message: {
@@ -301,7 +301,7 @@ describe("telegram-webhook callback query acknowledgment", () => {
       }),
     );
 
-    const handler = createTelegramWebhookHandler(baseConfig);
+    const { handler } = createTelegramWebhookHandler(baseConfig);
     const body = makeCallbackQueryBody("apr:run1:approve", 306);
     const res = await handler(postRequest(body));
 
@@ -331,7 +331,7 @@ describe("telegram-webhook callback query acknowledgment", () => {
       }),
     );
 
-    const handler = createTelegramWebhookHandler(baseConfig);
+    const { handler } = createTelegramWebhookHandler(baseConfig);
     const body = makeCallbackQueryBody("apr:stale:approve", 307);
     const res = await handler(postRequest(body));
 
@@ -356,7 +356,7 @@ describe("telegram-webhook callback query acknowledgment", () => {
       }),
     );
 
-    const handler = createTelegramWebhookHandler(baseConfig);
+    const { handler } = createTelegramWebhookHandler(baseConfig);
     const body = makeCallbackQueryBody("apr:run1:approve", 308);
     const res = await handler(postRequest(body));
 
@@ -380,7 +380,7 @@ describe("telegram-webhook callback query acknowledgment", () => {
       }),
     );
 
-    const handler = createTelegramWebhookHandler(baseConfig);
+    const { handler } = createTelegramWebhookHandler(baseConfig);
     const body = makeCallbackQueryBody("apr:run1:approve_once", 310);
     const res = await handler(postRequest(body));
 
@@ -422,7 +422,7 @@ describe("telegram-webhook callback query acknowledgment", () => {
       return Promise.resolve({});
     });
 
-    const handler = createTelegramWebhookHandler(baseConfig);
+    const { handler } = createTelegramWebhookHandler(baseConfig);
     const body = makeCallbackQueryBody("apr:run1:approve_once", 311);
     const res = await handler(postRequest(body));
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -468,7 +468,7 @@ describe("telegram-webhook callback query acknowledgment", () => {
       return Promise.resolve({});
     });
 
-    const handler = createTelegramWebhookHandler(baseConfig);
+    const { handler } = createTelegramWebhookHandler(baseConfig);
     const body = makeCallbackQueryBody("gapr:run1:approve", 309);
     const res = await handler(postRequest(body));
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -508,7 +508,7 @@ describe("telegram-webhook callback query acknowledgment", () => {
       return Promise.resolve({});
     });
 
-    const handler = createTelegramWebhookHandler(baseConfig);
+    const { handler } = createTelegramWebhookHandler(baseConfig);
     const body = makeCallbackQueryBody("apr:run1:approve_once", 312);
     const res = await handler(postRequest(body));
     await new Promise((resolve) => setTimeout(resolve, 0));

--- a/gateway/src/http/routes/twilio-sms-webhook.test.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.test.ts
@@ -120,7 +120,7 @@ describe("twilio-sms-webhook", () => {
   });
 
   it("rejects GET requests with 405", async () => {
-    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const { handler } = createTwilioSmsWebhookHandler(baseConfig);
     const req = new Request("http://localhost:7830/webhooks/twilio/sms", {
       method: "GET",
     });
@@ -129,7 +129,7 @@ describe("twilio-sms-webhook", () => {
   });
 
   it("rejects missing signature with 403", async () => {
-    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const { handler } = createTwilioSmsWebhookHandler(baseConfig);
     const req = new Request("http://localhost:7830/webhooks/twilio/sms", {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -140,7 +140,7 @@ describe("twilio-sms-webhook", () => {
   });
 
   it("rejects invalid signature with 403", async () => {
-    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const { handler } = createTwilioSmsWebhookHandler(baseConfig);
     const req = new Request("http://localhost:7830/webhooks/twilio/sms", {
       method: "POST",
       headers: {
@@ -154,7 +154,7 @@ describe("twilio-sms-webhook", () => {
   });
 
   it("rejects when twilioAuthToken is not configured (fail-closed)", async () => {
-    const handler = createTwilioSmsWebhookHandler({
+    const { handler } = createTwilioSmsWebhookHandler({
       ...baseConfig,
       twilioAuthToken: undefined,
     });
@@ -168,7 +168,7 @@ describe("twilio-sms-webhook", () => {
   });
 
   it("returns 400 when MessageSid is missing", async () => {
-    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const { handler } = createTwilioSmsWebhookHandler(baseConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = { Body: "hello", From: "+15551234567", To: "+15559876543" };
     const req = buildSignedSmsRequest(url, params, AUTH_TOKEN);
@@ -179,7 +179,7 @@ describe("twilio-sms-webhook", () => {
   });
 
   it("forwards valid SMS to runtime and returns 200", async () => {
-    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const { handler } = createTwilioSmsWebhookHandler(baseConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
       Body: "Hello from SMS",
@@ -207,7 +207,7 @@ describe("twilio-sms-webhook", () => {
   });
 
   it("deduplicates by MessageSid", async () => {
-    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const { handler } = createTwilioSmsWebhookHandler(baseConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
       Body: "dedup test",
@@ -235,7 +235,7 @@ describe("twilio-sms-webhook", () => {
       Promise.resolve({ forwarded: false, rejected: false }),
     );
 
-    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const { handler } = createTwilioSmsWebhookHandler(baseConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
       Body: "fail test",
@@ -249,7 +249,7 @@ describe("twilio-sms-webhook", () => {
   });
 
   it("allows retry after failed forwarding (does not dedup failures)", async () => {
-    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const { handler } = createTwilioSmsWebhookHandler(baseConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
       Body: "retry test",
@@ -284,7 +284,7 @@ describe("twilio-sms-webhook", () => {
   });
 
   it("allows retry after handleInbound throws (does not dedup exceptions)", async () => {
-    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const { handler } = createTwilioSmsWebhookHandler(baseConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
       Body: "throw test",
@@ -317,7 +317,7 @@ describe("twilio-sms-webhook", () => {
       Promise.resolve({ forwarded: false, rejected: true, rejectionReason: "No route" }),
     );
 
-    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const { handler } = createTwilioSmsWebhookHandler(baseConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
       Body: "rejected test",
@@ -333,7 +333,7 @@ describe("twilio-sms-webhook", () => {
   });
 
   it("rejects oversized payload via Content-Length header", async () => {
-    const handler = createTwilioSmsWebhookHandler({
+    const { handler } = createTwilioSmsWebhookHandler({
       ...baseConfig,
       maxWebhookPayloadBytes: 50,
     });
@@ -351,7 +351,7 @@ describe("twilio-sms-webhook", () => {
   });
 
   it("/new triggers resetConversation and does not forward as normal message", async () => {
-    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const { handler } = createTwilioSmsWebhookHandler(baseConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
       Body: "/new",
@@ -386,7 +386,7 @@ describe("twilio-sms-webhook", () => {
   });
 
   it("/new is case-insensitive and trims whitespace", async () => {
-    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const { handler } = createTwilioSmsWebhookHandler(baseConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
       Body: "  /NEW  ",
@@ -408,7 +408,7 @@ describe("twilio-sms-webhook", () => {
       unmappedPolicy: "reject",
       defaultAssistantId: undefined,
     };
-    const handler = createTwilioSmsWebhookHandler(rejectConfig);
+    const { handler } = createTwilioSmsWebhookHandler(rejectConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
       Body: "/new",
@@ -439,7 +439,7 @@ describe("twilio-sms-webhook", () => {
   });
 
   it("MMS payload (NumMedia > 0) sends unsupported notice and forwards text body", async () => {
-    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const { handler } = createTwilioSmsWebhookHandler(baseConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
       Body: "Check out this photo",
@@ -473,7 +473,7 @@ describe("twilio-sms-webhook", () => {
   });
 
   it("MMS detected via MediaUrl0 when NumMedia is absent forwards text body", async () => {
-    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const { handler } = createTwilioSmsWebhookHandler(baseConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
       Body: "Check out this photo",
@@ -511,7 +511,7 @@ describe("twilio-sms-webhook", () => {
       defaultAssistantId: undefined,
       assistantPhoneNumbers: { "ast-alpha": "+15559876543" },
     };
-    const handler = createTwilioSmsWebhookHandler(phoneConfig);
+    const { handler } = createTwilioSmsWebhookHandler(phoneConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
       Body: "Hello via phone routing",
@@ -537,7 +537,7 @@ describe("twilio-sms-webhook", () => {
       defaultAssistantId: undefined,
       assistantPhoneNumbers: { "ast-beta": "+15559876543" },
     };
-    const handler = createTwilioSmsWebhookHandler(phoneConfig);
+    const { handler } = createTwilioSmsWebhookHandler(phoneConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
       Body: "/new",
@@ -565,7 +565,7 @@ describe("twilio-sms-webhook", () => {
       defaultAssistantId: undefined,
       assistantPhoneNumbers: { "ast-beta": "+15559876543" },
     };
-    const handler = createTwilioSmsWebhookHandler(phoneConfig);
+    const { handler } = createTwilioSmsWebhookHandler(phoneConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
       Body: "MMS inbound",
@@ -595,7 +595,7 @@ describe("twilio-sms-webhook", () => {
       ...baseConfig,
       assistantPhoneNumbers: { "ast-alpha": "+15550001111" },
     };
-    const handler = createTwilioSmsWebhookHandler(phoneConfig);
+    const { handler } = createTwilioSmsWebhookHandler(phoneConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
       Body: "Hello fallthrough",
@@ -618,7 +618,7 @@ describe("twilio-sms-webhook", () => {
       defaultAssistantId: undefined,
       assistantPhoneNumbers: { "ast-alpha": "+15559876543" },
     };
-    const handler = createTwilioSmsWebhookHandler(phoneConfig);
+    const { handler } = createTwilioSmsWebhookHandler(phoneConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
       Body: "Hello via phone routing",
@@ -641,7 +641,7 @@ describe("twilio-sms-webhook", () => {
   });
 
   it("passes default routing override to handleInbound when no phone match", async () => {
-    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const { handler } = createTwilioSmsWebhookHandler(baseConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
       Body: "Hello default routing",
@@ -669,7 +669,7 @@ describe("twilio-sms-webhook", () => {
       unmappedPolicy: "reject",
       defaultAssistantId: undefined,
     };
-    const handler = createTwilioSmsWebhookHandler(rejectConfig);
+    const { handler } = createTwilioSmsWebhookHandler(rejectConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     // Use a unique From number to avoid the module-level rejection notice
     // rate limiter (shouldSendRejectionNotice) cooldown from other tests.
@@ -702,7 +702,7 @@ describe("twilio-sms-webhook", () => {
       Promise.resolve({ forwarded: false, rejected: true, rejectionReason: "test" }),
     );
 
-    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const { handler } = createTwilioSmsWebhookHandler(baseConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     // Use a unique From number to avoid the module-level rejection notice
     // rate limiter (shouldSendRejectionNotice) cooldown from other tests.
@@ -731,7 +731,7 @@ describe("twilio-sms-webhook", () => {
   });
 
   it("MMS detected via MediaContentType0 when NumMedia is absent forwards text body", async () => {
-    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const { handler } = createTwilioSmsWebhookHandler(baseConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
       Body: "Here is a file",
@@ -763,7 +763,7 @@ describe("twilio-sms-webhook", () => {
   });
 
   it("MMS with empty body sends unsupported notice but does not forward", async () => {
-    const handler = createTwilioSmsWebhookHandler(baseConfig);
+    const { handler } = createTwilioSmsWebhookHandler(baseConfig);
     const url = "http://localhost:7830/webhooks/twilio/sms";
     const params = {
       Body: "",

--- a/gateway/src/http/routes/whatsapp-webhook.test.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.test.ts
@@ -103,7 +103,7 @@ describe('whatsapp-webhook', () => {
   });
 
   it('validates GET verify-token handshake', async () => {
-    const handler = createWhatsAppWebhookHandler(baseConfig);
+    const { handler } = createWhatsAppWebhookHandler(baseConfig);
     const req = new Request(
       'http://localhost:7830/webhooks/whatsapp?hub.mode=subscribe&hub.verify_token=verify-token&hub.challenge=12345',
       { method: 'GET' },
@@ -115,7 +115,7 @@ describe('whatsapp-webhook', () => {
   });
 
   it('rejects GET verify-token handshake when token mismatches', async () => {
-    const handler = createWhatsAppWebhookHandler(baseConfig);
+    const { handler } = createWhatsAppWebhookHandler(baseConfig);
     const req = new Request(
       'http://localhost:7830/webhooks/whatsapp?hub.mode=subscribe&hub.verify_token=wrong&hub.challenge=12345',
       { method: 'GET' },
@@ -126,7 +126,7 @@ describe('whatsapp-webhook', () => {
   });
 
   it('fails closed when whatsappAppSecret is not configured', async () => {
-    const handler = createWhatsAppWebhookHandler({
+    const { handler } = createWhatsAppWebhookHandler({
       ...baseConfig,
       whatsappAppSecret: undefined,
     });
@@ -140,7 +140,7 @@ describe('whatsapp-webhook', () => {
   it('rejects POST when signature verification fails', async () => {
     verifyWhatsAppWebhookSignatureMock.mockImplementation(() => false);
 
-    const handler = createWhatsAppWebhookHandler(baseConfig);
+    const { handler } = createWhatsAppWebhookHandler(baseConfig);
     const res = await handler(buildPostReq({ object: 'whatsapp_business_account', entry: [] }));
 
     expect(res.status).toBe(403);
@@ -148,7 +148,7 @@ describe('whatsapp-webhook', () => {
   });
 
   it('acknowledges non-message payloads without forwarding', async () => {
-    const handler = createWhatsAppWebhookHandler(baseConfig);
+    const { handler } = createWhatsAppWebhookHandler(baseConfig);
     normalizeWhatsAppWebhookMock.mockImplementation(() => []);
 
     const res = await handler(buildPostReq({ object: 'whatsapp_business_account', entry: [] }));
@@ -160,7 +160,7 @@ describe('whatsapp-webhook', () => {
   });
 
   it('forwards normalized inbound WhatsApp messages to runtime with channel metadata', async () => {
-    const handler = createWhatsAppWebhookHandler(baseConfig);
+    const { handler } = createWhatsAppWebhookHandler(baseConfig);
 
     normalizeWhatsAppWebhookMock.mockImplementation(() => [{
       whatsappMessageId: 'wamid-1',
@@ -205,7 +205,7 @@ describe('whatsapp-webhook', () => {
   });
 
   it('returns 500 when runtime forwarding fails for a normalized message', async () => {
-    const handler = createWhatsAppWebhookHandler(baseConfig);
+    const { handler } = createWhatsAppWebhookHandler(baseConfig);
     normalizeWhatsAppWebhookMock.mockImplementation(() => [{
       whatsappMessageId: 'wamid-fail',
       event: {


### PR DESCRIPTION
## Summary
- Gateway webhook handler factories (`createTelegramWebhookHandler`, `createTwilioSmsWebhookHandler`, `createWhatsAppWebhookHandler`) now return `{ handler, dedupCache }` instead of a bare function
- Updated all gateway test files to destructure the `handler` property from the factory return value
- Fixes `TS2349: This expression is not callable` type errors across 8 test files

## Original prompt
Fix TypeScript type errors in gateway tests. The handler factory functions (like `createTelegramWebhookHandler`, `createTwilioSmsWebhookHandler`, `createWhatsappWebhookHandler`, etc.) now return `{ handler, dedupCache }` instead of being directly callable. All test files calling the result directly need to be updated to use `.handler(...)` instead. Affected files are in `gateway/src/__tests__/` and `gateway/src/http/routes/`. Run `cd gateway && bunx tsc --noEmit` to verify the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
