### PR TITLE
fix: address review feedback on PR #9753

### DIFF
--- a/assistant/src/gallery/default-gallery.ts
+++ b/assistant/src/gallery/default-gallery.ts
@@ -107,8 +107,8 @@ const focusTimerHtml = `<!DOCTYPE html>
   <div class="mode-label" id="modeLabel">Work Session</div>
   <div class="timer-display" id="timerDisplay">25:00</div>
   <div class="controls">
-    <button class="btn-primary" id="startBtn" onclick="toggleTimer()">Start</button>
-    <button class="btn-secondary" id="resetBtn" onclick="resetTimer()">Reset</button>
+    <button class="btn-primary" id="startBtn">Start</button>
+    <button class="btn-secondary" id="resetBtn">Reset</button>
   </div>
   <div class="stats">
     <div class="stat-item">
@@ -183,6 +183,9 @@ const focusTimerHtml = `<!DOCTYPE html>
     document.getElementById('modeLabel').classList.remove('break');
     updateDisplay();
   }
+
+  document.getElementById('startBtn').addEventListener('click', toggleTimer);
+  document.getElementById('resetBtn').addEventListener('click', resetTimer);
 
   updateDisplay();
 </script>
@@ -334,8 +337,8 @@ const habitTrackerHtml = `<!DOCTYPE html>
   <h1>Habit Tracker</h1>
 </div>
 <div class="add-form">
-  <input type="text" id="habitInput" placeholder="Add a new habit..." onkeydown="if(event.key==='Enter')addHabit()">
-  <button class="btn-primary" onclick="addHabit()">Add</button>
+  <input type="text" id="habitInput" placeholder="Add a new habit...">
+  <button class="btn-primary" id="addHabitBtn">Add</button>
 </div>
 <div class="days-header">
   <div></div>
@@ -387,12 +390,12 @@ const habitTrackerHtml = `<!DOCTYPE html>
       html += '<div class="habit-row">';
       html += '<div style="display:flex;align-items:center;gap:8px">';
       html += '<span class="habit-name">' + escapeHtml(record.data.name) + '</span>';
-      html += '<button class="delete-btn" onclick="deleteHabit(\\''+record.id+'\\')">x</button>';
+      html += '<button class="delete-btn" data-delete-habit="'+record.id+'">x</button>';
       html += '</div>';
       dates.forEach(function(date) {
         var checked = completedDates.indexOf(date) !== -1;
         html += '<div class="check-cell">';
-        html += '<button class="check-btn' + (checked ? ' checked' : '') + '" onclick="toggleDate(\\''+record.id+'\\',\\''+date+'\\')">';
+        html += '<button class="check-btn' + (checked ? ' checked' : '') + '" data-toggle-habit="'+record.id+'" data-toggle-date="'+date+'">';
         html += checked ? '\\u2713' : '';
         html += '</button></div>';
       });
@@ -437,6 +440,17 @@ const habitTrackerHtml = `<!DOCTYPE html>
       loadHabits();
     });
   }
+
+  document.getElementById('habitInput').addEventListener('keydown', function(event) {
+    if (event.key === 'Enter') addHabit();
+  });
+  document.getElementById('addHabitBtn').addEventListener('click', addHabit);
+  document.getElementById('habitsList').addEventListener('click', function(event) {
+    var btn = event.target.closest('[data-delete-habit]');
+    if (btn) { deleteHabit(btn.getAttribute('data-delete-habit')); return; }
+    var toggle = event.target.closest('[data-toggle-habit]');
+    if (toggle) { toggleDate(toggle.getAttribute('data-toggle-habit'), toggle.getAttribute('data-toggle-date')); }
+  });
 
   initDates();
   loadHabits();
@@ -629,9 +643,9 @@ const expenseTrackerHtml = `<!DOCTYPE html>
     <option value="entertainment">Entertainment</option>
     <option value="other">Other</option>
   </select>
-  <input type="text" class="input-desc" id="descInput" placeholder="Description..." onkeydown="if(event.key==='Enter')addExpense()">
+  <input type="text" class="input-desc" id="descInput" placeholder="Description...">
   <input type="date" class="input-date" id="dateInput">
-  <button class="btn-primary" onclick="addExpense()">Add</button>
+  <button class="btn-primary" id="addExpenseBtn">Add</button>
 </div>
 <div class="section-title">By Category</div>
 <div class="categories-grid" id="categoriesGrid"></div>
@@ -693,7 +707,7 @@ const expenseTrackerHtml = `<!DOCTYPE html>
         listHtml += '<div class="expense-meta">' + escapeHtml(r.data.category || 'other') + ' \\u00B7 ' + escapeHtml(r.data.date || '') + '</div>';
         listHtml += '</div>';
         listHtml += '<div class="expense-amount">$' + amt.toFixed(2) + '</div>';
-        listHtml += '<button class="delete-btn" onclick="deleteExpense(\\''+r.id+'\\')">x</button>';
+        listHtml += '<button class="delete-btn" data-delete-expense="'+r.id+'">x</button>';
         listHtml += '</div>';
       });
     }
@@ -723,6 +737,15 @@ const expenseTrackerHtml = `<!DOCTYPE html>
       loadExpenses();
     });
   }
+
+  document.getElementById('descInput').addEventListener('keydown', function(event) {
+    if (event.key === 'Enter') addExpense();
+  });
+  document.getElementById('addExpenseBtn').addEventListener('click', addExpense);
+  document.getElementById('expenseList').addEventListener('click', function(event) {
+    var btn = event.target.closest('[data-delete-expense]');
+    if (btn) { deleteExpense(btn.getAttribute('data-delete-expense')); }
+  });
 
   loadExpenses();
 </script>

--- a/assistant/src/runtime/routes/app-routes.ts
+++ b/assistant/src/runtime/routes/app-routes.ts
@@ -71,10 +71,14 @@ ${noncedHtml}
 </body>
 </html>`;
 
+  // App HTML is user- or LLM-generated and commonly contains inline event
+  // handlers (onclick, onkeydown, etc.). Nonce-only script-src blocks those
+  // because CSP nonces only authorize <script> blocks, not handler attributes.
+  // We keep 'unsafe-inline' so arbitrary app content works.
   const csp = [
     "default-src 'self'",
     `style-src 'self' 'nonce-${nonce}' 'unsafe-inline'`,
-    `script-src 'self' 'nonce-${nonce}'`,
+    "script-src 'self' 'unsafe-inline'",
     "img-src 'self' data: https:",
     "font-src 'self' data: https:",
     "object-src 'none'",


### PR DESCRIPTION
Address review feedback from PR #9753 (security: remove unsafe-inline from CSP script-src).

Both Codex and Devin flagged that the nonce-only script-src CSP breaks inline event handlers (onclick, onkeydown, etc.) because CSP nonces only authorize <script> blocks, not handler attributes.

Changes:
- Restore 'unsafe-inline' in script-src CSP — app HTML is user/LLM-generated and commonly uses inline event handlers. A nonce-only policy silently breaks those apps.
- Refactor all three gallery apps (Focus Timer, Habit Tracker, Expense Tracker) to use addEventListener and event delegation instead of inline handlers — good practice regardless of CSP.
- Add explanatory comment on why unsafe-inline is needed for the app-serving use case.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
