### PR TITLE
Fix: Remove duplicate ElevenLabs section from Connect tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -25,8 +25,7 @@ struct SettingsPanel: View {
     @State private var braveKeyText: String = ""
     @State private var perplexityKeyText: String = ""
     @State private var imageGenKeyText: String = ""
-    @State private var elevenLabsKeyText: String = ""
-    @State private var showingTrustRules = false
+@State private var showingTrustRules = false
     @State private var showingReminders = false
     @State private var showingScheduledTasks = false
     @State private var twitterClientId: String = ""
@@ -478,52 +477,6 @@ struct SettingsPanel: View {
                     VButton(label: "Save", style: .primary) {
                         store.saveImageGenKey(imageGenKeyText)
                         imageGenKeyText = ""
-                    }
-                }
-            }
-            .padding(VSpacing.lg)
-            .vCard(background: VColor.surfaceSubtle)
-
-            // ELEVENLABS section (for Voice Mode TTS)
-            VStack(alignment: .leading, spacing: VSpacing.md) {
-                Text("ElevenLabs")
-                    .font(VFont.sectionTitle)
-                    .foregroundColor(VColor.textPrimary)
-
-                if store.hasElevenLabsKey {
-                    HStack(spacing: VSpacing.sm) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(VColor.success)
-                            .font(.system(size: 14))
-                        Text(store.maskedElevenLabsKey)
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textSecondary)
-                        Spacer()
-                        VButton(label: "Clear", style: .danger) {
-                            store.clearElevenLabsKey()
-                            elevenLabsKeyText = ""
-                        }
-                    }
-                } else {
-                    HStack(spacing: VSpacing.xs) {
-                        Text("Enter ElevenLabs API Key")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textSecondary)
-                        VInfoTooltip("Get your key at elevenlabs.io/app/settings/api-keys")
-                    }
-
-                    SecureField("Your ElevenLabs API key", text: $elevenLabsKeyText)
-                        .vInputStyle()
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
-
-                    Text("Used for Voice Mode (text-to-speech). Get your key at elevenlabs.io/app/settings/api-keys")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
-
-                    VButton(label: "Save", style: .primary) {
-                        store.saveElevenLabsKey(elevenLabsKeyText)
-                        elevenLabsKeyText = ""
                     }
                 }
             }


### PR DESCRIPTION
## Summary
Addresses review feedback on #9944 — removes the ElevenLabs API key section from the Connect/Integrations tab since it now lives in the Voice settings tab.

Part of #9929
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
