### PR TITLE
fix: write bearer token file early in daemon startup

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -103,6 +103,26 @@ export async function runDaemon(): Promise<void> {
     migrateToWorkspaceLayout();
     ensureDataDir();
 
+    // Resolve and write the bearer token as early as possible so the CLI
+    // (which polls for this file during gateway startup) doesn't time out
+    // waiting for Qdrant or other slow init steps to finish.
+    const httpTokenPath = getHttpTokenPath();
+    let bearerToken = getRuntimeProxyBearerToken();
+    if (!bearerToken) {
+      try {
+        const existing = readFileSync(httpTokenPath, 'utf-8').trim();
+        if (existing) bearerToken = existing;
+      } catch {
+        // File doesn't exist or can't be read — will generate below
+      }
+    }
+    if (!bearerToken) {
+      bearerToken = randomBytes(32).toString('hex');
+    }
+    writeFileSync(httpTokenPath, bearerToken, { mode: 0o600 });
+    chmodSync(httpTokenPath, 0o600);
+    log.info('Daemon startup: bearer token written');
+
     log.info('Daemon startup: migrations complete');
 
     seedInterfaceFiles();
@@ -266,26 +286,6 @@ export async function runDaemon(): Promise<void> {
     let runtimeHttp: RuntimeHttpServer | null = null;
     const httpPort = getRuntimeHttpPort();
     log.info({ httpPort }, 'Daemon startup: starting runtime HTTP server');
-
-    // Resolve the bearer token in priority order:
-    //   1. Explicit env var (e.g. cloud deploys)
-    //   2. Existing token file on disk (preserves QR-paired iOS devices across restarts)
-    //   3. Fresh random token (first-time startup)
-    const httpTokenPath = getHttpTokenPath();
-    let bearerToken = getRuntimeProxyBearerToken();
-    if (!bearerToken) {
-      try {
-        const existing = readFileSync(httpTokenPath, 'utf-8').trim();
-        if (existing) bearerToken = existing;
-      } catch {
-        // File doesn't exist or can't be read — will generate below
-      }
-    }
-    if (!bearerToken) {
-      bearerToken = randomBytes(32).toString('hex');
-    }
-    writeFileSync(httpTokenPath, bearerToken, { mode: 0o600 });
-    chmodSync(httpTokenPath, 0o600);
 
     const hostname = getRuntimeHttpHost();
 


### PR DESCRIPTION
## Summary
- Moves the `http-token` file resolution and write to right after `ensureDataDir()`, before DB init, Qdrant, schedulers, or any other slow initialization steps
- Fixes a race condition where the CLI's 30s poll timeout for the bearer token file was being exceeded when Qdrant startup was slow (binary download, `/readyz` polling)
- No behavioral change — same token resolution logic (env var → existing file → fresh random), just runs earlier

## Test plan
- [ ] Hatch a local assistant and verify gateway starts without "Waiting for bearer token file..." delay
- [ ] Verify `~/.vellum/http-token` is written before "Daemon startup: DB initialized" log line
- [ ] Verify existing token is preserved across daemon restarts (iOS pairing continuity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9974" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
