### PR TITLE
Fix: Remove wrong key mapping and duplicate IPC message

### DIFF
--- a/assistant/src/daemon/handlers/config-voice.ts
+++ b/assistant/src/daemon/handlers/config-voice.ts
@@ -42,7 +42,6 @@ const NATURAL_LANGUAGE_MAP: Record<string, ActivationKey> = {
   fn_shift: 'fn_shift',
   'fn+shift': 'fn_shift',
   'fn shift': 'fn_shift',
-  'ctrl+shift': 'fn_shift',
   'shift+fn': 'fn_shift',
   none: 'none',
   off: 'none',

--- a/assistant/src/tools/system/voice-config.ts
+++ b/assistant/src/tools/system/voice-config.ts
@@ -47,14 +47,6 @@ export const voiceConfigUpdateTool: Tool = {
       return { content: result.reason, isError: true };
     }
 
-    if (context.sendToClient) {
-      context.sendToClient({
-        type: 'client_settings_update',
-        key: 'activationKey',
-        value: result.value,
-      });
-    }
-
     const labels: Record<string, string> = {
       fn: 'Fn/Globe key',
       ctrl: 'Control key',


### PR DESCRIPTION
## Summary
Addresses review feedback on #9966:
- Removes incorrect 'ctrl+shift' -> 'fn_shift' mapping (no ctrl+shift key exists)
- Removes duplicate sendToClient from tool, keeping only the broadcast side effect

Part of #9929
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
