### PR TITLE
Fix slackFromEnv env var check

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -433,7 +433,7 @@ function main() {
   }
 
   const telegramFromEnv = isTelegramConfigured();
-  const slackFromEnv = !!(config.slackChannelBotToken && config.slackChannelAppToken);
+  const slackFromEnv = !!(process.env.SLACK_CHANNEL_BOT_TOKEN && process.env.SLACK_CHANNEL_APP_TOKEN);
 
   const credentialWatcher = new CredentialWatcher((event) => {
     if (event.telegramChanged && !telegramFromEnv) {


### PR DESCRIPTION
Fix slackFromEnv to check process.env directly instead of config values that may include credential store tokens.\n\nAddresses review feedback on #9872 and #9901.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
