### PR TITLE
fix: handle undefined response in request logger for WebSocket upgrades

### DIFF
--- a/assistant/src/runtime/middleware/request-logger.ts
+++ b/assistant/src/runtime/middleware/request-logger.ts
@@ -11,6 +11,9 @@ const log = getLogger('http-request');
 
 /**
  * Wrap a request handler to log request metadata and response timing.
+ *
+ * The handler may return `undefined` for WebSocket upgrades (Bun consumes
+ * the request and there is no HTTP response to send).
  */
 export async function withRequestLogging(
   req: Request,
@@ -34,6 +37,17 @@ export async function withRequestLogging(
   }
 
   const latencyMs = Math.round(performance.now() - start);
+
+  // WebSocket upgrades return undefined — log and pass through without
+  // dereferencing response properties.
+  if (!response) {
+    log.info(
+      { method, path, latencyMs },
+      `${method} ${path} -> ws-upgrade (${latencyMs}ms)`,
+    );
+    return response;
+  }
+
   const status = response.status;
 
   const logData = {


### PR DESCRIPTION
Address review feedback from PR #9821 (feat: add HTTP request/response logging middleware). The Codex review identified that withRequestLogging() would crash on WebSocket upgrade paths (/v1/browser-relay, /v1/calls/relay) because those handlers return undefined after a successful server.upgrade(). Added a guard to check for undefined response before accessing response.status.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
