### PR TITLE
Fix: Restore indentation in SettingsPanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -25,7 +25,7 @@ struct SettingsPanel: View {
     @State private var braveKeyText: String = ""
     @State private var perplexityKeyText: String = ""
     @State private var imageGenKeyText: String = ""
-@State private var showingTrustRules = false
+    @State private var showingTrustRules = false
     @State private var showingReminders = false
     @State private var showingScheduledTasks = false
     @State private var twitterClientId: String = ""


### PR DESCRIPTION
## Summary
Addresses review feedback on #9971 — restores 4-space indentation on showingTrustRules property that was lost during the ElevenLabs section removal.

Part of #9929
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
