### PR TITLE
Remove Slack guardian row and fix docs typo

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -663,10 +663,7 @@ struct SettingsConnectTab: View {
                     .foregroundColor(VColor.error)
             }
 
-            if store.slackChannelHasBotToken && store.slackChannelHasAppToken {
-                Divider().background(VColor.surfaceBorder)
-                guardianStatusRow(channel: "slack")
-            }
+
         }
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -469,7 +469,7 @@ The Slack channel requires two tokens:
 | Token | Format | Purpose |
 |-------|--------|---------|
 | App token | `xapp-...` | Used for `apps.connections.open` to establish the Socket Mode WebSocket connection |
-| Bot token | `xbot-...` / `xoxb-...` | Used for `chat.postMessage` to send outbound messages and for `auth.test` validation |
+| Bot token | `xoxb-...` | Used for `chat.postMessage` to send outbound messages and for `auth.test` validation |
 
 Both tokens are stored in secure storage (`credential:slack_channel:app_token`, `credential:slack_channel:bot_token`) via the assistant's Slack channel config endpoints (see `assistant/ARCHITECTURE.md`). The gateway reads them via its `credential-reader` module using the same keychain-first fallback strategy as Telegram credentials.
 


### PR DESCRIPTION
Remove non-functional guardian row from Slack channel card (guardian not wired up for Slack in MVP) and fix xbot- typo to xoxb- in architecture docs.\n\nAddresses review feedback on #9903 and #9906.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
