### PR TITLE
fix: address review feedback on PR #9795

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -390,13 +390,17 @@ export class RuntimeHttpServer {
       }
     }
 
-    // Per-bearer-token rate limiting for /v1/* endpoints, with per-IP fallback
-    // for unauthenticated requests (lower limits to reduce abuse surface).
+    // Per-client-IP rate limiting for /v1/* endpoints. Authenticated requests
+    // get a higher limit; unauthenticated requests get a lower limit to reduce
+    // abuse surface. We key on IP rather than bearer token because the gateway
+    // uses a single shared token for all proxied requests, which would collapse
+    // all users into one bucket.
     if (path.startsWith('/v1/')) {
+      const clientIp = extractClientIp(req, server);
       const token = extractBearerToken(req);
       const result = token
-        ? apiRateLimiter.check(token)
-        : ipRateLimiter.check(extractClientIp(req, server));
+        ? apiRateLimiter.check(clientIp)
+        : ipRateLimiter.check(clientIp);
       if (!result.allowed) {
         return rateLimitResponse(result);
       }

--- a/assistant/src/runtime/middleware/rate-limiter.ts
+++ b/assistant/src/runtime/middleware/rate-limiter.ts
@@ -1,5 +1,5 @@
-// Per-bearer-token sliding-window rate limiter for /v1/* API endpoints.
-// Tracks request counts per token and returns 429 when the limit is exceeded.
+// Per-client-IP sliding-window rate limiter for /v1/* API endpoints.
+// Tracks request counts per key and returns 429 when the limit is exceeded.
 // Follows the same sliding-window pattern as gateway/src/auth-rate-limiter.ts.
 
 import type { HttpErrorResponse } from '../http-errors.js';
@@ -33,9 +33,9 @@ export class TokenRateLimiter {
    * Check whether the request should be allowed and record it.
    * Returns rate limit metadata for response headers.
    */
-  check(token: string): RateLimitResult {
+  check(key: string): RateLimitResult {
     const now = Date.now();
-    let timestamps = this.requests.get(token);
+    let timestamps = this.requests.get(key);
 
     if (!timestamps) {
       if (this.requests.size >= this.maxTrackedKeys) {
@@ -46,7 +46,7 @@ export class TokenRateLimiter {
         }
       }
       timestamps = [];
-      this.requests.set(token, timestamps);
+      this.requests.set(key, timestamps);
     }
 
     const cutoff = now - this.windowMs;
@@ -82,12 +82,12 @@ export class TokenRateLimiter {
 
   private evictStale(now: number): void {
     const cutoff = now - this.windowMs;
-    for (const [token, timestamps] of this.requests) {
+    for (const [key, timestamps] of this.requests) {
       while (timestamps.length > 0 && timestamps[0] <= cutoff) {
         timestamps.shift();
       }
       if (timestamps.length === 0) {
-        this.requests.delete(token);
+        this.requests.delete(key);
       }
     }
   }
@@ -125,7 +125,7 @@ export function rateLimitResponse(result: RateLimitResult): Response {
   });
 }
 
-/** Singleton rate limiter for the runtime HTTP API (per-bearer-token). */
+/** Singleton rate limiter for authenticated /v1/* requests (per-client-IP). */
 export const apiRateLimiter = new TokenRateLimiter();
 
 /** Singleton rate limiter for unauthenticated requests (per-IP, lower limits). */


### PR DESCRIPTION
Address review feedback from PR #9795 (feat: add per-bearer-token rate limiting for HTTP API)

The Codex review flagged that the rate limiter keyed on the bearer token, but the gateway uses a single shared bearer token for all proxied requests. This collapsed all gateway-proxied users into one rate limit bucket.

**Fix:** Key rate limiting on client IP (via X-Forwarded-For / X-Real-IP / peer address) instead of the bearer token. The two-tier rate limit structure is preserved — authenticated requests still get the higher 60/min limit, unauthenticated get 20/min — but each client is now tracked independently.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9881" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
