### PR TITLE
docs: add assistant-driven judgement principle to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,6 +336,18 @@ Prefer skills in `assistant/skills/vellum-skills/` that teach the model how to u
 
 Keep the system prompt as minimal as possible. Avoid adding instructions about how to use tools; only document what tools exist when they are basic, primitive, and universally useful. Prefer CLI programs that the assistant can progressively learn to use via `--help`.
 
+## Assistant-Driven Judgement
+
+All judgement calls that affect the user's experience should be made by the assistant through the daemon process — not by hard-coded logic or deterministic heuristics in application code.
+
+Concretely:
+- **Prefer LLM judgement over if/else.** When a decision requires interpreting intent, tone, priority, relevance, or any other subjective quality, route it through the assistant rather than encoding a fixed rule. Hard-coded heuristics are brittle and cannot adapt to context the way the model can.
+- **Reserve deterministic logic for mechanical operations.** Parsing, validation, data transformation, access control, and protocol enforcement are fine as code. The line is: if the decision requires understanding meaning or context, it belongs to the assistant; if it's purely structural or policy-enforced, code is appropriate.
+- **Don't approximate the assistant with heuristics.** If you find yourself writing a cascade of string matches, keyword checks, or scoring functions to simulate what the model would decide, stop — that's a sign the decision should be delegated to the daemon instead.
+- **Treat the daemon as the judgement layer.** The assistant carries user context, preferences, conversation history, and identity. Decisions routed through it benefit from all of that. Decisions made in application code discard it.
+
+When in doubt, ask: "Am I encoding a judgement that the assistant could make better with context?" If yes, route it through the daemon.
+
 ## Migration Guidance
 
 When touching existing tool-based flows, migrate behavior toward skill-driven CLI usage instead of adding new registered tools.


### PR DESCRIPTION
## Summary
- Adds a new "Assistant-Driven Judgement" section to AGENTS.md establishing the principle that subjective decisions affecting user experience should be routed through the assistant daemon, not hard-coded as deterministic heuristics
- Provides concrete guidance on when to use LLM judgement vs deterministic code (meaning/context → assistant; structural/policy → code)

## Original prompt
Update AGENTS.md to have something to help instill the following intent: All judgements should be determined by the assistant through the daemon process. We should avoid using hard-coded logic and deterministic heuristics for most judgement calls that impact the user's experience. We want as much as possible to be driven by the assistant itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
