### PR TITLE
fix: validate daemon PID is alive in macOS client health check

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -599,6 +599,23 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     }
     #endif
 
+    // MARK: - PID Validation
+
+    /// Check whether the daemon process is alive by reading the PID file and
+    /// sending signal 0 to the process. Returns `false` if the PID file is
+    /// missing, unreadable, or the process is not running.
+    #if os(macOS)
+    public static func isDaemonProcessAlive(environment: [String: String]? = nil) -> Bool {
+        let pidPath = VellumAssistantShared.resolvePidPath(environment: environment)
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: pidPath)),
+              let pidString = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let pid = pid_t(pidString) else {
+            return false
+        }
+        return kill(pid, 0) == 0
+    }
+    #endif
+
     // MARK: - Send
 
     public enum SendError: Error, LocalizedError {

--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -40,6 +40,16 @@ extension DaemonClient {
         let parameters: NWParameters
 
         if case .socket(let path) = config.transport {
+            // Validate the daemon process is alive before attempting a socket connection.
+            // The socket file can outlive the daemon (crash, unclean shutdown), causing
+            // NWConnection to hang until the connect timeout instead of failing fast.
+            if FileManager.default.fileExists(atPath: path), !Self.isDaemonProcessAlive() {
+                log.warning("Stale daemon socket detected — PID is dead, removing socket at \(path, privacy: .public)")
+                try? FileManager.default.removeItem(atPath: path)
+                isConnecting = false
+                throw NWError.posix(.ECONNREFUSED)
+            }
+
             log.info("Connecting to daemon socket at \(path, privacy: .public)")
             endpoint = NWEndpoint.unix(path: path)
             parameters = NWParameters()


### PR DESCRIPTION
## Summary
- Add PID file validation to macOS DaemonClient socket connection path
- Verify daemon process is actually alive before attempting socket connection, not just that socket file exists
- Clean up stale socket files and fail fast when PID is dead, triggering the existing reconnect/restart flow

## Original prompt
Socket health validation — verify daemon PID is alive in macOS client, not just that socket file exists, so the app can detect a dead daemon and trigger a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
