### PR TITLE
fix: new thread "+" button silently failing on threads with assistant-only messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -133,13 +133,13 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
     func createThread() {
         // If the active thread is still empty, just keep it instead of creating another.
-        // Skip this optimisation for private threads — they have different persistence
-        // semantics and should not be silently reused as standard threads.
+        // Only reuse when the thread is truly fresh: no messages at all, no persisted
+        // session, and not a private thread (which have different persistence semantics).
         if let activeId = activeThreadId,
            let vm = chatViewModels[activeId],
-           !vm.messages.contains(where: { $0.role == .user }) {
+           vm.messages.isEmpty {
             let activeThread = threads.first(where: { $0.id == activeId })
-            if activeThread?.kind != .private {
+            if activeThread?.kind != .private && activeThread?.sessionId == nil {
                 return
             }
         }


### PR DESCRIPTION
## Summary
- The empty-thread-reuse guard in `createThread()` was too aggressive — it treated any thread without user messages as "empty", including threads with assistant greetings, notification content, or restored sessions
- Changed the check from `!vm.messages.contains(where: { $0.role == .user })` to `vm.messages.isEmpty` so threads with any visible content are not silently reused
- Added `sessionId == nil` check so restored/persisted conversations are never silently reused

## Original prompt
Sometimes when I click the "+" button to the right of "Threads" in the side nav of the mac app, it doesn't actually start a new conversation thread like it should

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
