### PR TITLE
M6: Gateway and runtime tests for Slack channel

### DIFF
--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -1,0 +1,230 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'slack-channel-cfg-test-'));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({}),
+  loadConfig: () => ({}),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  saveConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  getIpcBlobDir: () => join(testDir, 'ipc-blobs'),
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  readHttpToken: () => undefined,
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    isDebug: () => false,
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+      isDebug: () => false,
+    }),
+  }),
+}));
+
+// Mock secure key storage
+let secureKeyStore: Record<string, string> = {};
+
+mock.module('../security/secure-keys.js', () => ({
+  getSecureKey: (account: string) => secureKeyStore[account] ?? undefined,
+  setSecureKey: (account: string, value: string) => {
+    secureKeyStore[account] = value;
+    return true;
+  },
+  deleteSecureKey: (account: string) => {
+    if (account in secureKeyStore) {
+      delete secureKeyStore[account];
+      return true;
+    }
+    return false;
+  },
+  listSecureKeys: () => Object.keys(secureKeyStore),
+  getBackendType: () => 'encrypted',
+  isDowngradedFromKeychain: () => false,
+  _resetBackend: () => {},
+  _setBackend: () => {},
+}));
+
+// Mock credential metadata store
+let credentialMetadataStore: Array<{ service: string; field: string; accountInfo?: string }> = [];
+
+mock.module('../tools/credentials/metadata-store.js', () => ({
+  getCredentialMetadata: (service: string, field: string) =>
+    credentialMetadataStore.find((m) => m.service === service && m.field === field) ?? undefined,
+  upsertCredentialMetadata: (service: string, field: string, policy?: Record<string, unknown>) => {
+    const existing = credentialMetadataStore.find((m) => m.service === service && m.field === field);
+    if (existing) {
+      if (policy?.accountInfo !== undefined) existing.accountInfo = policy.accountInfo as string;
+      return existing;
+    }
+    const record = { service, field, accountInfo: policy?.accountInfo as string | undefined };
+    credentialMetadataStore.push(record);
+    return record;
+  },
+  deleteCredentialMetadata: (service: string, field: string) => {
+    const idx = credentialMetadataStore.findIndex((m) => m.service === service && m.field === field);
+    if (idx !== -1) {
+      credentialMetadataStore.splice(idx, 1);
+      return true;
+    }
+    return false;
+  },
+  listCredentialMetadata: () => credentialMetadataStore,
+  assertMetadataWritable: () => {},
+  _setMetadataPath: () => {},
+}));
+
+// Mock fetch for Slack API validation
+const originalFetch = globalThis.fetch;
+
+import {
+  getSlackChannelConfig,
+  setSlackChannelConfig,
+  clearSlackChannelConfig,
+} from '../daemon/handlers/config-slack-channel.js';
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+describe('Slack channel config handler', () => {
+  beforeEach(() => {
+    secureKeyStore = {};
+    credentialMetadataStore = [];
+    globalThis.fetch = originalFetch;
+  });
+
+  test('GET returns correct shape when not configured', () => {
+    const result = getSlackChannelConfig();
+    expect(result.success).toBe(true);
+    expect(result.hasBotToken).toBe(false);
+    expect(result.hasAppToken).toBe(false);
+    expect(result.connected).toBe(false);
+  });
+
+  test('GET returns connected: true when both tokens are set', () => {
+    secureKeyStore['credential:slack_channel:bot_token'] = 'xoxb-test';
+    secureKeyStore['credential:slack_channel:app_token'] = 'xapp-test';
+
+    const result = getSlackChannelConfig();
+    expect(result.success).toBe(true);
+    expect(result.hasBotToken).toBe(true);
+    expect(result.hasAppToken).toBe(true);
+    expect(result.connected).toBe(true);
+  });
+
+  test('GET returns metadata when available', () => {
+    secureKeyStore['credential:slack_channel:bot_token'] = 'xoxb-test';
+    credentialMetadataStore.push({
+      service: 'slack_channel',
+      field: 'bot_token',
+      accountInfo: JSON.stringify({
+        teamId: 'T123',
+        teamName: 'TestTeam',
+        botUserId: 'U_BOT',
+        botUsername: 'testbot',
+      }),
+    });
+
+    const result = getSlackChannelConfig();
+    expect(result.teamId).toBe('T123');
+    expect(result.teamName).toBe('TestTeam');
+    expect(result.botUserId).toBe('U_BOT');
+    expect(result.botUsername).toBe('testbot');
+  });
+
+  test('POST validates app token shape (xapp- prefix required)', async () => {
+    const result = await setSlackChannelConfig(undefined, 'invalid-token');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('xapp-');
+  });
+
+  test('POST accepts valid app token with xapp- prefix', async () => {
+    const result = await setSlackChannelConfig(undefined, 'xapp-valid-token-123');
+    expect(result.success).toBe(true);
+    expect(result.hasAppToken).toBe(true);
+    expect(secureKeyStore['credential:slack_channel:app_token']).toBe('xapp-valid-token-123');
+  });
+
+  test('POST validates bot token via Slack auth.test API', async () => {
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify({
+        ok: true,
+        team_id: 'T_TEAM',
+        team: 'MyTeam',
+        user_id: 'U_BOT',
+        user: 'mybot',
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof globalThis.fetch;
+
+    const result = await setSlackChannelConfig('xoxb-valid-bot-token');
+    expect(result.success).toBe(true);
+    expect(result.hasBotToken).toBe(true);
+    expect(result.teamId).toBe('T_TEAM');
+    expect(result.teamName).toBe('MyTeam');
+  });
+
+  test('POST returns error when Slack auth.test rejects bot token', async () => {
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify({
+        ok: false,
+        error: 'invalid_auth',
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof globalThis.fetch;
+
+    const result = await setSlackChannelConfig('xoxb-bad-token');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('invalid_auth');
+  });
+
+  test('DELETE clears credentials', () => {
+    secureKeyStore['credential:slack_channel:bot_token'] = 'xoxb-test';
+    secureKeyStore['credential:slack_channel:app_token'] = 'xapp-test';
+    credentialMetadataStore.push({ service: 'slack_channel', field: 'bot_token' });
+    credentialMetadataStore.push({ service: 'slack_channel', field: 'app_token' });
+
+    const result = clearSlackChannelConfig();
+    expect(result.success).toBe(true);
+    expect(result.hasBotToken).toBe(false);
+    expect(result.hasAppToken).toBe(false);
+    expect(result.connected).toBe(false);
+
+    expect(secureKeyStore['credential:slack_channel:bot_token']).toBeUndefined();
+    expect(secureKeyStore['credential:slack_channel:app_token']).toBeUndefined();
+    expect(credentialMetadataStore).toHaveLength(0);
+  });
+});

--- a/gateway/src/__tests__/slack-config.test.ts
+++ b/gateway/src/__tests__/slack-config.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect } from "bun:test";
+import { isSlackChannelConfigured, type GatewayConfig } from "../config.js";
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    defaultAssistantId: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
+    maxWebhookPayloadBytes: 1048576,
+    port: 7830,
+    routingEntries: [],
+    runtimeBearerToken: undefined,
+    runtimeGatewayOriginSecret: undefined,
+    runtimeInitialBackoffMs: 500,
+    runtimeMaxRetries: 2,
+    runtimeProxyBearerToken: undefined,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: false,
+    runtimeTimeoutMs: 30000,
+    shutdownDrainMs: 5000,
+    telegramApiBaseUrl: "https://api.telegram.org",
+    telegramBotToken: undefined,
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    telegramWebhookSecret: undefined,
+    twilioAuthToken: undefined,
+    twilioAccountSid: undefined,
+    twilioPhoneNumber: undefined,
+    smsDeliverAuthBypass: false,
+    ingressPublicBaseUrl: undefined,
+    unmappedPolicy: "reject",
+    whatsappPhoneNumberId: undefined,
+    whatsappAccessToken: undefined,
+    whatsappAppSecret: undefined,
+    whatsappWebhookVerifyToken: undefined,
+    whatsappDeliverAuthBypass: false,
+    whatsappTimeoutMs: 15000,
+    whatsappMaxRetries: 3,
+    whatsappInitialBackoffMs: 1000,
+    slackChannelBotToken: undefined,
+    slackChannelAppToken: undefined,
+    slackDeliverAuthBypass: false,
+    trustProxy: false,
+    ...overrides,
+  } as GatewayConfig;
+}
+
+describe("isSlackChannelConfigured", () => {
+  test("returns true when both tokens are set", () => {
+    const config = makeConfig({
+      slackChannelBotToken: "xoxb-test-token",
+      slackChannelAppToken: "xapp-test-token",
+    });
+    expect(isSlackChannelConfigured(config)).toBe(true);
+  });
+
+  test("returns false when bot token is missing", () => {
+    const config = makeConfig({
+      slackChannelBotToken: undefined,
+      slackChannelAppToken: "xapp-test-token",
+    });
+    expect(isSlackChannelConfigured(config)).toBe(false);
+  });
+
+  test("returns false when app token is missing", () => {
+    const config = makeConfig({
+      slackChannelBotToken: "xoxb-test-token",
+      slackChannelAppToken: undefined,
+    });
+    expect(isSlackChannelConfigured(config)).toBe(false);
+  });
+
+  test("returns false when both tokens are missing", () => {
+    const config = makeConfig({
+      slackChannelBotToken: undefined,
+      slackChannelAppToken: undefined,
+    });
+    expect(isSlackChannelConfigured(config)).toBe(false);
+  });
+});

--- a/gateway/src/__tests__/slack-deliver.test.ts
+++ b/gateway/src/__tests__/slack-deliver.test.ts
@@ -1,0 +1,260 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import type { GatewayConfig } from "../config.js";
+
+type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => new Response());
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { createSlackDeliverHandler } = await import("../http/routes/slack-deliver.js");
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  const merged: GatewayConfig = {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    defaultAssistantId: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
+    maxWebhookPayloadBytes: 1048576,
+    port: 7830,
+    routingEntries: [],
+    runtimeBearerToken: undefined,
+    runtimeGatewayOriginSecret: undefined,
+    runtimeInitialBackoffMs: 500,
+    runtimeMaxRetries: 2,
+    runtimeProxyBearerToken: undefined,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: false,
+    runtimeTimeoutMs: 30000,
+    shutdownDrainMs: 5000,
+    telegramApiBaseUrl: "https://api.telegram.org",
+    telegramBotToken: undefined,
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    telegramWebhookSecret: undefined,
+    twilioAuthToken: undefined,
+    twilioAccountSid: undefined,
+    twilioPhoneNumber: undefined,
+    smsDeliverAuthBypass: false,
+    ingressPublicBaseUrl: undefined,
+    unmappedPolicy: "reject",
+    whatsappPhoneNumberId: undefined,
+    whatsappAccessToken: undefined,
+    whatsappAppSecret: undefined,
+    whatsappWebhookVerifyToken: undefined,
+    whatsappDeliverAuthBypass: false,
+    whatsappTimeoutMs: 15000,
+    whatsappMaxRetries: 3,
+    whatsappInitialBackoffMs: 1000,
+    slackChannelBotToken: "xoxb-test-bot-token",
+    slackChannelAppToken: undefined,
+    slackDeliverAuthBypass: true,
+    trustProxy: false,
+    ...overrides,
+  } as GatewayConfig;
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
+}
+
+const TOKEN = "test-deliver-token";
+
+function makeRequest(
+  body: unknown,
+  headers?: Record<string, string>,
+  queryString = "",
+): Request {
+  return new Request(`http://localhost:7830/deliver/slack${queryString}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+let fetchCalls: { url: string; body?: unknown; headers?: Record<string, string> }[];
+
+beforeEach(() => {
+  fetchCalls = [];
+  fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    let body: unknown;
+    try {
+      if (init?.body) body = JSON.parse(String(init.body));
+    } catch { /* not JSON */ }
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      const h = init.headers;
+      if (h && typeof h === "object" && !Array.isArray(h)) {
+        for (const [k, v] of Object.entries(h)) {
+          headers[k.toLowerCase()] = v;
+        }
+      }
+    }
+    fetchCalls.push({ url, body, headers });
+
+    // Slack API response
+    if (url.includes("slack.com/api/chat.postMessage")) {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response("Not found", { status: 404 });
+  });
+});
+
+describe("slack-deliver endpoint", () => {
+  test("returns 401 when auth is required and missing", async () => {
+    const handler = createSlackDeliverHandler(
+      makeConfig({ runtimeProxyBearerToken: TOKEN, slackDeliverAuthBypass: false }),
+    );
+    const req = makeRequest({ chatId: "C123", text: "hello" });
+    const res = await handler(req);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  test("returns 200 with valid payload containing chatId and text", async () => {
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = makeRequest({ chatId: "C123", text: "hello" });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    // Verify the Slack API was called with the correct payload
+    const slackCall = fetchCalls.find((c) => c.url.includes("chat.postMessage"));
+    expect(slackCall).toBeDefined();
+    expect((slackCall!.body as any).channel).toBe("C123");
+    expect((slackCall!.body as any).text).toBe("hello");
+  });
+
+  test("threadTs query param gets passed as thread_ts to Slack API", async () => {
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = makeRequest(
+      { chatId: "C123", text: "reply in thread" },
+      undefined,
+      "?threadTs=1700000000.000050",
+    );
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    const slackCall = fetchCalls.find((c) => c.url.includes("chat.postMessage"));
+    expect(slackCall).toBeDefined();
+    expect((slackCall!.body as any).thread_ts).toBe("1700000000.000050");
+  });
+
+  test("returns 400 when chatId/to is missing", async () => {
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = makeRequest({ text: "hello" });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("chatId is required");
+  });
+
+  test("returns 400 with 'not supported' message when attachments are provided", async () => {
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = makeRequest({ chatId: "C123", text: "hello", attachments: [{ id: "att-1" }] });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("not supported");
+  });
+
+  test("returns 503 when bot token is not configured", async () => {
+    const handler = createSlackDeliverHandler(
+      makeConfig({ slackChannelBotToken: undefined }),
+    );
+    const req = makeRequest({ chatId: "C123", text: "hello" });
+    const res = await handler(req);
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toContain("not configured");
+  });
+
+  test("accepts 'to' as alias for chatId", async () => {
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = makeRequest({ to: "C_TO_CHAN", text: "hello" });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    const slackCall = fetchCalls.find((c) => c.url.includes("chat.postMessage"));
+    expect(slackCall).toBeDefined();
+    expect((slackCall!.body as any).channel).toBe("C_TO_CHAN");
+  });
+
+  test("returns 400 when text is missing", async () => {
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = makeRequest({ chatId: "C123" });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("text is required");
+  });
+
+  test("returns 400 for invalid JSON", async () => {
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = new Request("http://localhost:7830/deliver/slack", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not-json",
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON");
+  });
+
+  test("returns 405 for GET requests", async () => {
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = new Request("http://localhost:7830/deliver/slack", {
+      method: "GET",
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(405);
+  });
+
+  test("sends Authorization header with bot token to Slack API", async () => {
+    const handler = createSlackDeliverHandler(
+      makeConfig({ slackChannelBotToken: "xoxb-my-secret-token" }),
+    );
+    const req = makeRequest({ chatId: "C123", text: "hello" });
+    await handler(req);
+
+    const slackCall = fetchCalls.find((c) => c.url.includes("chat.postMessage"));
+    expect(slackCall).toBeDefined();
+    expect(slackCall!.headers!["authorization"]).toBe("Bearer xoxb-my-secret-token");
+  });
+
+  test("returns 502 when Slack API returns ok: false", async () => {
+    fetchMock = mock(async () => {
+      return new Response(JSON.stringify({ ok: false, error: "channel_not_found" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = makeRequest({ chatId: "C123", text: "hello" });
+    const res = await handler(req);
+    expect(res.status).toBe(502);
+  });
+
+  test("does not include thread_ts when threadTs query param is absent", async () => {
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = makeRequest({ chatId: "C123", text: "hello" });
+    await handler(req);
+
+    const slackCall = fetchCalls.find((c) => c.url.includes("chat.postMessage"));
+    expect(slackCall).toBeDefined();
+    expect((slackCall!.body as any).thread_ts).toBeUndefined();
+  });
+});

--- a/gateway/src/__tests__/slack-normalize.test.ts
+++ b/gateway/src/__tests__/slack-normalize.test.ts
@@ -1,0 +1,216 @@
+import { describe, test, expect } from "bun:test";
+import {
+  stripBotMention,
+  normalizeSlackAppMention,
+  type SlackAppMentionEvent,
+} from "../slack/normalize.js";
+import type { GatewayConfig } from "../config.js";
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    defaultAssistantId: "default-assistant",
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
+    maxWebhookPayloadBytes: 1048576,
+    port: 7830,
+    routingEntries: [],
+    runtimeBearerToken: undefined,
+    runtimeGatewayOriginSecret: undefined,
+    runtimeInitialBackoffMs: 500,
+    runtimeMaxRetries: 2,
+    runtimeProxyBearerToken: undefined,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: false,
+    runtimeTimeoutMs: 30000,
+    shutdownDrainMs: 5000,
+    telegramApiBaseUrl: "https://api.telegram.org",
+    telegramBotToken: undefined,
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    telegramWebhookSecret: undefined,
+    twilioAuthToken: undefined,
+    twilioAccountSid: undefined,
+    twilioPhoneNumber: undefined,
+    smsDeliverAuthBypass: false,
+    ingressPublicBaseUrl: undefined,
+    unmappedPolicy: "default",
+    whatsappPhoneNumberId: undefined,
+    whatsappAccessToken: undefined,
+    whatsappAppSecret: undefined,
+    whatsappWebhookVerifyToken: undefined,
+    whatsappDeliverAuthBypass: false,
+    whatsappTimeoutMs: 15000,
+    whatsappMaxRetries: 3,
+    whatsappInitialBackoffMs: 1000,
+    slackChannelBotToken: undefined,
+    slackChannelAppToken: undefined,
+    slackDeliverAuthBypass: false,
+    trustProxy: false,
+    ...overrides,
+  } as GatewayConfig;
+}
+
+function makeEvent(overrides: Partial<SlackAppMentionEvent> = {}): SlackAppMentionEvent {
+  return {
+    type: "app_mention",
+    user: "U_USER123",
+    text: "<@U123BOT> hello world",
+    ts: "1700000000.000100",
+    channel: "C_CHANNEL1",
+    ...overrides,
+  };
+}
+
+describe("stripBotMention", () => {
+  test("strips a single leading bot mention", () => {
+    expect(stripBotMention("<@U123BOT> hello world")).toBe("hello world");
+  });
+
+  test("strips multiple leading bot mentions", () => {
+    expect(stripBotMention("<@U123BOT> <@U456OTHER> hello")).toBe("hello");
+  });
+
+  test("falls back to original text when stripping produces empty string", () => {
+    expect(stripBotMention("<@U123BOT>")).toBe("<@U123BOT>");
+  });
+
+  test("falls back to original trimmed text when stripping produces whitespace only", () => {
+    expect(stripBotMention("<@U123BOT>   ")).toBe("<@U123BOT>");
+  });
+
+  test("returns text unchanged when no leading mention", () => {
+    expect(stripBotMention("hello world")).toBe("hello world");
+  });
+
+  test("does not strip mid-text mentions", () => {
+    expect(stripBotMention("hello <@U123BOT> world")).toBe("hello <@U123BOT> world");
+  });
+});
+
+describe("normalizeSlackAppMention", () => {
+  test("normalizes app_mention event with sourceChannel 'slack'", () => {
+    const config = makeConfig();
+    const event = makeEvent();
+    const result = normalizeSlackAppMention(event, "evt-001", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.sourceChannel).toBe("slack");
+    expect(result!.event.version).toBe("v1");
+  });
+
+  test("sets externalChatId to event.channel", () => {
+    const config = makeConfig();
+    const event = makeEvent({ channel: "C_MY_CHANNEL" });
+    const result = normalizeSlackAppMention(event, "evt-002", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.externalChatId).toBe("C_MY_CHANNEL");
+  });
+
+  test("externalMessageId uses client_msg_id when present", () => {
+    const config = makeConfig();
+    const event = makeEvent({ client_msg_id: "cmid-abc" });
+    const result = normalizeSlackAppMention(event, "evt-003", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.externalMessageId).toBe("cmid-abc");
+  });
+
+  test("externalMessageId falls back to ts when client_msg_id is absent", () => {
+    const config = makeConfig();
+    const event = makeEvent({ client_msg_id: undefined, ts: "1700000000.000100" });
+    const result = normalizeSlackAppMention(event, "evt-004", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.externalMessageId).toBe("1700000000.000100");
+  });
+
+  test("mention stripping: '<@U123BOT> hello world' becomes 'hello world'", () => {
+    const config = makeConfig();
+    const event = makeEvent({ text: "<@U123BOT> hello world" });
+    const result = normalizeSlackAppMention(event, "evt-005", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.content).toBe("hello world");
+  });
+
+  test("mention stripping with empty result falls back to original text", () => {
+    const config = makeConfig();
+    const event = makeEvent({ text: "<@U123BOT>" });
+    const result = normalizeSlackAppMention(event, "evt-006", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.content).toBe("<@U123BOT>");
+  });
+
+  test("thread_ts is preserved in return value", () => {
+    const config = makeConfig();
+    const event = makeEvent({ thread_ts: "1700000000.000050" });
+    const result = normalizeSlackAppMention(event, "evt-007", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.threadTs).toBe("1700000000.000050");
+  });
+
+  test("threadTs falls back to ts when thread_ts is not present", () => {
+    const config = makeConfig();
+    const event = makeEvent({ thread_ts: undefined, ts: "1700000000.000100" });
+    const result = normalizeSlackAppMention(event, "evt-008", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.threadTs).toBe("1700000000.000100");
+  });
+
+  test("sender.externalUserId is set to event.user", () => {
+    const config = makeConfig();
+    const event = makeEvent({ user: "U_SENDER_42" });
+    const result = normalizeSlackAppMention(event, "evt-009", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.sender.externalUserId).toBe("U_SENDER_42");
+  });
+
+  test("channel field is set in return value", () => {
+    const config = makeConfig();
+    const event = makeEvent({ channel: "C_RETURN_CHAN" });
+    const result = normalizeSlackAppMention(event, "evt-010", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.channel).toBe("C_RETURN_CHAN");
+  });
+
+  test("source.updateId is set to eventId", () => {
+    const config = makeConfig();
+    const event = makeEvent();
+    const result = normalizeSlackAppMention(event, "my-event-id", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.source.updateId).toBe("my-event-id");
+  });
+
+  test("returns null when routing rejects the event", () => {
+    const config = makeConfig({
+      unmappedPolicy: "reject",
+      defaultAssistantId: undefined,
+      routingEntries: [],
+    });
+    const event = makeEvent();
+    const result = normalizeSlackAppMention(event, "evt-011", config);
+
+    expect(result).toBeNull();
+  });
+
+  test("raw event is included in the result", () => {
+    const config = makeConfig();
+    const event = makeEvent();
+    const result = normalizeSlackAppMention(event, "evt-012", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.raw).toEqual(event as unknown as Record<string, unknown>);
+  });
+});


### PR DESCRIPTION
Add test coverage for Slack channel:\n\n- Slack event normalization tests\n- /deliver/slack route tests\n- Slack config tests\n- Slack channel config handler tests\n\nPart of #9858
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
