### PR TITLE
fix: remove invalid @escaping from tuple return type

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/PermissionPromptOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/PermissionPromptOverlay.swift
@@ -140,7 +140,7 @@ final class PermissionPromptOverlay {
         for kind: PromptKind,
         onGrantAccess: @escaping () -> Void,
         onDismiss: @escaping () -> Void
-    ) -> (title: String, body: String, primaryTitle: String, primaryAction: @escaping () -> Void, secondaryTitle: String, secondaryAction: @escaping () -> Void) {
+    ) -> (title: String, body: String, primaryTitle: String, primaryAction: () -> Void, secondaryTitle: String, secondaryAction: () -> Void) {
         switch kind {
         case .notDetermined(let keyName):
             return (


### PR DESCRIPTION
## Summary
- `@escaping` is only valid on function parameter positions, not in tuple return types
- PR #9983 introduced this in `PermissionPromptOverlay.swift`, causing a build error
- Closures in returned tuples are inherently escaping, so the annotation is unnecessary

## Test plan
- [ ] `./build.sh` compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/9999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
