### PR TITLE
feat: add atomic write path for bulletin sync

### DIFF
--- a/assistant/src/__tests__/update-bulletin.test.ts
+++ b/assistant/src/__tests__/update-bulletin.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -235,5 +235,26 @@ describe('syncUpdateBulletinOnStartup', () => {
     const afterThird = readFileSync(workspacePath, 'utf-8');
 
     expect(afterThird).toBe(afterFirst);
+  });
+
+  it('write path produces valid UTF-8 with trailing newline', () => {
+    syncUpdateBulletinOnStartup();
+    const workspacePath = join(tempDir, 'UPDATES.md');
+    const content = readFileSync(workspacePath, 'utf-8');
+
+    expect(content.length).toBeGreaterThan(0);
+    expect(content.endsWith('\n')).toBe(true);
+
+    // Verify round-trip through Buffer produces identical content (valid UTF-8)
+    const roundTripped = Buffer.from(content, 'utf-8').toString('utf-8');
+    expect(roundTripped).toBe(content);
+  });
+
+  it('no temp file leftovers after successful write', () => {
+    syncUpdateBulletinOnStartup();
+
+    const entries = readdirSync(tempDir);
+    const tmpFiles = entries.filter((e) => e.includes('.tmp.'));
+    expect(tmpFiles).toHaveLength(0);
   });
 });

--- a/assistant/src/config/update-bulletin.ts
+++ b/assistant/src/config/update-bulletin.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { stripCommentLines } from './system-prompt.js';
@@ -12,6 +12,25 @@ import {
 } from './update-bulletin-state.js';
 import { APP_VERSION } from '../version.js';
 import { getWorkspacePromptPath } from '../util/platform.js';
+
+/**
+ * Writes content to a file via a temp-file + rename to prevent partial/truncated
+ * writes if the process crashes mid-write.
+ */
+function atomicWriteFileSync(filePath: string, content: string): void {
+  const tmpPath = `${filePath}.tmp.${process.pid}`;
+  try {
+    writeFileSync(tmpPath, content, 'utf-8');
+    renameSync(tmpPath, filePath);
+  } catch (err) {
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      /* ignore cleanup errors */
+    }
+    throw err;
+  }
+}
 
 /**
  * Materializes the current release's update bulletin on startup.
@@ -50,12 +69,12 @@ export function syncUpdateBulletinOnStartup(): void {
 
   if (!existsSync(workspacePath)) {
     const content = appendReleaseBlock('', currentReleaseId, templateContent);
-    writeFileSync(workspacePath, content, 'utf-8');
+    atomicWriteFileSync(workspacePath, content);
   } else {
     const existing = readFileSync(workspacePath, 'utf-8');
     if (!hasReleaseBlock(existing, currentReleaseId)) {
       const updated = appendReleaseBlock(existing, currentReleaseId, templateContent);
-      writeFileSync(workspacePath, updated, 'utf-8');
+      atomicWriteFileSync(workspacePath, updated);
     }
   }
 


### PR DESCRIPTION
PR 14 of the UPDATES.md bulletin rollout plan.

## Summary

- Adds an `atomicWriteFileSync` helper that writes to a temp file and renames it into place, preventing partial/truncated `UPDATES.md` writes if the process crashes mid-write.
- Replaces both `writeFileSync(workspacePath, ...)` calls in `syncUpdateBulletinOnStartup` with the new atomic helper.
- Adds two new tests: valid UTF-8 with trailing newline verification, and no leftover temp files after successful writes.

## Test plan

- [x] All 11 existing + new tests pass (`bun test src/__tests__/update-bulletin.test.ts`)
- [x] Write path produces valid UTF-8 with trailing newline
- [x] No `.tmp.*` file leftovers remain after successful sync
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
