### PR TITLE
M5: Fallback to skills.sh when native capability fails

### DIFF
--- a/assistant/src/__tests__/skillssh-cli.test.ts
+++ b/assistant/src/__tests__/skillssh-cli.test.ts
@@ -1,0 +1,306 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+import { createCli } from '../skills/skillssh-cli.js';
+
+// ─── Fetch mock setup ───────────────────────────────────────────────────────────
+
+const originalFetch = globalThis.fetch;
+const originalStdoutWrite = process.stdout.write;
+const originalStderrWrite = process.stderr.write;
+
+let stdoutOutput = '';
+let stderrOutput = '';
+
+function mockFetch(handler: (url: string) => Response | Promise<Response>): void {
+  globalThis.fetch = mock((input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    return Promise.resolve(handler(url));
+  }) as unknown as typeof fetch;
+}
+
+function captureOutput(): void {
+  stdoutOutput = '';
+  stderrOutput = '';
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    stdoutOutput += typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    stderrOutput += typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+}
+
+beforeEach(() => {
+  globalThis.fetch = originalFetch;
+  process.stdout.write = originalStdoutWrite;
+  process.stderr.write = originalStderrWrite;
+  process.exitCode = undefined;
+  stdoutOutput = '';
+  stderrOutput = '';
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  process.stdout.write = originalStdoutWrite;
+  process.stderr.write = originalStderrWrite;
+  process.exitCode = undefined;
+});
+
+// ─── Shared test data ────────────────────────────────────────────────────────────
+
+function makeSearchApiResponse() {
+  return {
+    query: 'youtube',
+    skills: [
+      {
+        id: 'inference-sh-9/skills/youtube-thumbnail-design',
+        skillId: 'youtube-thumbnail-design',
+        name: 'youtube-thumbnail-design',
+        installs: 1577,
+        source: 'inference-sh-9/skills',
+      },
+    ],
+    count: 1,
+    duration_ms: 17,
+  };
+}
+
+function makeAuditApiResponse(skillId: string, risk = 'safe') {
+  return {
+    [skillId]: {
+      ath: { risk, analyzedAt: '2026-02-25T17:35:40.633Z' },
+      socket: { risk, analyzedAt: '2026-02-25T17:38:29.066Z', alerts: 0, score: 95 },
+    },
+  };
+}
+
+function makeCombinedFetchHandler(
+  searchResponse: object,
+  auditResponses: Record<string, object>,
+) {
+  return (url: string) => {
+    if (url.includes('skills.sh/api/search')) {
+      return new Response(JSON.stringify(searchResponse), { status: 200 });
+    }
+    if (url.includes('add-skill.vercel.sh/audit')) {
+      // Extract the skills param to find the right audit response
+      const parsedUrl = new URL(url);
+      const skillParam = parsedUrl.searchParams.get('skills') ?? '';
+      const auditData = auditResponses[skillParam] ?? {};
+      return new Response(JSON.stringify(auditData), { status: 200 });
+    }
+    return new Response('Not Found', { status: 404 });
+  };
+}
+
+// ─── Search command ──────────────────────────────────────────────────────────────
+
+describe('search command', () => {
+  test('outputs formatted search results', async () => {
+    const searchResp = makeSearchApiResponse();
+    const auditResp = {
+      'youtube-thumbnail-design': makeAuditApiResponse('youtube-thumbnail-design')['youtube-thumbnail-design'],
+    };
+
+    mockFetch(makeCombinedFetchHandler(searchResp, { 'youtube-thumbnail-design': auditResp }));
+    captureOutput();
+
+    const cli = createCli();
+    await cli.parseAsync(['node', 'skillssh-cli', 'search', 'youtube', '--limit', '5']);
+
+    expect(stdoutOutput).toContain('Found 1 skill(s)');
+    expect(stdoutOutput).toContain('youtube-thumbnail-design');
+    expect(stdoutOutput).toContain('[SAFE]');
+    expect(stdoutOutput).toContain('1577');
+  });
+
+  test('outputs JSON when --json flag is set', async () => {
+    const searchResp = makeSearchApiResponse();
+    const auditResp = {
+      'youtube-thumbnail-design': makeAuditApiResponse('youtube-thumbnail-design')['youtube-thumbnail-design'],
+    };
+
+    mockFetch(makeCombinedFetchHandler(searchResp, { 'youtube-thumbnail-design': auditResp }));
+    captureOutput();
+
+    const cli = createCli();
+    await cli.parseAsync(['node', 'skillssh-cli', 'search', 'youtube', '--json']);
+
+    const parsed = JSON.parse(stdoutOutput);
+    expect(parsed.query).toBe('youtube');
+    expect(parsed.skills).toHaveLength(1);
+    expect(parsed.skills[0].skillId).toBe('youtube-thumbnail-design');
+    expect(parsed.skills[0].overallRisk).toBe('safe');
+  });
+
+  test('shows "no skills found" for empty results', async () => {
+    mockFetch((url) => {
+      if (url.includes('skills.sh/api/search')) {
+        return new Response(JSON.stringify({ query: 'nonexistent', skills: [], count: 0 }), { status: 200 });
+      }
+      return new Response('Not Found', { status: 404 });
+    });
+    captureOutput();
+
+    const cli = createCli();
+    await cli.parseAsync(['node', 'skillssh-cli', 'search', 'nonexistent']);
+
+    expect(stdoutOutput).toContain('No skills found');
+  });
+
+  test('reports errors to stderr', async () => {
+    mockFetch(() => new Response('Internal Server Error', { status: 500 }));
+    captureOutput();
+
+    const cli = createCli();
+    await cli.parseAsync(['node', 'skillssh-cli', 'search', 'fail']);
+
+    expect(stderrOutput).toContain('Error:');
+    expect(process.exitCode).toBe(1);
+  });
+});
+
+// ─── Evaluate command ────────────────────────────────────────────────────────────
+
+describe('evaluate command', () => {
+  test('outputs formatted security decision for safe skill', async () => {
+    mockFetch((url) => {
+      if (url.includes('add-skill.vercel.sh/audit')) {
+        return new Response(
+          JSON.stringify(makeAuditApiResponse('my-skill')),
+          { status: 200 },
+        );
+      }
+      return new Response('Not Found', { status: 404 });
+    });
+    captureOutput();
+
+    const cli = createCli();
+    await cli.parseAsync(['node', 'skillssh-cli', 'evaluate', 'org/repo', 'my-skill']);
+
+    expect(stdoutOutput).toContain('Security evaluation for org/repo/my-skill');
+    expect(stdoutOutput).toContain('proceed');
+    expect(stdoutOutput).toContain('[SAFE]');
+  });
+
+  test('outputs do_not_recommend for critical risk', async () => {
+    mockFetch((url) => {
+      if (url.includes('add-skill.vercel.sh/audit')) {
+        return new Response(
+          JSON.stringify({
+            'risky-skill': {
+              ath: { risk: 'safe', analyzedAt: '2026-01-01T00:00:00Z' },
+              snyk: { risk: 'critical', analyzedAt: '2026-01-01T00:00:00Z', alerts: 5 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response('Not Found', { status: 404 });
+    });
+    captureOutput();
+
+    const cli = createCli();
+    await cli.parseAsync(['node', 'skillssh-cli', 'evaluate', 'org/repo', 'risky-skill']);
+
+    expect(stdoutOutput).toContain('do_not_recommend');
+    expect(stdoutOutput).toContain('[CRITICAL]');
+    expect(stdoutOutput).toContain('Snyk');
+  });
+
+  test('outputs JSON when --json flag is set', async () => {
+    mockFetch((url) => {
+      if (url.includes('add-skill.vercel.sh/audit')) {
+        return new Response(
+          JSON.stringify(makeAuditApiResponse('my-skill')),
+          { status: 200 },
+        );
+      }
+      return new Response('Not Found', { status: 404 });
+    });
+    captureOutput();
+
+    const cli = createCli();
+    await cli.parseAsync(['node', 'skillssh-cli', 'evaluate', 'org/repo', 'my-skill', '--json']);
+
+    const parsed = JSON.parse(stdoutOutput);
+    expect(parsed.recommendation).toBe('proceed');
+    expect(parsed.overallRisk).toBe('safe');
+    expect(parsed.auditSummary).toBeArray();
+  });
+
+  test('reports fetch errors', async () => {
+    mockFetch(() => new Response('Server Error', { status: 500 }));
+    captureOutput();
+
+    const cli = createCli();
+    await cli.parseAsync(['node', 'skillssh-cli', 'evaluate', 'org/repo', 'my-skill']);
+
+    expect(stderrOutput).toContain('Error:');
+    expect(process.exitCode).toBe(1);
+  });
+});
+
+// ─── Install command ─────────────────────────────────────────────────────────────
+
+describe('install command', () => {
+  test('reports error when security check blocks installation', async () => {
+    mockFetch((url) => {
+      if (url.includes('add-skill.vercel.sh/audit')) {
+        return new Response(
+          JSON.stringify({
+            'dangerous-skill': {
+              snyk: { risk: 'critical', analyzedAt: '2026-01-01T00:00:00Z' },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response('Not Found', { status: 404 });
+    });
+    captureOutput();
+
+    const cli = createCli();
+    await cli.parseAsync(['node', 'skillssh-cli', 'install', 'org/repo', 'dangerous-skill']);
+
+    expect(stderrOutput).toContain('Installation failed');
+    expect(stderrOutput).toContain('do_not_recommend');
+    expect(process.exitCode).toBe(1);
+  });
+
+  test('reports error in JSON mode when security check blocks', async () => {
+    mockFetch((url) => {
+      if (url.includes('add-skill.vercel.sh/audit')) {
+        return new Response(
+          JSON.stringify({
+            'dangerous-skill': {
+              snyk: { risk: 'critical', analyzedAt: '2026-01-01T00:00:00Z' },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response('Not Found', { status: 404 });
+    });
+    captureOutput();
+
+    const cli = createCli();
+    await cli.parseAsync(['node', 'skillssh-cli', 'install', 'org/repo', 'dangerous-skill', '--json']);
+
+    const parsed = JSON.parse(stdoutOutput);
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toContain('do_not_recommend');
+  });
+
+  test('reports fetch errors', async () => {
+    mockFetch(() => new Response('Server Error', { status: 500 }));
+    captureOutput();
+
+    const cli = createCli();
+    await cli.parseAsync(['node', 'skillssh-cli', 'install', 'org/repo', 'my-skill']);
+
+    expect(stderrOutput).toContain('Error:');
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/assistant/src/__tests__/skillssh-cli.test.ts
+++ b/assistant/src/__tests__/skillssh-cli.test.ts
@@ -291,6 +291,7 @@ describe('install command', () => {
     const parsed = JSON.parse(stdoutOutput);
     expect(parsed.success).toBe(false);
     expect(parsed.error).toContain('do_not_recommend');
+    expect(process.exitCode).toBe(1);
   });
 
   test('reports fetch errors', async () => {

--- a/assistant/src/config/bundled-skills/skillssh-fallback/SKILL.md
+++ b/assistant/src/config/bundled-skills/skillssh-fallback/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: "skillssh-fallback"
+description: "Search, evaluate, and install third-party skills from skills.sh with security audit visibility"
+user-invocable: false
+disable-model-invocation: false
+metadata:
+  vellum:
+    requires:
+      bins: ["bun"]
+---
+
+# Skills.sh Fallback
+
+When a native capability fails or the user asks for something that could be handled by a third-party skill, use this workflow to search, evaluate, and install skills from skills.sh.
+
+## When to trigger
+
+- A tool or capability the user needs is not currently available
+- A native command fails and a third-party skill could provide the functionality
+- The user explicitly asks to find or install a skill for a specific task
+
+## CLI commands
+
+All commands are run via:
+
+```bash
+bun run assistant/src/skills/skillssh-cli.ts <command> [options]
+```
+
+### Search for skills
+
+```bash
+bun run assistant/src/skills/skillssh-cli.ts search "<query>" --limit 5
+```
+
+Returns a list of matching skills with their risk levels and audit details. Use `--json` for machine-readable output.
+
+### Evaluate a specific skill
+
+```bash
+bun run assistant/src/skills/skillssh-cli.ts evaluate <source> <skillId>
+```
+
+Fetches the security audit and produces a recommendation. The `source` is the GitHub repo path (e.g. `inference-sh-9/skills`) and `skillId` is the skill name (e.g. `youtube-thumbnail-design`). Use `--json` for machine-readable output.
+
+### Install a skill
+
+```bash
+bun run assistant/src/skills/skillssh-cli.ts install <source> <skillId>
+```
+
+Runs the full install flow with security check. Pass `--override` to install despite a `do_not_recommend` security assessment. Use `--json` for machine-readable output.
+
+## Workflow
+
+Follow these steps in order. Do not skip the security evaluation or user confirmation.
+
+### 1. Search
+
+Run the search command with a relevant query describing what the user needs. Present the results to the user, highlighting the skill name, risk level, and install count.
+
+### 2. Evaluate security
+
+For the skill the user selects (or the best match), run the evaluate command. The security recommendation will be one of:
+
+- **proceed** -- Safe/low risk. All audits passed. You may proceed with installation after confirming with the user.
+- **proceed_with_caution** -- Medium risk detected. Present the rationale to the user and get explicit confirmation before installing.
+- **do_not_recommend** -- High, critical, or unknown risk. Warn the user strongly. Explain the specific risks identified in the rationale. Only install if the user explicitly overrides after understanding the risks.
+
+### 3. Present to user
+
+Always tell the user:
+- The skill name and what it does
+- The security recommendation and rationale
+- For `proceed_with_caution`: which audit dimensions flagged medium risk
+- For `do_not_recommend`: the specific risk level and which providers flagged it
+
+Ask for explicit confirmation before proceeding.
+
+### 4. Install (if approved)
+
+If the recommendation is `proceed` or `proceed_with_caution` and the user confirms:
+
+```bash
+bun run assistant/src/skills/skillssh-cli.ts install <source> <skillId>
+```
+
+If the recommendation is `do_not_recommend` and the user explicitly overrides:
+
+```bash
+bun run assistant/src/skills/skillssh-cli.ts install <source> <skillId> --override
+```
+
+### 5. Load the installed skill
+
+After successful installation, load the skill so it becomes available in the current session:
+
+```
+skill_load skill=<skillId>
+```
+
+Then retry the original task using the newly loaded skill's capabilities.
+
+## Loop guards
+
+- Attempt the fallback flow at most **once per user request**. If the installed skill also fails, report the failure to the user rather than searching for another skill.
+- Do not re-search for skills that were already evaluated and rejected (by the user or by security policy) in the same session.

--- a/assistant/src/config/bundled-skills/skillssh-fallback/SKILL.md
+++ b/assistant/src/config/bundled-skills/skillssh-fallback/SKILL.md
@@ -24,13 +24,13 @@ When a native capability fails or the user asks for something that could be hand
 All commands are run via:
 
 ```bash
-bun run assistant/src/skills/skillssh-cli.ts <command> [options]
+bun run src/skills/skillssh-cli.ts <command> [options]
 ```
 
 ### Search for skills
 
 ```bash
-bun run assistant/src/skills/skillssh-cli.ts search "<query>" --limit 5
+bun run src/skills/skillssh-cli.ts search "<query>" --limit 5
 ```
 
 Returns a list of matching skills with their risk levels and audit details. Use `--json` for machine-readable output.
@@ -38,7 +38,7 @@ Returns a list of matching skills with their risk levels and audit details. Use 
 ### Evaluate a specific skill
 
 ```bash
-bun run assistant/src/skills/skillssh-cli.ts evaluate <source> <skillId>
+bun run src/skills/skillssh-cli.ts evaluate <source> <skillId>
 ```
 
 Fetches the security audit and produces a recommendation. The `source` is the GitHub repo path (e.g. `inference-sh-9/skills`) and `skillId` is the skill name (e.g. `youtube-thumbnail-design`). Use `--json` for machine-readable output.
@@ -46,7 +46,7 @@ Fetches the security audit and produces a recommendation. The `source` is the Gi
 ### Install a skill
 
 ```bash
-bun run assistant/src/skills/skillssh-cli.ts install <source> <skillId>
+bun run src/skills/skillssh-cli.ts install <source> <skillId>
 ```
 
 Runs the full install flow with security check. Pass `--override` to install despite a `do_not_recommend` security assessment. Use `--json` for machine-readable output.
@@ -82,13 +82,13 @@ Ask for explicit confirmation before proceeding.
 If the recommendation is `proceed` or `proceed_with_caution` and the user confirms:
 
 ```bash
-bun run assistant/src/skills/skillssh-cli.ts install <source> <skillId>
+bun run src/skills/skillssh-cli.ts install <source> <skillId>
 ```
 
 If the recommendation is `do_not_recommend` and the user explicitly overrides:
 
 ```bash
-bun run assistant/src/skills/skillssh-cli.ts install <source> <skillId> --override
+bun run src/skills/skillssh-cli.ts install <source> <skillId> --override
 ```
 
 ### 5. Load the installed skill

--- a/assistant/src/skills/skillssh-cli.ts
+++ b/assistant/src/skills/skillssh-cli.ts
@@ -171,6 +171,7 @@ export function createCli(): Command {
 
         if (opts.json) {
           process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+          if (!result.success) process.exitCode = 1;
         } else {
           if (result.success) {
             process.stdout.write(

--- a/assistant/src/skills/skillssh-cli.ts
+++ b/assistant/src/skills/skillssh-cli.ts
@@ -196,7 +196,7 @@ export function createCli(): Command {
 // ─── Entry point ─────────────────────────────────────────────────────────────
 
 // Only run when executed directly (not when imported for testing)
-const isDirectExecution = import.meta.url === Bun.main || process.argv[1]?.endsWith('skillssh-cli.ts');
+const isDirectExecution = import.meta.main || process.argv[1]?.endsWith('skillssh-cli.ts');
 if (isDirectExecution) {
   const program = createCli();
   program.parseAsync(process.argv).catch((err) => {

--- a/assistant/src/skills/skillssh-cli.ts
+++ b/assistant/src/skills/skillssh-cli.ts
@@ -1,0 +1,205 @@
+#!/usr/bin/env bun
+/**
+ * CLI wrapper for skills.sh operations.
+ *
+ * Provides search, evaluate, and install subcommands that wrap the
+ * underlying TypeScript modules so skills can teach the assistant
+ * to drive them via CLI rather than requiring registered tools.
+ */
+
+import { Command } from 'commander';
+
+import { makeSecurityDecision } from './security-decision.js';
+import type { SecurityDecision } from './security-decision.js';
+import {
+  skillsshFetchAudit,
+  skillsshSearchWithAudit,
+} from './skillssh.js';
+import type { SkillsShSearchWithAuditItem } from './skillssh.js';
+import { skillsshInstall } from './skillssh-install.js';
+
+// ─── Output helpers ──────────────────────────────────────────────────────────
+
+function formatRiskBadge(risk: string): string {
+  const badges: Record<string, string> = {
+    safe: '[SAFE]',
+    low: '[LOW]',
+    medium: '[MEDIUM]',
+    high: '[HIGH]',
+    critical: '[CRITICAL]',
+    unknown: '[UNKNOWN]',
+  };
+  return badges[risk] ?? `[${risk.toUpperCase()}]`;
+}
+
+function formatSearchResults(skills: SkillsShSearchWithAuditItem[], query: string): string {
+  if (skills.length === 0) {
+    return `No skills found for query: "${query}"`;
+  }
+
+  const lines: string[] = [`Found ${skills.length} skill(s) for "${query}":\n`];
+
+  for (const skill of skills) {
+    lines.push(`  ${skill.name} (${skill.source}/${skill.skillId})`);
+    lines.push(`    Risk: ${formatRiskBadge(skill.overallRisk)}  Installs: ${skill.installs}`);
+
+    const providers = ['ath', 'socket', 'snyk'] as const;
+    const auditParts: string[] = [];
+    for (const p of providers) {
+      const dim = skill.audit[p];
+      if (dim) {
+        let detail = `${p}: ${dim.risk}`;
+        if (dim.alerts != null) detail += ` (${dim.alerts} alert${dim.alerts === 1 ? '' : 's'})`;
+        if (dim.score != null) detail += ` (score ${dim.score}/100)`;
+        auditParts.push(detail);
+      }
+    }
+    if (auditParts.length > 0) {
+      lines.push(`    Audit: ${auditParts.join(', ')}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function formatSecurityDecision(decision: SecurityDecision, source: string, skillId: string): string {
+  const lines: string[] = [
+    `Security evaluation for ${source}/${skillId}:\n`,
+    `  Recommendation: ${decision.recommendation}`,
+    `  Overall risk: ${formatRiskBadge(decision.overallRisk)}`,
+    `  Rationale: ${decision.rationale}`,
+  ];
+
+  if (decision.auditSummary.length > 0) {
+    lines.push('');
+    lines.push('  Audit dimensions:');
+    for (const dim of decision.auditSummary) {
+      const label = dim.provider.charAt(0).toUpperCase() + dim.provider.slice(1);
+      let detail = `    ${label}: ${dim.risk} (analyzed ${dim.analyzedAt})`;
+      if (dim.details) detail += ` — ${dim.details}`;
+      lines.push(detail);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ─── CLI definition ──────────────────────────────────────────────────────────
+
+export function createCli(): Command {
+  const program = new Command()
+    .name('skillssh-cli')
+    .description('Search, evaluate, and install skills from skills.sh')
+    .version('1.0.0');
+
+  program
+    .command('search')
+    .description('Search skills.sh and return results with audit risk levels')
+    .argument('<query>', 'Search query')
+    .option('-l, --limit <n>', 'Max results to return', '5')
+    .option('--json', 'Output as JSON')
+    .action(async (query: string, opts: { limit: string; json?: boolean }) => {
+      try {
+        const limit = parseInt(opts.limit, 10);
+        const result = await skillsshSearchWithAudit(query, { limit });
+
+        if (opts.json) {
+          process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+        } else {
+          process.stdout.write(formatSearchResults(result.skills, result.query) + '\n');
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`Error: ${message}\n`);
+        process.exitCode = 1;
+      }
+    });
+
+  program
+    .command('evaluate')
+    .description('Fetch audit and produce a security recommendation for a skill')
+    .argument('<source>', 'GitHub repo path (e.g. owner/repo)')
+    .argument('<skillId>', 'Skill identifier')
+    .option('--json', 'Output as JSON')
+    .action(async (source: string, skillId: string, opts: { json?: boolean }) => {
+      try {
+        const audit = await skillsshFetchAudit(source, skillId);
+        const decision = makeSecurityDecision(audit);
+
+        if (opts.json) {
+          process.stdout.write(JSON.stringify(decision, null, 2) + '\n');
+        } else {
+          process.stdout.write(formatSecurityDecision(decision, source, skillId) + '\n');
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`Error: ${message}\n`);
+        process.exitCode = 1;
+      }
+    });
+
+  program
+    .command('install')
+    .description('Install a skill from skills.sh with security check')
+    .argument('<source>', 'GitHub repo path (e.g. owner/repo)')
+    .argument('<skillId>', 'Skill identifier')
+    .option('--override', 'Override security restrictions for do_not_recommend skills')
+    .option('--json', 'Output as JSON')
+    .action(async (source: string, skillId: string, opts: { override?: boolean; json?: boolean }) => {
+      try {
+        // Fetch audit and make security decision
+        const audit = await skillsshFetchAudit(source, skillId);
+        const securityDecision = makeSecurityDecision(audit);
+
+        // Build candidate from audit data
+        const candidate: SkillsShSearchWithAuditItem = {
+          id: `${source}/${skillId}`,
+          skillId,
+          name: skillId,
+          installs: 0,
+          source,
+          audit,
+          overallRisk: securityDecision.overallRisk,
+        };
+
+        const result = await skillsshInstall({
+          candidate,
+          securityDecision,
+          userOverride: opts.override,
+        });
+
+        if (opts.json) {
+          process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+        } else {
+          if (result.success) {
+            process.stdout.write(
+              `Successfully installed ${result.skillId} at ${result.installedPath}\n` +
+              `Installed via: ${result.installedVia}\n`,
+            );
+          } else {
+            process.stderr.write(`Installation failed: ${result.error}\n`);
+            process.exitCode = 1;
+          }
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`Error: ${message}\n`);
+        process.exitCode = 1;
+      }
+    });
+
+  return program;
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────────────
+
+// Only run when executed directly (not when imported for testing)
+const isDirectExecution = import.meta.url === Bun.main || process.argv[1]?.endsWith('skillssh-cli.ts');
+if (isDirectExecution) {
+  const program = createCli();
+  program.parseAsync(process.argv).catch((err) => {
+    process.stderr.write(`Fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

- Add a CLI wrapper (`assistant/src/skills/skillssh-cli.ts`) that exposes `search`, `evaluate`, and `install` subcommands for skills.sh operations
- Create a bundled skill (`assistant/src/config/bundled-skills/skillssh-fallback/SKILL.md`) that teaches the assistant the full fallback workflow: search -> evaluate security -> present to user -> install if approved -> load skill
- Add comprehensive tests for all CLI subcommands

## Test plan

- [x] All 11 CLI tests pass (`bun test src/__tests__/skillssh-cli.test.ts`)
- [x] Existing skillssh and security-decision tests still pass
- [x] Gateway-only guard test passes (no runtime URL references)
- [x] TypeScript type-check clean for new files

Part of #9776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
