### PR TITLE
fix: skip local embedding backend after onnxruntime import failure

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -9,6 +9,11 @@ import { OpenAIEmbeddingBackend } from './embedding-openai.js';
 
 const log = getLogger('memory-embeddings');
 
+// Tracks whether the local embedding backend has permanently failed to load
+// (e.g., onnxruntime-node missing in a compiled binary). Once set, `auto` mode
+// skips `local` as primary, avoiding repeated fallback latency and cost.
+let localBackendBroken = false;
+
 /**
  * Lazy wrapper around LocalEmbeddingBackend that dynamically imports the
  * module on first use. This avoids eagerly loading @huggingface/transformers
@@ -17,6 +22,7 @@ const log = getLogger('memory-embeddings');
  * import would crash the entire daemon at startup. By deferring the import,
  * the failure is contained and other embedding backends can be used instead.
  */
+
 class LazyLocalEmbeddingBackend implements EmbeddingBackend {
   readonly provider = 'local' as const;
   readonly model: string;
@@ -36,9 +42,15 @@ class LazyLocalEmbeddingBackend implements EmbeddingBackend {
     if (this.delegate) return this.delegate;
     if (!this.initPromise) {
       this.initPromise = (async () => {
-        const { LocalEmbeddingBackend } = await import('./embedding-local.js');
-        this.delegate = new LocalEmbeddingBackend(this.model);
-        return this.delegate;
+        try {
+          const { LocalEmbeddingBackend } = await import('./embedding-local.js');
+          this.delegate = new LocalEmbeddingBackend(this.model);
+          return this.delegate;
+        } catch (err) {
+          localBackendBroken = true;
+          log.warn({ err }, 'Local embedding backend permanently unavailable; auto mode will skip it');
+          throw err;
+        }
       })();
     }
     return this.initPromise;
@@ -104,6 +116,7 @@ export function clearEmbeddingBackendCache(): void {
   backendCache.clear();
   vectorCache.clear();
   vectorCacheBytes = 0;
+  localBackendBroken = false;
 }
 
 function cacheKey(provider: string, model: string): string {
@@ -163,6 +176,7 @@ export function selectEmbeddingBackend(config: AssistantConfig): EmbeddingBacken
   for (const provider of order) {
     switch (provider) {
       case 'local':
+        if (localBackendBroken) continue;
         return {
           backend: getCachedOrCreate('local', config.memory.embeddings.localModel,
             () => new LazyLocalEmbeddingBackend(config.memory.embeddings.localModel)),


### PR DESCRIPTION
Address review feedback on PR #9843. When onnxruntime-node fails to load, remember the failure so auto mode stops selecting local as primary backend on subsequent calls, avoiding repeated fallback latency.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
