### PR TITLE
fix: check conversationTimeoutPaused in isThinking subscriber

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -127,7 +127,7 @@ final class VoiceModeManager: ObservableObject {
                 guard let self, self.state == .idle else { return }
                 if thinking {
                     self.cancelConversationTimeout()
-                } else {
+                } else if !self.conversationTimeoutPaused {
                     self.startConversationTimeout()
                 }
             }


### PR DESCRIPTION
The isThinkingCancellable Combine subscriber was calling startConversationTimeout() directly without checking the conversationTimeoutPaused flag, which could re-arm the timeout during CU escalation. Addresses feedback from #9818.