### PR TITLE
Fix: Validate PTT key and propagate queued message metadata

### DIFF
--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -10,6 +10,7 @@ import {
   injectGuardianContext,
   injectTemporalContext,
   resolveChannelCapabilities,
+  sanitizePttActivationKey,
   stripChannelCapabilityContext,
   stripChannelTurnContext,
   stripGuardianContext,
@@ -785,5 +786,53 @@ describe('applyRuntimeInjections with channelTurnContext', () => {
 
     expect(result.length).toBe(1);
     expect(result[0].content.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizePttActivationKey
+// ---------------------------------------------------------------------------
+
+describe('sanitizePttActivationKey', () => {
+  test('returns undefined for null/undefined input', () => {
+    expect(sanitizePttActivationKey(null)).toBeUndefined();
+    expect(sanitizePttActivationKey(undefined)).toBeUndefined();
+  });
+
+  test('passes through valid keys', () => {
+    expect(sanitizePttActivationKey('fn')).toBe('fn');
+    expect(sanitizePttActivationKey('ctrl')).toBe('ctrl');
+    expect(sanitizePttActivationKey('fn_shift')).toBe('fn_shift');
+    expect(sanitizePttActivationKey('none')).toBe('none');
+  });
+
+  test('returns "unknown" for invalid keys', () => {
+    expect(sanitizePttActivationKey('malicious\nprompt injection')).toBe('unknown');
+    expect(sanitizePttActivationKey('arbitrary_value')).toBe('unknown');
+    expect(sanitizePttActivationKey('')).toBe('unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveChannelCapabilities sanitizes pttActivationKey
+// ---------------------------------------------------------------------------
+
+describe('resolveChannelCapabilities with PTT metadata', () => {
+  test('sanitizes valid pttActivationKey', () => {
+    const caps = resolveChannelCapabilities('macos', 'macos', { pttActivationKey: 'fn' });
+    expect(caps.pttActivationKey).toBe('fn');
+  });
+
+  test('sanitizes invalid pttActivationKey to unknown', () => {
+    const caps = resolveChannelCapabilities('macos', 'macos', { pttActivationKey: 'evil\nprompt' });
+    expect(caps.pttActivationKey).toBe('unknown');
+  });
+
+  test('passes through microphonePermissionGranted', () => {
+    const caps = resolveChannelCapabilities('macos', 'macos', {
+      pttActivationKey: 'fn',
+      microphonePermissionGranted: true,
+    });
+    expect(caps.microphonePermissionGranted).toBe(true);
   });
 });

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -89,6 +89,13 @@ export async function handleUserMessage(
       assistantMessageInterface: ipcInterface,
     };
 
+    // Update channel capabilities eagerly so both immediate and queued paths
+    // reflect the latest PTT / microphone state from the client.
+    session.setChannelCapabilities(resolveChannelCapabilities(ipcChannel, ipcInterface, {
+      pttActivationKey: msg.pttActivationKey,
+      microphonePermissionGranted: msg.microphonePermissionGranted,
+    }));
+
     const dispatchUserMessage = (
       content: string,
       attachments: UserMessageAttachment[],
@@ -167,10 +174,6 @@ export async function handleUserMessage(
       // IPC/desktop user IS the guardian — default to guardian role so messages
       // are not tagged 'unverified_channel' (which blocks memory extraction).
       session.setGuardianContext({ actorRole: 'guardian', sourceChannel: ipcChannel });
-      session.setChannelCapabilities(resolveChannelCapabilities(ipcChannel, ipcInterface, {
-        pttActivationKey: msg.pttActivationKey,
-        microphonePermissionGranted: msg.microphonePermissionGranted,
-      }));
       session.setCommandIntent(null);
       // Fire-and-forget: don't block the IPC handler so the connection can
       // continue receiving messages (e.g. cancel, confirmations, or

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -43,6 +43,15 @@ export interface GuardianRuntimeContext {
   denialReason?: 'no_binding' | 'no_identity';
 }
 
+/** Allowed push-to-talk activation key values. Used to validate client-provided keys before system-prompt injection. */
+const PTT_KEY_ALLOWLIST = new Set(['fn', 'ctrl', 'fn_shift', 'none']);
+
+/** Validate a PTT activation key against the allowlist. Returns the key if valid, 'unknown' otherwise. */
+export function sanitizePttActivationKey(key: string | undefined | null): string | undefined {
+  if (key == null) return undefined;
+  return PTT_KEY_ALLOWLIST.has(key) ? key : 'unknown';
+}
+
 /** Optional PTT metadata provided by the client alongside each message. */
 export interface PttMetadata {
   pttActivationKey?: string;
@@ -96,7 +105,7 @@ export function resolveChannelCapabilities(
         dashboardCapable: supportsDesktopUi,
         supportsDynamicUi: supportsDesktopUi,
         supportsVoiceInput: supportsDesktopUi,
-        pttActivationKey: pttMetadata?.pttActivationKey,
+        pttActivationKey: sanitizePttActivationKey(pttMetadata?.pttActivationKey),
         microphonePermissionGranted: pttMetadata?.microphonePermissionGranted,
       };
     }


### PR DESCRIPTION
## Summary
Addresses review feedback on #9953:
- Validates pttActivationKey against allowlist before system prompt injection (prevents prompt injection)
- Propagates PTT metadata for queued messages

Part of #9929
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
