### PR TITLE
fix: index user-uploaded attachments for asset_search

### DIFF
--- a/assistant/src/daemon/session-messaging.ts
+++ b/assistant/src/daemon/session-messaging.ts
@@ -10,6 +10,7 @@ import { v4 as uuid } from 'uuid';
 import { createUserMessage } from '../agent/message-types.js';
 import type { TurnChannelContext, TurnInterfaceContext } from '../channels/types.js';
 import { parseChannelId, parseInterfaceId } from '../channels/types.js';
+import { AttachmentUploadError, linkAttachmentToMessage, uploadAttachment } from '../memory/attachments-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import type { SecretPrompter } from '../permissions/secret-prompter.js';
@@ -230,6 +231,22 @@ export async function persistUserMessage(
 
     if (!persistedUserMessage.id) {
       throw new Error('Failed to persist user message');
+    }
+
+    // Index user attachments in the attachments table so asset_search can find them.
+    for (let i = 0; i < attachments.length; i++) {
+      const a = attachments[i];
+      if (!a.data) continue;
+      try {
+        const stored = uploadAttachment(a.filename, a.mimeType, a.data);
+        linkAttachmentToMessage(persistedUserMessage.id, stored.id, i);
+      } catch (err) {
+        if (err instanceof AttachmentUploadError) {
+          log.warn({ filename: a.filename, error: err.message }, 'Skipping user attachment indexing');
+        } else {
+          log.error({ filename: a.filename, err }, 'Failed to index user attachment');
+        }
+      }
     }
 
     return persistedUserMessage.id;

--- a/assistant/src/daemon/session-messaging.ts
+++ b/assistant/src/daemon/session-messaging.ts
@@ -10,7 +10,7 @@ import { v4 as uuid } from 'uuid';
 import { createUserMessage } from '../agent/message-types.js';
 import type { TurnChannelContext, TurnInterfaceContext } from '../channels/types.js';
 import { parseChannelId, parseInterfaceId } from '../channels/types.js';
-import { AttachmentUploadError, linkAttachmentToMessage, uploadAttachment } from '../memory/attachments-store.js';
+import { AttachmentUploadError, linkAttachmentToMessage, uploadAttachment, validateAttachmentUpload } from '../memory/attachments-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import type { SecretPrompter } from '../permissions/secret-prompter.js';
@@ -238,6 +238,11 @@ export async function persistUserMessage(
       const a = attachments[i];
       if (!a.data) continue;
       try {
+        const validation = validateAttachmentUpload(a.filename, a.mimeType);
+        if (!validation.ok) {
+          log.warn({ filename: a.filename, error: validation.error }, 'Skipping user attachment indexing: validation failed');
+          continue;
+        }
         const stored = uploadAttachment(a.filename, a.mimeType, a.data);
         linkAttachmentToMessage(persistedUserMessage.id, stored.id, i);
       } catch (err) {


### PR DESCRIPTION
## Summary
- User-uploaded attachments (e.g. zip files dropped into chat) were embedded inline in the message content JSON but never inserted into the `attachments` table
- This meant `asset_search` returned no results and `asset_materialize` couldn't locate user files
- `persistUserMessage()` now calls `uploadAttachment()` + `linkAttachmentToMessage()` for each user attachment, with content-hash dedup to avoid duplicates

## Test plan
- [ ] Upload a zip file via drag-and-drop in the chat composer
- [ ] Verify `asset_search` finds the uploaded file by filename or MIME type
- [ ] Verify `asset_materialize` can write the file to disk from the attachment ID
- [ ] Verify re-uploading the same file doesn't create duplicate entries (content-hash dedup)
- [ ] Verify that upload failures (invalid base64, oversized files) are logged but don't block message sending

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9895" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
