### PR TITLE
fix: remove nonce from CSP style-src to allow unsafe-inline styles

### DIFF
--- a/assistant/src/runtime/routes/app-routes.ts
+++ b/assistant/src/runtime/routes/app-routes.ts
@@ -77,7 +77,7 @@ ${noncedHtml}
   // We keep 'unsafe-inline' so arbitrary app content works.
   const csp = [
     "default-src 'self'",
-    `style-src 'self' 'nonce-${nonce}' 'unsafe-inline'`,
+    "style-src 'self' 'unsafe-inline'",
     "script-src 'self' 'unsafe-inline'",
     "img-src 'self' data: https:",
     "font-src 'self' data: https:",


### PR DESCRIPTION
Address review feedback on PR #9856. Per CSP spec, when a nonce is present in style-src, 'unsafe-inline' is silently ignored. Since we don't inject nonces into <style> tags (only <script>), user/LLM-generated inline styles were being blocked. Remove the nonce from style-src to match the fix already applied to script-src.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
