### PR TITLE
fix: use getDbPath() for migration recovery instructions

### DIFF
--- a/assistant/src/memory/migrations/validate-migration-state.ts
+++ b/assistant/src/memory/migrations/validate-migration-state.ts
@@ -1,5 +1,6 @@
 import { IntegrityError } from '../../util/errors.js';
 import { getLogger } from '../../util/logger.js';
+import { getDbPath } from '../../util/platform.js';
 import { type DrizzleDb,getSqliteFrom } from '../db-connection.js';
 import { MIGRATION_REGISTRY, type MigrationValidationResult } from './registry.js';
 
@@ -41,7 +42,7 @@ export function recoverCrashedMigrations(database: DrizzleDb): string[] {
       '',
       'Clearing stalled checkpoints so they can be retried on this startup.',
       'If retries continue to fail, manually inspect the database:',
-      '  sqlite3 ~/.vellum/data/assistant.db "SELECT * FROM memory_checkpoints"',
+      `  sqlite3 ${getDbPath()} "SELECT * FROM memory_checkpoints"`,
     ].join('\n'),
   );
 
@@ -126,7 +127,7 @@ export function validateMigrationState(database: DrizzleDb): MigrationValidation
         `The following migrations were retried but still did not complete: ${crashed.join(', ')}`,
         '',
         'Manual intervention is required. Inspect the database and resolve:',
-        '  sqlite3 ~/.vellum/data/assistant.db "DELETE FROM memory_checkpoints WHERE key = \'<migration_key>\'"',
+        `  sqlite3 ${getDbPath()} "DELETE FROM memory_checkpoints WHERE key = '<migration_key>'"`,
         'Then restart the daemon.',
       ].join('\n'),
     );


### PR DESCRIPTION
Address review feedback from PR #9767 (fix: block daemon startup on migration dependency violations)

The Codex review flagged that the crash-recovery log messages hardcoded `~/.vellum/data/assistant.db` for the sqlite3 recovery command, but the actual DB path is resolved dynamically via `getDbPath()` which resolves to `~/.vellum/workspace/data/db/assistant.db`. Following the logged command would modify the wrong file.

Fix: import `getDbPath()` from `platform.ts` and use it in both recovery log messages so operators always get the correct path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
