### PR TITLE
fix: await recursive drainQueue calls to prevent unhandled rejections

### DIFF
--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -244,7 +244,7 @@ export async function drainQueue(session: ProcessSessionContext, reason: QueueDr
       next.onEvent({ type: 'error', message });
     }
     // Continue draining regardless of success/failure
-    drainQueue(session);
+    await drainQueue(session);
     return;
   }
 
@@ -287,7 +287,7 @@ export async function drainQueue(session: ProcessSessionContext, reason: QueueDr
     // runAgentLoop never ran, so its finally block won't clear this
     session.preactivatedSkillIds = undefined;
     // Continue draining — don't strand remaining messages
-    drainQueue(session);
+    await drainQueue(session);
     return;
   }
 


### PR DESCRIPTION
Address review feedback from PR #9810: add `await` to both recursive `drainQueue()` calls in `session-process.ts` (lines 247 and 290) so the drain chain executes sequentially, errors propagate correctly, and shared state is not mutated concurrently.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
