### PR TITLE
fix: preserve user-uploaded images across context management

### DIFF
--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -267,8 +267,30 @@ export class ContextWindowManager {
       summaryCalls += 1;
     }
 
+    // Extract user-uploaded image blocks from compacted messages so they
+    // remain accessible to the assistant in subsequent turns. Tool-result
+    // screenshots are NOT preserved — only top-level image blocks in user
+    // messages, which represent intentional user uploads.
+    const preservedImageBlocks: ContentBlock[] = [];
+    for (const msg of compactableMessages) {
+      if (msg.role !== 'user') continue;
+      for (const block of msg.content) {
+        if (block.type === 'image') {
+          preservedImageBlocks.push(block);
+        }
+      }
+    }
+
+    const summaryMessage = createContextSummaryMessage(summary);
+    if (preservedImageBlocks.length > 0) {
+      summaryMessage.content.push(
+        { type: 'text', text: '[The following images were uploaded by the user in earlier messages and are preserved for reference.]' },
+        ...preservedImageBlocks,
+      );
+    }
+
     const compactedMessages = [
-      createContextSummaryMessage(summary),
+      summaryMessage,
       ...messages.slice(keepPlan.keepFromIndex),
     ];
     const estimatedInputTokens = estimatePromptTokens(

--- a/assistant/src/daemon/session-media-retry.ts
+++ b/assistant/src/daemon/session-media-retry.ts
@@ -30,16 +30,12 @@ export function stripMediaPayloadsForRetry(messages: Message[]): { messages: Mes
   const nextMessages = messages.map((msg, msgIndex) => {
     const nextContent: ContentBlock[] = [];
     for (const block of msg.content) {
+      // Top-level image blocks are user-uploaded attachments — always preserve
+      // them so the assistant can reference previously shared images. Only
+      // images inside tool_result blocks (e.g. browser screenshots) are
+      // stripped to save context.
       if (block.type === 'image') {
-        const keep = latestUserIndex === msgIndex && keptLatestMediaBlocks < RETRY_KEEP_LATEST_MEDIA_BLOCKS;
-        if (keep) {
-          keptLatestMediaBlocks += 1;
-          nextContent.push(block);
-        } else {
-          replacedBlocks += 1;
-          modified = true;
-          nextContent.push(imageBlockToStub(block));
-        }
+        nextContent.push(block);
         continue;
       }
 


### PR DESCRIPTION
## Summary
- **Stop stripping user-uploaded images during context-too-large retry** (`session-media-retry.ts`): Top-level `image` blocks in user messages are now always preserved. Tool-result screenshots (inside `tool_result.contentBlocks`) are still stripped as before.
- **Carry forward user-uploaded images during context compaction** (`window-manager.ts`): When old messages are summarized, user-uploaded image blocks are extracted and appended to the summary message so the assistant can still reference them.

Previously, when a user uploaded an image (e.g. "use this as my avatar"), the assistant could lose access to it after context compaction or a context-too-large retry, forcing it to ask the user to re-upload via File Request.

## Test plan
- [x] Existing `context-window-manager.test.ts` tests pass (13/13)
- [ ] Verify user-uploaded image persists across context compaction in a long conversation
- [ ] Verify user-uploaded image survives context-too-large retry scenario
- [ ] Confirm tool-result screenshots (browser captures) are still stripped as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
