### PR TITLE
M3: Gateway /deliver/slack route, schema, and transport hints

### DIFF
--- a/gateway/src/channels/transport-hints.ts
+++ b/gateway/src/channels/transport-hints.ts
@@ -29,6 +29,23 @@ export function buildSmsTransportMetadata(): { hints: string[]; uxBrief: string 
   };
 }
 
+export const SLACK_CHANNEL_TRANSPORT_HINTS = [
+  "chat-first-medium",
+  "threaded-channel",
+  "mention-triggered",
+  "defer-dashboard-only-tasks",
+] as const;
+
+export const SLACK_CHANNEL_TRANSPORT_UX_BRIEF =
+  "Slack is a threaded channel medium. Replies should stay in-thread when a thread_ts is present. Use plain text or Slack mrkdwn formatting; avoid markdown tables and complex block layouts.";
+
+export function buildSlackTransportMetadata(): { hints: string[]; uxBrief: string } {
+  return {
+    hints: [...SLACK_CHANNEL_TRANSPORT_HINTS],
+    uxBrief: SLACK_CHANNEL_TRANSPORT_UX_BRIEF,
+  };
+}
+
 export const WHATSAPP_CHANNEL_TRANSPORT_HINTS = [
   "chat-first-medium",
   "channel-safe-onboarding",

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -1,0 +1,96 @@
+import type { GatewayConfig } from "../../config.js";
+import { fetchImpl } from "../../fetch.js";
+import { getLogger } from "../../logger.js";
+import { checkDeliverAuth } from "../middleware/deliver-auth.js";
+
+const log = getLogger("slack-deliver");
+
+export function createSlackDeliverHandler(config: GatewayConfig) {
+  return async (req: Request): Promise<Response> => {
+    const traceId = req.headers.get("x-trace-id") ?? undefined;
+    const tlog = traceId ? log.child({ traceId }) : log;
+
+    if (req.method !== "POST") {
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+
+    const authResponse = checkDeliverAuth(req, config, "slackDeliverAuthBypass");
+    if (authResponse) return authResponse;
+
+    if (!config.slackChannelBotToken) {
+      tlog.error("Slack bot token not configured");
+      return Response.json(
+        { error: "Slack integration not configured" },
+        { status: 503 },
+      );
+    }
+
+    let body: {
+      chatId?: string;
+      to?: string;
+      text?: string;
+      assistantId?: string;
+      attachments?: unknown[];
+    };
+    try {
+      body = (await req.json()) as typeof body;
+    } catch {
+      return Response.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    if (body.attachments && Array.isArray(body.attachments) && body.attachments.length > 0) {
+      return Response.json(
+        { error: "Slack attachments not supported in MVP" },
+        { status: 400 },
+      );
+    }
+
+    // Accept `chatId` as an alias for `to` so runtime channel callbacks work without translation.
+    const chatId = body.chatId ?? body.to;
+
+    if (!chatId || typeof chatId !== "string") {
+      return Response.json({ error: "chatId is required" }, { status: 400 });
+    }
+
+    const { text } = body;
+
+    if (!text || typeof text !== "string") {
+      return Response.json({ error: "text is required" }, { status: 400 });
+    }
+
+    // Support threading via query param
+    const threadTs = new URL(req.url).searchParams.get("threadTs") ?? undefined;
+
+    try {
+      const slackBody: Record<string, string> = {
+        channel: chatId,
+        text,
+      };
+      if (threadTs) {
+        slackBody.thread_ts = threadTs;
+      }
+
+      const response = await fetchImpl("https://slack.com/api/chat.postMessage", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${config.slackChannelBotToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(slackBody),
+      });
+
+      const data = (await response.json()) as { ok?: boolean; error?: string };
+
+      if (!data.ok) {
+        tlog.error({ chatId, slackError: data.error }, "Slack API returned error");
+        return Response.json({ error: "Delivery failed" }, { status: 502 });
+      }
+    } catch (err) {
+      tlog.error({ err, chatId }, "Failed to deliver Slack message");
+      return Response.json({ error: "Delivery failed" }, { status: 502 });
+    }
+
+    tlog.info({ chatId, hasThreadTs: !!threadTs }, "Slack message sent");
+    return Response.json({ ok: true });
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -18,6 +18,7 @@ import { createTwilioSmsWebhookHandler } from "./http/routes/twilio-sms-webhook.
 import { createSmsDeliverHandler } from "./http/routes/sms-deliver.js";
 import { createWhatsAppWebhookHandler } from "./http/routes/whatsapp-webhook.js";
 import { createWhatsAppDeliverHandler } from "./http/routes/whatsapp-deliver.js";
+import { createSlackDeliverHandler } from "./http/routes/slack-deliver.js";
 import { createOAuthCallbackHandler } from "./http/routes/oauth-callback.js";
 import { createPairingProxyHandler } from "./http/routes/pairing-proxy.js";
 import { validateBearerToken } from "./http/auth/bearer.js";
@@ -127,6 +128,7 @@ function main() {
   const handleSmsDeliver = createSmsDeliverHandler(config);
   const { handler: handleWhatsAppWebhook, dedupCache: whatsappDedupCache } = createWhatsAppWebhookHandler(config);
   const handleWhatsAppDeliver = createWhatsAppDeliverHandler(config);
+  const handleSlackDeliver = createSlackDeliverHandler(config);
   const handleOAuthCallback = createOAuthCallbackHandler(config);
   const pairingProxy = createPairingProxyHandler(config);
 
@@ -172,6 +174,7 @@ function main() {
         url.pathname === "/deliver/telegram" ||
         url.pathname === "/deliver/sms" ||
         url.pathname === "/deliver/whatsapp" ||
+        url.pathname === "/deliver/slack" ||
         url.pathname.startsWith("/pairing/") ||
         url.pathname === "/webhooks/oauth/callback" ||
         (url.pathname.startsWith("/v1/") &&
@@ -276,6 +279,20 @@ function main() {
           );
         }
         const res = await handleWhatsAppDeliver(tracedReq);
+        if (res.status === 401) {
+          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+        }
+        return res;
+      }
+
+      if (url.pathname === "/deliver/slack") {
+        if (!config.slackChannelBotToken) {
+          return Response.json(
+            { error: "Slack integration not configured" },
+            { status: 503 },
+          );
+        }
+        const res = await handleSlackDeliver(tracedReq);
         if (res.status === 401) {
           authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
         }

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -819,6 +819,72 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/deliver/slack": {
+        post: {
+          summary: "Slack delivery (internal)",
+          description:
+            "Internal endpoint called by the assistant runtime to deliver outbound messages to a Slack channel via chat.postMessage. Not intended for external use.",
+          operationId: "slackDeliver",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/SlackDeliverRequest" },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Message delivered",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/SlackDeliverOk" },
+                },
+              },
+            },
+            "400": {
+              description: "Invalid JSON, missing required fields, or unsupported attachments",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "405": {
+              description: "Method not allowed (only POST accepted)",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "502": {
+              description: "Failed to deliver via Slack API",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "503": {
+              description: "Slack integration not configured",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
       "/{path}": {
         get: {
           summary: "Runtime proxy",
@@ -1146,6 +1212,24 @@ export function buildSchema(): Record<string, unknown> {
             mimeType: { type: "string" },
             sizeBytes: { type: "integer" },
             kind: { type: "string" },
+          },
+        },
+        SlackDeliverRequest: {
+          type: "object",
+          required: ["chatId", "text"],
+          description: "Request to deliver a message to a Slack channel. Accepts either `chatId` or `to` (alias) as the Slack channel ID.",
+          properties: {
+            chatId: { type: "string", description: "Slack channel ID to deliver the message to" },
+            to: { type: "string", description: "Alias for `chatId` — used by runtime channel callback payloads" },
+            text: { type: "string", description: "Text content to send", minLength: 1 },
+            assistantId: { type: "string", description: "Optional assistant ID" },
+          },
+        },
+        SlackDeliverOk: {
+          type: "object",
+          required: ["ok"],
+          properties: {
+            ok: { type: "boolean" },
           },
         },
         IntegrationsStatusResponse: {


### PR DESCRIPTION
Add Slack delivery endpoint and supporting gateway infrastructure:\n\n- /deliver/slack route with auth, threading, and chat.postMessage\n- OpenAPI schema entries for Slack delivery\n- Slack transport hints and UX brief\n\nPart of #9858
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
