### PR TITLE
fix: address review feedback on PR #9871

### DIFF
--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -15,6 +15,7 @@ const COMPACTION_COOLDOWN_MS = 2 * 60 * 1000;
 const MIN_GAIN_TOKENS_DURING_COOLDOWN = 1200;
 const SEVERE_PRESSURE_RATIO = 0.95;
 const MIN_COMPACTABLE_PERSISTED_MESSAGES = 2;
+const MAX_PRESERVED_IMAGE_BLOCKS = 5;
 const INTERNAL_CONTEXT_SUMMARY_MESSAGES = new WeakSet<Message>();
 
 const SUMMARY_SYSTEM_PROMPT = [
@@ -291,6 +292,12 @@ export class ContextWindowManager {
       }
     }
 
+    // Cap preserved images to avoid unbounded accumulation across cycles.
+    // Older images (carried forward) are at the front; keep the most recent.
+    if (preservedImageBlocks.length > MAX_PRESERVED_IMAGE_BLOCKS) {
+      preservedImageBlocks.splice(0, preservedImageBlocks.length - MAX_PRESERVED_IMAGE_BLOCKS);
+    }
+
     const summaryMessage = createContextSummaryMessage(summary);
     if (preservedImageBlocks.length > 0) {
       summaryMessage.content.push(
@@ -448,7 +455,7 @@ export function getSummaryFromContextMessage(message: Message | undefined): stri
 
 function stripContextSummaryTags(text: string): string {
   let inner = text.slice(CONTEXT_SUMMARY_MARKER.length);
-  const closeIdx = inner.indexOf('</context_summary>');
+  const closeIdx = inner.lastIndexOf('</context_summary>');
   if (closeIdx !== -1) {
     inner = inner.slice(0, closeIdx);
   }

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -271,7 +271,17 @@ export class ContextWindowManager {
     // remain accessible to the assistant in subsequent turns. Tool-result
     // screenshots are NOT preserved — only top-level image blocks in user
     // messages, which represent intentional user uploads.
+    // Also carry forward any images already preserved in the existing summary
+    // message so they survive multiple compaction cycles.
     const preservedImageBlocks: ContentBlock[] = [];
+    if (existingSummary != null) {
+      const summaryMsg = messages[0];
+      for (const block of summaryMsg.content) {
+        if (block.type === 'image') {
+          preservedImageBlocks.push(block);
+        }
+      }
+    }
     for (const msg of compactableMessages) {
       if (msg.role !== 'user') continue;
       for (const block of msg.content) {
@@ -438,8 +448,9 @@ export function getSummaryFromContextMessage(message: Message | undefined): stri
 
 function stripContextSummaryTags(text: string): string {
   let inner = text.slice(CONTEXT_SUMMARY_MARKER.length);
-  if (inner.endsWith('</context_summary>')) {
-    inner = inner.slice(0, -'</context_summary>'.length);
+  const closeIdx = inner.indexOf('</context_summary>');
+  if (closeIdx !== -1) {
+    inner = inner.slice(0, closeIdx);
   }
   return inner.trim();
 }

--- a/assistant/src/daemon/session-media-retry.ts
+++ b/assistant/src/daemon/session-media-retry.ts
@@ -30,12 +30,19 @@ export function stripMediaPayloadsForRetry(messages: Message[]): { messages: Mes
   const nextMessages = messages.map((msg, msgIndex) => {
     const nextContent: ContentBlock[] = [];
     for (const block of msg.content) {
-      // Top-level image blocks are user-uploaded attachments — always preserve
-      // them so the assistant can reference previously shared images. Only
-      // images inside tool_result blocks (e.g. browser screenshots) are
-      // stripped to save context.
+      // Top-level image blocks are user-uploaded attachments. Keep the latest
+      // few (in the most recent user message) and strip older ones so the
+      // retry can actually reduce context size when images are the cause.
       if (block.type === 'image') {
-        nextContent.push(block);
+        const keep = latestUserIndex === msgIndex && keptLatestMediaBlocks < RETRY_KEEP_LATEST_MEDIA_BLOCKS;
+        if (keep) {
+          keptLatestMediaBlocks += 1;
+          nextContent.push(block);
+        } else {
+          replacedBlocks += 1;
+          modified = true;
+          nextContent.push(imageBlockToStub(block));
+        }
         continue;
       }
 


### PR DESCRIPTION
## Summary
- Restore keep-latest logic for top-level images in `stripMediaPayloadsForRetry` so context-too-large recovery can actually reduce payload size when images are the cause
- Fix `stripContextSummaryTags` to use `indexOf` instead of `endsWith`, preventing summary corruption when preserved image annotation text blocks trail the closing `</context_summary>` tag
- Carry forward previously preserved images from the existing summary message so they survive multiple compaction cycles

## Test plan
- [x] Existing `context-window-manager` tests pass (13/13)
- [ ] Verify media retry strips older top-level images while keeping latest 3
- [ ] Verify summary extraction works correctly after compaction with preserved images
- [ ] Verify images survive multiple compaction cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)