### PR TITLE
Fix: Open correct settings pane for dual permission denial

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/PermissionPromptOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/PermissionPromptOverlay.swift
@@ -174,7 +174,9 @@ final class PermissionPromptOverlay {
             case .both:
                 title = "Permissions Required"
                 body = "Push-to-talk requires microphone and speech recognition access. You can grant access in System Settings. (Triggered by \(keyName) key)"
-                openSettings = { PermissionManager.openMicrophoneSettings() }
+                openSettings = {
+                    NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy")!)
+                }
             }
 
             return (


### PR DESCRIPTION
## Summary
When both mic and speech recognition are denied, opens the general Privacy & Security pane instead of just the Microphone pane.

Part of #9929
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
