### PR TITLE
fix: guard PID cleanup to current process on startup failure

### DIFF
--- a/assistant/src/daemon/daemon-control.ts
+++ b/assistant/src/daemon/daemon-control.ts
@@ -125,6 +125,15 @@ export function cleanupPidFile(): void {
   }
 }
 
+/** Only remove the PID file if it belongs to the given process. Prevents a
+ *  failing second startup from deleting the PID of an already-running daemon. */
+export function cleanupPidFileIfOwner(ownerPid: number): void {
+  const currentPid = readPid();
+  if (currentPid === ownerPid) {
+    cleanupPidFile();
+  }
+}
+
 export function isDaemonRunning(): boolean {
   const pid = readPid();
   if (pid == null) return false;

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -48,7 +48,7 @@ import { listWorkItems, updateWorkItem } from '../work-items/work-item-store.js'
 import { WorkspaceHeartbeatService } from '../workspace/heartbeat-service.js';
 import { createApprovalConversationGenerator,createApprovalCopyGenerator } from './approval-generators.js';
 import { hasNoAuthOverride, hasUngatedNoAuthOverride } from './connection-policy.js';
-import { cleanupPidFile,writePid } from './daemon-control.js';
+import { cleanupPidFile, cleanupPidFileIfOwner, writePid } from './daemon-control.js';
 import { createGuardianActionCopyGenerator } from './guardian-action-generators.js';
 import { initPairingHandlers } from './handlers/pairing.js';
 import { installCliLaunchers } from './install-cli-launchers.js';
@@ -389,7 +389,7 @@ export async function runDaemon(): Promise<void> {
     });
   } catch (err) {
     log.error({ err }, 'Daemon startup failed — cleaning up');
-    cleanupPidFile();
+    cleanupPidFileIfOwner(process.pid);
     if (socketCreated) {
       try {
         removeSocketFile(getSocketPath());


### PR DESCRIPTION
Address review feedback from PR #9841 (fix: clean up PID file on daemon startup crash). The catch block in runDaemon() now only removes the PID file if it belongs to the current process, preventing a failing second startup attempt from deleting the PID of an already-running daemon.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
