### PR TITLE
fix: report 'down' health when no active provider can be selected

### DIFF
--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -160,7 +160,7 @@ export function getProviderDebugStatus(
   }
 
   let overallHealth: 'healthy' | 'degraded' | 'down' = 'down';
-  if (registered.length > 0) {
+  if (registered.length > 0 && selection.selectedPrimary) {
     if (!failoverHealth) {
       overallHealth = 'healthy';
     } else {


### PR DESCRIPTION
When resolveProviderSelection returns selectedPrimary: null (e.g. provider=anthropic configured but only an OpenAI key present with empty providerOrder), getProviderDebugStatus was incorrectly reporting overallHealth as 'healthy' as long as any provider was registered and no cached failover existed. This adds the selectedPrimary null-check so /v1/debug correctly reports 'down' in that scenario.

Addresses review feedback from PR #9825.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
