### PR TITLE
fix: address review feedback on PR #9757

### DIFF
--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -134,6 +134,7 @@ mock.module('../tools/registry.js', () => ({
     for (const id of skillIds) {
       mockSkillRefCount.set(id, (mockSkillRefCount.get(id) ?? 0) + 1);
     }
+    return tools;
   },
   unregisterSkillTools: (skillId: string) => {
     mockUnregisteredSkillIds.push(skillId);

--- a/assistant/src/__tests__/skill-projection.benchmark.test.ts
+++ b/assistant/src/__tests__/skill-projection.benchmark.test.ts
@@ -96,10 +96,18 @@ mock.module('node:fs', () => ({
   existsSync: () => true,
 }));
 
+const benchmarkRegistry = new Map<string, unknown>();
 mock.module('../tools/registry.js', () => ({
-  registerSkillTools: () => {},
-  unregisterSkillTools: () => {},
-  getTool: () => undefined,
+  registerSkillTools: (tools: Array<{ name: string; [k: string]: unknown }>) => {
+    for (const t of tools) benchmarkRegistry.set(t.name, t);
+    return tools;
+  },
+  unregisterSkillTools: (skillId: string) => {
+    for (const [name, t] of benchmarkRegistry) {
+      if ((t as { ownerSkillId?: string }).ownerSkillId === skillId) benchmarkRegistry.delete(name);
+    }
+  },
+  getTool: (name: string) => benchmarkRegistry.get(name),
 }));
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/session-skill-tools.ts
+++ b/assistant/src/daemon/session-skill-tools.ts
@@ -308,6 +308,14 @@ export function projectSkillTools(
           log.info({ skillId, bundled: skill.bundled }, 'Skill bundled status changed, re-registering tools');
           unregisterSkillTools(skillId);
           accepted = registerSkillTools(tools);
+        } else {
+          // Filter to only tools that are actually registered for this skill.
+          // Some tools may have been skipped during initial registration due
+          // to core-name collisions — don't let them leak back in.
+          accepted = tools.filter((t) => {
+            const reg = getTool(t.name);
+            return reg !== undefined && reg.origin === 'skill' && reg.ownerSkillId === skillId;
+          });
         }
       }
 


### PR DESCRIPTION
Address review feedback from PR #9757 (feat: add skill tool name collision detection)

## Changes

1. **Fix collision-filtered tools leaking on subsequent turns**: On turn 2+ when skill hash is unchanged, `accepted` was initialized to the full `tools` array and never reassigned in the else branch. Tools that were skipped during initial registration due to core-name collisions would leak back into the LLM projection. Fixed by filtering `accepted` to only include tools actually registered for this skill in the registry.

2. **Fix test mock return values**: The `registerSkillTools` mock in `session-skill-tools.test.ts` didn't return the tools array (implicitly returning `undefined`), which would cause `TypeError: undefined is not iterable` when iterating over `accepted`. Added `return tools;`.

3. **Fix benchmark mock**: Updated `skill-projection.benchmark.test.ts` mock to return tools from `registerSkillTools` and track registered tools in a map so `getTool` returns correct results on subsequent turns.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
