### PR TITLE
fix: allow zero candidate budget and conditionally omit degradation notice

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -479,14 +479,17 @@ function formatRecallResult(
   const noticeTokenCost = degradationNotice
     ? estimateTextTokens(degradationNotice) + 2 // +2 for '\n\n' separator
     : 0;
-  const candidateBudget = Math.max(1, maxInjectTokens - noticeTokenCost);
+  // When the notice alone exceeds the budget, skip it entirely so
+  // injectedText never exceeds maxInjectTokens.
+  const budgetForNotice = noticeTokenCost <= maxInjectTokens;
+  const candidateBudget = budgetForNotice ? maxInjectTokens - noticeTokenCost : maxInjectTokens;
 
   const selected = trimToTokenBudget(merged, candidateBudget, config.memory.retrieval.injectionFormat);
   markItemUsage(selected);
 
   let injectedText = buildInjectedText(selected, config.memory.retrieval.injectionFormat);
 
-  if (degradationNotice) {
+  if (degradationNotice && budgetForNotice) {
     injectedText = injectedText.length > 0
       ? injectedText + '\n\n' + degradationNotice
       : degradationNotice;


### PR DESCRIPTION
Address review feedback on PR #9885. When maxInjectTokens is smaller than the degradation notice token cost, the notice is now skipped entirely and the full budget goes to candidates. This prevents injectedText from exceeding the declared token cap in low-budget configurations.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
