### PR TITLE
feat: add bundled UPDATES.md template

### DIFF
--- a/assistant/src/config/templates/UPDATES.md
+++ b/assistant/src/config/templates/UPDATES.md
@@ -1,0 +1,16 @@
+_ Lines starting with _ are comments — they won't appear in the system prompt
+
+# UPDATES.md
+
+_ This file contains release update notes for the assistant.
+_ Each release block is wrapped with HTML comment markers:
+_   <!-- vellum-update-release:<version> -->
+_   ...release notes...
+_   <!-- /vellum-update-release:<version> -->
+_
+_ Format is freeform markdown. Write notes that help the assistant
+_ understand what changed and how it affects behavior, capabilities,
+_ or available tools. Focus on what matters to the user experience.
+
+## What's New
+


### PR DESCRIPTION
PR 01 of the UPDATES.md bulletin rollout plan.

## Summary

- Adds `assistant/src/config/templates/UPDATES.md` — a release-note source template following the existing template conventions (`_` prefix comment lines, freeform markdown)
- The template will be materialized to `~/.vellum/workspace/UPDATES.md` and used as the source for release update notes surfaced to the assistant
- Includes comment-line guidance explaining the purpose, format, and HTML comment marker convention for release blocks

## Test plan

- [x] TypeScript type check passes (pre-existing errors unrelated to this change)
- [x] Template follows existing conventions (comment lines with `_` prefix, freeform markdown structure)

---

**Original prompt:** Add bundled `UPDATES.md` template for release bulletins (PR 01 of rollout plan).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9975" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
