### PR TITLE
feat(parental): require PIN setup before enabling parental controls

### DIFF
--- a/assistant/src/daemon/handlers/config-parental.ts
+++ b/assistant/src/daemon/handlers/config-parental.ts
@@ -162,6 +162,21 @@ export function handleParentalControlUpdate(
     }
   }
 
+  // Prevent enabling parental controls without a PIN — a PIN is required so
+  // the user cannot be locked out or the controls bypassed by simply toggling.
+  if (msg.enabled === true && !pinExists) {
+    ctx.send(socket, {
+      type: 'parental_control_update_response',
+      success: false,
+      error: 'Cannot enable parental controls without setting a PIN first',
+      enabled: settings.enabled,
+      has_pin: pinExists,
+      content_restrictions: settings.contentRestrictions,
+      blocked_tool_categories: settings.blockedToolCategories,
+    });
+    return;
+  }
+
   // When enabling for the very first time, default all restrictions to ON so
   // the parent starts from a safe baseline. We track first-time initialization
   // with an explicit `initialized` flag rather than inferring it from empty

--- a/clients/ios/Views/Settings/IOSParentalControlSection.swift
+++ b/clients/ios/Views/Settings/IOSParentalControlSection.swift
@@ -26,6 +26,8 @@ struct IOSParentalControlSection: View {
     // Retained after a successful unlock so that subsequent update calls can
     // forward the PIN to the daemon (required when parental mode is enabled).
     @State private var unlockedPIN: String?
+    // Shown when the user tries to enable parental controls without a PIN set.
+    @State private var showingSetPINForEnable: Bool = false
 
     private var daemon: DaemonClient? { clientProvider.client as? DaemonClient }
 
@@ -41,7 +43,11 @@ struct IOSParentalControlSection: View {
                         Toggle("", isOn: Binding(
                             get: { isEnabled },
                             set: { newValue in
-                                if !newValue && isEnabled && hasPIN && !isUnlocked {
+                                if newValue && !isEnabled && !hasPIN {
+                                    // Enabling without a PIN — require the user to create one
+                                    // first so parental controls are always PIN-protected.
+                                    showingSetPINForEnable = true
+                                } else if !newValue && isEnabled && hasPIN && !isUnlocked {
                                     showingUnlock = true
                                 } else {
                                     updateEnabled(newValue)
@@ -113,6 +119,21 @@ struct IOSParentalControlSection: View {
                     errorMessage = nil
                 case .failure:
                     errorMessage = "Incorrect PIN."
+                }
+            }
+        }
+        .sheet(isPresented: $showingSetPINForEnable) {
+            IOSSetPINForEnableSheet(daemon: daemon) { result in
+                showingSetPINForEnable = false
+                switch result {
+                case .success(let pin):
+                    // PIN is now set; cache it as the unlocked credential and enable.
+                    isUnlocked = true
+                    unlockedPIN = pin
+                    hasPIN = true
+                    updateEnabled(true)
+                case .failure(let msg):
+                    errorMessage = msg
                 }
             }
         }
@@ -411,6 +432,91 @@ struct IOSPINSheet: View {
                 if let r = response {
                     if r.success { onComplete(.success(mode)) }
                     else { errorMessage = r.error ?? "Operation failed." }
+                } else { errorMessage = "No response from assistant." }
+            }
+        }
+    }
+}
+
+// MARK: - Set-PIN-for-Enable Sheet (iOS)
+
+enum IOSSetPINForEnableResult { case success(pin: String); case failure(String) }
+
+struct IOSSetPINForEnableSheet: View {
+    let daemon: DaemonClient?
+    let onComplete: (IOSSetPINForEnableResult) -> Void
+
+    @State private var newPIN: String = ""
+    @State private var confirmPIN: String = ""
+    @State private var isLoading: Bool = false
+    @State private var errorMessage: String?
+    @Environment(\.dismiss) private var dismiss
+
+    private var canSubmit: Bool {
+        newPIN.count == 6 && newPIN.allSatisfy({ $0.isNumber }) && newPIN == confirmPIN
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Text("A PIN is required to protect parental control settings. Create one now to enable parental controls.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                Section("New PIN") {
+                    SecureField("6-digit PIN", text: $newPIN)
+                        .keyboardType(.numberPad)
+                    SecureField("Confirm PIN", text: $confirmPIN)
+                        .keyboardType(.numberPad)
+                }
+                if let error = errorMessage {
+                    Section { Text(error).foregroundStyle(.red) }
+                }
+            }
+            .navigationTitle("Set Parental PIN")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if isLoading {
+                        ProgressView()
+                    } else {
+                        Button("Enable") { submit() }.disabled(!canSubmit)
+                    }
+                }
+            }
+        }
+    }
+
+    private func submit() {
+        guard canSubmit else { return }
+        guard newPIN == confirmPIN else { errorMessage = "PINs do not match."; return }
+        isLoading = true; errorMessage = nil
+        let stream = daemon?.subscribe()
+        Task {
+            do {
+                try daemon?.sendParentalControlSetPin(newPin: newPIN)
+            } catch {
+                await MainActor.run { isLoading = false; errorMessage = error.localizedDescription }
+                return
+            }
+            let response: ParentalControlSetPinResponseMessage? = await withTaskGroup(of: ParentalControlSetPinResponseMessage?.self) { group in
+                group.addTask {
+                    guard let stream else { return nil }
+                    for await msg in stream { if case .parentalControlSetPinResponse(let r) = msg { return r } }
+                    return nil
+                }
+                group.addTask { try? await Task.sleep(nanoseconds: 8_000_000_000); return nil }
+                let first = await group.next() ?? nil; group.cancelAll(); return first
+            }
+            await MainActor.run {
+                isLoading = false
+                if let r = response {
+                    if r.success { onComplete(.success(pin: newPIN)) }
+                    else { errorMessage = r.error ?? "Failed to set PIN." }
                 } else { errorMessage = "No response from assistant." }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsParentalTab.swift
@@ -38,6 +38,10 @@ struct SettingsParentalTab: View {
     // forward the PIN to the daemon (required when parental mode is enabled).
     @State private var unlockedPIN: String?
 
+    // -- Set-PIN-to-enable sheet (shown when enabling parental controls without an existing PIN) --
+    @State private var showingSetPINForEnableSheet: Bool = false
+
+
     // -- Child: request permission sheet --
     @State private var showingRequestPermissionSheet: Bool = false
     @State private var requestToolName: String = ""
@@ -142,6 +146,24 @@ struct SettingsParentalTab: View {
                 }
             )
         }
+        .sheet(isPresented: $showingSetPINForEnableSheet) {
+            SetPINForEnableSheet(
+                onComplete: { result in
+                    showingSetPINForEnableSheet = false
+                    switch result {
+                    case .success(let pin):
+                        // PIN is now set; cache it as the unlocked credential and enable
+                        isUnlocked = true
+                        unlockedPIN = pin
+                        hasPIN = true
+                        updateEnabled(true)
+                    case .failure(let msg):
+                        errorMessage = msg
+                    }
+                },
+                daemonClient: daemonClient
+            )
+        }
     }
 
     // MARK: - Sections
@@ -171,8 +193,12 @@ struct SettingsParentalTab: View {
                 Toggle("", isOn: Binding(
                     get: { isEnabled },
                     set: { newValue in
-                        // Toggling off a PIN-locked session requires PIN verification
-                        if !newValue && isEnabled && hasPIN && !isUnlocked {
+                        if newValue && !isEnabled && !hasPIN {
+                            // Enabling without an existing PIN — require the user to create
+                            // one first so parental controls are always PIN-protected.
+                            showingSetPINForEnableSheet = true
+                        } else if !newValue && isEnabled && hasPIN && !isUnlocked {
+                            // Toggling off a PIN-locked session requires PIN verification
                             showingUnlockSheet = true
                         } else {
                             updateEnabled(newValue)
@@ -1193,6 +1219,132 @@ private struct PINSheet: View {
                         onComplete(.success(mode))
                     } else {
                         errorMessage = r.error ?? "Operation failed."
+                    }
+                } else {
+                    errorMessage = "No response from daemon."
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Set PIN for Enable Sheet
+
+/// Result type for the set-PIN-to-enable flow.
+private enum SetPINForEnableResult {
+    case success(pin: String)
+    case failure(String)
+}
+
+/// Sheet shown when the user tries to enable parental controls but has no PIN set.
+/// The user must create a 6-digit PIN before parental controls can be activated.
+@MainActor
+private struct SetPINForEnableSheet: View {
+    let onComplete: (SetPINForEnableResult) -> Void
+    var daemonClient: DaemonClient?
+
+    @State private var pin: String = ""
+    @State private var confirmPIN: String = ""
+    @State private var isLoading: Bool = false
+    @State private var errorMessage: String?
+
+    @Environment(\.dismiss) private var dismiss
+
+    private var canEnable: Bool {
+        pin.count == 6 && pin.allSatisfy({ $0.isNumber }) && pin == confirmPIN
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            Text("Set Parental PIN")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textPrimary)
+
+            Text("Create a PIN to protect parental settings. You'll need this to switch back to Parental profile.")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            SecureField("PIN (6 digits)", text: $pin)
+                .textFieldStyle(.roundedBorder)
+                .font(VFont.body)
+
+            SecureField("Confirm PIN", text: $confirmPIN)
+                .textFieldStyle(.roundedBorder)
+                .font(VFont.body)
+
+            if let error = errorMessage {
+                Text(error)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
+            }
+
+            HStack {
+                Spacer()
+                VButton(label: "Cancel", style: .secondary) {
+                    dismiss()
+                }
+                VButton(label: "Enable", style: .primary) {
+                    submit()
+                }
+                .disabled(isLoading || !canEnable)
+            }
+        }
+        .padding(VSpacing.xl)
+        .frame(width: 320)
+        .background(VColor.background)
+    }
+
+    private func submit() {
+        guard canEnable else { return }
+        errorMessage = nil
+
+        guard pin.count == 6, pin.allSatisfy({ $0.isNumber }) else {
+            errorMessage = "PIN must be exactly 6 digits."
+            return
+        }
+        guard pin == confirmPIN else {
+            errorMessage = "PINs do not match."
+            return
+        }
+
+        isLoading = true
+        let stream = daemonClient?.subscribe()
+        Task {
+            do {
+                try daemonClient?.sendParentalControlSetPin(newPin: pin)
+            } catch {
+                await MainActor.run {
+                    isLoading = false
+                    errorMessage = error.localizedDescription
+                }
+                return
+            }
+
+            let response: ParentalControlSetPinResponseMessage? = await withTaskGroup(of: ParentalControlSetPinResponseMessage?.self) { group in
+                group.addTask {
+                    guard let stream else { return nil }
+                    for await message in stream {
+                        if case .parentalControlSetPinResponse(let msg) = message { return msg }
+                    }
+                    return nil
+                }
+                group.addTask {
+                    try? await Task.sleep(nanoseconds: 8_000_000_000)
+                    return nil
+                }
+                let first = await group.next() ?? nil
+                group.cancelAll()
+                return first
+            }
+
+            await MainActor.run {
+                isLoading = false
+                if let r = response {
+                    if r.success {
+                        onComplete(.success(pin: pin))
+                    } else {
+                        errorMessage = r.error ?? "Failed to set PIN."
                     }
                 } else {
                     errorMessage = "No response from daemon."


### PR DESCRIPTION
## Summary
- Intercept the 'Enable Parental Controls' toggle to show a Set PIN sheet first
- Parental controls can only be enabled after a 6-digit PIN is confirmed
- Backend guard: handleParentalControlUpdate returns error if enabled=true but no PIN is set
- Cancelling the PIN setup leaves the toggle off

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
