### PR TITLE
fix: address review feedback on PR #9816

### DIFF
--- a/assistant/src/runtime/http-errors.ts
+++ b/assistant/src/runtime/http-errors.ts
@@ -21,6 +21,7 @@ export type HttpErrorCode =
   | 'FORBIDDEN'
   | 'NOT_FOUND'
   | 'CONFLICT'
+  | 'GONE'
   | 'RATE_LIMITED'
   | 'UNPROCESSABLE_ENTITY'
   | 'INTERNAL_ERROR'
@@ -69,4 +70,24 @@ export function httpError(
     error: { code, message, ...(details !== undefined ? { details } : {}) },
   };
   return Response.json(body, { status });
+}
+
+/**
+ * Derive the appropriate `HttpErrorCode` from an HTTP status code.
+ * Useful when domain functions return a numeric status and a generic error
+ * message — this maps the status to a semantically correct error code.
+ */
+export function httpErrorCodeFromStatus(status: number): HttpErrorCode {
+  switch (status) {
+    case 400: return 'BAD_REQUEST';
+    case 401: return 'UNAUTHORIZED';
+    case 403: return 'FORBIDDEN';
+    case 404: return 'NOT_FOUND';
+    case 409: return 'CONFLICT';
+    case 410: return 'GONE';
+    case 422: return 'UNPROCESSABLE_ENTITY';
+    case 429: return 'RATE_LIMITED';
+    case 503: return 'SERVICE_UNAVAILABLE';
+    default:  return 'INTERNAL_ERROR';
+  }
 }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -554,7 +554,7 @@ export class RuntimeHttpServer {
     const twilioSubpath = resolvedTwilioSubpath;
 
     if (GATEWAY_ONLY_BLOCKED_SUBPATHS.has(twilioSubpath)) {
-      return httpError('NOT_FOUND', 'Direct webhook access disabled. Use the gateway.', 410);
+      return httpError('GONE', 'Direct webhook access disabled. Use the gateway.', 410);
     }
 
     const validation = await validateTwilioWebhook(req);

--- a/assistant/src/runtime/routes/call-routes.ts
+++ b/assistant/src/runtime/routes/call-routes.ts
@@ -11,7 +11,7 @@
 import { answerCall, cancelCall, getCallStatus, relayInstruction,startCall } from '../../calls/call-domain.js';
 import { getConfig } from '../../config/loader.js';
 import { VALID_CALLER_IDENTITY_MODES } from '../../config/schema.js';
-import { httpError } from '../http-errors.js';
+import { httpError, httpErrorCodeFromStatus } from '../http-errors.js';
 
 // ── Idempotency cache ─────────────────────────────────────────────────────────
 // Stores serialized 201 responses keyed by idempotencyKey for 5 minutes so
@@ -96,7 +96,8 @@ export async function handleStartCall(req: Request, assistantId: string = 'self'
   });
 
   if (!result.ok) {
-    return httpError('INTERNAL_ERROR', result.error, result.status ?? 500);
+    const status = result.status ?? 500;
+    return httpError(httpErrorCodeFromStatus(status), result.error, status);
   }
 
   const responseBody = {
@@ -122,7 +123,8 @@ export function handleGetCallStatus(callSessionId: string): Response {
   const result = getCallStatus(callSessionId);
 
   if (!result.ok) {
-    return httpError('INTERNAL_ERROR', result.error, result.status ?? 500);
+    const status = result.status ?? 500;
+    return httpError(httpErrorCodeFromStatus(status), result.error, status);
   }
 
   const { session } = result;
@@ -161,7 +163,8 @@ export async function handleCancelCall(req: Request, callSessionId: string): Pro
   const result = await cancelCall({ callSessionId, reason });
 
   if (!result.ok) {
-    return httpError('INTERNAL_ERROR', result.error, result.status ?? 500);
+    const status = result.status ?? 500;
+    return httpError(httpErrorCodeFromStatus(status), result.error, status);
   }
 
   return Response.json({
@@ -193,7 +196,8 @@ export async function handleAnswerCall(req: Request, callSessionId: string): Pro
   });
 
   if (!result.ok) {
-    return httpError('INTERNAL_ERROR', result.error, result.status ?? 500);
+    const status = result.status ?? 500;
+    return httpError(httpErrorCodeFromStatus(status), result.error, status);
   }
 
   return Response.json({ ok: true, questionId: result.questionId });
@@ -222,7 +226,8 @@ export async function handleInstructionCall(req: Request, callSessionId: string)
   });
 
   if (!result.ok) {
-    return httpError('INTERNAL_ERROR', result.error, result.status ?? 500);
+    const status = result.status ?? 500;
+    return httpError(httpErrorCodeFromStatus(status), result.error, status);
   }
 
   return Response.json({ ok: true });


### PR DESCRIPTION
Address review feedback from PR #9816 (refactor: migrate route error responses to standard format)

Changes:
- Add httpErrorCodeFromStatus() helper to map HTTP status codes to semantically correct HttpErrorCode values
- Fix call-routes.ts: use httpErrorCodeFromStatus() instead of hardcoding INTERNAL_ERROR for all error paths (400/403/404/409 now get correct codes)
- Add GONE to HttpErrorCode type union
- Fix http-server.ts: use GONE instead of NOT_FOUND for blocked Twilio webhook subpaths (HTTP 410)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
