### PR TITLE
fix: add authenticationRequired case to SessionErrorCategory switch

### DIFF
--- a/clients/shared/Features/Chat/ChatSessionError.swift
+++ b/clients/shared/Features/Chat/ChatSessionError.swift
@@ -10,6 +10,7 @@ public enum SessionErrorCategory: Equatable, Sendable {
     case sessionAborted
     case processingFailed
     case regenerateFailed
+    case authenticationRequired
     case unknown
 
     public init(from code: SessionErrorCode) {
@@ -30,6 +31,8 @@ public enum SessionErrorCategory: Equatable, Sendable {
             self = .processingFailed
         case .regenerateFailed:
             self = .regenerateFailed
+        case .authenticationRequired:
+            self = .authenticationRequired
         case .unknown:
             self = .unknown
         }
@@ -54,6 +57,8 @@ public enum SessionErrorCategory: Equatable, Sendable {
             return "Click Retry or send your message again. Copy debug info if the problem repeats."
         case .regenerateFailed:
             return "Click Retry to regenerate, or send a new message instead."
+        case .authenticationRequired:
+            return "Sign in or check your credentials in Settings to continue."
         case .unknown:
             return "Click Retry or send a new message. Copy debug info if the problem repeats."
         }


### PR DESCRIPTION
## Summary
- Add missing `.authenticationRequired` case to `SessionErrorCategory` enum and its `init(from:)` switch, fixing the non-exhaustive switch compile error in the macOS build CI.

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22459897396

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
