### PR TITLE
fix: map x86_64 to x64 in ONNX binary stripping for Intel Mac support

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -174,7 +174,9 @@ build_binaries() {
     if [ -d "$onnx_bin" ]; then
         find "$onnx_bin" -mindepth 1 -maxdepth 1 -not -name darwin -exec rm -rf {} +
         if [ "$UNIVERSAL_BUILD" != true ] && [ -d "$onnx_bin/darwin" ]; then
-            find "$onnx_bin/darwin" -mindepth 1 -maxdepth 1 -not -name "$(uname -m)" -exec rm -rf {} +
+            local arch=$(uname -m)
+            [ "$arch" = "x86_64" ] && arch="x64"
+            find "$onnx_bin/darwin" -mindepth 1 -maxdepth 1 -not -name "$arch" -exec rm -rf {} +
         fi
     fi
     # Copy bundled skills
@@ -326,7 +328,9 @@ if [ "$DAEMON_BIN_NEEDS_BUILD" = true ]; then
     if [ -d "$onnx_bin" ]; then
         find "$onnx_bin" -mindepth 1 -maxdepth 1 -not -name darwin -exec rm -rf {} +
         if [ "$UNIVERSAL_BUILD" != true ] && [ -d "$onnx_bin/darwin" ]; then
-            find "$onnx_bin/darwin" -mindepth 1 -maxdepth 1 -not -name "$(uname -m)" -exec rm -rf {} +
+            _arch=$(uname -m)
+            [ "$_arch" = "x86_64" ] && _arch="x64"
+            find "$onnx_bin/darwin" -mindepth 1 -maxdepth 1 -not -name "$_arch" -exec rm -rf {} +
         fi
     fi
 fi


### PR DESCRIPTION
Address review feedback on PR #9874. Maps uname -m output (x86_64) to the onnxruntime-node directory name (x64) so that ONNX binary stripping doesn't delete the needed native libraries on Intel Macs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
