### PR TITLE
feat: allow file_read/file_edit/file_write for UPDATES.md

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -927,6 +927,30 @@ describe('Permission Checker', () => {
       expect(result.matchedRule!.id).toBe('default:allow-file_write-bootstrap');
     });
 
+    test('file_read of workspace UPDATES.md is auto-allowed', async () => {
+      const updatesPath = join(checkerTestDir, 'workspace', 'UPDATES.md');
+      const result = await check('file_read', { path: updatesPath }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.matchedRule).toBeDefined();
+      expect(result.matchedRule!.id).toBe('default:allow-file_read-updates');
+    });
+
+    test('file_write of workspace UPDATES.md is auto-allowed', async () => {
+      const updatesPath = join(checkerTestDir, 'workspace', 'UPDATES.md');
+      const result = await check('file_write', { path: updatesPath }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.matchedRule).toBeDefined();
+      expect(result.matchedRule!.id).toBe('default:allow-file_write-updates');
+    });
+
+    test('file_edit of workspace UPDATES.md is auto-allowed', async () => {
+      const updatesPath = join(checkerTestDir, 'workspace', 'UPDATES.md');
+      const result = await check('file_edit', { path: updatesPath }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.matchedRule).toBeDefined();
+      expect(result.matchedRule!.id).toBe('default:allow-file_edit-updates');
+    });
+
     test('file_write of non-workspace file is not auto-allowed', async () => {
       const otherPath = join(checkerTestDir, 'workspace', 'OTHER.md');
       const result = await check('file_write', { path: otherPath }, '/tmp');

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -105,7 +105,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   // and write these without prompting.  Also allow `rm BOOTSTRAP.md` so the
   // agent can delete it at the end of the onboarding ritual.
   const workspaceDir = join(getRootDir(), 'workspace').replaceAll('\\', '/');
-  const WORKSPACE_PROMPT_FILES = ['IDENTITY.md', 'USER.md', 'SOUL.md', 'BOOTSTRAP.md'] as const;
+  const WORKSPACE_PROMPT_FILES = ['IDENTITY.md', 'USER.md', 'SOUL.md', 'BOOTSTRAP.md', 'UPDATES.md'] as const;
   const WORKSPACE_FILE_TOOLS = ['file_read', 'file_write', 'file_edit'] as const;
   const workspacePromptRules = WORKSPACE_FILE_TOOLS.flatMap((tool) =>
     WORKSPACE_PROMPT_FILES.map((file) => ({


### PR DESCRIPTION
PR 06 of the UPDATES.md bulletin rollout plan.

## Summary
- Adds `UPDATES.md` to the `WORKSPACE_PROMPT_FILES` allowlist in `assistant/src/permissions/defaults.ts`
- This auto-generates default allow rules for `file_read`, `file_write`, and `file_edit` targeting `<workspaceDir>/UPDATES.md`
- Adds three corresponding test cases in `assistant/src/__tests__/checker.test.ts` verifying all three operations are auto-allowed

## Test plan
- [x] All 354 existing checker tests pass
- [x] New tests verify `file_read`, `file_write`, and `file_edit` for `UPDATES.md` are auto-allowed with correct rule IDs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
