### PR TITLE
fix: permission status icons look like clickable remove buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -1001,9 +1001,9 @@ struct SettingsPanel: View {
 
                 Spacer()
 
-                Image(systemName: granted ? "checkmark.circle.fill" : "xmark.circle.fill")
+                Image(systemName: granted ? "checkmark.circle.fill" : "circle")
                     .font(.system(size: 16))
-                    .foregroundColor(granted ? VColor.success : VColor.error)
+                    .foregroundColor(granted ? VColor.success : VColor.textMuted)
             }
             .padding(VSpacing.md)
             .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
- Changed the "not granted" permission icon from `xmark.circle.fill` (red) to `circle` (muted gray)
- The red X icons were being mistaken for clickable "remove permission" buttons
- The unfilled circle now clearly reads as a "not yet configured" status indicator, contrasting with the green filled checkmark for granted permissions

## Original prompt
smol feedback: i thought the red x's here were clickable icons to remove the permission, assuming it was already configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9928" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
