### PR TITLE
fix: capture app context before transcription finalization

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -241,11 +241,11 @@ final class VoiceModeManager: ObservableObject {
         voiceService.resetStreamingTTS()
 
         Task {
-            let text = await voiceService.stopRecordingAndGetTranscription()
-            // Capture context sequentially on the MainActor after recording
-            // stops. The .processing state transition above already prevents
-            // further transcription, so there is no recording-window concern.
+            // Capture context on MainActor before awaiting transcription so it
+            // reflects the app the user was looking at when they spoke, not
+            // whatever app may be frontmost after the async wait completes.
             let ctx = DictationContextCapture.capture()
+            let text = await voiceService.stopRecordingAndGetTranscription()
             let trimmed = (text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
 
             guard !trimmed.isEmpty, let chatViewModel else {


### PR DESCRIPTION
Moves DictationContextCapture.capture() before stopRecordingAndGetTranscription() so the captured context reflects the app the user was looking at when they spoke, not after a potential app switch during transcription wait. Addresses feedback from #9835.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
