### PR TITLE
Voice guardian timeout: route remaining copy through daemon

### DIFF
--- a/assistant/src/__tests__/guardian-action-copy-generator.test.ts
+++ b/assistant/src/__tests__/guardian-action-copy-generator.test.ts
@@ -23,6 +23,8 @@ const ALL_SCENARIOS: GuardianActionMessageScenario[] = [
   'guardian_followup_failed',
   'guardian_followup_declined_ack',
   'guardian_followup_clarification',
+  'guardian_expired_disambiguation',
+  'guardian_followup_disambiguation',
   'guardian_stale_answered',
   'guardian_stale_expired',
   'guardian_stale_followup',
@@ -85,6 +87,23 @@ describe('guardian-action-copy-generator', () => {
         failureReason: 'The phone number is not valid.',
       });
       expect(msg).toContain('The phone number is not valid.');
+    });
+
+    test('guardian_expired_disambiguation includes request codes when provided', () => {
+      const msg = getGuardianActionFallbackMessage({
+        scenario: 'guardian_expired_disambiguation',
+        requestCodes: ['Q1A2B3', 'Q9Z8Y7'],
+      });
+      expect(msg).toContain('Q1A2B3');
+      expect(msg).toContain('Q9Z8Y7');
+    });
+
+    test('guardian_followup_disambiguation includes request codes when provided', () => {
+      const msg = getGuardianActionFallbackMessage({
+        scenario: 'guardian_followup_disambiguation',
+        requestCodes: ['QFOO12'],
+      });
+      expect(msg).toContain('QFOO12');
     });
 
     test('outbound_message_copy includes lateAnswerText and questionText', () => {

--- a/assistant/src/__tests__/guardian-action-no-hardcoded-copy.test.ts
+++ b/assistant/src/__tests__/guardian-action-no-hardcoded-copy.test.ts
@@ -48,6 +48,14 @@ const BANNED_PATTERNS: { pattern: RegExp; description: string }[] = [
     pattern: /['"`]Would you like to call them back or send/i,
     description: 'follow-up prompt must go through composer (string literal)',
   },
+  {
+    pattern: /['"`]You have multiple expired guardian questions\./i,
+    description: 'expired disambiguation must go through composer (string literal)',
+  },
+  {
+    pattern: /['"`]You have multiple pending follow-up questions\./i,
+    description: 'follow-up disambiguation must go through composer (string literal)',
+  },
 ];
 
 describe('guardian action no-hardcoded-copy guard', () => {

--- a/assistant/src/__tests__/guardian-action-sweep.test.ts
+++ b/assistant/src/__tests__/guardian-action-sweep.test.ts
@@ -85,7 +85,7 @@ describe('guardian-action-sweep', () => {
     try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
   });
 
-  test('sweepExpiredGuardianActions expires requests past their expiresAt', () => {
+  test('sweepExpiredGuardianActions expires requests past their expiresAt', async () => {
     const convId = 'conv-sweep-1';
     ensureConversation(convId);
 
@@ -119,7 +119,7 @@ describe('guardian-action-sweep', () => {
       'sent',
     );
 
-    sweepExpiredGuardianActions('http://localhost:3000');
+    await sweepExpiredGuardianActions('http://localhost:3000');
 
     const updatedRequest = getGuardianActionRequest(request.id);
     expect(updatedRequest).not.toBeNull();
@@ -130,7 +130,7 @@ describe('guardian-action-sweep', () => {
     expect(deliveries[0].status).toBe('expired');
   });
 
-  test('sweepExpiredGuardianActions expires pending questions', () => {
+  test('sweepExpiredGuardianActions expires pending questions', async () => {
     const convId = 'conv-sweep-2';
     ensureConversation(convId);
 
@@ -155,13 +155,13 @@ describe('guardian-action-sweep', () => {
     // Verify the question is still pending before sweep
     expect(getPendingQuestion(session.id)).not.toBeNull();
 
-    sweepExpiredGuardianActions('http://localhost:3000');
+    await sweepExpiredGuardianActions('http://localhost:3000');
 
     // Pending question should be expired
     expect(getPendingQuestion(session.id)).toBeNull();
   });
 
-  test('sweepExpiredGuardianActions does nothing when no expired requests exist', () => {
+  test('sweepExpiredGuardianActions does nothing when no expired requests exist', async () => {
     const convId = 'conv-sweep-3';
     ensureConversation(convId);
 
@@ -184,7 +184,7 @@ describe('guardian-action-sweep', () => {
       expiresAt: Date.now() + 60_000, // expires in 60s
     });
 
-    sweepExpiredGuardianActions('http://localhost:3000');
+    await sweepExpiredGuardianActions('http://localhost:3000');
 
     const updatedRequest = getGuardianActionRequest(request.id);
     expect(updatedRequest!.status).toBe('pending');
@@ -220,7 +220,7 @@ describe('guardian-action-sweep', () => {
     });
     updateDeliveryStatus(delivery.id, 'sent');
 
-    sweepExpiredGuardianActions('http://localhost:3000');
+    await sweepExpiredGuardianActions('http://localhost:3000');
 
     // Wait for the fire-and-forget async delivery to complete
     await new Promise(resolve => setTimeout(resolve, 50));
@@ -229,7 +229,7 @@ describe('guardian-action-sweep', () => {
     expect(deliveredMessages.length).toBeGreaterThanOrEqual(1);
   });
 
-  test('sweepExpiredGuardianActions skips failed deliveries', () => {
+  test('sweepExpiredGuardianActions skips failed deliveries', async () => {
     const convId = 'conv-sweep-5';
     ensureConversation(convId);
 
@@ -260,7 +260,7 @@ describe('guardian-action-sweep', () => {
 
     deliveredMessages.length = 0;
 
-    sweepExpiredGuardianActions('http://localhost:3000');
+    await sweepExpiredGuardianActions('http://localhost:3000');
 
     // Should NOT have sent an expiry notice for a failed delivery
     expect(deliveredMessages).toHaveLength(0);

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -590,12 +590,17 @@ export class CallController {
                 { callSessionId: this.callSessionId, requestId: pendingActionRequest.id },
                 'Marked guardian action request as timed out',
               );
-              sendGuardianExpiryNotices(
+              void sendGuardianExpiryNotices(
                 deliveries,
                 pendingActionRequest.assistantId,
                 getGatewayInternalBaseUrl(),
                 readHttpToken() ?? undefined,
-              );
+              ).catch((err) => {
+                log.error(
+                  { err, callSessionId: this.callSessionId, requestId: pendingActionRequest.id },
+                  'Failed to send guardian action expiry notices after call timeout',
+                );
+              });
             }
 
             // Expire pending questions and update call state

--- a/assistant/src/calls/guardian-action-sweep.ts
+++ b/assistant/src/calls/guardian-action-sweep.ts
@@ -17,7 +17,8 @@ import {
   getExpiredGuardianActionRequests,
 } from '../memory/guardian-action-store.js';
 import { deliverChannelReply } from '../runtime/gateway-client.js';
-import { getGuardianActionFallbackMessage } from '../runtime/guardian-action-message-composer.js';
+import type { GuardianActionCopyGenerator } from '../runtime/http-types.js';
+import { composeGuardianActionMessageGenerative } from '../runtime/guardian-action-message-composer.js';
 import { getLogger } from '../util/logger.js';
 import { expirePendingQuestions } from './call-store.js';
 
@@ -35,42 +36,52 @@ let sweepTimer: ReturnType<typeof setInterval> | null = null;
  * Deliveries must be captured *before* their status is changed to 'expired'
  * so the sent/pending filter still matches.
  */
-export function sendGuardianExpiryNotices(
+export async function sendGuardianExpiryNotices(
   deliveries: GuardianActionDelivery[],
   assistantId: string,
   gatewayBaseUrl: string,
   bearerToken?: string,
-): void {
+  guardianActionCopyGenerator?: GuardianActionCopyGenerator,
+): Promise<void> {
   for (const delivery of deliveries) {
     if (delivery.status !== 'sent' && delivery.status !== 'pending') continue;
 
+    const expiryText = await composeGuardianActionMessageGenerative(
+      {
+        scenario: 'guardian_stale_expired',
+        channel: delivery.destinationChannel,
+      },
+      {},
+      guardianActionCopyGenerator,
+    );
+
     if ((delivery.destinationChannel === 'vellum' || delivery.destinationChannel === 'macos' || delivery.destinationChannel === 'mac') && delivery.destinationConversationId) {
-      // Add expiry message to vellum guardian thread
-      const expiryText = getGuardianActionFallbackMessage({ scenario: 'guardian_stale_expired' });
-      void addMessage(
-        delivery.destinationConversationId,
-        'assistant',
-        JSON.stringify([{ type: 'text', text: expiryText }]),
-        { userMessageChannel: 'voice', assistantMessageChannel: 'vellum', userMessageInterface: 'voice', assistantMessageInterface: 'vellum' },
-      ).catch((err) => log.error({ err, deliveryId: delivery.id }, 'Failed to add expiry message to guardian thread'));
+      // Add expiry message to vellum guardian thread.
+      try {
+        await addMessage(
+          delivery.destinationConversationId,
+          'assistant',
+          JSON.stringify([{ type: 'text', text: expiryText }]),
+          { userMessageChannel: 'voice', assistantMessageChannel: 'vellum', userMessageInterface: 'voice', assistantMessageInterface: 'vellum' },
+        );
+      } catch (err) {
+        log.error({ err, deliveryId: delivery.id }, 'Failed to add expiry message to guardian thread');
+      }
     } else if (delivery.destinationChatId) {
       // External channel — send expiry notice
       const deliverUrl = `${gatewayBaseUrl}/deliver/${delivery.destinationChannel}`;
-      void (async () => {
-        try {
-          const channelExpiryText = getGuardianActionFallbackMessage({ scenario: 'guardian_stale_expired' });
-          await deliverChannelReply(deliverUrl, {
-            chatId: delivery.destinationChatId!,
-            text: channelExpiryText,
-            assistantId,
-          }, bearerToken);
-        } catch (err) {
-          log.error(
-            { err, deliveryId: delivery.id, channel: delivery.destinationChannel },
-            'Failed to deliver guardian action expiry notice',
-          );
-        }
-      })();
+      try {
+        await deliverChannelReply(deliverUrl, {
+          chatId: delivery.destinationChatId,
+          text: expiryText,
+          assistantId,
+        }, bearerToken);
+      } catch (err) {
+        log.error(
+          { err, deliveryId: delivery.id, channel: delivery.destinationChannel },
+          'Failed to deliver guardian action expiry notice',
+        );
+      }
     }
   }
 }
@@ -81,6 +92,7 @@ export function sendGuardianExpiryNotices(
 export async function sweepExpiredGuardianActions(
   gatewayBaseUrl: string,
   bearerToken?: string,
+  guardianActionCopyGenerator?: GuardianActionCopyGenerator,
 ): Promise<void> {
   const expired = getExpiredGuardianActionRequests();
 
@@ -99,18 +111,25 @@ export async function sweepExpiredGuardianActions(
       'Expired guardian action request',
     );
 
-    sendGuardianExpiryNotices(deliveries, request.assistantId, gatewayBaseUrl, bearerToken);
+    await sendGuardianExpiryNotices(
+      deliveries,
+      request.assistantId,
+      gatewayBaseUrl,
+      bearerToken,
+      guardianActionCopyGenerator,
+    );
   }
 }
 
 export function startGuardianActionSweep(
   gatewayBaseUrl: string,
   bearerToken?: string,
+  guardianActionCopyGenerator?: GuardianActionCopyGenerator,
 ): void {
   if (sweepTimer) return;
   sweepTimer = setInterval(async () => {
     try {
-      await sweepExpiredGuardianActions(gatewayBaseUrl, bearerToken);
+      await sweepExpiredGuardianActions(gatewayBaseUrl, bearerToken, guardianActionCopyGenerator);
     } catch (err) {
       log.error({ err }, 'Guardian action sweep failed');
     }

--- a/assistant/src/calls/guardian-action-sweep.ts
+++ b/assistant/src/calls/guardian-action-sweep.ts
@@ -27,6 +27,7 @@ const log = getLogger('guardian-action-sweep');
 const SWEEP_INTERVAL_MS = 60_000;
 
 let sweepTimer: ReturnType<typeof setInterval> | null = null;
+let sweepInProgress = false;
 
 /**
  * Send expiry notices to all delivery destinations for a guardian action
@@ -46,42 +47,38 @@ export async function sendGuardianExpiryNotices(
   for (const delivery of deliveries) {
     if (delivery.status !== 'sent' && delivery.status !== 'pending') continue;
 
-    const expiryText = await composeGuardianActionMessageGenerative(
-      {
-        scenario: 'guardian_stale_expired',
-        channel: delivery.destinationChannel,
-      },
-      {},
-      guardianActionCopyGenerator,
-    );
+    try {
+      const expiryText = await composeGuardianActionMessageGenerative(
+        {
+          scenario: 'guardian_stale_expired',
+          channel: delivery.destinationChannel,
+        },
+        {},
+        guardianActionCopyGenerator,
+      );
 
-    if ((delivery.destinationChannel === 'vellum' || delivery.destinationChannel === 'macos' || delivery.destinationChannel === 'mac') && delivery.destinationConversationId) {
-      // Add expiry message to vellum guardian thread.
-      try {
+      if ((delivery.destinationChannel === 'vellum' || delivery.destinationChannel === 'macos' || delivery.destinationChannel === 'mac') && delivery.destinationConversationId) {
+        // Add expiry message to vellum guardian thread.
         await addMessage(
           delivery.destinationConversationId,
           'assistant',
           JSON.stringify([{ type: 'text', text: expiryText }]),
           { userMessageChannel: 'voice', assistantMessageChannel: 'vellum', userMessageInterface: 'voice', assistantMessageInterface: 'vellum' },
         );
-      } catch (err) {
-        log.error({ err, deliveryId: delivery.id }, 'Failed to add expiry message to guardian thread');
-      }
-    } else if (delivery.destinationChatId) {
-      // External channel — send expiry notice
-      const deliverUrl = `${gatewayBaseUrl}/deliver/${delivery.destinationChannel}`;
-      try {
+      } else if (delivery.destinationChatId) {
+        // External channel — send expiry notice
+        const deliverUrl = `${gatewayBaseUrl}/deliver/${delivery.destinationChannel}`;
         await deliverChannelReply(deliverUrl, {
           chatId: delivery.destinationChatId,
           text: expiryText,
           assistantId,
         }, bearerToken);
-      } catch (err) {
-        log.error(
-          { err, deliveryId: delivery.id, channel: delivery.destinationChannel },
-          'Failed to deliver guardian action expiry notice',
-        );
       }
+    } catch (err) {
+      log.error(
+        { err, deliveryId: delivery.id, channel: delivery.destinationChannel },
+        'Failed to compose or deliver guardian action expiry notice',
+      );
     }
   }
 }
@@ -128,10 +125,14 @@ export function startGuardianActionSweep(
 ): void {
   if (sweepTimer) return;
   sweepTimer = setInterval(async () => {
+    if (sweepInProgress) return;
+    sweepInProgress = true;
     try {
       await sweepExpiredGuardianActions(gatewayBaseUrl, bearerToken, guardianActionCopyGenerator);
     } catch (err) {
       log.error({ err }, 'Guardian action sweep failed');
+    } finally {
+      sweepInProgress = false;
     }
   }, SWEEP_INTERVAL_MS);
 }
@@ -141,4 +142,5 @@ export function stopGuardianActionSweep(): void {
     clearInterval(sweepTimer);
     sweepTimer = null;
   }
+  sweepInProgress = false;
 }

--- a/assistant/src/runtime/guardian-action-message-composer.ts
+++ b/assistant/src/runtime/guardian-action-message-composer.ts
@@ -26,6 +26,8 @@ export type GuardianActionMessageScenario =
   | 'guardian_followup_failed'
   | 'guardian_followup_declined_ack'
   | 'guardian_followup_clarification'
+  | 'guardian_expired_disambiguation'
+  | 'guardian_followup_disambiguation'
   | 'guardian_stale_answered'
   | 'guardian_stale_expired'
   | 'guardian_stale_followup'
@@ -45,6 +47,7 @@ export interface GuardianActionMessageContext {
   followupAction?: string;
   failureReason?: string;
   counterpartyPhone?: string;
+  requestCodes?: string[];
 }
 
 export interface ComposeGuardianActionMessageOptions {
@@ -141,6 +144,8 @@ export function includesRequiredKeywords(text: string, requiredKeywords: string[
  * or SMS delivery.
  */
 export function getGuardianActionFallbackMessage(context: GuardianActionMessageContext): string {
+  const listedCodes = formatGuardianRequestCodes(context.requestCodes);
+
   switch (context.scenario) {
     case 'caller_timeout_acknowledgment':
       return context.guardianIdentifier
@@ -175,6 +180,16 @@ export function getGuardianActionFallbackMessage(context: GuardianActionMessageC
 
     case 'guardian_followup_clarification':
       return "Sorry, I didn't quite catch that. Would you like to call them back, send them a message, or skip it for now?";
+
+    case 'guardian_expired_disambiguation':
+      return listedCodes
+        ? `You have multiple expired guardian questions. Please prefix your reply with the reference code (${listedCodes}) so I know which question you're answering.`
+        : 'You have multiple expired guardian questions. Please prefix your reply with the reference code so I know which question you\'re answering.';
+
+    case 'guardian_followup_disambiguation':
+      return listedCodes
+        ? `You have multiple pending follow-up questions. Please prefix your reply with the reference code (${listedCodes}) so I know which question you're responding to.`
+        : 'You have multiple pending follow-up questions. Please prefix your reply with the reference code so I know which question you\'re responding to.';
 
     case 'guardian_stale_answered':
       return 'This question has already been answered from another channel.';
@@ -221,4 +236,10 @@ export function getGuardianActionFallbackMessage(context: GuardianActionMessageC
       return `Guardian action update. ${String(_exhaustive)}`;
     }
   }
+}
+
+function formatGuardianRequestCodes(requestCodes: string[] | undefined): string {
+  if (!Array.isArray(requestCodes)) return '';
+  const cleaned = requestCodes.map((code) => code.trim()).filter((code) => code.length > 0);
+  return cleaned.join(', ');
 }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -316,7 +316,7 @@ export class RuntimeHttpServer {
     startGuardianExpirySweep(getGatewayInternalBaseUrl(), this.bearerToken, this.approvalCopyGenerator);
     log.info('Guardian approval expiry sweep started');
 
-    startGuardianActionSweep(getGatewayInternalBaseUrl(), this.bearerToken);
+    startGuardianActionSweep(getGatewayInternalBaseUrl(), this.bearerToken, this.guardianActionCopyGenerator);
     log.info('Guardian action expiry sweep started');
 
     log.info('Running in gateway-only ingress mode. Direct webhook routes disabled.');

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -943,11 +943,20 @@ export async function handleChannelInbound(
                 const req = getGuardianActionRequest(d.requestId);
                 return req ? req.requestCode : null;
               })
-              .filter(Boolean);
+              .filter((code): code is string => typeof code === 'string' && code.length > 0);
+            const disambiguationText = await composeGuardianActionMessageGenerative(
+              {
+                scenario: 'guardian_expired_disambiguation',
+                requestCodes: codes,
+                channel: sourceChannel,
+              },
+              {},
+              guardianActionCopyGenerator,
+            );
             try {
               await deliverChannelReply(replyCallbackUrl, {
                 chatId: externalChatId,
-                text: `You have multiple expired guardian questions. Please prefix your reply with the reference code (${codes.join(', ')}) to indicate which question you are answering.`,
+                text: disambiguationText,
                 assistantId,
               }, bearerToken);
             } catch (err) {
@@ -1063,11 +1072,20 @@ export async function handleChannelInbound(
                 const req = getGuardianActionRequest(d.requestId);
                 return req ? req.requestCode : null;
               })
-              .filter(Boolean);
+              .filter((code): code is string => typeof code === 'string' && code.length > 0);
+            const disambiguationText = await composeGuardianActionMessageGenerative(
+              {
+                scenario: 'guardian_followup_disambiguation',
+                requestCodes: codes,
+                channel: sourceChannel,
+              },
+              {},
+              guardianActionCopyGenerator,
+            );
             try {
               await deliverChannelReply(replyCallbackUrl, {
                 chatId: externalChatId,
-                text: `You have multiple pending follow-up questions. Please prefix your reply with the reference code (${codes.join(', ')}) to indicate which question you are responding to.`,
+                text: disambiguationText,
                 assistantId,
               }, bearerToken);
             } catch (err) {

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -950,7 +950,7 @@ export async function handleChannelInbound(
                 requestCodes: codes,
                 channel: sourceChannel,
               },
-              {},
+              { requiredKeywords: codes },
               guardianActionCopyGenerator,
             );
             try {
@@ -1079,7 +1079,7 @@ export async function handleChannelInbound(
                 requestCodes: codes,
                 channel: sourceChannel,
               },
-              {},
+              { requiredKeywords: codes },
               guardianActionCopyGenerator,
             );
             try {


### PR DESCRIPTION
## Summary
- route guardian action sweep expiry notices through `composeGuardianActionMessageGenerative` with daemon generator injection
- replace inbound hardcoded multi-request disambiguation replies with composed guardian-action scenarios
- add/extend guard tests to keep these paths non-hardcoded

## Validation
- `bun test src/__tests__/guardian-action-*.test.ts`

## Context
Follow-up fix after #9735 to remove remaining deterministic user-facing text in the guardian timeout/follow-up flow.