### PR TITLE
fix: Slack channel routing, double socket, and guardian UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -96,6 +96,7 @@ struct SettingsConnectTab: View {
             store.refreshChannelGuardianStatus(channel: "telegram")
             store.refreshChannelGuardianStatus(channel: "sms")
             store.refreshChannelGuardianStatus(channel: "voice")
+            store.refreshChannelGuardianStatus(channel: "slack")
             store.fetchSlackChannelConfig()
             gatewayExpanded = store.ingressPublicBaseUrl.isEmpty
         }
@@ -663,6 +664,10 @@ struct SettingsConnectTab: View {
                     .foregroundColor(VColor.error)
             }
 
+            if store.slackChannelHasBotToken && store.slackChannelHasAppToken {
+                Divider().background(VColor.surfaceBorder)
+                guardianStatusRow(channel: "slack")
+            }
 
         }
         .padding(VSpacing.lg)
@@ -1231,6 +1236,7 @@ struct SettingsConnectTab: View {
             case "telegram": return store.telegramGuardianIdentity
             case "sms": return store.smsGuardianIdentity
             case "voice": return store.voiceGuardianIdentity
+            case "slack": return store.slackGuardianIdentity
             default: return nil
             }
         }()
@@ -1239,6 +1245,7 @@ struct SettingsConnectTab: View {
             case "telegram": return store.telegramGuardianVerified
             case "sms": return store.smsGuardianVerified
             case "voice": return store.voiceGuardianVerified
+            case "slack": return store.slackGuardianVerified
             default: return false
             }
         }()
@@ -1247,6 +1254,7 @@ struct SettingsConnectTab: View {
             case "telegram": return store.telegramGuardianVerificationInProgress
             case "sms": return store.smsGuardianVerificationInProgress
             case "voice": return store.voiceGuardianVerificationInProgress
+            case "slack": return store.slackGuardianVerificationInProgress
             default: return false
             }
         }()
@@ -1255,6 +1263,7 @@ struct SettingsConnectTab: View {
             case "telegram": return store.telegramGuardianInstruction
             case "sms": return store.smsGuardianInstruction
             case "voice": return store.voiceGuardianInstruction
+            case "slack": return store.slackGuardianInstruction
             default: return nil
             }
         }()
@@ -1263,6 +1272,7 @@ struct SettingsConnectTab: View {
             case "telegram": return store.telegramGuardianError
             case "sms": return store.smsGuardianError
             case "voice": return store.voiceGuardianError
+            case "slack": return store.slackGuardianError
             default: return nil
             }
         }()
@@ -1271,6 +1281,7 @@ struct SettingsConnectTab: View {
             case "telegram": return store.telegramGuardianAlreadyBound
             case "sms": return store.smsGuardianAlreadyBound
             case "voice": return store.voiceGuardianAlreadyBound
+            case "slack": return store.slackGuardianAlreadyBound
             default: return false
             }
         }()
@@ -1279,6 +1290,7 @@ struct SettingsConnectTab: View {
             case "telegram": return store.telegramOutboundSessionId
             case "sms": return store.smsOutboundSessionId
             case "voice": return store.voiceOutboundSessionId
+            case "slack": return store.slackOutboundSessionId
             default: return nil
             }
         }()
@@ -1287,6 +1299,7 @@ struct SettingsConnectTab: View {
             case "telegram": return store.telegramOutboundExpiresAt
             case "sms": return store.smsOutboundExpiresAt
             case "voice": return store.voiceOutboundExpiresAt
+            case "slack": return store.slackOutboundExpiresAt
             default: return nil
             }
         }()
@@ -1295,6 +1308,7 @@ struct SettingsConnectTab: View {
             case "telegram": return store.telegramOutboundNextResendAt
             case "sms": return store.smsOutboundNextResendAt
             case "voice": return store.voiceOutboundNextResendAt
+            case "slack": return store.slackOutboundNextResendAt
             default: return nil
             }
         }()
@@ -1303,6 +1317,7 @@ struct SettingsConnectTab: View {
             case "telegram": return store.telegramOutboundSendCount
             case "sms": return store.smsOutboundSendCount
             case "voice": return store.voiceOutboundSendCount
+            case "slack": return store.slackOutboundSendCount
             default: return 0
             }
         }()
@@ -1312,6 +1327,7 @@ struct SettingsConnectTab: View {
             case "telegram": return store.telegramOutboundCode
             case "sms": return store.smsOutboundCode
             case "voice": return store.voiceOutboundCode
+            case "slack": return store.slackOutboundCode
             default: return nil
             }
         }()

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -137,6 +137,17 @@ public final class SettingsStore: ObservableObject {
     @Published var voiceGuardianError: String?
     @Published var voiceGuardianAlreadyBound: Bool = false
 
+    // MARK: - Channel Guardian State (Slack)
+
+    @Published var slackGuardianIdentity: String?
+    @Published var slackGuardianUsername: String?
+    @Published var slackGuardianDisplayName: String?
+    @Published var slackGuardianVerified: Bool = false
+    @Published var slackGuardianVerificationInProgress: Bool = false
+    @Published var slackGuardianInstruction: String?
+    @Published var slackGuardianError: String?
+    @Published var slackGuardianAlreadyBound: Bool = false
+
     // MARK: - Outbound Guardian Session State (Telegram)
 
     @Published var telegramOutboundSessionId: String?
@@ -161,6 +172,14 @@ public final class SettingsStore: ObservableObject {
     @Published var voiceOutboundNextResendAt: Date?
     @Published var voiceOutboundSendCount: Int = 0
     @Published var voiceOutboundCode: String?
+
+    // MARK: - Outbound Guardian Session State (Slack)
+
+    @Published var slackOutboundSessionId: String?
+    @Published var slackOutboundExpiresAt: Date?
+    @Published var slackOutboundNextResendAt: Date?
+    @Published var slackOutboundSendCount: Int = 0
+    @Published var slackOutboundCode: String?
 
     // MARK: - Slack Channel Integration State
 
@@ -600,6 +619,28 @@ public final class SettingsStore: ObservableObject {
                     let isAlreadyBound = response.error == "already_bound"
                     self.voiceGuardianAlreadyBound = isAlreadyBound
                     self.voiceGuardianError = isAlreadyBound
+                        ? "A guardian is already bound. Revoke it first or replace it."
+                        : response.error
+                }
+            case "slack":
+                self.slackGuardianVerificationInProgress = false
+                if response.success {
+                    self.slackGuardianIdentity = response.guardianExternalUserId
+                    self.slackGuardianUsername = Self.reflectedString(response, key: "guardianUsername")
+                    self.slackGuardianDisplayName = Self.reflectedString(response, key: "guardianDisplayName")
+                    let isVerified = response.bound ?? false
+                    self.slackGuardianVerified = isVerified
+                    if isVerified {
+                        self.slackGuardianInstruction = nil
+                    } else if let instruction = response.instruction {
+                        self.slackGuardianInstruction = instruction
+                    }
+                    self.slackGuardianError = nil
+                    self.slackGuardianAlreadyBound = false
+                } else {
+                    let isAlreadyBound = response.error == "already_bound"
+                    self.slackGuardianAlreadyBound = isAlreadyBound
+                    self.slackGuardianError = isAlreadyBound
                         ? "A guardian is already bound. Revoke it first or replace it."
                         : response.error
                 }
@@ -1185,6 +1226,11 @@ public final class SettingsStore: ObservableObject {
             voiceGuardianError = nil
             voiceGuardianAlreadyBound = false
             voiceGuardianInstruction = nil
+        case "slack":
+            slackGuardianVerificationInProgress = true
+            slackGuardianError = nil
+            slackGuardianAlreadyBound = false
+            slackGuardianInstruction = nil
         default:
             return
         }
@@ -1201,6 +1247,9 @@ public final class SettingsStore: ObservableObject {
                 case "voice":
                     voiceGuardianVerificationInProgress = false
                     voiceGuardianError = "Daemon is not connected. Reconnect and try again."
+                case "slack":
+                    slackGuardianVerificationInProgress = false
+                    slackGuardianError = "Daemon is not connected. Reconnect and try again."
                 default:
                     break
                 }
@@ -1227,6 +1276,9 @@ public final class SettingsStore: ObservableObject {
             case "voice":
                 voiceGuardianVerificationInProgress = false
                 voiceGuardianError = "Failed to start verification. Try again."
+            case "slack":
+                slackGuardianVerificationInProgress = false
+                slackGuardianError = "Failed to start verification. Try again."
             default:
                 break
             }
@@ -1246,6 +1298,9 @@ public final class SettingsStore: ObservableObject {
         case "voice":
             voiceGuardianVerificationInProgress = false
             voiceGuardianInstruction = nil
+        case "slack":
+            slackGuardianVerificationInProgress = false
+            slackGuardianInstruction = nil
         default:
             break
         }
@@ -1269,6 +1324,8 @@ public final class SettingsStore: ObservableObject {
             smsGuardianInstruction = nil
         case "voice":
             voiceGuardianInstruction = nil
+        case "slack":
+            slackGuardianInstruction = nil
         default:
             break
         }
@@ -1297,6 +1354,10 @@ public final class SettingsStore: ObservableObject {
             voiceGuardianVerificationInProgress = true
             voiceGuardianError = nil
             voiceGuardianAlreadyBound = false
+        case "slack":
+            slackGuardianVerificationInProgress = true
+            slackGuardianError = nil
+            slackGuardianAlreadyBound = false
         default:
             return
         }
@@ -1312,6 +1373,9 @@ public final class SettingsStore: ObservableObject {
                 case "voice":
                     voiceGuardianVerificationInProgress = false
                     voiceGuardianError = "Daemon is not connected. Reconnect and try again."
+                case "slack":
+                    slackGuardianVerificationInProgress = false
+                    slackGuardianError = "Daemon is not connected. Reconnect and try again."
                 default:
                     break
                 }
@@ -1335,6 +1399,9 @@ public final class SettingsStore: ObservableObject {
             case "voice":
                 voiceGuardianVerificationInProgress = false
                 voiceGuardianError = "Failed to start verification. Try again."
+            case "slack":
+                slackGuardianVerificationInProgress = false
+                slackGuardianError = "Failed to start verification. Try again."
             default:
                 break
             }
@@ -1363,6 +1430,8 @@ public final class SettingsStore: ObservableObject {
             smsGuardianVerificationInProgress = false
         case "voice":
             voiceGuardianVerificationInProgress = false
+        case "slack":
+            slackGuardianVerificationInProgress = false
         default:
             break
         }
@@ -1398,6 +1467,12 @@ public final class SettingsStore: ObservableObject {
             voiceOutboundNextResendAt = nil
             voiceOutboundSendCount = 0
             voiceOutboundCode = nil
+        case "slack":
+            slackOutboundSessionId = nil
+            slackOutboundExpiresAt = nil
+            slackOutboundNextResendAt = nil
+            slackOutboundSendCount = 0
+            slackOutboundCode = nil
         default:
             break
         }
@@ -1463,6 +1538,17 @@ public final class SettingsStore: ObservableObject {
             if let nextResendAt { voiceOutboundNextResendAt = nextResendAt }
             if let sendCount { voiceOutboundSendCount = sendCount }
             if let secret { voiceOutboundCode = secret }
+        case "slack":
+            if sessionId != slackOutboundSessionId {
+                slackOutboundNextResendAt = nil
+                slackOutboundSendCount = 0
+                slackOutboundCode = nil
+            }
+            slackOutboundSessionId = sessionId
+            if let expiresAt { slackOutboundExpiresAt = expiresAt }
+            if let nextResendAt { slackOutboundNextResendAt = nextResendAt }
+            if let sendCount { slackOutboundSendCount = sendCount }
+            if let secret { slackOutboundCode = secret }
         default:
             break
         }
@@ -1480,6 +1566,7 @@ public final class SettingsStore: ObservableObject {
             ("telegram", telegramGuardianVerificationInProgress),
             ("sms", smsGuardianVerificationInProgress),
             ("voice", voiceGuardianVerificationInProgress),
+            ("slack", slackGuardianVerificationInProgress),
         ].filter(\.1)
         if inProgressChannels.count == 1 {
             return inProgressChannels.first?.0
@@ -1502,6 +1589,8 @@ public final class SettingsStore: ObservableObject {
             smsGuardianInstruction = nil
         case "voice":
             voiceGuardianInstruction = nil
+        case "slack":
+            slackGuardianInstruction = nil
         default:
             break
         }
@@ -1532,6 +1621,12 @@ public final class SettingsStore: ObservableObject {
                 if self.voiceGuardianError == nil {
                     self.voiceGuardianError = "Timed out waiting for verification instructions. Try again."
                 }
+            case "slack":
+                self.slackGuardianVerificationInProgress = false
+                self.slackGuardianInstruction = nil
+                if self.slackGuardianError == nil {
+                    self.slackGuardianError = "Timed out waiting for verification instructions. Try again."
+                }
             default:
                 break
             }
@@ -1541,7 +1636,7 @@ public final class SettingsStore: ObservableObject {
     }
 
     private func startGuardianStatusPolling(for channel: String) {
-        guard channel == "telegram" || channel == "sms" || channel == "voice" else { return }
+        guard channel == "telegram" || channel == "sms" || channel == "voice" || channel == "slack" else { return }
         stopGuardianStatusPolling(for: channel)
         guardianStatusPollingDeadlines[channel] = Date().addingTimeInterval(guardianStatusPollWindow)
         scheduleGuardianStatusPoll(for: channel, delay: guardianStatusPollInterval)

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -144,10 +144,25 @@ export function loadConfig(): GatewayConfig {
   const routingJson = process.env.GATEWAY_ASSISTANT_ROUTING_JSON || "{}";
   const routingEntries = parseRoutingJson(routingJson);
 
-  const defaultAssistantId =
+  // Default assistant: env var > config.json assistant.id
+  let defaultAssistantId =
     process.env.GATEWAY_DEFAULT_ASSISTANT_ID || undefined;
+  if (!defaultAssistantId) {
+    try {
+      const cfgPath = join(getRootDir(), "workspace", "config.json");
+      const raw = readFileSync(cfgPath, "utf-8");
+      const data = JSON.parse(raw);
+      if (data?.assistant?.id && typeof data.assistant.id === "string") {
+        defaultAssistantId = data.assistant.id;
+      }
+    } catch {
+      // config file may not exist yet
+    }
+  }
 
-  const unmappedPolicyRaw = process.env.GATEWAY_UNMAPPED_POLICY || "reject";
+  // When a default assistant is available, default to routing unmapped chats to it
+  const unmappedPolicyRaw = process.env.GATEWAY_UNMAPPED_POLICY
+    || (defaultAssistantId ? "default" : "reject");
   if (unmappedPolicyRaw !== "reject" && unmappedPolicyRaw !== "default") {
     throw new Error(
       `GATEWAY_UNMAPPED_POLICY must be "reject" or "default", got "${unmappedPolicyRaw}"`,

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -481,16 +481,21 @@ function main() {
     }
 
     if (event.slackChannelChanged && !slackFromEnv) {
+      const newBot = event.slackChannelCredentials?.botToken;
+      const newApp = event.slackChannelCredentials?.appToken;
+      const changed = newBot !== config.slackChannelBotToken || newApp !== config.slackChannelAppToken;
       if (event.slackChannelCredentials) {
-        config.slackChannelBotToken = event.slackChannelCredentials.botToken;
-        config.slackChannelAppToken = event.slackChannelCredentials.appToken;
+        config.slackChannelBotToken = newBot;
+        config.slackChannelAppToken = newApp;
         log.info("Slack channel credentials loaded from credential vault");
       } else {
         config.slackChannelBotToken = undefined;
         config.slackChannelAppToken = undefined;
         log.info("Slack channel credentials cleared");
       }
-      startSlackSocket();
+      if (changed) {
+        startSlackSocket();
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
Fixes three issues found during QA of the Slack channel feature (#9858):

1. **Gateway routing** — Slack events were rejected with "No route matched" because the gateway required `GATEWAY_DEFAULT_ASSISTANT_ID` env var. Now reads the assistant ID from `config.json` automatically and defaults `unmappedPolicy` to `"default"` when a default assistant is available.

2. **Double socket connection** — Socket Mode WebSocket connected twice on startup (once from boot, once from credential watcher). The watcher callback now compares new credentials against current config and skips `startSlackSocket()` if unchanged.

3. **Guardian UI** — Wires up full guardian verification support for Slack in the macOS Settings Connect tab. Adds all `@Published` state properties, updates ~25 switch statements across `SettingsStore.swift` and `SettingsConnectTab.swift`, and adds the guardian row back to the Slack card.

## Test plan
- [ ] Gateway starts with Slack configured — single WebSocket connection (not double)
- [ ] `@pax` mention in Slack routes to assistant without env vars
- [ ] Slack card shows guardian verification row when credentials are configured
- [ ] Guardian verification flow works for Slack channel

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
