### PR TITLE
fix: resolve Swift type-checker timeout in MainWindowView

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -477,89 +477,93 @@ struct MainWindowView: View {
             }
     }
 
+    /// Top bar extracted to break up type-checker complexity.
+    private var topBarView: some View {
+        HStack(spacing: VSpacing.sm) {
+            VIconButton(label: "Sidebar", icon: "sidebar.left", isActive: sidebarExpanded, iconOnly: true, tooltip: sidebarExpanded ? "Collapse sidebar" : "Expand sidebar") {
+                withAnimation(VAnimation.panel) {
+                    sidebarExpanded.toggle()
+                }
+            }
+            if isChatBubbleVisible {
+                ChatBubbleToggle(
+                    isActive: isChatBubbleActive,
+                    tooltip: isChatBubbleActive ? "Hide chat" : "Show chat",
+                    onToggle: { toggleChatBubble() }
+                )
+            }
+            Spacer()
+            PTTKeyIndicator {
+                settingsStore.pendingSettingsTab = .voice
+                windowState.selection = .panel(.settings)
+            }
+            if windowState.isShowingChat || isChatBubbleActive {
+                // Copy Thread button — only visible when there's content to copy
+                if threadManager.activeViewModel?.messages.contains(where: {
+                    !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                }) == true {
+                    VIconButton(
+                        label: "Copy thread",
+                        icon: copyThread.showConfirmation ? "checkmark" : "list.clipboard",
+                        isActive: copyThread.showConfirmation,
+                        iconOnly: true,
+                        tooltip: copyThread.showConfirmation ? "Copied!" : "Copy thread"
+                    ) {
+                        let messages = threadManager.activeViewModel?.messages ?? []
+                        let title = threadManager.activeThread?.title
+                        let names = resolveParticipantNames()
+                        let markdown = ChatTranscriptFormatter.threadMarkdown(
+                            messages: messages,
+                            threadTitle: title,
+                            participantNames: names
+                        )
+                        guard !markdown.isEmpty else { return }
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(markdown, forType: .string)
+                        copyThread.cancel()
+                        copyThread.showConfirmation = true
+                        let timer = DispatchWorkItem { [copyThread] in copyThread.showConfirmation = false }
+                        copyThread.confirmationTimer = timer
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: timer)
+                    }
+                }
+
+                // Voice mode toggle
+                VIconButton(
+                    label: "Voice Mode",
+                    icon: voiceModeManager.state != .off ? "waveform.circle.fill" : "waveform.circle",
+                    isActive: voiceModeManager.state != .off,
+                    iconOnly: true,
+                    tooltip: voiceModeManager.state != .off ? "Exit voice mode" : "Voice mode"
+                ) {
+                    toggleVoiceMode()
+                }
+
+                // Temporary chat toggle — always visible on private threads (so users can exit temp chat),
+                // only visible on normal threads when no messages exist yet
+                if threadManager.activeThread?.kind == .private || threadManager.activeViewModel?.messages.contains(where: {
+                    !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                }) != true {
+                    TemporaryChatToggle(
+                        isActive: threadManager.activeThread?.kind == .private,
+                        tooltip: threadManager.activeThread?.kind == .private ? "Exit temporary chat" : "Temporary chat",
+                        onToggle: { toggleTemporaryChat() }
+                    )
+                }
+            }
+        }
+        .padding(.leading, trafficLightPadding)
+        .padding(.trailing, VSpacing.lg)
+        .frame(height: 36)
+        .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+    }
+
     /// Core layout extracted to break up type-checker complexity.
     private var coreLayoutView: some View {
         GeometryReader { geometry in
             Group {
                 VStack(spacing: 0) {
-                    // Top bar (always visible, above sidebar)
-                    HStack(spacing: VSpacing.sm) {
-                        VIconButton(label: "Sidebar", icon: "sidebar.left", isActive: sidebarExpanded, iconOnly: true, tooltip: sidebarExpanded ? "Collapse sidebar" : "Expand sidebar") {
-                            withAnimation(VAnimation.panel) {
-                                sidebarExpanded.toggle()
-                            }
-                        }
-                        if isChatBubbleVisible {
-                            ChatBubbleToggle(
-                                isActive: isChatBubbleActive,
-                                tooltip: isChatBubbleActive ? "Hide chat" : "Show chat",
-                                onToggle: { toggleChatBubble() }
-                            )
-                        }
-                        Spacer()
-                        PTTKeyIndicator {
-                            settingsStore.pendingSettingsTab = .wakeWord
-                            windowState.selection = .panel(.settings)
-                        }
-                        if windowState.isShowingChat || isChatBubbleActive {
-                            // Copy Thread button — only visible when there's content to copy
-                            if threadManager.activeViewModel?.messages.contains(where: {
-                                !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                            }) == true {
-                                VIconButton(
-                                    label: "Copy thread",
-                                    icon: copyThread.showConfirmation ? "checkmark" : "list.clipboard",
-                                    isActive: copyThread.showConfirmation,
-                                    iconOnly: true,
-                                    tooltip: copyThread.showConfirmation ? "Copied!" : "Copy thread"
-                                ) {
-                                    let messages = threadManager.activeViewModel?.messages ?? []
-                                    let title = threadManager.activeThread?.title
-                                    let names = resolveParticipantNames()
-                                    let markdown = ChatTranscriptFormatter.threadMarkdown(
-                                        messages: messages,
-                                        threadTitle: title,
-                                        participantNames: names
-                                    )
-                                    guard !markdown.isEmpty else { return }
-                                    NSPasteboard.general.clearContents()
-                                    NSPasteboard.general.setString(markdown, forType: .string)
-                                    copyThread.cancel()
-                                    copyThread.showConfirmation = true
-                                    let timer = DispatchWorkItem { [copyThread] in copyThread.showConfirmation = false }
-                                    copyThread.confirmationTimer = timer
-                                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: timer)
-                                }
-                            }
-
-                            // Voice mode toggle
-                            VIconButton(
-                                label: "Voice Mode",
-                                icon: voiceModeManager.state != .off ? "waveform.circle.fill" : "waveform.circle",
-                                isActive: voiceModeManager.state != .off,
-                                iconOnly: true,
-                                tooltip: voiceModeManager.state != .off ? "Exit voice mode" : "Voice mode"
-                            ) {
-                                toggleVoiceMode()
-                            }
-
-                            // Temporary chat toggle — always visible on private threads (so users can exit temp chat),
-                            // only visible on normal threads when no messages exist yet
-                            if threadManager.activeThread?.kind == .private || threadManager.activeViewModel?.messages.contains(where: {
-                                !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                            }) != true {
-                                TemporaryChatToggle(
-                                    isActive: threadManager.activeThread?.kind == .private,
-                                    tooltip: threadManager.activeThread?.kind == .private ? "Exit temporary chat" : "Temporary chat",
-                                    onToggle: { toggleTemporaryChat() }
-                                )
-                            }
-                        }
-                    }
-                    .padding(.leading, trafficLightPadding)
-                    .padding(.trailing, VSpacing.lg)
-                    .frame(height: 36)
-                    .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+                    topBarView
 
                     // Main container: sidebar + content with uniform padding
                     HStack(spacing: 16) {


### PR DESCRIPTION
## Summary
- Extract `topBarView` from `coreLayoutView` to fix "compiler is unable to type-check this expression in reasonable time" error
- Fix latent `.wakeWord` → `.voice` reference in `SettingsTab` that was hidden by the type-checker timeout

## Test plan
- [ ] `cd clients/macos && ./build.sh` compiles successfully
- [ ] Top bar UI unchanged (sidebar toggle, chat bubble, copy thread, voice mode, temp chat all work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
