### PR TITLE
fix: defer jobs on QdrantCircuitOpenError instead of failing them permanently

### DIFF
--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -18,6 +18,7 @@ import {
   RETRY_MAX_ATTEMPTS,
   retryDelayForAttempt,
 } from './job-utils.js';
+import { QdrantCircuitOpenError } from './qdrant-circuit-breaker.js';
 import {
   claimMemoryJobs,
   completeMemoryJob,
@@ -186,6 +187,13 @@ function handleJobError(job: MemoryJob, err: unknown): void {
       log.error({ jobId: job.id, type: job.type }, 'Embedding backend unavailable, job exceeded max deferrals');
     } else {
       log.debug({ jobId: job.id, type: job.type }, 'Embedding backend unavailable, deferring job');
+    }
+  } else if (err instanceof QdrantCircuitOpenError) {
+    const result = deferMemoryJob(job.id);
+    if (result === 'failed') {
+      log.error({ jobId: job.id, type: job.type }, 'Qdrant circuit breaker open, job exceeded max deferrals');
+    } else {
+      log.debug({ jobId: job.id, type: job.type }, 'Qdrant circuit breaker open, deferring job');
     }
   } else {
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Address review feedback from PR #9797 (feat: add circuit breaker for Qdrant client)

Both Codex and Devin identified that QdrantCircuitOpenError was not recognized as a transient/retryable error by handleJobError in jobs-worker.ts. When the Qdrant circuit breaker opens, classifyError falls through to 'fatal', causing embedding and vector deletion jobs to be permanently failed instead of deferred for retry after the breaker cools down.

Fix: treat QdrantCircuitOpenError the same as BackendUnavailableError — defer the job so it retries after the circuit breaker cooldown period.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
