### PR TITLE
fix: await async addMessage/sendMessage calls in tests

### DIFF
--- a/assistant/src/__tests__/media-reuse-story.e2e.test.ts
+++ b/assistant/src/__tests__/media-reuse-story.e2e.test.ts
@@ -365,7 +365,7 @@ describe('Story E2E: selfie yesterday -> generated image today', () => {
       generatedImageBase64,
     );
 
-    const msgB = addMessage(threadB.id, 'assistant', 'Here is your generated portrait!');
+    const msgB = await addMessage(threadB.id, 'assistant', 'Here is your generated portrait!');
     linkAttachmentToMessage(msgB.id, outputAttachment.id, 0);
 
     // Verify the output attachment exists in the DB via raw search
@@ -475,7 +475,7 @@ describe('Private-thread variant: cross-thread media blocking', () => {
     // Upload selfie in a private thread
     const privateThread = createConversation({ title: 'Private selfie thread', threadType: 'private' });
     const selfie = uploadAttachment('private-selfie.png', 'image/png', TINY_PNG_BASE64);
-    const msg = addMessage(privateThread.id, 'user', 'My private selfie');
+    const msg = await addMessage(privateThread.id, 'user', 'My private selfie');
     linkAttachmentToMessage(msg.id, selfie.id, 0);
 
     // Search from a standard thread
@@ -499,7 +499,7 @@ describe('Private-thread variant: cross-thread media blocking', () => {
     const privateThread = createConversation({ title: 'Private selfie thread', threadType: 'private' });
     const base64 = Buffer.from('private image data').toString('base64');
     const selfie = uploadAttachment('private-selfie.png', 'image/png', base64);
-    const msg = addMessage(privateThread.id, 'user', 'My private selfie');
+    const msg = await addMessage(privateThread.id, 'user', 'My private selfie');
     linkAttachmentToMessage(msg.id, selfie.id, 0);
 
     // Try to materialize from a standard thread
@@ -523,7 +523,7 @@ describe('Private-thread variant: cross-thread media blocking', () => {
   test('selfie in private thread IS accessible from the same private thread', async () => {
     const privateThread = createConversation({ title: 'Private selfie thread', threadType: 'private' });
     const selfie = uploadAttachment('private-selfie.png', 'image/png', TINY_PNG_BASE64);
-    const msg = addMessage(privateThread.id, 'user', 'My private selfie');
+    const msg = await addMessage(privateThread.id, 'user', 'My private selfie');
     linkAttachmentToMessage(msg.id, selfie.id, 0);
 
     // Search from the same private thread
@@ -552,7 +552,7 @@ describe('Private-thread variant: cross-thread media blocking', () => {
   test('selfie in private thread A is NOT accessible from private thread B', async () => {
     const privateThreadA = createConversation({ title: 'Private thread A', threadType: 'private' });
     const selfie = uploadAttachment('thread-a-selfie.png', 'image/png', TINY_PNG_BASE64);
-    const msgA = addMessage(privateThreadA.id, 'user', 'Selfie in thread A');
+    const msgA = await addMessage(privateThreadA.id, 'user', 'Selfie in thread A');
     linkAttachmentToMessage(msgA.id, selfie.id, 0);
 
     // Search from a different private thread

--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -3577,11 +3577,11 @@ describe('Memory regressions', () => {
   });
 
   // PR-17: addMessage() passes conversation scope to the indexer
-  test('addMessage inherits private conversation scope on memory segments', () => {
+  test('addMessage inherits private conversation scope on memory segments', async () => {
     const conv = createConversation({ title: 'Private thread', threadType: 'private' });
     expect(conv.memoryScopeId).toMatch(/^private:/);
 
-    const msg = addMessage(conv.id, 'user', 'My secret project details for the private thread.');
+    const msg = await addMessage(conv.id, 'user', 'My secret project details for the private thread.');
 
     const db = getDb();
     const segments = db
@@ -3596,11 +3596,11 @@ describe('Memory regressions', () => {
     }
   });
 
-  test('addMessage uses default scope for standard conversations', () => {
+  test('addMessage uses default scope for standard conversations', async () => {
     const conv = createConversation({ title: 'Standard thread', threadType: 'standard' });
     expect(conv.memoryScopeId).toBe('default');
 
-    const msg = addMessage(conv.id, 'user', 'Normal conversation content for testing scope defaults.');
+    const msg = await addMessage(conv.id, 'user', 'Normal conversation content for testing scope defaults.');
 
     const db = getDb();
     const segments = db
@@ -4018,7 +4018,7 @@ describe('Memory regressions', () => {
     const privScope = getConversationMemoryScopeId(privConv.id);
     expect(privScope).toMatch(/^private:/);
 
-    const privMsg = addMessage(
+    const privMsg = await addMessage(
       privConv.id,
       'user',
       'I prefer using the Zephyr framework for all backend microservices.',
@@ -4095,7 +4095,7 @@ describe('Memory regressions', () => {
     const stdScope = getConversationMemoryScopeId(stdConv.id);
     expect(stdScope).toBe('default');
 
-    const stdMsg = addMessage(
+    const stdMsg = await addMessage(
       stdConv.id,
       'user',
       'I prefer using the Obsidian editor for all my note-taking workflows.',
@@ -4558,7 +4558,7 @@ describe('Memory regressions', () => {
 
   // ── Provenance plumbing tests ────────────────────────────────────────
 
-  test('provenance fields are preserved in stored message metadata', () => {
+  test('provenance fields are preserved in stored message metadata', async () => {
     const conv = createConversation('provenance-preserve');
     const metadata = {
       userMessageChannel: 'telegram' as const,
@@ -4567,7 +4567,7 @@ describe('Memory regressions', () => {
       provenanceGuardianExternalUserId: 'guardian-123',
       provenanceRequesterIdentifier: 'Alice',
     };
-    const msg = addMessage(conv.id, 'user', 'Hello from telegram', metadata);
+    const msg = await addMessage(conv.id, 'user', 'Hello from telegram', metadata);
 
     const db = getDb();
     const stored = db
@@ -4628,7 +4628,7 @@ describe('Memory regressions', () => {
     expect(result.provenanceRequesterIdentifier).toBe('Charlie');
   });
 
-  test('indexMessageNow receives provenanceActorRole when metadata includes it', () => {
+  test('indexMessageNow receives provenanceActorRole when metadata includes it', async () => {
     const conv = createConversation('provenance-indexer');
     const metadata = {
       provenanceActorRole: 'non-guardian' as const,
@@ -4636,7 +4636,7 @@ describe('Memory regressions', () => {
     };
     // addMessage parses metadata and passes provenanceActorRole to indexMessageNow.
     // We verify indirectly: the message is persisted with metadata and segments are indexed.
-    const msg = addMessage(conv.id, 'user', 'Test provenance indexing message with enough content to segment', metadata);
+    const msg = await addMessage(conv.id, 'user', 'Test provenance indexing message with enough content to segment', metadata);
     expect(msg.id).toBeTruthy();
 
     // Verify segments were created (indexMessageNow was called successfully)

--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -85,8 +85,8 @@ describe('Runtime attachment metadata', () => {
 
     // Set up conversation and messages using "self" as the assistantId
     const mapping = getOrCreateConversation(conversationKey);
-    conversationStore.addMessage(mapping.conversationId, 'user', 'Hello');
-    const assistantMsg = conversationStore.addMessage(
+    await conversationStore.addMessage(mapping.conversationId, 'user', 'Hello');
+    const assistantMsg = await conversationStore.addMessage(
       mapping.conversationId,
       'assistant',
       JSON.stringify([{ type: 'text', text: 'Here is a chart' }]),
@@ -124,8 +124,8 @@ describe('Runtime attachment metadata', () => {
     const conversationKey = 'test-conv-2';
 
     const mapping = getOrCreateConversation(conversationKey);
-    conversationStore.addMessage(mapping.conversationId, 'user', 'Hello');
-    conversationStore.addMessage(
+    await conversationStore.addMessage(mapping.conversationId, 'user', 'Hello');
+    await conversationStore.addMessage(
       mapping.conversationId,
       'assistant',
       JSON.stringify([{ type: 'text', text: 'No attachments here' }]),

--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -381,14 +381,14 @@ describe('getAttachmentsForMessage', () => {
     db.run('DELETE FROM conversations');
   });
 
-  function createMessage(role: string, content: string): string {
+  async function createMessage(role: string, content: string): Promise<string> {
     const conv = createConversation('test');
-    const msg = addMessage(conv.id, role, content);
+    const msg = await addMessage(conv.id, role, content);
     return msg.id;
   }
 
-  test('returns attachments linked to a message', () => {
-    const msgId = createMessage('assistant', 'Here is a chart');
+  test('returns attachments linked to a message', async () => {
+    const msgId = await createMessage('assistant', 'Here is a chart');
     const stored = uploadAttachment('chart.png', 'image/png', 'iVBOR');
     linkAttachmentToMessage(msgId, stored.id, 0);
 
@@ -404,8 +404,8 @@ describe('getAttachmentsForMessage', () => {
     expect(getAttachmentsForMessage('msg-nonexistent')).toEqual([]);
   });
 
-  test('returns multiple attachments in position order', () => {
-    const msgId = createMessage('assistant', 'Two files');
+  test('returns multiple attachments in position order', async () => {
+    const msgId = await createMessage('assistant', 'Two files');
     const a1 = uploadAttachment('first.txt', 'text/plain', 'AAAA');
     const a2 = uploadAttachment('second.txt', 'text/plain', 'BBBB');
 
@@ -418,8 +418,8 @@ describe('getAttachmentsForMessage', () => {
     expect(result[1].originalFilename).toBe('second.txt');
   });
 
-  test('returns all attachments linked to a message', () => {
-    const msgId = createMessage('assistant', 'Mixed');
+  test('returns all attachments linked to a message', async () => {
+    const msgId = await createMessage('assistant', 'Mixed');
     const a1 = uploadAttachment('a.png', 'image/png', 'AAAA');
     const a2 = uploadAttachment('b.png', 'image/png', 'BBBB');
 

--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -393,13 +393,13 @@ describe('SubagentManager abort race guard', () => {
 });
 
 describe('SubagentManager sendMessage validation', () => {
-  test('rejects empty content without throwing', () => {
+  test('rejects empty content without throwing', async () => {
     const manager = new SubagentManager();
     const subagentId = 'sub-1';
     injectFakeSubagent(manager, subagentId, makeState(subagentId));
 
-    expect(manager.sendMessage(subagentId, '')).toBe('empty');
-    expect(manager.sendMessage(subagentId, '   ')).toBe('empty');
-    expect(manager.sendMessage(subagentId, '\n\t')).toBe('empty');
+    expect(await manager.sendMessage(subagentId, '')).toBe('empty');
+    expect(await manager.sendMessage(subagentId, '   ')).toBe('empty');
+    expect(await manager.sendMessage(subagentId, '\n\t')).toBe('empty');
   });
 });

--- a/assistant/src/__tests__/swarm-session-integration.test.ts
+++ b/assistant/src/__tests__/swarm-session-integration.test.ts
@@ -134,7 +134,7 @@ describe('swarm through AgentLoop', () => {
     const loop = new AgentLoop(mockProvider, 'system prompt', {}, tools, toolExecutor);
     const messages: Message[] = [{ role: 'user', content: [{ type: 'text', text: 'Build a feature' }] }];
 
-    const history = await loop.run(messages, (e) => events.push(e));
+    const history = await loop.run(messages, (e) => { events.push(e); });
 
     // Should have tool_use event
     const toolUseEvents = events.filter(e => e.type === 'tool_use');
@@ -186,7 +186,7 @@ describe('swarm through AgentLoop', () => {
     const messages: Message[] = [{ role: 'user', content: [{ type: 'text', text: 'go' }] }];
 
     // Should not hang or throw
-    const history = await loop.run(messages, (e) => events.push(e), controller.signal);
+    const history = await loop.run(messages, (e) => { events.push(e); }, controller.signal);
     expect(history.length).toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
## Summary
- Add `await` to `addMessage()` calls across test files after it became async
- Add `await` to `sendMessage()` calls in subagent manager tests
- Fix arrow function body style in swarm session integration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
