### PR TITLE
feat(parental): profile switcher as standalone sidebar row, Control Center hidden in child mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -644,7 +644,9 @@ struct MainWindowView: View {
                 }
                 .overlay {
                     // Click-outside-to-dismiss background for control center drawer
-                    if sidebar.showControlCenterDrawer {
+                    // Must mirror the same condition as the drawer itself: hidden in child profile
+                    let isChildProfile = settingsStore.isParentalEnabled && settingsStore.activeProfile == "child"
+                    if sidebar.showControlCenterDrawer && !isChildProfile {
                         Color.clear
                             .contentShape(Rectangle())
                             .onTapGesture {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -65,6 +65,7 @@ struct MainWindowView: View {
     @State private var requestedHomeBaseAtLaunch = false
     @AppStorage("isAppChatOpen") var isAppChatOpen: Bool = false
     @State private var jitPermissionManager = JITPermissionManager()
+    @State private var showingProfileSwitchSheet: Bool = false
     /// Stores the thread ID the user was on before entering temporary chat,
     /// so we can restore it when they exit instead of jumping to visibleThreads.first
     /// (which may be a pinned thread unrelated to what they were doing).
@@ -654,8 +655,9 @@ struct MainWindowView: View {
                     }
                 }
                 .overlay(alignment: .bottomLeading) {
-                    // Control center drawer rendered at top level so it floats above all content
-                    if sidebar.showControlCenterDrawer {
+                    // Control center drawer — never shown for child profile
+                    let isChildProfile = settingsStore.isParentalEnabled && settingsStore.activeProfile == "child"
+                    if sidebar.showControlCenterDrawer && !isChildProfile {
                         let drawerWidth = sidebarExpandedWidth - VSpacing.sm * 2
                         let drawerX = sidebarExpanded
                             ? 16 + VSpacing.sm
@@ -1089,6 +1091,24 @@ struct MainWindowView: View {
         } message: {
             Text("Enter a new name for this thread")
         }
+        .sheet(isPresented: $showingProfileSwitchSheet) {
+            ProfileSwitchSheet(
+                targetProfile: "parental",
+                currentProfile: settingsStore.activeProfile,
+                onComplete: { result in
+                    switch result {
+                    case .success(let pin):
+                        Task {
+                            await settingsStore.switchProfile(to: "parental", pin: pin)
+                            showingProfileSwitchSheet = false
+                        }
+                    case .failure:
+                        break
+                    }
+                },
+                daemonClient: daemonClient
+            )
+        }
     }
 
     // MARK: - Home Base Helpers
@@ -1213,14 +1233,34 @@ struct MainWindowView: View {
 
             Spacer(minLength: VSpacing.sm)
 
-            // Control Center row (fixed)
-            ControlCenterRow(
-                onToggle: {
-                    withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
-                        sidebar.showControlCenterDrawer.toggle()
+            // Control Center row (fixed) — hidden for child profile since children
+            // cannot access settings. The profile switcher below remains always visible.
+            let isChildProfile = settingsStore.isParentalEnabled && settingsStore.activeProfile == "child"
+            if !isChildProfile {
+                ControlCenterRow(
+                    onToggle: {
+                        withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
+                            sidebar.showControlCenterDrawer.toggle()
+                        }
                     }
-                }
-            )
+                )
+            }
+
+            // Profile switcher row — always visible when parental controls are active,
+            // even in child mode, so the child can always switch back to parental.
+            if settingsStore.isParentalEnabled {
+                ProfileSwitcherSidebarRow(
+                    activeProfile: settingsStore.activeProfile,
+                    isExpanded: true,
+                    onSwitch: {
+                        if settingsStore.activeProfile == "parental" {
+                            Task { await settingsStore.switchProfile(to: "child", pin: nil) }
+                        } else {
+                            showingProfileSwitchSheet = true
+                        }
+                    }
+                )
+            }
         }
     }
 
@@ -1250,10 +1290,29 @@ struct MainWindowView: View {
 
             Spacer()
 
-            SidebarNavRow(icon: "gearshape", label: "Control Center", isActive: false, isExpanded: false) {
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
-                    sidebar.showControlCenterDrawer.toggle()
+            // Control Center row — hidden for child profile
+            let isChildProfile = settingsStore.isParentalEnabled && settingsStore.activeProfile == "child"
+            if !isChildProfile {
+                SidebarNavRow(icon: "gearshape", label: "Control Center", isActive: false, isExpanded: false) {
+                    withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
+                        sidebar.showControlCenterDrawer.toggle()
+                    }
                 }
+            }
+
+            // Profile switcher icon — always visible when parental controls are active
+            if settingsStore.isParentalEnabled {
+                ProfileSwitcherSidebarRow(
+                    activeProfile: settingsStore.activeProfile,
+                    isExpanded: false,
+                    onSwitch: {
+                        if settingsStore.activeProfile == "parental" {
+                            Task { await settingsStore.switchProfile(to: "child", pin: nil) }
+                        } else {
+                            showingProfileSwitchSheet = true
+                        }
+                    }
+                )
             }
 
             Spacer().frame(height: 0)
@@ -1470,6 +1529,56 @@ private struct ControlCenterRow: View {
         )
         .padding(.horizontal, VSpacing.sm)
         .padding(.bottom, VSpacing.sm)
+    }
+}
+
+/// A sidebar row (or icon-only button when collapsed) for switching between
+/// parental and child profiles. Always visible when parental controls are on,
+/// including in child mode — so the child can always switch back to parental.
+private struct ProfileSwitcherSidebarRow: View {
+    let activeProfile: String
+    var isExpanded: Bool = true
+    let onSwitch: () -> Void
+    @State private var isHovered = false
+
+    private var isParental: Bool { activeProfile == "parental" }
+    private var avatarIcon: String { isParental ? "person.crop.circle.fill" : "figure.child.circle.fill" }
+    private var avatarColor: Color { isParental ? VColor.accent : VColor.success }
+    private var profileLabel: String { isParental ? "Parental" : "Child" }
+
+    var body: some View {
+        Button(action: onSwitch) {
+            HStack(spacing: isExpanded ? VSpacing.sm : 0) {
+                Image(systemName: avatarIcon)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundColor(avatarColor)
+                    .frame(width: 18)
+                if isExpanded {
+                    Text(profileLabel)
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(VColor.textPrimary)
+                    Spacer()
+                    Image(systemName: "arrow.left.arrow.right")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
+            .padding(.leading, isExpanded ? VSpacing.md : 0)
+            .padding(.trailing, isExpanded ? VSpacing.sm : 0)
+            .padding(.vertical, VSpacing.sm)
+            .frame(maxWidth: .infinity, alignment: isExpanded ? .leading : .center)
+            .background(isHovered ? adaptiveColor(light: Color(hex: 0xD4DFD0), dark: Moss._700).opacity(0.5) : .clear)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, isExpanded ? VSpacing.sm : VSpacing.xs)
+        .padding(.bottom, VSpacing.sm)
+        .help(isExpanded ? "Switch profile" : "\(profileLabel) profile — tap to switch")
+        .onHover { hovering in
+            isHovered = hovering
+            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
@@ -38,10 +38,6 @@ struct SettingsParentalTab: View {
     // forward the PIN to the daemon (required when parental mode is enabled).
     @State private var unlockedPIN: String?
 
-    // -- Profile switcher --
-    @State private var showingProfileSwitchSheet: Bool = false
-    @State private var profileSwitchError: String? = nil
-
     // -- Child: request permission sheet --
     @State private var showingRequestPermissionSheet: Bool = false
     @State private var requestToolName: String = ""
@@ -67,10 +63,6 @@ struct SettingsParentalTab: View {
                     pendingApprovalsSection
                 }
 
-                // Profile switcher — always visible when parental controls are enabled,
-                // regardless of lock state (switching to child doesn't need unlock).
-                profileSwitcherSection
-
                 if isUnlocked || !hasPIN {
                     pinSection
                     contentRestrictionsSection
@@ -90,31 +82,6 @@ struct SettingsParentalTab: View {
         .onAppear {
             loadSettings()
             settingsStore.loadActivityLog()
-        }
-        .sheet(isPresented: $showingProfileSwitchSheet) {
-            ProfileSwitchSheet(
-                onComplete: { result in
-                    switch result {
-                    case .success(let pin):
-                        Task {
-                            await settingsStore.switchProfile(to: "parental", pin: pin)
-                            if settingsStore.profileSwitchError == nil {
-                                showingProfileSwitchSheet = false
-                                // Cache the PIN so the parental profile can immediately
-                                // respond to pending approval requests without a separate
-                                // unlock step.
-                                isUnlocked = true
-                                unlockedPIN = pin
-                            } else {
-                                profileSwitchError = settingsStore.profileSwitchError
-                            }
-                        }
-                    case .failure:
-                        profileSwitchError = "Incorrect PIN."
-                    }
-                },
-                daemonClient: daemonClient
-            )
         }
         .sheet(isPresented: $showingPINSheet) {
             PINSheet(
@@ -233,84 +200,6 @@ struct SettingsParentalTab: View {
         }
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)
-    }
-
-    // MARK: - Profile Switcher
-
-    private var profileSwitcherSection: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            Text("Active Profile")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.textPrimary)
-
-            Text("Switch between Parental (admin) and Child profiles. Switching back to Parental requires your PIN.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textSecondary)
-                .fixedSize(horizontal: false, vertical: true)
-                .textSelection(.enabled)
-
-            // Current profile display with avatar
-            HStack(spacing: VSpacing.sm) {
-                profileAvatar(for: settingsStore.activeProfile)
-                VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                    Text("Active Profile")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
-                    Text(settingsStore.activeProfile == "parental" ? "Parental (Admin)" : "Child")
-                        .font(VFont.bodyMedium)
-                        .foregroundColor(VColor.textPrimary)
-                }
-                Spacer()
-                HStack(spacing: VSpacing.xs) {
-                    VButton(
-                        label: "Parental (Admin)",
-                        style: settingsStore.activeProfile == "parental" ? .primary : .secondary
-                    ) {
-                        switchProfile(to: "parental")
-                    }
-                    VButton(
-                        label: "Child",
-                        style: settingsStore.activeProfile == "child" ? .primary : .secondary
-                    ) {
-                        switchProfile(to: "child")
-                    }
-                }
-            }
-
-            if let err = profileSwitchError {
-                Text(err)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.error)
-                    .textSelection(.enabled)
-            }
-        }
-        .padding(VSpacing.lg)
-        .vCard(background: VColor.surfaceSubtle)
-    }
-
-    /// Renders an SF Symbol avatar appropriate for the given profile identifier.
-    /// Parental profile uses `person.crop.circle.fill` in accent (violet);
-    /// child profile uses `figure.child.circle.fill` in success (emerald).
-    @ViewBuilder
-    private func profileAvatar(for profile: String) -> some View {
-        let isParental = profile == "parental"
-        Image(systemName: isParental ? "person.crop.circle.fill" : "figure.child.circle.fill")
-            .font(.system(size: 32))
-            .foregroundColor(isParental ? VColor.accent : VColor.success)
-            .accessibilityLabel(isParental ? "Parental profile" : "Child profile")
-    }
-
-    private func switchProfile(to target: String) {
-        profileSwitchError = nil
-        if target == "child" {
-            // No PIN required to enter child mode
-            Task {
-                await settingsStore.switchProfile(to: "child", pin: nil)
-            }
-        } else {
-            // Switching back to parental requires PIN verification
-            showingProfileSwitchSheet = true
-        }
     }
 
     private var pinSection: some View {
@@ -1417,11 +1306,15 @@ private struct UnlockSheet: View {
 
 // MARK: - Profile Switch Sheet
 
-/// PIN prompt shown when a child-mode user attempts to switch back to the
-/// parental (admin) profile. Reuses the same daemon verify-pin IPC call as UnlockSheet.
+/// PIN prompt shown when attempting to switch to the parental (admin) profile.
+/// Exposed as `internal` so that MainWindowView can present it from the sidebar
+/// without going through the Settings tab. The `onComplete` closure receives the
+/// verified PIN on success so the caller can forward it to `settingsStore.switchProfile`.
 @MainActor
-private struct ProfileSwitchSheet: View {
-    let onComplete: (UnlockResult) -> Void
+struct ProfileSwitchSheet: View {
+    let targetProfile: String
+    let currentProfile: String
+    let onComplete: (Result<String, Error>) -> Void
     var daemonClient: DaemonClient?
 
     @State private var pin: String = ""
@@ -1526,9 +1419,10 @@ private struct ProfileSwitchSheet: View {
                 isLoading = false
                 if let r = response {
                     if r.verified {
-                        onComplete(.success(pin: pin))
+                        onComplete(.success(pin))
                     } else {
-                        onComplete(.failure)
+                        struct PINError: Error {}
+                        onComplete(.failure(PINError()))
                         errorMessage = "Incorrect PIN."
                     }
                 } else {


### PR DESCRIPTION
## Summary
- Remove Active Profile section from Parental Settings tab
- Add standalone profile switcher row in sidebar below the Control Center button (visible when parental controls are enabled, always accessible including in child mode)
- Hide Control Center button/drawer for child profile (child cannot access settings)
- Profile avatar icons: person.crop.circle.fill (violet/parental) and figure.child.circle.fill (emerald/child)
- Switching to Child: immediate; switching to Parental: PIN sheet

## Original prompt
Active profile should not be a section inside parental settings. Should be a menu item below the Control Center button in sidebar, separate from Control Center (which is hidden for child profile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
