### PR TITLE
test: add atomic write failure path test for bulletin sync

### DIFF
--- a/assistant/src/__tests__/update-bulletin.test.ts
+++ b/assistant/src/__tests__/update-bulletin.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -255,6 +255,30 @@ describe('syncUpdateBulletinOnStartup', () => {
 
     const entries = readdirSync(tempDir);
     const tmpFiles = entries.filter((e) => e.includes('.tmp.'));
+    expect(tmpFiles).toHaveLength(0);
+  });
+
+  it('preserves existing file when atomic write fails', () => {
+    const workspacePath = join(tempDir, 'UPDATES.md');
+    const originalContent = '<!-- vellum-update-release:0.9.0 -->\nOriginal content.\n';
+    writeFileSync(workspacePath, originalContent, 'utf-8');
+
+    // Make tempDir read-only so the temp file creation fails.
+    // On macOS/Linux, 0o555 prevents new file creation inside the directory.
+    chmodSync(tempDir, 0o555);
+    try {
+      expect(() => syncUpdateBulletinOnStartup()).toThrow();
+    } finally {
+      chmodSync(tempDir, 0o755);
+    }
+
+    // Original content should be preserved (atomic write never renamed over it)
+    const content = readFileSync(workspacePath, 'utf-8');
+    expect(content).toBe(originalContent);
+
+    // No temp file leftovers
+    const entries = readdirSync(tempDir);
+    const tmpFiles = entries.filter((e: string) => e.includes('.tmp.'));
     expect(tmpFiles).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

- Adds a failure-path test for the atomic write in `update-bulletin.ts` that simulates a write failure (read-only directory) and verifies: the original file content is preserved, no temp file leftovers remain, and the function throws.
- Addresses review finding (P3): tests previously only covered success/no-temp-leftovers but not the failure path.

## Test plan

- [x] New test passes locally (`bun test src/__tests__/update-bulletin.test.ts` — 12/12 pass)
- [x] Test validates three failure-path invariants: original content preservation, no temp file leftovers, function throws on write failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
