### PR TITLE
feat: add bulletin checkpoint state helpers

### DIFF
--- a/assistant/src/__tests__/update-bulletin-state.test.ts
+++ b/assistant/src/__tests__/update-bulletin-state.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, mock } from 'bun:test';
+
+const store = new Map<string, string>();
+
+mock.module('../memory/checkpoints.js', () => ({
+  getMemoryCheckpoint: mock((key: string) => store.get(key) ?? null),
+  setMemoryCheckpoint: mock((key: string, value: string) => store.set(key, value)),
+}));
+
+const {
+  getActiveReleases,
+  setActiveReleases,
+  getCompletedReleases,
+  setCompletedReleases,
+  isReleaseCompleted,
+  markReleasesCompleted,
+  addActiveRelease,
+} = await import('../config/update-bulletin-state.js');
+
+describe('update-bulletin-state', () => {
+  beforeEach(() => {
+    store.clear();
+  });
+
+  describe('empty/default state', () => {
+    it('returns empty array when no active releases checkpoint exists', () => {
+      expect(getActiveReleases()).toEqual([]);
+    });
+
+    it('returns empty array when no completed releases checkpoint exists', () => {
+      expect(getCompletedReleases()).toEqual([]);
+    });
+
+    it('isReleaseCompleted returns false when no completed releases exist', () => {
+      expect(isReleaseCompleted('1.0.0')).toBe(false);
+    });
+  });
+
+  describe('corrupt checkpoint content', () => {
+    it('returns empty array for invalid JSON in active releases', () => {
+      store.set('updates:active_releases', 'not-json{{{');
+      expect(getActiveReleases()).toEqual([]);
+    });
+
+    it('returns empty array for invalid JSON in completed releases', () => {
+      store.set('updates:completed_releases', '}{broken');
+      expect(getCompletedReleases()).toEqual([]);
+    });
+
+    it('returns empty array when checkpoint contains a non-array JSON value', () => {
+      store.set('updates:active_releases', '"just-a-string"');
+      expect(getActiveReleases()).toEqual([]);
+    });
+
+    it('filters out non-string values from the array', () => {
+      store.set('updates:active_releases', '["1.0.0", 42, null, "2.0.0"]');
+      expect(getActiveReleases()).toEqual(['1.0.0', '2.0.0']);
+    });
+  });
+
+  describe('round-trip serialization', () => {
+    it('write then read returns same data for active releases', () => {
+      const releases = ['1.0.0', '2.0.0', '3.0.0'];
+      setActiveReleases(releases);
+      expect(getActiveReleases()).toEqual(releases);
+    });
+
+    it('write then read returns same data for completed releases', () => {
+      const releases = ['0.9.0', '1.0.0'];
+      setCompletedReleases(releases);
+      expect(getCompletedReleases()).toEqual(releases);
+    });
+
+    it('isReleaseCompleted returns true for a completed release', () => {
+      setCompletedReleases(['1.0.0', '2.0.0']);
+      expect(isReleaseCompleted('1.0.0')).toBe(true);
+      expect(isReleaseCompleted('2.0.0')).toBe(true);
+      expect(isReleaseCompleted('3.0.0')).toBe(false);
+    });
+  });
+
+  describe('dedupe behavior', () => {
+    it('setActiveReleases deduplicates entries', () => {
+      setActiveReleases(['1.0.0', '2.0.0', '1.0.0', '2.0.0', '1.0.0']);
+      expect(getActiveReleases()).toEqual(['1.0.0', '2.0.0']);
+    });
+
+    it('setCompletedReleases deduplicates entries', () => {
+      setCompletedReleases(['a', 'b', 'a']);
+      expect(getCompletedReleases()).toEqual(['a', 'b']);
+    });
+
+    it('addActiveRelease does not duplicate an existing release', () => {
+      setActiveReleases(['1.0.0']);
+      addActiveRelease('1.0.0');
+      expect(getActiveReleases()).toEqual(['1.0.0']);
+    });
+
+    it('markReleasesCompleted does not duplicate existing entries', () => {
+      setCompletedReleases(['1.0.0']);
+      markReleasesCompleted(['1.0.0', '2.0.0']);
+      expect(getCompletedReleases()).toEqual(['1.0.0', '2.0.0']);
+    });
+  });
+
+  describe('sort behavior', () => {
+    it('active releases are sorted alphabetically', () => {
+      setActiveReleases(['c-release', 'a-release', 'b-release']);
+      expect(getActiveReleases()).toEqual(['a-release', 'b-release', 'c-release']);
+    });
+
+    it('completed releases are sorted alphabetically', () => {
+      setCompletedReleases(['3.0.0', '1.0.0', '2.0.0']);
+      expect(getCompletedReleases()).toEqual(['1.0.0', '2.0.0', '3.0.0']);
+    });
+
+    it('addActiveRelease maintains sorted order', () => {
+      setActiveReleases(['a', 'c']);
+      addActiveRelease('b');
+      expect(getActiveReleases()).toEqual(['a', 'b', 'c']);
+    });
+
+    it('markReleasesCompleted maintains sorted order', () => {
+      setCompletedReleases(['c']);
+      markReleasesCompleted(['a', 'b']);
+      expect(getCompletedReleases()).toEqual(['a', 'b', 'c']);
+    });
+  });
+});

--- a/assistant/src/config/update-bulletin-state.ts
+++ b/assistant/src/config/update-bulletin-state.ts
@@ -1,0 +1,49 @@
+import { getMemoryCheckpoint, setMemoryCheckpoint } from '../memory/checkpoints.js';
+
+const ACTIVE_RELEASES_KEY = 'updates:active_releases';
+const COMPLETED_RELEASES_KEY = 'updates:completed_releases';
+
+function parseReleaseArray(raw: string | null): string[] {
+  if (raw === null) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === 'string');
+  } catch {
+    return [];
+  }
+}
+
+function dedupAndSort(releases: string[]): string[] {
+  return [...new Set(releases)].sort();
+}
+
+export function getActiveReleases(): string[] {
+  return parseReleaseArray(getMemoryCheckpoint(ACTIVE_RELEASES_KEY));
+}
+
+export function setActiveReleases(releases: string[]): void {
+  setMemoryCheckpoint(ACTIVE_RELEASES_KEY, JSON.stringify(dedupAndSort(releases)));
+}
+
+export function getCompletedReleases(): string[] {
+  return parseReleaseArray(getMemoryCheckpoint(COMPLETED_RELEASES_KEY));
+}
+
+export function setCompletedReleases(releases: string[]): void {
+  setMemoryCheckpoint(COMPLETED_RELEASES_KEY, JSON.stringify(dedupAndSort(releases)));
+}
+
+export function isReleaseCompleted(version: string): boolean {
+  return getCompletedReleases().includes(version);
+}
+
+export function markReleasesCompleted(versions: string[]): void {
+  const existing = getCompletedReleases();
+  setCompletedReleases([...existing, ...versions]);
+}
+
+export function addActiveRelease(version: string): void {
+  const existing = getActiveReleases();
+  setActiveReleases([...existing, version]);
+}


### PR DESCRIPTION
PR 11 of the UPDATES.md bulletin rollout plan.

## Summary
- Adds checkpoint read/write helpers (`getActiveReleases`, `setActiveReleases`, `getCompletedReleases`, `setCompletedReleases`, `isReleaseCompleted`, `markReleasesCompleted`, `addActiveRelease`) for tracking active and completed release bulletins via memory checkpoints.
- Normalizes invalid/corrupt JSON to empty arrays for graceful degradation.
- Deduplicates and sorts release IDs before writing.

## Test plan
- [x] Empty/default state returns empty arrays when no checkpoint exists
- [x] Corrupt checkpoint content returns empty array for invalid JSON
- [x] Round-trip serialization: write then read returns same data
- [x] Dedupe behavior: adding duplicate release IDs results in single entry
- [x] Sort behavior: releases are sorted alphabetically
- [x] All 18 tests passing

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
