### PR TITLE
fix: normalize conversationId + escape titles in thread candidates

### DIFF
--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -385,12 +385,15 @@ export function validateThreadActions(
     if (action.action === 'start_new') {
       result[channel] = { action: 'start_new' };
     } else if (action.action === 'reuse_existing') {
-      const conversationId = action.conversationId;
-      if (typeof conversationId !== 'string' || !conversationId.trim()) {
+      const rawConversationId = action.conversationId;
+      if (typeof rawConversationId !== 'string' || !rawConversationId.trim()) {
         log.warn({ channel }, 'LLM returned reuse_existing without conversationId — downgrading to start_new');
         result[channel] = { action: 'start_new' };
         continue;
       }
+
+      // Normalize: the LLM may return a valid ID with leading/trailing whitespace
+      const conversationId = rawConversationId.trim();
 
       // Strict validation: the conversationId must exist in the candidate set
       const candidateIds = validCandidateIds.get(channel);

--- a/assistant/src/notifications/thread-candidates.ts
+++ b/assistant/src/notifications/thread-candidates.ts
@@ -241,13 +241,20 @@ export function serializeCandidatesForPrompt(candidateSet: ThreadCandidateSet): 
 
     const lines: string[] = [`Channel: ${channel}`];
     for (const c of candidates) {
+      // Escape title to prevent format corruption from quotes or newlines in
+      // user/model-provided text. JSON.stringify produces a safe single-line
+      // quoted string; we strip the outer quotes since we wrap in our own.
+      const safeTitle = c.title
+        ? JSON.stringify(c.title).slice(1, -1)
+        : '(untitled)';
       const parts: string[] = [
         `  - id=${c.conversationId}`,
-        `title="${c.title ?? '(untitled)'}"`,
+        `title="${safeTitle}"`,
         `updated=${new Date(c.updatedAt).toISOString()}`,
       ];
       if (c.latestSourceEventName) {
-        parts.push(`lastEvent="${c.latestSourceEventName}"`);
+        const safeEventName = JSON.stringify(c.latestSourceEventName).slice(1, -1);
+        parts.push(`lastEvent="${safeEventName}"`);
       }
       if (c.guardianContext) {
         parts.push(`pendingRequests=${c.guardianContext.pendingUnresolvedRequestCount}`);


### PR DESCRIPTION
## Summary
- Trim/normalize conversationId before candidate lookup validation to prevent whitespace-induced downgrades
- Escape thread titles (JSON-encode or strip newlines/quotes) in candidate serialization to prevent format corruption
- Addresses review feedback on #9995

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/9995

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
