### PR TITLE
feat: add bulletin behavior instructions to system prompt

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -275,6 +275,18 @@ describe('buildSystemPrompt', () => {
     expect(result).not.toContain('## Recent Updates');
   });
 
+  test('includes update handling instructions when UPDATES.md exists', () => {
+    writeFileSync(join(TEST_DIR, 'UPDATES.md'), '# v1.3\n\nSome update notes.');
+    const result = buildSystemPrompt();
+    expect(result).toContain('### Update Handling');
+    expect(result).toContain('Use your judgment');
+  });
+
+  test('omits update handling instructions when UPDATES.md is absent', () => {
+    const result = buildSystemPrompt();
+    expect(result).not.toContain('### Update Handling');
+  });
+
   test('strips comment lines starting with _ from prompt files', () => {
     writeFileSync(
       join(TEST_DIR, 'IDENTITY.md'),

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -116,9 +116,19 @@ export function buildSystemPrompt(tier: ResponseTier = 'high'): string {
     );
   }
   if (updates) {
-    parts.push(
-      '## Recent Updates\n\n' + updates,
-    );
+    parts.push([
+      '## Recent Updates',
+      '',
+      updates,
+      '',
+      '### Update Handling',
+      '',
+      'Use your judgment to decide when and how to surface updates to the user:',
+      '- Inform the user about updates that are relevant to what they are doing or asking about.',
+      '- Apply assistant-relevant changes (e.g., new tools, behavior adjustments) without forced announcement.',
+      '- Do not interrupt the user with updates unprompted — weave them naturally into conversation when relevant.',
+      '- When you are satisfied all updates have been actioned or communicated, delete `UPDATES.md` to signal completion.',
+    ].join('\n'));
   }
   parts.push(buildConfigSection());
   parts.push(buildPostToolResponseSection());


### PR DESCRIPTION
PR 04 of the UPDATES.md bulletin rollout plan. Adds judgment-based behavioral instructions for how the assistant should handle update notes.

## Changes

**`assistant/src/config/system-prompt.ts`**
- Enhanced the `if (updates)` block to include a `### Update Handling` subsection with behavioral instructions:
  - Surface relevant updates naturally during conversation
  - Apply assistant-relevant changes (new tools, behavior adjustments) without forced announcement
  - Don't interrupt users with updates unprompted
  - Delete `UPDATES.md` when all updates have been actioned or communicated

**`assistant/src/__tests__/system-prompt.test.ts`**
- Added test: `includes update handling instructions when UPDATES.md exists`
- Added test: `omits update handling instructions when UPDATES.md is absent`

## Test plan
- [x] All 49 system-prompt tests pass
- [x] New tests verify handling instructions presence/absence based on UPDATES.md existence
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
