### PR TITLE
feat: load workspace UPDATES.md into system prompt

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -257,6 +257,24 @@ describe('buildSystemPrompt', () => {
     });
   });
 
+  test('includes UPDATES.md content when file exists', () => {
+    writeFileSync(join(TEST_DIR, 'UPDATES.md'), '# v1.2\n\nNew feature added.');
+    const result = buildSystemPrompt();
+    expect(result).toContain('## Recent Updates');
+    expect(result).toContain('New feature added.');
+  });
+
+  test('omits updates section when UPDATES.md is empty', () => {
+    writeFileSync(join(TEST_DIR, 'UPDATES.md'), '   \n  \n  ');
+    const result = buildSystemPrompt();
+    expect(result).not.toContain('## Recent Updates');
+  });
+
+  test('omits updates section when UPDATES.md does not exist', () => {
+    const result = buildSystemPrompt();
+    expect(result).not.toContain('## Recent Updates');
+  });
+
   test('strips comment lines starting with _ from prompt files', () => {
     writeFileSync(
       join(TEST_DIR, 'IDENTITY.md'),

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -93,11 +93,14 @@ export function buildSystemPrompt(tier: ResponseTier = 'high'): string {
 
   const looksPath = getWorkspacePromptPath('LOOKS.md');
 
+  const updatesPath = getWorkspacePromptPath('UPDATES.md');
+
   const soul = readPromptFile(soulPath);
   const identity = readPromptFile(identityPath);
   const user = readPromptFile(userPath);
   const looks = readPromptFile(looksPath);
   const bootstrap = readPromptFile(bootstrapPath);
+  const updates = readPromptFile(updatesPath);
 
   // ── Core sections (all tiers) ──
   const parts: string[] = [];
@@ -110,6 +113,11 @@ export function buildSystemPrompt(tier: ResponseTier = 'high'): string {
       '# First-Run Ritual\n\n'
       + 'BOOTSTRAP.md is present — this is your first conversation. Follow its instructions.\n\n'
       + bootstrap,
+    );
+  }
+  if (updates) {
+    parts.push(
+      '## Recent Updates\n\n' + updates,
     );
   }
   parts.push(buildConfigSection());


### PR DESCRIPTION
PR 03 of the UPDATES.md bulletin rollout plan. Appends workspace UPDATES.md content to the system prompt when present.

## Changes

- Read `UPDATES.md` from the workspace prompt directory in `buildSystemPrompt()`
- When present and non-empty, append it as a `## Recent Updates` section (after bootstrap, before config)
- Added 3 tests: file exists with content, empty file, missing file

## Test plan

- [x] `bun test src/__tests__/system-prompt.test.ts` — all 47 tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
