### PR TITLE
fix: add missing authenticationRequired case to ChatErrorToastView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -170,6 +170,8 @@ struct ChatSessionErrorToast: View {
             return "stop.circle.fill"
         case .processingFailed, .regenerateFailed:
             return "arrow.triangle.2.circlepath"
+        case .authenticationRequired:
+            return "lock.fill"
         case .unknown:
             return "exclamationmark.triangle.fill"
         }


### PR DESCRIPTION
## Summary
- PR #9836 added `.authenticationRequired` to the `SessionErrorCategory` enum in `ChatSessionError.swift` but missed updating the exhaustive switch in `ChatErrorToastView.swift`, causing a build error
- Adds the missing case with a `lock.fill` SF Symbol icon

## Test plan
- [ ] Verify `./build.sh` compiles without errors
- [ ] Verify `./build.sh lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
