### PR TITLE
feat: add deletion completion and merge semantics to bulletin sync

### DIFF
--- a/assistant/src/__tests__/update-bulletin.test.ts
+++ b/assistant/src/__tests__/update-bulletin.test.ts
@@ -158,4 +158,82 @@ describe('syncUpdateBulletinOnStartup', () => {
     const active: string[] = JSON.parse(raw!);
     expect(active).toContain('1.0.0');
   });
+
+  it('marks active releases as completed when UPDATES.md is deleted', () => {
+    // Pre-populate active releases in the store
+    store.set('updates:active_releases', JSON.stringify(['0.8.0', '0.9.0']));
+
+    // Workspace file does not exist — simulates the assistant having deleted it
+    const workspacePath = join(tempDir, 'UPDATES.md');
+    expect(existsSync(workspacePath)).toBe(false);
+
+    syncUpdateBulletinOnStartup();
+
+    // Active set should be cleared (except for the newly-added current release)
+    const activeRaw = store.get('updates:active_releases');
+    expect(activeRaw).toBeDefined();
+    const active: string[] = JSON.parse(activeRaw!);
+    // The old releases should not be in the active set
+    expect(active).not.toContain('0.8.0');
+    expect(active).not.toContain('0.9.0');
+
+    // The old releases should now be completed
+    const completedRaw = store.get('updates:completed_releases');
+    expect(completedRaw).toBeDefined();
+    const completed: string[] = JSON.parse(completedRaw!);
+    expect(completed).toContain('0.8.0');
+    expect(completed).toContain('0.9.0');
+  });
+
+  it('does not recreate completed release after deletion', () => {
+    // First run — creates the workspace file and marks 1.0.0 active
+    syncUpdateBulletinOnStartup();
+    const workspacePath = join(tempDir, 'UPDATES.md');
+    expect(existsSync(workspacePath)).toBe(true);
+
+    // Simulate assistant deleting the file to signal completion
+    rmSync(workspacePath);
+    expect(existsSync(workspacePath)).toBe(false);
+
+    // Second run — deletion-completion should mark 1.0.0 completed
+    syncUpdateBulletinOnStartup();
+
+    // The file should NOT be recreated since the release is now completed
+    expect(existsSync(workspacePath)).toBe(false);
+  });
+
+  it('merges pending old block with new release block', () => {
+    const workspacePath = join(tempDir, 'UPDATES.md');
+    // Pre-create workspace file with an old release block
+    const oldContent =
+      '<!-- vellum-update-release:0.9.0 -->\nOld release notes for 0.9.0.\n<!-- /vellum-update-release:0.9.0 -->\n';
+    writeFileSync(workspacePath, oldContent, 'utf-8');
+
+    syncUpdateBulletinOnStartup();
+
+    const content = readFileSync(workspacePath, 'utf-8');
+    // Both old and new release blocks should be present
+    expect(content).toContain('<!-- vellum-update-release:0.9.0 -->');
+    expect(content).toContain('Old release notes for 0.9.0.');
+    expect(content).toContain('<!-- vellum-update-release:1.0.0 -->');
+  });
+
+  it('idempotent on repeated sync calls', () => {
+    // First call
+    syncUpdateBulletinOnStartup();
+    const workspacePath = join(tempDir, 'UPDATES.md');
+    const afterFirst = readFileSync(workspacePath, 'utf-8');
+
+    // Second call
+    syncUpdateBulletinOnStartup();
+    const afterSecond = readFileSync(workspacePath, 'utf-8');
+
+    expect(afterSecond).toBe(afterFirst);
+
+    // Third call for good measure
+    syncUpdateBulletinOnStartup();
+    const afterThird = readFileSync(workspacePath, 'utf-8');
+
+    expect(afterThird).toBe(afterFirst);
+  });
 });

--- a/assistant/src/config/update-bulletin.ts
+++ b/assistant/src/config/update-bulletin.ts
@@ -3,20 +3,41 @@ import { join } from 'node:path';
 
 import { stripCommentLines } from './system-prompt.js';
 import { appendReleaseBlock, hasReleaseBlock } from './update-bulletin-format.js';
-import { addActiveRelease, isReleaseCompleted } from './update-bulletin-state.js';
+import {
+  addActiveRelease,
+  getActiveReleases,
+  isReleaseCompleted,
+  markReleasesCompleted,
+  setActiveReleases,
+} from './update-bulletin-state.js';
 import { APP_VERSION } from '../version.js';
 import { getWorkspacePromptPath } from '../util/platform.js';
 
 /**
  * Materializes the current release's update bulletin on startup.
  *
- * Reads the bundled UPDATES.md template, strips comment lines, and
+ * First checks for deletion-completion: if the workspace UPDATES.md was
+ * deleted while releases were active, those releases are marked completed
+ * (the assistant signals "done" by deleting the file).
+ *
+ * Then reads the bundled UPDATES.md template, strips comment lines, and
  * appends a release block to the workspace UPDATES.md if one doesn't
  * already exist for this version. Skips completed releases entirely.
  */
 export function syncUpdateBulletinOnStartup(): void {
   const currentReleaseId = APP_VERSION;
+  const workspacePath = getWorkspacePromptPath('UPDATES.md');
 
+  // --- Deletion completion ---
+  // If UPDATES.md was deleted and there are active releases, the assistant
+  // has signaled it is done with those updates. Mark them completed.
+  const activeReleases = getActiveReleases();
+  if (!existsSync(workspacePath) && activeReleases.length > 0) {
+    markReleasesCompleted(activeReleases);
+    setActiveReleases([]);
+  }
+
+  // --- Template materialization ---
   const templatePath = join(import.meta.dirname ?? __dirname, 'templates', 'UPDATES.md');
   if (!existsSync(templatePath)) return;
 
@@ -26,8 +47,6 @@ export function syncUpdateBulletinOnStartup(): void {
   if (!templateContent || templateContent.trim().length === 0) return;
 
   if (isReleaseCompleted(currentReleaseId)) return;
-
-  const workspacePath = getWorkspacePromptPath('UPDATES.md');
 
   if (!existsSync(workspacePath)) {
     const content = appendReleaseBlock('', currentReleaseId, templateContent);


### PR DESCRIPTION
PR 13 of the UPDATES.md bulletin rollout plan.

## Summary

- Adds deletion-completion logic to `syncUpdateBulletinOnStartup()`: when the workspace `UPDATES.md` file is missing but there are active releases tracked in the checkpoint store, all active releases are marked completed and the active set is cleared. This is the mechanism by which the assistant signals "I'm done with these updates" — by deleting the file.
- The deletion-completion check runs **before** template materialization, so a release that was just completed via deletion won't be re-created.
- Existing merge behavior preserved: pending old release blocks in the workspace file are kept alongside newly materialized blocks.

## Test plan

- [x] `marks active releases as completed when UPDATES.md is deleted` — pre-populates active releases, verifies they move to completed when workspace file is absent
- [x] `does not recreate completed release after deletion` — full round-trip: create file, delete it, re-sync, verify file stays deleted
- [x] `merges pending old block with new release block` — pre-existing v0.9.0 block coexists with newly materialized v1.0.0 block
- [x] `idempotent on repeated sync calls` — three consecutive syncs produce identical file content
- [x] All 9 tests passing (5 existing + 4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
