### PR TITLE
fix: use dynamic arch detection in incremental ONNX binary stripping

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -325,8 +325,8 @@ if [ "$DAEMON_BIN_NEEDS_BUILD" = true ]; then
     onnx_bin="$SCRIPT_DIR/daemon-bin/node_modules/onnxruntime-node/bin/napi-v3"
     if [ -d "$onnx_bin" ]; then
         find "$onnx_bin" -mindepth 1 -maxdepth 1 -not -name darwin -exec rm -rf {} +
-        if [ -d "$onnx_bin/darwin" ]; then
-            find "$onnx_bin/darwin" -mindepth 1 -maxdepth 1 -not -name arm64 -exec rm -rf {} +
+        if [ "$UNIVERSAL_BUILD" != true ] && [ -d "$onnx_bin/darwin" ]; then
+            find "$onnx_bin/darwin" -mindepth 1 -maxdepth 1 -not -name "$(uname -m)" -exec rm -rf {} +
         fi
     fi
 fi


### PR DESCRIPTION
Address review feedback from PR #9802 (fix: externalize onnxruntime-node in daemon build to fix dylib loading).

The incremental daemon build path in build.sh hardcoded `arm64` when stripping non-native ONNX runtime binaries, breaking x64 and universal builds. This aligns it with the `build_binaries()` function which correctly uses `$(uname -m)` and checks `$UNIVERSAL_BUILD`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
