### PR TITLE
fix: address review feedback on PR #9806

### DIFF
--- a/assistant/src/runtime/middleware/rate-limiter.ts
+++ b/assistant/src/runtime/middleware/rate-limiter.ts
@@ -132,23 +132,17 @@ export const apiRateLimiter = new TokenRateLimiter();
 export const ipRateLimiter = new TokenRateLimiter(DEFAULT_IP_MAX_REQUESTS, DEFAULT_IP_WINDOW_MS, MAX_TRACKED_IPS);
 
 /**
- * Extract the client IP from a request, checking proxy headers first.
- * Falls back to the Bun server's requestIP() for the actual peer address.
+ * Extract the client IP from a request using the actual peer address.
+ *
+ * The runtime sits behind the gateway and should not trust X-Forwarded-For or
+ * X-Real-IP headers — a client can spoof those to rotate IPs and bypass
+ * per-IP rate limits. The gateway handles proxy-header trust with an explicit
+ * trustProxy flag; here we always use the peer address from Bun's requestIP().
  */
 export function extractClientIp(
   req: Request,
   server: { requestIP(req: Request): { address: string } | null },
 ): string {
-  // X-Forwarded-For can contain a comma-separated list; the leftmost is the original client.
-  const forwarded = req.headers.get('x-forwarded-for');
-  if (forwarded) {
-    const first = forwarded.split(',')[0].trim();
-    if (first) return first;
-  }
-
-  const realIp = req.headers.get('x-real-ip');
-  if (realIp) return realIp.trim();
-
   const peerIp = server.requestIP(req);
   return peerIp?.address ?? '0.0.0.0';
 }


### PR DESCRIPTION
Address review feedback from PR #9806 (feat: add per-IP rate limiting fallback for unauthenticated endpoints)

Both Codex and Devin identified that extractClientIp unconditionally trusts X-Forwarded-For and X-Real-IP headers, allowing trivial rate-limit bypass via IP spoofing. Since the runtime sits behind the gateway, removed proxy header logic entirely and now always use server.requestIP() for the peer address.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
