### PR TITLE
fix: sort sidebar threads by message activity, not click

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -83,9 +83,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     @Published private(set) var busyThreadIds: Set<UUID> = []
 
     /// Threads that are not archived — used by the UI to populate the sidebar.
-    /// Sorted: pinned first (by pinnedOrder ascending), then unpinned by createdAt descending.
-    /// Using createdAt (not lastInteractedAt) keeps thread positions stable — only
-    /// pinning/unpinning causes a thread to move in the sidebar.
+    /// Sorted: pinned first (by pinnedOrder ascending), then unpinned by lastInteractedAt descending.
+    /// Threads move to the top when messages are sent or received, but NOT when clicked/selected.
     var visibleThreads: [ThreadModel] {
         threads.filter { !$0.isArchived && $0.kind != .private }.sorted { a, b in
             if a.isPinned && b.isPinned {
@@ -93,7 +92,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             }
             if a.isPinned { return true }
             if b.isPinned { return false }
-            return a.createdAt > b.createdAt
+            return a.lastInteractedAt > b.lastInteractedAt
         }
     }
 


### PR DESCRIPTION
## Summary
- Changed sidebar thread sorting from `createdAt` to `lastInteractedAt` so threads rise to the top when messages are sent/received, but stay put when simply clicked/selected
- `lastInteractedAt` is already updated on user message send (`onUserMessageSent`) and assistant message arrival (`handleAssistantMessageArrival`), but NOT on thread click (`selectThread`)

## Original prompt
make it so clicking a thread in the desktop app (and possibly on mobile) doesnt automatically move it to the top of the threads list. only sending (or receiving) new messages should move it to most recent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
