### PR TITLE
fix: run context capture on MainActor instead of async let

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -241,15 +241,11 @@ final class VoiceModeManager: ObservableObject {
         voiceService.resetStreamingTTS()
 
         Task {
-            // Run context capture concurrently with transcription finalization.
-            // Both start after silence is detected (recording stops inside
-            // stopRecordingAndGetTranscription), so context captures the app
-            // the user was looking at when they spoke, and any AX query delay
-            // in capture() doesn't extend the recording window.
-            async let ctx = DictationContextCapture.capture()
-            async let transcription = voiceService.stopRecordingAndGetTranscription()
-
-            let text = await transcription
+            let text = await voiceService.stopRecordingAndGetTranscription()
+            // Capture context sequentially on the MainActor after recording
+            // stops. The .processing state transition above already prevents
+            // further transcription, so there is no recording-window concern.
+            let ctx = DictationContextCapture.capture()
             let trimmed = (text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
 
             guard !trimmed.isEmpty, let chatViewModel else {
@@ -269,17 +265,16 @@ final class VoiceModeManager: ObservableObject {
             // Build the context prefix from captured app context. Sanitize
             // attacker-controlled values (window titles, selected text) to
             // prevent prompt injection and excessive length.
-            let capturedCtx = await ctx
             var contextPrefix = ""
-            if !capturedCtx.appName.isEmpty {
-                var parts: [String] = ["app: \(capturedCtx.appName)"]
-                if !capturedCtx.windowTitle.isEmpty {
-                    let sanitizedTitle = Self.sanitize(capturedCtx.windowTitle, maxLength: 200)
+            if !ctx.appName.isEmpty {
+                var parts: [String] = ["app: \(ctx.appName)"]
+                if !ctx.windowTitle.isEmpty {
+                    let sanitizedTitle = Self.sanitize(ctx.windowTitle, maxLength: 200)
                     if !sanitizedTitle.isEmpty {
                         parts.append("window: \"\(sanitizedTitle)\"")
                     }
                 }
-                if let selected = capturedCtx.selectedText, !selected.isEmpty {
+                if let selected = ctx.selectedText, !selected.isEmpty {
                     let sanitizedSelected = Self.sanitize(selected, maxLength: 500)
                     if !sanitizedSelected.isEmpty {
                         parts.append("selected text: \"\(sanitizedSelected)\"")


### PR DESCRIPTION
Reverts the async let on DictationContextCapture.capture() which moved it off the main thread, breaking clipboard fallback (NSPasteboard, RunLoop) and AppKit usage. Context capture now runs sequentially after stopRecordingAndGetTranscription() on the MainActor. The recording window concern is already handled by the .processing state transition. Addresses feedback from #9827.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
