### PR TITLE
fix: bypass PID liveness gate for custom socket transports and guard cleanup

### DIFF
--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -43,9 +43,22 @@ extension DaemonClient {
             // Validate the daemon process is alive before attempting a socket connection.
             // The socket file can outlive the daemon (crash, unclean shutdown), causing
             // NWConnection to hang until the connect timeout instead of failing fast.
-            if FileManager.default.fileExists(atPath: path), !Self.isDaemonProcessAlive() {
+            //
+            // Skip this check for custom socket transports (VELLUM_DAEMON_SOCKET) —
+            // SSH-forwarded or external sockets have no local PID file.
+            let isCustomSocket = ProcessInfo.processInfo.environment["VELLUM_DAEMON_SOCKET"] != nil
+            if !isCustomSocket, FileManager.default.fileExists(atPath: path), !Self.isDaemonProcessAlive() {
                 log.warning("Stale daemon socket detected — PID is dead, removing socket at \(path, privacy: .public)")
-                try? FileManager.default.removeItem(atPath: path)
+                // Only remove the path if it is actually a Unix socket, not a regular file.
+                var isSocket = false
+                if let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+                   let fileType = attrs[.type] as? FileAttributeType,
+                   fileType == .typeSocket {
+                    isSocket = true
+                }
+                if isSocket {
+                    try? FileManager.default.removeItem(atPath: path)
+                }
                 isConnecting = false
                 throw NWError.posix(.ECONNREFUSED)
             }


### PR DESCRIPTION
Addresses review feedback on #9842:

1. Skips PID liveness check when a custom socket transport is in use (VELLUM_DAEMON_SOCKET), so SSH-forwarded/external sockets are not rejected.
2. Guards stale-socket cleanup to only remove actual Unix socket files, not regular files.

Original prompt: Address the feedback on PR #9842
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
