### PR TITLE
fix: defer PID file write until daemon is ready

### DIFF
--- a/assistant/src/daemon/daemon-control.ts
+++ b/assistant/src/daemon/daemon-control.ts
@@ -161,19 +161,19 @@ export async function startDaemon(): Promise<{
     throw new DaemonError('Failed to start daemon: no PID returned');
   }
 
-  writePid(pid);
-
-  // Wait for socket to appear
+  // Wait for socket to appear before writing the PID file. Writing it
+  // earlier would leave an orphaned PID file if the daemon crashes during
+  // initialization — callers would think the daemon is still running.
   const timeouts = readDaemonTimeouts();
   const maxWait = timeouts.startupSocketWaitMs;
   const interval = 100;
   let waited = 0;
   while (waited < maxWait) {
     if (existsSync(socketPath)) {
+      writePid(pid);
       return { pid, alreadyRunning: false };
     }
     if (childExited) {
-      cleanupPidFile();
       const stderr = readFileSync(stderrPath, 'utf-8').trim();
       const detail = stderr
         ? `\n${stderr}`


### PR DESCRIPTION
## Summary
- Move PID file write to after daemon socket is confirmed available
- Prevents orphaned PID files when daemon crashes during initialization
- PID file now accurately reflects a running, connectable daemon

## Original prompt
Defer PID file write until after socket bind succeeds or critical initialization completes, rather than writing it before the daemon is fully started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
