### PR TITLE
M3: Model-mediated security recommendation and user override flow

### DIFF
--- a/assistant/src/__tests__/security-decision.test.ts
+++ b/assistant/src/__tests__/security-decision.test.ts
@@ -130,6 +130,7 @@ describe('makeSecurityDecision', () => {
 
       expect(decision.recommendation).toBe('do_not_recommend');
       expect(decision.overallRisk).toBe('unknown');
+      expect(decision.rationale).toContain('Ath');
     });
   });
 
@@ -287,6 +288,44 @@ describe('OverrideTracker', () => {
     expect(tracker.getOverrides()).toHaveLength(2);
     expect(tracker.getOverrides()[0].overallRiskAtOverride).toBe('medium');
     expect(tracker.getOverrides()[1].overallRiskAtOverride).toBe('high');
+  });
+
+  test('recordOverride snapshots the input — later mutations do not affect history', () => {
+    const tracker = createOverrideTracker();
+
+    const override = {
+      skillId: 'tool',
+      source: 'org/repo',
+      overriddenAt: '2025-06-15T10:00:00Z',
+      overallRiskAtOverride: 'medium',
+      recommendation: 'proceed_with_caution',
+    };
+
+    tracker.recordOverride(override);
+
+    // Mutate the original object after recording
+    override.overallRiskAtOverride = 'MUTATED';
+
+    const recorded = tracker.getOverrides();
+    expect(recorded[0].overallRiskAtOverride).toBe('medium');
+  });
+
+  test('getOverrides entries are independent — mutating one does not affect internals', () => {
+    const tracker = createOverrideTracker();
+
+    tracker.recordOverride({
+      skillId: 'tool',
+      source: 'org/repo',
+      overriddenAt: '2025-06-15T10:00:00Z',
+      overallRiskAtOverride: 'medium',
+      recommendation: 'proceed_with_caution',
+    });
+
+    const first = tracker.getOverrides();
+    first[0].overallRiskAtOverride = 'MUTATED';
+
+    const second = tracker.getOverrides();
+    expect(second[0].overallRiskAtOverride).toBe('medium');
   });
 
   test('getOverrides returns a defensive copy', () => {

--- a/assistant/src/__tests__/security-decision.test.ts
+++ b/assistant/src/__tests__/security-decision.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, test } from 'bun:test';
+
+import { makeSecurityDecision } from '../skills/security-decision.js';
+import { createOverrideTracker } from '../skills/install-override.js';
+import type { SkillsShAuditReport } from '../skills/skillssh.js';
+
+// ─── makeSecurityDecision ────────────────────────────────────────────────────────
+
+describe('makeSecurityDecision', () => {
+  describe('proceed recommendation', () => {
+    test('safe risk across all dimensions', () => {
+      const audit: SkillsShAuditReport = {
+        ath: { risk: 'safe', analyzedAt: '2025-01-01T00:00:00Z' },
+        socket: { risk: 'safe', analyzedAt: '2025-01-01T00:00:00Z', score: 95 },
+        snyk: { risk: 'safe', analyzedAt: '2025-01-01T00:00:00Z' },
+      };
+
+      const decision = makeSecurityDecision(audit);
+
+      expect(decision.recommendation).toBe('proceed');
+      expect(decision.overallRisk).toBe('safe');
+      expect(decision.rationale).toBe(
+        'All security audits passed with safe/low risk ratings.',
+      );
+    });
+
+    test('low risk across all dimensions', () => {
+      const audit: SkillsShAuditReport = {
+        ath: { risk: 'low', analyzedAt: '2025-01-01T00:00:00Z' },
+        socket: { risk: 'low', analyzedAt: '2025-01-01T00:00:00Z' },
+      };
+
+      const decision = makeSecurityDecision(audit);
+
+      expect(decision.recommendation).toBe('proceed');
+      expect(decision.overallRisk).toBe('low');
+    });
+
+    test('mixed safe and low risk still recommends proceed', () => {
+      const audit: SkillsShAuditReport = {
+        ath: { risk: 'safe', analyzedAt: '2025-01-01T00:00:00Z' },
+        socket: { risk: 'low', analyzedAt: '2025-01-01T00:00:00Z' },
+        snyk: { risk: 'safe', analyzedAt: '2025-01-01T00:00:00Z' },
+      };
+
+      const decision = makeSecurityDecision(audit);
+
+      expect(decision.recommendation).toBe('proceed');
+      expect(decision.overallRisk).toBe('low');
+    });
+  });
+
+  describe('proceed_with_caution recommendation', () => {
+    test('medium risk triggers caution', () => {
+      const audit: SkillsShAuditReport = {
+        ath: { risk: 'safe', analyzedAt: '2025-01-01T00:00:00Z' },
+        socket: { risk: 'medium', analyzedAt: '2025-01-02T00:00:00Z', score: 64 },
+        snyk: { risk: 'low', analyzedAt: '2025-01-01T00:00:00Z' },
+      };
+
+      const decision = makeSecurityDecision(audit);
+
+      expect(decision.recommendation).toBe('proceed_with_caution');
+      expect(decision.overallRisk).toBe('medium');
+      expect(decision.rationale).toContain('Medium risk detected');
+      expect(decision.rationale).toContain('Socket reports score 64/100');
+    });
+
+    test('medium risk with alerts in rationale', () => {
+      const audit: SkillsShAuditReport = {
+        socket: { risk: 'medium', analyzedAt: '2025-01-02T00:00:00Z', alerts: 1, score: 64 },
+      };
+
+      const decision = makeSecurityDecision(audit);
+
+      expect(decision.recommendation).toBe('proceed_with_caution');
+      expect(decision.rationale).toContain('1 alert');
+      expect(decision.rationale).toContain('score 64/100');
+    });
+  });
+
+  describe('do_not_recommend recommendation', () => {
+    test('high risk triggers do not recommend', () => {
+      const audit: SkillsShAuditReport = {
+        ath: { risk: 'safe', analyzedAt: '2025-01-01T00:00:00Z' },
+        snyk: { risk: 'high', analyzedAt: '2025-01-03T00:00:00Z' },
+      };
+
+      const decision = makeSecurityDecision(audit);
+
+      expect(decision.recommendation).toBe('do_not_recommend');
+      expect(decision.overallRisk).toBe('high');
+      expect(decision.rationale).toContain('High risk detected');
+      expect(decision.rationale).toContain('Snyk');
+    });
+
+    test('critical risk triggers do not recommend', () => {
+      const audit: SkillsShAuditReport = {
+        snyk: { risk: 'critical', analyzedAt: '2025-01-03T00:00:00Z', alerts: 5 },
+        socket: { risk: 'critical', analyzedAt: '2025-01-03T00:00:00Z', score: 12 },
+      };
+
+      const decision = makeSecurityDecision(audit);
+
+      expect(decision.recommendation).toBe('do_not_recommend');
+      expect(decision.overallRisk).toBe('critical');
+      expect(decision.rationale).toContain('Critical risk detected');
+      expect(decision.rationale).toContain('Snyk');
+      expect(decision.rationale).toContain('Socket');
+    });
+
+    test('unknown risk (empty audit) triggers do not recommend', () => {
+      const audit: SkillsShAuditReport = {};
+
+      const decision = makeSecurityDecision(audit);
+
+      expect(decision.recommendation).toBe('do_not_recommend');
+      expect(decision.overallRisk).toBe('unknown');
+      expect(decision.rationale).toBe(
+        'No audit data available. Unable to assess security risk.',
+      );
+    });
+
+    test('unrecognized risk label treated as unknown', () => {
+      const audit: SkillsShAuditReport = {
+        ath: { risk: 'banana', analyzedAt: '2025-01-01T00:00:00Z' },
+      };
+
+      const decision = makeSecurityDecision(audit);
+
+      expect(decision.recommendation).toBe('do_not_recommend');
+      expect(decision.overallRisk).toBe('unknown');
+    });
+  });
+
+  describe('audit dimension summary mapping', () => {
+    test('maps all providers present in the audit', () => {
+      const audit: SkillsShAuditReport = {
+        ath: { risk: 'safe', analyzedAt: '2025-01-01T00:00:00Z' },
+        socket: { risk: 'low', analyzedAt: '2025-01-02T00:00:00Z', score: 88 },
+        snyk: { risk: 'safe', analyzedAt: '2025-01-03T00:00:00Z', alerts: 0 },
+      };
+
+      const decision = makeSecurityDecision(audit);
+
+      expect(decision.auditSummary).toHaveLength(3);
+      expect(decision.auditSummary[0]).toEqual({
+        provider: 'ath',
+        risk: 'safe',
+        analyzedAt: '2025-01-01T00:00:00Z',
+        details: undefined,
+      });
+      expect(decision.auditSummary[1]).toEqual({
+        provider: 'socket',
+        risk: 'low',
+        analyzedAt: '2025-01-02T00:00:00Z',
+        details: 'score 88/100',
+      });
+      expect(decision.auditSummary[2]).toEqual({
+        provider: 'snyk',
+        risk: 'safe',
+        analyzedAt: '2025-01-03T00:00:00Z',
+        details: '0 alerts',
+      });
+    });
+
+    test('includes both alerts and score when present', () => {
+      const audit: SkillsShAuditReport = {
+        socket: { risk: 'medium', analyzedAt: '2025-01-01T00:00:00Z', alerts: 2, score: 55 },
+      };
+
+      const decision = makeSecurityDecision(audit);
+
+      expect(decision.auditSummary[0].details).toBe('2 alerts, score 55/100');
+    });
+
+    test('singular "alert" for count of 1', () => {
+      const audit: SkillsShAuditReport = {
+        snyk: { risk: 'low', analyzedAt: '2025-01-01T00:00:00Z', alerts: 1 },
+      };
+
+      const decision = makeSecurityDecision(audit);
+
+      expect(decision.auditSummary[0].details).toBe('1 alert');
+    });
+
+    test('empty audit produces empty summary', () => {
+      const decision = makeSecurityDecision({});
+
+      expect(decision.auditSummary).toEqual([]);
+    });
+
+    test('only includes providers with data', () => {
+      const audit: SkillsShAuditReport = {
+        socket: { risk: 'safe', analyzedAt: '2025-01-01T00:00:00Z' },
+      };
+
+      const decision = makeSecurityDecision(audit);
+
+      expect(decision.auditSummary).toHaveLength(1);
+      expect(decision.auditSummary[0].provider).toBe('socket');
+    });
+  });
+});
+
+// ─── OverrideTracker ─────────────────────────────────────────────────────────────
+
+describe('OverrideTracker', () => {
+  test('initially has no overrides', () => {
+    const tracker = createOverrideTracker();
+
+    expect(tracker.getOverrides()).toEqual([]);
+    expect(tracker.hasOverride('some-skill', 'some-org/repo')).toBe(false);
+  });
+
+  test('records and retrieves an override', () => {
+    const tracker = createOverrideTracker();
+
+    tracker.recordOverride({
+      skillId: 'dangerous-tool',
+      source: 'evil-org/repo',
+      overriddenAt: '2025-06-15T10:00:00Z',
+      overallRiskAtOverride: 'high',
+      recommendation: 'do_not_recommend',
+    });
+
+    expect(tracker.hasOverride('dangerous-tool', 'evil-org/repo')).toBe(true);
+    expect(tracker.hasOverride('dangerous-tool', 'other-org/repo')).toBe(false);
+    expect(tracker.hasOverride('safe-tool', 'evil-org/repo')).toBe(false);
+
+    const overrides = tracker.getOverrides();
+    expect(overrides).toHaveLength(1);
+    expect(overrides[0]).toEqual({
+      skillId: 'dangerous-tool',
+      source: 'evil-org/repo',
+      overriddenAt: '2025-06-15T10:00:00Z',
+      overallRiskAtOverride: 'high',
+      recommendation: 'do_not_recommend',
+    });
+  });
+
+  test('supports multiple overrides for different skills', () => {
+    const tracker = createOverrideTracker();
+
+    tracker.recordOverride({
+      skillId: 'skill-a',
+      source: 'org/repo',
+      overriddenAt: '2025-06-15T10:00:00Z',
+      overallRiskAtOverride: 'medium',
+      recommendation: 'proceed_with_caution',
+    });
+
+    tracker.recordOverride({
+      skillId: 'skill-b',
+      source: 'other/repo',
+      overriddenAt: '2025-06-15T11:00:00Z',
+      overallRiskAtOverride: 'high',
+      recommendation: 'do_not_recommend',
+    });
+
+    expect(tracker.hasOverride('skill-a', 'org/repo')).toBe(true);
+    expect(tracker.hasOverride('skill-b', 'other/repo')).toBe(true);
+    expect(tracker.getOverrides()).toHaveLength(2);
+  });
+
+  test('re-recording the same skill keeps a full audit trail', () => {
+    const tracker = createOverrideTracker();
+
+    tracker.recordOverride({
+      skillId: 'risky-tool',
+      source: 'org/repo',
+      overriddenAt: '2025-06-15T10:00:00Z',
+      overallRiskAtOverride: 'medium',
+      recommendation: 'proceed_with_caution',
+    });
+
+    tracker.recordOverride({
+      skillId: 'risky-tool',
+      source: 'org/repo',
+      overriddenAt: '2025-06-15T12:00:00Z',
+      overallRiskAtOverride: 'high',
+      recommendation: 'do_not_recommend',
+    });
+
+    expect(tracker.hasOverride('risky-tool', 'org/repo')).toBe(true);
+    // Both records kept for audit trail
+    expect(tracker.getOverrides()).toHaveLength(2);
+    expect(tracker.getOverrides()[0].overallRiskAtOverride).toBe('medium');
+    expect(tracker.getOverrides()[1].overallRiskAtOverride).toBe('high');
+  });
+
+  test('getOverrides returns a defensive copy', () => {
+    const tracker = createOverrideTracker();
+
+    tracker.recordOverride({
+      skillId: 'tool',
+      source: 'org/repo',
+      overriddenAt: '2025-06-15T10:00:00Z',
+      overallRiskAtOverride: 'medium',
+      recommendation: 'proceed_with_caution',
+    });
+
+    const first = tracker.getOverrides();
+    const second = tracker.getOverrides();
+    expect(first).not.toBe(second);
+    expect(first).toEqual(second);
+  });
+});

--- a/assistant/src/skills/install-override.ts
+++ b/assistant/src/skills/install-override.ts
@@ -36,8 +36,9 @@ export function createOverrideTracker(): OverrideTracker {
   return {
     recordOverride(override: InstallOverride): void {
       const key = overrideKey(override.skillId, override.source);
-      // Allow re-recording (e.g. risk level changed), but keep the full audit trail
-      overrides.push(override);
+      // Allow re-recording (e.g. risk level changed), but keep the full audit trail.
+      // Clone so later mutations to the caller's object don't rewrite history.
+      overrides.push({ ...override });
       seen.add(key);
     },
 
@@ -46,7 +47,7 @@ export function createOverrideTracker(): OverrideTracker {
     },
 
     getOverrides(): InstallOverride[] {
-      return [...overrides];
+      return overrides.map((o) => ({ ...o }));
     },
   };
 }

--- a/assistant/src/skills/install-override.ts
+++ b/assistant/src/skills/install-override.ts
@@ -1,0 +1,52 @@
+// ─── Types ──────────────────────────────────────────────────────────────────────
+
+export interface InstallOverride {
+  skillId: string;
+  source: string;
+  overriddenAt: string;
+  overallRiskAtOverride: string;
+  recommendation: string;
+}
+
+export interface OverrideTracker {
+  /** Record that a user explicitly overrode a security recommendation. */
+  recordOverride(override: InstallOverride): void;
+  /** Check if a user has previously overridden for this skill from this source. */
+  hasOverride(skillId: string, source: string): boolean;
+  /** Get all recorded overrides. */
+  getOverrides(): InstallOverride[];
+}
+
+// ─── In-memory implementation ───────────────────────────────────────────────────
+
+/**
+ * Session-scoped override tracker. Records are kept in memory for the
+ * duration of the process -- no persistence yet. The interface is designed
+ * so a persistent backend can be swapped in later without changing callers.
+ */
+export function createOverrideTracker(): OverrideTracker {
+  const overrides: InstallOverride[] = [];
+
+  function overrideKey(skillId: string, source: string): string {
+    return `${source}/${skillId}`;
+  }
+
+  const seen = new Set<string>();
+
+  return {
+    recordOverride(override: InstallOverride): void {
+      const key = overrideKey(override.skillId, override.source);
+      // Allow re-recording (e.g. risk level changed), but keep the full audit trail
+      overrides.push(override);
+      seen.add(key);
+    },
+
+    hasOverride(skillId: string, source: string): boolean {
+      return seen.has(overrideKey(skillId, source));
+    },
+
+    getOverrides(): InstallOverride[] {
+      return [...overrides];
+    },
+  };
+}

--- a/assistant/src/skills/security-decision.ts
+++ b/assistant/src/skills/security-decision.ts
@@ -88,8 +88,15 @@ function buildRationale(
 
     case 'do_not_recommend': {
       const riskLabel = overallRisk.charAt(0).toUpperCase() + overallRisk.slice(1);
+      const KNOWN_SAFE_RISKS: Record<string, true> = { safe: true, low: true, medium: true };
       const flaggedProviders = auditSummary
-        .filter((s) => s.risk === overallRisk || s.risk === 'critical' || s.risk === 'high')
+        .filter(
+          (s) =>
+            s.risk === overallRisk ||
+            s.risk === 'critical' ||
+            s.risk === 'high' ||
+            !Object.hasOwn(KNOWN_SAFE_RISKS, s.risk),
+        )
         .map((s) => s.provider.charAt(0).toUpperCase() + s.provider.slice(1));
       const providerNames =
         flaggedProviders.length > 0 ? ` by ${flaggedProviders.join(' and ')}` : '';

--- a/assistant/src/skills/security-decision.ts
+++ b/assistant/src/skills/security-decision.ts
@@ -1,0 +1,115 @@
+import type { SkillsShAuditReport, SkillsShAuditDimension } from './skillssh.js';
+import type { SkillsShRisk } from './remote-skill-policy.js';
+import { deriveOverallRisk } from './skillssh.js';
+
+// ─── Types ──────────────────────────────────────────────────────────────────────
+
+export type SecurityRecommendation = 'proceed' | 'proceed_with_caution' | 'do_not_recommend';
+
+export interface SecurityDecision {
+  recommendation: SecurityRecommendation;
+  overallRisk: SkillsShRisk;
+  rationale: string;
+  auditSummary: AuditDimensionSummary[];
+}
+
+export interface AuditDimensionSummary {
+  provider: string;
+  risk: string;
+  analyzedAt: string;
+  details?: string;
+}
+
+// ─── Decision logic ─────────────────────────────────────────────────────────────
+
+function recommendationFromRisk(risk: SkillsShRisk): SecurityRecommendation {
+  switch (risk) {
+    case 'safe':
+    case 'low':
+      return 'proceed';
+    case 'medium':
+      return 'proceed_with_caution';
+    case 'high':
+    case 'critical':
+    case 'unknown':
+      return 'do_not_recommend';
+  }
+}
+
+function buildDimensionDetails(dim: SkillsShAuditDimension): string | undefined {
+  const parts: string[] = [];
+  if (dim.alerts != null) parts.push(`${dim.alerts} alert${dim.alerts === 1 ? '' : 's'}`);
+  if (dim.score != null) parts.push(`score ${dim.score}/100`);
+  return parts.length > 0 ? parts.join(', ') : undefined;
+}
+
+function buildAuditSummary(audit: SkillsShAuditReport): AuditDimensionSummary[] {
+  const summaries: AuditDimensionSummary[] = [];
+  const providers = ['ath', 'socket', 'snyk'] as const;
+
+  for (const provider of providers) {
+    const dim = audit[provider];
+    if (dim) {
+      summaries.push({
+        provider,
+        risk: dim.risk,
+        analyzedAt: dim.analyzedAt,
+        details: buildDimensionDetails(dim),
+      });
+    }
+  }
+
+  return summaries;
+}
+
+function buildRationale(
+  recommendation: SecurityRecommendation,
+  overallRisk: SkillsShRisk,
+  auditSummary: AuditDimensionSummary[],
+): string {
+  if (auditSummary.length === 0) {
+    return 'No audit data available. Unable to assess security risk.';
+  }
+
+  switch (recommendation) {
+    case 'proceed':
+      return 'All security audits passed with safe/low risk ratings.';
+
+    case 'proceed_with_caution': {
+      const mediumProviders = auditSummary
+        .filter((s) => s.risk === 'medium')
+        .map((s) => {
+          const label = s.provider.charAt(0).toUpperCase() + s.provider.slice(1);
+          return s.details ? `${label} reports ${s.details}` : label;
+        });
+      const providerInfo = mediumProviders.length > 0 ? ` ${mediumProviders.join('. ')}.` : '';
+      return `Medium risk detected.${providerInfo}`;
+    }
+
+    case 'do_not_recommend': {
+      const riskLabel = overallRisk.charAt(0).toUpperCase() + overallRisk.slice(1);
+      const flaggedProviders = auditSummary
+        .filter((s) => s.risk === overallRisk || s.risk === 'critical' || s.risk === 'high')
+        .map((s) => s.provider.charAt(0).toUpperCase() + s.provider.slice(1));
+      const providerNames =
+        flaggedProviders.length > 0 ? ` by ${flaggedProviders.join(' and ')}` : '';
+      return `${riskLabel} risk detected${providerNames}. Review the audit details before proceeding.`;
+    }
+  }
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────────────
+
+/**
+ * Evaluate a skills.sh audit report and produce a structured security recommendation.
+ * The recommendation is purely advisory -- callers decide whether to act on it
+ * or present it to the user for an override decision.
+ */
+export function makeSecurityDecision(audit: SkillsShAuditReport): SecurityDecision {
+  const overallRisk = deriveOverallRisk(audit);
+  const recommendation = recommendationFromRisk(overallRisk);
+  const auditSummary = buildAuditSummary(audit);
+  const rationale = buildRationale(recommendation, overallRisk, auditSummary);
+
+  return { recommendation, overallRisk, rationale, auditSummary };
+}


### PR DESCRIPTION
Add security decision module that evaluates skills.sh audit data and produces structured recommendations (proceed/proceed_with_caution/do_not_recommend) with rationale. Add in-memory override tracker for recording user override decisions. Part of #9776.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9838" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
