### PR TITLE
M7: Architecture docs update for Slack channel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 Bun + TypeScript monorepo with multiple packages:
 
 - `assistant/` — Main backend service (Bun + TypeScript)
-- `gateway/` — Telegram webhook gateway (Bun + TypeScript)
+- `gateway/` — Channel ingress gateway (Bun + TypeScript)
 - `clients/` — Client apps (macOS/iOS/etc). See `clients/AGENTS.md` and platform docs like `clients/macos/CLAUDE.md`.
 - `scripts/` — Utility scripts
 - `.claude/` — Claude Code slash commands and helper scripts (see `.claude/README.md`)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -213,6 +213,9 @@ graph TB
         GW_SMS_DELIVER["SMS Deliver<br/>/deliver/sms<br/>(internal, from runtime)"]
         GW_WA_WEBHOOK["WhatsApp Webhook<br/>/webhooks/whatsapp<br/>(HMAC-SHA256 validated)"]
         GW_WA_DELIVER["WhatsApp Deliver<br/>/deliver/whatsapp<br/>(internal, from runtime)"]
+        GW_SLACK_SOCKET["Slack Socket Mode<br/>WebSocket via<br/>apps.connections.open"]
+        GW_SLACK_NORMALIZE["Slack Normalize<br/>app_mention events<br/>+ bot-mention stripping"]
+        GW_SLACK_DELIVER["Slack Deliver<br/>/deliver/slack<br/>(internal, from runtime)"]
         GW_OAUTH["OAuth Callback<br/>/webhooks/oauth/callback"]
         GW_PROXY["Runtime Proxy<br/>(optional, bearer auth)"]
         GW_PROBES["/healthz + /readyz<br/>k8s liveness/readiness"]
@@ -359,6 +362,12 @@ graph TB
     GW_WA_WEBHOOK -->|"HMAC-SHA256 verify<br/>+ normalize + dedup<br/>+ route resolver"| GW_FORWARD
     HTTP_SERVER -->|"POST /deliver/whatsapp<br/>(via gatewayInternalBaseUrl)"| GW_WA_DELIVER
     GW_WA_DELIVER -->|"Meta Cloud API<br/>/{phoneNumberId}/messages"| GW_WA_WEBHOOK
+
+    %% Gateway flow — Slack channel (Socket Mode WebSocket)
+    GW_SLACK_SOCKET -->|"app_mention events<br/>ACK + dedup"| GW_SLACK_NORMALIZE
+    GW_SLACK_NORMALIZE -->|"normalize + route resolver"| GW_FORWARD
+    HTTP_SERVER -->|"POST /deliver/slack<br/>(via gatewayInternalBaseUrl)"| GW_SLACK_DELIVER
+    GW_SLACK_DELIVER -->|"Slack API<br/>chat.postMessage"| GW_SLACK_SOCKET
 
     %% Gateway flow — OAuth callback
     GW_OAUTH -->|"forward code + state"| HTTP_SERVER

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -134,6 +134,48 @@ These can be set via environment variables or stored in the credential vault (ke
 
 **SMS Compliance & Admin**: The `twilio_config` IPC contract extends beyond credential and number management with compliance and admin actions: `sms_compliance_status` detects toll-free vs local number type and fetches verification status; `sms_submit_tollfree_verification`, `sms_update_tollfree_verification`, and `sms_delete_tollfree_verification` manage the Twilio toll-free verification lifecycle; `release_number` removes a phone number from the Twilio account and clears all local references. All compliance actions validate required fields and Twilio enum values before calling the API.
 
+### Slack Channel (Socket Mode)
+
+The Slack channel provides text-based messaging via Slack's Socket Mode API. Unlike other channels that use HTTP webhooks, Slack uses a persistent WebSocket connection managed by the gateway — no public ingress URL is required. The assistant-side manages credential storage and validation through HTTP config endpoints.
+
+**Control-plane endpoints** (`/v1/integrations/slack/channel/config`):
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/v1/integrations/slack/channel/config` | GET | Returns current config status: `hasBotToken`, `hasAppToken`, `connected`, plus workspace metadata (`teamId`, `teamName`, `botUserId`, `botUsername`) |
+| `/v1/integrations/slack/channel/config` | POST | Validates and stores credentials. Body: `{ botToken?: string, appToken?: string }` |
+| `/v1/integrations/slack/channel/config` | DELETE | Clears all Slack channel credentials from secure storage and credential metadata |
+
+All endpoints are bearer-authenticated via the runtime HTTP token (`~/.vellum/http-token`).
+
+**Credential storage pattern:**
+
+Both tokens are stored in the secure key store (macOS Keychain with encrypted file fallback):
+
+| Secure key | Content |
+|-----------|---------|
+| `credential:slack_channel:bot_token` | Slack bot token (used for `chat.postMessage` and `auth.test`) |
+| `credential:slack_channel:app_token` | Slack app token (`xapp-...`, used for Socket Mode `apps.connections.open`) |
+
+Workspace metadata (team ID, team name, bot user ID, bot username) is stored as JSON in the credential metadata store under `('slack_channel', 'bot_token')`.
+
+**Token validation via `auth.test`:**
+
+When a bot token is provided via `POST /v1/integrations/slack/channel/config`, the handler calls `POST https://slack.com/api/auth.test` with the token before storing it. A successful response yields workspace metadata (`team_id`, `team`, `user_id`, `user`) that is persisted alongside the token. If `auth.test` fails, the token is rejected and not stored.
+
+The app token is validated by format only — it must start with `xapp-`.
+
+**Connection status:**
+
+The `GET` endpoint reports `connected: true` only when both `hasBotToken` and `hasAppToken` are true. If only one token is stored, a `warning` field describes which token is missing.
+
+**Key source files:**
+
+| File | Purpose |
+|------|---------|
+| `src/daemon/handlers/config-slack-channel.ts` | Business logic for get/set/clear Slack channel config |
+| `src/runtime/routes/integration-routes.ts` | HTTP route handlers for `/v1/integrations/slack/channel/config` |
+
 ---
 
 

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -4,7 +4,7 @@ This document owns public-ingress and channel webhook architecture. The repo-lev
 
 ## Ingress Boundary Architecture — Gateway-Only Public Ingress
 
-All external webhook endpoints (Telegram, Twilio, OAuth, future channels) are handled exclusively by the gateway. The runtime never exposes webhook ingress. The runtime-proxy explicitly blocks forwarding of `/webhooks/*` paths.
+All external webhook endpoints (Telegram, Twilio, WhatsApp, OAuth) and persistent channel connections (Slack Socket Mode) are handled exclusively by the gateway. The runtime never exposes webhook ingress. The runtime-proxy explicitly blocks forwarding of `/webhooks/*` paths.
 
 This boundary is enforced at three layers:
 
@@ -18,6 +18,7 @@ Internet
   +-- Twilio ----------> Gateway POST /webhooks/twilio/*    --> Runtime /v1/internal/twilio/*
   +-- OAuth Provider ---> Gateway GET  /webhooks/oauth/callback --> Runtime /v1/internal/oauth/callback
   +-- Telegram --------> Gateway POST /webhooks/telegram    --> Runtime /v1/channels/inbound
+  +-- Slack ------------> Gateway (Socket Mode WebSocket)   --> Runtime /v1/channels/inbound
   |
   +-- Tunnel (ngrok, Cloudflare, etc.)
        |
@@ -433,6 +434,58 @@ In single-assistant mode (the default local deployment), routing is automaticall
 - `GATEWAY_DEFAULT_ASSISTANT_ID` is set to the current assistant's ID
 
 In multi-assistant mode, the operator must configure `GATEWAY_ASSISTANT_ROUTING_JSON` to map specific chat/user IDs to assistant IDs.
+
+### Slack Channel (Socket Mode)
+
+The Slack channel enables inbound and outbound messaging via Slack's Socket Mode API. Unlike Telegram, SMS, and WhatsApp which use HTTP webhook ingress, Slack uses a persistent WebSocket connection — no public ingress URL is required.
+
+**Connection lifecycle** (`apps.connections.open`):
+
+1. The gateway calls `POST https://slack.com/api/apps.connections.open` with the Slack app-level token (`xapp-...`) to obtain a WebSocket URL.
+2. A `SlackSocketModeClient` opens the WebSocket and maintains a single active connection.
+3. On connection, the client resets its reconnect counter. On close or error, it schedules a reconnect with capped exponential backoff (1s base, 30s max) plus 0-50% jitter.
+4. Slack may send a `disconnect` envelope to request a reconnect (e.g., server rotation). The client handles this by closing the current socket and reconnecting immediately (attempt counter reset to 0).
+
+**Event processing** (inbound):
+
+1. Every Socket Mode envelope is ACKed immediately by echoing `{ envelope_id }` back on the WebSocket — this is required by Slack regardless of whether the event is processed.
+2. Only `events_api` envelopes with `app_mention` events are processed in MVP. Other envelope types (slash commands, interactive payloads) are ACKed but ignored.
+3. Events are deduplicated by `event_id` using an in-memory `Map<string, number>` with a 24-hour TTL. A periodic cleanup sweep runs every hour to evict expired entries.
+4. The `normalizeSlackAppMention()` function strips leading bot-mention tokens (`<@U...>`) from the message text and produces a `GatewayInboundEventV1` with `sourceChannel: "slack"`, using the Slack channel ID as `externalChatId` and the sender's user ID as `externalUserId`.
+5. Routing uses the standard `resolveAssistant()` chain (chat_id -> user_id -> default/reject). Events that cannot be routed are dropped.
+6. The normalized event is forwarded to the runtime via `POST /v1/channels/inbound` with Slack-specific transport hints and a `replyCallbackUrl` pointing to `/deliver/slack`.
+
+**Egress** (`POST /deliver/slack`):
+
+1. The runtime calls the gateway's `/deliver/slack` endpoint with `{ chatId, text }` or `{ to, text }` (alias). The `chatId` field maps to the Slack channel ID where the reply should be posted.
+2. The gateway authenticates the request via bearer token (same fail-closed model as other deliver endpoints).
+3. The gateway posts the message via `POST https://slack.com/api/chat.postMessage` using the bot token.
+4. Threading is supported via a `threadTs` query parameter on the deliver URL. When present, replies are posted as thread replies to the specified message timestamp.
+
+**Credential management:**
+
+The Slack channel requires two tokens:
+
+| Token | Format | Purpose |
+|-------|--------|---------|
+| App token | `xapp-...` | Used for `apps.connections.open` to establish the Socket Mode WebSocket connection |
+| Bot token | `xbot-...` / `xoxb-...` | Used for `chat.postMessage` to send outbound messages and for `auth.test` validation |
+
+Both tokens are stored in secure storage (`credential:slack_channel:app_token`, `credential:slack_channel:bot_token`) via the assistant's Slack channel config endpoints (see `assistant/ARCHITECTURE.md`). The gateway reads them via its `credential-reader` module using the same keychain-first fallback strategy as Telegram credentials.
+
+**Auto-reconnect behavior:**
+
+The Socket Mode client auto-reconnects on any WebSocket close or error. The backoff schedule is: `min(1000 * 2^attempt, 30000)` + random jitter. After a successful connection, the attempt counter resets. Slack-initiated disconnects (envelope `type: "disconnect"`) trigger an immediate reconnect with no backoff.
+
+**Key modules:**
+
+| Module | Purpose |
+|--------|---------|
+| `gateway/src/slack/socket-mode.ts` | `SlackSocketModeClient` — WebSocket lifecycle, ACK, dedup, auto-reconnect |
+| `gateway/src/slack/normalize.ts` | `normalizeSlackAppMention()` — event normalization and bot-mention stripping |
+| `gateway/src/http/routes/slack-deliver.ts` | `/deliver/slack` — outbound message delivery via `chat.postMessage` |
+
+**Limitations (MVP):** Text-only — attachments are rejected. Only `app_mention` events are processed (direct messages to the bot are not handled). Rich approval UI (inline buttons) is not supported.
 
 ---
 


### PR DESCRIPTION
## Summary

Update architecture documentation for Slack channel:

- **Gateway ARCHITECTURE.md**: Added "Slack Channel (Socket Mode)" section documenting Socket Mode WebSocket connection via `apps.connections.open`, event normalization for `app_mention` events, `/deliver/slack` route for outbound messages, credential management (app token + bot token), auto-reconnect with capped exponential backoff, and event deduplication. Updated ingress boundary diagram and description to include Slack.
- **Assistant ARCHITECTURE.md**: Added "Slack Channel (Socket Mode)" section documenting `GET/POST/DELETE /v1/integrations/slack/channel/config` endpoints, credential storage pattern in secure key store, and token validation via Slack `auth.test`.
- **Root ARCHITECTURE.md**: Updated the system overview Mermaid diagram to include Slack Socket Mode, normalize, and deliver nodes with data flow connections.
- **AGENTS.md**: Updated gateway description from "Telegram webhook gateway" to "Channel ingress gateway".

Part of #9858

## Test plan

- [ ] Verify Mermaid diagrams render correctly
- [ ] Confirm documentation style matches existing Telegram, SMS, and WhatsApp sections
- [ ] Review accuracy of documented behavior against implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
