### PR TITLE
feat: notification thread reuse — decision contract + candidate context

### DIFF
--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -9,7 +9,9 @@
 import { describe, expect, test } from 'bun:test';
 
 import { composeFallbackCopy } from '../notifications/copy-composer.js';
+import { validateThreadActions } from '../notifications/decision-engine.js';
 import type { NotificationSignal } from '../notifications/signal.js';
+import type { ThreadCandidateSet } from '../notifications/thread-candidates.js';
 import type { NotificationChannel } from '../notifications/types.js';
 
 // -- Helpers -----------------------------------------------------------------
@@ -168,6 +170,140 @@ describe('notification decision strategy', () => {
         });
         expect(signal.attentionHints.urgency).toBe(urgency);
       }
+    });
+  });
+
+  // -- Thread action validation -----------------------------------------------
+
+  describe('thread action validation', () => {
+    const validChannels: NotificationChannel[] = ['vellum', 'telegram'];
+    const candidateSet: ThreadCandidateSet = {
+      vellum: [
+        {
+          conversationId: 'conv-001',
+          title: 'Reminder thread',
+          updatedAt: Date.now(),
+          latestSourceEventName: 'reminder.fired',
+          channel: 'vellum',
+        },
+        {
+          conversationId: 'conv-002',
+          title: 'Guardian thread',
+          updatedAt: Date.now(),
+          latestSourceEventName: 'guardian.question',
+          channel: 'vellum',
+          guardianContext: { pendingUnresolvedRequestCount: 2 },
+        },
+      ],
+      telegram: [
+        {
+          conversationId: 'conv-003',
+          title: 'Telegram thread',
+          updatedAt: Date.now(),
+          latestSourceEventName: 'reminder.fired',
+          channel: 'telegram',
+        },
+      ],
+    };
+
+    test('accepts start_new action', () => {
+      const result = validateThreadActions(
+        { vellum: { action: 'start_new' } },
+        validChannels,
+        candidateSet,
+      );
+      expect(result.vellum).toEqual({ action: 'start_new' });
+    });
+
+    test('accepts reuse_existing with valid candidate conversationId', () => {
+      const result = validateThreadActions(
+        { vellum: { action: 'reuse_existing', conversationId: 'conv-001' } },
+        validChannels,
+        candidateSet,
+      );
+      expect(result.vellum).toEqual({ action: 'reuse_existing', conversationId: 'conv-001' });
+    });
+
+    test('downgrades reuse_existing with invalid conversationId to start_new', () => {
+      const result = validateThreadActions(
+        { vellum: { action: 'reuse_existing', conversationId: 'conv-INVALID' } },
+        validChannels,
+        candidateSet,
+      );
+      expect(result.vellum).toEqual({ action: 'start_new' });
+    });
+
+    test('downgrades reuse_existing without conversationId to start_new', () => {
+      const result = validateThreadActions(
+        { vellum: { action: 'reuse_existing' } },
+        validChannels,
+        candidateSet,
+      );
+      expect(result.vellum).toEqual({ action: 'start_new' });
+    });
+
+    test('downgrades reuse_existing with empty conversationId to start_new', () => {
+      const result = validateThreadActions(
+        { vellum: { action: 'reuse_existing', conversationId: '  ' } },
+        validChannels,
+        candidateSet,
+      );
+      expect(result.vellum).toEqual({ action: 'start_new' });
+    });
+
+    test('rejects reuse_existing targeting a different channel candidate', () => {
+      // conv-003 is a telegram candidate, not a vellum candidate
+      const result = validateThreadActions(
+        { vellum: { action: 'reuse_existing', conversationId: 'conv-003' } },
+        validChannels,
+        candidateSet,
+      );
+      expect(result.vellum).toEqual({ action: 'start_new' });
+    });
+
+    test('ignores thread actions for channels not in validChannels', () => {
+      const result = validateThreadActions(
+        { sms: { action: 'start_new' } },
+        validChannels,
+        candidateSet,
+      );
+      expect(result).toEqual({});
+    });
+
+    test('handles null/undefined input gracefully', () => {
+      expect(validateThreadActions(null, validChannels, candidateSet)).toEqual({});
+      expect(validateThreadActions(undefined, validChannels, candidateSet)).toEqual({});
+    });
+
+    test('handles missing candidate set — all reuse_existing downgrade to start_new', () => {
+      const result = validateThreadActions(
+        { vellum: { action: 'reuse_existing', conversationId: 'conv-001' } },
+        validChannels,
+        undefined,
+      );
+      expect(result.vellum).toEqual({ action: 'start_new' });
+    });
+
+    test('supports multiple channels simultaneously', () => {
+      const result = validateThreadActions(
+        {
+          vellum: { action: 'reuse_existing', conversationId: 'conv-002' },
+          telegram: { action: 'start_new' },
+        },
+        validChannels,
+        candidateSet,
+      );
+      expect(result.vellum).toEqual({ action: 'reuse_existing', conversationId: 'conv-002' });
+      expect(result.telegram).toEqual({ action: 'start_new' });
+    });
+
+    test('ignores unknown action values', () => {
+      const result = validateThreadActions(
+        { vellum: { action: 'unknown_action' } },
+        validChannels,
+        candidateSet,
+      );
+      expect(result.vellum).toBeUndefined();
     });
   });
 });

--- a/assistant/src/__tests__/notification-thread-candidates.test.ts
+++ b/assistant/src/__tests__/notification-thread-candidates.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Focused tests for thread candidate building and prompt serialization.
+ *
+ * Validates that the candidate builder produces correct, lightweight metadata
+ * and that the prompt serializer formats it in a token-efficient way.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import type { ThreadCandidate, ThreadCandidateSet } from '../notifications/thread-candidates.js';
+import { serializeCandidatesForPrompt } from '../notifications/thread-candidates.js';
+import type { NotificationChannel } from '../notifications/types.js';
+
+// -- serializeCandidatesForPrompt tests ---------------------------------------
+
+describe('serializeCandidatesForPrompt', () => {
+  test('returns null for empty candidate set', () => {
+    expect(serializeCandidatesForPrompt({})).toBeNull();
+  });
+
+  test('returns null when all channels have empty arrays', () => {
+    const set: ThreadCandidateSet = { vellum: [] };
+    expect(serializeCandidatesForPrompt(set)).toBeNull();
+  });
+
+  test('serializes a single channel with one candidate', () => {
+    const set: ThreadCandidateSet = {
+      vellum: [
+        {
+          conversationId: 'conv-001',
+          title: 'Reminder thread',
+          updatedAt: 1700000000000,
+          latestSourceEventName: 'reminder.fired',
+          channel: 'vellum' as NotificationChannel,
+        },
+      ],
+    };
+
+    const result = serializeCandidatesForPrompt(set);
+    expect(result).not.toBeNull();
+    expect(result).toContain('Channel: vellum');
+    expect(result).toContain('id=conv-001');
+    expect(result).toContain('title="Reminder thread"');
+    expect(result).toContain('lastEvent="reminder.fired"');
+  });
+
+  test('serializes untitled conversations with placeholder', () => {
+    const set: ThreadCandidateSet = {
+      vellum: [
+        {
+          conversationId: 'conv-002',
+          title: null,
+          updatedAt: 1700000000000,
+          latestSourceEventName: null,
+          channel: 'vellum' as NotificationChannel,
+        },
+      ],
+    };
+
+    const result = serializeCandidatesForPrompt(set)!;
+    expect(result).toContain('title="(untitled)"');
+    expect(result).not.toContain('lastEvent=');
+  });
+
+  test('includes guardian context when present', () => {
+    const set: ThreadCandidateSet = {
+      vellum: [
+        {
+          conversationId: 'conv-003',
+          title: 'Guardian thread',
+          updatedAt: 1700000000000,
+          latestSourceEventName: 'guardian.question',
+          channel: 'vellum' as NotificationChannel,
+          guardianContext: { pendingUnresolvedRequestCount: 3 },
+        },
+      ],
+    };
+
+    const result = serializeCandidatesForPrompt(set)!;
+    expect(result).toContain('pendingRequests=3');
+  });
+
+  test('serializes multiple channels', () => {
+    const set: ThreadCandidateSet = {
+      vellum: [
+        {
+          conversationId: 'conv-001',
+          title: 'Vellum thread',
+          updatedAt: 1700000000000,
+          latestSourceEventName: 'reminder.fired',
+          channel: 'vellum' as NotificationChannel,
+        },
+      ],
+      telegram: [
+        {
+          conversationId: 'conv-002',
+          title: 'Telegram thread',
+          updatedAt: 1700000000000,
+          latestSourceEventName: 'guardian.question',
+          channel: 'telegram' as NotificationChannel,
+        },
+      ],
+    };
+
+    const result = serializeCandidatesForPrompt(set)!;
+    expect(result).toContain('Channel: vellum');
+    expect(result).toContain('Channel: telegram');
+    expect(result).toContain('id=conv-001');
+    expect(result).toContain('id=conv-002');
+  });
+
+  test('serializes multiple candidates per channel', () => {
+    const set: ThreadCandidateSet = {
+      vellum: [
+        {
+          conversationId: 'conv-001',
+          title: 'First thread',
+          updatedAt: 1700000000000,
+          latestSourceEventName: 'reminder.fired',
+          channel: 'vellum' as NotificationChannel,
+        },
+        {
+          conversationId: 'conv-002',
+          title: 'Second thread',
+          updatedAt: 1699999000000,
+          latestSourceEventName: 'guardian.question',
+          channel: 'vellum' as NotificationChannel,
+          guardianContext: { pendingUnresolvedRequestCount: 1 },
+        },
+      ],
+    };
+
+    const result = serializeCandidatesForPrompt(set)!;
+    expect(result).toContain('id=conv-001');
+    expect(result).toContain('id=conv-002');
+    expect(result).toContain('pendingRequests=1');
+  });
+});
+
+// -- ThreadCandidate type correctness -----------------------------------------
+
+describe('ThreadCandidate type', () => {
+  test('candidate has all required fields', () => {
+    const candidate: ThreadCandidate = {
+      conversationId: 'conv-test',
+      title: 'Test',
+      updatedAt: Date.now(),
+      latestSourceEventName: 'test.event',
+      channel: 'vellum' as NotificationChannel,
+    };
+    expect(candidate.conversationId).toBe('conv-test');
+    expect(candidate.guardianContext).toBeUndefined();
+  });
+
+  test('candidate can include guardian context', () => {
+    const candidate: ThreadCandidate = {
+      conversationId: 'conv-test',
+      title: 'Test',
+      updatedAt: Date.now(),
+      latestSourceEventName: 'guardian.question',
+      channel: 'vellum' as NotificationChannel,
+      guardianContext: { pendingUnresolvedRequestCount: 5 },
+    };
+    expect(candidate.guardianContext?.pendingUnresolvedRequestCount).toBe(5);
+  });
+});

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -19,18 +19,20 @@ import { getLogger } from '../util/logger.js';
 import { createDecision } from './decisions-store.js';
 import { getPreferenceSummary } from './preference-summary.js';
 import type { NotificationSignal, RoutingIntent } from './signal.js';
-import type { NotificationChannel, NotificationDecision, RenderedChannelCopy } from './types.js';
+import { type ThreadCandidateSet, buildThreadCandidates, serializeCandidatesForPrompt } from './thread-candidates.js';
+import type { NotificationChannel, NotificationDecision, RenderedChannelCopy, ThreadAction } from './types.js';
 
 const log = getLogger('notification-decision-engine');
 
 const DECISION_TIMEOUT_MS = 15_000;
-const PROMPT_VERSION = 'v3';
+const PROMPT_VERSION = 'v4';
 
 // ── System prompt ──────────────────────────────────────────────────────
 
 function buildSystemPrompt(
   availableChannels: NotificationChannel[],
   preferenceContext?: string,
+  candidateContext?: string,
 ): string {
   const sections: string[] = [
     `You are a notification routing engine. Given a signal describing an event, decide whether the user should be notified, on which channel(s), and compose the notification copy.`,
@@ -73,6 +75,26 @@ function buildSystemPrompt(
     `- \`threadSeedMessage\` is the opening message in the internal notification thread — it can be richer and more contextual.`,
     `  - For vellum (desktop): 2-4 short sentences with useful context and clear next step if action is required.`,
     `  - Never dump raw JSON. Include only human-readable context.`,
+    ``,
+    `Thread reuse guidelines:`,
+    `- For each selected channel, decide whether to start a new conversation thread or reuse an existing one.`,
+    `- Set \`threadActions\` keyed by channel name with \`action\` = "start_new" or "reuse_existing" (with \`conversationId\` from the candidates).`,
+    `- Prefer \`reuse_existing\` when the signal is clearly a continuation or update of an existing notification thread (same event type, related context).`,
+    `- Prefer \`start_new\` when the signal is a distinct event that deserves its own thread.`,
+    `- You may ONLY reuse a conversationId that appears in the provided candidate list. Any other ID will be rejected and downgraded to start_new.`,
+    `- When no candidates are available for a channel, always use start_new.`,
+  );
+
+  if (candidateContext) {
+    sections.push(
+      ``,
+      `<thread-candidates>`,
+      candidateContext,
+      `</thread-candidates>`,
+    );
+  }
+
+  sections.push(
     ``,
     `You MUST respond using the \`record_notification_decision\` tool. Do not respond with text.`,
   );
@@ -158,6 +180,30 @@ function buildDecisionTool(availableChannels: NotificationChannel[]) {
             ]),
           ),
         },
+        threadActions: {
+          type: 'object',
+          description: 'Per-channel thread action: start a new thread or reuse an existing candidate. Keyed by channel name.',
+          properties: Object.fromEntries(
+            availableChannels.map((ch) => [
+              ch,
+              {
+                type: 'object',
+                properties: {
+                  action: {
+                    type: 'string',
+                    enum: ['start_new', 'reuse_existing'],
+                    description: 'Whether to start a new thread or reuse an existing one.',
+                  },
+                  conversationId: {
+                    type: 'string',
+                    description: 'Required when action is reuse_existing. Must be a conversationId from the provided thread candidates.',
+                  },
+                },
+                required: ['action'],
+              },
+            ]),
+          ),
+        },
         deepLinkTarget: {
           type: 'object',
           description: 'Optional deep link metadata for navigating to the source context',
@@ -237,6 +283,7 @@ const VALID_CHANNELS = new Set<string>(getDeliverableChannels());
 function validateDecisionOutput(
   input: Record<string, unknown>,
   availableChannels: NotificationChannel[],
+  candidateSet?: ThreadCandidateSet,
 ): NotificationDecision | null {
   if (typeof input.shouldNotify !== 'boolean') return null;
   if (typeof input.reasoningSummary !== 'string') return null;
@@ -277,6 +324,9 @@ function validateDecisionOutput(
     }
   }
 
+  // Validate threadActions — strictly against the provided candidate set
+  const threadActions = validateThreadActions(input.threadActions, validChannels, candidateSet);
+
   const deepLinkTarget = input.deepLinkTarget && typeof input.deepLinkTarget === 'object'
     ? input.deepLinkTarget as Record<string, unknown>
     : undefined;
@@ -286,11 +336,80 @@ function validateDecisionOutput(
     selectedChannels: validChannels,
     reasoningSummary: input.reasoningSummary,
     renderedCopy,
+    threadActions: Object.keys(threadActions).length > 0 ? threadActions : undefined,
     deepLinkTarget,
     dedupeKey: input.dedupeKey,
     confidence,
     fallbackUsed: false,
   };
+}
+
+// ── Thread action validation ───────────────────────────────────────────
+
+/**
+ * Validate and sanitize thread actions from LLM output.
+ *
+ * - reuse_existing targets are checked against the candidate set; invalid
+ *   targets are downgraded to start_new with a warning.
+ * - Channels not in the selected set are ignored.
+ * - Missing actions for selected channels default to start_new (handled
+ *   downstream, not materialized here to keep the output compact).
+ */
+export function validateThreadActions(
+  raw: unknown,
+  validChannels: NotificationChannel[],
+  candidateSet?: ThreadCandidateSet,
+): Partial<Record<NotificationChannel, ThreadAction>> {
+  const result: Partial<Record<NotificationChannel, ThreadAction>> = {};
+
+  if (!raw || typeof raw !== 'object') return result;
+
+  const actionsObj = raw as Record<string, unknown>;
+  const channelSet = new Set(validChannels);
+
+  // Build a lookup of valid candidate conversationIds per channel
+  const validCandidateIds = new Map<NotificationChannel, Set<string>>();
+  if (candidateSet) {
+    for (const [ch, candidates] of Object.entries(candidateSet) as [NotificationChannel, { conversationId: string }[]][]) {
+      validCandidateIds.set(ch, new Set(candidates.map((c) => c.conversationId)));
+    }
+  }
+
+  for (const [ch, actionRaw] of Object.entries(actionsObj)) {
+    if (!channelSet.has(ch as NotificationChannel)) continue;
+    if (!actionRaw || typeof actionRaw !== 'object') continue;
+
+    const channel = ch as NotificationChannel;
+    const action = actionRaw as Record<string, unknown>;
+
+    if (action.action === 'start_new') {
+      result[channel] = { action: 'start_new' };
+    } else if (action.action === 'reuse_existing') {
+      const conversationId = action.conversationId;
+      if (typeof conversationId !== 'string' || !conversationId.trim()) {
+        log.warn({ channel }, 'LLM returned reuse_existing without conversationId — downgrading to start_new');
+        result[channel] = { action: 'start_new' };
+        continue;
+      }
+
+      // Strict validation: the conversationId must exist in the candidate set
+      const candidateIds = validCandidateIds.get(channel);
+      if (!candidateIds || !candidateIds.has(conversationId)) {
+        log.warn(
+          { channel, conversationId },
+          'LLM returned reuse_existing with conversationId not in candidate set — downgrading to start_new',
+        );
+        result[channel] = { action: 'start_new' };
+        continue;
+      }
+
+      result[channel] = { action: 'reuse_existing', conversationId };
+    }
+    // Unknown action values are silently ignored — the channel will default
+    // to start_new downstream.
+  }
+
+  return result;
 }
 
 // ── Core evaluation function ───────────────────────────────────────────
@@ -317,6 +436,16 @@ export async function evaluateSignal(
     }
   }
 
+  // Build thread candidate set for reuse decisions. Wrapped in try/catch
+  // so candidate lookup failures do not block the decision path.
+  let candidateSet: ThreadCandidateSet | undefined;
+  try {
+    candidateSet = buildThreadCandidates(availableChannels, signal.assistantId);
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    log.warn({ err: errMsg }, 'Failed to build thread candidates, proceeding without candidates');
+  }
+
   const provider = getConfiguredProvider();
   if (!provider) {
     log.warn('Configured provider unavailable for notification decision, using fallback');
@@ -327,7 +456,7 @@ export async function evaluateSignal(
 
   let decision: NotificationDecision;
   try {
-    decision = await classifyWithLLM(signal, availableChannels, resolvedPreferenceContext, decisionModelIntent);
+    decision = await classifyWithLLM(signal, availableChannels, resolvedPreferenceContext, decisionModelIntent, candidateSet);
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
     log.warn({ err: errMsg }, 'Notification decision LLM call failed, using fallback');
@@ -346,11 +475,13 @@ async function classifyWithLLM(
   availableChannels: NotificationChannel[],
   preferenceContext: string | undefined,
   modelIntent: ModelIntent,
+  candidateSet?: ThreadCandidateSet,
 ): Promise<NotificationDecision> {
   const provider = getConfiguredProvider()!;
   const { signal: abortSignal, cleanup } = createTimeout(DECISION_TIMEOUT_MS);
 
-  const systemPrompt = buildSystemPrompt(availableChannels, preferenceContext);
+  const candidateContext = candidateSet ? serializeCandidatesForPrompt(candidateSet) ?? undefined : undefined;
+  const systemPrompt = buildSystemPrompt(availableChannels, preferenceContext, candidateContext);
   const prompt = buildUserPrompt(signal);
   const tool = buildDecisionTool(availableChannels);
 
@@ -379,6 +510,7 @@ async function classifyWithLLM(
     const validated = validateDecisionOutput(
       toolBlock.input as Record<string, unknown>,
       availableChannels,
+      candidateSet,
     );
     if (!validated) {
       log.warn('Invalid notification decision output from LLM, using fallback');
@@ -470,6 +602,19 @@ export function enforceRoutingIntent(
 function persistDecision(signal: NotificationSignal, decision: NotificationDecision): string | undefined {
   try {
     const decisionId = uuid();
+
+    // Summarize thread actions for the audit trail
+    const threadActionSummary: Record<string, string> = {};
+    if (decision.threadActions) {
+      for (const [ch, ta] of Object.entries(decision.threadActions)) {
+        if (ta.action === 'reuse_existing') {
+          threadActionSummary[ch] = `reuse:${ta.conversationId}`;
+        } else {
+          threadActionSummary[ch] = 'start_new';
+        }
+      }
+    }
+
     createDecision({
       id: decisionId,
       notificationEventId: signal.signalId,
@@ -483,6 +628,7 @@ function persistDecision(signal: NotificationSignal, decision: NotificationDecis
         dedupeKey: decision.dedupeKey,
         channelCount: decision.selectedChannels.length,
         hasCopy: Object.keys(decision.renderedCopy).length > 0,
+        ...(Object.keys(threadActionSummary).length > 0 ? { threadActions: threadActionSummary } : {}),
       },
     });
     return decisionId;

--- a/assistant/src/notifications/thread-candidates.ts
+++ b/assistant/src/notifications/thread-candidates.ts
@@ -1,0 +1,234 @@
+/**
+ * Thread candidate builder for notification thread reuse.
+ *
+ * Builds a lightweight candidate set of recent notification conversations
+ * per channel that the decision engine can choose to reuse instead of
+ * starting a new thread. Includes guardian-specific context (pending
+ * unresolved request count) when available.
+ *
+ * The candidate set is intentionally compact — only the fields the LLM
+ * needs for a routing decision, not full conversation contents.
+ */
+
+import { and, desc, eq, isNotNull } from 'drizzle-orm';
+
+import { getDb } from '../memory/db.js';
+import { countPendingByConversation } from '../memory/guardian-approvals.js';
+import { conversations, notificationDeliveries, notificationDecisions, notificationEvents } from '../memory/schema.js';
+import { getLogger } from '../util/logger.js';
+import type { NotificationChannel } from './types.js';
+
+const log = getLogger('thread-candidates');
+
+/** Maximum number of candidate threads to surface per channel. */
+const MAX_CANDIDATES_PER_CHANNEL = 5;
+
+/** Only consider conversations updated within this window (ms). */
+const CANDIDATE_RECENCY_WINDOW_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+// -- Public types -------------------------------------------------------------
+
+/** Guardian-specific context attached to a thread candidate when available. */
+export interface GuardianCandidateContext {
+  /** Number of unresolved (pending) guardian approval requests in this conversation. */
+  pendingUnresolvedRequestCount: number;
+}
+
+/** A single candidate conversation that the decision engine can select for reuse. */
+export interface ThreadCandidate {
+  conversationId: string;
+  title: string | null;
+  updatedAt: number;
+  /** The source event name from the most recent notification delivered to this conversation. */
+  latestSourceEventName: string | null;
+  channel: NotificationChannel;
+  /** Guardian-specific context, present only when there are relevant guardian records. */
+  guardianContext?: GuardianCandidateContext;
+}
+
+/** Candidate set for the decision engine, keyed by channel. */
+export type ThreadCandidateSet = Partial<Record<NotificationChannel, ThreadCandidate[]>>;
+
+// -- Core builder -------------------------------------------------------------
+
+/**
+ * Build the thread candidate set for all selected channels.
+ *
+ * Queries recent notification-sourced conversations that were delivered
+ * to each channel and enriches them with guardian-specific metadata
+ * when available.
+ *
+ * Errors are caught per-channel so a failure in one channel does not
+ * block candidates for others.
+ */
+export function buildThreadCandidates(
+  channels: NotificationChannel[],
+  assistantId: string,
+): ThreadCandidateSet {
+  const result: ThreadCandidateSet = {};
+  const cutoff = Date.now() - CANDIDATE_RECENCY_WINDOW_MS;
+
+  for (const channel of channels) {
+    try {
+      const candidates = buildCandidatesForChannel(channel, assistantId, cutoff);
+      if (candidates.length > 0) {
+        result[channel] = candidates;
+      }
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      log.warn({ err: errMsg, channel }, 'Failed to build thread candidates for channel');
+    }
+  }
+
+  return result;
+}
+
+// -- Per-channel query --------------------------------------------------------
+
+/**
+ * Query recent notification conversations for a given channel.
+ *
+ * Joins notification_deliveries -> notification_decisions -> notification_events
+ * to find conversations that were created by the notification pipeline for
+ * this channel, then enriches with guardian context.
+ */
+function buildCandidatesForChannel(
+  channel: NotificationChannel,
+  assistantId: string,
+  cutoffMs: number,
+): ThreadCandidate[] {
+  const db = getDb();
+
+  // Find recent notification deliveries for this channel that have a
+  // conversationId and were successfully sent.
+  const rows = db
+    .select({
+      conversationId: notificationDeliveries.conversationId,
+      channel: notificationDeliveries.channel,
+      deliverySentAt: notificationDeliveries.sentAt,
+      sourceEventName: notificationEvents.sourceEventName,
+      convTitle: conversations.title,
+      convUpdatedAt: conversations.updatedAt,
+    })
+    .from(notificationDeliveries)
+    .innerJoin(
+      notificationDecisions,
+      eq(notificationDeliveries.notificationDecisionId, notificationDecisions.id),
+    )
+    .innerJoin(
+      notificationEvents,
+      eq(notificationDecisions.notificationEventId, notificationEvents.id),
+    )
+    .innerJoin(
+      conversations,
+      eq(notificationDeliveries.conversationId, conversations.id),
+    )
+    .where(
+      and(
+        eq(notificationDeliveries.channel, channel),
+        eq(notificationDeliveries.assistantId, assistantId),
+        eq(notificationDeliveries.status, 'sent'),
+        isNotNull(notificationDeliveries.conversationId),
+      ),
+    )
+    .orderBy(desc(notificationDeliveries.sentAt))
+    .limit(MAX_CANDIDATES_PER_CHANNEL * 3) // over-fetch to allow deduplication
+    .all();
+
+  // Deduplicate by conversationId (keep the most recent delivery per conversation)
+  const seen = new Set<string>();
+  const candidates: ThreadCandidate[] = [];
+
+  for (const row of rows) {
+    if (!row.conversationId) continue;
+    if (seen.has(row.conversationId)) continue;
+
+    // Apply recency filter on the conversation's updatedAt
+    if (row.convUpdatedAt < cutoffMs) continue;
+
+    seen.add(row.conversationId);
+
+    const candidate: ThreadCandidate = {
+      conversationId: row.conversationId,
+      title: row.convTitle,
+      updatedAt: row.convUpdatedAt,
+      latestSourceEventName: row.sourceEventName ?? null,
+      channel: channel,
+    };
+
+    // Enrich with guardian context
+    const guardianContext = buildGuardianContext(row.conversationId, assistantId);
+    if (guardianContext) {
+      candidate.guardianContext = guardianContext;
+    }
+
+    candidates.push(candidate);
+
+    if (candidates.length >= MAX_CANDIDATES_PER_CHANNEL) break;
+  }
+
+  return candidates;
+}
+
+// -- Guardian context enrichment ----------------------------------------------
+
+/**
+ * Build guardian-specific context for a candidate conversation.
+ * Returns null when there is no guardian-relevant data.
+ */
+function buildGuardianContext(
+  conversationId: string,
+  assistantId: string,
+): GuardianCandidateContext | null {
+  try {
+    const pendingCount = countPendingByConversation(conversationId, assistantId);
+    if (pendingCount > 0) {
+      return { pendingUnresolvedRequestCount: pendingCount };
+    }
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    log.warn({ err: errMsg, conversationId }, 'Failed to query guardian context for candidate');
+  }
+
+  return null;
+}
+
+// -- Prompt serialization -----------------------------------------------------
+
+/**
+ * Serialize a thread candidate set into a compact text block suitable for
+ * injection into the decision engine's user prompt.
+ *
+ * Designed to be token-efficient while giving the LLM enough context
+ * to make a reuse decision.
+ */
+export function serializeCandidatesForPrompt(candidateSet: ThreadCandidateSet): string | null {
+  const channelEntries = Object.entries(candidateSet) as [NotificationChannel, ThreadCandidate[]][];
+  if (channelEntries.length === 0) return null;
+
+  const sections: string[] = [];
+
+  for (const [channel, candidates] of channelEntries) {
+    if (candidates.length === 0) continue;
+
+    const lines: string[] = [`Channel: ${channel}`];
+    for (const c of candidates) {
+      const parts: string[] = [
+        `  - id=${c.conversationId}`,
+        `title="${c.title ?? '(untitled)'}"`,
+        `updated=${new Date(c.updatedAt).toISOString()}`,
+      ];
+      if (c.latestSourceEventName) {
+        parts.push(`lastEvent="${c.latestSourceEventName}"`);
+      }
+      if (c.guardianContext) {
+        parts.push(`pendingRequests=${c.guardianContext.pendingUnresolvedRequestCount}`);
+      }
+      lines.push(parts.join(' '));
+    }
+    sections.push(lines.join('\n'));
+  }
+
+  if (sections.length === 0) return null;
+  return sections.join('\n\n');
+}

--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -79,12 +79,30 @@ export interface RenderedChannelCopy {
   threadSeedMessage?: string;
 }
 
+// -- Thread action types ------------------------------------------------------
+
+/** Start a new conversation thread for the notification delivery. */
+export interface ThreadActionStartNew {
+  action: 'start_new';
+}
+
+/** Reuse an existing conversation thread identified by conversationId. */
+export interface ThreadActionReuseExisting {
+  action: 'reuse_existing';
+  conversationId: string;
+}
+
+/** Per-channel thread action — either start a new thread or reuse an existing one. */
+export type ThreadAction = ThreadActionStartNew | ThreadActionReuseExisting;
+
 /** Output produced by the notification decision engine for a given signal. */
 export interface NotificationDecision {
   shouldNotify: boolean;
   selectedChannels: NotificationChannel[];
   reasoningSummary: string;
   renderedCopy: Partial<Record<NotificationChannel, RenderedChannelCopy>>;
+  /** Per-channel thread action. When absent for a channel, defaults to start_new. */
+  threadActions?: Partial<Record<NotificationChannel, ThreadAction>>;
   deepLinkTarget?: Record<string, unknown>;
   dedupeKey: string;
   confidence: number;


### PR DESCRIPTION
## Summary
- Extended notification decision output with per-channel thread actions (start_new / reuse_existing)
- Created thread-candidates.ts to build candidate set per channel with metadata
- Updated decision engine to inject candidate context and parse thread action
- Added validation: invalid reuse targets safely downgrade to start_new
- Closes #9948

## Original prompt
[daemon-thread-reuse] M1: Decision Contract + Candidate Context (#9948)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
