### PR TITLE
fix: harden getDefaultRuleTemplates against partial config mocks

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -2724,11 +2724,26 @@ describe('Permission Checker', () => {
     );
 
     test('getDefaultRuleTemplates has no extra rules when extraDirs is empty', () => {
-      // Default testConfig has no skills property → getConfig returns default
-      // with extraDirs: []
       const templates = getDefaultRuleTemplates();
       const extraRules = templates.filter((t) => t.id.includes('extra-'));
       expect(extraRules.length).toBe(0);
+    });
+
+    test('getDefaultRuleTemplates tolerates partial config mocks', () => {
+      const originalSkills = testConfig.skills;
+      const originalSandbox = testConfig.sandbox;
+      try {
+        testConfig.skills = {} as any;
+        testConfig.sandbox = {} as any;
+
+        const templates = getDefaultRuleTemplates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.some((t) => t.id.includes('extra-'))).toBe(false);
+        expect(templates.some((t) => t.id === 'default:allow-bash-global')).toBe(false);
+      } finally {
+        testConfig.skills = originalSkills;
+        testConfig.sandbox = originalSandbox;
+      }
     });
   });
 

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -37,6 +37,13 @@ const COMPUTER_USE_TOOLS = [
  * Computed at runtime so paths reflect the configured root directory.
  */
 export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
+  // Some test suites mock getConfig() with partial objects; treat missing
+  // branches as defaults so rule generation remains deterministic.
+  const config = getConfig() as {
+    sandbox?: { enabled?: boolean };
+    skills?: { load?: { extraDirs?: unknown } };
+  };
+
   const hostFileRules = HOST_FILE_TOOLS.map((tool) => ({
     id: `default:ask-${tool}-global`,
     tool,
@@ -62,7 +69,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   // them (including high-risk) so the user is never prompted for sandbox work.
   // Only emit this rule when the sandbox is actually enabled; otherwise bash
   // commands execute on the host and must go through normal permission checks.
-  const sandboxEnabled = getConfig().sandbox.enabled;
+  const sandboxEnabled = config.sandbox?.enabled === true;
   const sandboxShellRule: DefaultRuleTemplate | null = sandboxEnabled
     ? {
         id: 'default:allow-bash-global',
@@ -149,7 +156,10 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
 
   // Append any user-configured extra skill directories so they get the
   // same default ask rules as managed and bundled dirs.
-  const extraDirs = getConfig().skills.load.extraDirs;
+  const rawExtraDirs = config.skills?.load?.extraDirs;
+  const extraDirs = Array.isArray(rawExtraDirs)
+    ? rawExtraDirs.filter((dir): dir is string => typeof dir === 'string')
+    : [];
   for (let i = 0; i < extraDirs.length; i++) {
     skillDirs.push({ dir: extraDirs[i].replaceAll('\\', '/'), label: `extra-${i}` });
   }


### PR DESCRIPTION
## Summary

- Use optional chaining for `config.sandbox?.enabled` and `config.skills?.load?.extraDirs` in `getDefaultRuleTemplates()` so partial config objects (common in test mocks) don't throw.
- Add runtime type guard to filter `extraDirs` to only valid strings.
- Add test covering the partial-config code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
