### PR TITLE
fix: add createdAt to IPC session response for stable sidebar ordering

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1347,6 +1347,7 @@ exports[`IPC message snapshots ServerMessage types session_list_response seriali
 {
   "sessions": [
     {
+      "createdAt": 1699999000,
       "id": "sess-001",
       "threadType": "standard",
       "title": "First session",
@@ -1359,6 +1360,7 @@ exports[`IPC message snapshots ServerMessage types session_list_response seriali
         "lastSeenSignalType": "macos_notification_view",
         "latestAssistantMessageAt": 1700001000,
       },
+      "createdAt": 1700000000,
       "id": "sess-002",
       "threadType": "standard",
       "title": "Second session",

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -839,8 +839,8 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   session_list_response: {
     type: 'session_list_response',
     sessions: [
-      { id: 'sess-001', title: 'First session', updatedAt: 1700000000, threadType: 'standard' },
-      { id: 'sess-002', title: 'Second session', updatedAt: 1700001000, threadType: 'standard', assistantAttention: { hasUnseenLatestAssistantMessage: true, latestAssistantMessageAt: 1700001000, lastSeenConfidence: 'explicit', lastSeenSignalType: 'macos_notification_view' } },
+      { id: 'sess-001', title: 'First session', createdAt: 1699999000, updatedAt: 1700000000, threadType: 'standard' },
+      { id: 'sess-002', title: 'Second session', createdAt: 1700000000, updatedAt: 1700001000, threadType: 'standard', assistantAttention: { hasUnseenLatestAssistantMessage: true, latestAssistantMessageAt: 1700001000, lastSeenConfidence: 'explicit', lastSeenSignalType: 'macos_notification_view' } },
     ],
   },
   sessions_clear_response: {

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -565,6 +565,7 @@ export function handleSessionList(socket: net.Socket, ctx: HandlerContext, offse
       return {
         id: c.id,
         title: c.title ?? 'Untitled',
+        createdAt: c.createdAt,
         updatedAt: c.updatedAt,
         threadType: normalizeThreadType(c.threadType),
         source: c.source ?? 'user',

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -13,11 +13,11 @@
     "_ParentalControlClientMessages",
     "_SchedulesClientMessages",
     "_SessionsClientMessages",
+    "_SettingsClientMessages",
     "_SkillsClientMessages",
     "_SubagentsClientMessages",
     "_SurfacesClientMessages",
     "_TrustClientMessages",
-    "_SettingsClientMessages",
     "_WorkItemsClientMessages",
     "_WorkspaceClientMessages"
   ],

--- a/assistant/src/daemon/ipc-contract/sessions.ts
+++ b/assistant/src/daemon/ipc-contract/sessions.ts
@@ -213,7 +213,7 @@ export interface AssistantAttention {
 
 export interface SessionListResponse {
   type: 'session_list_response';
-  sessions: Array<{ id: string; title: string; updatedAt: number; threadType?: ThreadType; source?: string; channelBinding?: ChannelBinding; conversationOriginChannel?: ChannelId; conversationOriginInterface?: InterfaceId; assistantAttention?: AssistantAttention }>;
+  sessions: Array<{ id: string; title: string; createdAt: number; updatedAt: number; threadType?: ThreadType; source?: string; channelBinding?: ChannelBinding; conversationOriginChannel?: ChannelId; conversationOriginInterface?: InterfaceId; assistantAttention?: AssistantAttention }>;
   /** Whether more sessions exist beyond the returned page. */
   hasMore?: boolean;
 }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -627,6 +627,7 @@ export class RuntimeHttpServer {
             return {
               id: c.id,
               title: c.title ?? 'Untitled',
+              createdAt: c.createdAt,
               updatedAt: c.updatedAt,
               threadType: c.threadType === 'private' ? 'private' : 'standard',
               source: c.source ?? 'user',

--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -309,7 +309,8 @@ class IOSThreadStore: ObservableObject {
         for session in filteredSessions {
             let thread = IOSThread(
                 title: session.title,
-                createdAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
+                createdAt: Date(timeIntervalSince1970: TimeInterval(session.createdAt) / 1000.0),
+                lastActivityAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
                 sessionId: session.id
             )
             let vm = ChatViewModel(daemonClient: daemonClient)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -386,9 +386,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
             let thread = ThreadModel(
                 title: session.title,
-                createdAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
+                createdAt: Date(timeIntervalSince1970: TimeInterval(session.createdAt) / 1000.0),
                 sessionId: session.id,
                 isArchived: isSessionArchived(session.id),
+                lastInteractedAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
                 kind: session.threadType == "private" ? .private : .standard,
                 source: session.source,
                 hasUnseenLatestAssistantMessage: session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -201,9 +201,10 @@ final class ThreadSessionRestorer {
 
             let thread = ThreadModel(
                 title: title,
-                createdAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
+                createdAt: Date(timeIntervalSince1970: TimeInterval(session.createdAt) / 1000.0),
                 sessionId: session.id,
                 isArchived: delegate.isSessionArchived(session.id),
+                lastInteractedAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
                 kind: kind,
                 source: session.source,
                 hasUnseenLatestAssistantMessage: session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false

--- a/clients/macos/vellum-assistantTests/PrivateThreadPersistenceTests.swift
+++ b/clients/macos/vellum-assistantTests/PrivateThreadPersistenceTests.swift
@@ -65,6 +65,7 @@ struct PrivateThreadPersistenceTests {
                 [
                     "id": "private-session-e2e",
                     "title": "Private Thread",
+                    "createdAt": 4000,
                     "updatedAt": 5000,
                     "threadType": "private"
                 ]
@@ -107,6 +108,7 @@ struct PrivateThreadPersistenceTests {
                 [
                     "id": "standard-session-e2e",
                     "title": "Standard Thread",
+                    "createdAt": 2000,
                     "updatedAt": 3000,
                     "threadType": "standard"
                 ]
@@ -139,9 +141,9 @@ struct PrivateThreadPersistenceTests {
         let sessionListJSON: [String: Any] = [
             "type": "session_list_response",
             "sessions": [
-                ["id": "s-private-1", "title": "Private A", "updatedAt": 5000, "threadType": "private"],
-                ["id": "s-standard-1", "title": "Standard B", "updatedAt": 4000, "threadType": "standard"],
-                ["id": "s-private-2", "title": "Private C", "updatedAt": 3000, "threadType": "private"],
+                ["id": "s-private-1", "title": "Private A", "createdAt": 4000, "updatedAt": 5000, "threadType": "private"],
+                ["id": "s-standard-1", "title": "Standard B", "createdAt": 3000, "updatedAt": 4000, "threadType": "standard"],
+                ["id": "s-private-2", "title": "Private C", "createdAt": 2000, "updatedAt": 3000, "threadType": "private"],
             ]
         ]
         let data = try! JSONSerialization.data(withJSONObject: sessionListJSON)
@@ -173,7 +175,7 @@ struct PrivateThreadPersistenceTests {
         let legacyJSON: [String: Any] = [
             "type": "session_list_response",
             "sessions": [
-                ["id": "legacy-1", "title": "Old Chat", "updatedAt": 2000],
+                ["id": "legacy-1", "title": "Old Chat", "createdAt": 1000, "updatedAt": 2000],
             ]
         ]
         let data = try! JSONSerialization.data(withJSONObject: legacyJSON)
@@ -200,8 +202,8 @@ struct PrivateThreadPersistenceTests {
 
         // Build sessions array manually: first has threadType, second doesn't
         let sessions: [[String: Any]] = [
-            ["id": "modern-1", "title": "Modern Private", "updatedAt": 5000, "threadType": "private"],
-            ["id": "legacy-1", "title": "Legacy Chat", "updatedAt": 4000],
+            ["id": "modern-1", "title": "Modern Private", "createdAt": 4000, "updatedAt": 5000, "threadType": "private"],
+            ["id": "legacy-1", "title": "Legacy Chat", "createdAt": 3000, "updatedAt": 4000],
         ]
         let dict: [String: Any] = ["type": "session_list_response", "sessions": sessions]
         let data = try! JSONSerialization.data(withJSONObject: dict)

--- a/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
@@ -78,9 +78,9 @@ final class MockThreadRestorerDelegate: ThreadRestorerDelegate {
 // MARK: - Helpers
 
 /// Build an IPCSessionListResponse via JSON round-trip.
-private func makeSessionListResponse(sessions: [(id: String, title: String, updatedAt: Int, threadType: String?, channelBinding: [String: Any]?)]) -> SessionListResponseMessage {
+private func makeSessionListResponse(sessions: [(id: String, title: String, createdAt: Int, updatedAt: Int, threadType: String?, channelBinding: [String: Any]?)]) -> SessionListResponseMessage {
     let sessionDicts = sessions.map { session -> [String: Any] in
-        var dict: [String: Any] = ["id": session.id, "title": session.title, "updatedAt": session.updatedAt]
+        var dict: [String: Any] = ["id": session.id, "title": session.title, "createdAt": session.createdAt, "updatedAt": session.updatedAt]
         if let threadType = session.threadType {
             dict["threadType"] = threadType
         }
@@ -96,12 +96,12 @@ private func makeSessionListResponse(sessions: [(id: String, title: String, upda
 
 /// Convenience overload with threadType but no channelBinding.
 private func makeSessionListResponse(sessions: [(id: String, title: String, updatedAt: Int, threadType: String?)]) -> SessionListResponseMessage {
-    makeSessionListResponse(sessions: sessions.map { ($0.id, $0.title, $0.updatedAt, $0.threadType, nil) })
+    makeSessionListResponse(sessions: sessions.map { ($0.id, $0.title, $0.updatedAt, $0.updatedAt, $0.threadType, nil) })
 }
 
 /// Convenience overload without threadType for existing tests.
 private func makeSessionListResponse(sessions: [(id: String, title: String, updatedAt: Int)]) -> SessionListResponseMessage {
-    makeSessionListResponse(sessions: sessions.map { ($0.id, $0.title, $0.updatedAt, nil) })
+    makeSessionListResponse(sessions: sessions.map { ($0.id, $0.title, $0.updatedAt, $0.updatedAt, nil, nil) })
 }
 
 /// Build an IPCHistoryResponse via JSON round-trip.

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -3792,6 +3792,7 @@ public struct IPCSessionListResponse: Codable, Sendable {
 public struct IPCSessionListResponseSession: Codable, Sendable {
     public let id: String
     public let title: String
+    public let createdAt: Int
     public let updatedAt: Int
     public let threadType: String?
     public let source: String?
@@ -3802,9 +3803,10 @@ public struct IPCSessionListResponseSession: Codable, Sendable {
     /// Attention state metadata for a conversation's latest assistant message.
     public let assistantAttention: IPCAssistantAttention?
 
-    public init(id: String, title: String, updatedAt: Int, threadType: String? = nil, source: String? = nil, channelBinding: IPCChannelBinding? = nil, conversationOriginChannel: String? = nil, conversationOriginInterface: String? = nil, assistantAttention: IPCAssistantAttention? = nil) {
+    public init(id: String, title: String, createdAt: Int, updatedAt: Int, threadType: String? = nil, source: String? = nil, channelBinding: IPCChannelBinding? = nil, conversationOriginChannel: String? = nil, conversationOriginInterface: String? = nil, assistantAttention: IPCAssistantAttention? = nil) {
         self.id = id
         self.title = title
+        self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.threadType = threadType
         self.source = source

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -21,6 +21,7 @@ struct ConversationsListResponse: Decodable {
     struct Session: Decodable {
         let id: String
         let title: String
+        let createdAt: Int
         let updatedAt: Int
         let threadType: String?
         let source: String?
@@ -504,7 +505,7 @@ final class HTTPTransport {
             do {
                 let decoded = try decoder.decode(ConversationsListResponse.self, from: data)
                 let sessions = decoded.sessions.map {
-                    IPCSessionListResponseSession(id: $0.id, title: $0.title, updatedAt: $0.updatedAt, threadType: $0.threadType, source: $0.source, channelBinding: $0.channelBinding, conversationOriginChannel: $0.conversationOriginChannel, conversationOriginInterface: $0.conversationOriginInterface, assistantAttention: $0.assistantAttention)
+                    IPCSessionListResponseSession(id: $0.id, title: $0.title, createdAt: $0.createdAt, updatedAt: $0.updatedAt, threadType: $0.threadType, source: $0.source, channelBinding: $0.channelBinding, conversationOriginChannel: $0.conversationOriginChannel, conversationOriginInterface: $0.conversationOriginInterface, assistantAttention: $0.assistantAttention)
                 }
                 onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: sessions, hasMore: decoded.hasMore)))
             } catch {


### PR DESCRIPTION
## Summary
- Added createdAt field to the IPC session list response alongside existing updatedAt
- Updated ThreadManager.appendThreads and ThreadSessionRestorer to use real createdAt for ThreadModel creation
- This ensures sidebar thread order is truly stable across app restarts (not derived from updatedAt)
- Addresses review feedback on #9964

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/9964

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
