### PR TITLE
M8: Add PTT key indicator to menu bar and toolbar

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -7,6 +7,7 @@ extension Notification.Name {
     static let updateDynamicWorkspace = Notification.Name("MainWindow.updateDynamicWorkspace")
     static let dismissDynamicWorkspace = Notification.Name("MainWindow.dismissDynamicWorkspace")
     static let openDocumentEditor = Notification.Name("MainWindow.openDocumentEditor")
+    static let navigateToSettingsTab = Notification.Name("MainWindow.navigateToSettingsTab")
 }
 
 /// Manages API keys in the macOS login keychain.

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -211,7 +211,26 @@ extension AppDelegate {
         return true
     }
 
+    /// Builds the status item tooltip, appending PTT key info when enabled.
+    private func menuBarTooltip() -> String {
+        let activationKey = UserDefaults.standard.string(forKey: "activationKey") ?? "fn"
+        let keyName: String? = {
+            switch activationKey {
+            case "fn": return "Fn"
+            case "ctrl": return "Ctrl"
+            case "fn_shift": return "Fn+Shift"
+            case "none": return nil
+            default: return nil
+            }
+        }()
+        if let keyName {
+            return "Vellum — hold \(keyName) to talk"
+        }
+        return "Vellum"
+    }
+
     func configureMenuBarIcon(_ button: NSStatusBarButton) {
+        button.toolTip = menuBarTooltip()
         let iconSize: CGFloat = 18
         let dotSize: CGFloat = 6
         let dotPadding: CGFloat = 0.5

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -497,6 +497,10 @@ struct MainWindowView: View {
                             )
                         }
                         Spacer()
+                        PTTKeyIndicator {
+                            windowState.selection = .panel(.settings)
+                            NotificationCenter.default.post(name: .navigateToSettingsTab, object: SettingsTab.wakeWord)
+                        }
                         if windowState.isShowingChat || isChatBubbleActive {
                             // Copy Thread button — only visible when there's content to copy
                             if threadManager.activeViewModel?.messages.contains(where: {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PTTKeyIndicator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PTTKeyIndicator.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Small pill in the toolbar showing the current push-to-talk activation key.
+/// Hidden when PTT is disabled (activationKey == "none").
+/// Tapping navigates to the Voice/Wake Word settings tab.
+struct PTTKeyIndicator: View {
+    @AppStorage("activationKey") private var activationKey: String = "fn"
+    @State private var isHovered = false
+
+    let onTap: () -> Void
+
+    private var displayName: String? {
+        switch activationKey {
+        case "fn": return "Fn"
+        case "ctrl": return "Ctrl"
+        case "fn_shift": return "Fn+\u{21E7}"
+        case "none": return nil
+        default: return nil
+        }
+    }
+
+    var body: some View {
+        if let keyName = displayName {
+            Button(action: onTap) {
+                HStack(spacing: 4) {
+                    Image(systemName: "mic.fill")
+                        .font(.system(size: 9))
+                    Text(keyName)
+                        .font(VFont.caption)
+                }
+                .foregroundColor(isHovered ? VColor.textPrimary : VColor.textSecondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(
+                    Capsule()
+                        .fill(isHovered ? VColor.surfaceSubtle.opacity(0.8) : VColor.surfaceSubtle)
+                )
+                .overlay(
+                    Capsule()
+                        .strokeBorder(VColor.surfaceBorder, lineWidth: 0.5)
+                )
+            }
+            .buttonStyle(.plain)
+            .onHover { hovering in
+                isHovered = hovering
+            }
+            .help("Push-to-talk: hold \(keyName)")
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -135,6 +135,11 @@ struct SettingsPanel: View {
                 }
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .navigateToSettingsTab)) { notification in
+            if let tab = notification.object as? SettingsTab {
+                selectedTab = tab
+            }
+        }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             // Primary mechanism: Check permissions when app becomes active.
             // This handles the common case where the user grants permission in


### PR DESCRIPTION
## Summary
- Adds a mic + key pill indicator to the NavigationToolbar showing the current PTT key
- Clicking the pill navigates to Voice settings
- Hidden when PTT is disabled
- Menu bar tooltip now includes PTT key info (e.g., 'hold Fn to talk')

Part of #9929
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
