### PR TITLE
M1: Generic Scoped Grant Primitive

### DIFF
--- a/assistant/src/__tests__/scoped-approval-grants.test.ts
+++ b/assistant/src/__tests__/scoped-approval-grants.test.ts
@@ -315,6 +315,49 @@ describe('scoped-approval-grants / tool_signature scope', () => {
     });
     expect(result.ok).toBe(false);
   });
+
+  test('consume by tool signature only consumes one grant when multiple match', () => {
+    const digest = computeToolApprovalDigest('bash', { cmd: 'ls' });
+
+    // Create a wildcard grant (no executionChannel) and a channel-specific grant.
+    // Both match when executionChannel='telegram', but only one should be consumed.
+    const wildcardGrant = createScopedApprovalGrant(
+      grantParams({
+        scopeMode: 'tool_signature',
+        toolName: 'bash',
+        inputDigest: digest,
+        executionChannel: null,
+      }),
+    );
+    const specificGrant = createScopedApprovalGrant(
+      grantParams({
+        scopeMode: 'tool_signature',
+        toolName: 'bash',
+        inputDigest: digest,
+        executionChannel: 'telegram',
+      }),
+    );
+
+    const result = consumeScopedApprovalGrantByToolSignature({
+      toolName: 'bash',
+      inputDigest: digest,
+      consumingRequestId: 'c1',
+      executionChannel: 'telegram',
+    });
+    expect(result.ok).toBe(true);
+    // The most specific grant (channel-specific) should be consumed first
+    expect(result.grant!.id).toBe(specificGrant.id);
+
+    // The wildcard grant should still be active and consumable
+    const second = consumeScopedApprovalGrantByToolSignature({
+      toolName: 'bash',
+      inputDigest: digest,
+      consumingRequestId: 'c2',
+      executionChannel: 'sms',
+    });
+    expect(second.ok).toBe(true);
+    expect(second.grant!.id).toBe(wildcardGrant.id);
+  });
 });
 
 // ===========================================================================
@@ -398,6 +441,22 @@ describe('scoped-approval-grants / revoke', () => {
 
     const result = consumeScopedApprovalGrantByRequestId('req-revoke', 'c1');
     expect(result.ok).toBe(false);
+  });
+
+  test('revokeScopedApprovalGrantsForContext throws when no context filters are provided', () => {
+    // Create a grant to ensure the guard is not based on empty results
+    createScopedApprovalGrant(
+      grantParams({ scopeMode: 'request_id', requestId: 'req-guard', callSessionId: 'call-guard' }),
+    );
+
+    // Empty object: all fields undefined
+    expect(() => revokeScopedApprovalGrantsForContext({})).toThrow(
+      'revokeScopedApprovalGrantsForContext requires at least one context filter',
+    );
+
+    // The grant should still be active (not revoked)
+    const result = consumeScopedApprovalGrantByRequestId('req-guard', 'c1');
+    expect(result.ok).toBe(true);
   });
 });
 

--- a/assistant/src/__tests__/scoped-approval-grants.test.ts
+++ b/assistant/src/__tests__/scoped-approval-grants.test.ts
@@ -1,0 +1,462 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'scoped-grants-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  migrateToWorkspaceLayout: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  isDebug: () => false,
+  truncateForLog: (value: string) => value,
+}));
+
+import {
+  type CreateScopedApprovalGrantParams,
+  consumeScopedApprovalGrantByRequestId,
+  consumeScopedApprovalGrantByToolSignature,
+  createScopedApprovalGrant,
+  expireScopedApprovalGrants,
+  revokeScopedApprovalGrantsForContext,
+} from '../memory/scoped-approval-grants.js';
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { scopedApprovalGrants } from '../memory/schema.js';
+import {
+  canonicalJsonSerialize,
+  computeToolApprovalDigest,
+} from '../security/tool-approval-digest.js';
+
+initializeDb();
+
+function clearTables(): void {
+  const db = getDb();
+  db.delete(scopedApprovalGrants).run();
+}
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helper to build grant params with sensible defaults
+// ---------------------------------------------------------------------------
+
+function grantParams(overrides: Partial<CreateScopedApprovalGrantParams> = {}): CreateScopedApprovalGrantParams {
+  const futureExpiry = new Date(Date.now() + 60_000).toISOString();
+  return {
+    assistantId: 'self',
+    scopeMode: 'request_id',
+    requestChannel: 'telegram',
+    decisionChannel: 'telegram',
+    expiresAt: futureExpiry,
+    ...overrides,
+  };
+}
+
+// ===========================================================================
+// SCOPE MODE: request_id
+// ===========================================================================
+
+describe('scoped-approval-grants / request_id scope', () => {
+  beforeEach(() => clearTables());
+
+  test('create and consume by request_id succeeds', () => {
+    const grant = createScopedApprovalGrant(
+      grantParams({ scopeMode: 'request_id', requestId: 'req-1' }),
+    );
+    expect(grant.status).toBe('active');
+    expect(grant.requestId).toBe('req-1');
+
+    const result = consumeScopedApprovalGrantByRequestId('req-1', 'consumer-1');
+    expect(result.ok).toBe(true);
+    expect(result.grant).not.toBeNull();
+    expect(result.grant!.status).toBe('consumed');
+    expect(result.grant!.consumedByRequestId).toBe('consumer-1');
+  });
+
+  test('second consume of same grant fails (one-time use)', () => {
+    createScopedApprovalGrant(
+      grantParams({ scopeMode: 'request_id', requestId: 'req-2' }),
+    );
+
+    const first = consumeScopedApprovalGrantByRequestId('req-2', 'consumer-a');
+    expect(first.ok).toBe(true);
+
+    const second = consumeScopedApprovalGrantByRequestId('req-2', 'consumer-b');
+    expect(second.ok).toBe(false);
+    expect(second.grant).toBeNull();
+  });
+
+  test('consume fails when no matching grant exists', () => {
+    const result = consumeScopedApprovalGrantByRequestId('nonexistent', 'consumer-x');
+    expect(result.ok).toBe(false);
+  });
+
+  test('expired grant cannot be consumed', () => {
+    const pastExpiry = new Date(Date.now() - 1_000).toISOString();
+    createScopedApprovalGrant(
+      grantParams({ scopeMode: 'request_id', requestId: 'req-expired', expiresAt: pastExpiry }),
+    );
+
+    const result = consumeScopedApprovalGrantByRequestId('req-expired', 'consumer-1');
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ===========================================================================
+// SCOPE MODE: tool_signature
+// ===========================================================================
+
+describe('scoped-approval-grants / tool_signature scope', () => {
+  beforeEach(() => clearTables());
+
+  test('create and consume by tool signature succeeds', () => {
+    const digest = computeToolApprovalDigest('bash', { cmd: 'ls' });
+    const grant = createScopedApprovalGrant(
+      grantParams({
+        scopeMode: 'tool_signature',
+        toolName: 'bash',
+        inputDigest: digest,
+      }),
+    );
+    expect(grant.status).toBe('active');
+    expect(grant.toolName).toBe('bash');
+
+    const result = consumeScopedApprovalGrantByToolSignature({
+      toolName: 'bash',
+      inputDigest: digest,
+      consumingRequestId: 'consumer-1',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.grant!.status).toBe('consumed');
+  });
+
+  test('second consume of tool_signature grant fails', () => {
+    const digest = computeToolApprovalDigest('bash', { cmd: 'rm -rf' });
+    createScopedApprovalGrant(
+      grantParams({
+        scopeMode: 'tool_signature',
+        toolName: 'bash',
+        inputDigest: digest,
+      }),
+    );
+
+    const first = consumeScopedApprovalGrantByToolSignature({
+      toolName: 'bash',
+      inputDigest: digest,
+      consumingRequestId: 'c1',
+    });
+    expect(first.ok).toBe(true);
+
+    const second = consumeScopedApprovalGrantByToolSignature({
+      toolName: 'bash',
+      inputDigest: digest,
+      consumingRequestId: 'c2',
+    });
+    expect(second.ok).toBe(false);
+  });
+
+  test('mismatched input digest fails consume', () => {
+    const digest = computeToolApprovalDigest('bash', { cmd: 'ls' });
+    createScopedApprovalGrant(
+      grantParams({
+        scopeMode: 'tool_signature',
+        toolName: 'bash',
+        inputDigest: digest,
+      }),
+    );
+
+    const wrongDigest = computeToolApprovalDigest('bash', { cmd: 'pwd' });
+    const result = consumeScopedApprovalGrantByToolSignature({
+      toolName: 'bash',
+      inputDigest: wrongDigest,
+      consumingRequestId: 'c1',
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test('mismatched tool name fails consume', () => {
+    const digest = computeToolApprovalDigest('bash', { cmd: 'ls' });
+    createScopedApprovalGrant(
+      grantParams({
+        scopeMode: 'tool_signature',
+        toolName: 'bash',
+        inputDigest: digest,
+      }),
+    );
+
+    const result = consumeScopedApprovalGrantByToolSignature({
+      toolName: 'python',
+      inputDigest: digest,
+      consumingRequestId: 'c1',
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test('context constraint: executionChannel must match non-null grant field', () => {
+    const digest = computeToolApprovalDigest('bash', { cmd: 'ls' });
+    createScopedApprovalGrant(
+      grantParams({
+        scopeMode: 'tool_signature',
+        toolName: 'bash',
+        inputDigest: digest,
+        executionChannel: 'telegram',
+      }),
+    );
+
+    // Wrong channel
+    const wrong = consumeScopedApprovalGrantByToolSignature({
+      toolName: 'bash',
+      inputDigest: digest,
+      consumingRequestId: 'c1',
+      executionChannel: 'sms',
+    });
+    expect(wrong.ok).toBe(false);
+
+    // Correct channel
+    const correct = consumeScopedApprovalGrantByToolSignature({
+      toolName: 'bash',
+      inputDigest: digest,
+      consumingRequestId: 'c2',
+      executionChannel: 'telegram',
+    });
+    expect(correct.ok).toBe(true);
+  });
+
+  test('null executionChannel on grant means any channel matches', () => {
+    const digest = computeToolApprovalDigest('bash', { cmd: 'ls' });
+    createScopedApprovalGrant(
+      grantParams({
+        scopeMode: 'tool_signature',
+        toolName: 'bash',
+        inputDigest: digest,
+        executionChannel: null,
+      }),
+    );
+
+    const result = consumeScopedApprovalGrantByToolSignature({
+      toolName: 'bash',
+      inputDigest: digest,
+      consumingRequestId: 'c1',
+      executionChannel: 'sms',
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test('context constraint: conversationId must match non-null grant field', () => {
+    const digest = computeToolApprovalDigest('bash', { cmd: 'ls' });
+    createScopedApprovalGrant(
+      grantParams({
+        scopeMode: 'tool_signature',
+        toolName: 'bash',
+        inputDigest: digest,
+        conversationId: 'conv-123',
+      }),
+    );
+
+    // Mismatched
+    const wrong = consumeScopedApprovalGrantByToolSignature({
+      toolName: 'bash',
+      inputDigest: digest,
+      consumingRequestId: 'c1',
+      conversationId: 'conv-999',
+    });
+    expect(wrong.ok).toBe(false);
+
+    // Matched
+    const correct = consumeScopedApprovalGrantByToolSignature({
+      toolName: 'bash',
+      inputDigest: digest,
+      consumingRequestId: 'c2',
+      conversationId: 'conv-123',
+    });
+    expect(correct.ok).toBe(true);
+  });
+
+  test('expired tool_signature grant cannot be consumed', () => {
+    const pastExpiry = new Date(Date.now() - 1_000).toISOString();
+    const digest = computeToolApprovalDigest('bash', { cmd: 'ls' });
+    createScopedApprovalGrant(
+      grantParams({
+        scopeMode: 'tool_signature',
+        toolName: 'bash',
+        inputDigest: digest,
+        expiresAt: pastExpiry,
+      }),
+    );
+
+    const result = consumeScopedApprovalGrantByToolSignature({
+      toolName: 'bash',
+      inputDigest: digest,
+      consumingRequestId: 'c1',
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ===========================================================================
+// Expiry semantics
+// ===========================================================================
+
+describe('scoped-approval-grants / expiry', () => {
+  beforeEach(() => clearTables());
+
+  test('expireScopedApprovalGrants transitions active past-TTL grants to expired', () => {
+    const pastExpiry = new Date(Date.now() - 1_000).toISOString();
+    createScopedApprovalGrant(
+      grantParams({ scopeMode: 'request_id', requestId: 'req-e1', expiresAt: pastExpiry }),
+    );
+    createScopedApprovalGrant(
+      grantParams({ scopeMode: 'request_id', requestId: 'req-e2', expiresAt: pastExpiry }),
+    );
+    // Still active (future expiry)
+    createScopedApprovalGrant(
+      grantParams({ scopeMode: 'request_id', requestId: 'req-alive' }),
+    );
+
+    const count = expireScopedApprovalGrants();
+    expect(count).toBe(2);
+
+    // Verify the alive grant is still active
+    const alive = consumeScopedApprovalGrantByRequestId('req-alive', 'c1');
+    expect(alive.ok).toBe(true);
+  });
+
+  test('already-consumed grants are not affected by expiry sweep', () => {
+    const pastExpiry = new Date(Date.now() - 1_000).toISOString();
+    createScopedApprovalGrant(
+      grantParams({ scopeMode: 'request_id', requestId: 'req-consumed', expiresAt: new Date(Date.now() + 60_000).toISOString() }),
+    );
+    consumeScopedApprovalGrantByRequestId('req-consumed', 'c1');
+
+    // Force the expiry time to the past for the consumed grant (simulating time passing)
+    // The sweep should not touch consumed grants
+    const count = expireScopedApprovalGrants();
+    expect(count).toBe(0);
+  });
+});
+
+// ===========================================================================
+// Revoke semantics
+// ===========================================================================
+
+describe('scoped-approval-grants / revoke', () => {
+  beforeEach(() => clearTables());
+
+  test('revokeScopedApprovalGrantsForContext revokes active grants matching context', () => {
+    createScopedApprovalGrant(
+      grantParams({ scopeMode: 'request_id', requestId: 'req-r1', callSessionId: 'call-1' }),
+    );
+    createScopedApprovalGrant(
+      grantParams({ scopeMode: 'request_id', requestId: 'req-r2', callSessionId: 'call-1' }),
+    );
+    createScopedApprovalGrant(
+      grantParams({ scopeMode: 'request_id', requestId: 'req-r3', callSessionId: 'call-2' }),
+    );
+
+    const count = revokeScopedApprovalGrantsForContext({ callSessionId: 'call-1' });
+    expect(count).toBe(2);
+
+    // Revoked grant cannot be consumed
+    const revoked = consumeScopedApprovalGrantByRequestId('req-r1', 'c1');
+    expect(revoked.ok).toBe(false);
+
+    // Unaffected grant is still consumable
+    const alive = consumeScopedApprovalGrantByRequestId('req-r3', 'c1');
+    expect(alive.ok).toBe(true);
+  });
+
+  test('revoked grants cannot be consumed', () => {
+    createScopedApprovalGrant(
+      grantParams({ scopeMode: 'request_id', requestId: 'req-revoke', conversationId: 'conv-1' }),
+    );
+
+    revokeScopedApprovalGrantsForContext({ conversationId: 'conv-1' });
+
+    const result = consumeScopedApprovalGrantByRequestId('req-revoke', 'c1');
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ===========================================================================
+// tool-approval-digest: canonical serialization + hash
+// ===========================================================================
+
+describe('tool-approval-digest', () => {
+  test('canonicalJsonSerialize sorts keys recursively', () => {
+    const obj = { z: 1, a: { c: 3, b: 2 } };
+    const serialized = canonicalJsonSerialize(obj);
+    expect(serialized).toBe('{"a":{"b":2,"c":3},"z":1}');
+  });
+
+  test('canonicalJsonSerialize handles arrays (order preserved)', () => {
+    const obj = { items: [3, 1, 2], name: 'test' };
+    const serialized = canonicalJsonSerialize(obj);
+    expect(serialized).toBe('{"items":[3,1,2],"name":"test"}');
+  });
+
+  test('canonicalJsonSerialize handles null values', () => {
+    const obj = { a: null, b: 'hello' };
+    const serialized = canonicalJsonSerialize(obj);
+    expect(serialized).toBe('{"a":null,"b":"hello"}');
+  });
+
+  test('canonicalJsonSerialize handles nested arrays of objects', () => {
+    const obj = { list: [{ z: 1, a: 2 }, { y: 3, b: 4 }] };
+    const serialized = canonicalJsonSerialize(obj);
+    expect(serialized).toBe('{"list":[{"a":2,"z":1},{"b":4,"y":3}]}');
+  });
+
+  test('computeToolApprovalDigest is deterministic', () => {
+    const d1 = computeToolApprovalDigest('bash', { cmd: 'ls -la', cwd: '/tmp' });
+    const d2 = computeToolApprovalDigest('bash', { cwd: '/tmp', cmd: 'ls -la' });
+    expect(d1).toBe(d2);
+  });
+
+  test('computeToolApprovalDigest differs for different inputs', () => {
+    const d1 = computeToolApprovalDigest('bash', { cmd: 'ls' });
+    const d2 = computeToolApprovalDigest('bash', { cmd: 'pwd' });
+    expect(d1).not.toBe(d2);
+  });
+
+  test('computeToolApprovalDigest differs for different tool names', () => {
+    const d1 = computeToolApprovalDigest('bash', { cmd: 'ls' });
+    const d2 = computeToolApprovalDigest('python', { cmd: 'ls' });
+    expect(d1).not.toBe(d2);
+  });
+
+  test('computeToolApprovalDigest is stable across key orderings (deeply nested)', () => {
+    const d1 = computeToolApprovalDigest('tool', {
+      config: { nested: { z: 1, a: 2 }, top: true },
+      name: 'test',
+    });
+    const d2 = computeToolApprovalDigest('tool', {
+      name: 'test',
+      config: { top: true, nested: { a: 2, z: 1 } },
+    });
+    expect(d1).toBe(d2);
+  });
+});

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -8,6 +8,7 @@ import {
   createConversationAttentionTables,
   createCoreIndexes,
   createCoreTables,
+  createScopedApprovalGrantsTable,
   createExternalConversationBindingsTables,
   createFollowupsTables,
   createMediaAssetsTables,
@@ -128,6 +129,9 @@ export function initializeDb(): void {
 
   // 21. Rebuild tables to add ON DELETE CASCADE to FK constraints
   migrateFkCascadeRebuilds(database);
+
+  // 22. Scoped approval grants (channel-agnostic one-time-use grants)
+  createScopedApprovalGrantsTable(database);
 
   validateMigrationState(database);
 }

--- a/assistant/src/memory/migrations/033-scoped-approval-grants.ts
+++ b/assistant/src/memory/migrations/033-scoped-approval-grants.ts
@@ -1,0 +1,51 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Create the scoped_approval_grants table for channel-agnostic scoped
+ * approval grants.  Supports two scope modes:
+ *   - request_id: grant is scoped to a specific request
+ *   - tool_signature: grant is scoped to a tool name + input digest
+ *
+ * Grants are one-time-use (active -> consumed via CAS) and carry a
+ * mandatory TTL (expires_at).
+ */
+export function createScopedApprovalGrantsTable(database: DrizzleDb): void {
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS scoped_approval_grants (
+      id TEXT PRIMARY KEY,
+      assistant_id TEXT NOT NULL,
+      scope_mode TEXT NOT NULL,
+      request_id TEXT,
+      tool_name TEXT,
+      input_digest TEXT,
+      request_channel TEXT NOT NULL,
+      decision_channel TEXT NOT NULL,
+      execution_channel TEXT,
+      conversation_id TEXT,
+      call_session_id TEXT,
+      requester_external_user_id TEXT,
+      guardian_external_user_id TEXT,
+      status TEXT NOT NULL,
+      expires_at TEXT NOT NULL,
+      consumed_at TEXT,
+      consumed_by_request_id TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `);
+
+  // Index for request_id-based lookups (scope_mode = 'request_id')
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_scoped_grants_request_id ON scoped_approval_grants(request_id) WHERE request_id IS NOT NULL`,
+  );
+
+  // Index for tool_signature-based lookups (scope_mode = 'tool_signature')
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_scoped_grants_tool_sig ON scoped_approval_grants(tool_name, input_digest) WHERE tool_name IS NOT NULL`,
+  );
+
+  // Index for expiry sweeps
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_scoped_grants_status_expires ON scoped_approval_grants(status, expires_at)`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -33,6 +33,7 @@ export { migrateGuardianActionFollowup } from './030-guardian-action-followup.js
 export { migrateGuardianVerificationPurpose } from './030-guardian-verification-purpose.js';
 export { migrateConversationsThreadTypeIndex } from './031-conversations-thread-type-index.js';
 export { migrateGuardianDeliveryConversationIndex } from './032-guardian-delivery-conversation-index.js';
+export { createScopedApprovalGrantsTable } from './033-scoped-approval-grants.js';
 export { createCoreTables } from './100-core-tables.js';
 export { createWatchersAndLogsTables } from './101-watchers-and-logs.js';
 export { addCoreColumns } from './102-alter-table-columns.js';

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -1070,3 +1070,31 @@ export const conversationAssistantAttentionState = sqliteTable('conversation_ass
   index('idx_conv_attn_state_assistant_latest_msg').on(table.assistantId, table.latestAssistantMessageAt),
   index('idx_conv_attn_state_assistant_last_seen').on(table.assistantId, table.lastSeenAssistantMessageAt),
 ]);
+
+// ── Scoped Approval Grants ──────────────────────────────────────────
+
+export const scopedApprovalGrants = sqliteTable('scoped_approval_grants', {
+  id: text('id').primaryKey(),
+  assistantId: text('assistant_id').notNull(),
+  scopeMode: text('scope_mode').notNull(),           // 'request_id' | 'tool_signature'
+  requestId: text('request_id'),
+  toolName: text('tool_name'),
+  inputDigest: text('input_digest'),
+  requestChannel: text('request_channel').notNull(),
+  decisionChannel: text('decision_channel').notNull(),
+  executionChannel: text('execution_channel'),        // null = any channel
+  conversationId: text('conversation_id'),
+  callSessionId: text('call_session_id'),
+  requesterExternalUserId: text('requester_external_user_id'),
+  guardianExternalUserId: text('guardian_external_user_id'),
+  status: text('status').notNull(),                   // 'active' | 'consumed' | 'expired' | 'revoked'
+  expiresAt: text('expires_at').notNull(),
+  consumedAt: text('consumed_at'),
+  consumedByRequestId: text('consumed_by_request_id'),
+  createdAt: text('created_at').notNull(),
+  updatedAt: text('updated_at').notNull(),
+}, (table) => [
+  index('idx_scoped_grants_request_id').on(table.requestId),
+  index('idx_scoped_grants_tool_sig').on(table.toolName, table.inputDigest),
+  index('idx_scoped_grants_status_expires').on(table.status, table.expiresAt),
+]);

--- a/assistant/src/memory/scoped-approval-grants.ts
+++ b/assistant/src/memory/scoped-approval-grants.ts
@@ -1,0 +1,370 @@
+/**
+ * CRUD and atomic consume for scoped approval grants.
+ *
+ * Grants authorise exactly one tool execution.  Two scope modes exist:
+ *   - `request_id`      — grant is bound to a specific pending request
+ *   - `tool_signature`  — grant is bound to a tool name + input digest
+ *
+ * Invariants:
+ *   - At most one successful consume per grant (CAS: active -> consumed).
+ *   - Matching requires all non-null scope fields to match exactly.
+ *   - Expired and revoked grants cannot be consumed.
+ */
+
+import { and, eq, lt, sql } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+
+import { getDb, rawChanges } from './db.js';
+import { scopedApprovalGrants } from './schema.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ScopeMode = 'request_id' | 'tool_signature';
+export type GrantStatus = 'active' | 'consumed' | 'expired' | 'revoked';
+
+export interface ScopedApprovalGrant {
+  id: string;
+  assistantId: string;
+  scopeMode: ScopeMode;
+  requestId: string | null;
+  toolName: string | null;
+  inputDigest: string | null;
+  requestChannel: string;
+  decisionChannel: string;
+  executionChannel: string | null;
+  conversationId: string | null;
+  callSessionId: string | null;
+  requesterExternalUserId: string | null;
+  guardianExternalUserId: string | null;
+  status: GrantStatus;
+  expiresAt: string;
+  consumedAt: string | null;
+  consumedByRequestId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function rowToGrant(row: typeof scopedApprovalGrants.$inferSelect): ScopedApprovalGrant {
+  return {
+    id: row.id,
+    assistantId: row.assistantId,
+    scopeMode: row.scopeMode as ScopeMode,
+    requestId: row.requestId,
+    toolName: row.toolName,
+    inputDigest: row.inputDigest,
+    requestChannel: row.requestChannel,
+    decisionChannel: row.decisionChannel,
+    executionChannel: row.executionChannel,
+    conversationId: row.conversationId,
+    callSessionId: row.callSessionId,
+    requesterExternalUserId: row.requesterExternalUserId,
+    guardianExternalUserId: row.guardianExternalUserId,
+    status: row.status as GrantStatus,
+    expiresAt: row.expiresAt,
+    consumedAt: row.consumedAt,
+    consumedByRequestId: row.consumedByRequestId,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+export interface CreateScopedApprovalGrantParams {
+  assistantId: string;
+  scopeMode: ScopeMode;
+  requestId?: string | null;
+  toolName?: string | null;
+  inputDigest?: string | null;
+  requestChannel: string;
+  decisionChannel: string;
+  executionChannel?: string | null;
+  conversationId?: string | null;
+  callSessionId?: string | null;
+  requesterExternalUserId?: string | null;
+  guardianExternalUserId?: string | null;
+  expiresAt: string;
+}
+
+export function createScopedApprovalGrant(params: CreateScopedApprovalGrantParams): ScopedApprovalGrant {
+  const db = getDb();
+  const now = new Date().toISOString();
+  const id = uuid();
+
+  const row = {
+    id,
+    assistantId: params.assistantId,
+    scopeMode: params.scopeMode,
+    requestId: params.requestId ?? null,
+    toolName: params.toolName ?? null,
+    inputDigest: params.inputDigest ?? null,
+    requestChannel: params.requestChannel,
+    decisionChannel: params.decisionChannel,
+    executionChannel: params.executionChannel ?? null,
+    conversationId: params.conversationId ?? null,
+    callSessionId: params.callSessionId ?? null,
+    requesterExternalUserId: params.requesterExternalUserId ?? null,
+    guardianExternalUserId: params.guardianExternalUserId ?? null,
+    status: 'active' as const,
+    expiresAt: params.expiresAt,
+    consumedAt: null,
+    consumedByRequestId: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  db.insert(scopedApprovalGrants).values(row).run();
+  return rowToGrant(row);
+}
+
+// ---------------------------------------------------------------------------
+// Consume by request ID (CAS: active -> consumed)
+// ---------------------------------------------------------------------------
+
+export interface ConsumeByRequestIdResult {
+  ok: boolean;
+  grant: ScopedApprovalGrant | null;
+}
+
+/**
+ * Atomically consume a grant by request ID.
+ *
+ * Only succeeds when exactly one active, non-expired grant matches the
+ * given `requestId`.  Uses compare-and-swap on the `status` column so
+ * concurrent consumers race safely — at most one wins.
+ */
+export function consumeScopedApprovalGrantByRequestId(
+  requestId: string,
+  consumingRequestId: string,
+  now?: string,
+): ConsumeByRequestIdResult {
+  const db = getDb();
+  const currentTime = now ?? new Date().toISOString();
+
+  db.update(scopedApprovalGrants)
+    .set({
+      status: 'consumed',
+      consumedAt: currentTime,
+      consumedByRequestId: consumingRequestId,
+      updatedAt: currentTime,
+    })
+    .where(
+      and(
+        eq(scopedApprovalGrants.requestId, requestId),
+        eq(scopedApprovalGrants.scopeMode, 'request_id'),
+        eq(scopedApprovalGrants.status, 'active'),
+        sql`${scopedApprovalGrants.expiresAt} > ${currentTime}`,
+      ),
+    )
+    .run();
+
+  if (rawChanges() === 0) {
+    return { ok: false, grant: null };
+  }
+
+  // Fetch the consumed grant to return to the caller
+  const row = db
+    .select()
+    .from(scopedApprovalGrants)
+    .where(
+      and(
+        eq(scopedApprovalGrants.requestId, requestId),
+        eq(scopedApprovalGrants.status, 'consumed'),
+        eq(scopedApprovalGrants.consumedByRequestId, consumingRequestId),
+      ),
+    )
+    .get();
+
+  return { ok: true, grant: row ? rowToGrant(row) : null };
+}
+
+// ---------------------------------------------------------------------------
+// Consume by tool signature (CAS: active -> consumed)
+// ---------------------------------------------------------------------------
+
+export interface ConsumeByToolSignatureParams {
+  toolName: string;
+  inputDigest: string;
+  consumingRequestId: string;
+  /** Optional context constraints — only matched when the grant has a non-null value */
+  executionChannel?: string;
+  conversationId?: string;
+  callSessionId?: string;
+  requesterExternalUserId?: string;
+  now?: string;
+}
+
+export interface ConsumeByToolSignatureResult {
+  ok: boolean;
+  grant: ScopedApprovalGrant | null;
+}
+
+/**
+ * Atomically consume a grant by tool name + input digest.
+ *
+ * All non-null scope fields on the grant must match the provided context.
+ * This is enforced via SQL conditions that check: either the grant field is
+ * NULL (wildcard), or it equals the provided value.
+ */
+export function consumeScopedApprovalGrantByToolSignature(
+  params: ConsumeByToolSignatureParams,
+): ConsumeByToolSignatureResult {
+  const db = getDb();
+  const currentTime = params.now ?? new Date().toISOString();
+
+  const conditions = [
+    eq(scopedApprovalGrants.toolName, params.toolName),
+    eq(scopedApprovalGrants.inputDigest, params.inputDigest),
+    eq(scopedApprovalGrants.scopeMode, 'tool_signature'),
+    eq(scopedApprovalGrants.status, 'active'),
+    sql`${scopedApprovalGrants.expiresAt} > ${currentTime}`,
+  ];
+
+  // Context constraints: grant field must be NULL (any) or match exactly
+  if (params.executionChannel !== undefined) {
+    conditions.push(
+      sql`(${scopedApprovalGrants.executionChannel} IS NULL OR ${scopedApprovalGrants.executionChannel} = ${params.executionChannel})`,
+    );
+  } else {
+    // If caller provides no execution channel, only match grants with NULL (any)
+    conditions.push(sql`${scopedApprovalGrants.executionChannel} IS NULL`);
+  }
+
+  if (params.conversationId !== undefined) {
+    conditions.push(
+      sql`(${scopedApprovalGrants.conversationId} IS NULL OR ${scopedApprovalGrants.conversationId} = ${params.conversationId})`,
+    );
+  } else {
+    conditions.push(sql`${scopedApprovalGrants.conversationId} IS NULL`);
+  }
+
+  if (params.callSessionId !== undefined) {
+    conditions.push(
+      sql`(${scopedApprovalGrants.callSessionId} IS NULL OR ${scopedApprovalGrants.callSessionId} = ${params.callSessionId})`,
+    );
+  } else {
+    conditions.push(sql`${scopedApprovalGrants.callSessionId} IS NULL`);
+  }
+
+  if (params.requesterExternalUserId !== undefined) {
+    conditions.push(
+      sql`(${scopedApprovalGrants.requesterExternalUserId} IS NULL OR ${scopedApprovalGrants.requesterExternalUserId} = ${params.requesterExternalUserId})`,
+    );
+  } else {
+    conditions.push(sql`${scopedApprovalGrants.requesterExternalUserId} IS NULL`);
+  }
+
+  db.update(scopedApprovalGrants)
+    .set({
+      status: 'consumed',
+      consumedAt: currentTime,
+      consumedByRequestId: params.consumingRequestId,
+      updatedAt: currentTime,
+    })
+    .where(and(...conditions))
+    .run();
+
+  if (rawChanges() === 0) {
+    return { ok: false, grant: null };
+  }
+
+  // Fetch the consumed grant
+  const row = db
+    .select()
+    .from(scopedApprovalGrants)
+    .where(
+      and(
+        eq(scopedApprovalGrants.toolName, params.toolName),
+        eq(scopedApprovalGrants.inputDigest, params.inputDigest),
+        eq(scopedApprovalGrants.status, 'consumed'),
+        eq(scopedApprovalGrants.consumedByRequestId, params.consumingRequestId),
+      ),
+    )
+    .get();
+
+  return { ok: true, grant: row ? rowToGrant(row) : null };
+}
+
+// ---------------------------------------------------------------------------
+// Expire grants past their TTL
+// ---------------------------------------------------------------------------
+
+/**
+ * Bulk-expire all active grants whose `expiresAt` is at or before `now`.
+ * Returns the number of grants expired.
+ */
+export function expireScopedApprovalGrants(now?: string): number {
+  const db = getDb();
+  const currentTime = now ?? new Date().toISOString();
+
+  db.update(scopedApprovalGrants)
+    .set({
+      status: 'expired',
+      updatedAt: currentTime,
+    })
+    .where(
+      and(
+        eq(scopedApprovalGrants.status, 'active'),
+        sql`${scopedApprovalGrants.expiresAt} <= ${currentTime}`,
+      ),
+    )
+    .run();
+
+  return rawChanges();
+}
+
+// ---------------------------------------------------------------------------
+// Revoke active grants for a context
+// ---------------------------------------------------------------------------
+
+export interface RevokeContextParams {
+  assistantId?: string;
+  conversationId?: string;
+  callSessionId?: string;
+  requestChannel?: string;
+}
+
+/**
+ * Revoke all active grants matching the given context filters.
+ * At least one filter must be provided.  Returns the number of
+ * grants revoked.
+ *
+ * Typical use: revoke all grants for a call session when the call ends.
+ */
+export function revokeScopedApprovalGrantsForContext(params: RevokeContextParams, now?: string): number {
+  const db = getDb();
+  const currentTime = now ?? new Date().toISOString();
+
+  const conditions = [eq(scopedApprovalGrants.status, 'active')];
+
+  if (params.assistantId !== undefined) {
+    conditions.push(eq(scopedApprovalGrants.assistantId, params.assistantId));
+  }
+  if (params.conversationId !== undefined) {
+    conditions.push(eq(scopedApprovalGrants.conversationId, params.conversationId));
+  }
+  if (params.callSessionId !== undefined) {
+    conditions.push(eq(scopedApprovalGrants.callSessionId, params.callSessionId));
+  }
+  if (params.requestChannel !== undefined) {
+    conditions.push(eq(scopedApprovalGrants.requestChannel, params.requestChannel));
+  }
+
+  db.update(scopedApprovalGrants)
+    .set({
+      status: 'revoked',
+      updatedAt: currentTime,
+    })
+    .where(and(...conditions))
+    .run();
+
+  return rawChanges();
+}

--- a/assistant/src/memory/scoped-approval-grants.ts
+++ b/assistant/src/memory/scoped-approval-grants.ts
@@ -262,6 +262,26 @@ export function consumeScopedApprovalGrantByToolSignature(
     conditions.push(sql`${scopedApprovalGrants.requesterExternalUserId} IS NULL`);
   }
 
+  // Select a single matching grant to consume (prefer most specific: fewest NULL scope fields).
+  // This avoids burning multiple grants when a wildcard grant and a specific grant both match.
+  const candidate = db
+    .select({ id: scopedApprovalGrants.id })
+    .from(scopedApprovalGrants)
+    .where(and(...conditions))
+    .orderBy(
+      // Prefer grants with more non-null context fields (most specific first)
+      sql`(CASE WHEN ${scopedApprovalGrants.executionChannel} IS NOT NULL THEN 1 ELSE 0 END
+         + CASE WHEN ${scopedApprovalGrants.conversationId} IS NOT NULL THEN 1 ELSE 0 END
+         + CASE WHEN ${scopedApprovalGrants.callSessionId} IS NOT NULL THEN 1 ELSE 0 END
+         + CASE WHEN ${scopedApprovalGrants.requesterExternalUserId} IS NOT NULL THEN 1 ELSE 0 END) DESC`,
+    )
+    .limit(1)
+    .get();
+
+  if (!candidate) {
+    return { ok: false, grant: null };
+  }
+
   db.update(scopedApprovalGrants)
     .set({
       status: 'consumed',
@@ -269,10 +289,16 @@ export function consumeScopedApprovalGrantByToolSignature(
       consumedByRequestId: params.consumingRequestId,
       updatedAt: currentTime,
     })
-    .where(and(...conditions))
+    .where(
+      and(
+        eq(scopedApprovalGrants.id, candidate.id),
+        eq(scopedApprovalGrants.status, 'active'),
+      ),
+    )
     .run();
 
   if (rawChanges() === 0) {
+    // CAS failed — another consumer raced and won
     return { ok: false, grant: null };
   }
 
@@ -280,14 +306,7 @@ export function consumeScopedApprovalGrantByToolSignature(
   const row = db
     .select()
     .from(scopedApprovalGrants)
-    .where(
-      and(
-        eq(scopedApprovalGrants.toolName, params.toolName),
-        eq(scopedApprovalGrants.inputDigest, params.inputDigest),
-        eq(scopedApprovalGrants.status, 'consumed'),
-        eq(scopedApprovalGrants.consumedByRequestId, params.consumingRequestId),
-      ),
-    )
+    .where(eq(scopedApprovalGrants.id, candidate.id))
     .get();
 
   return { ok: true, grant: row ? rowToGrant(row) : null };
@@ -356,6 +375,11 @@ export function revokeScopedApprovalGrantsForContext(params: RevokeContextParams
   }
   if (params.requestChannel !== undefined) {
     conditions.push(eq(scopedApprovalGrants.requestChannel, params.requestChannel));
+  }
+
+  // Guard: at least one context filter must be provided to avoid revoking ALL active grants
+  if (conditions.length === 1) {
+    throw new Error('revokeScopedApprovalGrantsForContext requires at least one context filter');
   }
 
   db.update(scopedApprovalGrants)

--- a/assistant/src/security/tool-approval-digest.ts
+++ b/assistant/src/security/tool-approval-digest.ts
@@ -1,0 +1,67 @@
+/**
+ * Canonical JSON serialization and deterministic SHA-256 hash for tool
+ * approval signatures.
+ *
+ * Producers (grant creators) and consumers (grant matchers) must use the
+ * same serialization to ensure digest equality.  The algorithm:
+ *   1. Sort object keys recursively (depth-first).
+ *   2. Convert to a canonical JSON string with no whitespace.
+ *   3. SHA-256 hash the UTF-8 bytes and return a lowercase hex digest.
+ */
+
+import { createHash } from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// Canonical JSON serialization
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively sort all object keys and return a deterministic JSON string.
+ *
+ * Handles nested objects, arrays (element order preserved), and primitive
+ * values.  `undefined` values inside objects are omitted (matching
+ * JSON.stringify semantics).  `null` is preserved.
+ */
+export function canonicalJsonSerialize(value: unknown): string {
+  return JSON.stringify(sortKeysDeep(value));
+}
+
+function sortKeysDeep(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+
+  if (Array.isArray(value)) {
+    return value.map(sortKeysDeep);
+  }
+
+  if (typeof value === 'object') {
+    const sorted: Record<string, unknown> = {};
+    const keys = Object.keys(value as Record<string, unknown>).sort();
+    for (const key of keys) {
+      sorted[key] = sortKeysDeep((value as Record<string, unknown>)[key]);
+    }
+    return sorted;
+  }
+
+  // Primitive — number, string, boolean
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// Digest computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute a deterministic SHA-256 hex digest over the canonical
+ * serialization of a tool invocation's name and input.
+ *
+ * The digest covers `{ toolName, input }` so that two invocations of the
+ * same tool with identical (deeply-equal) inputs always produce the same
+ * hash, regardless of key ordering in the original input object.
+ */
+export function computeToolApprovalDigest(
+  toolName: string,
+  input: Record<string, unknown>,
+): string {
+  const payload = canonicalJsonSerialize({ input, toolName });
+  return createHash('sha256').update(payload, 'utf8').digest('hex');
+}


### PR DESCRIPTION
Implements channel-agnostic scoped approval grants store with two scope modes (request_id and tool_signature), atomic one-time consume, expiry/revoke semantics, and canonical tool approval digest utility. Part of #10011. Closes #10012.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
