### PR TITLE
fix: remove redundant schema-only dedupe_key index (PR #9804 feedback)

### DIFF
--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -940,9 +940,7 @@ export const notificationEvents = sqliteTable('notification_events', {
   dedupeKey: text('dedupe_key'),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
-}, (table) => [
-  index('idx_notification_events_dedupe_key').on(table.dedupeKey),
-]);
+});
 
 export const notificationDecisions = sqliteTable('notification_decisions', {
   id: text('id').primaryKey(),


### PR DESCRIPTION
Address review feedback from PR #9804 (perf: add index on notificationEvents(dedupeKey)).

Both Codex and Devin identified that the index added in schema.ts was never materialized at runtime because the DB is initialized via raw SQL migrations in 114-notifications.ts, not Drizzle schema push. Additionally, the existing compound unique index `idx_notification_events_dedupe` on `(assistant_id, dedupe_key) WHERE dedupe_key IS NOT NULL` already covers the actual query pattern in events-store.ts which filters on both assistantId and dedupeKey.

This PR removes the redundant schema-only index declaration.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
