### PR TITLE
M1: Gateway Slack config, credentials, and credential watcher

### DIFF
--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { getLogger, type LogFileConfig } from "./logger.js";
-import { getRootDir, readKeychainCredential, readCredential, readTwilioCredentials, readWhatsAppCredentials } from "./credential-reader.js";
+import { getRootDir, readKeychainCredential, readCredential, readTwilioCredentials, readWhatsAppCredentials, readSlackChannelCredentials } from "./credential-reader.js";
 
 const log = getLogger("config");
 
@@ -78,6 +78,15 @@ export type GatewayConfig = {
   whatsappTimeoutMs: number;
   whatsappMaxRetries: number;
   whatsappInitialBackoffMs: number;
+  /** Slack Bot User OAuth Token (xoxb-...) for Slack as a channel. */
+  slackChannelBotToken: string | undefined;
+  /** Slack App-Level Token (xapp-...) for Socket Mode. */
+  slackChannelAppToken: string | undefined;
+  /**
+   * When true, the /deliver/slack endpoint allows unauthenticated access
+   * even when no bearer token is configured. Intended for local development only.
+   */
+  slackDeliverAuthBypass: boolean;
   /** When true, trust X-Forwarded-For for client IP resolution (set when behind a reverse proxy). */
   trustProxy: boolean;
 };
@@ -341,6 +350,25 @@ export function loadConfig(): GatewayConfig {
     throw new Error("GATEWAY_WHATSAPP_INITIAL_BACKOFF_MS must be a positive number");
   }
 
+  // Slack channel credentials: env var > credential store (keychain / encrypted file)
+  const slackChannelCreds = readSlackChannelCredentials();
+  const slackChannelBotToken =
+    process.env.SLACK_CHANNEL_BOT_TOKEN || slackChannelCreds?.botToken || undefined;
+  const slackChannelAppToken =
+    process.env.SLACK_CHANNEL_APP_TOKEN || slackChannelCreds?.appToken || undefined;
+
+  const slackDeliverAuthBypassRaw = process.env.GATEWAY_SLACK_DELIVER_AUTH_BYPASS;
+  if (
+    slackDeliverAuthBypassRaw !== undefined &&
+    slackDeliverAuthBypassRaw !== "true" &&
+    slackDeliverAuthBypassRaw !== "false"
+  ) {
+    throw new Error(
+      `GATEWAY_SLACK_DELIVER_AUTH_BYPASS must be "true" or "false", got "${slackDeliverAuthBypassRaw}"`,
+    );
+  }
+  let slackDeliverAuthBypass = slackDeliverAuthBypassRaw === "true";
+
   const smsDeliverAuthBypassRaw = process.env.GATEWAY_SMS_DELIVER_AUTH_BYPASS;
   if (
     smsDeliverAuthBypassRaw !== undefined &&
@@ -370,6 +398,10 @@ export function loadConfig(): GatewayConfig {
     if (whatsappDeliverAuthBypass) {
       log.warn("GATEWAY_WHATSAPP_DELIVER_AUTH_BYPASS is set but ignored in production (APP_VERSION=%s)", appVersion);
       whatsappDeliverAuthBypass = false;
+    }
+    if (slackDeliverAuthBypass) {
+      log.warn("GATEWAY_SLACK_DELIVER_AUTH_BYPASS is set but ignored in production (APP_VERSION=%s)", appVersion);
+      slackDeliverAuthBypass = false;
     }
   }
 
@@ -431,6 +463,9 @@ export function loadConfig(): GatewayConfig {
       hasWhatsAppAppSecret: !!whatsappAppSecret,
       hasWhatsAppWebhookVerifyToken: !!whatsappWebhookVerifyToken,
       whatsappDeliverAuthBypass,
+      hasSlackChannelBotToken: !!slackChannelBotToken,
+      hasSlackChannelAppToken: !!slackChannelAppToken,
+      slackDeliverAuthBypass,
       trustProxy,
     },
     "Configuration loaded",
@@ -478,6 +513,14 @@ export function loadConfig(): GatewayConfig {
     whatsappTimeoutMs,
     whatsappMaxRetries,
     whatsappInitialBackoffMs,
+    slackChannelBotToken,
+    slackChannelAppToken,
+    slackDeliverAuthBypass,
     trustProxy,
   };
+}
+
+/** Returns true when both Slack channel tokens are present. */
+export function isSlackChannelConfigured(config: GatewayConfig): boolean {
+  return !!config.slackChannelBotToken && !!config.slackChannelAppToken;
 }

--- a/gateway/src/credential-reader.ts
+++ b/gateway/src/credential-reader.ts
@@ -299,6 +299,59 @@ export function readTwilioCredentials(): TwilioCredentials | null {
   }
 }
 
+export type SlackChannelCredentials = {
+  /** Slack Bot User OAuth Token (xoxb-...). */
+  botToken: string;
+  /** Slack App-Level Token for Socket Mode (xapp-...). */
+  appToken: string;
+};
+
+/**
+ * Check the credential metadata file for Slack channel credentials and read
+ * them from secure storage (keychain on macOS, then encrypted store).
+ *
+ * Returns `null` if:
+ * - The metadata file doesn't exist or can't be parsed
+ * - Slack channel bot_token or app_token entries are missing from metadata
+ * - The actual secret values can't be read from any backend
+ */
+export function readSlackChannelCredentials(): SlackChannelCredentials | null {
+  try {
+    const metadataPath = getMetadataPath();
+    if (!existsSync(metadataPath)) return null;
+
+    const raw = readFileSync(metadataPath, "utf-8");
+    const data = JSON.parse(raw);
+    if (!data || !Array.isArray(data.credentials)) return null;
+
+    const hasBotToken = data.credentials.some(
+      (c: { service?: string; field?: string }) =>
+        c.service === "slack_channel" && c.field === "bot_token",
+    );
+    const hasAppToken = data.credentials.some(
+      (c: { service?: string; field?: string }) =>
+        c.service === "slack_channel" && c.field === "app_token",
+    );
+
+    if (!hasBotToken || !hasAppToken) return null;
+
+    const botToken = readCredentialWithFallback("credential:slack_channel:bot_token");
+    const appToken = readCredentialWithFallback("credential:slack_channel:app_token");
+
+    if (!botToken || !appToken) {
+      log.warn(
+        "Slack channel credential metadata exists but secrets could not be read from any backend",
+      );
+      return null;
+    }
+
+    return { botToken, appToken };
+  } catch (err) {
+    log.debug({ err }, "Failed to read Slack channel credentials");
+    return null;
+  }
+}
+
 export type WhatsAppCredentials = {
   /** WhatsApp Business phone number ID (numeric string). */
   phoneNumberId: string;

--- a/gateway/src/credential-watcher.ts
+++ b/gateway/src/credential-watcher.ts
@@ -15,9 +15,11 @@ import {
   readTelegramCredentials,
   readTwilioCredentials,
   readWhatsAppCredentials,
+  readSlackChannelCredentials,
   type TelegramCredentials,
   type TwilioCredentials,
   type WhatsAppCredentials,
+  type SlackChannelCredentials,
 } from "./credential-reader.js";
 
 const log = getLogger("credential-watcher");
@@ -31,6 +33,8 @@ export type CredentialChangeEvent = {
   twilioChanged: boolean;
   whatsappCredentials: WhatsAppCredentials | null;
   whatsappChanged: boolean;
+  slackChannelCredentials: SlackChannelCredentials | null;
+  slackChannelChanged: boolean;
 };
 
 export type CredentialChangeCallback = (event: CredentialChangeEvent) => void;
@@ -47,6 +51,8 @@ export class CredentialWatcher {
   private lastWhatsAppAccessToken: string | undefined;
   private lastWhatsAppAppSecret: string | undefined;
   private lastWhatsAppWebhookVerifyToken: string | undefined;
+  private lastSlackChannelBotToken: string | undefined;
+  private lastSlackChannelAppToken: string | undefined;
   private callback: CredentialChangeCallback;
   private metadataPath: string;
 
@@ -138,6 +144,7 @@ export class CredentialWatcher {
     const telegramCredentials = readTelegramCredentials();
     const twilioCredentials = readTwilioCredentials();
     const whatsappCredentials = readWhatsAppCredentials();
+    const slackChannelCredentials = readSlackChannelCredentials();
 
     const newBotToken = telegramCredentials?.botToken;
     const newWebhookSecret = telegramCredentials?.webhookSecret;
@@ -147,6 +154,8 @@ export class CredentialWatcher {
     const newWhatsAppAccessToken = whatsappCredentials?.accessToken;
     const newWhatsAppAppSecret = whatsappCredentials?.appSecret;
     const newWhatsAppWebhookVerifyToken = whatsappCredentials?.webhookVerifyToken;
+    const newSlackChannelBotToken = slackChannelCredentials?.botToken;
+    const newSlackChannelAppToken = slackChannelCredentials?.appToken;
 
     const telegramChanged =
       newBotToken !== this.lastBotToken ||
@@ -162,7 +171,11 @@ export class CredentialWatcher {
       newWhatsAppAppSecret !== this.lastWhatsAppAppSecret ||
       newWhatsAppWebhookVerifyToken !== this.lastWhatsAppWebhookVerifyToken;
 
-    if (!telegramChanged && !twilioChanged && !whatsappChanged) {
+    const slackChannelChanged =
+      newSlackChannelBotToken !== this.lastSlackChannelBotToken ||
+      newSlackChannelAppToken !== this.lastSlackChannelAppToken;
+
+    if (!telegramChanged && !twilioChanged && !whatsappChanged && !slackChannelChanged) {
       return;
     }
 
@@ -174,6 +187,8 @@ export class CredentialWatcher {
     this.lastWhatsAppAccessToken = newWhatsAppAccessToken;
     this.lastWhatsAppAppSecret = newWhatsAppAppSecret;
     this.lastWhatsAppWebhookVerifyToken = newWhatsAppWebhookVerifyToken;
+    this.lastSlackChannelBotToken = newSlackChannelBotToken;
+    this.lastSlackChannelAppToken = newSlackChannelAppToken;
 
     if (telegramChanged) {
       log.info(
@@ -193,6 +208,12 @@ export class CredentialWatcher {
         "WhatsApp credentials changed",
       );
     }
+    if (slackChannelChanged) {
+      log.info(
+        { hasCredentials: !!slackChannelCredentials },
+        "Slack channel credentials changed",
+      );
+    }
 
     this.callback({
       telegramCredentials,
@@ -201,6 +222,8 @@ export class CredentialWatcher {
       twilioChanged,
       whatsappCredentials,
       whatsappChanged,
+      slackChannelCredentials,
+      slackChannelChanged,
     });
   }
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -374,6 +374,7 @@ function main() {
   }
 
   const telegramFromEnv = isTelegramConfigured();
+  const slackFromEnv = !!(config.slackChannelBotToken && config.slackChannelAppToken);
 
   const credentialWatcher = new CredentialWatcher((event) => {
     if (event.telegramChanged && !telegramFromEnv) {
@@ -420,7 +421,7 @@ function main() {
       }
     }
 
-    if (event.slackChannelChanged) {
+    if (event.slackChannelChanged && !slackFromEnv) {
       if (event.slackChannelCredentials) {
         config.slackChannelBotToken = event.slackChannelCredentials.botToken;
         config.slackChannelAppToken = event.slackChannelCredentials.appToken;

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -419,6 +419,18 @@ function main() {
         log.info("WhatsApp credentials cleared");
       }
     }
+
+    if (event.slackChannelChanged) {
+      if (event.slackChannelCredentials) {
+        config.slackChannelBotToken = event.slackChannelCredentials.botToken;
+        config.slackChannelAppToken = event.slackChannelCredentials.appToken;
+        log.info("Slack channel credentials loaded from credential vault");
+      } else {
+        config.slackChannelBotToken = undefined;
+        config.slackChannelAppToken = undefined;
+        log.info("Slack channel credentials cleared");
+      }
+    }
   });
 
   credentialWatcher.start();

--- a/gateway/src/types.ts
+++ b/gateway/src/types.ts
@@ -2,7 +2,7 @@ import type { ChannelId } from './channels/types.js';
 
 export type GatewayInboundEventV1 = {
   version: "v1";
-  sourceChannel: Extract<ChannelId, 'telegram' | 'sms' | 'whatsapp'>;
+  sourceChannel: Extract<ChannelId, 'telegram' | 'sms' | 'whatsapp' | 'slack'>;
   receivedAt: string;
   routing: {
     assistantId: string;


### PR DESCRIPTION
Add foundational gateway configuration for Slack as a channel:\n\n- Add slack to sourceChannel union in GatewayInboundEventV1\n- Add slackChannelBotToken, slackChannelAppToken config fields with env var fallbacks\n- Add SlackChannelCredentials type and readSlackChannelCredentials() to credential reader\n- Add Slack credential watching to CredentialWatcher\n\nPart of #9858
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
