### PR TITLE
fix: address review feedback on PR #9771

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -10,7 +10,7 @@ import * as conversationStore from '../../memory/conversation-store.js';
 import { GENERATING_TITLE, queueGenerateConversationTitle, UNTITLED_FALLBACK } from '../../memory/conversation-title-service.js';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
 import { checkIngressForSecrets } from '../../security/secret-ingress.js';
-import { redactSecrets } from '../../security/secret-scanner.js';
+import { compileCustomPatterns, redactSecrets } from '../../security/secret-scanner.js';
 import { getSubagentManager } from '../../subagent/index.js';
 import { silentlyWithLog } from '../../util/silently.js';
 import { truncate } from '../../util/truncate.js';
@@ -193,10 +193,13 @@ export async function handleUserMessage(
           category: 'secret_blocked',
         });
 
+        const compiledCustom = config.secretDetection.customPatterns?.length
+          ? compileCustomPatterns(config.secretDetection.customPatterns)
+          : undefined;
         const redactedMessageText = redactSecrets(messageText, {
           enabled: true,
           base64Threshold: config.secretDetection.entropyThreshold,
-        }).trim();
+        }, compiledCustom).trim();
 
         // Redirect: trigger a secure prompt so the user can enter the secret safely.
         // After save, continue the same request with redacted text so the model keeps

--- a/assistant/src/security/secret-scanner.ts
+++ b/assistant/src/security/secret-scanner.ts
@@ -683,13 +683,20 @@ export interface CustomPatternInput {
 
 /**
  * Compile user-provided custom patterns into SecretPattern objects.
- * Invalid regex patterns are logged and skipped.
+ * Invalid regex patterns and patterns that can match empty strings are
+ * logged and skipped — an empty-match pattern would cause infinite loops
+ * in the `while (regex.exec(...))` scanning loops.
  */
 export function compileCustomPatterns(inputs: CustomPatternInput[]): SecretPattern[] {
   const compiled: SecretPattern[] = [];
   for (const { label, pattern } of inputs) {
     try {
-      compiled.push({ type: label, regex: new RegExp(pattern, 'g') });
+      const regex = new RegExp(pattern, 'g');
+      if (regex.test('')) {
+        log.warn({ label, pattern }, 'Skipping custom secret pattern that matches empty strings');
+        continue;
+      }
+      compiled.push({ type: label, regex });
     } catch (err) {
       log.warn({ label, pattern, error: String(err) }, 'Skipping invalid custom secret pattern');
     }


### PR DESCRIPTION
Address review feedback from PR #9771 (feat: add support for custom secret scanner patterns via config)

## Changes

1. **Reject custom patterns that match empty strings** (Codex P1): Patterns like `^` or `.*?` that can match an empty string would cause infinite loops in the `while (regex.exec(...))` scanning loops since `lastIndex` never advances. `compileCustomPatterns` now tests each compiled regex against the empty string and skips patterns that match.

2. **Pass custom patterns to redactSecrets in sessions.ts** (Devin): When `checkIngressForSecrets` blocks a message detected by a custom pattern, the subsequent `redactSecrets` call was not passing custom patterns, allowing the raw secret to leak unredacted into model context. Now compiles and passes custom patterns to `redactSecrets` just like `checkIngressForSecrets` does.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
