### PR TITLE
fix: replace full schedule scan with aggregate SQL counts in debug endpoint

### DIFF
--- a/assistant/src/runtime/routes/debug-routes.ts
+++ b/assistant/src/runtime/routes/debug-routes.ts
@@ -7,7 +7,7 @@ import { statSync } from 'node:fs';
 import { getDbPath } from '../../util/platform.js';
 import { countConversations } from '../../memory/conversation-store.js';
 import { getMemoryJobCounts } from '../../memory/jobs-store.js';
-import { listSchedules } from '../../schedule/schedule-store.js';
+import { countSchedules } from '../../schedule/schedule-store.js';
 import { rawAll } from '../../memory/db.js';
 import { getConfig } from '../../config/loader.js';
 import { getProviderDebugStatus } from '../../providers/registry.js';
@@ -42,8 +42,7 @@ export function handleDebug(): Response {
 
   const memoryJobCounts = getMemoryJobCounts();
 
-  const schedules = listSchedules();
-  const enabledSchedules = schedules.filter((s) => s.enabled).length;
+  const scheduleCounts = countSchedules();
 
   const config = getConfig();
   const providerOrder = Array.isArray(config.providerOrder) ? config.providerOrder : [];
@@ -64,8 +63,8 @@ export function handleDebug(): Response {
       memory: memoryJobCounts,
     },
     schedules: {
-      total: schedules.length,
-      enabled: enabledSchedules,
+      total: scheduleCounts.total,
+      enabled: scheduleCounts.enabled,
     },
     timestamp: new Date(now).toISOString(),
   });

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -1,5 +1,5 @@
 import { Cron } from 'croner';
-import { and, asc, desc, eq, lte } from 'drizzle-orm';
+import { and, asc, desc, eq, lte, sql } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
 import { getDb } from '../memory/db.js';
@@ -118,6 +118,18 @@ export function getSchedule(id: string): ScheduleJob | null {
     .get();
   if (!row) return null;
   return parseJobRow(row);
+}
+
+export function countSchedules(): { total: number; enabled: number } {
+  const db = getDb();
+  const row = db
+    .select({
+      total: sql<number>`COUNT(*)`,
+      enabled: sql<number>`SUM(CASE WHEN ${scheduleJobs.enabled} THEN 1 ELSE 0 END)`,
+    })
+    .from(scheduleJobs)
+    .get();
+  return { total: row?.total ?? 0, enabled: row?.enabled ?? 0 };
 }
 
 export function listSchedules(options?: { enabledOnly?: boolean }): ScheduleJob[] {


### PR DESCRIPTION
Address review feedback from PR #9807 (feat: add /v1/debug introspection endpoint). Replaces listSchedules() in the debug endpoint with a new countSchedules() function that counts total and enabled schedules via SQL aggregation instead of loading every row.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9878" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
