### PR TITLE
fix: defer semantic search until after early termination check

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -139,21 +139,7 @@ async function collectAndMergeCandidates(
   // A per-call scopePolicyOverride takes precedence over the global policy.
   const scopeIds = buildScopeFilter(scopeId, scopePolicy, opts?.scopePolicyOverride);
 
-  // -- Start async semantic search early so the network round-trip overlaps
-  // with all synchronous work (lexical, recency, direct item, entity). --
   let semanticSearchFailed = false;
-  const semanticPromise = queryVector
-    ? semanticSearch(queryVector, opts?.provider ?? 'unknown', opts?.model ?? 'unknown', config.memory.retrieval.semanticTopK, excludeMessageIds, scopeIds)
-        .catch((err): Candidate[] => {
-          semanticSearchFailed = true;
-          if (isQdrantConnectionError(err)) {
-            log.warn({ err }, 'Qdrant is unavailable — semantic search disabled, memory recall will be degraded');
-          } else {
-            log.warn({ err }, 'Semantic search failed, continuing with other retrieval methods');
-          }
-          return [];
-        })
-    : null;
 
   // -- Phase 1: cheap local searches (always run) --
   const lexical = lexicalSearch(query, config.memory.retrieval.lexicalTopK, excludeMessageIds, scopeIds);
@@ -236,8 +222,7 @@ async function collectAndMergeCandidates(
 
   // -- Early termination check --
   // If cheap sources already produced enough high-relevance candidates,
-  // skip entity search. The semantic promise (if started) will resolve
-  // on its own via .catch() — we just ignore its results.
+  // skip semantic and entity search entirely.
   //
   // Deduplicate before counting: lexical and recency can return the same
   // segment (common when recent messages match the query), so checking raw
@@ -274,8 +259,23 @@ async function collectAndMergeCandidates(
   let relationExpandedItemCount = 0;
 
   if (!canTerminateEarly) {
+    // Start semantic search now that we know early termination won't apply.
+    // The network round-trip overlaps with entity search below.
+    const semanticPromise = queryVector
+      ? semanticSearch(queryVector, opts?.provider ?? 'unknown', opts?.model ?? 'unknown', config.memory.retrieval.semanticTopK, excludeMessageIds, scopeIds)
+          .catch((err): Candidate[] => {
+            semanticSearchFailed = true;
+            if (isQdrantConnectionError(err)) {
+              log.warn({ err }, 'Qdrant is unavailable — semantic search disabled, memory recall will be degraded');
+            } else {
+              log.warn({ err }, 'Semantic search failed, continuing with other retrieval methods');
+            }
+            return [];
+          })
+      : null;
+
     // Entity search is synchronous — run it while the semantic promise
-    // (started above) is still in flight.
+    // is in flight.
     if (config.memory.entity.enabled) {
       const entitySearchResult = entitySearch(
         query,


### PR DESCRIPTION
Address review feedback from PR #9766 (perf: parallelize independent memory retrieval sources)

The Codex review identified that semanticSearch() was kicked off before the early termination check, causing unnecessary Qdrant calls when cheap candidates (lexical, recency, direct) already satisfy the early termination threshold.

This fix moves the semantic search initiation to after the early termination check, inside the !canTerminateEarly block. The semantic promise still overlaps with entity search for parallelism when it does run.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
