### PR TITLE
fix: gracefully degrade when proactive TLS renewal fails

### DIFF
--- a/assistant/src/daemon/tls-certs.ts
+++ b/assistant/src/daemon/tls-certs.ts
@@ -42,6 +42,8 @@ function computeFingerprint(cert: X509Certificate): string {
   return cert.fingerprint256.replace(/:/g, '').toLowerCase();
 }
 
+type CertStatus = 'valid' | 'approaching_expiry' | 'invalid';
+
 /**
  * Check whether an existing cert+key pair is valid:
  * - All three files exist (cert, key, fingerprint)
@@ -49,8 +51,12 @@ function computeFingerprint(cert: X509Certificate): string {
  * - Cert is not expired
  * - Fingerprint file exists and matches the cert
  * - Private key is valid and matches the certificate
+ *
+ * Returns 'valid' if the cert is good, 'approaching_expiry' if it's still usable
+ * but expires within 30 days (renewal should be attempted), or 'invalid' if the
+ * cert cannot be used at all.
  */
-async function isExistingCertValid(): Promise<boolean> {
+async function checkCertStatus(): Promise<CertStatus> {
   const certPath = getTlsCertPath();
   const keyPath = getTlsKeyPath();
   const fpPath = getTlsFingerprintPath();
@@ -63,7 +69,7 @@ async function isExistingCertValid(): Promise<boolean> {
   ]);
 
   if (!certExists || !keyExists || !fpExists) {
-    return false;
+    return 'invalid';
   }
 
   try {
@@ -80,21 +86,14 @@ async function isExistingCertValid(): Promise<boolean> {
     const notAfter = new Date(x509.validTo);
     if (notAfter <= now) {
       log.info('Existing TLS certificate has expired, will regenerate');
-      return false;
-    }
-
-    // Auto-renew if the certificate expires within 30 days
-    const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
-    if (notAfter.getTime() - now.getTime() < thirtyDaysMs) {
-      log.info('TLS certificate approaching expiry, regenerating...');
-      return false;
+      return 'invalid';
     }
 
     // Check fingerprint matches
     const actualFp = computeFingerprint(x509);
     if (actualFp !== storedFp.trim()) {
       log.info('TLS fingerprint mismatch, will regenerate');
-      return false;
+      return 'invalid';
     }
 
     // Verify the private key is valid and matches the certificate's public key.
@@ -103,13 +102,20 @@ async function isExistingCertValid(): Promise<boolean> {
     const privateKey = createPrivateKey(keyPem);
     if (!x509.checkPrivateKey(privateKey)) {
       log.info('TLS private key does not match certificate, will regenerate');
-      return false;
+      return 'invalid';
     }
 
-    return true;
+    // Cert is structurally valid — check if it's approaching expiry
+    const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
+    if (notAfter.getTime() - now.getTime() < thirtyDaysMs) {
+      log.info('TLS certificate approaching expiry, will attempt renewal');
+      return 'approaching_expiry';
+    }
+
+    return 'valid';
   } catch (err) {
     log.warn({ err }, 'Failed to validate existing TLS certificate, will regenerate');
-    return false;
+    return 'invalid';
   }
 }
 
@@ -133,8 +139,9 @@ export async function ensureTlsCert(): Promise<{ cert: string; key: string; fing
   const keyPath = getTlsKeyPath();
   const fpPath = getTlsFingerprintPath();
 
-  // Check if existing cert is still valid
-  if (await isExistingCertValid()) {
+  const status = await checkCertStatus();
+
+  if (status === 'valid') {
     const [cert, key, fingerprint] = await Promise.all([
       readFile(certPath, 'utf-8'),
       readFile(keyPath, 'utf-8'),
@@ -144,7 +151,33 @@ export async function ensureTlsCert(): Promise<{ cert: string; key: string; fing
     return { cert, key, fingerprint: fingerprint.trim() };
   }
 
-  // Generate new cert
+  if (status === 'approaching_expiry') {
+    // Attempt proactive renewal, but fall back to the existing cert if it fails.
+    // The existing cert is still valid — an outage from a failed renewal would be worse
+    // than continuing with a cert that expires in <30 days.
+    try {
+      return await generateNewCert(tlsDir, certPath, keyPath, fpPath);
+    } catch (err) {
+      log.warn({ err }, 'Proactive TLS renewal failed, continuing with existing certificate');
+      const [cert, key, fingerprint] = await Promise.all([
+        readFile(certPath, 'utf-8'),
+        readFile(keyPath, 'utf-8'),
+        readFile(fpPath, 'utf-8'),
+      ]);
+      return { cert, key, fingerprint: fingerprint.trim() };
+    }
+  }
+
+  // status === 'invalid' — must regenerate, no fallback
+  return await generateNewCert(tlsDir, certPath, keyPath, fpPath);
+}
+
+async function generateNewCert(
+  tlsDir: string,
+  certPath: string,
+  keyPath: string,
+  fpPath: string,
+): Promise<{ cert: string; key: string; fingerprint: string }> {
   log.info('Generating new self-signed TLS certificate');
   await mkdir(tlsDir, { recursive: true });
 


### PR DESCRIPTION
Address review feedback from PR #9761 (feat: add automatic TLS certificate renewal before expiry).

The proactive renewal (certs expiring within 30 days) previously marked the cert as invalid, forcing full regeneration. If regeneration failed (e.g., missing openssl, filesystem permissions), startup would throw instead of using the still-valid cert.

Now: checkCertStatus() returns a three-way discriminant (valid/approaching_expiry/invalid). When approaching_expiry, ensureTlsCert() attempts renewal but catches failures and falls back to the existing cert. When invalid, it regenerates without fallback as before.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
