### PR TITLE
fix: accept empty sessionId on session errors as broadcast for 401 recovery

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1381,7 +1381,8 @@ extension ChatViewModel {
             }
 
         case .sessionError(let msg):
-            guard sessionId != nil, belongsToSession(msg.sessionId) else { return }
+            // Empty sessionId is treated as a broadcast (e.g. transport-level 401)
+            guard sessionId != nil, msg.sessionId.isEmpty || belongsToSession(msg.sessionId) else { return }
             log.error("Session error [\(msg.code.rawValue, privacy: .public)]: \(msg.userMessage, privacy: .private)")
             isWorkspaceRefinementInFlight = false
             refinementFlushTask?.cancel()


### PR DESCRIPTION
Address review feedback from PR #9830 (feat: implement HTTP token refresh in iOS client). The handleAuthenticationFailure() method emits session_error with sessionId: "" but ChatViewModel's belongsToSession() filter rejects empty strings that don't match the active session, causing 401-triggered errors to be silently dropped. Fix: treat empty sessionId on session errors as a broadcast that matches any active session.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
