### PR TITLE
M5: Deep-link to specific settings tabs

### DIFF
--- a/assistant/src/daemon/handlers/navigate-settings.ts
+++ b/assistant/src/daemon/handlers/navigate-settings.ts
@@ -1,0 +1,27 @@
+import type { HandlerContext } from './shared.js';
+
+/**
+ * Valid settings tab identifiers matching the macOS client's SettingsTab enum.
+ * These correspond to the raw values the Swift client expects.
+ */
+export const SETTINGS_TABS = [
+  'Connect',
+  'Integrations',
+  'Trust',
+  'Schedules',
+  'Heartbeat',
+  'Wake Word',
+  'Appearance',
+  'Advanced',
+  'Parental',
+] as const;
+
+export type SettingsTabId = (typeof SETTINGS_TABS)[number];
+
+/**
+ * Broadcast a `navigate_settings` message to all connected clients,
+ * opening the settings panel to the specified tab.
+ */
+export function navigateToSettingsTab(ctx: HandlerContext, tab: SettingsTabId): void {
+  ctx.broadcast({ type: 'navigate_settings', tab });
+}

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -259,6 +259,7 @@
     "message_queued",
     "message_queued_deleted",
     "model_info",
+    "navigate_settings",
     "notification_intent",
     "notification_thread_created",
     "oauth_connect_result",

--- a/assistant/src/daemon/ipc-contract/integrations.ts
+++ b/assistant/src/daemon/ipc-contract/integrations.ts
@@ -334,6 +334,11 @@ export interface OpenUrl {
   title?: string;
 }
 
+export interface NavigateSettings {
+  type: 'navigate_settings';
+  tab: string;
+}
+
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
 export type _IntegrationsClientMessages =
@@ -369,4 +374,5 @@ export type _IntegrationsServerMessages =
   | IntegrationListResponse
   | IntegrationConnectResult
   | OAuthConnectResultResponse
-  | OpenUrl;
+  | OpenUrl
+  | NavigateSettings;

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -989,6 +989,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             }
         }
 
+        daemonClient.onNavigateSettings = { [weak self] msg in
+            Task { @MainActor in
+                self?.showSettingsTab(msg.tab)
+            }
+        }
+
         daemonClient.onPairingApprovalRequest = { [weak self] msg in
             guard let self else { return }
             if self.pairingApprovalWindow == nil {
@@ -2177,6 +2183,14 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     @objc public func showSettingsWindow(_ sender: Any?) {
         showMainWindow()
         mainWindow?.windowState.selection = .panel(.settings)
+    }
+
+    /// Opens the settings panel and navigates to a specific tab.
+    public func showSettingsTab(_ tab: String) {
+        if let settingsTab = SettingsTab(rawValue: tab) {
+            services.settingsStore.pendingSettingsTab = settingsTab
+        }
+        showSettingsWindow(nil)
     }
 
     // MARK: - Application Lifecycle

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -96,6 +96,16 @@ struct SettingsPanel: View {
             if testerModel == nil, let dc = daemonClient {
                 testerModel = ToolPermissionTesterModel(daemonClient: dc)
             }
+            if let pending = store.pendingSettingsTab {
+                selectedTab = pending
+                store.pendingSettingsTab = nil
+            }
+        }
+        .onChange(of: store.pendingSettingsTab) { _, newTab in
+            if let tab = newTab {
+                selectedTab = tab
+                store.pendingSettingsTab = nil
+            }
         }
         .onDisappear {
             daemonClient?.onIntegrationListResponse = nil

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -10,6 +10,12 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 /// (main window side panel) and its extracted tab views.
 @MainActor
 public final class SettingsStore: ObservableObject {
+    // MARK: - Navigation
+
+    /// Set externally (e.g. via IPC) to deep-link into a specific settings tab.
+    /// SettingsPanel observes this and clears it after applying.
+    @Published var pendingSettingsTab: SettingsTab?
+
     // MARK: - API Key State
 
     @Published var hasKey: Bool

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -380,6 +380,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends an `open_url` message.
     public var onOpenUrl: ((OpenUrlMessage) -> Void)?
 
+    /// Called when the daemon sends a `navigate_settings` message.
+    public var onNavigateSettings: ((IPCNavigateSettings) -> Void)?
+
     /// Called when the daemon sends a `ui_layout_config` message.
     public var onLayoutConfig: ((UiLayoutConfigMessage) -> Void)?
 

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -162,6 +162,8 @@ extension DaemonClient {
             onPublishPageResponse?(msg)
         case .openUrl(let msg):
             onOpenUrl?(msg)
+        case .navigateSettings(let msg):
+            onNavigateSettings?(msg)
         case .unpublishPageResponse:
             break // Handled via specific callback if needed
         case .memoryStatus(let msg):

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -2918,6 +2918,16 @@ public struct IPCModelSetRequest: Codable, Sendable {
     }
 }
 
+public struct IPCNavigateSettings: Codable, Sendable {
+    public let type: String
+    public let tab: String
+
+    public init(type: String, tab: String) {
+        self.type = type
+        self.tab = tab
+    }
+}
+
 /// Broadcast to connected macOS clients when a notification should be displayed.
 public struct IPCNotificationIntent: Codable, Sendable {
     public let type: String

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2289,6 +2289,7 @@ public enum ServerMessage: Decodable, Sendable {
     case ipcBlobProbeResult(IpcBlobProbeResultMessage)
     case daemonStatus(DaemonStatusMessage)
     case openUrl(OpenUrlMessage)
+    case navigateSettings(IPCNavigateSettings)
     case integrationListResponse(IPCIntegrationListResponse)
     case integrationConnectResult(IPCIntegrationConnectResult)
     case oauthConnectResult(IPCOAuthConnectResultResponse)
@@ -2616,6 +2617,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "open_url":
             let message = try OpenUrlMessage(from: decoder)
             self = .openUrl(message)
+        case "navigate_settings":
+            let message = try IPCNavigateSettings(from: decoder)
+            self = .navigateSettings(message)
         case "get_signing_identity":
             let message = try IPCGetSigningIdentityRequest(from: decoder)
             self = .getSigningIdentity(message)


### PR DESCRIPTION
## Summary
- Adds navigate_settings IPC message for daemon-to-client settings tab navigation
- Swift-side handler opens the settings panel to a specific tab
- SettingsPanel tab selection is now externally controllable via SettingsStore
- Enables the assistant to say "I've opened your Voice settings" and actually do it

Part of #9929
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
