### PR TITLE
fix: remove redundant scope_id+status index from schema (#9792)

### DIFF
--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -91,7 +91,6 @@ export const memoryItems = sqliteTable('memory_items', {
 }, (table) => [
   index('idx_memory_items_scope_id').on(table.scopeId),
   index('idx_memory_items_fingerprint').on(table.fingerprint),
-  index('idx_memory_items_scope_id_status').on(table.scopeId, table.status),
 ]);
 
 export const memoryItemSources = sqliteTable('memory_item_sources', {


### PR DESCRIPTION
Address review feedback from PR #9792 (perf: add compound index on memoryItems(scopeId, status)).

Both Codex and Devin flagged that:
1. The new idx_memory_items_scope_id_status index was only in the Drizzle schema — no runtime migration created it, so it was a no-op.
2. The existing idx_memory_items_scope_status_kind on (scope_id, status, kind) already covers (scope_id, status) queries via SQLite leftmost-prefix matching, making the 2-column index redundant.

Fix: remove the redundant index declaration from schema.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
