### PR TITLE
M3: Guardian Reuse Correctness (Mac/Vellum Disambiguation)

### DIFF
--- a/assistant/src/__tests__/guardian-action-late-reply.test.ts
+++ b/assistant/src/__tests__/guardian-action-late-reply.test.ts
@@ -35,9 +35,12 @@ import {
   createGuardianActionDelivery,
   createGuardianActionRequest,
   expireGuardianActionRequest,
+  getExpiredDeliveriesByConversation,
   getExpiredDeliveriesByDestination,
   getExpiredDeliveryByConversation,
+  getFollowupDeliveriesByConversation,
   getGuardianActionRequest,
+  getPendingDeliveriesByConversation,
   resolveGuardianActionRequest,
   startFollowupFromExpiredRequest,
   updateDeliveryStatus,
@@ -290,5 +293,133 @@ describe('guardian-action-late-reply', () => {
     });
 
     expect(text).toContain('expired');
+  });
+
+  // ── Multiple deliveries in one conversation (disambiguation) ──────
+
+  describe('multi-delivery disambiguation in reused conversations', () => {
+    // Helper to create a pending request with delivery in a shared conversation
+    function createPendingInSharedConv(sourceConvId: string, sharedDeliveryConvId: string) {
+      ensureConversation(sourceConvId);
+      const session = createCallSession({
+        conversationId: sourceConvId,
+        provider: 'twilio',
+        fromNumber: '+15550001111',
+        toNumber: '+15550002222',
+      });
+      const pq = createPendingQuestion(session.id, `Question from ${sourceConvId}`);
+      const request = createGuardianActionRequest({
+        kind: 'ask_guardian',
+        sourceChannel: 'voice',
+        sourceConversationId: sourceConvId,
+        callSessionId: session.id,
+        pendingQuestionId: pq.id,
+        questionText: pq.questionText,
+        expiresAt: Date.now() + 60_000,
+      });
+      const delivery = createGuardianActionDelivery({
+        requestId: request.id,
+        destinationChannel: 'vellum',
+        destinationConversationId: sharedDeliveryConvId,
+      });
+      updateDeliveryStatus(delivery.id, 'sent');
+      return { request, delivery };
+    }
+
+    test('multiple pending deliveries in same conversation are returned by getPendingDeliveriesByConversation', () => {
+      const sharedConv = 'shared-reused-conv-pending';
+      ensureConversation(sharedConv);
+
+      const { request: req1 } = createPendingInSharedConv('src-p1', sharedConv);
+      const { request: req2 } = createPendingInSharedConv('src-p2', sharedConv);
+
+      const deliveries = getPendingDeliveriesByConversation(sharedConv);
+      expect(deliveries).toHaveLength(2);
+
+      const requestIds = deliveries.map((d) => d.requestId);
+      expect(requestIds).toContain(req1.id);
+      expect(requestIds).toContain(req2.id);
+    });
+
+    test('request codes are unique across multiple requests in same conversation', () => {
+      const sharedConv = 'shared-reused-conv-codes';
+      ensureConversation(sharedConv);
+
+      const { request: req1 } = createPendingInSharedConv('src-code1', sharedConv);
+      const { request: req2 } = createPendingInSharedConv('src-code2', sharedConv);
+
+      expect(req1.requestCode).not.toBe(req2.requestCode);
+      expect(req1.requestCode).toHaveLength(6);
+      expect(req2.requestCode).toHaveLength(6);
+    });
+
+    test('multiple expired deliveries in same conversation are returned by getExpiredDeliveriesByConversation', () => {
+      const sharedConv = 'shared-reused-conv-expired';
+      ensureConversation(sharedConv);
+
+      const { request: req1 } = createPendingInSharedConv('src-e1', sharedConv);
+      const { request: req2 } = createPendingInSharedConv('src-e2', sharedConv);
+
+      expireGuardianActionRequest(req1.id, 'sweep_timeout');
+      expireGuardianActionRequest(req2.id, 'sweep_timeout');
+
+      const deliveries = getExpiredDeliveriesByConversation(sharedConv);
+      expect(deliveries).toHaveLength(2);
+
+      const requestIds = deliveries.map((d) => d.requestId);
+      expect(requestIds).toContain(req1.id);
+      expect(requestIds).toContain(req2.id);
+    });
+
+    test('multiple followup deliveries in same conversation are returned by getFollowupDeliveriesByConversation', () => {
+      const sharedConv = 'shared-reused-conv-followup';
+      ensureConversation(sharedConv);
+
+      const { request: req1 } = createPendingInSharedConv('src-fu1', sharedConv);
+      const { request: req2 } = createPendingInSharedConv('src-fu2', sharedConv);
+
+      expireGuardianActionRequest(req1.id, 'sweep_timeout');
+      expireGuardianActionRequest(req2.id, 'sweep_timeout');
+      startFollowupFromExpiredRequest(req1.id, 'late answer 1');
+      startFollowupFromExpiredRequest(req2.id, 'late answer 2');
+
+      const deliveries = getFollowupDeliveriesByConversation(sharedConv);
+      expect(deliveries).toHaveLength(2);
+
+      const requestIds = deliveries.map((d) => d.requestId);
+      expect(requestIds).toContain(req1.id);
+      expect(requestIds).toContain(req2.id);
+    });
+
+    test('resolving one pending request leaves the other still pending in shared conversation', () => {
+      const sharedConv = 'shared-reused-conv-resolve-one';
+      ensureConversation(sharedConv);
+
+      const { request: req1 } = createPendingInSharedConv('src-r1', sharedConv);
+      const { request: req2 } = createPendingInSharedConv('src-r2', sharedConv);
+
+      resolveGuardianActionRequest(req1.id, 'answer to first', 'vellum');
+
+      const remaining = getPendingDeliveriesByConversation(sharedConv);
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].requestId).toBe(req2.id);
+    });
+
+    test('request code prefix matching is case-insensitive', () => {
+      const sharedConv = 'shared-reused-conv-case';
+      ensureConversation(sharedConv);
+
+      const { request: req1 } = createPendingInSharedConv('src-case1', sharedConv);
+      const code = req1.requestCode; // e.g. "A1B2C3"
+
+      // Simulate case-insensitive prefix matching as done in session-process.ts
+      const userInput = `${code.toLowerCase()} the answer is 42`;
+      const matched = userInput.toUpperCase().startsWith(code);
+      expect(matched).toBe(true);
+
+      // After stripping the code prefix, the answer text is extracted
+      const answerText = userInput.slice(code.length).trim();
+      expect(answerText).toBe('the answer is 42');
+    });
   });
 });

--- a/assistant/src/__tests__/guardian-action-store.test.ts
+++ b/assistant/src/__tests__/guardian-action-store.test.ts
@@ -31,8 +31,16 @@ import {
   cancelGuardianActionRequest,
   createGuardianActionDelivery,
   createGuardianActionRequest,
+  expireGuardianActionRequest,
   getDeliveriesByRequestId,
+  getExpiredDeliveriesByConversation,
+  getExpiredDeliveryByConversation,
+  getFollowupDeliveriesByConversation,
+  getFollowupDeliveryByConversation,
   getGuardianActionRequest,
+  getPendingDeliveriesByConversation,
+  getPendingDeliveryByConversation,
+  startFollowupFromExpiredRequest,
   updateDeliveryStatus,
 } from '../memory/guardian-action-store.js';
 import { conversations } from '../memory/schema.js';
@@ -73,6 +81,180 @@ describe('guardian-action-store', () => {
       // best-effort cleanup
     }
   });
+
+  // ── Helper to create a pending request+delivery targeting a conversation ──
+  function createPendingRequestWithDelivery(convId: string, deliveryConvId: string) {
+    ensureConversation(convId);
+    const session = createCallSession({
+      conversationId: convId,
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15550002222',
+    });
+    const pq = createPendingQuestion(session.id, `Question for ${convId}`);
+    const request = createGuardianActionRequest({
+      kind: 'ask_guardian',
+      sourceChannel: 'voice',
+      sourceConversationId: convId,
+      callSessionId: session.id,
+      pendingQuestionId: pq.id,
+      questionText: pq.questionText,
+      expiresAt: Date.now() + 60_000,
+    });
+    const delivery = createGuardianActionDelivery({
+      requestId: request.id,
+      destinationChannel: 'vellum',
+      destinationConversationId: deliveryConvId,
+    });
+    updateDeliveryStatus(delivery.id, 'sent');
+    return { request, delivery };
+  }
+
+  // ── getPendingDeliveriesByConversation ──────────────────────────────
+
+  test('getPendingDeliveriesByConversation returns all pending deliveries for a conversation', () => {
+    const sharedConvId = 'shared-pending-conv';
+    ensureConversation(sharedConvId);
+
+    const { request: req1 } = createPendingRequestWithDelivery('source-conv-p1', sharedConvId);
+    const { request: req2 } = createPendingRequestWithDelivery('source-conv-p2', sharedConvId);
+
+    const deliveries = getPendingDeliveriesByConversation(sharedConvId);
+    expect(deliveries).toHaveLength(2);
+
+    const requestIds = deliveries.map((d) => d.requestId);
+    expect(requestIds).toContain(req1.id);
+    expect(requestIds).toContain(req2.id);
+  });
+
+  test('getPendingDeliveriesByConversation returns single delivery (fast path preserved)', () => {
+    const convId = 'single-pending-conv';
+    ensureConversation(convId);
+
+    const { request } = createPendingRequestWithDelivery('source-conv-single-p', convId);
+
+    const deliveries = getPendingDeliveriesByConversation(convId);
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].requestId).toBe(request.id);
+  });
+
+  test('getPendingDeliveryByConversation returns first from multiple (backward compat)', () => {
+    const convId = 'compat-pending-conv';
+    ensureConversation(convId);
+
+    createPendingRequestWithDelivery('source-conv-compat-p1', convId);
+    createPendingRequestWithDelivery('source-conv-compat-p2', convId);
+
+    const single = getPendingDeliveryByConversation(convId);
+    expect(single).not.toBeNull();
+  });
+
+  test('getPendingDeliveriesByConversation returns empty for non-matching conversation', () => {
+    ensureConversation('other-conv');
+    createPendingRequestWithDelivery('source-conv-no-match', 'other-conv');
+
+    const deliveries = getPendingDeliveriesByConversation('nonexistent-conv');
+    expect(deliveries).toHaveLength(0);
+  });
+
+  // ── getExpiredDeliveriesByConversation ──────────────────────────────
+
+  test('getExpiredDeliveriesByConversation returns all expired deliveries for a conversation', () => {
+    const sharedConvId = 'shared-expired-conv';
+    ensureConversation(sharedConvId);
+
+    const { request: req1 } = createPendingRequestWithDelivery('source-conv-e1', sharedConvId);
+    const { request: req2 } = createPendingRequestWithDelivery('source-conv-e2', sharedConvId);
+
+    expireGuardianActionRequest(req1.id, 'sweep_timeout');
+    expireGuardianActionRequest(req2.id, 'sweep_timeout');
+
+    const deliveries = getExpiredDeliveriesByConversation(sharedConvId);
+    expect(deliveries).toHaveLength(2);
+
+    const requestIds = deliveries.map((d) => d.requestId);
+    expect(requestIds).toContain(req1.id);
+    expect(requestIds).toContain(req2.id);
+  });
+
+  test('getExpiredDeliveryByConversation returns first from multiple (backward compat)', () => {
+    const convId = 'compat-expired-conv';
+    ensureConversation(convId);
+
+    const { request: req1 } = createPendingRequestWithDelivery('source-conv-compat-e1', convId);
+    const { request: req2 } = createPendingRequestWithDelivery('source-conv-compat-e2', convId);
+
+    expireGuardianActionRequest(req1.id, 'sweep_timeout');
+    expireGuardianActionRequest(req2.id, 'sweep_timeout');
+
+    const single = getExpiredDeliveryByConversation(convId);
+    expect(single).not.toBeNull();
+  });
+
+  test('getExpiredDeliveriesByConversation excludes deliveries with followup already started', () => {
+    const convId = 'expired-with-followup-conv';
+    ensureConversation(convId);
+
+    const { request: req1 } = createPendingRequestWithDelivery('source-conv-ef1', convId);
+    const { request: req2 } = createPendingRequestWithDelivery('source-conv-ef2', convId);
+
+    expireGuardianActionRequest(req1.id, 'sweep_timeout');
+    expireGuardianActionRequest(req2.id, 'sweep_timeout');
+
+    // Start followup on req1 — only req2 should remain in the expired query
+    startFollowupFromExpiredRequest(req1.id, 'late answer');
+
+    const deliveries = getExpiredDeliveriesByConversation(convId);
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].requestId).toBe(req2.id);
+  });
+
+  // ── getFollowupDeliveriesByConversation ─────────────────────────────
+
+  test('getFollowupDeliveriesByConversation returns all awaiting_guardian_choice deliveries', () => {
+    const convId = 'shared-followup-conv';
+    ensureConversation(convId);
+
+    const { request: req1 } = createPendingRequestWithDelivery('source-conv-f1', convId);
+    const { request: req2 } = createPendingRequestWithDelivery('source-conv-f2', convId);
+
+    expireGuardianActionRequest(req1.id, 'sweep_timeout');
+    expireGuardianActionRequest(req2.id, 'sweep_timeout');
+
+    startFollowupFromExpiredRequest(req1.id, 'late answer 1');
+    startFollowupFromExpiredRequest(req2.id, 'late answer 2');
+
+    const deliveries = getFollowupDeliveriesByConversation(convId);
+    expect(deliveries).toHaveLength(2);
+
+    const requestIds = deliveries.map((d) => d.requestId);
+    expect(requestIds).toContain(req1.id);
+    expect(requestIds).toContain(req2.id);
+  });
+
+  test('getFollowupDeliveryByConversation returns first from multiple (backward compat)', () => {
+    const convId = 'compat-followup-conv';
+    ensureConversation(convId);
+
+    const { request: req1 } = createPendingRequestWithDelivery('source-conv-compat-f1', convId);
+    const { request: req2 } = createPendingRequestWithDelivery('source-conv-compat-f2', convId);
+
+    expireGuardianActionRequest(req1.id, 'sweep_timeout');
+    expireGuardianActionRequest(req2.id, 'sweep_timeout');
+
+    startFollowupFromExpiredRequest(req1.id, 'late 1');
+    startFollowupFromExpiredRequest(req2.id, 'late 2');
+
+    const single = getFollowupDeliveryByConversation(convId);
+    expect(single).not.toBeNull();
+  });
+
+  test('getFollowupDeliveriesByConversation returns empty for non-matching conversation', () => {
+    const deliveries = getFollowupDeliveriesByConversation('nonexistent-conv');
+    expect(deliveries).toHaveLength(0);
+  });
+
+  // ── cancelGuardianActionRequest ─────────────────────────────────────
 
   test('cancelGuardianActionRequest cancels both pending and sent deliveries', () => {
     const conversationId = 'conv-guardian-cancel';

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -15,10 +15,10 @@ import * as conversationStore from '../memory/conversation-store.js';
 import { provenanceFromGuardianContext } from '../memory/conversation-store.js';
 import {
   finalizeFollowup,
-  getExpiredDeliveryByConversation,
-  getFollowupDeliveryByConversation,
+  getExpiredDeliveriesByConversation,
+  getFollowupDeliveriesByConversation,
   getGuardianActionRequest,
-  getPendingDeliveryByConversation,
+  getPendingDeliveriesByConversation,
   progressFollowupState,
   resolveGuardianActionRequest,
   startFollowupFromExpiredRequest,
@@ -383,34 +383,323 @@ export async function processMessage(
   session.currentPage = currentPage;
 
   // ── Guardian action answer interception (mac channel) ──
-  // If this conversation has a pending guardian action delivery, treat the
+  // If this conversation has pending guardian action deliveries, treat the
   // user message as the guardian's answer instead of running the agent loop.
-  const guardianDelivery = getPendingDeliveryByConversation(session.conversationId);
-  if (guardianDelivery) {
-    const guardianRequest = getGuardianActionRequest(guardianDelivery.requestId);
-    if (guardianRequest && guardianRequest.status === 'pending') {
-      const guardianIfCtx = session.getTurnInterfaceContext();
-      const guardianChannelMeta = { userMessageChannel: 'vellum' as const, assistantMessageChannel: 'vellum' as const, userMessageInterface: guardianIfCtx?.userMessageInterface ?? 'vellum', assistantMessageInterface: guardianIfCtx?.assistantMessageInterface ?? 'vellum', provenanceActorRole: 'guardian' as const };
-      const userMsg = createUserMessage(content, attachments);
-      const persisted = await conversationStore.addMessage(
-        session.conversationId,
-        'user',
-        JSON.stringify(userMsg.content),
-        guardianChannelMeta,
-      );
-      session.messages.push(userMsg);
+  // When multiple deliveries exist in the same reused thread, require a
+  // request-code prefix for disambiguation (matching the channel path pattern).
+  const pendingDeliveries = getPendingDeliveriesByConversation(session.conversationId);
+  if (pendingDeliveries.length > 0) {
+    let matchedDelivery = pendingDeliveries.length === 1 ? pendingDeliveries[0] : null;
+    let answerText = content;
 
-      // Attempt to deliver the answer to the call first. Only resolve
-      // the guardian action request if answerCall succeeds, so that a
-      // failed delivery leaves the request pending for retry from
-      // another channel.
-      const answerResult = await answerCall({ callSessionId: guardianRequest.callSessionId, answer: content });
+    // Multiple pending deliveries: require request code prefix for disambiguation
+    if (pendingDeliveries.length > 1) {
+      for (const d of pendingDeliveries) {
+        const req = getGuardianActionRequest(d.requestId);
+        if (req && content.toUpperCase().startsWith(req.requestCode)) {
+          matchedDelivery = d;
+          answerText = content.slice(req.requestCode.length).trim();
+          break;
+        }
+      }
 
-      if ('ok' in answerResult && answerResult.ok) {
-        const resolved = resolveGuardianActionRequest(guardianRequest.id, content, 'vellum');
-        const replyText = resolved
-          ? 'Your answer has been relayed to the call.'
-          : await composeGuardianActionMessageGenerative({ scenario: 'guardian_stale_answered' }, {}, _guardianActionCopyGenerator);
+      if (!matchedDelivery) {
+        const guardianIfCtx = session.getTurnInterfaceContext();
+        const guardianChannelMeta = { userMessageChannel: 'vellum' as const, assistantMessageChannel: 'vellum' as const, userMessageInterface: guardianIfCtx?.userMessageInterface ?? 'vellum', assistantMessageInterface: guardianIfCtx?.assistantMessageInterface ?? 'vellum', provenanceActorRole: 'guardian' as const };
+        const userMsg = createUserMessage(content, attachments);
+        const persisted = await conversationStore.addMessage(
+          session.conversationId,
+          'user',
+          JSON.stringify(userMsg.content),
+          guardianChannelMeta,
+        );
+        session.messages.push(userMsg);
+
+        const codes = pendingDeliveries
+          .map((d) => { const req = getGuardianActionRequest(d.requestId); return req ? req.requestCode : null; })
+          .filter((code): code is string => typeof code === 'string' && code.length > 0);
+        const disambiguationText = `You have multiple pending guardian questions. Please prefix your reply with the reference code (${codes.join(', ')}) to indicate which question you are answering.`;
+        const disambiguationMsg = createAssistantMessage(disambiguationText);
+        await conversationStore.addMessage(
+          session.conversationId,
+          'assistant',
+          JSON.stringify(disambiguationMsg.content),
+          guardianChannelMeta,
+        );
+        session.messages.push(disambiguationMsg);
+        onEvent({ type: 'assistant_text_delta', text: disambiguationText });
+        onEvent({ type: 'message_complete', sessionId: session.conversationId });
+        return persisted.id;
+      }
+    }
+
+    if (matchedDelivery) {
+      const guardianRequest = getGuardianActionRequest(matchedDelivery.requestId);
+      if (guardianRequest && guardianRequest.status === 'pending') {
+        const guardianIfCtx = session.getTurnInterfaceContext();
+        const guardianChannelMeta = { userMessageChannel: 'vellum' as const, assistantMessageChannel: 'vellum' as const, userMessageInterface: guardianIfCtx?.userMessageInterface ?? 'vellum', assistantMessageInterface: guardianIfCtx?.assistantMessageInterface ?? 'vellum', provenanceActorRole: 'guardian' as const };
+        const userMsg = createUserMessage(content, attachments);
+        const persisted = await conversationStore.addMessage(
+          session.conversationId,
+          'user',
+          JSON.stringify(userMsg.content),
+          guardianChannelMeta,
+        );
+        session.messages.push(userMsg);
+
+        // Attempt to deliver the answer to the call first. Only resolve
+        // the guardian action request if answerCall succeeds, so that a
+        // failed delivery leaves the request pending for retry from
+        // another channel.
+        const answerResult = await answerCall({ callSessionId: guardianRequest.callSessionId, answer: answerText });
+
+        if ('ok' in answerResult && answerResult.ok) {
+          const resolved = resolveGuardianActionRequest(guardianRequest.id, answerText, 'vellum');
+          const replyText = resolved
+            ? 'Your answer has been relayed to the call.'
+            : await composeGuardianActionMessageGenerative({ scenario: 'guardian_stale_answered' }, {}, _guardianActionCopyGenerator);
+          const replyMsg = createAssistantMessage(replyText);
+          await conversationStore.addMessage(
+            session.conversationId,
+            'assistant',
+            JSON.stringify(replyMsg.content),
+            guardianChannelMeta,
+          );
+          session.messages.push(replyMsg);
+          onEvent({ type: 'assistant_text_delta', text: replyText });
+        } else {
+          const errorDetail = 'error' in answerResult ? answerResult.error : 'Unknown error';
+          log.warn({ callSessionId: guardianRequest.callSessionId, error: errorDetail }, 'answerCall failed for mac guardian answer');
+          const failureText = await composeGuardianActionMessageGenerative(
+            { scenario: 'guardian_answer_delivery_failed' },
+            {},
+            _guardianActionCopyGenerator,
+          );
+          const failMsg = createAssistantMessage(failureText);
+          await conversationStore.addMessage(
+            session.conversationId,
+            'assistant',
+            JSON.stringify(failMsg.content),
+            guardianChannelMeta,
+          );
+          session.messages.push(failMsg);
+          onEvent({ type: 'assistant_text_delta', text: failureText });
+        }
+        onEvent({ type: 'message_complete', sessionId: session.conversationId });
+        return persisted.id;
+      }
+    }
+  }
+
+  // ── Expired guardian action late answer interception (mac channel) ──
+  // If no pending delivery was found, check for expired requests eligible
+  // for follow-up (status='expired', followup_state='none'). When multiple
+  // expired deliveries exist, require request-code prefix for disambiguation.
+  const expiredDeliveries = getExpiredDeliveriesByConversation(session.conversationId);
+  if (expiredDeliveries.length > 0) {
+    let matchedExpired = expiredDeliveries.length === 1 ? expiredDeliveries[0] : null;
+    let expiredAnswerText = content;
+
+    // Multiple expired deliveries: require request code prefix for disambiguation
+    if (expiredDeliveries.length > 1) {
+      for (const d of expiredDeliveries) {
+        const req = getGuardianActionRequest(d.requestId);
+        if (req && content.toUpperCase().startsWith(req.requestCode)) {
+          matchedExpired = d;
+          expiredAnswerText = content.slice(req.requestCode.length).trim();
+          break;
+        }
+      }
+
+      if (!matchedExpired) {
+        const guardianIfCtx = session.getTurnInterfaceContext();
+        const guardianChannelMeta = { userMessageChannel: 'vellum' as const, assistantMessageChannel: 'vellum' as const, userMessageInterface: guardianIfCtx?.userMessageInterface ?? 'vellum', assistantMessageInterface: guardianIfCtx?.assistantMessageInterface ?? 'vellum', provenanceActorRole: 'guardian' as const };
+        const userMsg = createUserMessage(content, attachments);
+        const persisted = await conversationStore.addMessage(
+          session.conversationId,
+          'user',
+          JSON.stringify(userMsg.content),
+          guardianChannelMeta,
+        );
+        session.messages.push(userMsg);
+
+        const codes = expiredDeliveries
+          .map((d) => { const req = getGuardianActionRequest(d.requestId); return req ? req.requestCode : null; })
+          .filter((code): code is string => typeof code === 'string' && code.length > 0);
+        const disambiguationText = await composeGuardianActionMessageGenerative(
+          { scenario: 'guardian_expired_disambiguation', requestCodes: codes },
+          { requiredKeywords: codes },
+          _guardianActionCopyGenerator,
+        );
+        const disambiguationMsg = createAssistantMessage(disambiguationText);
+        await conversationStore.addMessage(
+          session.conversationId,
+          'assistant',
+          JSON.stringify(disambiguationMsg.content),
+          guardianChannelMeta,
+        );
+        session.messages.push(disambiguationMsg);
+        onEvent({ type: 'assistant_text_delta', text: disambiguationText });
+        onEvent({ type: 'message_complete', sessionId: session.conversationId });
+        return persisted.id;
+      }
+    }
+
+    if (matchedExpired) {
+      const expiredRequest = getGuardianActionRequest(matchedExpired.requestId);
+      if (expiredRequest && expiredRequest.status === 'expired' && expiredRequest.followupState === 'none') {
+        const guardianIfCtx = session.getTurnInterfaceContext();
+        const guardianChannelMeta = { userMessageChannel: 'vellum' as const, assistantMessageChannel: 'vellum' as const, userMessageInterface: guardianIfCtx?.userMessageInterface ?? 'vellum', assistantMessageInterface: guardianIfCtx?.assistantMessageInterface ?? 'vellum', provenanceActorRole: 'guardian' as const };
+        const userMsg = createUserMessage(content, attachments);
+        const persisted = await conversationStore.addMessage(
+          session.conversationId,
+          'user',
+          JSON.stringify(userMsg.content),
+          guardianChannelMeta,
+        );
+        session.messages.push(userMsg);
+
+        const followupResult = startFollowupFromExpiredRequest(expiredRequest.id, expiredAnswerText);
+        if (followupResult) {
+          const followupText = await composeGuardianActionMessageGenerative(
+            {
+              scenario: 'guardian_late_answer_followup',
+              questionText: expiredRequest.questionText,
+              lateAnswerText: expiredAnswerText,
+            },
+            {},
+            _guardianActionCopyGenerator,
+          );
+          const replyMsg = createAssistantMessage(followupText);
+          await conversationStore.addMessage(
+            session.conversationId,
+            'assistant',
+            JSON.stringify(replyMsg.content),
+            guardianChannelMeta,
+          );
+          session.messages.push(replyMsg);
+          onEvent({ type: 'assistant_text_delta', text: followupText });
+        } else {
+          // Follow-up already started or conflict — send stale message
+          const staleText = await composeGuardianActionMessageGenerative(
+            { scenario: 'guardian_stale_expired' },
+            {},
+            _guardianActionCopyGenerator,
+          );
+          const staleMsg = createAssistantMessage(staleText);
+          await conversationStore.addMessage(
+            session.conversationId,
+            'assistant',
+            JSON.stringify(staleMsg.content),
+            guardianChannelMeta,
+          );
+          session.messages.push(staleMsg);
+          onEvent({ type: 'assistant_text_delta', text: staleText });
+        }
+        onEvent({ type: 'message_complete', sessionId: session.conversationId });
+        return persisted.id;
+      }
+    }
+  }
+
+  // ── Guardian follow-up conversation interception (mac channel) ──
+  // When a request is in `awaiting_guardian_choice` state, the guardian has
+  // already been asked "call back or send a message?". Their next message
+  // is the reply — route it through the conversation engine. When multiple
+  // follow-up deliveries exist, require request-code prefix for disambiguation.
+  const followupDeliveries = getFollowupDeliveriesByConversation(session.conversationId);
+  if (followupDeliveries.length > 0) {
+    let matchedFollowup = followupDeliveries.length === 1 ? followupDeliveries[0] : null;
+    let followupReplyText = content;
+
+    // Multiple follow-up deliveries: require request code prefix for disambiguation
+    if (followupDeliveries.length > 1) {
+      for (const d of followupDeliveries) {
+        const req = getGuardianActionRequest(d.requestId);
+        if (req && content.toUpperCase().startsWith(req.requestCode)) {
+          matchedFollowup = d;
+          followupReplyText = content.slice(req.requestCode.length).trim();
+          break;
+        }
+      }
+
+      if (!matchedFollowup) {
+        const guardianIfCtx = session.getTurnInterfaceContext();
+        const guardianChannelMeta = { userMessageChannel: 'vellum' as const, assistantMessageChannel: 'vellum' as const, userMessageInterface: guardianIfCtx?.userMessageInterface ?? 'vellum', assistantMessageInterface: guardianIfCtx?.assistantMessageInterface ?? 'vellum', provenanceActorRole: 'guardian' as const };
+        const userMsg = createUserMessage(content, attachments);
+        const persisted = await conversationStore.addMessage(
+          session.conversationId,
+          'user',
+          JSON.stringify(userMsg.content),
+          guardianChannelMeta,
+        );
+        session.messages.push(userMsg);
+
+        const codes = followupDeliveries
+          .map((d) => { const req = getGuardianActionRequest(d.requestId); return req ? req.requestCode : null; })
+          .filter((code): code is string => typeof code === 'string' && code.length > 0);
+        const disambiguationText = await composeGuardianActionMessageGenerative(
+          { scenario: 'guardian_followup_disambiguation', requestCodes: codes },
+          { requiredKeywords: codes },
+          _guardianActionCopyGenerator,
+        );
+        const disambiguationMsg = createAssistantMessage(disambiguationText);
+        await conversationStore.addMessage(
+          session.conversationId,
+          'assistant',
+          JSON.stringify(disambiguationMsg.content),
+          guardianChannelMeta,
+        );
+        session.messages.push(disambiguationMsg);
+        onEvent({ type: 'assistant_text_delta', text: disambiguationText });
+        onEvent({ type: 'message_complete', sessionId: session.conversationId });
+        return persisted.id;
+      }
+    }
+
+    if (matchedFollowup) {
+      const followupRequest = getGuardianActionRequest(matchedFollowup.requestId);
+      if (followupRequest && followupRequest.followupState === 'awaiting_guardian_choice') {
+        const guardianIfCtx = session.getTurnInterfaceContext();
+        const guardianChannelMeta = { userMessageChannel: 'vellum' as const, assistantMessageChannel: 'vellum' as const, userMessageInterface: guardianIfCtx?.userMessageInterface ?? 'vellum', assistantMessageInterface: guardianIfCtx?.assistantMessageInterface ?? 'vellum', provenanceActorRole: 'guardian' as const };
+        const userMsg = createUserMessage(content, attachments);
+        const persisted = await conversationStore.addMessage(
+          session.conversationId,
+          'user',
+          JSON.stringify(userMsg.content),
+          guardianChannelMeta,
+        );
+        session.messages.push(userMsg);
+
+        const turnResult = await processGuardianFollowUpTurn(
+          {
+            questionText: followupRequest.questionText,
+            lateAnswerText: followupRequest.lateAnswerText ?? '',
+            guardianReply: followupReplyText,
+          },
+          _guardianFollowUpGenerator,
+        );
+
+        // Apply the disposition to the follow-up state machine.
+        // Both progressFollowupState and finalizeFollowup are compare-and-set:
+        // they return null when the transition was not applied (e.g. a concurrent
+        // reply already advanced the state). In that case we notify the guardian
+        // that the request was already resolved and skip action execution.
+        let stateApplied = true;
+        if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
+          stateApplied = progressFollowupState(followupRequest.id, 'dispatching', turnResult.disposition) !== null;
+        } else if (turnResult.disposition === 'decline') {
+          stateApplied = finalizeFollowup(followupRequest.id, 'declined') !== null;
+        }
+        // keep_pending: no state change — guardian can reply again
+
+        if (!stateApplied) {
+          log.warn({ requestId: followupRequest.id, disposition: turnResult.disposition }, 'Follow-up state transition failed (already resolved)');
+        }
+
+        const replyText = stateApplied
+          ? turnResult.replyText
+          : await composeGuardianActionMessageGenerative({ scenario: 'guardian_stale_followup' }, {}, _guardianActionCopyGenerator);
         const replyMsg = createAssistantMessage(replyText);
         await conversationStore.addMessage(
           session.conversationId,
@@ -420,176 +709,37 @@ export async function processMessage(
         );
         session.messages.push(replyMsg);
         onEvent({ type: 'assistant_text_delta', text: replyText });
-      } else {
-        const errorDetail = 'error' in answerResult ? answerResult.error : 'Unknown error';
-        log.warn({ callSessionId: guardianRequest.callSessionId, error: errorDetail }, 'answerCall failed for mac guardian answer');
-        const failureText = await composeGuardianActionMessageGenerative(
-          { scenario: 'guardian_answer_delivery_failed' },
-          {},
-          _guardianActionCopyGenerator,
-        );
-        const failMsg = createAssistantMessage(failureText);
-        await conversationStore.addMessage(
-          session.conversationId,
-          'assistant',
-          JSON.stringify(failMsg.content),
-          guardianChannelMeta,
-        );
-        session.messages.push(failMsg);
-        onEvent({ type: 'assistant_text_delta', text: failureText });
+        onEvent({ type: 'message_complete', sessionId: session.conversationId });
+
+        // Execute the action and send a completion/failure message (fire-and-forget).
+        // The initial reply above acknowledges the guardian's choice; the executor
+        // carries out the actual call_back or message_back and posts a second message.
+        if (stateApplied && (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back')) {
+          void (async () => {
+            try {
+              const execResult = await executeFollowupAction(
+                followupRequest.id,
+                turnResult.disposition as 'call_back' | 'message_back',
+                _guardianActionCopyGenerator,
+              );
+              const completionMsg = createAssistantMessage(execResult.guardianReplyText);
+              await conversationStore.addMessage(
+                session.conversationId,
+                'assistant',
+                JSON.stringify(completionMsg.content),
+                guardianChannelMeta,
+              );
+              session.messages.push(completionMsg);
+              onEvent({ type: 'assistant_text_delta', text: execResult.guardianReplyText });
+              onEvent({ type: 'message_complete', sessionId: session.conversationId });
+            } catch (execErr) {
+              log.error({ err: execErr, requestId: followupRequest.id }, 'Follow-up action execution or completion message failed');
+            }
+          })();
+        }
+
+        return persisted.id;
       }
-      onEvent({ type: 'message_complete', sessionId: session.conversationId });
-      return persisted.id;
-    }
-  }
-
-  // ── Expired guardian action late answer interception (mac channel) ──
-  // If no pending delivery was found, check for expired requests eligible
-  // for follow-up (status='expired', followup_state='none').
-  const expiredDelivery = getExpiredDeliveryByConversation(session.conversationId);
-  if (expiredDelivery) {
-    const expiredRequest = getGuardianActionRequest(expiredDelivery.requestId);
-    if (expiredRequest && expiredRequest.status === 'expired' && expiredRequest.followupState === 'none') {
-      const guardianIfCtx = session.getTurnInterfaceContext();
-      const guardianChannelMeta = { userMessageChannel: 'vellum' as const, assistantMessageChannel: 'vellum' as const, userMessageInterface: guardianIfCtx?.userMessageInterface ?? 'vellum', assistantMessageInterface: guardianIfCtx?.assistantMessageInterface ?? 'vellum', provenanceActorRole: 'guardian' as const };
-      const userMsg = createUserMessage(content, attachments);
-      const persisted = await conversationStore.addMessage(
-        session.conversationId,
-        'user',
-        JSON.stringify(userMsg.content),
-        guardianChannelMeta,
-      );
-      session.messages.push(userMsg);
-
-      const followupResult = startFollowupFromExpiredRequest(expiredRequest.id, content);
-      if (followupResult) {
-        const followupText = await composeGuardianActionMessageGenerative(
-          {
-            scenario: 'guardian_late_answer_followup',
-            questionText: expiredRequest.questionText,
-            lateAnswerText: content,
-          },
-          {},
-          _guardianActionCopyGenerator,
-        );
-        const replyMsg = createAssistantMessage(followupText);
-        await conversationStore.addMessage(
-          session.conversationId,
-          'assistant',
-          JSON.stringify(replyMsg.content),
-          guardianChannelMeta,
-        );
-        session.messages.push(replyMsg);
-        onEvent({ type: 'assistant_text_delta', text: followupText });
-      } else {
-        // Follow-up already started or conflict — send stale message
-        const staleText = await composeGuardianActionMessageGenerative(
-          { scenario: 'guardian_stale_expired' },
-          {},
-          _guardianActionCopyGenerator,
-        );
-        const staleMsg = createAssistantMessage(staleText);
-        await conversationStore.addMessage(
-          session.conversationId,
-          'assistant',
-          JSON.stringify(staleMsg.content),
-          guardianChannelMeta,
-        );
-        session.messages.push(staleMsg);
-        onEvent({ type: 'assistant_text_delta', text: staleText });
-      }
-      onEvent({ type: 'message_complete', sessionId: session.conversationId });
-      return persisted.id;
-    }
-  }
-
-  // ── Guardian follow-up conversation interception (mac channel) ──
-  // When a request is in `awaiting_guardian_choice` state, the guardian has
-  // already been asked "call back or send a message?". Their next message
-  // is the reply — route it through the conversation engine.
-  const followupDelivery = getFollowupDeliveryByConversation(session.conversationId);
-  if (followupDelivery) {
-    const followupRequest = getGuardianActionRequest(followupDelivery.requestId);
-    if (followupRequest && followupRequest.followupState === 'awaiting_guardian_choice') {
-      const guardianIfCtx = session.getTurnInterfaceContext();
-      const guardianChannelMeta = { userMessageChannel: 'vellum' as const, assistantMessageChannel: 'vellum' as const, userMessageInterface: guardianIfCtx?.userMessageInterface ?? 'vellum', assistantMessageInterface: guardianIfCtx?.assistantMessageInterface ?? 'vellum', provenanceActorRole: 'guardian' as const };
-      const userMsg = createUserMessage(content, attachments);
-      const persisted = await conversationStore.addMessage(
-        session.conversationId,
-        'user',
-        JSON.stringify(userMsg.content),
-        guardianChannelMeta,
-      );
-      session.messages.push(userMsg);
-
-      const turnResult = await processGuardianFollowUpTurn(
-        {
-          questionText: followupRequest.questionText,
-          lateAnswerText: followupRequest.lateAnswerText ?? '',
-          guardianReply: content,
-        },
-        _guardianFollowUpGenerator,
-      );
-
-      // Apply the disposition to the follow-up state machine.
-      // Both progressFollowupState and finalizeFollowup are compare-and-set:
-      // they return null when the transition was not applied (e.g. a concurrent
-      // reply already advanced the state). In that case we notify the guardian
-      // that the request was already resolved and skip action execution.
-      let stateApplied = true;
-      if (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back') {
-        stateApplied = progressFollowupState(followupRequest.id, 'dispatching', turnResult.disposition) !== null;
-      } else if (turnResult.disposition === 'decline') {
-        stateApplied = finalizeFollowup(followupRequest.id, 'declined') !== null;
-      }
-      // keep_pending: no state change — guardian can reply again
-
-      if (!stateApplied) {
-        log.warn({ requestId: followupRequest.id, disposition: turnResult.disposition }, 'Follow-up state transition failed (already resolved)');
-      }
-
-      const replyText = stateApplied
-        ? turnResult.replyText
-        : await composeGuardianActionMessageGenerative({ scenario: 'guardian_stale_followup' }, {}, _guardianActionCopyGenerator);
-      const replyMsg = createAssistantMessage(replyText);
-      await conversationStore.addMessage(
-        session.conversationId,
-        'assistant',
-        JSON.stringify(replyMsg.content),
-        guardianChannelMeta,
-      );
-      session.messages.push(replyMsg);
-      onEvent({ type: 'assistant_text_delta', text: replyText });
-      onEvent({ type: 'message_complete', sessionId: session.conversationId });
-
-      // Execute the action and send a completion/failure message (fire-and-forget).
-      // The initial reply above acknowledges the guardian's choice; the executor
-      // carries out the actual call_back or message_back and posts a second message.
-      if (stateApplied && (turnResult.disposition === 'call_back' || turnResult.disposition === 'message_back')) {
-        void (async () => {
-          try {
-            const execResult = await executeFollowupAction(
-              followupRequest.id,
-              turnResult.disposition as 'call_back' | 'message_back',
-              _guardianActionCopyGenerator,
-            );
-            const completionMsg = createAssistantMessage(execResult.guardianReplyText);
-            await conversationStore.addMessage(
-              session.conversationId,
-              'assistant',
-              JSON.stringify(completionMsg.content),
-              guardianChannelMeta,
-            );
-            session.messages.push(completionMsg);
-            onEvent({ type: 'assistant_text_delta', text: execResult.guardianReplyText });
-            onEvent({ type: 'message_complete', sessionId: session.conversationId });
-          } catch (execErr) {
-            log.error({ err: execErr, requestId: followupRequest.id }, 'Follow-up action execution or completion message failed');
-          }
-        })();
-      }
-
-      return persisted.id;
     }
   }
 

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -595,6 +595,16 @@ export function getPendingDeliveriesByDestination(
  * Look up a pending delivery by destination conversation ID (for mac channel routing).
  */
 export function getPendingDeliveryByConversation(conversationId: string): GuardianActionDelivery | null {
+  const all = getPendingDeliveriesByConversation(conversationId);
+  return all.length > 0 ? all[0] : null;
+}
+
+/**
+ * Look up all pending deliveries by destination conversation ID.
+ * Used for disambiguation when a reused vellum thread has multiple active
+ * guardian requests.
+ */
+export function getPendingDeliveriesByConversation(conversationId: string): GuardianActionDelivery[] {
   try {
     const db = getDb();
     const rows = db
@@ -612,11 +622,11 @@ export function getPendingDeliveryByConversation(conversationId: string): Guardi
         ),
       )
       .all();
-    return rows.length > 0 ? rowToDelivery(rows[0].delivery) : null;
+    return rows.map((r) => rowToDelivery(r.delivery));
   } catch (err) {
     if (err instanceof Error && err.message.includes('no such table')) {
       log.warn({ err }, 'guardian tables not yet created');
-      return null;
+      return [];
     }
     throw err;
   }
@@ -669,6 +679,16 @@ export function getExpiredDeliveriesByDestination(
  * Look up an expired delivery by destination conversation ID (for mac channel routing).
  */
 export function getExpiredDeliveryByConversation(conversationId: string): GuardianActionDelivery | null {
+  const all = getExpiredDeliveriesByConversation(conversationId);
+  return all.length > 0 ? all[0] : null;
+}
+
+/**
+ * Look up all expired deliveries by destination conversation ID.
+ * Used for disambiguation when a reused vellum thread has multiple expired
+ * guardian requests eligible for follow-up.
+ */
+export function getExpiredDeliveriesByConversation(conversationId: string): GuardianActionDelivery[] {
   try {
     const db = getDb();
     const rows = db
@@ -687,11 +707,11 @@ export function getExpiredDeliveryByConversation(conversationId: string): Guardi
         ),
       )
       .all();
-    return rows.length > 0 ? rowToDelivery(rows[0].delivery) : null;
+    return rows.map((r) => rowToDelivery(r.delivery));
   } catch (err) {
     if (err instanceof Error && err.message.includes('no such table')) {
       log.warn({ err }, 'guardian tables not yet created');
-      return null;
+      return [];
     }
     throw err;
   }
@@ -746,6 +766,16 @@ export function getFollowupDeliveriesByDestination(
  * state by destination conversation ID (for mac channel routing).
  */
 export function getFollowupDeliveryByConversation(conversationId: string): GuardianActionDelivery | null {
+  const all = getFollowupDeliveriesByConversation(conversationId);
+  return all.length > 0 ? all[0] : null;
+}
+
+/**
+ * Look up all deliveries for requests in `awaiting_guardian_choice` follow-up
+ * state by destination conversation ID. Used for disambiguation when a reused
+ * vellum thread has multiple follow-up guardian requests.
+ */
+export function getFollowupDeliveriesByConversation(conversationId: string): GuardianActionDelivery[] {
   try {
     const db = getDb();
     const rows = db
@@ -764,11 +794,11 @@ export function getFollowupDeliveryByConversation(conversationId: string): Guard
         ),
       )
       .all();
-    return rows.length > 0 ? rowToDelivery(rows[0].delivery) : null;
+    return rows.map((r) => rowToDelivery(r.delivery));
   } catch (err) {
     if (err instanceof Error && err.message.includes('no such table')) {
       log.warn({ err }, 'guardian tables not yet created');
-      return null;
+      return [];
     }
     throw err;
   }


### PR DESCRIPTION
Adds request-code disambiguation to the vellum/mac guardian path for reused threads with multiple active requests. Preserves single-match fast path. Part of #9946.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
