### PR TITLE
Fix: PTT indicator settings navigation race condition

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -498,8 +498,8 @@ struct MainWindowView: View {
                         }
                         Spacer()
                         PTTKeyIndicator {
+                            settingsStore.pendingSettingsTab = .wakeWord
                             windowState.selection = .panel(.settings)
-                            NotificationCenter.default.post(name: .navigateToSettingsTab, object: SettingsTab.wakeWord)
                         }
                         if windowState.isShowingChat || isChatBubbleActive {
                             // Copy Thread button — only visible when there's content to copy


### PR DESCRIPTION
## Summary
Addresses review feedback on #9943 — uses SettingsStore.pendingSettingsTab instead of synchronous NotificationCenter post to avoid the race condition where SettingsPanel isn't mounted yet.

Part of #9929
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
