### PR TITLE
fix: handle authenticationRequired case in macOS and iOS icon switches

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -411,6 +411,7 @@ struct ChatContentView: View {
         case .sessionAborted: return "stop.circle.fill"
         case .processingFailed, .regenerateFailed: return "arrow.triangle.2.circlepath"
         case .contextTooLarge: return "text.badge.xmark"
+        case .authenticationRequired: return "lock.fill"
         case .unknown: return "exclamationmark.triangle.fill"
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -170,6 +170,8 @@ struct ChatSessionErrorToast: View {
             return "stop.circle.fill"
         case .processingFailed, .regenerateFailed:
             return "arrow.triangle.2.circlepath"
+        case .authenticationRequired:
+            return "lock.fill"
         case .unknown:
             return "exclamationmark.triangle.fill"
         }


### PR DESCRIPTION
Address review feedback from PR #9836: add missing .authenticationRequired case to exhaustive switches in ChatErrorToastView.swift (macOS) and ChatContentView.swift (iOS) to prevent compile errors.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
