### PR TITLE
fix: stabilize sidebar thread order — only pin/unpin causes movement

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -83,7 +83,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     @Published private(set) var busyThreadIds: Set<UUID> = []
 
     /// Threads that are not archived — used by the UI to populate the sidebar.
-    /// Sorted: pinned first (by pinnedOrder ascending), then unpinned by lastInteractedAt descending.
+    /// Sorted: pinned first (by pinnedOrder ascending), then unpinned by createdAt descending.
+    /// Using createdAt (not lastInteractedAt) keeps thread positions stable — only
+    /// pinning/unpinning causes a thread to move in the sidebar.
     var visibleThreads: [ThreadModel] {
         threads.filter { !$0.isArchived && $0.kind != .private }.sorted { a, b in
             if a.isPinned && b.isPinned {
@@ -91,7 +93,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             }
             if a.isPinned { return true }
             if b.isPinned { return false }
-            return a.lastInteractedAt > b.lastInteractedAt
+            return a.createdAt > b.createdAt
         }
     }
 


### PR DESCRIPTION
## Summary
- Changed `visibleThreads` sort key from `lastInteractedAt` to `createdAt` for unpinned threads
- Previously, sending or receiving any message updated `lastInteractedAt`, causing that thread to jump to the top of the sidebar unexpectedly
- Now threads maintain a stable position based on creation time — only pinning/unpinning causes movement
- `lastInteractedAt` is still used in the quick input window's "recent threads" list, which is unaffected

## Original prompt
right now, threads in the side nav move in the mac app for unexpected reasons. The only thing that should cause a thread to move is if it's pinned or unpinned. Help me fix this

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
