### PR TITLE
feat(parental): move profile switcher to Control Center drawer in sidebar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -69,6 +69,7 @@ struct MainWindowView: View {
     /// so we can restore it when they exit instead of jumping to visibleThreads.first
     /// (which may be a pinned thread unrelated to what they were doing).
     @State private var preTemporaryChatThreadId: UUID?
+    @State private var showingProfileSwitchSheet: Bool = false
 
     @AppStorage("sidebarExpanded") var sidebarExpanded: Bool = true
     @AppStorage("themePreference") private var themePreference: String = "system"
@@ -668,7 +669,19 @@ struct MainWindowView: View {
                             onDebug: {
                                 sidebar.showControlCenterDrawer = false
                                 windowState.selection = .panel(.debug)
-                            }
+                            },
+                            onSwitchProfile: settingsStore.isParentalEnabled ? {
+                                if settingsStore.activeProfile == "parental" {
+                                    // No PIN needed to enter child mode — switch directly
+                                    sidebar.showControlCenterDrawer = false
+                                    Task { await settingsStore.switchProfile(to: "child", pin: nil) }
+                                } else {
+                                    // Switching back to parental requires PIN — show sheet
+                                    sidebar.showControlCenterDrawer = false
+                                    showingProfileSwitchSheet = true
+                                }
+                            } : nil,
+                            activeProfile: settingsStore.isParentalEnabled ? settingsStore.activeProfile : nil
                         )
                         .frame(width: drawerWidth)
                         .offset(x: drawerX, y: -28)
@@ -836,6 +849,27 @@ struct MainWindowView: View {
             if let pending = sidebar.threadPendingDeletion, let newValue, newValue != pending {
                 sidebar.threadPendingDeletion = nil
             }
+        }
+        .sheet(isPresented: $showingProfileSwitchSheet) {
+            ProfileSwitchSheet(
+                onComplete: { result in
+                    switch result {
+                    case .success(let pin):
+                        Task {
+                            await settingsStore.switchProfile(to: "parental", pin: pin)
+                            // Only dismiss if the switch succeeded; the sheet's inline error
+                            // message handles the failure case (it stays open).
+                            if settingsStore.profileSwitchError == nil {
+                                showingProfileSwitchSheet = false
+                            }
+                        }
+                    case .failure:
+                        // ProfileSwitchSheet shows "Incorrect PIN." inline — no extra action needed
+                        break
+                    }
+                },
+                daemonClient: daemonClient
+            )
         }
     }
 
@@ -1476,9 +1510,20 @@ private struct ControlCenterRow: View {
 private struct DrawerMenuView: View {
     let onSettings: () -> Void
     let onDebug: () -> Void
+    // Parental profile switcher — nil when parental controls are disabled
+    let onSwitchProfile: (() -> Void)?
+    let activeProfile: String?
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             DrawerMenuItem(icon: "gearshape", label: "Settings", action: onSettings)
+
+            if let onSwitch = onSwitchProfile, let profile = activeProfile {
+                VColor.surfaceBorder.frame(height: 1)
+                    .padding(.vertical, VSpacing.xs)
+
+                DrawerProfileItem(activeProfile: profile, action: onSwitch)
+            }
 
             VColor.surfaceBorder.frame(height: 1)
                 .padding(.vertical, VSpacing.xs)
@@ -1516,6 +1561,50 @@ private struct DrawerMenuItem: View {
                     .font(.custom("Inter", size: 13))
                     .foregroundColor(VColor.textPrimary)
                 Spacer()
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.sm)
+            .background(isHovered ? VColor.hoverOverlay.opacity(0.06) : Color.clear)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            isHovered = hovering
+            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+    }
+}
+
+/// A row in the Control Center drawer that shows the active parental/child profile
+/// and lets the user switch to the other profile with a single tap.
+private struct DrawerProfileItem: View {
+    let activeProfile: String
+    let action: () -> Void
+    @State private var isHovered = false
+
+    private var isParental: Bool { activeProfile == "parental" }
+    private var avatarIcon: String { isParental ? "person.crop.circle.fill" : "figure.child.circle.fill" }
+    private var avatarColor: Color { isParental ? VColor.accent : VColor.success }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: VSpacing.md) {
+                Image(systemName: avatarIcon)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(avatarColor)
+                    .frame(width: 18)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(isParental ? "Parental" : "Child")
+                        .font(.custom("Inter", size: 13))
+                        .foregroundColor(VColor.textPrimary)
+                    Text("Switch profile")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(VColor.textMuted)
             }
             .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.sm)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
@@ -38,10 +38,6 @@ struct SettingsParentalTab: View {
     // forward the PIN to the daemon (required when parental mode is enabled).
     @State private var unlockedPIN: String?
 
-    // -- Profile switcher --
-    @State private var showingProfileSwitchSheet: Bool = false
-    @State private var profileSwitchError: String? = nil
-
     // -- Child: request permission sheet --
     @State private var showingRequestPermissionSheet: Bool = false
     @State private var requestToolName: String = ""
@@ -67,10 +63,6 @@ struct SettingsParentalTab: View {
                     pendingApprovalsSection
                 }
 
-                // Profile switcher — always visible when parental controls are enabled,
-                // regardless of lock state (switching to child doesn't need unlock).
-                profileSwitcherSection
-
                 if isUnlocked || !hasPIN {
                     pinSection
                     contentRestrictionsSection
@@ -90,31 +82,6 @@ struct SettingsParentalTab: View {
         .onAppear {
             loadSettings()
             settingsStore.loadActivityLog()
-        }
-        .sheet(isPresented: $showingProfileSwitchSheet) {
-            ProfileSwitchSheet(
-                onComplete: { result in
-                    switch result {
-                    case .success(let pin):
-                        Task {
-                            await settingsStore.switchProfile(to: "parental", pin: pin)
-                            if settingsStore.profileSwitchError == nil {
-                                showingProfileSwitchSheet = false
-                                // Cache the PIN so the parental profile can immediately
-                                // respond to pending approval requests without a separate
-                                // unlock step.
-                                isUnlocked = true
-                                unlockedPIN = pin
-                            } else {
-                                profileSwitchError = settingsStore.profileSwitchError
-                            }
-                        }
-                    case .failure:
-                        profileSwitchError = "Incorrect PIN."
-                    }
-                },
-                daemonClient: daemonClient
-            )
         }
         .sheet(isPresented: $showingPINSheet) {
             PINSheet(
@@ -233,84 +200,6 @@ struct SettingsParentalTab: View {
         }
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)
-    }
-
-    // MARK: - Profile Switcher
-
-    private var profileSwitcherSection: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            Text("Active Profile")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.textPrimary)
-
-            Text("Switch between Parental (admin) and Child profiles. Switching back to Parental requires your PIN.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textSecondary)
-                .fixedSize(horizontal: false, vertical: true)
-                .textSelection(.enabled)
-
-            // Current profile display with avatar
-            HStack(spacing: VSpacing.sm) {
-                profileAvatar(for: settingsStore.activeProfile)
-                VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                    Text("Active Profile")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
-                    Text(settingsStore.activeProfile == "parental" ? "Parental (Admin)" : "Child")
-                        .font(VFont.bodyMedium)
-                        .foregroundColor(VColor.textPrimary)
-                }
-                Spacer()
-                HStack(spacing: VSpacing.xs) {
-                    VButton(
-                        label: "Parental (Admin)",
-                        style: settingsStore.activeProfile == "parental" ? .primary : .secondary
-                    ) {
-                        switchProfile(to: "parental")
-                    }
-                    VButton(
-                        label: "Child",
-                        style: settingsStore.activeProfile == "child" ? .primary : .secondary
-                    ) {
-                        switchProfile(to: "child")
-                    }
-                }
-            }
-
-            if let err = profileSwitchError {
-                Text(err)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.error)
-                    .textSelection(.enabled)
-            }
-        }
-        .padding(VSpacing.lg)
-        .vCard(background: VColor.surfaceSubtle)
-    }
-
-    /// Renders an SF Symbol avatar appropriate for the given profile identifier.
-    /// Parental profile uses `person.crop.circle.fill` in accent (violet);
-    /// child profile uses `figure.child.circle.fill` in success (emerald).
-    @ViewBuilder
-    private func profileAvatar(for profile: String) -> some View {
-        let isParental = profile == "parental"
-        Image(systemName: isParental ? "person.crop.circle.fill" : "figure.child.circle.fill")
-            .font(.system(size: 32))
-            .foregroundColor(isParental ? VColor.accent : VColor.success)
-            .accessibilityLabel(isParental ? "Parental profile" : "Child profile")
-    }
-
-    private func switchProfile(to target: String) {
-        profileSwitchError = nil
-        if target == "child" {
-            // No PIN required to enter child mode
-            Task {
-                await settingsStore.switchProfile(to: "child", pin: nil)
-            }
-        } else {
-            // Switching back to parental requires PIN verification
-            showingProfileSwitchSheet = true
-        }
     }
 
     private var pinSection: some View {
@@ -1315,7 +1204,7 @@ private struct PINSheet: View {
 
 // MARK: - Unlock Sheet
 
-private enum UnlockResult {
+enum UnlockResult {
     case success(pin: String)
     case failure
 }
@@ -1420,7 +1309,7 @@ private struct UnlockSheet: View {
 /// PIN prompt shown when a child-mode user attempts to switch back to the
 /// parental (admin) profile. Reuses the same daemon verify-pin IPC call as UnlockSheet.
 @MainActor
-private struct ProfileSwitchSheet: View {
+struct ProfileSwitchSheet: View {
     let onComplete: (UnlockResult) -> Void
     var daemonClient: DaemonClient?
 


### PR DESCRIPTION
## Summary
- Remove Active Profile section from Parental Settings tab
- Add profile switcher row to the Control Center drawer (gear menu at bottom of sidebar), visible only when parental controls are enabled
- Switching to Child profile is immediate; switching to Parental shows PIN sheet

## Original prompt
Active profile should not be a section inside parental settings — should be a profile select button under the Control Center menu in sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
