### PR TITLE
fix: persist token to disk before updating in-memory auth state in rotation flow

### DIFF
--- a/assistant/docs/architecture/http-token-refresh.md
+++ b/assistant/docs/architecture/http-token-refresh.md
@@ -148,9 +148,16 @@ private isValidToken(provided: string): boolean {
   return false;
 }
 
-// Routine rotation: set grace period, emit event
+// Persist token to disk before updating in-memory auth state.
+// If disk write fails, in-memory state is unchanged — clients
+// keep using the old token and are never locked out.
 private rotateToken(revoke: boolean): string {
   const newToken = generateToken();
+
+  // Step 1: persist to disk first — if this throws, auth state is untouched
+  writeTokenToDisk(newToken);
+
+  // Step 2: update in-memory auth state (only after disk success)
   if (revoke) {
     // Revocation: immediate invalidation, no SSE push
     this.currentToken = newToken;
@@ -164,7 +171,6 @@ private rotateToken(revoke: boolean): string {
     this.graceDeadline = Date.now() + GRACE_PERIOD_MS;
     this.emitTokenRotatedEvent(newToken, this.graceDeadline);
   }
-  writeTokenToDisk(newToken);
   return newToken;
 }
 ```


### PR DESCRIPTION
Address review feedback on PR #9890. Updates the rotateToken pseudocode in the architecture doc to persist the new token to disk before updating in-memory auth state, preventing client lockout if disk persistence fails.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
