### PR TITLE
fix: compute degradation notice budget correctly without separator when no candidates

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -476,9 +476,11 @@ function formatRecallResult(
   const degradationNotice = collected.semanticSearchFailed
     ? '[Note: Semantic search is currently unavailable. Memory recall is limited to lexical and recency matching — results may be incomplete or miss semantically relevant memories.]'
     : undefined;
-  const noticeTokenCost = degradationNotice
-    ? estimateTextTokens(degradationNotice) + 2 // +2 for '\n\n' separator
+  const noticeOnlyTokenCost = degradationNotice
+    ? estimateTextTokens(degradationNotice)
     : 0;
+  // +2 for '\n\n' separator — only needed when candidates are also present
+  const noticeTokenCost = noticeOnlyTokenCost + (degradationNotice ? 2 : 0);
   // When the notice alone exceeds the budget, skip it entirely so
   // injectedText never exceeds maxInjectTokens.
   const budgetForNotice = noticeTokenCost <= maxInjectTokens;
@@ -489,7 +491,13 @@ function formatRecallResult(
 
   let injectedText = buildInjectedText(selected, config.memory.retrieval.injectionFormat);
 
-  if (degradationNotice && budgetForNotice) {
+  // Show the notice if it fits: when candidates are present the separator
+  // cost was already reserved; when no candidates were selected, the notice
+  // alone (without separator) may still fit even if the full cost didn't.
+  const canShowNotice = degradationNotice && (
+    budgetForNotice || (selected.length === 0 && noticeOnlyTokenCost <= maxInjectTokens)
+  );
+  if (canShowNotice) {
     injectedText = injectedText.length > 0
       ? injectedText + '\n\n' + degradationNotice
       : degradationNotice;


### PR DESCRIPTION
Addresses review feedback on #9924:

The notice token cost was always including +2 for the separator, but the separator is only used when candidates are selected. Now computes separate costs with/without separator and uses the appropriate one based on whether candidates were selected.

Original prompt: Address the feedback on PR #9924
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
