### PR TITLE
fix: prevent empty thread from getting stuck on loading spinner

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -664,7 +664,12 @@ public final class ChatViewModel: ObservableObject {
             messages[i].stripHeavyContent()
         }
         displayedMessageCount = Self.messagePageSize
-        isHistoryLoaded = false
+        // Only mark history as unloaded if there's a session to reload from.
+        // Threads without a session (new, empty) have nothing to fetch —
+        // resetting the flag would leave the UI stuck on a loading spinner.
+        if sessionId != nil {
+            isHistoryLoaded = false
+        }
     }
 
     /// Surface the user is currently viewing in workspace mode.


### PR DESCRIPTION
## Summary
- Only reset `isHistoryLoaded` in `trimForBackground()` when the thread has a session to reload from
- Threads without a session (new, empty) have nothing to fetch — resetting the flag leaves the UI stuck on a loading spinner when switching back

## Root cause
1. Create new thread (no session, `isHistoryLoaded = true`)
2. Switch to another thread → `trimForBackground()` sets `isHistoryLoaded = false`
3. Switch back → `loadHistoryIfNeeded` bails (no `sessionId`) → `isHistoryLoaded` stays `false` → stuck loading

## Test plan
- [ ] Create a new thread, switch to another, switch back — should show empty state, not loading spinner
- [ ] Create a thread, send a message, switch away, switch back — history loads normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
