### PR TITLE
feat: add release-block formatter/parser helpers

### DIFF
--- a/assistant/src/__tests__/update-bulletin-format.test.ts
+++ b/assistant/src/__tests__/update-bulletin-format.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  appendReleaseBlock,
+  extractReleaseIds,
+  hasReleaseBlock,
+  releaseMarker,
+} from '../config/update-bulletin-format.js';
+
+describe('releaseMarker', () => {
+  test('returns an HTML comment with the version embedded', () => {
+    expect(releaseMarker('1.2.3')).toBe('<!-- vellum-update-release:1.2.3 -->');
+  });
+
+  test('handles pre-release / build-metadata versions', () => {
+    expect(releaseMarker('2.0.0-beta.1+build.42')).toBe(
+      '<!-- vellum-update-release:2.0.0-beta.1+build.42 -->',
+    );
+  });
+});
+
+describe('hasReleaseBlock', () => {
+  const content = [
+    '<!-- vellum-update-release:1.0.0 -->',
+    '## 1.0.0',
+    'Initial release.',
+    '',
+    '<!-- vellum-update-release:1.1.0 -->',
+    '## 1.1.0',
+    'Second release.',
+  ].join('\n');
+
+  test('returns true when the marker is present', () => {
+    expect(hasReleaseBlock(content, '1.0.0')).toBe(true);
+    expect(hasReleaseBlock(content, '1.1.0')).toBe(true);
+  });
+
+  test('returns false when the marker is absent', () => {
+    expect(hasReleaseBlock(content, '2.0.0')).toBe(false);
+  });
+
+  test('returns false for empty content', () => {
+    expect(hasReleaseBlock('', '1.0.0')).toBe(false);
+  });
+});
+
+describe('appendReleaseBlock', () => {
+  test('appends to empty content', () => {
+    const result = appendReleaseBlock('', '1.0.0', '## 1.0.0\nInitial release.');
+    expect(result).toBe(
+      '<!-- vellum-update-release:1.0.0 -->\n## 1.0.0\nInitial release.\n',
+    );
+  });
+
+  test('preserves prior blocks when appending', () => {
+    const existing =
+      '<!-- vellum-update-release:1.0.0 -->\n## 1.0.0\nFirst.\n';
+    const result = appendReleaseBlock(existing, '1.1.0', '## 1.1.0\nSecond.');
+
+    // Prior block is untouched
+    expect(result).toContain('<!-- vellum-update-release:1.0.0 -->');
+    expect(result).toContain('## 1.0.0\nFirst.');
+
+    // New block is appended
+    expect(result).toContain('<!-- vellum-update-release:1.1.0 -->');
+    expect(result).toContain('## 1.1.0\nSecond.');
+
+    // New block comes after old block
+    const oldIdx = result.indexOf('<!-- vellum-update-release:1.0.0 -->');
+    const newIdx = result.indexOf('<!-- vellum-update-release:1.1.0 -->');
+    expect(newIdx).toBeGreaterThan(oldIdx);
+  });
+
+  test('inserts separator when existing content lacks trailing newline', () => {
+    const existing = '<!-- vellum-update-release:1.0.0 -->\nFirst.';
+    const result = appendReleaseBlock(existing, '1.1.0', 'Second.');
+
+    // Double newline separates the blocks when there was no trailing newline
+    expect(result).toContain('First.\n\n<!-- vellum-update-release:1.1.0 -->');
+  });
+});
+
+describe('extractReleaseIds', () => {
+  test('returns all version strings from multiple markers', () => {
+    const content = [
+      '<!-- vellum-update-release:1.0.0 -->',
+      'Block one.',
+      '<!-- vellum-update-release:1.1.0 -->',
+      'Block two.',
+      '<!-- vellum-update-release:2.0.0-rc.1 -->',
+      'Block three.',
+    ].join('\n');
+
+    expect(extractReleaseIds(content)).toEqual([
+      '1.0.0',
+      '1.1.0',
+      '2.0.0-rc.1',
+    ]);
+  });
+
+  test('returns empty array for empty content', () => {
+    expect(extractReleaseIds('')).toEqual([]);
+  });
+
+  test('returns empty array when no markers are present', () => {
+    expect(extractReleaseIds('Just some text\nwith no markers.')).toEqual([]);
+  });
+
+  test('handles duplicate markers', () => {
+    const content = [
+      '<!-- vellum-update-release:1.0.0 -->',
+      'Block one.',
+      '<!-- vellum-update-release:1.0.0 -->',
+      'Duplicate block.',
+    ].join('\n');
+
+    expect(extractReleaseIds(content)).toEqual(['1.0.0', '1.0.0']);
+  });
+});

--- a/assistant/src/config/update-bulletin-format.ts
+++ b/assistant/src/config/update-bulletin-format.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure helpers for reading and writing release blocks in the update bulletin.
+ *
+ * Each release block is delimited by an HTML comment marker so that
+ * concurrent appends (from different branches) are merge-safe -- they
+ * simply add a new block at the end without conflicting with existing ones.
+ */
+
+const MARKER_PREFIX = '<!-- vellum-update-release:';
+const MARKER_SUFFIX = ' -->';
+const MARKER_REGEX = /<!-- vellum-update-release:(.+?) -->/g;
+
+/** Returns the HTML comment marker for a given release version. */
+export function releaseMarker(version: string): string {
+  return `${MARKER_PREFIX}${version}${MARKER_SUFFIX}`;
+}
+
+/** Returns true if `content` already contains the release marker for `version`. */
+export function hasReleaseBlock(content: string, version: string): boolean {
+  return content.includes(releaseMarker(version));
+}
+
+/**
+ * Appends a new release block (marker + body) to `content`.
+ *
+ * Preserves all existing content and formatting. A blank line is inserted
+ * between the previous content and the new block when the existing content
+ * does not already end with a newline.
+ */
+export function appendReleaseBlock(
+  content: string,
+  version: string,
+  body: string,
+): string {
+  const marker = releaseMarker(version);
+  const block = `${marker}\n${body}`;
+
+  if (content.length === 0) return `${block}\n`;
+
+  const separator = content.endsWith('\n') ? '\n' : '\n\n';
+  return `${content}${separator}${block}\n`;
+}
+
+/** Extracts all version strings from release markers found in `content`. */
+export function extractReleaseIds(content: string): string[] {
+  const ids: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = MARKER_REGEX.exec(content)) !== null) {
+    ids.push(match[1]);
+  }
+  return ids;
+}


### PR DESCRIPTION
## Summary

PR 10 of the UPDATES.md bulletin rollout plan. Adds pure helper functions for release markers and merge-safe file updates.

- `releaseMarker(version)` — generates the HTML comment marker for a release
- `hasReleaseBlock(content, version)` — checks if content already contains a release block
- `appendReleaseBlock(content, version, body)` — appends a new release block preserving prior content
- `extractReleaseIds(content)` — extracts all version strings from release markers

All functions are pure, deterministic, and side-effect-free. Full test coverage including edge cases (empty content, duplicate markers, missing trailing newlines).

## Test plan

- [x] Marker generation format verified
- [x] `hasReleaseBlock` returns true/false correctly
- [x] `appendReleaseBlock` preserves prior blocks and handles separators
- [x] `extractReleaseIds` returns all versions including duplicates
- [x] Edge cases: empty content, no markers, duplicate markers
- [x] Type-check passes (no new errors)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9976" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
