### PR TITLE
feat: allow rm UPDATES.md in workspace scope

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -671,7 +671,7 @@ describe('Trust Store', () => {
       expect(defaults).toHaveLength(NUM_DEFAULTS);
       for (const rule of defaults) {
         expect(rule.priority).toBe(DEFAULT_PRIORITY_BY_ID.get(rule.id)!);
-        if (rule.id === 'default:allow-bash-rm-bootstrap') {
+        if (rule.id === 'default:allow-bash-rm-bootstrap' || rule.id === 'default:allow-bash-rm-updates') {
           expect(rule.scope).toBe(join(testDir, 'workspace'));
         } else {
           expect(rule.scope).toBe('everywhere');
@@ -693,12 +693,16 @@ describe('Trust Store', () => {
         'browser_close',
         'browser_extract',
         'browser_fill_credential',
+        'browser_hover',
         'browser_navigate',
         'browser_press_key',
         'browser_screenshot',
+        'browser_scroll',
+        'browser_select_option',
         'browser_snapshot',
         'browser_type',
         'browser_wait_for',
+        'browser_wait_for_download',
         'computer_use_click',
         'computer_use_double_click',
         'computer_use_drag',
@@ -840,6 +844,18 @@ describe('Trust Store', () => {
       expect(other).not.toBeNull();
       expect(other!.id).not.toBe('default:allow-bash-rm-bootstrap');
       expect(other!.id).toBe('default:allow-bash-global');
+    });
+
+    test('updates delete rule matches only when workingDir is the workspace dir', () => {
+      const workspaceDir = join(testDir, 'workspace');
+      const match = findHighestPriorityRule('bash', ['rm UPDATES.md'], workspaceDir);
+      expect(match).not.toBeNull();
+      expect(match!.id).toBe('default:allow-bash-rm-updates');
+      expect(match!.decision).toBe('allow');
+      // Outside workspace, should NOT match the updates rule
+      const other = findHighestPriorityRule('bash', ['rm UPDATES.md'], '/tmp/other-project');
+      expect(other).not.toBeNull();
+      expect(other!.id).not.toBe('default:allow-bash-rm-updates');
     });
 
     test('default ask does not affect files outside protected directory', () => {

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -127,6 +127,15 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     priority: 100,
   };
 
+  const updatesDeleteRule: DefaultRuleTemplate = {
+    id: 'default:allow-bash-rm-updates',
+    tool: 'bash',
+    pattern: 'rm UPDATES.md',
+    scope: workspaceDir,
+    decision: 'allow',
+    priority: 100,
+  };
+
   // Skill source directories — writing or editing skill source files should
   // require explicit user approval so a compromised agent loop cannot silently
   // modify skill code to escalate privileges.
@@ -248,6 +257,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     ...managedSkillRules,
     ...workspacePromptRules,
     bootstrapDeleteRule,
+    updatesDeleteRule,
     ...skillSourceMutationRules,
     skillLoadRule,
     browserNavigateRule,


### PR DESCRIPTION
PR 07 of the UPDATES.md bulletin rollout plan.

Adds a default allow rule (`default:allow-bash-rm-updates`) so the assistant can delete `UPDATES.md` without permission friction, mirroring the existing `rm BOOTSTRAP.md` rule. Scoped to the workspace directory only.

## Changes
- `assistant/src/permissions/defaults.ts`: Added `updatesDeleteRule` with workspace scope
- `assistant/src/__tests__/trust-store.test.ts`: Added test verifying the rule matches in workspace dir but not outside it; also fixed pre-existing test gap for newer browser tools

## Test plan
- [x] `bun test src/__tests__/trust-store.test.ts` — all 126 tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
