### PR TITLE
M4: Runtime Slack channel config endpoints

### DIFF
--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -1,0 +1,180 @@
+import { deleteSecureKey, getSecureKey, setSecureKey } from '../../security/secure-keys.js';
+import { deleteCredentialMetadata, getCredentialMetadata, upsertCredentialMetadata } from '../../tools/credentials/metadata-store.js';
+import { log } from './shared.js';
+
+// -- Result type --
+
+export interface SlackChannelConfigResult {
+  success: boolean;
+  hasBotToken: boolean;
+  hasAppToken: boolean;
+  connected: boolean;
+  teamId?: string;
+  teamName?: string;
+  botUserId?: string;
+  botUsername?: string;
+  error?: string;
+  warning?: string;
+}
+
+// -- Metadata stored as JSON in accountInfo --
+
+interface SlackChannelMetadata {
+  teamId?: string;
+  teamName?: string;
+  botUserId?: string;
+  botUsername?: string;
+}
+
+function parseMetadata(raw: string | undefined): SlackChannelMetadata {
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as SlackChannelMetadata;
+  } catch {
+    return {};
+  }
+}
+
+// -- Business logic --
+
+export function getSlackChannelConfig(): SlackChannelConfigResult {
+  const hasBotToken = !!getSecureKey('credential:slack_channel:bot_token');
+  const hasAppToken = !!getSecureKey('credential:slack_channel:app_token');
+  const meta = getCredentialMetadata('slack_channel', 'bot_token');
+  const metadata = parseMetadata(meta?.accountInfo);
+  return {
+    success: true,
+    hasBotToken,
+    hasAppToken,
+    connected: hasBotToken && hasAppToken,
+    ...metadata,
+  };
+}
+
+export async function setSlackChannelConfig(
+  botToken?: string,
+  appToken?: string,
+): Promise<SlackChannelConfigResult> {
+  let metadata: SlackChannelMetadata = {};
+  let warning: string | undefined;
+
+  // Validate and store bot token
+  if (botToken) {
+    // Validate bot token by calling Slack auth.test
+    try {
+      const res = await fetch('https://slack.com/api/auth.test', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${botToken}` },
+      });
+      const data = (await res.json()) as {
+        ok: boolean;
+        error?: string;
+        team_id?: string;
+        team?: string;
+        user_id?: string;
+        user?: string;
+      };
+      if (!data.ok) {
+        return {
+          success: false,
+          hasBotToken: false,
+          hasAppToken: !!getSecureKey('credential:slack_channel:app_token'),
+          connected: false,
+          error: `Slack API validation failed: ${data.error ?? 'unknown error'}`,
+        };
+      }
+      metadata = {
+        teamId: data.team_id,
+        teamName: data.team,
+        botUserId: data.user_id,
+        botUsername: data.user,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        hasBotToken: false,
+        hasAppToken: !!getSecureKey('credential:slack_channel:app_token'),
+        connected: false,
+        error: `Failed to validate bot token: ${message}`,
+      };
+    }
+
+    const stored = setSecureKey('credential:slack_channel:bot_token', botToken);
+    if (!stored) {
+      return {
+        success: false,
+        hasBotToken: false,
+        hasAppToken: !!getSecureKey('credential:slack_channel:app_token'),
+        connected: false,
+        error: 'Failed to store bot token in secure storage',
+      };
+    }
+
+    upsertCredentialMetadata('slack_channel', 'bot_token', {
+      accountInfo: JSON.stringify(metadata),
+    });
+  } else {
+    // Use existing metadata if no new bot token provided
+    const existingMeta = getCredentialMetadata('slack_channel', 'bot_token');
+    metadata = parseMetadata(existingMeta?.accountInfo);
+  }
+
+  // Validate and store app token
+  if (appToken) {
+    if (!appToken.startsWith('xapp-')) {
+      return {
+        success: false,
+        hasBotToken: !!getSecureKey('credential:slack_channel:bot_token'),
+        hasAppToken: false,
+        connected: false,
+        error: 'Invalid app token: must start with "xapp-"',
+      };
+    }
+
+    const stored = setSecureKey('credential:slack_channel:app_token', appToken);
+    if (!stored) {
+      return {
+        success: false,
+        hasBotToken: !!getSecureKey('credential:slack_channel:bot_token'),
+        hasAppToken: false,
+        connected: false,
+        error: 'Failed to store app token in secure storage',
+      };
+    }
+
+    upsertCredentialMetadata('slack_channel', 'app_token', {});
+  }
+
+  const hasBotToken = !!getSecureKey('credential:slack_channel:bot_token');
+  const hasAppToken = !!getSecureKey('credential:slack_channel:app_token');
+
+  if (hasBotToken && !hasAppToken) {
+    warning = 'Bot token stored but app token is missing — connection incomplete.';
+  } else if (!hasBotToken && hasAppToken) {
+    warning = 'App token stored but bot token is missing — connection incomplete.';
+  }
+
+  return {
+    success: true,
+    hasBotToken,
+    hasAppToken,
+    connected: hasBotToken && hasAppToken,
+    ...metadata,
+    ...(warning ? { warning } : {}),
+  };
+}
+
+export function clearSlackChannelConfig(): SlackChannelConfigResult {
+  deleteSecureKey('credential:slack_channel:bot_token');
+  deleteCredentialMetadata('slack_channel', 'bot_token');
+  deleteSecureKey('credential:slack_channel:app_token');
+  deleteCredentialMetadata('slack_channel', 'app_token');
+
+  return {
+    success: true,
+    hasBotToken: false,
+    hasAppToken: false,
+    connected: false,
+  };
+}

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -120,11 +120,14 @@ import { handleSubscribeAssistantEvents } from './routes/events-routes.js';
 import { handleGetIdentity,handleHealth } from './routes/identity-routes.js';
 import {
   handleCancelOutbound,
+  handleClearSlackChannelConfig,
   handleClearTelegramConfig,
   handleCreateGuardianChallenge,
   handleGetGuardianStatus,
+  handleGetSlackChannelConfig,
   handleGetTelegramConfig,
   handleResendOutbound,
+  handleSetSlackChannelConfig,
   handleSetTelegramCommands,
   handleSetTelegramConfig,
   handleSetupTelegram,
@@ -680,6 +683,11 @@ export class RuntimeHttpServer {
       if (endpoint === 'integrations/telegram/config' && req.method === 'DELETE') return await handleClearTelegramConfig();
       if (endpoint === 'integrations/telegram/commands' && req.method === 'POST') return await handleSetTelegramCommands(req);
       if (endpoint === 'integrations/telegram/setup' && req.method === 'POST') return await handleSetupTelegram(req);
+
+      // Integrations — Slack channel config
+      if (endpoint === 'integrations/slack/channel/config' && req.method === 'GET') return handleGetSlackChannelConfig();
+      if (endpoint === 'integrations/slack/channel/config' && req.method === 'POST') return await handleSetSlackChannelConfig(req);
+      if (endpoint === 'integrations/slack/channel/config' && req.method === 'DELETE') return handleClearSlackChannelConfig();
 
       // Integrations — Guardian verification
       if (endpoint === 'integrations/guardian/challenge' && req.method === 'POST') return await handleCreateGuardianChallenge(req);

--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -8,6 +8,11 @@
  * POST   /v1/integrations/telegram/commands — register bot commands
  * POST   /v1/integrations/telegram/setup    — composite: set config + register commands
  *
+ * Slack channel:
+ * GET    /v1/integrations/slack/channel/config — get current config status
+ * POST   /v1/integrations/slack/channel/config — validate and store credentials
+ * DELETE /v1/integrations/slack/channel/config — clear credentials
+ *
  * Guardian verification:
  * POST   /v1/integrations/guardian/challenge        — create a verification challenge
  * GET    /v1/integrations/guardian/status            — check guardian binding status
@@ -22,6 +27,11 @@ import {
   getGuardianStatus,
 } from '../../daemon/handlers/config-channels.js';
 import { httpError } from '../http-errors.js';
+import {
+  clearSlackChannelConfig,
+  getSlackChannelConfig,
+  setSlackChannelConfig,
+} from '../../daemon/handlers/config-slack-channel.js';
 import {
   clearTelegramConfig,
   getTelegramConfig,
@@ -91,6 +101,38 @@ export async function handleSetupTelegram(req: Request): Promise<Response> {
   const result = await setupTelegram(body.commands, body.botToken);
   const status = result.success ? 200 : 400;
   return Response.json(result, { status });
+}
+
+// ---------------------------------------------------------------------------
+// Slack channel config
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /v1/integrations/slack/channel/config
+ */
+export function handleGetSlackChannelConfig(): Response {
+  const result = getSlackChannelConfig();
+  return Response.json(result);
+}
+
+/**
+ * POST /v1/integrations/slack/channel/config
+ *
+ * Body: { botToken?: string, appToken?: string }
+ */
+export async function handleSetSlackChannelConfig(req: Request): Promise<Response> {
+  const body = (await req.json()) as { botToken?: string; appToken?: string };
+  const result = await setSlackChannelConfig(body.botToken, body.appToken);
+  const status = result.success ? 200 : 400;
+  return Response.json(result, { status });
+}
+
+/**
+ * DELETE /v1/integrations/slack/channel/config
+ */
+export function handleClearSlackChannelConfig(): Response {
+  const result = clearSlackChannelConfig();
+  return Response.json(result);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Add HTTP endpoints for Slack channel configuration:\n\n- GET /v1/integrations/slack/channel/config — read config status\n- POST /v1/integrations/slack/channel/config — validate and store credentials\n- DELETE /v1/integrations/slack/channel/config — clear credentials\n\nPart of #9858
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
