### PR TITLE
fix: reject custom secret patterns that produce zero-length matches

### DIFF
--- a/assistant/src/security/secret-scanner.ts
+++ b/assistant/src/security/secret-scanner.ts
@@ -696,6 +696,15 @@ export function compileCustomPatterns(inputs: CustomPatternInput[]): SecretPatte
         log.warn({ label, pattern }, 'Skipping custom secret pattern that matches empty strings');
         continue;
       }
+      // Zero-width assertions (lookaheads, \b, etc.) pass the empty-string check
+      // but still produce zero-length matches on real text, stalling the exec loop.
+      regex.lastIndex = 0;
+      const sampleMatch = regex.exec('abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-/+=');
+      regex.lastIndex = 0;
+      if (sampleMatch && sampleMatch[0].length === 0) {
+        log.warn({ label, pattern }, 'Skipping custom secret pattern that produces zero-length matches');
+        continue;
+      }
       compiled.push({ type: label, regex });
     } catch (err) {
       log.warn({ label, pattern, error: String(err) }, 'Skipping invalid custom secret pattern');


### PR DESCRIPTION
Address review feedback on PR #9854. Adds a secondary check that tests compiled custom regex patterns against a sample string to detect zero-width matches (e.g., lookaheads, word boundaries) that would cause infinite loops in the scanning loops.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
