### PR TITLE
fix: write PID file before throwing on daemon startup timeout

### DIFF
--- a/assistant/src/daemon/daemon-control.ts
+++ b/assistant/src/daemon/daemon-control.ts
@@ -232,6 +232,10 @@ export async function startDaemon(): Promise<{
     waited += interval;
   }
 
+  // The child process is still running but the socket hasn't appeared yet.
+  // Write the PID file so isDaemonRunning()/stopDaemon() can still track
+  // and manage the orphaned process.
+  writePid(pid);
   throw new DaemonError(
     `Daemon started but socket not available after ${maxWait}ms`,
   );


### PR DESCRIPTION
Address review feedback from PR #9839 (fix: defer PID file write until daemon is ready).

Both Codex and Devin flagged that the timeout path in startDaemon() throws without writing the PID file, leaving an orphaned daemon process that cannot be detected by isDaemonRunning() or stopped by stopDaemon(). This fix writes the PID file before throwing so the process remains manageable.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
