### PR TITLE
fix: prevent multiple threads appearing active in side nav

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -766,14 +766,17 @@ struct MainWindowView: View {
     @ViewBuilder
     private func threadItem(_ thread: ThreadModel) -> some View {
         let isSelected: Bool = {
-            // Any panel selection deselects all threads
-            if case .panel = windowState.selection {
+            switch windowState.selection {
+            case .panel:
                 return false
+            case .thread(let id):
+                return id == thread.id
+            case .appEditing(_, let threadId):
+                return threadId == thread.id
+            case .app, .none:
+                // No explicit thread in selection; fall back to the persistent thread.
+                return thread.id == windowState.persistentThreadId
             }
-            if thread.id == windowState.persistentThreadId { return true }
-            if case .thread(let id) = windowState.selection, id == thread.id { return true }
-            if case .appEditing(_, let threadId) = windowState.selection, threadId == thread.id { return true }
-            return false
         }()
         let isHovered = sidebar.isHoveredThread == thread.id
         let isBusy = threadManager.isThreadBusy(thread.id)


### PR DESCRIPTION
## Summary
- Rewrote the `isSelected` logic in `threadItem()` to use an exhaustive `switch` on `windowState.selection` instead of independent `if` checks
- When `selection` is `.thread(id)` or `.appEditing(_, threadId)`, only that thread highlights — `persistentThreadId` is no longer checked as a parallel path
- The `persistentThreadId` fallback now only applies when `selection` is `.app` or `.none` (no explicit thread)

## Root cause
`persistentThreadId` and `windowState.selection` could point to different threads (e.g., when `openConversationThread` sets `activeThreadId` without updating `selection`). The old code checked both independently, so two threads could both match `isSelected == true` through different branches.

## Original prompt
We sometimes show multiple conversation threads as active in the side nav, but there should only ever be up to one. Help me find the root cause and fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
