### PR TITLE
fix: prevent clicking a thread from reordering it to the top

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -979,11 +979,16 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// avoids O(n) IPC calls per streaming response (one per text delta) while
     /// still advancing the server-side seen cursor.
     private func handleAssistantMessageArrival(threadId: UUID, previousSnapshot: AssistantActivitySnapshot?, currentSnapshot: AssistantActivitySnapshot) {
-        // Skip during thread restoration — loadHistoryIfNeeded populates
-        // messages which triggers the Combine publisher, but those are
-        // historical messages, not fresh assistant replies. Without this
-        // guard the handler would clear real unread state on app launch.
+        // Skip during thread restoration or history re-hydration —
+        // loadHistoryIfNeeded populates messages which triggers the Combine
+        // publisher, but those are historical messages, not fresh assistant
+        // replies. Without this guard the handler would clear real unread
+        // state on app launch, or bump threads to the top when clicking on
+        // them causes an evicted ViewModel to reload its history.
         guard !isRestoringThreads else { return }
+        if let vm = chatViewModels[threadId], vm.isLoadingHistory || !vm.isHistoryLoaded {
+            return
+        }
         guard let index = threads.firstIndex(where: { $0.id == threadId }) else { return }
         updateLastInteracted(threadId: threadId)
         if threadId == activeThreadId {


### PR DESCRIPTION
## Summary
- Skip `updateLastInteracted` during history re-hydration so clicking a thread with an LRU-evicted ViewModel doesn't bump it to the top of the sidebar
- The bug: click thread → ViewModel re-created → history loads → Combine `$messages` publisher fires → `handleAssistantMessageArrival` → `updateLastInteracted` → thread jumps to top

## Test plan
- [ ] Click on an old thread further down the sidebar — verify it stays in place
- [ ] Send a message in a thread — verify it moves to the top
- [ ] Receive an assistant reply — verify the thread moves to the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
