### PR TITLE
fix: improve auto-deny UX when user chats during pending confirmation

### DIFF
--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -123,7 +123,7 @@ export class PermissionPrompter {
     for (const [requestId, pending] of this.pending) {
       clearTimeout(pending.timer);
       this.pending.delete(requestId);
-      pending.resolve({ decision: 'deny', decisionContext: 'auto_denied_new_user_message' });
+      pending.resolve({ decision: 'deny', decisionContext: 'The user sent a new message instead of responding to this permission prompt. Stop what you are doing and respond to the user\'s new message. Do NOT retry this tool or request permission again until the user asks you to.' });
     }
   }
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -827,6 +827,12 @@ public final class ChatViewModel: ObservableObject {
         let hasSkillInvocation = pendingSkillInvocation != nil
         guard !text.isEmpty || hasAttachments || hasSkillInvocation else { return }
 
+        // If there's a pending tool confirmation, mark it as denied in the UI.
+        // The daemon auto-denies it server-side when it receives this message.
+        if let pendingIndex = messages.firstIndex(where: { $0.confirmation?.state == .pending }) {
+            messages[pendingIndex].confirmation?.state = .denied
+        }
+
         // When "/model" or "/models" is sent, refresh model state so the picker/table has fresh data
         if (text == "/model" || text == "/models") && !hasSkillInvocation {
             do {


### PR DESCRIPTION
## Summary
- Update `decisionContext` in `denyAllPending()` to instruct the agent to stop and respond to the user's follow-up message instead of immediately re-requesting the denied tool
- Mark the confirmation card as `.denied` in the client UI when the user sends a message while a confirmation is pending, so the card visually updates immediately

## Test plan
- [ ] Trigger a tool approval prompt, then type a follow-up message like "why do you need this?"
- [ ] Verify the confirmation card updates to denied state
- [ ] Verify the agent responds to the question instead of re-requesting the tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9893" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
