### PR TITLE
fix: notification clicks now consistently navigate to the backing conversation thread

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -440,9 +440,14 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
         // Handle activity completion notifications
         if categoryId == "ACTIVITY_COMPLETE" {
+            let sessionId = response.notification.request.content.userInfo["sessionId"] as? String
             await MainActor.run {
                 guard !self.isBootstrapping else { return }
-                self.showMainWindow()
+                if let sessionId, !sessionId.isEmpty {
+                    self.openConversationThread(conversationId: sessionId)
+                } else {
+                    self.showMainWindow()
+                }
             }
             return
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -330,6 +330,9 @@ extension AppDelegate {
                 return false
             }
             threadManager.activeThreadId = thread.id
+            // Switch the main content area to the chat thread so the user sees it
+            // even if they were last viewing a panel, app, or other non-chat view.
+            mainWindow?.windowState.selection = nil
             // Clear unseen state and notify the daemon when deep-linking into a
             // conversation. selectThread's unseen-clear is guarded by
             // id != previousActiveId, which is false when activeThreadId was

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -610,18 +610,19 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     func makeViewModel() -> ChatViewModel {
-        let viewModel = ChatViewModel(daemonClient: daemonClient, onToolCallsComplete: { [weak self] toolCalls in
+        let viewModel = ChatViewModel(daemonClient: daemonClient)
+        viewModel.onToolCallsComplete = { [weak self, weak viewModel] toolCalls in
             guard let self, let service = self.activityNotificationService else { return }
-            // Send notification when tool calls complete
+            let sessionId = viewModel?.sessionId ?? ""
             Task { @MainActor in
                 await service.notifySessionComplete(
                     summary: "Tool execution completed",
                     steps: toolCalls.count,
                     toolCalls: toolCalls,
-                    sessionId: "" // Session ID not needed for chat-based notifications
+                    sessionId: sessionId
                 )
             }
-        })
+        }
         viewModel.shouldAcceptConfirmation = { [weak self, weak viewModel] in
             guard let self, let viewModel else { return false }
             return self.isLatestToolUseRecipient(viewModel)


### PR DESCRIPTION
## Summary
- Reset `windowState.selection` to `nil` in `openConversationThread` so the chat view is shown even when the user was last viewing a panel, app, or settings
- Extract `sessionId` from `ACTIVITY_COMPLETE` notification userInfo and deep-link to the conversation thread via `openConversationThread`
- Pass the real `sessionId` from `ChatViewModel` to activity notifications instead of an empty string, enabling thread deep-linking for chat-based completions

## Original prompt
Clicking the "View" button in Mac desktop notifications now long consistently takes me to the relevant conversation thread that backs that notification. Help me find the root cause and fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
