### PR TITLE
fix: buffer existing cert/key before proactive TLS renewal attempt

### DIFF
--- a/assistant/src/daemon/tls-certs.ts
+++ b/assistant/src/daemon/tls-certs.ts
@@ -152,19 +152,20 @@ export async function ensureTlsCert(): Promise<{ cert: string; key: string; fing
   }
 
   if (status === 'approaching_expiry') {
-    // Attempt proactive renewal, but fall back to the existing cert if it fails.
-    // The existing cert is still valid — an outage from a failed renewal would be worse
-    // than continuing with a cert that expires in <30 days.
+    // Buffer existing cert/key/fingerprint before attempting renewal.
+    // generateNewCert() overwrites key.pem in-place, so if it fails mid-flight
+    // (e.g., key written but cert generation fails), reading from disk in the
+    // catch block would return a mismatched key/cert pair.
+    const [existingCert, existingKey, existingFp] = await Promise.all([
+      readFile(certPath, 'utf-8'),
+      readFile(keyPath, 'utf-8'),
+      readFile(fpPath, 'utf-8'),
+    ]);
     try {
       return await generateNewCert(tlsDir, certPath, keyPath, fpPath);
     } catch (err) {
       log.warn({ err }, 'Proactive TLS renewal failed, continuing with existing certificate');
-      const [cert, key, fingerprint] = await Promise.all([
-        readFile(certPath, 'utf-8'),
-        readFile(keyPath, 'utf-8'),
-        readFile(fpPath, 'utf-8'),
-      ]);
-      return { cert, key, fingerprint: fingerprint.trim() };
+      return { cert: existingCert, key: existingKey, fingerprint: existingFp.trim() };
     }
   }
 


### PR DESCRIPTION
Address review feedback on PR #9851. Reads and buffers the existing cert, key, and fingerprint before calling generateNewCert(), so the catch block returns known-good values if renewal fails mid-flight (e.g., after key is overwritten but before cert is generated).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
