### PR TITLE
Migrate browser relay clients to gateway ingress

### DIFF
--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -8,7 +8,7 @@
 
 import type { ExtensionCommand, ExtensionResponse, ExtensionHeartbeat } from '../../../assistant/src/browser-extension-relay/protocol.js';
 
-const DEFAULT_RELAY_PORT = 7821;
+const DEFAULT_RELAY_PORT = 7830;
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const RECONNECT_BASE_MS = 1_000;
 const RECONNECT_MAX_MS = 30_000;

--- a/clients/chrome-extension/popup/popup.html
+++ b/clients/chrome-extension/popup/popup.html
@@ -124,7 +124,7 @@
   <input
     type="text"
     id="port-input"
-    placeholder="7821"
+    placeholder="7830"
     autocomplete="off"
     spellcheck="false"
   />
@@ -134,7 +134,7 @@
     <button id="btn-disconnect" disabled>Disconnect</button>
   </div>
 
-  <p class="hint">Token is stored locally in your browser. Find it at <code>~/.vellum/http-token</code>. Port defaults to 7821.</p>
+  <p class="hint">Token is stored locally in your browser. Find it at <code>~/.vellum/http-token</code>. Port defaults to 7830.</p>
 
   <script type="module" src="popup.js"></script>
 </body>

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -1976,7 +1976,7 @@ struct SettingsConnectTab: View {
             let base = store.localGatewayTarget.hasSuffix("/")
                 ? String(store.localGatewayTarget.dropLast())
                 : store.localGatewayTarget
-            guard let url = URL(string: "\(base)/healthz") else {
+            guard let url = URL(string: "\(base)/v1/health") else {
                 isRegeneratingToken = false
                 return
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -1973,9 +1973,13 @@ struct SettingsConnectTab: View {
         }
         // Wait for the daemon to restart and become reachable with the new token.
         Task {
-            let port = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"]
-                .flatMap(Int.init) ?? 7821
-            let url = URL(string: "http://localhost:\(port)/healthz")!
+            let base = store.localGatewayTarget.hasSuffix("/")
+                ? String(store.localGatewayTarget.dropLast())
+                : store.localGatewayTarget
+            guard let url = URL(string: "\(base)/healthz") else {
+                isRegeneratingToken = false
+                return
+            }
             var request = URLRequest(url: url)
             request.setValue("Bearer \(newToken)", forHTTPHeaderField: "Authorization")
             request.timeoutInterval = 2

--- a/gateway/src/__tests__/browser-relay-websocket.test.ts
+++ b/gateway/src/__tests__/browser-relay-websocket.test.ts
@@ -140,6 +140,43 @@ describe("createBrowserRelayWebsocketHandler", () => {
     expect(res).toBeUndefined();
     expect(fakeServer.upgrade).toHaveBeenCalledTimes(1);
   });
+
+  test("returns 403 when non-loopback host is requested from a public peer", () => {
+    const config = makeConfig({ runtimeProxyBearerToken: TEST_TOKEN });
+    const handler = createBrowserRelayWebsocketHandler(config);
+    const req = new Request(
+      `http://gateway.example.com:7830/v1/browser-relay?token=${TEST_TOKEN}`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const fakeServer = {
+      requestIP: mock(() => ({ address: "8.8.8.8", family: "IPv4", port: 54000 })),
+      upgrade: mock(() => true),
+    } as unknown as import("bun").Server<any>;
+
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(403);
+    expect(fakeServer.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("allows non-loopback host when peer is private network", () => {
+    const config = makeConfig({ runtimeProxyBearerToken: TEST_TOKEN });
+    const handler = createBrowserRelayWebsocketHandler(config);
+    const req = new Request(
+      `http://gateway.example.com:7830/v1/browser-relay?token=${TEST_TOKEN}`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const fakeServer = {
+      requestIP: mock(() => ({ address: "10.42.0.8", family: "IPv4", port: 54000 })),
+      upgrade: mock(() => true),
+    } as unknown as import("bun").Server<any>;
+
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeUndefined();
+    expect(fakeServer.upgrade).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("getBrowserRelayWebsocketHandlers", () => {

--- a/gateway/src/__tests__/browser-relay-websocket.test.ts
+++ b/gateway/src/__tests__/browser-relay-websocket.test.ts
@@ -1,0 +1,189 @@
+import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+import type { GatewayConfig } from "../config.js";
+import {
+  createBrowserRelayWebsocketHandler,
+  getBrowserRelayWebsocketHandlers,
+} from "../http/routes/browser-relay-websocket.js";
+
+const WS_CONNECTING = WebSocket.CONNECTING; // 0
+const WS_OPEN = WebSocket.OPEN; // 1
+const WS_CLOSED = WebSocket.CLOSED; // 3
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  const merged: GatewayConfig = {
+    telegramBotToken: "tok",
+    telegramWebhookSecret: "wh-ver",
+    telegramApiBaseUrl: "https://api.telegram.org",
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeBearerToken: undefined,
+    runtimeGatewayOriginSecret: undefined,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    runtimeProxyBearerToken: undefined,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
+    twilioAuthToken: undefined,
+    twilioAccountSid: undefined,
+    twilioPhoneNumber: undefined,
+    smsDeliverAuthBypass: false,
+    ingressPublicBaseUrl: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    whatsappPhoneNumberId: undefined,
+    whatsappAccessToken: undefined,
+    whatsappAppSecret: undefined,
+    whatsappWebhookVerifyToken: undefined,
+    whatsappDeliverAuthBypass: false,
+    whatsappTimeoutMs: 15000,
+    whatsappMaxRetries: 3,
+    whatsappInitialBackoffMs: 1000,
+    trustProxy: false,
+    ...overrides,
+  };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
+}
+
+function createFakeDownstreamWs(data: Record<string, unknown> = {}) {
+  const sent: (string | Uint8Array)[] = [];
+  const closes: { code: number; reason: string }[] = [];
+  return {
+    data,
+    sent,
+    closes,
+    send: mock((msg: string | Uint8Array) => {
+      sent.push(msg);
+    }),
+    close: mock((code?: number, reason?: string) => {
+      closes.push({ code: code ?? 1000, reason: reason ?? "" });
+    }),
+  };
+}
+
+function createFakeUpstreamWs() {
+  const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+  const sent: unknown[] = [];
+  return {
+    readyState: WS_CONNECTING as number,
+    sent,
+    listeners,
+    addEventListener: mock((event: string, cb: (...args: unknown[]) => void) => {
+      (listeners[event] ??= []).push(cb);
+    }),
+    send: mock((msg: unknown) => {
+      sent.push(msg);
+    }),
+    close: mock(() => {}),
+    emit(event: string, detail: unknown = {}) {
+      for (const cb of listeners[event] ?? []) {
+        cb(detail);
+      }
+    },
+  };
+}
+
+describe("createBrowserRelayWebsocketHandler", () => {
+  const TEST_TOKEN = "relay-token-abc123";
+
+  test("upgrades when token query parameter is valid", () => {
+    const config = makeConfig({ runtimeProxyBearerToken: TEST_TOKEN });
+    const handler = createBrowserRelayWebsocketHandler(config);
+    const req = new Request(
+      `http://localhost:7830/v1/browser-relay?token=${TEST_TOKEN}`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const fakeServer = { upgrade: mock(() => true) } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeUndefined();
+    expect(fakeServer.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns 401 when token is missing", () => {
+    const config = makeConfig({ runtimeProxyBearerToken: TEST_TOKEN });
+    const handler = createBrowserRelayWebsocketHandler(config);
+    const req = new Request("http://localhost:7830/v1/browser-relay", {
+      headers: { upgrade: "websocket" },
+    });
+    const fakeServer = { upgrade: mock(() => true) } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(401);
+    expect(fakeServer.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("allows unauthenticated upgrade when runtime proxy auth is disabled", () => {
+    const config = makeConfig({ runtimeProxyRequireAuth: false, runtimeProxyBearerToken: undefined });
+    const handler = createBrowserRelayWebsocketHandler(config);
+    const req = new Request("http://localhost:7830/v1/browser-relay", {
+      headers: { upgrade: "websocket" },
+    });
+    const fakeServer = { upgrade: mock(() => true) } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeUndefined();
+    expect(fakeServer.upgrade).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("getBrowserRelayWebsocketHandlers", () => {
+  const OriginalWebSocket = globalThis.WebSocket;
+  let fakeUpstream: ReturnType<typeof createFakeUpstreamWs>;
+  let handlers: ReturnType<typeof getBrowserRelayWebsocketHandlers>;
+
+  beforeEach(() => {
+    fakeUpstream = createFakeUpstreamWs();
+    const MockWS = mock(() => fakeUpstream);
+    Object.assign(MockWS, {
+      CONNECTING: WS_CONNECTING,
+      OPEN: WS_OPEN,
+      CLOSING: 2,
+      CLOSED: WS_CLOSED,
+    });
+    globalThis.WebSocket = MockWS as unknown as typeof WebSocket;
+    handlers = getBrowserRelayWebsocketHandlers();
+  });
+
+  afterAll(() => {
+    globalThis.WebSocket = OriginalWebSocket;
+  });
+
+  test("open targets runtime browser-relay websocket and flushes buffered messages", () => {
+    const ws = createFakeDownstreamWs({
+      wsType: "browser-relay",
+      config: makeConfig({
+        assistantRuntimeBaseUrl: "http://runtime.internal:7821",
+        runtimeBearerToken: "runtime-token",
+      }),
+    });
+
+    handlers.open(ws as never);
+    handlers.message(ws as never, "hello-before-open");
+
+    const MockWS = globalThis.WebSocket as unknown as ReturnType<typeof mock>;
+    expect(MockWS).toHaveBeenCalledWith("ws://runtime.internal:7821/v1/browser-relay?token=runtime-token");
+
+    fakeUpstream.readyState = WS_OPEN;
+    fakeUpstream.emit("open");
+    expect(fakeUpstream.sent).toEqual(["hello-before-open"]);
+
+    fakeUpstream.emit("message", { data: "runtime-message" });
+    expect(ws.sent).toEqual(["runtime-message"]);
+  });
+});

--- a/gateway/src/http/routes/browser-relay-websocket.ts
+++ b/gateway/src/http/routes/browser-relay-websocket.ts
@@ -90,8 +90,9 @@ export function getBrowserRelayWebsocketHandlers() {
       const upstreamToken = config.runtimeBearerToken || config.runtimeProxyBearerToken || ws.data.clientToken;
       const query = upstreamToken ? `?token=${encodeURIComponent(upstreamToken)}` : "";
       const upstreamUrl = `${runtimeBase}/v1/browser-relay${query}`;
+      const logSafeUpstreamUrl = `${runtimeBase}/v1/browser-relay${upstreamToken ? "?token=<redacted>" : ""}`;
 
-      log.info({ upstreamUrl }, "Opening upstream browser relay WS to runtime");
+      log.info({ upstreamUrl: logSafeUpstreamUrl }, "Opening upstream browser relay WS to runtime");
 
       const upstream = new WebSocket(upstreamUrl);
       ws.data.upstream = upstream;

--- a/gateway/src/http/routes/browser-relay-websocket.ts
+++ b/gateway/src/http/routes/browser-relay-websocket.ts
@@ -1,0 +1,158 @@
+import type { GatewayConfig } from "../../config.js";
+import { getLogger } from "../../logger.js";
+import { validateBearerToken } from "../auth/bearer.js";
+
+const log = getLogger("browser-relay-ws");
+
+// Cap buffered messages to prevent unbounded memory growth if upstream stalls
+const MAX_PENDING_MESSAGES = 100;
+
+export type BrowserRelaySocketData = {
+  wsType: "browser-relay";
+  config: GatewayConfig;
+  clientToken?: string;
+  upstream?: WebSocket;
+  pendingMessages?: (string | ArrayBuffer | Uint8Array)[];
+};
+
+/**
+ * Create a WebSocket upgrade handler that proxies browser-relay frames between
+ * the local Chrome extension and the runtime's /v1/browser-relay endpoint.
+ */
+export function createBrowserRelayWebsocketHandler(config: GatewayConfig) {
+  return function handleUpgrade(
+    req: Request,
+    server: import("bun").Server<unknown>,
+  ): Response | undefined {
+    if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+      return new Response("Upgrade Required", { status: 426 });
+    }
+
+    const url = new URL(req.url);
+
+    const authResponse = checkBrowserRelayAuth(req, url, config);
+    if (authResponse) return authResponse;
+
+    const upgraded = server.upgrade(req, {
+      data: {
+        wsType: "browser-relay",
+        config,
+        clientToken: url.searchParams.get("token") ?? undefined,
+      },
+    });
+
+    if (!upgraded) {
+      return new Response("WebSocket upgrade failed", { status: 500 });
+    }
+
+    // Return undefined to indicate upgrade was handled
+    return undefined;
+  };
+}
+
+function checkBrowserRelayAuth(
+  req: Request,
+  url: URL,
+  config: GatewayConfig,
+): Response | null {
+  if (!config.runtimeProxyRequireAuth) return null;
+
+  if (!config.runtimeProxyBearerToken) {
+    log.error("Browser relay WS: no bearer token configured — rejecting (fail-closed)");
+    return new Response("Service not configured: bearer token required", { status: 503 });
+  }
+
+  const authHeader = req.headers.get("authorization");
+  const queryToken = url.searchParams.get("token");
+  const tokenSource = authHeader ?? (queryToken ? `Bearer ${queryToken}` : null);
+
+  const result = validateBearerToken(tokenSource, config.runtimeProxyBearerToken);
+  if (!result.authorized) {
+    log.warn({ reason: result.reason }, "Browser relay WS: authentication failed");
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  return null;
+}
+
+/**
+ * WebSocket handler config for Bun.serve() that proxies frames to runtime.
+ */
+export function getBrowserRelayWebsocketHandlers() {
+  return {
+    open(ws: import("bun").ServerWebSocket<BrowserRelaySocketData>) {
+      const { config } = ws.data;
+
+      // Initialize message buffer for frames arriving before upstream connects
+      ws.data.pendingMessages = [];
+
+      const runtimeBase = config.assistantRuntimeBaseUrl.replace(/^http/, "ws");
+      const upstreamToken = config.runtimeBearerToken || config.runtimeProxyBearerToken || ws.data.clientToken;
+      const query = upstreamToken ? `?token=${encodeURIComponent(upstreamToken)}` : "";
+      const upstreamUrl = `${runtimeBase}/v1/browser-relay${query}`;
+
+      log.info({ upstreamUrl }, "Opening upstream browser relay WS to runtime");
+
+      const upstream = new WebSocket(upstreamUrl);
+      ws.data.upstream = upstream;
+
+      upstream.addEventListener("open", () => {
+        log.info("Upstream browser relay WS connected");
+        const pending = ws.data.pendingMessages;
+        if (pending) {
+          for (const msg of pending) {
+            upstream.send(msg);
+          }
+          ws.data.pendingMessages = undefined;
+        }
+      });
+
+      upstream.addEventListener("message", (event) => {
+        const data = typeof event.data === "string"
+          ? event.data
+          : new Uint8Array(event.data as ArrayBuffer);
+        ws.send(data);
+      });
+
+      upstream.addEventListener("close", (event) => {
+        log.info({ code: event.code }, "Upstream browser relay WS closed");
+        ws.close(event.code, event.reason);
+      });
+
+      upstream.addEventListener("error", (event) => {
+        log.error({ error: event }, "Upstream browser relay WS error");
+        ws.close(1011, "Upstream error");
+      });
+    },
+
+    message(
+      ws: import("bun").ServerWebSocket<BrowserRelaySocketData>,
+      message: string | ArrayBuffer | Uint8Array,
+    ) {
+      const upstream = ws.data.upstream;
+      if (upstream && upstream.readyState === WebSocket.OPEN) {
+        upstream.send(message);
+      } else if (ws.data.pendingMessages) {
+        if (ws.data.pendingMessages.length >= MAX_PENDING_MESSAGES) {
+          log.warn("Browser relay pending message buffer overflow — closing connection");
+          ws.close(1008, "Buffer overflow");
+          return;
+        }
+        ws.data.pendingMessages.push(message);
+      }
+    },
+
+    close(
+      ws: import("bun").ServerWebSocket<BrowserRelaySocketData>,
+      code: number,
+      reason: string,
+    ) {
+      const { upstream } = ws.data;
+      log.info({ code, reason }, "Browser relay downstream WS closed");
+      ws.data.pendingMessages = undefined;
+      if (upstream && (upstream.readyState === WebSocket.OPEN || upstream.readyState === WebSocket.CONNECTING)) {
+        upstream.close(code, reason);
+      }
+    },
+  };
+}

--- a/gateway/src/http/routes/browser-relay-websocket.ts
+++ b/gateway/src/http/routes/browser-relay-websocket.ts
@@ -7,6 +7,41 @@ const log = getLogger("browser-relay-ws");
 // Cap buffered messages to prevent unbounded memory growth if upstream stalls
 const MAX_PENDING_MESSAGES = 100;
 
+function isLoopbackHost(hostname: string): boolean {
+  return hostname === "127.0.0.1" || hostname === "::1" || hostname === "localhost";
+}
+
+function isPrivateAddress(addr: string): boolean {
+  const v4Mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
+  const normalized = v4Mapped ? v4Mapped[1] : addr;
+
+  if (normalized.includes(".")) {
+    const parts = normalized.split(".").map(Number);
+    if (parts.length !== 4 || parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)) return false;
+
+    if (parts[0] === 127) return true;
+    if (parts[0] === 10) return true;
+    if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true;
+    if (parts[0] === 192 && parts[1] === 168) return true;
+    if (parts[0] === 169 && parts[1] === 254) return true;
+
+    return false;
+  }
+
+  const lower = normalized.toLowerCase();
+  if (lower === "::1") return true;
+  if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
+  if (lower.startsWith("fe80")) return true;
+
+  return false;
+}
+
+function isPrivateNetworkPeer(server: import("bun").Server<unknown>, req: Request): boolean {
+  const ip = server.requestIP(req);
+  if (!ip) return false;
+  return isPrivateAddress(ip.address);
+}
+
 export type BrowserRelaySocketData = {
   wsType: "browser-relay";
   config: GatewayConfig;
@@ -29,6 +64,11 @@ export function createBrowserRelayWebsocketHandler(config: GatewayConfig) {
     }
 
     const url = new URL(req.url);
+
+    // Match runtime policy: browser relay is local/private-network only.
+    if (!isLoopbackHost(url.hostname) && !isPrivateNetworkPeer(server, req)) {
+      return new Response("Browser relay only accepts connections from localhost", { status: 403 });
+    }
 
     const authResponse = checkBrowserRelayAuth(req, url, config);
     if (authResponse) return authResponse;

--- a/gateway/src/http/routes/twilio-relay-websocket.ts
+++ b/gateway/src/http/routes/twilio-relay-websocket.ts
@@ -19,7 +19,7 @@ type RelaySocketData = {
  * frames between Twilio and the runtime's /v1/calls/relay endpoint.
  */
 export function createTwilioRelayWebsocketHandler(config: GatewayConfig) {
-  return function handleUpgrade(req: Request, server: import("bun").Server<RelaySocketData>): Response | undefined {
+  return function handleUpgrade(req: Request, server: import("bun").Server<unknown>): Response | undefined {
     const url = new URL(req.url);
     const callSessionId = url.searchParams.get("callSessionId");
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -324,7 +324,7 @@ function main() {
         return undefined as unknown as Response;
       }
 
-      if (url.pathname === "/v1/browser-relay") {
+      if (config.runtimeProxyEnabled && url.pathname === "/v1/browser-relay") {
         const upgradeResult = handleBrowserRelayWs(req, server);
         if (upgradeResult !== undefined) return upgradeResult;
         // If upgrade was handled, Bun doesn't need a response

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -7,6 +7,11 @@ import { ConfigFileWatcher } from "./config-file-watcher.js";
 import { loadConfig, type GatewayConfig } from "./config.js";
 import { CredentialWatcher } from "./credential-watcher.js";
 import { createRuntimeProxyHandler } from "./http/routes/runtime-proxy.js";
+import {
+  createBrowserRelayWebsocketHandler,
+  getBrowserRelayWebsocketHandlers,
+  type BrowserRelaySocketData,
+} from "./http/routes/browser-relay-websocket.js";
 import { createTelegramDeliverHandler } from "./http/routes/telegram-deliver.js";
 import { createTelegramReconcileHandler } from "./http/routes/telegram-reconcile.js";
 import { createTelegramWebhookHandler } from "./http/routes/telegram-webhook.js";
@@ -37,6 +42,10 @@ let draining = false;
 
 // Shared rate limiter for auth failures and unauthenticated endpoints
 const authRateLimiter = new AuthRateLimiter();
+
+function isBrowserRelaySocketData(data: unknown): data is BrowserRelaySocketData {
+  return !!data && typeof data === "object" && (data as { wsType?: unknown }).wsType === "browser-relay";
+}
 
 function getClientIp(req: Request, server: ReturnType<typeof Bun.serve>, trustProxy: boolean): string {
   if (trustProxy) {
@@ -123,6 +132,9 @@ function main() {
   const handleTwilioStatusWebhook = createTwilioStatusWebhookHandler(config);
   const handleTwilioConnectActionWebhook = createTwilioConnectActionWebhookHandler(config);
   const handleTwilioRelayWs = createTwilioRelayWebsocketHandler(config);
+  const handleBrowserRelayWs = createBrowserRelayWebsocketHandler(config);
+  const twilioRelayWebsocketHandlers = getRelayWebsocketHandlers();
+  const browserRelayWebsocketHandlers = getBrowserRelayWebsocketHandlers();
   const { handler: handleTwilioSmsWebhook, dedupCache: smsDedupCache } = createTwilioSmsWebhookHandler(config);
   const handleSmsDeliver = createSmsDeliverHandler(config);
   const { handler: handleWhatsAppWebhook, dedupCache: whatsappDedupCache } = createWhatsAppWebhookHandler(config);
@@ -136,7 +148,29 @@ function main() {
 
   const server = Bun.serve({
     port: config.port,
-    websocket: getRelayWebsocketHandlers(),
+    websocket: {
+      open(ws) {
+        if (isBrowserRelaySocketData(ws.data)) {
+          browserRelayWebsocketHandlers.open(ws as never);
+          return;
+        }
+        twilioRelayWebsocketHandlers.open(ws as never);
+      },
+      message(ws, message) {
+        if (isBrowserRelaySocketData(ws.data)) {
+          browserRelayWebsocketHandlers.message(ws as never, message);
+          return;
+        }
+        twilioRelayWebsocketHandlers.message(ws as never, message);
+      },
+      close(ws, code, reason) {
+        if (isBrowserRelaySocketData(ws.data)) {
+          browserRelayWebsocketHandlers.close(ws as never, code, reason);
+          return;
+        }
+        twilioRelayWebsocketHandlers.close(ws as never, code, reason);
+      },
+    },
     error(err) {
       if (err instanceof CircuitBreakerOpenError) {
         return Response.json(
@@ -284,6 +318,13 @@ function main() {
 
       if (url.pathname === "/webhooks/twilio/relay" || url.pathname === "/v1/calls/relay") {
         const upgradeResult = handleTwilioRelayWs(req, server);
+        if (upgradeResult !== undefined) return upgradeResult;
+        // If upgrade was handled, Bun doesn't need a response
+        return undefined as unknown as Response;
+      }
+
+      if (url.pathname === "/v1/browser-relay") {
+        const upgradeResult = handleBrowserRelayWs(req, server);
         if (upgradeResult !== undefined) return upgradeResult;
         // If upgrade was handled, Bun doesn't need a response
         return undefined as unknown as Response;

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -212,6 +212,7 @@ function main() {
           url.pathname !== "/v1/calls/twilio/voice-webhook" &&
           url.pathname !== "/v1/calls/twilio/status" &&
           url.pathname !== "/v1/calls/twilio/connect-action" &&
+          url.pathname !== "/v1/browser-relay" &&
           url.pathname !== "/v1/calls/relay");
       if (isRateLimitedRoute) {
         const clientIp = getClientIp(req, svr, config.trustProxy);


### PR DESCRIPTION
## Summary
- migrate the remaining direct runtime client defaults from port `7821` to the gateway port `7830` in macOS settings and Chrome extension UI/worker
- add gateway websocket handling for `/v1/browser-relay` so browser-relay traffic can flow through gateway ingress instead of directly to the daemon
- add focused gateway tests for browser-relay websocket auth, upgrade, and proxy behavior

## Validation
- `cd gateway && bunx tsc --noEmit`
- `cd gateway && bun test src/__tests__/browser-relay-websocket.test.ts src/__tests__/twilio-relay-websocket.test.ts`