### PR TITLE
fix: prevent stale thread highlight when archiving during overlay

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -668,15 +668,13 @@ struct MainWindowView: View {
         .onChange(of: threadManager.activeThreadId) { oldId, newId in
             // Sync activeThreadId changes back to selectedThreadId to keep sidebar selection in sync
             selectedThreadId = newId
-            // Update persistentThreadId when the active thread changes, but only
-            // if the user is currently viewing a thread or has no selection (not an overlay).
+            // Always sync persistentThreadId so the sidebar highlights the
+            // correct thread — even when an overlay (.panel, .app) is active.
+            // Without this, archiving the active thread while viewing a panel
+            // leaves persistentThreadId pointing at the archived (invisible) thread
+            // and the sidebar shows no active highlight.
             if let newId {
-                switch windowState.selection {
-                case .thread, .none, .appEditing:
-                    windowState.persistentThreadId = newId
-                default:
-                    break
-                }
+                windowState.persistentThreadId = newId
             }
             if case .panel(.intelligence) = windowState.selection {
                 windowState.selection = nil


### PR DESCRIPTION
## Summary
- Always update `persistentThreadId` when `activeThreadId` changes, regardless of overlay state (`.panel`, `.app`)
- Previously the handler skipped the update during overlays, so archiving the active thread while a panel was open left `persistentThreadId` pointing to the archived (invisible) thread — the sidebar then showed no active highlight
- Addresses [review feedback](https://github.com/vellum-ai/vellum-assistant/pull/9939#discussion_r2861408811) on #9939

## Original prompt
address this feedback: https://github.com/vellum-ai/vellum-assistant/pull/9939#discussion_r2861408811

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
