### PR TITLE
fix: add package.json fallback for APP_VERSION

### DIFF
--- a/assistant/src/version.ts
+++ b/assistant/src/version.ts
@@ -1,3 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+function resolveVersion(): string {
+  const envVersion = process.env.APP_VERSION;
+  if (envVersion && envVersion !== '0.0.0-dev') return envVersion;
+
+  // Fall back to package.json version when env var is not set or is the dev placeholder.
+  try {
+    const pkgPath = join(import.meta.dirname ?? __dirname, '..', 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    if (pkg.version && typeof pkg.version === 'string') return pkg.version;
+  } catch {
+    // package.json missing or unreadable
+  }
+
+  return '0.0.0-dev';
+}
+
 // Version is embedded at compile time via --define in CI.
-// Falls back to "0.0.0-dev" for local development.
-export const APP_VERSION: string = process.env.APP_VERSION ?? "0.0.0-dev";
+// Falls back to package.json version, then "0.0.0-dev" for local development.
+export const APP_VERSION: string = resolveVersion();


### PR DESCRIPTION
Addresses review finding P1: APP_VERSION falls back to 0.0.0-dev in Docker/runtime when not injected. Adds a package.json version fallback so bulletin sync uses a real release ID.

## Summary
- `version.ts` previously fell back directly to `"0.0.0-dev"` when `APP_VERSION` env var was not set
- This caused bulletin sync to always use `"0.0.0-dev"` as the release ID in Docker/runtime environments, preventing release rollover from working
- Adds a fallback chain: `APP_VERSION` env var → `version` from `package.json` → `"0.0.0-dev"`
- The env var check also rejects `"0.0.0-dev"` as a valid env value (treating it the same as unset) so a stale injected value doesn't block the fallback

## Test plan
- [x] All 11 `update-bulletin.test.ts` tests pass
- [x] `version.ts` has no TypeScript errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
