### PR TITLE
Fix: PTT permission overlay distinguishes mic vs speech denial

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -260,9 +260,18 @@ final class VoiceInputManager {
             currentDictationContext = nil
             return
         }
-        if micStatus == .denied || micStatus == .restricted
-            || speechStatus == .denied || speechStatus == .restricted {
-            showPermissionPrompt(kind: .denied)
+        let micDenied = micStatus == .denied || micStatus == .restricted
+        let speechDenied = speechStatus == .denied || speechStatus == .restricted
+        if micDenied || speechDenied {
+            let deniedPermission: PermissionPromptOverlay.DeniedPermission
+            if micDenied && speechDenied {
+                deniedPermission = .both
+            } else if micDenied {
+                deniedPermission = .microphone
+            } else {
+                deniedPermission = .speechRecognition
+            }
+            showPermissionPrompt(kind: .denied, deniedPermission: deniedPermission)
             currentDictationContext = nil
             return
         }
@@ -362,7 +371,10 @@ final class VoiceInputManager {
 
     /// Show the permission prompt overlay explaining why access is needed and providing
     /// action buttons. After the user grants access, recording starts automatically.
-    private func showPermissionPrompt(kind: PermissionPromptKind) {
+    private func showPermissionPrompt(
+        kind: PermissionPromptKind,
+        deniedPermission: PermissionPromptOverlay.DeniedPermission = .both
+    ) {
         let keyName = activationKeyDisplayName
 
         switch kind {
@@ -383,7 +395,7 @@ final class VoiceInputManager {
 
         case .denied:
             permissionOverlay.show(
-                kind: .denied(keyName: keyName),
+                kind: .denied(keyName: keyName, deniedPermission: deniedPermission),
                 onGrantAccess: { },
                 onDismiss: { [weak self] in
                     self?.permissionOverlay.dismiss()
@@ -398,7 +410,7 @@ final class VoiceInputManager {
         let micGranted = await AVCaptureDevice.requestAccess(for: .audio)
         guard micGranted else {
             log.warning("Microphone access denied by user")
-            showPermissionPrompt(kind: .denied)
+            showPermissionPrompt(kind: .denied, deniedPermission: .microphone)
             return
         }
 
@@ -409,7 +421,7 @@ final class VoiceInputManager {
         }
         guard speechGranted else {
             log.warning("Speech recognition access denied by user")
-            showPermissionPrompt(kind: .denied)
+            showPermissionPrompt(kind: .denied, deniedPermission: .speechRecognition)
             return
         }
 

--- a/clients/macos/vellum-assistant/Features/Voice/PermissionPromptOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/PermissionPromptOverlay.swift
@@ -9,11 +9,19 @@ private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "Pe
 final class PermissionPromptOverlay {
     private var panel: NSPanel?
 
+    /// Which permission(s) are currently denied, so the overlay can show the correct
+    /// guidance and open the right System Settings pane.
+    enum DeniedPermission {
+        case microphone
+        case speechRecognition
+        case both
+    }
+
     enum PromptKind {
         /// Permission has never been requested — show explanation and "Grant Access" button.
         case notDetermined(keyName: String)
         /// Permission was denied — show guidance to System Settings.
-        case denied(keyName: String)
+        case denied(keyName: String, deniedPermission: DeniedPermission)
     }
 
     /// Show the permission prompt overlay centered near the top of the screen.
@@ -149,14 +157,33 @@ final class PermissionPromptOverlay {
                     onDismiss()
                 }
             )
-        case .denied(let keyName):
+        case .denied(let keyName, let deniedPermission):
+            let title: String
+            let body: String
+            let openSettings: () -> Void
+
+            switch deniedPermission {
+            case .microphone:
+                title = "Microphone Access Required"
+                body = "Push-to-talk requires microphone access. You can grant access in System Settings. (Triggered by \(keyName) key)"
+                openSettings = { PermissionManager.openMicrophoneSettings() }
+            case .speechRecognition:
+                title = "Speech Recognition Required"
+                body = "Push-to-talk requires speech recognition access. You can grant access in System Settings. (Triggered by \(keyName) key)"
+                openSettings = { PermissionManager.openSpeechRecognitionSettings() }
+            case .both:
+                title = "Permissions Required"
+                body = "Push-to-talk requires microphone and speech recognition access. You can grant access in System Settings. (Triggered by \(keyName) key)"
+                openSettings = { PermissionManager.openMicrophoneSettings() }
+            }
+
             return (
-                title: "Microphone Access Required",
-                body: "Push-to-talk requires microphone access. You can grant access in System Settings. (Triggered by \(keyName) key)",
+                title: title,
+                body: body,
                 primaryTitle: "Open System Settings",
                 primaryAction: { [weak self] in
                     self?.dismiss()
-                    PermissionManager.openMicrophoneSettings()
+                    openSettings()
                     onDismiss()
                 },
                 secondaryTitle: "Dismiss",
@@ -171,18 +198,30 @@ final class PermissionPromptOverlay {
     private func makeIconView(for kind: PromptKind) -> NSView {
         let symbolName: String
         let color: NSColor
+        let accessibilityLabel: String
 
         switch kind {
         case .notDetermined:
             symbolName = "mic.circle"
             color = .systemBlue
-        case .denied:
-            symbolName = "mic.slash.circle"
+            accessibilityLabel = "Microphone"
+        case .denied(_, let deniedPermission):
             color = .systemOrange
+            switch deniedPermission {
+            case .microphone:
+                symbolName = "mic.slash.circle"
+                accessibilityLabel = "Microphone denied"
+            case .speechRecognition:
+                symbolName = "waveform.circle"
+                accessibilityLabel = "Speech recognition denied"
+            case .both:
+                symbolName = "mic.slash.circle"
+                accessibilityLabel = "Permissions denied"
+            }
         }
 
         let imageView = NSImageView()
-        if let img = NSImage(systemSymbolName: symbolName, accessibilityDescription: "Microphone") {
+        if let img = NSImage(systemSymbolName: symbolName, accessibilityDescription: accessibilityLabel) {
             let config = NSImage.SymbolConfiguration(pointSize: 28, weight: .regular)
             imageView.image = img.withSymbolConfiguration(config)
             imageView.contentTintColor = color


### PR DESCRIPTION
## Summary
Addresses review feedback on #9942 — the denied permission overlay now correctly identifies whether microphone, speech recognition, or both permissions are denied and opens the correct System Settings pane.

Part of #9929
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
