### PR TITLE
fix: preserve classified risk level on permission-check exceptions

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -214,6 +214,13 @@ export class ToolExecutor {
 
       return execResult;
     } catch (err) {
+      // Extract classified risk level if the PermissionChecker attached it
+      // before re-throwing. This preserves audit accuracy for high-risk
+      // tool attempts that fail mid-permission-evaluation.
+      if (err instanceof Error && typeof (err as Error & { riskLevel?: string }).riskLevel === 'string') {
+        riskLevel = (err as Error & { riskLevel?: string }).riskLevel!;
+      }
+
       const durationMs = Date.now() - startTime;
       const msg = err instanceof Error ? err.message : String(err);
       const isAbort = err instanceof Error && err.name === 'AbortError';

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -44,218 +44,229 @@ export class PermissionChecker {
     const risk = await classifyRisk(name, input, context.workingDir, undefined, undefined, context.signal);
     const riskLevel: string = risk;
 
-    const policyContext = buildPolicyContext(tool, context);
-    const result = await check(name, input, context.workingDir, policyContext, undefined, context.signal);
+    // Wrap the rest of permission evaluation so that any exception
+    // carries the classified risk level back to the caller. Without
+    // this, the executor's catch block would fall back to the default
+    // low risk, degrading audit/alert accuracy for high-risk attempts.
+    try {
+      const policyContext = buildPolicyContext(tool, context);
+      const result = await check(name, input, context.workingDir, policyContext, undefined, context.signal);
 
-    // Private threads force prompting for side-effect tools even when a
-    // trust/allow rule would auto-allow. Deny decisions are preserved —
-    // only allow → prompt promotion happens here.
-    if (
-      context.forcePromptSideEffects
-      && result.decision === 'allow'
-      && isSideEffectTool(name, input)
-    ) {
-      result.decision = 'prompt';
-      result.reason = 'Private thread: side-effect tools require explicit approval';
-    }
-
-    if (result.decision === 'deny') {
-      const durationMs = Date.now() - startTime;
-      emitLifecycleEvent({
-        type: 'permission_denied',
-        toolName: name,
-        executionTarget,
-        input,
-        workingDir: context.workingDir,
-        sessionId: context.sessionId,
-        conversationId: context.conversationId,
-        requestId: context.requestId,
-        riskLevel,
-        decision: 'deny',
-        reason: result.reason,
-        durationMs,
-      });
-      return { allowed: false, decision: 'denied', riskLevel, content: result.reason };
-    }
-
-    if (result.decision === 'prompt') {
-      // Non-interactive sessions have no client to respond to prompts —
-      // deny immediately instead of blocking for the full permission timeout.
-      if (context.isInteractive === false) {
-        const durationMs = Date.now() - startTime;
-        log.info({ toolName: name, riskLevel }, 'Auto-denying prompt for non-interactive session');
-        emitLifecycleEvent({
-          type: 'permission_denied',
-          toolName: name,
-          executionTarget,
-          input,
-          workingDir: context.workingDir,
-          sessionId: context.sessionId,
-          conversationId: context.conversationId,
-          requestId: context.requestId,
-          riskLevel,
-          decision: 'deny',
-          reason: 'Non-interactive session: no client to approve prompt',
-          durationMs,
-        });
-        return {
-          allowed: false,
-          decision: 'denied',
-          riskLevel,
-          content: `Permission denied: tool "${name}" requires user approval but no interactive client is connected. The tool was not executed. To allow this tool in non-interactive sessions, add a trust rule via permission settings.`,
-        };
-      }
-
-      const allowlistOptions = await generateAllowlistOptions(name, input, context.signal);
-      const scopeOptions = generateScopeOptions(context.workingDir, name);
-      const previewDiff = computePreviewDiff(name, input, context.workingDir);
-
-      let sandboxed: boolean | undefined;
-      if (name === 'bash' && typeof input.command === 'string') {
-        const cfg = getConfig();
-        const sandboxConfig = context.sandboxOverride != null
-          ? { ...cfg.sandbox, enabled: context.sandboxOverride }
-          : cfg.sandbox;
-        const wrapped = wrapCommand(input.command, context.workingDir, sandboxConfig);
-        sandboxed = wrapped.sandboxed;
-      }
-
-      // Proxied bash prompts are non-persistent — no trust rule saving allowed
-      const persistentDecisionsAllowed = !(
-        name === 'bash'
-        && input.network_mode === 'proxied'
-      );
-
-      emitLifecycleEvent({
-        type: 'permission_prompt',
-        toolName: name,
-        executionTarget,
-        input,
-        workingDir: context.workingDir,
-        sessionId: context.sessionId,
-        conversationId: context.conversationId,
-        requestId: context.requestId,
-        riskLevel,
-        reason: result.reason,
-        allowlistOptions,
-        scopeOptions,
-        diff: previewDiff,
-        sandboxed,
-        persistentDecisionsAllowed,
-      });
-
-      await getHookManager().trigger('permission-request', {
-        toolName: name,
-        input: sanitizeToolInput(name, input),
-        riskLevel,
-        sessionId: context.sessionId,
-      });
-
-      const response = await this.prompter.prompt(
-        name,
-        input,
-        riskLevel,
-        allowlistOptions,
-        scopeOptions,
-        previewDiff,
-        sandboxed,
-        context.conversationId,
-        executionTarget,
-        persistentDecisionsAllowed,
-        context.signal,
-      );
-
-      const decision = response.decision;
-
-      await getHookManager().trigger('permission-resolve', {
-        toolName: name,
-        decision: response.decision,
-        riskLevel,
-        sessionId: context.sessionId,
-      });
-
-      if (response.decision === 'deny') {
-        const contextualDenial = typeof response.decisionContext === 'string'
-          ? response.decisionContext.trim()
-          : '';
-        const denialMessage = contextualDenial.length > 0
-          ? contextualDenial
-          : `Permission denied by user. The user chose not to allow the "${name}" tool. Do NOT retry this tool call immediately. Instead, tell the user that the action was not performed because they denied permission, and ask if they would like you to try again or take a different approach. Wait for the user to explicitly respond before retrying.`;
-        const denialReason = contextualDenial.length > 0
-          ? `Permission denied (${name}): contextual policy`
-          : 'Permission denied by user';
-        const durationMs = Date.now() - startTime;
-        emitLifecycleEvent({
-          type: 'permission_denied',
-          toolName: name,
-          executionTarget,
-          input,
-          workingDir: context.workingDir,
-          sessionId: context.sessionId,
-          conversationId: context.conversationId,
-          requestId: context.requestId,
-          riskLevel,
-          decision: 'deny',
-          reason: denialReason,
-          durationMs,
-        });
-        return { allowed: false, decision, riskLevel, content: denialMessage };
-      }
-
-      if (response.decision === 'always_deny') {
-        const ruleSaved = !!(persistentDecisionsAllowed && response.selectedPattern && response.selectedScope);
-        if (ruleSaved) {
-          addRule(name, response.selectedPattern!, response.selectedScope!, 'deny');
-        }
-        const denialReason = ruleSaved ? 'Permission denied by user (rule saved)' : 'Permission denied by user';
-        const denialMessage = ruleSaved
-          ? `Permission denied by user, and a rule was saved to always deny the "${name}" tool for this pattern. Do NOT retry this tool call. Inform the user that this action has been permanently blocked by their preference. If the user wants to allow it in the future, they can update their permission rules.`
-          : `Permission denied by user. The user chose not to allow the "${name}" tool. Do NOT retry this tool call immediately. Instead, tell the user that the action was not performed because they denied permission, and ask if they would like you to try again or take a different approach. Wait for the user to explicitly respond before retrying.`;
-        const durationMs = Date.now() - startTime;
-        emitLifecycleEvent({
-          type: 'permission_denied',
-          toolName: name,
-          executionTarget,
-          input,
-          workingDir: context.workingDir,
-          sessionId: context.sessionId,
-          conversationId: context.conversationId,
-          requestId: context.requestId,
-          riskLevel,
-          decision: 'always_deny',
-          reason: denialReason,
-          durationMs,
-        });
-        return { allowed: false, decision, riskLevel, content: denialMessage };
-      }
-
+      // Private threads force prompting for side-effect tools even when a
+      // trust/allow rule would auto-allow. Deny decisions are preserved —
+      // only allow → prompt promotion happens here.
       if (
-        persistentDecisionsAllowed
-        && (response.decision === 'always_allow' || response.decision === 'always_allow_high_risk')
-        && response.selectedPattern
-        && response.selectedScope
+        context.forcePromptSideEffects
+        && result.decision === 'allow'
+        && isSideEffectTool(name, input)
       ) {
-        const ruleOptions: {
-          allowHighRisk?: boolean;
-          executionTarget?: string;
-        } = {};
-
-        if (response.decision === 'always_allow_high_risk') {
-          ruleOptions.allowHighRisk = true;
-        }
-
-        if (policyContext?.executionTarget != null) {
-          ruleOptions.executionTarget = policyContext.executionTarget;
-        }
-
-        const hasOptions = Object.keys(ruleOptions).length > 0;
-        addRule(name, response.selectedPattern, response.selectedScope, 'allow', 100, hasOptions ? ruleOptions : undefined);
+        result.decision = 'prompt';
+        result.reason = 'Private thread: side-effect tools require explicit approval';
       }
 
-      return { allowed: true, decision, riskLevel };
-    }
+      if (result.decision === 'deny') {
+        const durationMs = Date.now() - startTime;
+        emitLifecycleEvent({
+          type: 'permission_denied',
+          toolName: name,
+          executionTarget,
+          input,
+          workingDir: context.workingDir,
+          sessionId: context.sessionId,
+          conversationId: context.conversationId,
+          requestId: context.requestId,
+          riskLevel,
+          decision: 'deny',
+          reason: result.reason,
+          durationMs,
+        });
+        return { allowed: false, decision: 'denied', riskLevel, content: result.reason };
+      }
 
-    // result.decision === 'allow'
-    return { allowed: true, decision: 'allow', riskLevel };
+      if (result.decision === 'prompt') {
+        // Non-interactive sessions have no client to respond to prompts —
+        // deny immediately instead of blocking for the full permission timeout.
+        if (context.isInteractive === false) {
+          const durationMs = Date.now() - startTime;
+          log.info({ toolName: name, riskLevel }, 'Auto-denying prompt for non-interactive session');
+          emitLifecycleEvent({
+            type: 'permission_denied',
+            toolName: name,
+            executionTarget,
+            input,
+            workingDir: context.workingDir,
+            sessionId: context.sessionId,
+            conversationId: context.conversationId,
+            requestId: context.requestId,
+            riskLevel,
+            decision: 'deny',
+            reason: 'Non-interactive session: no client to approve prompt',
+            durationMs,
+          });
+          return {
+            allowed: false,
+            decision: 'denied',
+            riskLevel,
+            content: `Permission denied: tool "${name}" requires user approval but no interactive client is connected. The tool was not executed. To allow this tool in non-interactive sessions, add a trust rule via permission settings.`,
+          };
+        }
+
+        const allowlistOptions = await generateAllowlistOptions(name, input, context.signal);
+        const scopeOptions = generateScopeOptions(context.workingDir, name);
+        const previewDiff = computePreviewDiff(name, input, context.workingDir);
+
+        let sandboxed: boolean | undefined;
+        if (name === 'bash' && typeof input.command === 'string') {
+          const cfg = getConfig();
+          const sandboxConfig = context.sandboxOverride != null
+            ? { ...cfg.sandbox, enabled: context.sandboxOverride }
+            : cfg.sandbox;
+          const wrapped = wrapCommand(input.command, context.workingDir, sandboxConfig);
+          sandboxed = wrapped.sandboxed;
+        }
+
+        // Proxied bash prompts are non-persistent — no trust rule saving allowed
+        const persistentDecisionsAllowed = !(
+          name === 'bash'
+          && input.network_mode === 'proxied'
+        );
+
+        emitLifecycleEvent({
+          type: 'permission_prompt',
+          toolName: name,
+          executionTarget,
+          input,
+          workingDir: context.workingDir,
+          sessionId: context.sessionId,
+          conversationId: context.conversationId,
+          requestId: context.requestId,
+          riskLevel,
+          reason: result.reason,
+          allowlistOptions,
+          scopeOptions,
+          diff: previewDiff,
+          sandboxed,
+          persistentDecisionsAllowed,
+        });
+
+        await getHookManager().trigger('permission-request', {
+          toolName: name,
+          input: sanitizeToolInput(name, input),
+          riskLevel,
+          sessionId: context.sessionId,
+        });
+
+        const response = await this.prompter.prompt(
+          name,
+          input,
+          riskLevel,
+          allowlistOptions,
+          scopeOptions,
+          previewDiff,
+          sandboxed,
+          context.conversationId,
+          executionTarget,
+          persistentDecisionsAllowed,
+          context.signal,
+        );
+
+        const decision = response.decision;
+
+        await getHookManager().trigger('permission-resolve', {
+          toolName: name,
+          decision: response.decision,
+          riskLevel,
+          sessionId: context.sessionId,
+        });
+
+        if (response.decision === 'deny') {
+          const contextualDenial = typeof response.decisionContext === 'string'
+            ? response.decisionContext.trim()
+            : '';
+          const denialMessage = contextualDenial.length > 0
+            ? contextualDenial
+            : `Permission denied by user. The user chose not to allow the "${name}" tool. Do NOT retry this tool call immediately. Instead, tell the user that the action was not performed because they denied permission, and ask if they would like you to try again or take a different approach. Wait for the user to explicitly respond before retrying.`;
+          const denialReason = contextualDenial.length > 0
+            ? `Permission denied (${name}): contextual policy`
+            : 'Permission denied by user';
+          const durationMs = Date.now() - startTime;
+          emitLifecycleEvent({
+            type: 'permission_denied',
+            toolName: name,
+            executionTarget,
+            input,
+            workingDir: context.workingDir,
+            sessionId: context.sessionId,
+            conversationId: context.conversationId,
+            requestId: context.requestId,
+            riskLevel,
+            decision: 'deny',
+            reason: denialReason,
+            durationMs,
+          });
+          return { allowed: false, decision, riskLevel, content: denialMessage };
+        }
+
+        if (response.decision === 'always_deny') {
+          const ruleSaved = !!(persistentDecisionsAllowed && response.selectedPattern && response.selectedScope);
+          if (ruleSaved) {
+            addRule(name, response.selectedPattern!, response.selectedScope!, 'deny');
+          }
+          const denialReason = ruleSaved ? 'Permission denied by user (rule saved)' : 'Permission denied by user';
+          const denialMessage = ruleSaved
+            ? `Permission denied by user, and a rule was saved to always deny the "${name}" tool for this pattern. Do NOT retry this tool call. Inform the user that this action has been permanently blocked by their preference. If the user wants to allow it in the future, they can update their permission rules.`
+            : `Permission denied by user. The user chose not to allow the "${name}" tool. Do NOT retry this tool call immediately. Instead, tell the user that the action was not performed because they denied permission, and ask if they would like you to try again or take a different approach. Wait for the user to explicitly respond before retrying.`;
+          const durationMs = Date.now() - startTime;
+          emitLifecycleEvent({
+            type: 'permission_denied',
+            toolName: name,
+            executionTarget,
+            input,
+            workingDir: context.workingDir,
+            sessionId: context.sessionId,
+            conversationId: context.conversationId,
+            requestId: context.requestId,
+            riskLevel,
+            decision: 'always_deny',
+            reason: denialReason,
+            durationMs,
+          });
+          return { allowed: false, decision, riskLevel, content: denialMessage };
+        }
+
+        if (
+          persistentDecisionsAllowed
+          && (response.decision === 'always_allow' || response.decision === 'always_allow_high_risk')
+          && response.selectedPattern
+          && response.selectedScope
+        ) {
+          const ruleOptions: {
+            allowHighRisk?: boolean;
+            executionTarget?: string;
+          } = {};
+
+          if (response.decision === 'always_allow_high_risk') {
+            ruleOptions.allowHighRisk = true;
+          }
+
+          if (policyContext?.executionTarget != null) {
+            ruleOptions.executionTarget = policyContext.executionTarget;
+          }
+
+          const hasOptions = Object.keys(ruleOptions).length > 0;
+          addRule(name, response.selectedPattern, response.selectedScope, 'allow', 100, hasOptions ? ruleOptions : undefined);
+        }
+
+        return { allowed: true, decision, riskLevel };
+      }
+
+      // result.decision === 'allow'
+      return { allowed: true, decision: 'allow', riskLevel };
+    } catch (err) {
+      if (err instanceof Error) {
+        (err as Error & { riskLevel?: string }).riskLevel = riskLevel;
+      }
+      throw err;
+    }
   }
 }


### PR DESCRIPTION
Address review feedback from PR #9798 (refactor: extract PermissionChecker class from executor.ts)

The PermissionChecker.checkPermission() method now attaches the classified risk level to any exception thrown after classifyRisk() succeeds. The executor's catch block extracts this risk level, ensuring error lifecycle events report the actual classified risk instead of defaulting to low.

This restores the audit accuracy that was regressed by the extraction refactor, where the inline flow previously assigned riskLevel before subsequent steps could throw.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
