### PR TITLE
M6: Move ElevenLabs TTS config into Voice tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -192,7 +192,7 @@ struct SettingsPanel: View {
         case .heartbeat:
             HeartbeatSettingsTab(daemonClient: daemonClient)
         case .voice:
-            VoiceSettingsView()
+            VoiceSettingsView(store: store)
         case .appearance:
             SettingsAppearanceTab(store: store)
         case .advanced:

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -5,10 +5,14 @@ import VellumAssistantShared
 /// enable/disable wake word listening, configure keyword phrase,
 /// and conversation timeout.
 struct VoiceSettingsView: View {
+    @ObservedObject var store: SettingsStore
+
     @AppStorage("activationKey") private var activationKey: String = "fn"
     @AppStorage("wakeWordEnabled") private var wakeWordEnabled: Bool = false
     @AppStorage("wakeWordTimeoutSeconds") private var wakeWordTimeoutSeconds: Int = 30
     @AppStorage("wakeWordKeyword") private var wakeWordKeyword: String = "computer"
+
+    @State private var elevenLabsKeyText: String = ""
 
     private let suggestedKeywords = ["computer", "jarvis", "hey vellum", "assistant"]
 
@@ -35,6 +39,12 @@ struct VoiceSettingsView: View {
             keywordSection
             timeoutSection
             privacyNote
+
+            // Text-to-Speech
+            ttsDivider
+            ttsStatusSection
+            ttsKeySection
+            ttsPrivacyNote
         }
     }
 
@@ -405,5 +415,102 @@ struct VoiceSettingsView: View {
                         .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
                 )
         )
+    }
+
+    // MARK: - TTS Section Divider
+
+    private var ttsDivider: some View {
+        HStack(spacing: VSpacing.md) {
+            Text("TEXT-TO-SPEECH")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(VColor.textMuted)
+                .tracking(1)
+
+            Rectangle()
+                .fill(VColor.surfaceBorder)
+                .frame(height: 1)
+        }
+    }
+
+    // MARK: - TTS Status
+
+    private var ttsStatusSection: some View {
+        HStack(spacing: VSpacing.sm) {
+            Circle()
+                .fill(store.hasElevenLabsKey ? VColor.success : VColor.textMuted)
+                .frame(width: 8, height: 8)
+
+            Text(store.hasElevenLabsKey ? "ElevenLabs API key saved" : "ElevenLabs not configured")
+                .font(VFont.body)
+                .foregroundColor(store.hasElevenLabsKey ? VColor.success : VColor.textSecondary)
+
+            Spacer()
+        }
+        .padding(VSpacing.lg)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(store.hasElevenLabsKey ? VColor.success.opacity(0.08) : VColor.surfaceSubtle)
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.lg)
+                        .strokeBorder(store.hasElevenLabsKey ? VColor.success.opacity(0.2) : VColor.surfaceBorder, lineWidth: 1)
+                )
+        )
+    }
+
+    // MARK: - TTS Key Section
+
+    private var ttsKeySection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("ElevenLabs API Key")
+                .font(VFont.bodyMedium)
+                .foregroundColor(VColor.textPrimary)
+
+            Text("ElevenLabs provides high-quality voice responses during voice conversations. An API key is required.")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+
+            if store.hasElevenLabsKey {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(VColor.success)
+                        .font(.system(size: 14))
+                    Text(store.maskedElevenLabsKey)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Spacer()
+                    VButton(label: "Remove", style: .danger) {
+                        store.clearElevenLabsKey()
+                        elevenLabsKeyText = ""
+                    }
+                }
+            } else {
+                SecureField("Your ElevenLabs API key", text: $elevenLabsKeyText)
+                    .vInputStyle()
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+
+                VButton(label: "Save", style: .primary) {
+                    store.saveElevenLabsKey(elevenLabsKeyText)
+                    elevenLabsKeyText = ""
+                }
+            }
+        }
+        .padding(VSpacing.lg)
+        .vCard(background: VColor.surfaceSubtle)
+    }
+
+    // MARK: - TTS Privacy Note
+
+    private var ttsPrivacyNote: some View {
+        HStack(alignment: .top, spacing: VSpacing.sm) {
+            Image(systemName: "lock.fill")
+                .font(.system(size: 10))
+                .foregroundColor(VColor.textMuted)
+
+            Text("Your API key is stored securely in the macOS Keychain and is only used to generate voice responses.")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .lineSpacing(2)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Adds a Text-to-Speech section to the Voice settings tab
- ElevenLabs API key can now be configured alongside PTT and wake word settings
- Consolidates all voice-related configuration in one place

Part of #9929
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
