### PR TITLE
docs: add update bulletin documentation and AGENTS guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,3 +353,12 @@ When in doubt, ask: "Am I encoding a judgement that the assistant could make bet
 When touching existing tool-based flows, migrate behavior toward skill-driven CLI usage instead of adding new registered tools.
 
 Reasoning: every registered tool increases model context overhead, while the model can usually learn CLI usage from skills on demand and install missing CLI dependencies when needed.
+
+## Release Update Hygiene
+
+When shipping a release that includes user-facing or assistant-facing changes:
+
+1. **Update the template**: Edit `assistant/src/config/templates/UPDATES.md` with freeform markdown describing what changed and how it affects behavior or capabilities.
+2. **Leave empty for no-op releases**: If the release has no relevant changes, keep the template empty or comment-only (lines starting with `_` are stripped).
+3. **Don't modify workspace files directly**: The workspace `UPDATES.md` is managed by the daemon's startup sync — never edit `~/.vellum/workspace/UPDATES.md` manually.
+4. **Checkpoint keys**: `updates:active_releases` and `updates:completed_releases` in the `memory_checkpoints` table track bulletin lifecycle. Don't manipulate these directly.

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -276,6 +276,33 @@ External users who are not the guardian can gain access to the assistant through
 | `src/memory/channel-guardian-store.ts` | Approval request and verification challenge persistence |
 | `src/config/vellum-skills/trusted-contacts/SKILL.md` | Skill teaching the assistant to manage contacts via HTTP API |
 
+### Update Bulletin System
+
+Release-driven update notification system that surfaces release notes to the assistant via the system prompt.
+
+**Data flow:**
+1. **Bundled template** (`src/config/templates/UPDATES.md`) — source of release notes, maintained per-release in the repo.
+2. **Startup sync** (`syncUpdateBulletinOnStartup()` in `src/config/update-bulletin.ts`) — materializes the bundled template into the workspace `UPDATES.md` on daemon boot. Uses atomic write (temp + rename) for crash safety.
+3. **System prompt injection** — `buildSystemPrompt()` reads workspace `UPDATES.md` and injects it as a `## Recent Updates` section with judgment-based handling instructions.
+4. **Completion by deletion** — the assistant deletes `UPDATES.md` when it has actioned all updates. Next startup detects the deletion and marks those releases as completed in checkpoint state.
+5. **Cross-release merge** — if pending updates from a prior release exist when a new release lands, both release blocks coexist in the same file.
+
+**Checkpoint keys** (in `memory_checkpoints` table):
+- `updates:active_releases` — JSON array of version strings currently active.
+- `updates:completed_releases` — JSON array of version strings already completed.
+
+**Key source files:**
+
+| File | Purpose |
+|------|---------|
+| `src/config/templates/UPDATES.md` | Bundled release-note template |
+| `src/config/update-bulletin.ts` | Startup sync logic (materialize, delete-complete, merge) |
+| `src/config/update-bulletin-format.ts` | Release block formatter/parser helpers |
+| `src/config/update-bulletin-state.ts` | Checkpoint state helpers for active/completed releases |
+| `src/config/system-prompt.ts` | Prompt injection of updates section |
+| `src/daemon/config-watcher.ts` | File watcher — evicts sessions on UPDATES.md changes |
+| `src/permissions/defaults.ts` | Auto-allow rules for file_read/write/edit + rm UPDATES.md |
+
 ---
 
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -50,6 +50,12 @@ cp .env.example .env
 | `RUNTIME_GATEWAY_ORIGIN_SECRET` | No | — | Dedicated secret for the `X-Gateway-Origin` proof header on `/channels/inbound`. When not set, falls back to the bearer token. Both gateway and runtime must share the same value. |
 | `VELLUM_DAEMON_SOCKET` | No | `~/.vellum/vellum.sock` | Override the daemon socket path |
 
+## Update Bulletin
+
+When a release includes relevant updates, the daemon materializes release notes from the bundled `src/config/templates/UPDATES.md` into `~/.vellum/workspace/UPDATES.md` on startup. The assistant uses judgment to surface updates to the user when relevant, and deletes the file when done.
+
+**For release maintainers:** Update `assistant/src/config/templates/UPDATES.md` with release notes before each relevant release. Leave the template empty (or comment-only) for releases with no user/assistant-facing changes.
+
 ## Usage
 
 ### Start the daemon


### PR DESCRIPTION
PR 16 (final) of the UPDATES.md bulletin rollout plan. Documents the new update bulletin system in architecture docs, README, and AGENTS.md.

## Summary

- **assistant/ARCHITECTURE.md**: New "Update Bulletin System" section documenting the data flow (bundled template -> startup sync -> system prompt injection -> completion by deletion -> cross-release merge), checkpoint keys, and key source files.
- **assistant/README.md**: New "Update Bulletin" section with guidance for release maintainers on updating the template.
- **AGENTS.md**: New "Release Update Hygiene" section with rules for maintaining the update bulletin template across releases.

## Validation

- TypeScript type-check: pre-existing errors only (unrelated to docs changes)
- Test suite: run with full dependency install
- Only documentation files modified — no code changes

## Test plan

- [x] Verify all referenced source files exist in the codebase
- [x] Run `bunx tsc --noEmit` — no new errors introduced
- [x] Run `bun test` — no new failures introduced
- [x] Confirm documentation accurately reflects the implemented system

---

**Original prompt:**

> Implement PR 16 of the UPDATES.md bulletin rollout plan — Docs + Architecture + AGENTS + Regression Sweep
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
