### PR TITLE
fix: guard scanText loop against zero-length regex matches

### DIFF
--- a/assistant/src/security/secret-scanner.ts
+++ b/assistant/src/security/secret-scanner.ts
@@ -609,6 +609,10 @@ function scanEncoded(
       pattern.regex.lastIndex = 0;
       let pm: RegExpExecArray | null;
       while ((pm = pattern.regex.exec(decoded)) != null) {
+        if (pm[0].length === 0) {
+          pattern.regex.lastIndex++;
+          continue;
+        }
         const value = pm[1] ?? pm[0];
         if (isPlaceholder(value)) continue;
         if (isAllowlisted(value)) continue;
@@ -742,6 +746,11 @@ export function scanText(
     pattern.regex.lastIndex = 0;
     let m: RegExpExecArray | null;
     while ((m = pattern.regex.exec(text)) != null) {
+      // Prevent infinite loops from zero-length matches (e.g. lookaheads, \b)
+      if (m[0].length === 0) {
+        pattern.regex.lastIndex++;
+        continue;
+      }
       // Use first capturing group if present, otherwise full match
       const value = m[1] ?? m[0];
       const startIndex = m.index + (m[0].indexOf(value));


### PR DESCRIPTION
Addresses review feedback on #9918:

The sample-string heuristic can't catch all zero-length patterns (e.g. `(?=\.)` or `(?<=foo)` when those tokens are absent from the sample). Adds a safety guard in both `scanText()` and `scanEncoded()`'s exec loops: when a match has zero length, advance `lastIndex` by 1 to prevent infinite loops. This is the standard safe pattern for zero-length regex matches.

The compile-time sample check remains as a best-effort filter, but the scan loop guard is the actual safety net.

Original prompt: Address the feedback on PR #9918
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
