### PR TITLE
fix: include destination in duplicate-delivery lookup

### DIFF
--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -14,7 +14,7 @@ import { v4 as uuid } from 'uuid';
 import { getLogger } from '../util/logger.js';
 import { pairDeliveryWithConversation } from './conversation-pairing.js';
 import { composeFallbackCopy } from './copy-composer.js';
-import { createDelivery, findDeliveryByDecisionAndChannel, updateDeliveryStatus } from './deliveries-store.js';
+import { createDelivery, findDeliveryByDecisionChannelAndDestination, updateDeliveryStatus } from './deliveries-store.js';
 import { resolveDestinations } from './destination-resolver.js';
 import type { NotificationSignal } from './signal.js';
 import type {
@@ -188,11 +188,11 @@ export class NotificationBroadcaster {
 
       try {
         if (hasPersistedDecision) {
-          const existingDelivery = findDeliveryByDecisionAndChannel(persistedDecisionId, channel);
+          const existingDelivery = findDeliveryByDecisionChannelAndDestination(persistedDecisionId, channel, destinationLabel);
           if (existingDelivery) {
             log.info(
               { channel, signalId: signal.signalId, existingDeliveryId: existingDelivery.id },
-              'Delivery already exists for this decision+channel — skipping duplicate',
+              'Delivery already exists for this decision+channel+destination — skipping duplicate',
             );
             results.push({
               channel,

--- a/assistant/src/notifications/deliveries-store.ts
+++ b/assistant/src/notifications/deliveries-store.ts
@@ -191,10 +191,11 @@ export function listDeliveries(decisionId: string): NotificationDeliveryRow[] {
   return rows.map(rowToDelivery);
 }
 
-/** Check whether a delivery already exists for a given decision+channel pair. */
-export function findDeliveryByDecisionAndChannel(
+/** Check whether a delivery already exists for a given decision+channel+destination triple. */
+export function findDeliveryByDecisionChannelAndDestination(
   decisionId: string,
   channel: NotificationChannel,
+  destination: string,
 ): NotificationDeliveryRow | undefined {
   const db = getDb();
   const row = db
@@ -204,6 +205,7 @@ export function findDeliveryByDecisionAndChannel(
       and(
         eq(notificationDeliveries.notificationDecisionId, decisionId),
         eq(notificationDeliveries.channel, channel),
+        eq(notificationDeliveries.destination, destination),
       ),
     )
     .get();


### PR DESCRIPTION
Address review feedback from PR #9796 (fix: add deduplication check in notification dispatch).

The duplicate-delivery check was matching only on decision+channel, which would suppress valid deliveries when the destination changed (e.g., after a Telegram/SMS rebind). Now includes destination in the lookup to match the existing uniqueness model (decision + channel + destination + attempt).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
