### PR TITLE
fix: reduce thread header spacing and open apps in view-only mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1168,7 +1168,6 @@ struct MainWindowView: View {
             VColor.divider
                 .frame(height: 1)
                 .padding(.horizontal, VSpacing.md)
-                .padding(.vertical, VSpacing.sm)
 
             // MARK: Threads (scrollable)
             SidebarThreadsHeader(onNewThread: {
@@ -1399,6 +1398,8 @@ struct MainWindowView: View {
 
     /// Open an app in the workspace view (main content area).
     private func openAppInWorkspace(app: AppListManager.AppItem) {
+        // Reset sticky chat dock so apps open in view-only mode by default
+        isAppChatOpen = false
         appListManager.recordAppOpen(
             id: app.id,
             name: app.name,
@@ -1490,14 +1491,14 @@ private struct SidebarThreadsHeader: View {
     var body: some View {
         HStack {
             Text("Threads")
-                .font(.system(size: 18, weight: .medium))
+                .font(.system(size: 13, weight: .medium))
                 .foregroundColor(VColor.textPrimary)
             Spacer()
             VIconButton(label: "New thread", icon: "plus", iconOnly: true, action: onNewThread)
         }
         .padding(.leading, 20)
         .padding(.trailing, VSpacing.md)
-        .padding(.vertical, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
     }
 }
 


### PR DESCRIPTION
## Summary
- Shrink Threads heading from 18pt to 13pt to match body text
- Remove extra vertical padding from divider above Threads header
- Reduce Threads header vertical padding from 8pt to 4pt
- Reset `isAppChatOpen` when opening an app so it defaults to view-only mode instead of sticky edit mode

## Test plan
- [ ] Verify Threads heading is smaller and spacing above it is tighter
- [ ] Open an app — should show in view-only mode, not edit mode
- [ ] Toggle chat dock on, close app, reopen app — should still open in view-only mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
