### PR TITLE
M4: Install skills.sh skills into managed store via assistant flow

### DIFF
--- a/assistant/src/__tests__/skillssh-install.test.ts
+++ b/assistant/src/__tests__/skillssh-install.test.ts
@@ -1,0 +1,490 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mock, spyOn } from 'bun:test';
+
+let TEST_DIR = '';
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => TEST_DIR,
+  getWorkspaceSkillsDir: () => join(TEST_DIR, 'skills'),
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { skillsshInstall } from '../skills/skillssh-install.js';
+import type { SkillsShInstallOptions, SkillsShProvenance } from '../skills/skillssh-install.js';
+import type { SecurityDecision } from '../skills/security-decision.js';
+import type { SkillsShSearchWithAuditItem } from '../skills/skillssh.js';
+import { readSkillProvenance } from '../skills/managed-store.js';
+
+// ─── Test helpers ────────────────────────────────────────────────────────────────
+
+function makeCandidate(overrides?: Partial<SkillsShSearchWithAuditItem>): SkillsShSearchWithAuditItem {
+  return {
+    id: 'test-org/test-repo/my-skill',
+    skillId: 'my-skill',
+    name: 'My Skill',
+    installs: 42,
+    source: 'test-org/test-repo',
+    audit: {
+      ath: { risk: 'safe', analyzedAt: '2025-01-01T00:00:00Z' },
+      socket: { risk: 'low', analyzedAt: '2025-01-02T00:00:00Z', score: 90 },
+    },
+    overallRisk: 'low',
+    ...overrides,
+  };
+}
+
+function makeProceedDecision(): SecurityDecision {
+  return {
+    recommendation: 'proceed',
+    overallRisk: 'low',
+    rationale: 'All security audits passed with safe/low risk ratings.',
+    auditSummary: [
+      { provider: 'ath', risk: 'safe', analyzedAt: '2025-01-01T00:00:00Z' },
+      { provider: 'socket', risk: 'low', analyzedAt: '2025-01-02T00:00:00Z', details: 'score 90/100' },
+    ],
+  };
+}
+
+function makeCautionDecision(): SecurityDecision {
+  return {
+    recommendation: 'proceed_with_caution',
+    overallRisk: 'medium',
+    rationale: 'Medium risk detected.',
+    auditSummary: [
+      { provider: 'socket', risk: 'medium', analyzedAt: '2025-01-02T00:00:00Z' },
+    ],
+  };
+}
+
+function makeDoNotRecommendDecision(): SecurityDecision {
+  return {
+    recommendation: 'do_not_recommend',
+    overallRisk: 'high',
+    rationale: 'High risk detected by Snyk. Review the audit details before proceeding.',
+    auditSummary: [
+      { provider: 'snyk', risk: 'high', analyzedAt: '2025-01-03T00:00:00Z' },
+    ],
+  };
+}
+
+/**
+ * Simulate a successful `npx skills add` by creating the expected
+ * skill directory and SKILL.md file in the managed skills dir.
+ */
+function simulateSuccessfulInstall(skillId: string): void {
+  const skillDir = join(TEST_DIR, 'skills', skillId);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, 'SKILL.md'), `---\nname: "${skillId}"\ndescription: "A test skill"\n---\n\n# ${skillId}\n`, 'utf-8');
+}
+
+// ─── Setup / Teardown ────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  TEST_DIR = mkdtempSync(join(tmpdir(), 'skillssh-install-test-'));
+  mkdirSync(join(TEST_DIR, 'skills'), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+  // Restore all spies
+  mock.restore();
+});
+
+// ─── Security gate tests ─────────────────────────────────────────────────────────
+
+describe('skillsshInstall security gate', () => {
+  test('blocks install when decision is do_not_recommend and no override', async () => {
+    const result = await skillsshInstall({
+      candidate: makeCandidate({ overallRisk: 'high' }),
+      securityDecision: makeDoNotRecommendDecision(),
+      userOverride: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.skillId).toBe('my-skill');
+    expect(result.installedVia).toBe('policy');
+    expect(result.error).toContain('Installation blocked');
+    expect(result.error).toContain('do_not_recommend');
+    expect(result.error).toContain('high risk');
+  });
+
+  test('blocks install when decision is do_not_recommend and override is undefined', async () => {
+    const result = await skillsshInstall({
+      candidate: makeCandidate({ overallRisk: 'high' }),
+      securityDecision: makeDoNotRecommendDecision(),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Installation blocked');
+  });
+
+  test('allows install when decision is do_not_recommend but override is true', async () => {
+    // Mock Bun.spawn to simulate a successful subprocess
+    const originalSpawn = Bun.spawn;
+    const mockSpawn = spyOn(Bun, 'spawn').mockImplementation((..._args: unknown[]) => {
+      const candidate = makeCandidate({ overallRisk: 'high' });
+      simulateSuccessfulInstall(candidate.skillId);
+
+      return {
+        stdout: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('Skill installed successfully'));
+            controller.close();
+          },
+        }),
+        stderr: new ReadableStream({
+          start(controller) { controller.close(); },
+        }),
+        exited: Promise.resolve(0),
+        pid: 12345,
+        kill: () => {},
+      } as unknown as ReturnType<typeof originalSpawn>;
+    });
+
+    try {
+      const result = await skillsshInstall({
+        candidate: makeCandidate({ overallRisk: 'high' }),
+        securityDecision: makeDoNotRecommendDecision(),
+        userOverride: true,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.installedVia).toBe('override');
+      expect(result.skillId).toBe('my-skill');
+      expect(result.installedPath).toBeDefined();
+    } finally {
+      mockSpawn.mockRestore();
+    }
+  });
+
+  test('allows install when decision is proceed', async () => {
+    const originalSpawn = Bun.spawn;
+    const mockSpawn = spyOn(Bun, 'spawn').mockImplementation((..._args: unknown[]) => {
+      simulateSuccessfulInstall('my-skill');
+
+      return {
+        stdout: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('Skill installed successfully'));
+            controller.close();
+          },
+        }),
+        stderr: new ReadableStream({
+          start(controller) { controller.close(); },
+        }),
+        exited: Promise.resolve(0),
+        pid: 12345,
+        kill: () => {},
+      } as unknown as ReturnType<typeof originalSpawn>;
+    });
+
+    try {
+      const result = await skillsshInstall({
+        candidate: makeCandidate(),
+        securityDecision: makeProceedDecision(),
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.installedVia).toBe('policy');
+      expect(result.skillId).toBe('my-skill');
+    } finally {
+      mockSpawn.mockRestore();
+    }
+  });
+
+  test('allows install when decision is proceed_with_caution', async () => {
+    const originalSpawn = Bun.spawn;
+    const mockSpawn = spyOn(Bun, 'spawn').mockImplementation((..._args: unknown[]) => {
+      simulateSuccessfulInstall('my-skill');
+
+      return {
+        stdout: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('Skill installed successfully'));
+            controller.close();
+          },
+        }),
+        stderr: new ReadableStream({
+          start(controller) { controller.close(); },
+        }),
+        exited: Promise.resolve(0),
+        pid: 12345,
+        kill: () => {},
+      } as unknown as ReturnType<typeof originalSpawn>;
+    });
+
+    try {
+      const result = await skillsshInstall({
+        candidate: makeCandidate({ overallRisk: 'medium' }),
+        securityDecision: makeCautionDecision(),
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.installedVia).toBe('policy');
+    } finally {
+      mockSpawn.mockRestore();
+    }
+  });
+});
+
+// ─── Provenance metadata tests ───────────────────────────────────────────────────
+
+describe('skillsshInstall provenance', () => {
+  test('stores provenance metadata on successful install', async () => {
+    const originalSpawn = Bun.spawn;
+    const mockSpawn = spyOn(Bun, 'spawn').mockImplementation((..._args: unknown[]) => {
+      simulateSuccessfulInstall('my-skill');
+
+      return {
+        stdout: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('OK'));
+            controller.close();
+          },
+        }),
+        stderr: new ReadableStream({
+          start(controller) { controller.close(); },
+        }),
+        exited: Promise.resolve(0),
+        pid: 12345,
+        kill: () => {},
+      } as unknown as ReturnType<typeof originalSpawn>;
+    });
+
+    try {
+      const candidate = makeCandidate();
+      const result = await skillsshInstall({
+        candidate,
+        securityDecision: makeProceedDecision(),
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.provenance).toBeDefined();
+      expect(result.provenance!.provider).toBe('skills.sh');
+      expect(result.provenance!.source).toBe('test-org/test-repo');
+      expect(result.provenance!.skillId).toBe('my-skill');
+      expect(result.provenance!.sourceUrl).toBe('https://skills.sh/skills/test-org/test-repo/my-skill');
+      expect(result.provenance!.auditSnapshot.overallRisk).toBe('low');
+      expect(result.provenance!.auditSnapshot.dimensions).toHaveLength(2);
+      expect(result.provenance!.auditSnapshot.dimensions[0]).toEqual({
+        provider: 'ath',
+        risk: 'safe',
+        analyzedAt: '2025-01-01T00:00:00Z',
+      });
+      expect(result.provenance!.auditSnapshot.capturedAt).toBeDefined();
+
+      // Verify the file was actually written
+      const provenancePath = join(TEST_DIR, 'skills', 'my-skill', '.provenance.json');
+      expect(existsSync(provenancePath)).toBe(true);
+
+      const storedProvenance = JSON.parse(readFileSync(provenancePath, 'utf-8'));
+      expect(storedProvenance.provider).toBe('skills.sh');
+      expect(storedProvenance.source).toBe('test-org/test-repo');
+    } finally {
+      mockSpawn.mockRestore();
+    }
+  });
+
+  test('provenance includes only dimensions present in the audit', async () => {
+    const originalSpawn = Bun.spawn;
+    const mockSpawn = spyOn(Bun, 'spawn').mockImplementation((..._args: unknown[]) => {
+      simulateSuccessfulInstall('my-skill');
+
+      return {
+        stdout: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('OK'));
+            controller.close();
+          },
+        }),
+        stderr: new ReadableStream({
+          start(controller) { controller.close(); },
+        }),
+        exited: Promise.resolve(0),
+        pid: 12345,
+        kill: () => {},
+      } as unknown as ReturnType<typeof originalSpawn>;
+    });
+
+    try {
+      // Only snyk dimension present
+      const candidate = makeCandidate({
+        audit: {
+          snyk: { risk: 'safe', analyzedAt: '2025-06-01T00:00:00Z' },
+        },
+        overallRisk: 'safe',
+      });
+
+      const result = await skillsshInstall({
+        candidate,
+        securityDecision: makeProceedDecision(),
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.provenance!.auditSnapshot.dimensions).toHaveLength(1);
+      expect(result.provenance!.auditSnapshot.dimensions[0].provider).toBe('snyk');
+    } finally {
+      mockSpawn.mockRestore();
+    }
+  });
+
+  test('does not store provenance on failed install', async () => {
+    const result = await skillsshInstall({
+      candidate: makeCandidate(),
+      securityDecision: makeDoNotRecommendDecision(),
+      userOverride: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.provenance).toBeUndefined();
+
+    const provenancePath = join(TEST_DIR, 'skills', 'my-skill', '.provenance.json');
+    expect(existsSync(provenancePath)).toBe(false);
+  });
+});
+
+// ─── Subprocess error handling ───────────────────────────────────────────────────
+
+describe('skillsshInstall error handling', () => {
+  test('returns error when subprocess exits with non-zero code', async () => {
+    const originalSpawn = Bun.spawn;
+    const mockSpawn = spyOn(Bun, 'spawn').mockImplementation((..._args: unknown[]) => {
+      return {
+        stdout: new ReadableStream({
+          start(controller) { controller.close(); },
+        }),
+        stderr: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('Error: skill not found'));
+            controller.close();
+          },
+        }),
+        exited: Promise.resolve(1),
+        pid: 12345,
+        kill: () => {},
+      } as unknown as ReturnType<typeof originalSpawn>;
+    });
+
+    try {
+      const result = await skillsshInstall({
+        candidate: makeCandidate(),
+        securityDecision: makeProceedDecision(),
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Error: skill not found');
+    } finally {
+      mockSpawn.mockRestore();
+    }
+  });
+
+  test('returns error when SKILL.md is not found after install', async () => {
+    const originalSpawn = Bun.spawn;
+    // Simulate subprocess success but without creating SKILL.md
+    const mockSpawn = spyOn(Bun, 'spawn').mockImplementation((..._args: unknown[]) => {
+      return {
+        stdout: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('Done'));
+            controller.close();
+          },
+        }),
+        stderr: new ReadableStream({
+          start(controller) { controller.close(); },
+        }),
+        exited: Promise.resolve(0),
+        pid: 12345,
+        kill: () => {},
+      } as unknown as ReturnType<typeof originalSpawn>;
+    });
+
+    try {
+      const result = await skillsshInstall({
+        candidate: makeCandidate(),
+        securityDecision: makeProceedDecision(),
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('SKILL.md not found');
+    } finally {
+      mockSpawn.mockRestore();
+    }
+  });
+
+  test('handles subprocess exceptions gracefully', async () => {
+    const mockSpawn = spyOn(Bun, 'spawn').mockImplementation(() => {
+      throw new Error('spawn failed: command not found');
+    });
+
+    try {
+      const result = await skillsshInstall({
+        candidate: makeCandidate(),
+        securityDecision: makeProceedDecision(),
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('spawn failed: command not found');
+    } finally {
+      mockSpawn.mockRestore();
+    }
+  });
+});
+
+// ─── Managed store provenance reading ────────────────────────────────────────────
+
+describe('readSkillProvenance', () => {
+  test('reads provenance from .provenance.json', () => {
+    const skillDir = join(TEST_DIR, 'skills', 'test-skill');
+    mkdirSync(skillDir, { recursive: true });
+
+    const provenance: SkillsShProvenance = {
+      provider: 'skills.sh',
+      source: 'org/repo',
+      skillId: 'test-skill',
+      sourceUrl: 'https://skills.sh/skills/org/repo/test-skill',
+      auditSnapshot: {
+        overallRisk: 'low',
+        dimensions: [
+          { provider: 'ath', risk: 'safe', analyzedAt: '2025-01-01T00:00:00Z' },
+        ],
+        capturedAt: '2025-01-15T00:00:00Z',
+      },
+    };
+
+    writeFileSync(join(skillDir, '.provenance.json'), JSON.stringify(provenance, null, 2), 'utf-8');
+
+    const result = readSkillProvenance('test-skill');
+    expect(result).not.toBeNull();
+    expect(result!.provider).toBe('skills.sh');
+    expect(result!.source).toBe('org/repo');
+    expect(result!.skillId).toBe('test-skill');
+    expect(result!.auditSnapshot!.overallRisk).toBe('low');
+  });
+
+  test('returns null when no provenance file exists', () => {
+    const skillDir = join(TEST_DIR, 'skills', 'no-provenance');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), '# No provenance\n', 'utf-8');
+
+    const result = readSkillProvenance('no-provenance');
+    expect(result).toBeNull();
+  });
+
+  test('returns null for malformed provenance JSON', () => {
+    const skillDir = join(TEST_DIR, 'skills', 'bad-provenance');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, '.provenance.json'), '{not valid json!!!', 'utf-8');
+
+    const result = readSkillProvenance('bad-provenance');
+    expect(result).toBeNull();
+  });
+});

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -18,7 +18,7 @@ function getClawhubProjectRoot(): string {
 }
 
 // Validate slug format (alphanumeric, hyphens, dots, underscores; optional namespace with single slash)
-function validateSlug(slug: string): boolean {
+export function validateSlug(slug: string): boolean {
   return /^[a-zA-Z0-9]([a-zA-Z0-9._-]*(\/[a-zA-Z0-9][a-zA-Z0-9._-]*)?)?$/.test(slug);
 }
 
@@ -57,6 +57,10 @@ function collectFileContents(dir: string, prefix = ''): Array<{ relPath: string;
 
   const entries = readdirSync(dir, { withFileTypes: true });
   for (const entry of entries) {
+    // Skip provenance metadata — it's written after hash recording and would
+    // cause false integrity mismatches on re-install.
+    if (entry.name === '.provenance.json') continue;
+
     const relPath = prefix ? `${prefix}/${entry.name}` : entry.name;
     const fullPath = join(dir, entry.name);
     if (entry.isDirectory()) {

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -154,6 +154,44 @@ export function readSkillVersion(id: string): string | null {
   }
 }
 
+// ─── Provenance metadata ──────────────────────────────────────────────────────
+
+export interface SkillProvenance {
+  provider: string;
+  source: string;
+  skillId: string;
+  sourceUrl: string;
+  auditSnapshot?: {
+    overallRisk: string;
+    dimensions: Array<{
+      provider: string;
+      risk: string;
+      analyzedAt: string;
+    }>;
+    capturedAt: string;
+  };
+}
+
+function getProvenancePath(id: string): string {
+  return join(getManagedSkillDir(id), '.provenance.json');
+}
+
+/**
+ * Read the provenance metadata for a managed skill, if present.
+ * Returns null when no provenance file exists or it cannot be parsed.
+ */
+export function readSkillProvenance(id: string): SkillProvenance | null {
+  const provenancePath = getProvenancePath(id);
+  if (!existsSync(provenancePath)) return null;
+  try {
+    const raw = readFileSync(provenancePath, 'utf-8');
+    return JSON.parse(raw) as SkillProvenance;
+  } catch {
+    log.warn({ id }, 'Failed to parse provenance metadata for managed skill');
+    return null;
+  }
+}
+
 // ─── Create / Delete ─────────────────────────────────────────────────────────
 
 export interface CreateManagedSkillParams {

--- a/assistant/src/skills/skillssh-install.ts
+++ b/assistant/src/skills/skillssh-install.ts
@@ -1,0 +1,214 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { getLogger } from '../util/logger.js';
+import { getWorkspaceSkillsDir } from '../util/platform.js';
+import { verifyAndRecordSkillHash } from './clawhub.js';
+import type { SecurityDecision } from './security-decision.js';
+import type { SkillsShSearchWithAuditItem } from './skillssh.js';
+
+const log = getLogger('skillssh-install');
+
+// ─── Types ──────────────────────────────────────────────────────────────────────
+
+export interface SkillsShInstallOptions {
+  /** The skill candidate from search-with-audit results */
+  candidate: SkillsShSearchWithAuditItem;
+  /** The security decision for this skill */
+  securityDecision: SecurityDecision;
+  /** Whether the user has explicitly overridden security restrictions */
+  userOverride?: boolean;
+}
+
+export interface SkillsShInstallResult {
+  success: boolean;
+  skillId: string;
+  /** The managed skill directory path */
+  installedPath?: string;
+  /** Error message if install failed */
+  error?: string;
+  /** Whether installation was allowed by policy or via user override */
+  installedVia: 'policy' | 'override';
+  /** Provenance metadata stored with the skill */
+  provenance?: SkillsShProvenance;
+}
+
+export interface SkillsShProvenance {
+  provider: 'skills.sh';
+  source: string;
+  skillId: string;
+  sourceUrl: string;
+  auditSnapshot: {
+    overallRisk: string;
+    dimensions: Array<{
+      provider: string;
+      risk: string;
+      analyzedAt: string;
+    }>;
+    capturedAt: string;
+  };
+}
+
+// ─── Path helpers ────────────────────────────────────────────────────────────────
+
+function getManagedSkillsDir(): string {
+  return getWorkspaceSkillsDir();
+}
+
+// `npx skills add` creates a `skills/` subdir inside its cwd,
+// so we use the parent of the managed skills dir as the project root.
+function getSkillsShProjectRoot(): string {
+  return dirname(getWorkspaceSkillsDir());
+}
+
+// ─── Subprocess runner ───────────────────────────────────────────────────────────
+
+async function runSkillsAdd(
+  source: string,
+  skillId: string,
+  opts?: { timeout?: number },
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const cwd = getSkillsShProjectRoot();
+  const timeout = opts?.timeout ?? 60000;
+
+  mkdirSync(cwd, { recursive: true });
+
+  const skillRef = `${source}/${skillId}`;
+  log.info({ skillRef, cwd }, 'Running npx skills add');
+
+  const proc = Bun.spawn(['npx', 'skills', 'add', skillRef], {
+    cwd,
+    env: { ...process.env },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  let timer: ReturnType<typeof setTimeout>;
+  const timeoutPromise = new Promise<[string, string]>((_, reject) => {
+    timer = setTimeout(() => {
+      proc.kill();
+      reject(new Error(`skills add command timed out after ${timeout}ms`));
+    }, timeout);
+  });
+
+  const [stdout, stderr] = await Promise.race([
+    Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]),
+    timeoutPromise,
+  ]).finally(() => clearTimeout(timer!));
+
+  // Suppress unhandled rejection from the losing timeout promise
+  timeoutPromise.catch(() => {});
+
+  const exitCode = await proc.exited;
+
+  log.info(
+    { exitCode, stdoutLen: stdout.length, stderrLen: stderr.length },
+    'skills add command completed',
+  );
+
+  return { stdout, stderr, exitCode };
+}
+
+// ─── Provenance builder ──────────────────────────────────────────────────────────
+
+function buildProvenance(candidate: SkillsShSearchWithAuditItem): SkillsShProvenance {
+  const dimensions: SkillsShProvenance['auditSnapshot']['dimensions'] = [];
+
+  for (const provider of ['ath', 'socket', 'snyk'] as const) {
+    const dim = candidate.audit[provider];
+    if (dim) {
+      dimensions.push({
+        provider,
+        risk: dim.risk,
+        analyzedAt: dim.analyzedAt,
+      });
+    }
+  }
+
+  return {
+    provider: 'skills.sh',
+    source: candidate.source,
+    skillId: candidate.skillId,
+    sourceUrl: `https://skills.sh/skills/${candidate.source}/${candidate.skillId}`,
+    auditSnapshot: {
+      overallRisk: candidate.overallRisk,
+      dimensions,
+      capturedAt: new Date().toISOString(),
+    },
+  };
+}
+
+// ─── Install function ────────────────────────────────────────────────────────────
+
+export async function skillsshInstall(
+  options: SkillsShInstallOptions,
+): Promise<SkillsShInstallResult> {
+  const { candidate, securityDecision, userOverride } = options;
+  const { skillId, source } = candidate;
+
+  // Gate: block do_not_recommend installs unless the user explicitly overrides
+  if (securityDecision.recommendation === 'do_not_recommend' && !userOverride) {
+    return {
+      success: false,
+      skillId,
+      installedVia: 'policy',
+      error:
+        `Installation blocked: security assessment is "${securityDecision.recommendation}" ` +
+        `(${securityDecision.overallRisk} risk). ${securityDecision.rationale}`,
+    };
+  }
+
+  const installedVia: 'policy' | 'override' =
+    securityDecision.recommendation === 'do_not_recommend' ? 'override' : 'policy';
+
+  try {
+    const result = await runSkillsAdd(source, skillId);
+
+    if (result.exitCode !== 0) {
+      const error = result.stderr.trim() || result.stdout.trim() || 'Unknown error';
+      return { success: false, skillId, installedVia, error };
+    }
+
+    // `npx skills add` installs into skills/<skillId>/SKILL.md relative to the project root.
+    // The project root is the parent of the managed skills dir, so the installed
+    // path lands inside the managed skills dir.
+    const installedDir = join(getManagedSkillsDir(), skillId);
+    const skillFile = join(installedDir, 'SKILL.md');
+
+    if (!existsSync(skillFile)) {
+      return {
+        success: false,
+        skillId,
+        installedVia,
+        error: `Installation completed but SKILL.md not found at expected path: ${skillFile}`,
+      };
+    }
+
+    // Record content integrity hash (trust-on-first-use)
+    verifyAndRecordSkillHash(skillId);
+
+    // Store provenance metadata alongside the skill
+    const provenance = buildProvenance(candidate);
+    const provenancePath = join(installedDir, '.provenance.json');
+    writeFileSync(provenancePath, JSON.stringify(provenance, null, 2) + '\n', 'utf-8');
+
+    log.info(
+      { skillId, source, installedVia, installedDir },
+      'skills.sh skill installed successfully',
+    );
+
+    return {
+      success: true,
+      skillId,
+      installedPath: installedDir,
+      installedVia,
+      provenance,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { success: false, skillId, installedVia, error: message };
+  }
+}

--- a/assistant/src/skills/skillssh-install.ts
+++ b/assistant/src/skills/skillssh-install.ts
@@ -3,7 +3,7 @@ import { dirname, join } from 'node:path';
 
 import { getLogger } from '../util/logger.js';
 import { getWorkspaceSkillsDir } from '../util/platform.js';
-import { verifyAndRecordSkillHash } from './clawhub.js';
+import { validateSlug, verifyAndRecordSkillHash } from './clawhub.js';
 import type { SecurityDecision } from './security-decision.js';
 import type { SkillsShSearchWithAuditItem } from './skillssh.js';
 
@@ -148,6 +148,18 @@ export async function skillsshInstall(
 ): Promise<SkillsShInstallResult> {
   const { candidate, securityDecision, userOverride } = options;
   const { skillId, source } = candidate;
+
+  // Reject invalid skill IDs before computing install paths — prevents empty
+  // strings, path traversal segments, or other malformed identifiers from
+  // targeting unexpected directories.
+  if (!validateSlug(skillId)) {
+    return {
+      success: false,
+      skillId,
+      installedVia: 'policy',
+      error: `Invalid skill ID: ${skillId}`,
+    };
+  }
 
   // Gate: block do_not_recommend installs unless the user explicitly overrides
   if (securityDecision.recommendation === 'do_not_recommend' && !userOverride) {


### PR DESCRIPTION
## Summary
- Implement install path for skills.sh skills with security decision enforcement (blocks `do_not_recommend` unless user override is provided)
- Subprocess-based installation via `npx skills add`, following the same patterns as `clawhub.ts`
- Provenance metadata storage (`.provenance.json`) alongside installed skills with audit snapshot
- Content integrity verification via `verifyAndRecordSkillHash()` (trust-on-first-use)
- Adds `readSkillProvenance()` to `managed-store.ts` for reading provenance data

Part of #9776.

## Test plan
- [x] Test that installation is blocked when security decision is `do_not_recommend` and no override
- [x] Test that installation proceeds when security decision is `do_not_recommend` but override is true
- [x] Test that installation proceeds for `proceed` and `proceed_with_caution` decisions
- [x] Test that provenance metadata is correctly constructed and stored
- [x] Test error handling for failed installs (non-zero exit, missing SKILL.md, spawn exceptions)
- [x] Test managed store provenance reading (valid, missing, malformed JSON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
