### PR TITLE
fix: align empty-template policy across template, tests, and docs

### DIFF
--- a/assistant/src/__tests__/update-bulletin.test.ts
+++ b/assistant/src/__tests__/update-bulletin.test.ts
@@ -94,15 +94,26 @@ mock.module('../version.js', () => ({
 
 const { syncUpdateBulletinOnStartup } = await import('../config/update-bulletin.js');
 
+// The real template is now comment-only (no materialized content). Tests that
+// exercise materialization need a template with real content, so we swap in a
+// test template before each test and restore the original afterwards.
+const TEMPLATE_PATH = join(import.meta.dirname, '..', 'config', 'templates', 'UPDATES.md');
+const originalTemplate = readFileSync(TEMPLATE_PATH, 'utf-8');
+const TEST_TEMPLATE = '## What\'s New\n\nTest release notes.\n';
+
 describe('syncUpdateBulletinOnStartup', () => {
   beforeEach(() => {
     store.clear();
     tempDir = join(tmpdir(), `update-bulletin-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     mkdirSync(tempDir, { recursive: true });
+    // Write a test template with real content so materialization proceeds
+    writeFileSync(TEMPLATE_PATH, TEST_TEMPLATE, 'utf-8');
   });
 
   afterEach(() => {
     rmSync(tempDir, { recursive: true, force: true });
+    // Restore the original comment-only template
+    writeFileSync(TEMPLATE_PATH, originalTemplate, 'utf-8');
   });
 
   it('creates workspace file on first eligible run', () => {
@@ -256,5 +267,15 @@ describe('syncUpdateBulletinOnStartup', () => {
     const entries = readdirSync(tempDir);
     const tmpFiles = entries.filter((e) => e.includes('.tmp.'));
     expect(tmpFiles).toHaveLength(0);
+  });
+
+  it('skips materialization when template is comment-only', () => {
+    // Restore the real comment-only template for this test
+    writeFileSync(TEMPLATE_PATH, originalTemplate, 'utf-8');
+
+    const workspacePath = join(tempDir, 'UPDATES.md');
+    syncUpdateBulletinOnStartup();
+
+    expect(existsSync(workspacePath)).toBe(false);
   });
 });

--- a/assistant/src/__tests__/update-template-contract.test.ts
+++ b/assistant/src/__tests__/update-template-contract.test.ts
@@ -1,9 +1,8 @@
 /**
- * Contract test: ensures the bundled UPDATES.md template exists and meets
- * the format expectations that the bulletin system depends on at runtime.
+ * Contract test: ensures the bundled UPDATES.md template exists and is readable.
  *
- * The "## What's New" heading is a structural contract — bulletin rendering
- * logic expects this section to be present in the template.
+ * The template may be comment-only (no real content) for no-op releases —
+ * the bulletin system treats an empty-after-stripping template as a skip signal.
  */
 
 import { existsSync, readFileSync } from 'node:fs';
@@ -17,13 +16,8 @@ describe('UPDATES.md template contract', () => {
     expect(existsSync(TEMPLATE_PATH)).toBe(true);
   });
 
-  test('template contains non-whitespace content', () => {
+  test('template is a readable UTF-8 file', () => {
     const content = readFileSync(TEMPLATE_PATH, 'utf-8');
-    expect(content.trim().length).toBeGreaterThan(0);
-  });
-
-  test('template contains the "## What\'s New" heading', () => {
-    const content = readFileSync(TEMPLATE_PATH, 'utf-8');
-    expect(content).toContain("## What's New");
+    expect(typeof content).toBe('string');
   });
 });

--- a/assistant/src/config/templates/UPDATES.md
+++ b/assistant/src/config/templates/UPDATES.md
@@ -1,7 +1,5 @@
 _ Lines starting with _ are comments — they won't appear in the system prompt
-
-# UPDATES.md
-
+_
 _ This file contains release update notes for the assistant.
 _ Each release block is wrapped with HTML comment markers:
 _   <!-- vellum-update-release:<version> -->
@@ -11,6 +9,7 @@ _
 _ Format is freeform markdown. Write notes that help the assistant
 _ understand what changed and how it affects behavior, capabilities,
 _ or available tools. Focus on what matters to the user experience.
-
-## What's New
-
+_
+_ To add release notes, replace this content with real markdown
+_ describing what changed. The sync will only materialize a bulletin
+_ when non-comment content is present.


### PR DESCRIPTION
## Summary

- Makes the bundled `UPDATES.md` template comment-only by default so no bulletin is materialized for releases without explicit update notes (fixes the placeholder noise issue)
- Relaxes the contract test to allow empty/comment-only templates (fixes the CI conflict with documented empty-template policy)
- Updates bulletin tests to swap in a test template with real content during setup and restore the original afterwards
- Adds a new test verifying the comment-only skip path works correctly

## Test plan

- [x] `bun test src/__tests__/update-template-contract.test.ts` passes (2 tests)
- [x] `bun test src/__tests__/update-bulletin.test.ts` passes (12 tests, including new skip test)
- [ ] Verify no other tests depend on the `## What's New` heading in the template

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
