### PR TITLE
fix: deny all pending confirmations in UI when user sends message

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -827,10 +827,10 @@ public final class ChatViewModel: ObservableObject {
         let hasSkillInvocation = pendingSkillInvocation != nil
         guard !text.isEmpty || hasAttachments || hasSkillInvocation else { return }
 
-        // If there's a pending tool confirmation, mark it as denied in the UI.
-        // The daemon auto-denies it server-side when it receives this message.
-        if let pendingIndex = messages.firstIndex(where: { $0.confirmation?.state == .pending }) {
-            messages[pendingIndex].confirmation?.state = .denied
+        // If there are pending tool confirmations, mark them all as denied in the UI.
+        // The daemon auto-denies them all server-side when it receives this message.
+        for i in messages.indices where messages[i].confirmation?.state == .pending {
+            messages[i].confirmation?.state = .denied
         }
 
         // When "/model" or "/models" is sent, refresh model state so the picker/table has fresh data


### PR DESCRIPTION
## Summary
- Replace `firstIndex` with a `for` loop to mark ALL pending confirmations as denied when the user sends a message
- Server-side `denyAllPending()` denies all, but the client only updated the first — remaining cards appeared stuck in pending state

## Original prompt
Addresses review feedback from #9893.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
