### PR TITLE
fix: mark local embedding backend broken on embed-time init failures

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -35,7 +35,18 @@ class LazyLocalEmbeddingBackend implements EmbeddingBackend {
 
   async embed(texts: string[], options?: EmbeddingRequestOptions): Promise<number[][]> {
     const backend = await this.getDelegate();
-    return backend.embed(texts, options);
+    try {
+      return await backend.embed(texts, options);
+    } catch (err) {
+      // The onnxruntime-node failure surfaces here during the first embed() call
+      // (via LocalEmbeddingBackend.initialize()). Mark broken so auto mode stops
+      // selecting local on subsequent requests.
+      if (!localBackendBroken && isInitializationError(err)) {
+        localBackendBroken = true;
+        log.warn({ err }, 'Local embedding backend permanently unavailable; auto mode will skip it');
+      }
+      throw err;
+    }
   }
 
   private async getDelegate(): Promise<EmbeddingBackend> {
@@ -55,6 +66,13 @@ class LazyLocalEmbeddingBackend implements EmbeddingBackend {
     }
     return this.initPromise;
   }
+}
+
+/** Detect errors thrown by LocalEmbeddingBackend.initialize() so we can
+ *  distinguish permanent init failures from transient embed-time errors. */
+function isInitializationError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.message.includes('Local embedding backend unavailable');
 }
 
 /** Global cache of embedding backend instances, keyed by "provider:model". */


### PR DESCRIPTION
Addresses review feedback on #9915:\n\nThe localBackendBroken flag was only set when the dynamic import/constructor failed, but onnxruntime failures happen later during embed() via initialize(). Now catches initialization failures during embed() and marks the backend as permanently broken so auto mode skips it.\n\nOriginal prompt: Address the feedback on PR #9915
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
