### PR TITLE
M5: macOS Connect UI — Slack channel card

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -94,6 +94,9 @@ declare -a SAFE_LINE_PATTERNS=(
     # TS: optional property type annotation (e.g. `clientSecret?: string;`)
     # Must end with type + optional semicolon/comma — no `=` assignment.
     "[Cc]lient[_-]?[Ss]ecret[?]?:[[:space:]]*(string|String)[?]?[[:space:]]*[;,][[:space:]]*$"
+    # Swift: named argument passing a variable (e.g. `clientSecret: trimmedSecret`)
+    # where the line ends with the identifier or has a trailing closing paren.
+    "[Cc]lient[Ss]ecret:[[:space:]]*[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*$"
     # AWS well-known example key used in documentation
     "AKIAIOSFODNN7EXAMPLE"
 )
@@ -206,6 +209,8 @@ if [ "${1:-}" = "--self-test" ]; then
     SAFE_VAR_NULLISH_SECRET='oauth2ClientSecret: clientSecret ?? undefined,'
     # Dotted property access as value (false positive to whitelist)
     SAFE_DOTTED_PROP_SECRET='    clientSecret: options.clientSecret,'
+    # Swift named argument passing a variable (false positive to whitelist)
+    SAFE_SWIFT_NAMED_ARG='                clientSecret: trimmedSecret'
     # AWS well-known example key (false positive to whitelist)
     SAFE_AWS_EXAMPLE_KEY='const EXAMPLE_KEY = "AKIAIOSFODNN7EXAMPLE";'
 
@@ -427,6 +432,10 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$SAFE_DOTTED_PROP_SECRET" && ! matches_safe_line_pattern "$SAFE_DOTTED_PROP_SECRET"; then
         echo -e "${RED}Self-test failed:${NC} dotted property clientSecret assignment false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_SWIFT_NAMED_ARG" && ! matches_safe_line_pattern "$SAFE_SWIFT_NAMED_ARG"; then
+        echo -e "${RED}Self-test failed:${NC} Swift named argument clientSecret false positive"
         exit 1
     fi
     if matches_secret_pattern "$SAFE_AWS_EXAMPLE_KEY" && ! matches_safe_line_pattern "$SAFE_AWS_EXAMPLE_KEY"; then

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -44,6 +44,11 @@ struct SettingsConnectTab: View {
     // Twilio number picker (Voice card)
     @State private var voiceNumberPickerExpanded = false
 
+    // Slack channel credential entry
+    @State private var slackChannelSetupExpanded = false
+    @State private var slackChannelBotTokenInput = ""
+    @State private var slackChannelAppTokenInput = ""
+
     // Email copy state
     @State private var emailCopied: Bool = false
 
@@ -91,6 +96,7 @@ struct SettingsConnectTab: View {
             store.refreshChannelGuardianStatus(channel: "telegram")
             store.refreshChannelGuardianStatus(channel: "sms")
             store.refreshChannelGuardianStatus(channel: "voice")
+            store.fetchSlackChannelConfig()
             gatewayExpanded = store.ingressPublicBaseUrl.isEmpty
         }
         .onChange(of: store.ingressPublicBaseUrl) { _, newValue in
@@ -435,6 +441,7 @@ struct SettingsConnectTab: View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
             mobileCard
             telegramCard
+            slackChannelCard
             twilioCard
             voiceCard
             emailCard
@@ -596,6 +603,127 @@ struct SettingsConnectTab: View {
                     telegramSetupExpanded = false
                 }
                 .disabled(telegramBotTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+    }
+
+    // MARK: - Slack Channel Card
+
+    private var slackChannelCard: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Slack")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+                Text("Message your assistant from Slack")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            }
+
+            if store.slackChannelHasBotToken && store.slackChannelHasAppToken {
+                channelStatusRow(
+                    label: "Bot",
+                    icon: "checkmark.circle.fill",
+                    iconColor: VColor.success,
+                    value: {
+                        var parts: [String] = []
+                        if let username = store.slackChannelBotUsername {
+                            parts.append("@\(username)")
+                        }
+                        if let team = store.slackChannelTeamName {
+                            parts.append(team)
+                        }
+                        return parts.isEmpty ? "Configured" : parts.joined(separator: " — ")
+                    }(),
+                    action: .init(label: "Clear", style: .danger, disabled: store.slackChannelSaveInProgress) {
+                        store.clearSlackChannelConfig()
+                        slackChannelBotTokenInput = ""
+                        slackChannelAppTokenInput = ""
+                        slackChannelSetupExpanded = false
+                    }
+                )
+            } else if slackChannelSetupExpanded {
+                slackChannelCredentialEntry
+            } else {
+                channelStatusRow(
+                    label: "Bot",
+                    icon: "exclamationmark.triangle",
+                    iconColor: VColor.warning,
+                    value: "Not configured",
+                    valueColor: VColor.textMuted,
+                    action: .init(label: "Set Up", style: .secondary) {
+                        slackChannelSetupExpanded = true
+                    }
+                )
+            }
+
+            if let error = store.slackChannelError {
+                Text(error)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
+            }
+
+            if store.slackChannelHasBotToken && store.slackChannelHasAppToken {
+                Divider().background(VColor.surfaceBorder)
+                guardianStatusRow(channel: "slack")
+            }
+        }
+        .padding(VSpacing.lg)
+        .vCard(background: VColor.surfaceSubtle)
+    }
+
+    // MARK: - Slack Channel Credential Entry
+
+    private var slackChannelCredentialEntry: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack {
+                Text("Slack Credentials")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+                Spacer()
+                VButton(label: "Cancel", style: .tertiary) {
+                    slackChannelSetupExpanded = false
+                    slackChannelBotTokenInput = ""
+                    slackChannelAppTokenInput = ""
+                }
+            }
+
+            SecureField("Bot Token (xoxb-...)", text: $slackChannelBotTokenInput)
+                .vInputStyle()
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+
+            SecureField("App Token (xapp-...)", text: $slackChannelAppTokenInput)
+                .vInputStyle()
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+
+            Text("Create a Slack app with Socket Mode enabled to get these tokens")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+
+            if store.slackChannelSaveInProgress {
+                HStack(spacing: VSpacing.sm) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Saving...")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                }
+            } else {
+                VButton(label: "Save", style: .primary) {
+                    store.saveSlackChannelConfig(
+                        botToken: slackChannelBotTokenInput,
+                        appToken: slackChannelAppTokenInput
+                    )
+                    slackChannelBotTokenInput = ""
+                    slackChannelAppTokenInput = ""
+                    slackChannelSetupExpanded = false
+                }
+                .disabled(
+                    slackChannelBotTokenInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    || slackChannelAppTokenInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                )
             }
         }
     }
@@ -1288,6 +1416,7 @@ struct SettingsConnectTab: View {
             switch channel {
             case "telegram": return "@username or chat ID"
             case "sms", "voice": return "+1234567890"
+            case "slack": return "Slack user ID"
             default: return "Destination"
             }
         }()

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -156,6 +156,16 @@ public final class SettingsStore: ObservableObject {
     @Published var voiceOutboundSendCount: Int = 0
     @Published var voiceOutboundCode: String?
 
+    // MARK: - Slack Channel Integration State
+
+    @Published var slackChannelHasBotToken: Bool = false
+    @Published var slackChannelHasAppToken: Bool = false
+    @Published var slackChannelConnected: Bool = false
+    @Published var slackChannelBotUsername: String?
+    @Published var slackChannelTeamName: String?
+    @Published var slackChannelSaveInProgress: Bool = false
+    @Published var slackChannelError: String?
+
     // MARK: - Email Integration State
 
     @Published var assistantEmail: String?
@@ -885,6 +895,130 @@ public final class SettingsStore: ObservableObject {
             try daemonClient.sendTelegramConfig(action: "clear")
         } catch {
             log.error("Failed to send Telegram config clear: \(error)")
+        }
+    }
+
+    // MARK: - Slack Channel Actions (HTTP-first)
+
+    /// Resolves the runtime HTTP base URL and bearer token for direct HTTP calls.
+    private func resolveRuntimeHTTP() -> (baseURL: String, token: String)? {
+        let port = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"]
+            .flatMap(Int.init) ?? 7821
+        guard let token = readHttpToken() else { return nil }
+        return ("http://localhost:\(port)", token)
+    }
+
+    func fetchSlackChannelConfig() {
+        guard let http = resolveRuntimeHTTP() else { return }
+        guard let url = URL(string: "\(http.baseURL)/v1/integrations/slack/channel/config") else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+        Task {
+            do {
+                let (data, response) = try await URLSession.shared.data(for: request)
+                guard let httpResp = response as? HTTPURLResponse else { return }
+                if httpResp.statusCode == 200 {
+                    if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                        self.slackChannelHasBotToken = json["hasBotToken"] as? Bool ?? false
+                        self.slackChannelHasAppToken = json["hasAppToken"] as? Bool ?? false
+                        self.slackChannelConnected = json["connected"] as? Bool ?? false
+                        self.slackChannelBotUsername = json["botUsername"] as? String
+                        self.slackChannelTeamName = json["teamName"] as? String
+                        self.slackChannelError = nil
+                    }
+                } else if httpResp.statusCode == 404 {
+                    self.slackChannelHasBotToken = false
+                    self.slackChannelHasAppToken = false
+                    self.slackChannelConnected = false
+                    self.slackChannelBotUsername = nil
+                    self.slackChannelTeamName = nil
+                }
+            } catch {
+                log.error("Failed to fetch Slack channel config: \(error)")
+            }
+        }
+    }
+
+    func saveSlackChannelConfig(botToken: String, appToken: String) {
+        let trimmedBot = botToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedApp = appToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedBot.isEmpty, !trimmedApp.isEmpty else { return }
+        slackChannelSaveInProgress = true
+        slackChannelError = nil
+        guard let http = resolveRuntimeHTTP() else {
+            slackChannelSaveInProgress = false
+            return
+        }
+        guard let url = URL(string: "\(http.baseURL)/v1/integrations/slack/channel/config") else {
+            slackChannelSaveInProgress = false
+            return
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 10
+        let body: [String: String] = ["botToken": trimmedBot, "appToken": trimmedApp]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        Task {
+            do {
+                let (data, response) = try await URLSession.shared.data(for: request)
+                self.slackChannelSaveInProgress = false
+                guard let httpResp = response as? HTTPURLResponse else { return }
+                if (200..<300).contains(httpResp.statusCode) {
+                    if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                        self.slackChannelHasBotToken = json["hasBotToken"] as? Bool ?? true
+                        self.slackChannelHasAppToken = json["hasAppToken"] as? Bool ?? true
+                        self.slackChannelConnected = json["connected"] as? Bool ?? false
+                        self.slackChannelBotUsername = json["botUsername"] as? String
+                        self.slackChannelTeamName = json["teamName"] as? String
+                        self.slackChannelError = nil
+                    } else {
+                        self.slackChannelHasBotToken = true
+                        self.slackChannelHasAppToken = true
+                    }
+                } else {
+                    let errorMsg: String
+                    if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                       let msg = json["error"] as? String {
+                        errorMsg = msg
+                    } else {
+                        errorMsg = "HTTP \(httpResp.statusCode)"
+                    }
+                    self.slackChannelError = "Failed to save: \(errorMsg)"
+                }
+            } catch {
+                self.slackChannelSaveInProgress = false
+                self.slackChannelError = "Failed to save: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    func clearSlackChannelConfig() {
+        slackChannelError = nil
+        guard let http = resolveRuntimeHTTP() else { return }
+        guard let url = URL(string: "\(http.baseURL)/v1/integrations/slack/channel/config") else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+        Task {
+            do {
+                let (_, response) = try await URLSession.shared.data(for: request)
+                guard let httpResp = response as? HTTPURLResponse else { return }
+                if (200..<300).contains(httpResp.statusCode) {
+                    self.slackChannelHasBotToken = false
+                    self.slackChannelHasAppToken = false
+                    self.slackChannelConnected = false
+                    self.slackChannelBotUsername = nil
+                    self.slackChannelTeamName = nil
+                    self.slackChannelError = nil
+                }
+            } catch {
+                log.error("Failed to clear Slack channel config: \(error)")
+            }
         }
     }
 


### PR DESCRIPTION
Add Slack channel configuration to macOS Settings Connect tab:

- Slack channel state properties in SettingsStore
- HTTP-first config methods (GET/POST/DELETE)
- Slack card with setup form, status display, and guardian row
- Fix pre-commit hook false positive for Swift named argument syntax

Part of #9858
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
