### PR TITLE
fix: inject X-Forwarded-For in gateway proxy and trust it conditionally in runtime

### DIFF
--- a/assistant/src/runtime/middleware/rate-limiter.ts
+++ b/assistant/src/runtime/middleware/rate-limiter.ts
@@ -132,17 +132,44 @@ export const apiRateLimiter = new TokenRateLimiter();
 export const ipRateLimiter = new TokenRateLimiter(DEFAULT_IP_MAX_REQUESTS, DEFAULT_IP_WINDOW_MS, MAX_TRACKED_IPS);
 
 /**
- * Extract the client IP from a request using the actual peer address.
- *
- * The runtime sits behind the gateway and should not trust X-Forwarded-For or
- * X-Real-IP headers — a client can spoof those to rotate IPs and bypass
- * per-IP rate limits. The gateway handles proxy-header trust with an explicit
- * trustProxy flag; here we always use the peer address from Bun's requestIP().
+ * Extract the client IP from a request. Only trusts proxy headers
+ * (X-Forwarded-For, X-Real-IP) when the peer IP is loopback or private,
+ * meaning the request arrived via the gateway. Direct connections from
+ * external clients use the peer IP, preventing header spoofing.
  */
 export function extractClientIp(
   req: Request,
   server: { requestIP(req: Request): { address: string } | null },
 ): string {
-  const peerIp = server.requestIP(req);
-  return peerIp?.address ?? '0.0.0.0';
+  const peerIp = server.requestIP(req)?.address ?? '0.0.0.0';
+
+  if (isTrustedPeer(peerIp)) {
+    const forwarded = req.headers.get('x-forwarded-for');
+    if (forwarded) {
+      const first = forwarded.split(',')[0].trim();
+      if (first) return first;
+    }
+
+    const realIp = req.headers.get('x-real-ip');
+    if (realIp) return realIp.trim();
+  }
+
+  return peerIp;
+}
+
+/** Returns true when the address is loopback or RFC-1918 private. */
+function isTrustedPeer(ip: string): boolean {
+  return (
+    ip === '127.0.0.1' ||
+    ip === '::1' ||
+    ip === '::ffff:127.0.0.1' ||
+    ip.startsWith('10.') ||
+    ip.startsWith('172.16.') || ip.startsWith('172.17.') || ip.startsWith('172.18.') ||
+    ip.startsWith('172.19.') || ip.startsWith('172.20.') || ip.startsWith('172.21.') ||
+    ip.startsWith('172.22.') || ip.startsWith('172.23.') || ip.startsWith('172.24.') ||
+    ip.startsWith('172.25.') || ip.startsWith('172.26.') || ip.startsWith('172.27.') ||
+    ip.startsWith('172.28.') || ip.startsWith('172.29.') || ip.startsWith('172.30.') ||
+    ip.startsWith('172.31.') ||
+    ip.startsWith('192.168.')
+  );
 }

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -16,7 +16,7 @@ const log = getLogger("runtime-proxy");
 const WEBHOOK_PATH_RE = /^\/webhooks\//;
 
 export function createRuntimeProxyHandler(config: GatewayConfig) {
-  return async (req: Request): Promise<Response> => {
+  return async (req: Request, clientIp?: string): Promise<Response> => {
     const start = performance.now();
     const url = new URL(req.url);
 
@@ -61,6 +61,12 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
     // the upstream service and must be forwarded.
     if (config.runtimeProxyRequireAuth) {
       reqHeaders.delete("authorization");
+    }
+
+    // Inject the real client IP so the runtime can rate-limit per-user,
+    // overwriting any client-supplied value to prevent spoofing.
+    if (clientIp) {
+      reqHeaders.set('x-forwarded-for', clientIp);
     }
 
     // Add the runtime's bearer token so the upstream accepts the request

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -337,7 +337,7 @@ function main() {
       }
 
       if (handleRuntimeProxy) {
-        const res = await handleRuntimeProxy(tracedReq);
+        const res = await handleRuntimeProxy(tracedReq, getClientIp(req, svr, config.trustProxy));
         if (res.status === 401) {
           authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
         }


### PR DESCRIPTION
Address review feedback on PR #9881. The gateway now injects X-Forwarded-For with the real client IP when proxying to the runtime. The runtime only trusts this header when the peer IP is loopback/private (i.e., the request came from the gateway), preventing spoofing from direct connections.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
