### PR TITLE
Fix: Gate activation key notification to activationKey updates only

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1106,7 +1106,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         // Handle client_settings_update from daemon: write to UserDefaults and post notification
         daemonClient.onClientSettingsUpdate = { msg in
             UserDefaults.standard.set(msg.value, forKey: msg.key)
-            NotificationCenter.default.post(name: .activationKeyChanged, object: nil)
+            if msg.key == "activationKey" {
+                NotificationCenter.default.post(name: .activationKeyChanged, object: nil)
+            }
         }
 
         // Restart DaemonClient connection when the health monitor relaunches


### PR DESCRIPTION
## Summary
Addresses review feedback on #9963 — only posts .activationKeyChanged notification when msg.key is 'activationKey', preventing unrelated settings updates from restarting voice input monitors.

Part of #9929
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
