### PR TITLE
feat: wire bulletin sync into daemon startup lifecycle

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -17,6 +17,7 @@ import {
 } from '../config/env.js';
 import { loadConfig } from '../config/loader.js';
 import { ensurePromptFiles } from '../config/system-prompt.js';
+import { syncUpdateBulletinOnStartup } from '../config/update-bulletin.js';
 import { HeartbeatService } from '../heartbeat/heartbeat-service.js';
 import { getHookManager } from '../hooks/manager.js';
 import { installTemplates } from '../hooks/templates.js';
@@ -138,6 +139,12 @@ export async function runDaemon(): Promise<void> {
     }
     initializeDb();
     log.info('Daemon startup: DB initialized');
+
+    try {
+      syncUpdateBulletinOnStartup();
+    } catch (err) {
+      log.warn({ err }, 'Bulletin sync failed — continuing startup');
+    }
 
     // Recover orphaned work items that were left in 'running' state when the
     // daemon previously crashed or was killed mid-task.


### PR DESCRIPTION
PR 15 of the UPDATES.md bulletin rollout plan. Calls `syncUpdateBulletinOnStartup()` after DB init during daemon startup, with non-fatal error handling.

## Changes

- Import `syncUpdateBulletinOnStartup` from `../config/update-bulletin.js` in `lifecycle.ts`
- Call it immediately after `initializeDb()` and the DB-initialized log, wrapped in a `try/catch` that logs a warning on failure and continues startup

## Placement rationale

- DB must be initialized first (bulletin checkpoints use SQLite)
- `ensurePromptFiles()` runs earlier in the sequence (bulletin file must exist)
- Runs before runtime traffic starts (IPC socket and HTTP server are opened later)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
