### PR TITLE
Fix deliver/slack JSON guard and schema

### DIFF
--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -38,6 +38,10 @@ export function createSlackDeliverHandler(config: GatewayConfig) {
       return Response.json({ error: "Invalid JSON" }, { status: 400 });
     }
 
+    if (typeof body !== 'object' || body === null) {
+      return Response.json({ ok: false, error: "Invalid request body" }, { status: 400 });
+    }
+
     if (body.attachments && Array.isArray(body.attachments) && body.attachments.length > 0) {
       return Response.json(
         { error: "Slack attachments not supported in MVP" },

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1216,7 +1216,6 @@ export function buildSchema(): Record<string, unknown> {
         },
         SlackDeliverRequest: {
           type: "object",
-          required: ["chatId", "text"],
           description: "Request to deliver a message to a Slack channel. Accepts either `chatId` or `to` (alias) as the Slack channel ID.",
           properties: {
             chatId: { type: "string", description: "Slack channel ID to deliver the message to" },
@@ -1224,6 +1223,10 @@ export function buildSchema(): Record<string, unknown> {
             text: { type: "string", description: "Text content to send", minLength: 1 },
             assistantId: { type: "string", description: "Optional assistant ID" },
           },
+          allOf: [
+            { anyOf: [{ required: ["chatId"] }, { required: ["to"] }] },
+            { required: ["text"] },
+          ],
         },
         SlackDeliverOk: {
           type: "object",


### PR DESCRIPTION
Add non-object JSON body rejection and fix OpenAPI schema to use anyOf for chatId/to aliasing.\n\nAddresses review feedback on #9899.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
