### PR TITLE
feat: add UPDATES.md to prompt config section

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -287,6 +287,12 @@ describe('buildSystemPrompt', () => {
     expect(result).not.toContain('### Update Handling');
   });
 
+  test('config section lists UPDATES.md', () => {
+    const result = buildSystemPrompt();
+    expect(result).toContain('`UPDATES.md`');
+    expect(result).toContain('Release update notes');
+  });
+
   test('strips comment lines starting with _ from prompt files', () => {
     writeFileSync(
       join(TEST_DIR, 'IDENTITY.md'),

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -640,6 +640,7 @@ function buildConfigSection(): string {
     '- `LOOKS.md` — Your avatar appearance: body/cheek colors and outfit (hat, shirt, accessory, held item).',
     '- `HEARTBEAT.md` — Checklist for periodic heartbeat runs. When heartbeat is enabled, the assistant runs this checklist on a timer and flags anything that needs attention. Edit this file to control what gets checked each run.',
     '- `BOOTSTRAP.md` — First-run ritual script (only present during onboarding; you delete it when done).',
+    '- `UPDATES.md` — Release update notes (created automatically on new releases; delete when updates are actioned).',
     '- `skills/` — Directory of installed skills (loaded automatically at startup).',
     '',
     '### Heartbeat',


### PR DESCRIPTION
PR 05 of the UPDATES.md bulletin rollout plan. Makes UPDATES.md discoverable in the Configuration file list.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
