### PR TITLE
fix: match theme toggle inner/outer corner radius

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1593,7 +1593,7 @@ private struct DrawerThemeToggle: View {
                                     ? VColor.hoverOverlay.opacity(0.1)
                                     : Color.clear
                             )
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
                     }
                     .buttonStyle(.plain)
                     .help(option.tooltip)


### PR DESCRIPTION
## Summary
- Changed the inner selected-item corner radius in `DrawerThemeToggle` from `VRadius.sm` (4pt) to `VRadius.md` (8pt) to match the outer container radius

## Original prompt
 the difference in border corner radius bothers me here. Help me fix it so that the roundness is the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
