### PR TITLE
fix: address review feedback on PR #9765

### DIFF
--- a/assistant/src/runtime/guardian-outbound-actions.ts
+++ b/assistant/src/runtime/guardian-outbound-actions.ts
@@ -70,7 +70,7 @@ function isTelegramChatId(destination: string): boolean {
  * "@username" count against the same per-destination rate window.
  * Numeric chat IDs are returned as-is.
  */
-function normalizeTelegramDestination(destination: string): string {
+export function normalizeTelegramDestination(destination: string): string {
   if (isTelegramChatId(destination)) return destination;
   return destination.replace(/^@/, '').toLowerCase();
 }

--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -31,10 +31,12 @@ import {
 } from '../../daemon/handlers/config-telegram.js';
 import {
   cancelOutbound,
+  normalizeTelegramDestination,
   resendOutbound,
   startOutbound,
 } from '../guardian-outbound-actions.js';
 import { guardianVerificationLimiter } from '../verification-rate-limiter.js';
+import { normalizePhoneNumber } from '../../util/phone.js';
 
 /**
  * GET /v1/integrations/telegram/config
@@ -147,8 +149,18 @@ export async function handleStartOutbound(req: Request): Promise<Response> {
     return httpError('BAD_REQUEST', 'The "channel" field is required.', 400);
   }
 
-  // Rate-limit by destination identity before processing
-  if (body.destination && guardianVerificationLimiter.isBlocked(body.destination)) {
+  // Normalize destination to prevent rate-limit bypass via format variations
+  // (e.g. "+15551234567" vs "(555) 123-4567", or "@User" vs "user")
+  let rateLimitKey = body.destination;
+  if (rateLimitKey) {
+    if (body.channel === 'sms' || body.channel === 'voice') {
+      rateLimitKey = normalizePhoneNumber(rateLimitKey) ?? rateLimitKey;
+    } else if (body.channel === 'telegram') {
+      rateLimitKey = normalizeTelegramDestination(rateLimitKey);
+    }
+  }
+
+  if (rateLimitKey && guardianVerificationLimiter.isBlocked(rateLimitKey)) {
     return httpError('RATE_LIMITED', 'Too many verification attempts for this identity. Please try again later.', 429);
   }
 
@@ -160,8 +172,8 @@ export async function handleStartOutbound(req: Request): Promise<Response> {
     originConversationId: body.originConversationId,
   });
 
-  if (!result.success && body.destination) {
-    guardianVerificationLimiter.recordFailure(body.destination);
+  if (!result.success && rateLimitKey) {
+    guardianVerificationLimiter.recordFailure(rateLimitKey);
   }
 
   const status = result.success ? 200 : (result.error === 'rate_limited' ? 429 : 400);


### PR DESCRIPTION
Address review feedback from PR #9765 (security: add rate limiting on guardian verification attempts)

Both Codex and Devin flagged the same issue: the rate limiter was using raw body.destination as the key, but startOutbound internally normalizes destinations (normalizePhoneNumber for SMS/voice, normalizeTelegramDestination for Telegram). This allowed bypass via format variations (e.g. +15551234567 vs (555) 123-4567, or @User vs user).

Fix: normalize the destination before using it as a rate limit key, using the same normalization functions that startOutbound uses.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9853" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
