### PR TITLE
M2: Gateway Socket Mode adapter and event normalization

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -4,7 +4,7 @@ import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { AuthRateLimiter } from "./auth-rate-limiter.js";
 import { ConfigFileWatcher } from "./config-file-watcher.js";
-import { loadConfig, type GatewayConfig } from "./config.js";
+import { loadConfig, isSlackChannelConfigured, type GatewayConfig } from "./config.js";
 import { CredentialWatcher } from "./credential-watcher.js";
 import { createRuntimeProxyHandler } from "./http/routes/runtime-proxy.js";
 import { createTelegramDeliverHandler } from "./http/routes/telegram-deliver.js";
@@ -24,6 +24,8 @@ import { validateBearerToken } from "./http/auth/bearer.js";
 import { getLogger, initLogger } from "./logger.js";
 import { CircuitBreakerOpenError } from "./runtime/client.js";
 import { buildSchema } from "./schema.js";
+import { createSlackSocketModeClient, type SlackSocketModeClient } from "./slack/socket-mode.js";
+import { handleInbound } from "./handlers/handle-inbound.js";
 import { callTelegramApi } from "./telegram/api.js";
 import { reconcileTelegramWebhook } from "./telegram/webhook-manager.js";
 
@@ -373,6 +375,46 @@ function main() {
     });
   }
 
+  // ── Slack Socket Mode lifecycle ──
+  let slackSocketClient: SlackSocketModeClient | null = null;
+
+  function startSlackSocket(): void {
+    if (slackSocketClient) {
+      slackSocketClient.stop();
+      slackSocketClient = null;
+    }
+    if (!isSlackChannelConfigured(config)) return;
+
+    slackSocketClient = createSlackSocketModeClient(
+      {
+        appToken: config.slackChannelAppToken!,
+        botToken: config.slackChannelBotToken!,
+        gatewayConfig: config,
+      },
+      (normalized) => {
+        const { threadTs, channel } = normalized;
+        const replyCallbackUrl =
+          `${config.gatewayInternalBaseUrl}/deliver/slack?threadTs=${encodeURIComponent(threadTs)}&channel=${encodeURIComponent(channel)}`;
+
+        handleInbound(config, normalized.event, {
+          replyCallbackUrl,
+          routingOverride: normalized.routing,
+        }).catch((err) => {
+          log.error({ err, channel, threadTs }, "Failed to forward Slack event to runtime");
+        });
+      },
+    );
+
+    slackSocketClient.start().catch((err) => {
+      log.error({ err }, "Failed to start Slack Socket Mode client");
+    });
+    log.info("Slack Socket Mode client started");
+  }
+
+  if (isSlackChannelConfigured(config)) {
+    startSlackSocket();
+  }
+
   const telegramFromEnv = isTelegramConfigured();
   const slackFromEnv = !!(config.slackChannelBotToken && config.slackChannelAppToken);
 
@@ -431,6 +473,7 @@ function main() {
         config.slackChannelAppToken = undefined;
         log.info("Slack channel credentials cleared");
       }
+      startSlackSocket();
     }
   });
 
@@ -474,6 +517,10 @@ function main() {
     telegramDedupCache.stopCleanup();
     smsDedupCache.stopCleanup();
     whatsappDedupCache.stopCleanup();
+    if (slackSocketClient) {
+      slackSocketClient.stop();
+      slackSocketClient = null;
+    }
     setTimeout(() => {
       log.info("Drain window elapsed, stopping server");
       server.stop(true);

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -1,0 +1,82 @@
+import type { GatewayConfig } from "../config.js";
+import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
+import type { RouteResult } from "../routing/types.js";
+import type { GatewayInboundEventV1 } from "../types.js";
+
+/**
+ * Slack `app_mention` event shape (subset relevant to normalization).
+ */
+export interface SlackAppMentionEvent {
+  type: "app_mention";
+  user: string;
+  text: string;
+  ts: string;
+  channel: string;
+  thread_ts?: string;
+  client_msg_id?: string;
+  event_ts?: string;
+}
+
+/**
+ * Strip leading bot-mention tokens (`<@U...>`) from the message text.
+ * Slack wraps mentions as `<@UXXXXXX>`, often at the start of an
+ * app_mention event's text field. We remove all leading occurrences
+ * so the assistant receives clean user content.
+ */
+export function stripBotMention(text: string): string {
+  const stripped = text.replace(/^(<@[A-Z0-9]+>\s*)+/i, "").trim();
+  return stripped || text.trim();
+}
+
+export type NormalizedSlackEvent = {
+  event: Omit<GatewayInboundEventV1, "routing">;
+  routing: RouteResult;
+  /** Thread timestamp for reply threading. */
+  threadTs: string;
+  /** Slack channel ID. */
+  channel: string;
+};
+
+/**
+ * Normalize a Slack `app_mention` event into the gateway's
+ * canonical inbound event shape, matching the pattern used by
+ * the Telegram normalizer.
+ *
+ * Returns null if the event cannot be routed.
+ */
+export function normalizeSlackAppMention(
+  event: SlackAppMentionEvent,
+  eventId: string,
+  config: GatewayConfig,
+): NormalizedSlackEvent | null {
+  const routing = resolveAssistant(config, event.channel, event.user);
+  if (isRejection(routing)) {
+    return null;
+  }
+
+  const content = stripBotMention(event.text);
+  const externalMessageId = event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
+
+  return {
+    event: {
+      version: "v1",
+      sourceChannel: "slack",
+      receivedAt: new Date().toISOString(),
+      message: {
+        content,
+        externalChatId: event.channel,
+        externalMessageId,
+      },
+      sender: {
+        externalUserId: event.user,
+      },
+      source: {
+        updateId: eventId,
+      },
+      raw: event as unknown as Record<string, unknown>,
+    },
+    routing,
+    threadTs: event.thread_ts ?? event.ts,
+    channel: event.channel,
+  };
+}

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -1,0 +1,259 @@
+import { getLogger } from "../logger.js";
+import { fetchImpl } from "../fetch.js";
+import type { GatewayConfig } from "../config.js";
+import { normalizeSlackAppMention, type SlackAppMentionEvent, type NormalizedSlackEvent } from "./normalize.js";
+
+const log = getLogger("slack-socket-mode");
+
+const BASE_BACKOFF_MS = 1_000;
+const MAX_BACKOFF_MS = 30_000;
+const DEDUP_TTL_MS = 24 * 60 * 60 * 1_000;
+const DEDUP_CLEANUP_INTERVAL_MS = 60 * 60 * 1_000;
+
+export type SlackSocketModeConfig = {
+  appToken: string;
+  botToken: string;
+  gatewayConfig: GatewayConfig;
+};
+
+/**
+ * Slack Socket Mode WebSocket client.
+ *
+ * Opens a Socket Mode connection via `apps.connections.open`, maintains
+ * a single active WebSocket, auto-reconnects with capped exponential
+ * backoff + jitter, ACKs every envelope immediately, deduplicates events
+ * by `event_id`, and emits normalized `app_mention` events via callback.
+ */
+export class SlackSocketModeClient {
+  private config: SlackSocketModeConfig;
+  private onEvent: (event: NormalizedSlackEvent) => void;
+  private ws: WebSocket | null = null;
+  private running = false;
+  private reconnectAttempt = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private dedupMap = new Map<string, number>();
+  private dedupCleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(config: SlackSocketModeConfig, onEvent: (event: NormalizedSlackEvent) => void) {
+    this.config = config;
+    this.onEvent = onEvent;
+  }
+
+  async start(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+    this.startDedupCleanup();
+    await this.connect();
+  }
+
+  stop(): void {
+    this.running = false;
+    this.stopDedupCleanup();
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) {
+      try {
+        this.ws.close(1000, "client shutdown");
+      } catch {
+        // ignore close errors during shutdown
+      }
+      this.ws = null;
+    }
+  }
+
+  private async connect(): Promise<void> {
+    if (!this.running) return;
+
+    let wsUrl: string;
+    try {
+      wsUrl = await this.getWebSocketUrl();
+    } catch (err) {
+      log.error({ err }, "Failed to obtain Socket Mode WebSocket URL");
+      this.scheduleReconnect();
+      return;
+    }
+
+    log.info("Connecting to Slack Socket Mode");
+
+    try {
+      const ws = new WebSocket(wsUrl);
+      this.ws = ws;
+
+      ws.addEventListener("open", () => {
+        log.info("Slack Socket Mode connected");
+        this.reconnectAttempt = 0;
+      });
+
+      ws.addEventListener("message", (messageEvent) => {
+        this.handleMessage(messageEvent.data as string);
+      });
+
+      ws.addEventListener("close", (closeEvent) => {
+        log.info({ code: closeEvent.code, reason: closeEvent.reason }, "Slack Socket Mode disconnected");
+        this.ws = null;
+        this.scheduleReconnect();
+      });
+
+      ws.addEventListener("error", (errorEvent) => {
+        log.error({ error: String(errorEvent) }, "Slack Socket Mode WebSocket error");
+      });
+    } catch (err) {
+      log.error({ err }, "Failed to create WebSocket connection");
+      this.ws = null;
+      this.scheduleReconnect();
+    }
+  }
+
+  private async getWebSocketUrl(): Promise<string> {
+    const resp = await fetchImpl("https://slack.com/api/apps.connections.open", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.config.appToken}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+    });
+
+    if (!resp.ok) {
+      throw new Error(`apps.connections.open HTTP ${resp.status}`);
+    }
+
+    const data = (await resp.json()) as { ok: boolean; url?: string; error?: string };
+    if (!data.ok || !data.url) {
+      throw new Error(`apps.connections.open failed: ${data.error ?? "unknown error"}`);
+    }
+
+    return data.url;
+  }
+
+  private handleMessage(raw: string): void {
+    let envelope: {
+      envelope_id?: string;
+      type?: string;
+      payload?: {
+        event_id?: string;
+        event?: SlackAppMentionEvent;
+      };
+      reason?: string;
+    };
+
+    try {
+      envelope = JSON.parse(raw);
+    } catch {
+      log.warn("Received non-JSON Socket Mode message");
+      return;
+    }
+
+    // ACK every envelope immediately
+    if (envelope.envelope_id && this.ws && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({ envelope_id: envelope.envelope_id }));
+    }
+
+    // Handle disconnect type: Slack asks us to reconnect
+    if (envelope.type === "disconnect") {
+      log.info({ reason: envelope.reason }, "Slack requested disconnect, reconnecting");
+      if (this.ws) {
+        try {
+          this.ws.close(1000, "server requested disconnect");
+        } catch {
+          // ignore
+        }
+        this.ws = null;
+      }
+      // Reconnect immediately (attempt 0 = minimal backoff)
+      this.reconnectAttempt = 0;
+      this.scheduleReconnect();
+      return;
+    }
+
+    // Only process events_api envelopes
+    if (envelope.type !== "events_api") return;
+
+    const eventPayload = envelope.payload;
+    if (!eventPayload?.event || !eventPayload.event_id) return;
+
+    // Only process app_mention events in MVP
+    if (eventPayload.event.type !== "app_mention") return;
+
+    // Deduplicate on event_id
+    const eventId = eventPayload.event_id;
+    if (this.dedupMap.has(eventId)) {
+      log.debug({ eventId }, "Duplicate Slack event, skipping");
+      return;
+    }
+    this.dedupMap.set(eventId, Date.now());
+
+    const normalized = normalizeSlackAppMention(
+      eventPayload.event,
+      eventId,
+      this.config.gatewayConfig,
+    );
+    if (!normalized) {
+      log.info(
+        { eventId, channel: eventPayload.event.channel },
+        "Slack event dropped by normalization/routing",
+      );
+      return;
+    }
+
+    this.onEvent(normalized);
+  }
+
+  private scheduleReconnect(): void {
+    if (!this.running) return;
+    if (this.reconnectTimer) return;
+
+    const backoff = Math.min(
+      BASE_BACKOFF_MS * Math.pow(2, this.reconnectAttempt),
+      MAX_BACKOFF_MS,
+    );
+    // Add jitter: 0-50% of backoff
+    const jitter = Math.random() * backoff * 0.5;
+    const delay = Math.round(backoff + jitter);
+
+    log.info({ attempt: this.reconnectAttempt, delayMs: delay }, "Scheduling Socket Mode reconnect");
+    this.reconnectAttempt++;
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect().catch((err) => {
+        log.error({ err }, "Reconnect failed");
+      });
+    }, delay);
+  }
+
+  private startDedupCleanup(): void {
+    this.stopDedupCleanup();
+    this.dedupCleanupTimer = setInterval(() => {
+      const now = Date.now();
+      let evicted = 0;
+      for (const [key, timestamp] of this.dedupMap) {
+        if (now - timestamp > DEDUP_TTL_MS) {
+          this.dedupMap.delete(key);
+          evicted++;
+        }
+      }
+      if (evicted > 0) {
+        log.debug({ evicted }, "Evicted expired Slack event dedup entries");
+      }
+    }, DEDUP_CLEANUP_INTERVAL_MS);
+  }
+
+  private stopDedupCleanup(): void {
+    if (this.dedupCleanupTimer) {
+      clearInterval(this.dedupCleanupTimer);
+      this.dedupCleanupTimer = null;
+    }
+  }
+}
+
+/**
+ * Factory function for creating a Slack Socket Mode client.
+ */
+export function createSlackSocketModeClient(
+  config: SlackSocketModeConfig,
+  onEvent: (event: NormalizedSlackEvent) => void,
+): SlackSocketModeClient {
+  return new SlackSocketModeClient(config, onEvent);
+}


### PR DESCRIPTION
Add Slack Socket Mode WebSocket client and event normalization:\n\n- SlackSocketModeClient with auto-reconnect, dedupe, and envelope ACK\n- normalizeSlackAppMention for app_mention events\n- Wire socket client lifecycle into gateway index.ts\n- Build reply callback URLs with thread context\n\nPart of #9858
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
