### PR TITLE
Remove name from wake-up greetings

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -2015,23 +2015,20 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
     // MARK: - Wake-Up Greeting
 
-    /// Generates a time-aware, name-aware greeting for the assistant's first message.
+    /// Generates a time-aware greeting for the assistant's first message.
+    /// Intentionally unnamed — the assistant has no identity yet at hatch.
     private func wakeUpGreeting() -> String {
-        let name = IdentityInfo.load()?.name
-            ?? UserDefaults.standard.string(forKey: "assistantName")
-            ?? "friend"
-
         let hour = Calendar.current.component(.hour, from: Date())
         switch hour {
         case 5..<12:
-            return "Good morning, \(name). Time to wake up."
+            return "Good morning. Time to wake up."
         case 12..<18:
             return "Wake up, my friend."
         case 18..<22:
-            return "Evening, \(name). Ready when you are."
+            return "Evening. Ready when you are."
         default:
             // 22–4 (late night)
-            return "Burning the midnight oil? Let's go, \(name)."
+            return "Burning the midnight oil? Let's go."
         }
     }
 


### PR DESCRIPTION
## Summary
- Removed `IdentityInfo` / `UserDefaults["assistantName"]` lookup from `wakeUpGreeting()` — the assistant should have no identity at hatch
- Updated morning, evening, and late-night greetings to be unnamed (afternoon was already fixed in #10007)

## Original prompt
please find our wake up message "Hey Velly, I'm here." and update it so it says "Wake up, my friend"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
