### PR TITLE
Improve inbound voice intro to include assistant name when known

### DIFF
--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -462,6 +462,8 @@ describe('voice-session-bridge', () => {
     const prompt: string = capturedPrompt;
 
     expect(prompt).toContain('this is an inbound call you are answering (not a call you initiated)');
+    expect(prompt).toContain('Introduce yourself once at the start using your assistant name if you know it');
+    expect(prompt).toContain('If your assistant name is not known, skip the name and just identify yourself as the guardian\'s assistant.');
     expect(prompt).toContain('Do NOT say "I\'m calling" or "I\'m calling on behalf of".');
   });
 

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -176,7 +176,7 @@ function buildVoiceCallControlPrompt(opts: {
       );
     } else {
       lines.push(
-        '7. If the latest user turn is "(call connected — deliver opening greeting)", this is an inbound call you are answering (not a call you initiated). Greet the caller warmly and ask how you can help. Do NOT say "I\'m calling" or "I\'m calling on behalf of". If you need to identify your role, use pickup framing like "I\'m [name]\'s assistant." Vary the wording; do not use a fixed template.',
+        '7. If the latest user turn is "(call connected — deliver opening greeting)", this is an inbound call you are answering (not a call you initiated). Greet the caller warmly and ask how you can help. Introduce yourself once at the start using your assistant name if you know it (for example: "Hey there, this is Ava, Sam\'s assistant. How can I help?"). If your assistant name is not known, skip the name and just identify yourself as the guardian\'s assistant. Do NOT say "I\'m calling" or "I\'m calling on behalf of". Vary the wording; do not use a fixed template.',
       );
     }
     lines.push(


### PR DESCRIPTION
## Summary
- update the inbound non-guardian voice opener rule to explicitly introduce with the assistant's own name when known
- keep fallback behavior explicit: if assistant name is unknown, still identify as the guardian's assistant
- preserve existing pickup framing and outbound-phrasing guardrails
- extend the voice-session bridge regression test to assert the new naming guidance

## Testing
- \bun test v1.3.9 (cf6cdbbb)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
