### PR TITLE
M1: Decision Contract + Candidate Context

### DIFF
--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -3,14 +3,22 @@
  *
  * Validates that the deterministic fallback correctly classifies signals based
  * on urgency + requiresAction, that channel selection respects connected channels,
- * and that the copy-composer generates correct fallback copy for known event names.
+ * the copy-composer generates correct fallback copy for known event names, and
+ * thread action types are structurally correct.
  */
 
 import { describe, expect, test } from 'bun:test';
 
 import { composeFallbackCopy } from '../notifications/copy-composer.js';
 import type { NotificationSignal } from '../notifications/signal.js';
-import type { NotificationChannel } from '../notifications/types.js';
+import type {
+  NotificationChannel,
+  NotificationDecision,
+  ThreadAction,
+  ThreadActionReuseExisting,
+  ThreadActionStartNew,
+  ThreadCandidate,
+} from '../notifications/types.js';
 
 // -- Helpers -----------------------------------------------------------------
 
@@ -168,6 +176,123 @@ describe('notification decision strategy', () => {
         });
         expect(signal.attentionHints.urgency).toBe(urgency);
       }
+    });
+  });
+
+  // -- Thread action types ---------------------------------------------------
+
+  describe('thread action types', () => {
+    test('start_new action has correct shape', () => {
+      const action: ThreadActionStartNew = { action: 'start_new' };
+      expect(action.action).toBe('start_new');
+    });
+
+    test('reuse_existing action requires conversationId', () => {
+      const action: ThreadActionReuseExisting = {
+        action: 'reuse_existing',
+        conversationId: 'conv-123',
+      };
+      expect(action.action).toBe('reuse_existing');
+      expect(action.conversationId).toBe('conv-123');
+    });
+
+    test('ThreadAction union discriminates correctly', () => {
+      const startNew: ThreadAction = { action: 'start_new' };
+      const reuse: ThreadAction = { action: 'reuse_existing', conversationId: 'conv-456' };
+
+      expect(startNew.action).toBe('start_new');
+      expect(reuse.action).toBe('reuse_existing');
+      if (reuse.action === 'reuse_existing') {
+        expect(reuse.conversationId).toBe('conv-456');
+      }
+    });
+
+    test('decision output can include threadActions per channel', () => {
+      const decision: NotificationDecision = {
+        shouldNotify: true,
+        selectedChannels: ['vellum', 'telegram'] as NotificationChannel[],
+        reasoningSummary: 'Test decision with thread actions',
+        renderedCopy: {},
+        dedupeKey: 'test-dedupe',
+        confidence: 0.9,
+        fallbackUsed: false,
+        threadActions: {
+          vellum: { action: 'start_new' },
+          telegram: { action: 'reuse_existing', conversationId: 'conv-789' },
+        },
+      };
+
+      expect(decision.threadActions?.vellum?.action).toBe('start_new');
+      expect(decision.threadActions?.telegram?.action).toBe('reuse_existing');
+      if (decision.threadActions?.telegram?.action === 'reuse_existing') {
+        expect(decision.threadActions.telegram.conversationId).toBe('conv-789');
+      }
+    });
+
+    test('decision output without threadActions defaults to undefined', () => {
+      const decision: NotificationDecision = {
+        shouldNotify: true,
+        selectedChannels: ['vellum'] as NotificationChannel[],
+        reasoningSummary: 'No thread actions specified',
+        renderedCopy: {},
+        dedupeKey: 'test-dedupe-2',
+        confidence: 0.8,
+        fallbackUsed: false,
+      };
+
+      expect(decision.threadActions).toBeUndefined();
+    });
+  });
+
+  // -- ThreadCandidate type ---------------------------------------------------
+
+  describe('thread candidate metadata', () => {
+    test('candidate has required fields', () => {
+      const candidate: ThreadCandidate = {
+        conversationId: 'conv-100',
+        title: 'Guardian: What is the gate code?',
+        updatedAt: Date.now(),
+        latestSourceEventName: 'guardian.question',
+        channel: 'vellum' as NotificationChannel,
+      };
+
+      expect(candidate.conversationId).toBe('conv-100');
+      expect(candidate.channel).toBe('vellum');
+      expect(candidate.latestSourceEventName).toBe('guardian.question');
+    });
+
+    test('candidate includes guardian-specific context when present', () => {
+      const candidate: ThreadCandidate = {
+        conversationId: 'conv-200',
+        title: 'Guardian Question Thread',
+        updatedAt: Date.now(),
+        latestSourceEventName: 'guardian.question',
+        channel: 'telegram' as NotificationChannel,
+        pendingGuardianRequestCount: 2,
+        recentCallSessionId: 'call-sess-abc',
+      };
+
+      expect(candidate.pendingGuardianRequestCount).toBe(2);
+      expect(candidate.recentCallSessionId).toBe('call-sess-abc');
+    });
+
+    test('signal can carry thread candidates per channel', () => {
+      const signal = makeSignal({
+        threadCandidates: {
+          vellum: [
+            {
+              conversationId: 'conv-300',
+              title: 'Reminder thread',
+              updatedAt: Date.now() - 60_000,
+              latestSourceEventName: 'reminder.fired',
+              channel: 'vellum' as NotificationChannel,
+            },
+          ],
+        },
+      });
+
+      expect(signal.threadCandidates?.vellum).toHaveLength(1);
+      expect(signal.threadCandidates?.vellum?.[0]?.conversationId).toBe('conv-300');
     });
   });
 });

--- a/assistant/src/__tests__/notification-thread-candidate-validation.test.ts
+++ b/assistant/src/__tests__/notification-thread-candidate-validation.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Focused tests for thread candidate validation in the notification decision
+ * engine. Validates that:
+ * - Valid reuse targets pass validation
+ * - Invalid reuse targets are rejected and downgraded to start_new
+ * - Candidate context is structurally correct and auditable
+ * - The isValidCandidateId guard works as expected
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { isValidCandidateId } from '../notifications/thread-candidates.js';
+import type {
+  NotificationChannel,
+  ThreadAction,
+  ThreadCandidate,
+} from '../notifications/types.js';
+
+// -- Helpers -----------------------------------------------------------------
+
+function makeCandidate(overrides?: Partial<ThreadCandidate>): ThreadCandidate {
+  return {
+    conversationId: 'conv-default',
+    title: 'Test Thread',
+    updatedAt: Date.now(),
+    latestSourceEventName: 'test.event',
+    channel: 'vellum' as NotificationChannel,
+    ...overrides,
+  };
+}
+
+// -- Tests -------------------------------------------------------------------
+
+describe('thread candidate validation', () => {
+  describe('isValidCandidateId', () => {
+    test('returns true when conversationId matches a candidate', () => {
+      const candidates = [
+        makeCandidate({ conversationId: 'conv-001' }),
+        makeCandidate({ conversationId: 'conv-002' }),
+      ];
+
+      expect(isValidCandidateId('conv-001', candidates)).toBe(true);
+      expect(isValidCandidateId('conv-002', candidates)).toBe(true);
+    });
+
+    test('returns false when conversationId does not match any candidate', () => {
+      const candidates = [
+        makeCandidate({ conversationId: 'conv-001' }),
+      ];
+
+      expect(isValidCandidateId('conv-999', candidates)).toBe(false);
+    });
+
+    test('returns false for empty candidate list', () => {
+      expect(isValidCandidateId('conv-001', [])).toBe(false);
+    });
+
+    test('returns false for empty string conversationId', () => {
+      const candidates = [
+        makeCandidate({ conversationId: 'conv-001' }),
+      ];
+
+      expect(isValidCandidateId('', candidates)).toBe(false);
+    });
+
+    test('matching is exact (no substring or prefix matching)', () => {
+      const candidates = [
+        makeCandidate({ conversationId: 'conv-001' }),
+      ];
+
+      expect(isValidCandidateId('conv-00', candidates)).toBe(false);
+      expect(isValidCandidateId('conv-0011', candidates)).toBe(false);
+      expect(isValidCandidateId('CONV-001', candidates)).toBe(false);
+    });
+  });
+
+  describe('candidate metadata structure', () => {
+    test('candidate without guardian context has no optional fields', () => {
+      const candidate = makeCandidate();
+
+      expect(candidate.pendingGuardianRequestCount).toBeUndefined();
+      expect(candidate.recentCallSessionId).toBeUndefined();
+    });
+
+    test('candidate with guardian context includes counts and session IDs', () => {
+      const candidate = makeCandidate({
+        pendingGuardianRequestCount: 3,
+        recentCallSessionId: 'call-123',
+      });
+
+      expect(candidate.pendingGuardianRequestCount).toBe(3);
+      expect(candidate.recentCallSessionId).toBe('call-123');
+    });
+
+    test('candidate with null title is valid', () => {
+      const candidate = makeCandidate({ title: null });
+      expect(candidate.title).toBeNull();
+    });
+
+    test('candidate with null latestSourceEventName is valid', () => {
+      const candidate = makeCandidate({ latestSourceEventName: null });
+      expect(candidate.latestSourceEventName).toBeNull();
+    });
+  });
+
+  describe('thread action downgrade semantics', () => {
+    test('start_new action does not require a conversationId', () => {
+      const action: ThreadAction = { action: 'start_new' };
+      expect(action.action).toBe('start_new');
+      expect('conversationId' in action).toBe(false);
+    });
+
+    test('reuse_existing with valid candidate is accepted', () => {
+      const candidates = [
+        makeCandidate({ conversationId: 'conv-valid' }),
+      ];
+      const proposedId = 'conv-valid';
+
+      // Simulate what the engine does: validate, then build the action
+      const isValid = isValidCandidateId(proposedId, candidates);
+      const action: ThreadAction = isValid
+        ? { action: 'reuse_existing', conversationId: proposedId }
+        : { action: 'start_new' };
+
+      expect(action.action).toBe('reuse_existing');
+      if (action.action === 'reuse_existing') {
+        expect(action.conversationId).toBe('conv-valid');
+      }
+    });
+
+    test('reuse_existing with invalid candidate is downgraded to start_new', () => {
+      const candidates = [
+        makeCandidate({ conversationId: 'conv-valid' }),
+      ];
+      const proposedId = 'conv-hacked';
+
+      const isValid = isValidCandidateId(proposedId, candidates);
+      const action: ThreadAction = isValid
+        ? { action: 'reuse_existing', conversationId: proposedId }
+        : { action: 'start_new' };
+
+      expect(action.action).toBe('start_new');
+    });
+
+    test('reuse_existing with empty candidate set is downgraded to start_new', () => {
+      const candidates: ThreadCandidate[] = [];
+      const proposedId = 'conv-any';
+
+      const isValid = isValidCandidateId(proposedId, candidates);
+      const action: ThreadAction = isValid
+        ? { action: 'reuse_existing', conversationId: proposedId }
+        : { action: 'start_new' };
+
+      expect(action.action).toBe('start_new');
+    });
+  });
+
+  describe('candidate set per channel', () => {
+    test('channels without candidates result in empty arrays', () => {
+      const candidateMap: Partial<Record<NotificationChannel, ThreadCandidate[]>> = {};
+
+      // When no candidates exist for vellum, the map has no entry
+      expect(candidateMap.vellum).toBeUndefined();
+    });
+
+    test('candidate set preserves channel association', () => {
+      const vellumCandidates = [
+        makeCandidate({ conversationId: 'conv-v1', channel: 'vellum' as NotificationChannel }),
+      ];
+      const telegramCandidates = [
+        makeCandidate({ conversationId: 'conv-t1', channel: 'telegram' as NotificationChannel }),
+      ];
+
+      const candidateMap: Partial<Record<NotificationChannel, ThreadCandidate[]>> = {
+        vellum: vellumCandidates,
+        telegram: telegramCandidates,
+      };
+
+      // Vellum candidate should not be valid for telegram and vice versa
+      expect(isValidCandidateId('conv-v1', candidateMap.vellum ?? [])).toBe(true);
+      expect(isValidCandidateId('conv-v1', candidateMap.telegram ?? [])).toBe(false);
+      expect(isValidCandidateId('conv-t1', candidateMap.telegram ?? [])).toBe(true);
+      expect(isValidCandidateId('conv-t1', candidateMap.vellum ?? [])).toBe(false);
+    });
+  });
+});

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -864,7 +864,9 @@ export const guardianActionDeliveries = sqliteTable('guardian_action_deliveries'
   lastError: text('last_error'),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
-});
+}, (table) => [
+  index('idx_guardian_action_deliveries_dest_conversation').on(table.destinationConversationId),
+]);
 
 // ── Assistant Inbox ──────────────────────────────────────────────────
 

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -19,18 +19,20 @@ import { getLogger } from '../util/logger.js';
 import { createDecision } from './decisions-store.js';
 import { getPreferenceSummary } from './preference-summary.js';
 import type { NotificationSignal, RoutingIntent } from './signal.js';
-import type { NotificationChannel, NotificationDecision, RenderedChannelCopy } from './types.js';
+import { isValidCandidateId } from './thread-candidates.js';
+import type { NotificationChannel, NotificationDecision, RenderedChannelCopy, ThreadAction, ThreadCandidate } from './types.js';
 
 const log = getLogger('notification-decision-engine');
 
 const DECISION_TIMEOUT_MS = 15_000;
-const PROMPT_VERSION = 'v3';
+const PROMPT_VERSION = 'v4';
 
 // ── System prompt ──────────────────────────────────────────────────────
 
 function buildSystemPrompt(
   availableChannels: NotificationChannel[],
   preferenceContext?: string,
+  threadCandidates?: Partial<Record<NotificationChannel, ThreadCandidate[]>>,
 ): string {
   const sections: string[] = [
     `You are a notification routing engine. Given a signal describing an event, decide whether the user should be notified, on which channel(s), and compose the notification copy.`,
@@ -73,6 +75,46 @@ function buildSystemPrompt(
     `- \`threadSeedMessage\` is the opening message in the internal notification thread — it can be richer and more contextual.`,
     `  - For vellum (desktop): 2-4 short sentences with useful context and clear next step if action is required.`,
     `  - Never dump raw JSON. Include only human-readable context.`,
+  );
+
+  // Thread action guidance — only included when candidates are available
+  const hasAnyCandidates = threadCandidates && Object.values(threadCandidates).some((c) => c && c.length > 0);
+  if (hasAnyCandidates) {
+    sections.push(
+      ``,
+      `Thread action (per channel):`,
+      `For each selected channel, decide whether to start a new thread or reuse an existing one.`,
+      `- Use \`start_new\` (default) when the signal represents a new topic or the existing threads are not contextually related.`,
+      `- Use \`reuse_existing\` when the signal is a continuation or follow-up to an existing thread (e.g. same guardian question, same call session, related reminder).`,
+      `  - You MUST set \`conversationId\` to one of the provided candidate IDs. Any other value will be rejected.`,
+      `  - Prefer reuse when there is a strong contextual link (same callSessionId, same sourceEventName, pending guardian requests).`,
+      `- When no candidates are listed for a channel, only \`start_new\` is valid.`,
+    );
+
+    sections.push(``, `<thread-candidates>`);
+    for (const [ch, candidates] of Object.entries(threadCandidates)) {
+      if (!candidates || candidates.length === 0) continue;
+      sections.push(`  Channel: ${ch}`);
+      for (const c of candidates) {
+        const parts = [
+          `    - conversationId: ${c.conversationId}`,
+          `      title: ${c.title ?? '(untitled)'}`,
+          `      updatedAt: ${new Date(c.updatedAt).toISOString()}`,
+          `      latestSourceEventName: ${c.latestSourceEventName ?? '(unknown)'}`,
+        ];
+        if (c.pendingGuardianRequestCount && c.pendingGuardianRequestCount > 0) {
+          parts.push(`      pendingGuardianRequests: ${c.pendingGuardianRequestCount}`);
+        }
+        if (c.recentCallSessionId) {
+          parts.push(`      recentCallSessionId: ${c.recentCallSessionId}`);
+        }
+        sections.push(parts.join('\n'));
+      }
+    }
+    sections.push(`</thread-candidates>`);
+  }
+
+  sections.push(
     ``,
     `You MUST respond using the \`record_notification_decision\` tool. Do not respond with text.`,
   );
@@ -115,62 +157,96 @@ function buildUserPrompt(signal: NotificationSignal): string {
 
 // ── Tool definition ────────────────────────────────────────────────────
 
-function buildDecisionTool(availableChannels: NotificationChannel[]) {
+function buildDecisionTool(
+  availableChannels: NotificationChannel[],
+  hasCandidates: boolean,
+) {
+  const properties: Record<string, unknown> = {
+    shouldNotify: {
+      type: 'boolean',
+      description: 'Whether the user should be notified about this signal',
+    },
+    selectedChannels: {
+      type: 'array',
+      items: {
+        type: 'string',
+        enum: availableChannels,
+      },
+      description: 'Which channels to deliver the notification on',
+    },
+    reasoningSummary: {
+      type: 'string',
+      description: 'Brief explanation of why this routing decision was made',
+    },
+    renderedCopy: {
+      type: 'object',
+      description: 'Notification copy keyed by channel name',
+      properties: Object.fromEntries(
+        availableChannels.map((ch) => [
+          ch,
+          {
+            type: 'object',
+            properties: {
+              title: { type: 'string', description: 'Short notification popup title (≤ 8 words)' },
+              body: { type: 'string', description: 'Concise notification popup body (≤ 2 sentences)' },
+              deliveryText: { type: 'string', description: 'Channel-native chat message text (for example Telegram). Must stand alone naturally.' },
+              threadTitle: { type: 'string', description: 'Optional thread title for grouped notifications' },
+              threadSeedMessage: { type: 'string', description: 'Richer opening message for the notification thread. More contextual than title/body. For vellum: 2-4 sentences. For telegram: 1-2 sentences. Never raw JSON.' },
+            },
+            required: ['title', 'body'],
+          },
+        ]),
+      ),
+    },
+    deepLinkTarget: {
+      type: 'object',
+      description: 'Optional deep link metadata for navigating to the source context',
+    },
+    dedupeKey: {
+      type: 'string',
+      description: 'A stable key derived from the signal to deduplicate repeated notifications for the same event',
+    },
+    confidence: {
+      type: 'number',
+      description: 'Confidence in the decision (0.0-1.0)',
+    },
+  };
+
+  // Only include the threadActions schema when candidates are available,
+  // keeping the tool schema minimal when thread reuse is not possible.
+  if (hasCandidates) {
+    properties.threadActions = {
+      type: 'object',
+      description: 'Per-channel thread action. For each selected channel, specify whether to start a new thread or reuse an existing candidate.',
+      properties: Object.fromEntries(
+        availableChannels.map((ch) => [
+          ch,
+          {
+            type: 'object',
+            properties: {
+              action: {
+                type: 'string',
+                enum: ['start_new', 'reuse_existing'],
+                description: 'Thread action: start_new creates a fresh thread, reuse_existing appends to an existing candidate thread.',
+              },
+              conversationId: {
+                type: 'string',
+                description: 'Required when action is reuse_existing. Must be a conversationId from the provided candidates.',
+              },
+            },
+            required: ['action'],
+          },
+        ]),
+      ),
+    };
+  }
+
   return {
     name: 'record_notification_decision',
     description: 'Record the notification routing decision for this signal',
     input_schema: {
       type: 'object' as const,
-      properties: {
-        shouldNotify: {
-          type: 'boolean',
-          description: 'Whether the user should be notified about this signal',
-        },
-        selectedChannels: {
-          type: 'array',
-          items: {
-            type: 'string',
-            enum: availableChannels,
-          },
-          description: 'Which channels to deliver the notification on',
-        },
-        reasoningSummary: {
-          type: 'string',
-          description: 'Brief explanation of why this routing decision was made',
-        },
-        renderedCopy: {
-          type: 'object',
-          description: 'Notification copy keyed by channel name',
-          properties: Object.fromEntries(
-            availableChannels.map((ch) => [
-              ch,
-              {
-                type: 'object',
-                properties: {
-                  title: { type: 'string', description: 'Short notification popup title (≤ 8 words)' },
-                  body: { type: 'string', description: 'Concise notification popup body (≤ 2 sentences)' },
-                  deliveryText: { type: 'string', description: 'Channel-native chat message text (for example Telegram). Must stand alone naturally.' },
-                  threadTitle: { type: 'string', description: 'Optional thread title for grouped notifications' },
-                  threadSeedMessage: { type: 'string', description: 'Richer opening message for the notification thread. More contextual than title/body. For vellum: 2-4 sentences. For telegram: 1-2 sentences. Never raw JSON.' },
-                },
-                required: ['title', 'body'],
-              },
-            ]),
-          ),
-        },
-        deepLinkTarget: {
-          type: 'object',
-          description: 'Optional deep link metadata for navigating to the source context',
-        },
-        dedupeKey: {
-          type: 'string',
-          description: 'A stable key derived from the signal to deduplicate repeated notifications for the same event',
-        },
-        confidence: {
-          type: 'number',
-          description: 'Confidence in the decision (0.0-1.0)',
-        },
-      },
+      properties,
       required: ['shouldNotify', 'selectedChannels', 'reasoningSummary', 'renderedCopy', 'dedupeKey', 'confidence'],
     },
   };
@@ -237,6 +313,7 @@ const VALID_CHANNELS = new Set<string>(getDeliverableChannels());
 function validateDecisionOutput(
   input: Record<string, unknown>,
   availableChannels: NotificationChannel[],
+  threadCandidates?: Partial<Record<NotificationChannel, ThreadCandidate[]>>,
 ): NotificationDecision | null {
   if (typeof input.shouldNotify !== 'boolean') return null;
   if (typeof input.reasoningSummary !== 'string') return null;
@@ -281,6 +358,9 @@ function validateDecisionOutput(
     ? input.deepLinkTarget as Record<string, unknown>
     : undefined;
 
+  // Validate threadActions — strictly check reuse targets against candidates
+  const threadActions = validateThreadActions(input.threadActions, validChannels, threadCandidates);
+
   return {
     shouldNotify: input.shouldNotify,
     selectedChannels: validChannels,
@@ -290,7 +370,67 @@ function validateDecisionOutput(
     dedupeKey: input.dedupeKey,
     confidence,
     fallbackUsed: false,
+    threadActions,
   };
+}
+
+/**
+ * Validate model-selected thread actions against the provided candidate set.
+ *
+ * Invalid reuse targets (conversationId not in candidates) are downgraded to
+ * start_new with a warning log, ensuring the pipeline never routes to an
+ * unvetted conversation.
+ */
+function validateThreadActions(
+  raw: unknown,
+  validChannels: NotificationChannel[],
+  threadCandidates?: Partial<Record<NotificationChannel, ThreadCandidate[]>>,
+): Partial<Record<NotificationChannel, ThreadAction>> | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+
+  const actionsObj = raw as Record<string, unknown>;
+  const result: Partial<Record<NotificationChannel, ThreadAction>> = {};
+  let hasAnyAction = false;
+
+  for (const ch of validChannels) {
+    const chAction = actionsObj[ch];
+    if (!chAction || typeof chAction !== 'object') continue;
+
+    const a = chAction as Record<string, unknown>;
+    if (typeof a.action !== 'string') continue;
+
+    if (a.action === 'start_new') {
+      result[ch] = { action: 'start_new' };
+      hasAnyAction = true;
+    } else if (a.action === 'reuse_existing') {
+      if (typeof a.conversationId !== 'string' || !a.conversationId.trim()) {
+        log.warn(
+          { channel: ch },
+          'LLM selected reuse_existing without a conversationId — downgrading to start_new',
+        );
+        result[ch] = { action: 'start_new' };
+        hasAnyAction = true;
+        continue;
+      }
+
+      const candidates = threadCandidates?.[ch] ?? [];
+      if (!isValidCandidateId(a.conversationId, candidates)) {
+        log.warn(
+          { channel: ch, conversationId: a.conversationId },
+          'LLM selected reuse_existing with invalid conversationId — downgrading to start_new',
+        );
+        result[ch] = { action: 'start_new' };
+        hasAnyAction = true;
+        continue;
+      }
+
+      result[ch] = { action: 'reuse_existing', conversationId: a.conversationId };
+      hasAnyAction = true;
+    }
+    // Unknown action values are silently dropped (channel defaults to start_new)
+  }
+
+  return hasAnyAction ? result : undefined;
 }
 
 // ── Core evaluation function ───────────────────────────────────────────
@@ -350,9 +490,13 @@ async function classifyWithLLM(
   const provider = getConfiguredProvider()!;
   const { signal: abortSignal, cleanup } = createTimeout(DECISION_TIMEOUT_MS);
 
-  const systemPrompt = buildSystemPrompt(availableChannels, preferenceContext);
+  const threadCandidates = signal.threadCandidates;
+  const hasCandidates = threadCandidates != null &&
+    Object.values(threadCandidates).some((c) => c && c.length > 0);
+
+  const systemPrompt = buildSystemPrompt(availableChannels, preferenceContext, threadCandidates);
   const prompt = buildUserPrompt(signal);
-  const tool = buildDecisionTool(availableChannels);
+  const tool = buildDecisionTool(availableChannels, hasCandidates);
 
   try {
     const response = await provider.sendMessage(
@@ -379,6 +523,7 @@ async function classifyWithLLM(
     const validated = validateDecisionOutput(
       toolBlock.input as Record<string, unknown>,
       availableChannels,
+      threadCandidates,
     );
     if (!validated) {
       log.warn('Invalid notification decision output from LLM, using fallback');

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -24,6 +24,7 @@ import { type DeterministicCheckContext, runDeterministicChecks } from './determ
 import { createEvent, updateEventDedupeKey } from './events-store.js';
 import { dispatchDecision } from './runtime-dispatch.js';
 import type { AttentionHints, NotificationSignal, RoutingIntent } from './signal.js';
+import { buildCandidatesForChannels } from './thread-candidates.js';
 import type { NotificationChannel, NotificationDeliveryResult } from './types.js';
 
 const log = getLogger('emit-signal');
@@ -205,6 +206,19 @@ export async function emitNotificationSignal(params: EmitSignalParams): Promise<
 
     // Step 2: Evaluate the signal through the decision engine
     const connectedChannels = getConnectedChannels(assistantId);
+
+    // Build candidate thread context per connected channel so the decision
+    // engine can choose between starting a new thread or reusing an existing one.
+    try {
+      const candidates = buildCandidatesForChannels(connectedChannels, assistantId);
+      if (Object.keys(candidates).length > 0) {
+        signal.threadCandidates = candidates;
+      }
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      log.warn({ err: errMsg, signalId }, 'Failed to build thread candidates — proceeding without');
+    }
+
     let decision = await evaluateSignal(signal, connectedChannels);
 
     // Step 2.5: Enforce routing intent policy (fire-time guard)

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -4,6 +4,8 @@
  * decision engine route contextually.
  */
 
+import type { NotificationChannel, ThreadCandidate } from './types.js';
+
 export interface AttentionHints {
   requiresAction: boolean;
   urgency: 'low' | 'medium' | 'high';
@@ -27,4 +29,10 @@ export interface NotificationSignal {
   routingIntent?: RoutingIntent;
   /** Free-form hints from the source for the decision engine (e.g. preferred channels). */
   routingHints?: Record<string, unknown>;
+  /**
+   * Per-channel candidate threads that the decision engine may select for reuse.
+   * Built by the thread-candidates module and injected before the decision call.
+   * Absent or empty means no reuse candidates are available (start_new only).
+   */
+  threadCandidates?: Partial<Record<NotificationChannel, ThreadCandidate[]>>;
 }

--- a/assistant/src/notifications/thread-candidates.ts
+++ b/assistant/src/notifications/thread-candidates.ts
@@ -1,0 +1,209 @@
+/**
+ * Build candidate thread sets per notification channel.
+ *
+ * Queries recent notification-sourced conversations and enriches them with
+ * guardian-specific context (pending request counts, call session associations)
+ * so the decision engine can make an informed reuse-vs-new-thread choice.
+ *
+ * The candidate set is intentionally lightweight: only metadata needed for the
+ * decision prompt is included, keeping token overhead low and the audit trail
+ * readable.
+ */
+
+import { and, desc, eq } from 'drizzle-orm';
+
+import { getDb } from '../memory/db.js';
+import {
+  guardianActionDeliveries,
+  guardianActionRequests,
+  notificationDeliveries,
+  notificationDecisions,
+  notificationEvents,
+} from '../memory/schema.js';
+import { getLogger } from '../util/logger.js';
+import type { NotificationChannel, ThreadCandidate } from './types.js';
+
+const log = getLogger('thread-candidates');
+
+/** Maximum number of candidate threads surfaced per channel. */
+const MAX_CANDIDATES_PER_CHANNEL = 5;
+
+/** Only consider threads updated within this window (ms). */
+const CANDIDATE_RECENCY_WINDOW_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+/**
+ * Build the set of candidate threads for a given channel that the decision
+ * engine may select for reuse.
+ *
+ * Returns an empty array when no recent notification threads exist for the
+ * channel, which signals the engine to use start_new.
+ */
+export function buildCandidatesForChannel(
+  channel: NotificationChannel,
+  assistantId: string,
+): ThreadCandidate[] {
+  try {
+    const db = getDb();
+    const cutoff = Date.now() - CANDIDATE_RECENCY_WINDOW_MS;
+
+    // Find recent notification deliveries for this channel that have a
+    // paired conversation. We join through decisions -> events to get
+    // the sourceEventName and filter by assistantId.
+    const rows = db
+      .select({
+        conversationId: notificationDeliveries.conversationId,
+        renderedTitle: notificationDeliveries.renderedTitle,
+        deliveryUpdatedAt: notificationDeliveries.updatedAt,
+        sourceEventName: notificationEvents.sourceEventName,
+        channel: notificationDeliveries.channel,
+      })
+      .from(notificationDeliveries)
+      .innerJoin(
+        notificationDecisions,
+        eq(notificationDeliveries.notificationDecisionId, notificationDecisions.id),
+      )
+      .innerJoin(
+        notificationEvents,
+        eq(notificationDecisions.notificationEventId, notificationEvents.id),
+      )
+      .where(
+        and(
+          eq(notificationDeliveries.channel, channel),
+          eq(notificationDeliveries.assistantId, assistantId),
+          eq(notificationDeliveries.status, 'sent'),
+        ),
+      )
+      .orderBy(desc(notificationDeliveries.updatedAt))
+      .limit(MAX_CANDIDATES_PER_CHANNEL * 3) // over-fetch to allow dedup
+      .all();
+
+    // Deduplicate by conversationId (keep the most recent delivery per conversation)
+    const seen = new Set<string>();
+    const candidates: ThreadCandidate[] = [];
+
+    for (const row of rows) {
+      if (!row.conversationId) continue;
+      if (row.deliveryUpdatedAt < cutoff) continue;
+      if (seen.has(row.conversationId)) continue;
+      seen.add(row.conversationId);
+
+      const candidate: ThreadCandidate = {
+        conversationId: row.conversationId,
+        title: row.renderedTitle,
+        updatedAt: row.deliveryUpdatedAt,
+        latestSourceEventName: row.sourceEventName,
+        channel: channel,
+      };
+
+      // Enrich with guardian-specific context when applicable
+      enrichGuardianContext(db, candidate);
+
+      candidates.push(candidate);
+      if (candidates.length >= MAX_CANDIDATES_PER_CHANNEL) break;
+    }
+
+    return candidates;
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    log.warn(
+      { err: errMsg, channel, assistantId },
+      'Failed to build thread candidates — returning empty set',
+    );
+    return [];
+  }
+}
+
+/**
+ * Build candidate sets for all selected channels in a single call.
+ * Returns a map of channel -> candidates.
+ */
+export function buildCandidatesForChannels(
+  channels: NotificationChannel[],
+  assistantId: string,
+): Partial<Record<NotificationChannel, ThreadCandidate[]>> {
+  const result: Partial<Record<NotificationChannel, ThreadCandidate[]>> = {};
+  for (const channel of channels) {
+    const candidates = buildCandidatesForChannel(channel, assistantId);
+    if (candidates.length > 0) {
+      result[channel] = candidates;
+    }
+  }
+  return result;
+}
+
+/**
+ * Validate that a model-selected conversationId is present in the provided
+ * candidate set for the given channel. Returns true only if the id is a
+ * valid candidate.
+ */
+export function isValidCandidateId(
+  conversationId: string,
+  candidates: ThreadCandidate[],
+): boolean {
+  return candidates.some((c) => c.conversationId === conversationId);
+}
+
+// -- Guardian context enrichment -----------------------------------------------
+
+function enrichGuardianContext(
+  db: ReturnType<typeof getDb>,
+  candidate: ThreadCandidate,
+): void {
+  try {
+    // Look for guardian action deliveries targeting this conversation
+    const deliveries = db
+      .select({
+        requestId: guardianActionDeliveries.requestId,
+      })
+      .from(guardianActionDeliveries)
+      .where(
+        eq(guardianActionDeliveries.destinationConversationId, candidate.conversationId),
+      )
+      .all();
+
+    if (deliveries.length === 0) return;
+
+    const requestIds = [...new Set(deliveries.map((d) => d.requestId))];
+
+    // Count pending requests and find the most recent callSessionId
+    let pendingCount = 0;
+    let recentCallSessionId: string | null = null;
+    let recentCreatedAt = 0;
+
+    for (const requestId of requestIds) {
+      const request = db
+        .select({
+          status: guardianActionRequests.status,
+          callSessionId: guardianActionRequests.callSessionId,
+          createdAt: guardianActionRequests.createdAt,
+        })
+        .from(guardianActionRequests)
+        .where(eq(guardianActionRequests.id, requestId))
+        .get();
+
+      if (!request) continue;
+
+      if (request.status === 'pending') {
+        pendingCount++;
+      }
+      if (request.createdAt > recentCreatedAt) {
+        recentCreatedAt = request.createdAt;
+        recentCallSessionId = request.callSessionId;
+      }
+    }
+
+    if (pendingCount > 0) {
+      candidate.pendingGuardianRequestCount = pendingCount;
+    }
+    if (recentCallSessionId) {
+      candidate.recentCallSessionId = recentCallSessionId;
+    }
+  } catch (err) {
+    // Guardian enrichment is best-effort; log and continue
+    const errMsg = err instanceof Error ? err.message : String(err);
+    log.warn(
+      { err: errMsg, conversationId: candidate.conversationId },
+      'Guardian context enrichment failed — continuing without',
+    );
+  }
+}

--- a/assistant/src/notifications/thread-candidates.ts
+++ b/assistant/src/notifications/thread-candidates.ts
@@ -10,7 +10,7 @@
  * readable.
  */
 
-import { and, desc, eq } from 'drizzle-orm';
+import { and, desc, eq, inArray } from 'drizzle-orm';
 
 import { getDb } from '../memory/db.js';
 import {
@@ -165,24 +165,22 @@ function enrichGuardianContext(
 
     const requestIds = [...new Set(deliveries.map((d) => d.requestId))];
 
-    // Count pending requests and find the most recent callSessionId
+    // Batch-fetch all guardian requests in one query to avoid N+1 lookups
+    const requests = db
+      .select({
+        status: guardianActionRequests.status,
+        callSessionId: guardianActionRequests.callSessionId,
+        createdAt: guardianActionRequests.createdAt,
+      })
+      .from(guardianActionRequests)
+      .where(inArray(guardianActionRequests.id, requestIds))
+      .all();
+
     let pendingCount = 0;
     let recentCallSessionId: string | null = null;
     let recentCreatedAt = 0;
 
-    for (const requestId of requestIds) {
-      const request = db
-        .select({
-          status: guardianActionRequests.status,
-          callSessionId: guardianActionRequests.callSessionId,
-          createdAt: guardianActionRequests.createdAt,
-        })
-        .from(guardianActionRequests)
-        .where(eq(guardianActionRequests.id, requestId))
-        .get();
-
-      if (!request) continue;
-
+    for (const request of requests) {
       if (request.status === 'pending') {
         pendingCount++;
       }

--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -79,6 +79,45 @@ export interface RenderedChannelCopy {
   threadSeedMessage?: string;
 }
 
+// -- Per-channel thread action types ------------------------------------------
+
+/**
+ * Thread action telling the broadcaster to start a new conversation thread.
+ * This is the default when no candidate is selected or on fallback.
+ */
+export interface ThreadActionStartNew {
+  action: 'start_new';
+}
+
+/**
+ * Thread action telling the broadcaster to reuse an existing conversation.
+ * The conversationId must match one of the daemon-provided candidates.
+ */
+export interface ThreadActionReuseExisting {
+  action: 'reuse_existing';
+  conversationId: string;
+}
+
+export type ThreadAction = ThreadActionStartNew | ThreadActionReuseExisting;
+
+/**
+ * Lightweight metadata about a candidate conversation thread that the
+ * decision engine can select for reuse. Built by the thread-candidates
+ * module and injected into the decision prompt per selected channel.
+ */
+export interface ThreadCandidate {
+  conversationId: string;
+  title: string | null;
+  updatedAt: number;
+  /** The most recent sourceEventName that created this thread, if known. */
+  latestSourceEventName: string | null;
+  channel: NotificationChannel;
+  /** Guardian-specific: count of pending (unresolved) guardian action requests associated with this thread. */
+  pendingGuardianRequestCount?: number;
+  /** Guardian-specific: most recent callSessionId associated with this thread, if any. */
+  recentCallSessionId?: string | null;
+}
+
 /** Output produced by the notification decision engine for a given signal. */
 export interface NotificationDecision {
   shouldNotify: boolean;
@@ -91,4 +130,6 @@ export interface NotificationDecision {
   fallbackUsed: boolean;
   /** UUID of the persisted decision row (set after persistence in the decision engine). */
   persistedDecisionId?: string;
+  /** Per-channel thread actions decided by the model. Absent channels default to start_new. */
+  threadActions?: Partial<Record<NotificationChannel, ThreadAction>>;
 }


### PR DESCRIPTION
Extends the notification decision engine to output per-channel thread actions (start_new / reuse_existing) using daemon-provided candidate thread context. Part of #9946.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
