### PR TITLE
feat: evict sessions on UPDATES.md file changes

### DIFF
--- a/assistant/src/__tests__/config-watcher.test.ts
+++ b/assistant/src/__tests__/config-watcher.test.ts
@@ -200,6 +200,14 @@ describe('ConfigWatcher workspace file handlers', () => {
     expect(evictCallCount).toBe(1);
   });
 
+  test('UPDATES.md change triggers onSessionEvict', async () => {
+    watcher.start(onSessionEvict);
+    simulateFileChange(WORKSPACE_DIR, 'UPDATES.md');
+
+    await new Promise((r) => setTimeout(r, 300));
+    expect(evictCallCount).toBe(1);
+  });
+
   test('config.json change calls refreshConfigFromSources', async () => {
     // Spy on refreshConfigFromSources to verify it is called
     const originalRefresh = watcher.refreshConfigFromSources.bind(watcher);

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -109,6 +109,7 @@ export class ConfigWatcher {
       'IDENTITY.md': () => onSessionEvict(),
       'USER.md': () => onSessionEvict(),
       'LOOKS.md': () => onSessionEvict(),
+      'UPDATES.md': () => onSessionEvict(),
     };
 
     const protectedHandlers: Record<string, () => void> = {


### PR DESCRIPTION
PR 09 of the UPDATES.md bulletin rollout plan. Adds UPDATES.md to the config watcher so file changes trigger session eviction.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
