### PR TITLE
fix: properly handle async rejections from addPointerMessage, persistCallCompletionMessage, and sweepExpiredGuardianActions

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -641,7 +641,9 @@ export class CallController {
 
         // Notify the voice conversation
         if (shouldNotifyCompletion && currentSession) {
-          persistCallCompletionMessage(currentSession.conversationId, this.callSessionId);
+          persistCallCompletionMessage(currentSession.conversationId, this.callSessionId).catch((err) => {
+            log.error({ err, conversationId: currentSession.conversationId, callSessionId: this.callSessionId }, 'Failed to persist call completion message');
+          });
           fireCallCompletionNotifier(currentSession.conversationId, this.callSessionId);
         }
 
@@ -650,6 +652,8 @@ export class CallController {
           const durationMs = currentSession.startedAt ? Date.now() - currentSession.startedAt : 0;
           addPointerMessage(currentSession.initiatedFromConversationId, 'completed', currentSession.toNumber, {
             duration: durationMs > 0 ? formatDuration(durationMs) : undefined,
+          }).catch((err) => {
+            log.warn({ conversationId: currentSession.initiatedFromConversationId, err }, 'Skipping pointer write — origin conversation may no longer exist');
           });
         }
         this.state = 'idle';
@@ -815,7 +819,9 @@ export class CallController {
         updateCallSession(this.callSessionId, { status: 'completed', endedAt: Date.now() });
         recordCallEvent(this.callSessionId, 'call_ended', { reason: 'max_duration' });
         if (shouldNotifyCompletion && currentSession) {
-          persistCallCompletionMessage(currentSession.conversationId, this.callSessionId);
+          persistCallCompletionMessage(currentSession.conversationId, this.callSessionId).catch((err) => {
+            log.error({ err, conversationId: currentSession.conversationId, callSessionId: this.callSessionId }, 'Failed to persist call completion message');
+          });
           fireCallCompletionNotifier(currentSession.conversationId, this.callSessionId);
         }
 
@@ -824,6 +830,8 @@ export class CallController {
           const durationMs = currentSession.startedAt ? Date.now() - currentSession.startedAt : 0;
           addPointerMessage(currentSession.initiatedFromConversationId, 'completed', currentSession.toNumber, {
             duration: durationMs > 0 ? formatDuration(durationMs) : undefined,
+          }).catch((err) => {
+            log.warn({ conversationId: currentSession.initiatedFromConversationId, err }, 'Skipping pointer write — origin conversation may no longer exist');
           });
         }
       }, 3000);

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -366,7 +366,9 @@ export async function startCall(input: StartCallInput): Promise<StartCallResult 
     log.info({ callSessionId: session.id, callSid }, 'Call initiated successfully');
 
     // Post a concise pointer message in the initiating conversation
-    addPointerMessage(conversationId, 'started', phoneNumber);
+    addPointerMessage(conversationId, 'started', phoneNumber).catch((err) => {
+      log.warn({ conversationId, err }, 'Failed to post call-started pointer message');
+    });
 
     return {
       ok: true,
@@ -392,7 +394,9 @@ export async function startCall(input: StartCallInput): Promise<StartCallResult 
     }
 
     // Post a failure pointer message in the initiating conversation
-    addPointerMessage(conversationId, 'failed', phoneNumber, { reason: msg });
+    addPointerMessage(conversationId, 'failed', phoneNumber, { reason: msg }).catch((pointerErr) => {
+      log.warn({ conversationId, err: pointerErr }, 'Failed to post call-failed pointer message');
+    });
 
     return { ok: false, error: `Error initiating call: ${msg}`, status: 500 };
   }

--- a/assistant/src/calls/guardian-action-sweep.ts
+++ b/assistant/src/calls/guardian-action-sweep.ts
@@ -88,9 +88,9 @@ export function startGuardianActionSweep(
   bearerToken?: string,
 ): void {
   if (sweepTimer) return;
-  sweepTimer = setInterval(() => {
+  sweepTimer = setInterval(async () => {
     try {
-      sweepExpiredGuardianActions(gatewayBaseUrl, bearerToken);
+      await sweepExpiredGuardianActions(gatewayBaseUrl, bearerToken);
     } catch (err) {
       log.error({ err }, 'Guardian action sweep failed');
     }

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -322,13 +322,11 @@ export class RelayConnection {
       // Post a pointer message in the initiating conversation
       if (session.initiatedFromConversationId) {
         const durationMs = session.startedAt ? Date.now() - session.startedAt : 0;
-        try {
-          addPointerMessage(session.initiatedFromConversationId, 'completed', session.toNumber, {
-            duration: durationMs > 0 ? formatDuration(durationMs) : undefined,
-          });
-        } catch (err) {
+        addPointerMessage(session.initiatedFromConversationId, 'completed', session.toNumber, {
+          duration: durationMs > 0 ? formatDuration(durationMs) : undefined,
+        }).catch((err) => {
           log.warn({ conversationId: session.initiatedFromConversationId, err }, 'Skipping pointer write — origin conversation may no longer exist');
-        }
+        });
       }
     } else {
       const detail = reason || (code ? `relay_closed_${code}` : 'relay_closed_abnormal');
@@ -344,18 +342,18 @@ export class RelayConnection {
 
       // Post a failure pointer message in the initiating conversation
       if (session.initiatedFromConversationId) {
-        try {
-          addPointerMessage(session.initiatedFromConversationId, 'failed', session.toNumber, {
-            reason: detail,
-          });
-        } catch (err) {
+        addPointerMessage(session.initiatedFromConversationId, 'failed', session.toNumber, {
+          reason: detail,
+        }).catch((err) => {
           log.warn({ conversationId: session.initiatedFromConversationId, err }, 'Skipping pointer write — origin conversation may no longer exist');
-        }
+        });
       }
     }
 
     expirePendingQuestions(this.callSessionId);
-    persistCallCompletionMessage(session.conversationId, this.callSessionId);
+    persistCallCompletionMessage(session.conversationId, this.callSessionId).catch((err) => {
+      log.error({ err, conversationId: session.conversationId, callSessionId: this.callSessionId }, 'Failed to persist call completion message');
+    });
     fireCallCompletionNotifier(session.conversationId, this.callSessionId);
   }
 
@@ -458,7 +456,7 @@ export class RelayConnection {
     const config = getConfig();
     const verificationConfig = config.calls.verification;
     if (!isInbound && verificationConfig.enabled) {
-      this.startVerification(session, verificationConfig);
+      await this.startVerification(session, verificationConfig);
     } else if (isInbound) {
       // For inbound calls, check if there's a pending voice guardian
       // challenge that the caller needs to complete before proceeding.
@@ -704,16 +702,14 @@ export class RelayConnection {
         // requesting chat sees a deterministic completion notice.
         const successSession = getCallSession(this.callSessionId);
         if (successSession?.initiatedFromConversationId) {
-          try {
-            addPointerMessage(
-              successSession.initiatedFromConversationId,
-              'guardian_verification_succeeded',
-              successSession.toNumber,
-              { channel: 'voice' },
-            );
-          } catch (err) {
+          addPointerMessage(
+            successSession.initiatedFromConversationId,
+            'guardian_verification_succeeded',
+            successSession.toNumber,
+            { channel: 'voice' },
+          ).catch((err) => {
             log.warn({ conversationId: successSession.initiatedFromConversationId, err }, 'Skipping pointer write — origin conversation may no longer exist');
-          }
+          });
         }
 
         setTimeout(() => {
@@ -770,22 +766,22 @@ export class RelayConnection {
         const failSession = getCallSession(this.callSessionId);
         if (failSession) {
           expirePendingQuestions(this.callSessionId);
-          persistCallCompletionMessage(failSession.conversationId, this.callSessionId);
+          persistCallCompletionMessage(failSession.conversationId, this.callSessionId).catch((err) => {
+            log.error({ err, conversationId: failSession.conversationId, callSessionId: this.callSessionId }, 'Failed to persist call completion message');
+          });
           fireCallCompletionNotifier(failSession.conversationId, this.callSessionId);
 
           // Emit a pointer message to the origin conversation so the
           // requesting chat sees a deterministic failure notice.
           if (isOutbound && failSession.initiatedFromConversationId) {
-            try {
-              addPointerMessage(
-                failSession.initiatedFromConversationId,
-                'guardian_verification_failed',
-                failSession.toNumber,
-                { channel: 'voice', reason: 'Max verification attempts exceeded' },
-              );
-            } catch (err) {
+            addPointerMessage(
+              failSession.initiatedFromConversationId,
+              'guardian_verification_failed',
+              failSession.toNumber,
+              { channel: 'voice', reason: 'Max verification attempts exceeded' },
+            ).catch((err) => {
               log.warn({ conversationId: failSession.initiatedFromConversationId, err }, 'Skipping pointer write — origin conversation may no longer exist');
-            }
+            });
           }
         }
 
@@ -995,16 +991,16 @@ export class RelayConnection {
             const session = getCallSession(this.callSessionId);
             if (session) {
               expirePendingQuestions(this.callSessionId);
-              persistCallCompletionMessage(session.conversationId, this.callSessionId);
+              persistCallCompletionMessage(session.conversationId, this.callSessionId).catch((err) => {
+                log.error({ err, conversationId: session.conversationId, callSessionId: this.callSessionId }, 'Failed to persist call completion message');
+              });
               fireCallCompletionNotifier(session.conversationId, this.callSessionId);
               if (session.initiatedFromConversationId) {
-                try {
-                  addPointerMessage(session.initiatedFromConversationId, 'failed', session.toNumber, {
-                    reason: 'Callee verification failed',
-                  });
-                } catch (err) {
+                addPointerMessage(session.initiatedFromConversationId, 'failed', session.toNumber, {
+                  reason: 'Callee verification failed',
+                }).catch((err) => {
                   log.warn({ conversationId: session.initiatedFromConversationId, err }, 'Skipping pointer write — origin conversation may no longer exist');
-                }
+                });
               }
             }
 

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -361,7 +361,9 @@ export async function handleStatusCallback(req: Request): Promise<Response> {
       expirePendingQuestions(session.id);
 
       if (!wasTerminal) {
-        persistCallCompletionMessage(session.conversationId, session.id);
+        persistCallCompletionMessage(session.conversationId, session.id).catch((err) => {
+          log.error({ err, conversationId: session.conversationId, callSessionId: session.id }, 'Failed to persist call completion message');
+        });
         fireCallCompletionNotifier(session.conversationId, session.id);
       }
     }


### PR DESCRIPTION
Address review feedback from PR #9770 (perf: replace Bun.sleepSync with async Bun.sleep in retry logic).

When several functions became async (addPointerMessage, persistCallCompletionMessage, sweepExpiredGuardianActions, startVerification), their callers were not updated to handle the returned promises. This caused:

1. Sync try/catch blocks that could not catch async rejections
2. Unhandled promise rejections from fire-and-forget calls
3. Silent error swallowing in setInterval callbacks

Fixes:
- guardian-action-sweep.ts: make setInterval callback async and await the sweep
- relay-server.ts: await startVerification; replace sync try/catch with .catch() for addPointerMessage and persistCallCompletionMessage
- twilio-routes.ts: add .catch() to persistCallCompletionMessage call
- call-controller.ts: add .catch() to persistCallCompletionMessage and addPointerMessage calls
- call-domain.ts: add .catch() to addPointerMessage calls
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9880" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
