### PR TITLE
fix: address review feedback on PR #9805

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -470,18 +470,26 @@ function formatRecallResult(
     1,
     Math.floor(options?.maxInjectTokensOverride ?? config.memory.retrieval.maxInjectTokens),
   );
-  const selected = trimToTokenBudget(merged, maxInjectTokens, config.memory.retrieval.injectionFormat);
+
+  // Reserve token budget for the degradation notice so it doesn't push
+  // injected text over maxInjectTokens when appended after trimming.
+  const degradationNotice = collected.semanticSearchFailed
+    ? '[Note: Semantic search is currently unavailable. Memory recall is limited to lexical and recency matching — results may be incomplete or miss semantically relevant memories.]'
+    : undefined;
+  const noticeTokenCost = degradationNotice
+    ? estimateTextTokens(degradationNotice) + 2 // +2 for '\n\n' separator
+    : 0;
+  const candidateBudget = Math.max(1, maxInjectTokens - noticeTokenCost);
+
+  const selected = trimToTokenBudget(merged, candidateBudget, config.memory.retrieval.injectionFormat);
   markItemUsage(selected);
 
   let injectedText = buildInjectedText(selected, config.memory.retrieval.injectionFormat);
 
-  // Surface degradation notice in the injected text so the model knows
-  // semantic search is unavailable and recall quality may be reduced.
-  if (collected.semanticSearchFailed) {
-    const notice = '[Note: Semantic search is currently unavailable. Memory recall is limited to lexical and recency matching — results may be incomplete or miss semantically relevant memories.]';
+  if (degradationNotice) {
     injectedText = injectedText.length > 0
-      ? injectedText + '\n\n' + notice
-      : notice;
+      ? injectedText + '\n\n' + degradationNotice
+      : degradationNotice;
   }
 
   const topCandidates: MemoryRecallCandiateDebug[] = selected.slice(0, 10).map((c) => ({


### PR DESCRIPTION
Address review feedback from PR #9805 (feat: surface Qdrant circuit-breaker state in memory retrieval)

Both Codex and Devin flagged the same issue: the degradation notice was appended after trimToTokenBudget, causing injectedText to potentially exceed maxInjectTokens by ~40 tokens.

Fix: reserve token budget for the degradation notice before calling trimToTokenBudget, so candidates are trimmed to a smaller budget that leaves room for the notice. The total injected text now stays within the maxInjectTokens contract.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
