### PR TITLE
fix: handle missing onnxruntime-node gracefully in compiled binary

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -4,11 +4,46 @@ import { getOllamaBaseUrlEnv } from '../config/env.js';
 import type { AssistantConfig } from '../config/types.js';
 import { getLogger } from '../util/logger.js';
 import { GeminiEmbeddingBackend } from './embedding-gemini.js';
-import { LocalEmbeddingBackend } from './embedding-local.js';
 import { OllamaEmbeddingBackend } from './embedding-ollama.js';
 import { OpenAIEmbeddingBackend } from './embedding-openai.js';
 
 const log = getLogger('memory-embeddings');
+
+/**
+ * Lazy wrapper around LocalEmbeddingBackend that dynamically imports the
+ * module on first use. This avoids eagerly loading @huggingface/transformers
+ * (which statically imports onnxruntime-node) at module evaluation time.
+ * In compiled binaries where onnxruntime-node isn't bundled, the static
+ * import would crash the entire daemon at startup. By deferring the import,
+ * the failure is contained and other embedding backends can be used instead.
+ */
+class LazyLocalEmbeddingBackend implements EmbeddingBackend {
+  readonly provider = 'local' as const;
+  readonly model: string;
+  private delegate: EmbeddingBackend | null = null;
+  private initPromise: Promise<EmbeddingBackend> | null = null;
+
+  constructor(model: string) {
+    this.model = model;
+  }
+
+  async embed(texts: string[], options?: EmbeddingRequestOptions): Promise<number[][]> {
+    const backend = await this.getDelegate();
+    return backend.embed(texts, options);
+  }
+
+  private async getDelegate(): Promise<EmbeddingBackend> {
+    if (this.delegate) return this.delegate;
+    if (!this.initPromise) {
+      this.initPromise = (async () => {
+        const { LocalEmbeddingBackend } = await import('./embedding-local.js');
+        this.delegate = new LocalEmbeddingBackend(this.model);
+        return this.delegate;
+      })();
+    }
+    return this.initPromise;
+  }
+}
 
 /** Global cache of embedding backend instances, keyed by "provider:model". */
 const backendCache = new Map<string, EmbeddingBackend>();
@@ -106,7 +141,7 @@ export function selectEmbeddingBackend(config: AssistantConfig): EmbeddingBacken
   if (requested === 'local') {
     return {
       backend: getCachedOrCreate('local', config.memory.embeddings.localModel,
-        () => new LocalEmbeddingBackend(config.memory.embeddings.localModel)),
+        () => new LazyLocalEmbeddingBackend(config.memory.embeddings.localModel)),
       reason: null,
     };
   }
@@ -128,10 +163,9 @@ export function selectEmbeddingBackend(config: AssistantConfig): EmbeddingBacken
   for (const provider of order) {
     switch (provider) {
       case 'local':
-        // Local embeddings are always available (model downloaded on first use)
         return {
           backend: getCachedOrCreate('local', config.memory.embeddings.localModel,
-            () => new LocalEmbeddingBackend(config.memory.embeddings.localModel)),
+            () => new LazyLocalEmbeddingBackend(config.memory.embeddings.localModel)),
           reason: null,
         };
       case 'openai':

--- a/assistant/src/memory/embedding-local.ts
+++ b/assistant/src/memory/embedding-local.ts
@@ -56,8 +56,18 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
 
   private async initialize(): Promise<void> {
     log.info({ model: this.model }, 'Loading local embedding model (first load downloads the model)');
-    const { pipeline } = await import('@huggingface/transformers');
-    this.extractor = await pipeline('feature-extraction', this.model, {
+    let transformers: typeof import('@huggingface/transformers');
+    try {
+      transformers = await import('@huggingface/transformers');
+    } catch (err) {
+      // onnxruntime-node is not bundled in compiled binaries, so the import
+      // fails at runtime. Surface a clear error so callers can fall back to
+      // another embedding backend.
+      throw new Error(
+        `Local embedding backend unavailable: failed to load @huggingface/transformers (${err instanceof Error ? err.message : String(err)})`,
+      );
+    }
+    this.extractor = await transformers.pipeline('feature-extraction', this.model, {
       dtype: 'fp32',
     }) as unknown as FeatureExtractionPipeline;
     log.info({ model: this.model }, 'Local embedding model loaded');


### PR DESCRIPTION
## Summary
- Wrap `@huggingface/transformers` import in `embedding-local.ts` with try-catch to handle missing `onnxruntime-node` at runtime
- Replace static import of `LocalEmbeddingBackend` in `embedding-backend.ts` with a lazy wrapper (`LazyLocalEmbeddingBackend`) that dynamically imports the module on first use — prevents the daemon from crashing at module evaluation time in compiled binaries where `onnxruntime-node` isn't bundled
- When local embeddings fail (e.g., in a compiled binary), the existing fallback chain in `embedWithBackend()` automatically tries other configured backends (OpenAI, Gemini, Ollama)
- Fixes daemon startup crash: `Cannot find package 'onnxruntime-node' from '/$bunfs/root/vellum-daemon'`

## Original prompt
Handle missing onnxruntime-node gracefully — catch the import error and fall back instead of crashing the entire daemon when running from a compiled binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
