### PR TITLE
M2: Structured Tool-Approval ASK_GUARDIAN Production

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -1305,6 +1305,46 @@ describe('call-controller', () => {
     controller.destroy();
   });
 
+  test('ASK_GUARDIAN_APPROVAL: handles JSON payloads containing }] in string values', async () => {
+    // The `}]` sequence inside a JSON string value previously caused the
+    // non-greedy regex to terminate early, truncating the JSON and leaking
+    // partial data into TTS output.
+    const approvalPayload = JSON.stringify({
+      question: 'Allow send_message?',
+      toolName: 'send_message',
+      input: { msg: 'test}]more', nested: { key: 'value with }] braces' } },
+    });
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      [`Let me check. [ASK_GUARDIAN_APPROVAL: ${approvalPayload}]`],
+    ));
+    const { session, relay, controller } = setupController('Send a message');
+
+    await controller.handleCallerUtterance('Send it');
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Verify controller entered waiting_on_user with the correct question
+    expect(controller.getState()).toBe('waiting_on_user');
+    const question = getPendingQuestion(session.id);
+    expect(question).not.toBeNull();
+    expect(question!.questionText).toBe('Allow send_message?');
+
+    // Verify tool metadata was parsed correctly
+    const pendingRequest = getPendingRequestByCallSessionId(session.id);
+    expect(pendingRequest).not.toBeNull();
+    expect(pendingRequest!.toolName).toBe('send_message');
+    expect(pendingRequest!.inputDigest).not.toBeNull();
+
+    // No partial JSON or marker text should leak into TTS output
+    const allText = relay.sentTokens.map((t) => t.token).join('');
+    expect(allText).not.toContain('[ASK_GUARDIAN_APPROVAL:');
+    expect(allText).not.toContain('send_message');
+    expect(allText).not.toContain('}]');
+    expect(allText).not.toContain('test}]more');
+    expect(allText).toContain('Let me check.');
+
+    controller.destroy();
+  });
+
   test('ASK_GUARDIAN_APPROVAL with malformed JSON: falls through to informational ASK_GUARDIAN', async () => {
     // Malformed JSON in the approval marker — should be ignored, and if there's
     // also an informational ASK_GUARDIAN marker, it should be used instead

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -1195,4 +1195,134 @@ describe('call-controller', () => {
 
     controller.destroy();
   });
+
+  // ── Structured tool-approval ASK_GUARDIAN_APPROVAL ──────────────────
+
+  test('ASK_GUARDIAN_APPROVAL: persists toolName and inputDigest on guardian action request', async () => {
+    const approvalPayload = JSON.stringify({
+      question: 'Allow send_email to bob@example.com?',
+      toolName: 'send_email',
+      input: { to: 'bob@example.com', subject: 'Hello' },
+    });
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      [`Let me check with your guardian. [ASK_GUARDIAN_APPROVAL: ${approvalPayload}]`],
+    ));
+    const { session, relay, controller } = setupController('Send an email');
+
+    await controller.handleCallerUtterance('Send an email to Bob');
+
+    // Give the async dispatchGuardianQuestion a tick to create the request
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Verify controller entered waiting_on_user
+    expect(controller.getState()).toBe('waiting_on_user');
+
+    // Verify a pending question was created with the correct text
+    const question = getPendingQuestion(session.id);
+    expect(question).not.toBeNull();
+    expect(question!.questionText).toBe('Allow send_email to bob@example.com?');
+
+    // Verify the guardian action request has tool metadata
+    const pendingRequest = getPendingRequestByCallSessionId(session.id);
+    expect(pendingRequest).not.toBeNull();
+    expect(pendingRequest!.toolName).toBe('send_email');
+    expect(pendingRequest!.inputDigest).not.toBeNull();
+    expect(pendingRequest!.inputDigest!.length).toBe(64); // SHA-256 hex = 64 chars
+
+    // The ASK_GUARDIAN_APPROVAL marker should NOT appear in the relay tokens
+    const allText = relay.sentTokens.map((t) => t.token).join('');
+    expect(allText).not.toContain('[ASK_GUARDIAN_APPROVAL:');
+    expect(allText).not.toContain('send_email');
+
+    controller.destroy();
+  });
+
+  test('ASK_GUARDIAN_APPROVAL: computes deterministic digest for same tool+input', async () => {
+    const approvalPayload = JSON.stringify({
+      question: 'Allow send_email?',
+      toolName: 'send_email',
+      input: { subject: 'Hello', to: 'bob@example.com' },
+    });
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      [`Checking. [ASK_GUARDIAN_APPROVAL: ${approvalPayload}]`],
+    ));
+    const { session, controller } = setupController('Send email');
+
+    await controller.handleCallerUtterance('Send it');
+    await new Promise((r) => setTimeout(r, 50));
+
+    const request1 = getPendingRequestByCallSessionId(session.id);
+    expect(request1).not.toBeNull();
+
+    // Compute expected digest independently using the same utility
+    const { computeToolApprovalDigest } = await import('../security/tool-approval-digest.js');
+    const expectedDigest = computeToolApprovalDigest('send_email', { subject: 'Hello', to: 'bob@example.com' });
+    expect(request1!.inputDigest).toBe(expectedDigest);
+
+    controller.destroy();
+  });
+
+  test('informational ASK_GUARDIAN: does NOT persist tool metadata (null toolName/inputDigest)', async () => {
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Let me check. [ASK_GUARDIAN: What date works best?]'],
+    ));
+    const { session, controller } = setupController('Book appointment');
+
+    await controller.handleCallerUtterance('I need to schedule something');
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Verify the guardian action request has NO tool metadata
+    const pendingRequest = getPendingRequestByCallSessionId(session.id);
+    expect(pendingRequest).not.toBeNull();
+    expect(pendingRequest!.toolName).toBeNull();
+    expect(pendingRequest!.inputDigest).toBeNull();
+    expect(pendingRequest!.questionText).toBe('What date works best?');
+
+    controller.destroy();
+  });
+
+  test('ASK_GUARDIAN_APPROVAL: strips marker from TTS output', async () => {
+    const approvalPayload = JSON.stringify({
+      question: 'Allow calendar_create?',
+      toolName: 'calendar_create',
+      input: { date: '2026-03-01', title: 'Meeting' },
+    });
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn([
+      'Let me get approval for that. ',
+      `[ASK_GUARDIAN_APPROVAL: ${approvalPayload}]`,
+      ' Thank you.',
+    ]));
+    const { relay, controller } = setupController('Create event');
+
+    await controller.handleCallerUtterance('Create a meeting');
+
+    const allText = relay.sentTokens.map((t) => t.token).join('');
+    expect(allText).toContain('Let me get approval');
+    expect(allText).not.toContain('[ASK_GUARDIAN_APPROVAL:');
+    expect(allText).not.toContain('calendar_create');
+    expect(allText).not.toContain('inputDigest');
+
+    controller.destroy();
+  });
+
+  test('ASK_GUARDIAN_APPROVAL with malformed JSON: falls through to informational ASK_GUARDIAN', async () => {
+    // Malformed JSON in the approval marker — should be ignored, and if there's
+    // also an informational ASK_GUARDIAN marker, it should be used instead
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Checking. [ASK_GUARDIAN_APPROVAL: {invalid json}] [ASK_GUARDIAN: Fallback question?]'],
+    ));
+    const { session, controller } = setupController('Test fallback');
+
+    await controller.handleCallerUtterance('Do something');
+    await new Promise((r) => setTimeout(r, 50));
+
+    const pendingRequest = getPendingRequestByCallSessionId(session.id);
+    expect(pendingRequest).not.toBeNull();
+    expect(pendingRequest!.questionText).toBe('Fallback question?');
+    // Tool metadata should be null since the approval marker was malformed
+    expect(pendingRequest!.toolName).toBeNull();
+    expect(pendingRequest!.inputDigest).toBeNull();
+
+    controller.destroy();
+  });
 });

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -335,4 +335,64 @@ describe('guardian-dispatch', () => {
     expect(vellumDelivery).toBeDefined();
     expect(vellumDelivery!.destination_conversation_id).toBe('conv-from-thread-created');
   });
+
+  test('persists toolName and inputDigest on guardian action request for tool-approval dispatches', async () => {
+    const convId = 'conv-dispatch-5';
+    ensureConversation(convId);
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15550002222',
+    });
+    const pq = createPendingQuestion(session.id, 'Allow send_email to bob@example.com?');
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: 'self',
+      pendingQuestion: pq,
+      toolName: 'send_email',
+      inputDigest: 'abc123def456',
+    });
+
+    const db = getDb();
+    const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const request = raw.query('SELECT * FROM guardian_action_requests WHERE call_session_id = ?').get(session.id) as
+      | { id: string; tool_name: string | null; input_digest: string | null }
+      | undefined;
+    expect(request).toBeDefined();
+    expect(request!.tool_name).toBe('send_email');
+    expect(request!.input_digest).toBe('abc123def456');
+  });
+
+  test('omitting toolName and inputDigest stores null for informational ASK_GUARDIAN dispatches', async () => {
+    const convId = 'conv-dispatch-6';
+    ensureConversation(convId);
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15550002222',
+    });
+    const pq = createPendingQuestion(session.id, 'What time works?');
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: 'self',
+      pendingQuestion: pq,
+    });
+
+    const db = getDb();
+    const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const request = raw.query('SELECT * FROM guardian_action_requests WHERE call_session_id = ?').get(session.id) as
+      | { id: string; tool_name: string | null; input_digest: string | null }
+      | undefined;
+    expect(request).toBeDefined();
+    expect(request!.tool_name).toBeNull();
+    expect(request!.input_digest).toBeNull();
+  });
 });

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -42,8 +42,85 @@ type ControllerState = 'idle' | 'processing' | 'waiting_on_user' | 'speaking';
 
 const ASK_GUARDIAN_CAPTURE_REGEX = /\[ASK_GUARDIAN:\s*(.+?)\]/;
 const ASK_GUARDIAN_MARKER_REGEX = /\[ASK_GUARDIAN:\s*.+?\]/g;
-const ASK_GUARDIAN_APPROVAL_CAPTURE_REGEX = /\[ASK_GUARDIAN_APPROVAL:\s*(\{.+?\})\]/;
-const ASK_GUARDIAN_APPROVAL_MARKER_REGEX = /\[ASK_GUARDIAN_APPROVAL:\s*\{.+?\}\]/g;
+/**
+ * Extract a balanced JSON object from text that starts with a known prefix
+ * (e.g. "[ASK_GUARDIAN_APPROVAL: "). Uses brace counting with string-literal
+ * awareness so that `}` or `}]` inside JSON string values does not terminate
+ * the match prematurely.
+ *
+ * Returns the extracted JSON string, the full marker text (prefix + JSON + "]"),
+ * and the start index within the input text — or null if no balanced match exists.
+ */
+function extractBalancedJson(
+  text: string,
+  prefix: string,
+): { json: string; fullMatch: string; startIndex: number } | null {
+  const prefixIdx = text.indexOf(prefix);
+  if (prefixIdx === -1) return null;
+
+  const jsonStart = prefixIdx + prefix.length;
+  if (jsonStart >= text.length || text[jsonStart] !== '{') return null;
+
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+
+  for (let i = jsonStart; i < text.length; i++) {
+    const ch = text[i];
+
+    if (escape) {
+      escape = false;
+      continue;
+    }
+
+    if (ch === '\\' && inString) {
+      escape = true;
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+
+    if (inString) continue;
+
+    if (ch === '{') {
+      depth++;
+    } else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        const jsonEnd = i + 1;
+        const json = text.slice(jsonStart, jsonEnd);
+        // Expect a closing ']' after the JSON object
+        const closingBracketIdx = jsonEnd;
+        const fullMatchEnd = closingBracketIdx < text.length && text[closingBracketIdx] === ']'
+          ? closingBracketIdx + 1
+          : jsonEnd;
+        const fullMatch = text.slice(prefixIdx, fullMatchEnd);
+        return { json, fullMatch, startIndex: prefixIdx };
+      }
+    }
+  }
+
+  return null; // Unbalanced braces
+}
+
+/**
+ * Strip all balanced ASK_GUARDIAN_APPROVAL markers from text, handling nested
+ * braces and string literals correctly.
+ */
+function stripGuardianApprovalMarkers(text: string): string {
+  const prefix = '[ASK_GUARDIAN_APPROVAL: ';
+  let result = text;
+  // Iterate to remove all occurrences (the string shrinks each time)
+  for (;;) {
+    const match = extractBalancedJson(result, prefix);
+    if (!match) break;
+    result = result.slice(0, match.startIndex) + result.slice(match.startIndex + match.fullMatch.length);
+  }
+  return result;
+}
 const USER_ANSWERED_MARKER_REGEX = /\[USER_ANSWERED:\s*.+?\]/g;
 const USER_INSTRUCTION_MARKER_REGEX = /\[USER_INSTRUCTION:\s*.+?\]/g;
 const CALL_OPENING_MARKER_REGEX = /\[CALL_OPENING\]/g;
@@ -56,8 +133,8 @@ const CALL_OPENING_ACK_MARKER = '[CALL_OPENING_ACK]';
 const END_CALL_MARKER = '[END_CALL]';
 
 function stripInternalSpeechMarkers(text: string): string {
-  return text
-    .replace(ASK_GUARDIAN_APPROVAL_MARKER_REGEX, '')
+  let result = stripGuardianApprovalMarkers(text);
+  result = result
     .replace(ASK_GUARDIAN_MARKER_REGEX, '')
     .replace(USER_ANSWERED_MARKER_REGEX, '')
     .replace(USER_INSTRUCTION_MARKER_REGEX, '')
@@ -66,6 +143,7 @@ function stripInternalSpeechMarkers(text: string): string {
     .replace(END_CALL_MARKER_REGEX, '')
     .replace(GUARDIAN_TIMEOUT_MARKER_REGEX, '')
     .replace(GUARDIAN_UNAVAILABLE_MARKER_REGEX, '');
+  return result;
 }
 
 export class CallController {
@@ -534,12 +612,14 @@ export class CallController {
         }
       }
 
-      // Check for structured tool-approval ASK_GUARDIAN_APPROVAL first, then informational ASK_GUARDIAN
-      const approvalMatch = responseText.match(ASK_GUARDIAN_APPROVAL_CAPTURE_REGEX);
+      // Check for structured tool-approval ASK_GUARDIAN_APPROVAL first, then informational ASK_GUARDIAN.
+      // Uses brace-balanced extraction so `}]` inside JSON string values does not
+      // truncate the payload or leak partial JSON into TTS output.
+      const approvalMatch = extractBalancedJson(responseText, '[ASK_GUARDIAN_APPROVAL: ');
       let toolApprovalMeta: { question: string; toolName: string; inputDigest: string } | null = null;
       if (approvalMatch) {
         try {
-          const parsed = JSON.parse(approvalMatch[1]) as { question?: string; toolName?: string; input?: Record<string, unknown> };
+          const parsed = JSON.parse(approvalMatch.json) as { question?: string; toolName?: string; input?: Record<string, unknown> };
           if (parsed.question && parsed.toolName && parsed.input) {
             const digest = computeToolApprovalDigest(parsed.toolName, parsed.input);
             toolApprovalMeta = { question: parsed.question, toolName: parsed.toolName, inputDigest: digest };

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -30,6 +30,7 @@ import {
 import { getGatewayInternalBaseUrl } from '../config/env.js';
 import { readHttpToken } from '../util/platform.js';
 import { dispatchGuardianQuestion } from './guardian-dispatch.js';
+import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
 import { sendGuardianExpiryNotices } from './guardian-action-sweep.js';
 import type { RelayConnection } from './relay-server.js';
 import type { PromptSpeakerContext } from './speaker-identification.js';
@@ -41,6 +42,8 @@ type ControllerState = 'idle' | 'processing' | 'waiting_on_user' | 'speaking';
 
 const ASK_GUARDIAN_CAPTURE_REGEX = /\[ASK_GUARDIAN:\s*(.+?)\]/;
 const ASK_GUARDIAN_MARKER_REGEX = /\[ASK_GUARDIAN:\s*.+?\]/g;
+const ASK_GUARDIAN_APPROVAL_CAPTURE_REGEX = /\[ASK_GUARDIAN_APPROVAL:\s*(\{.+?\})\]/;
+const ASK_GUARDIAN_APPROVAL_MARKER_REGEX = /\[ASK_GUARDIAN_APPROVAL:\s*\{.+?\}\]/g;
 const USER_ANSWERED_MARKER_REGEX = /\[USER_ANSWERED:\s*.+?\]/g;
 const USER_INSTRUCTION_MARKER_REGEX = /\[USER_INSTRUCTION:\s*.+?\]/g;
 const CALL_OPENING_MARKER_REGEX = /\[CALL_OPENING\]/g;
@@ -54,6 +57,7 @@ const END_CALL_MARKER = '[END_CALL]';
 
 function stripInternalSpeechMarkers(text: string): string {
   return text
+    .replace(ASK_GUARDIAN_APPROVAL_MARKER_REGEX, '')
     .replace(ASK_GUARDIAN_MARKER_REGEX, '')
     .replace(USER_ANSWERED_MARKER_REGEX, '')
     .replace(USER_INSTRUCTION_MARKER_REGEX, '')
@@ -414,6 +418,7 @@ export class CallController {
           // bracketed text (e.g. "[A]", "[note]") doesn't stall TTS.
           const afterBracket = ttsBuffer;
           const couldBeControl =
+            '[ASK_GUARDIAN_APPROVAL:'.startsWith(afterBracket) ||
             '[ASK_GUARDIAN:'.startsWith(afterBracket) ||
             '[USER_ANSWERED:'.startsWith(afterBracket) ||
             '[USER_INSTRUCTION:'.startsWith(afterBracket) ||
@@ -422,6 +427,7 @@ export class CallController {
             '[END_CALL]'.startsWith(afterBracket) ||
             '[GUARDIAN_TIMEOUT]'.startsWith(afterBracket) ||
             '[GUARDIAN_UNAVAILABLE]'.startsWith(afterBracket) ||
+            afterBracket.startsWith('[ASK_GUARDIAN_APPROVAL:') ||
             afterBracket.startsWith('[ASK_GUARDIAN:') ||
             afterBracket.startsWith('[USER_ANSWERED:') ||
             afterBracket.startsWith('[USER_INSTRUCTION:') ||
@@ -528,11 +534,28 @@ export class CallController {
         }
       }
 
-      // Check for ASK_GUARDIAN pattern
-      const askMatch = responseText.match(ASK_GUARDIAN_CAPTURE_REGEX);
-      if (askMatch) {
-        const questionText = askMatch[1];
+      // Check for structured tool-approval ASK_GUARDIAN_APPROVAL first, then informational ASK_GUARDIAN
+      const approvalMatch = responseText.match(ASK_GUARDIAN_APPROVAL_CAPTURE_REGEX);
+      let toolApprovalMeta: { question: string; toolName: string; inputDigest: string } | null = null;
+      if (approvalMatch) {
+        try {
+          const parsed = JSON.parse(approvalMatch[1]) as { question?: string; toolName?: string; input?: Record<string, unknown> };
+          if (parsed.question && parsed.toolName && parsed.input) {
+            const digest = computeToolApprovalDigest(parsed.toolName, parsed.input);
+            toolApprovalMeta = { question: parsed.question, toolName: parsed.toolName, inputDigest: digest };
+          }
+        } catch {
+          log.warn({ callSessionId: this.callSessionId }, 'Failed to parse ASK_GUARDIAN_APPROVAL JSON payload');
+        }
+      }
 
+      const askMatch = toolApprovalMeta
+        ? null // structured approval takes precedence
+        : responseText.match(ASK_GUARDIAN_CAPTURE_REGEX);
+
+      const questionText = toolApprovalMeta?.question ?? (askMatch ? askMatch[1] : null);
+
+      if (questionText) {
         if (this.isCallerGuardian()) {
           // Caller IS the guardian — don't dispatch cross-channel.
           // Queue an instruction so the next turn asks them directly.
@@ -569,6 +592,8 @@ export class CallController {
               conversationId: session.conversationId,
               assistantId: this.assistantId,
               pendingQuestion,
+              toolName: toolApprovalMeta?.toolName,
+              inputDigest: toolApprovalMeta?.inputDigest,
             });
           }
 

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -26,6 +26,10 @@ export interface GuardianDispatchParams {
   conversationId: string;
   assistantId: string;
   pendingQuestion: CallPendingQuestion;
+  /** Tool identity for tool-approval requests (absent for informational ASK_GUARDIAN). */
+  toolName?: string;
+  /** Canonical SHA-256 digest of tool input for tool-approval requests. */
+  inputDigest?: string;
 }
 
 function applyDeliveryStatus(deliveryId: string, result: NotificationDeliveryResult): void {
@@ -47,6 +51,8 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
     conversationId,
     assistantId,
     pendingQuestion,
+    toolName,
+    inputDigest,
   } = params;
 
   try {
@@ -62,6 +68,8 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
       pendingQuestionId: pendingQuestion.id,
       questionText: pendingQuestion.questionText,
       expiresAt,
+      toolName,
+      inputDigest,
     });
 
     log.info(

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -22,6 +22,7 @@ import {
   migrateChannelInboundDeliveredSegments,
   migrateConversationsThreadTypeIndex,
   migrateGuardianActionFollowup,
+  migrateGuardianActionToolMetadata,
   migrateGuardianDeliveryConversationIndex,
   migrateGuardianBootstrapToken,
   migrateGuardianVerificationPurpose,
@@ -101,6 +102,9 @@ export function initializeDb(): void {
 
   // 14c. Guardian action follow-up lifecycle columns (timeout reason, late answers)
   migrateGuardianActionFollowup(database);
+
+  // 14c2. Guardian action tool-approval metadata columns (tool_name, input_digest)
+  migrateGuardianActionToolMetadata(database);
 
   // 14d. Index on conversations.thread_type for frequent WHERE filters
   migrateConversationsThreadTypeIndex(database);

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -51,6 +51,8 @@ export interface GuardianActionRequest {
   lateAnsweredAt: number | null;
   followupAction: FollowupAction | null;
   followupCompletedAt: number | null;
+  toolName: string | null;
+  inputDigest: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -97,6 +99,8 @@ function rowToRequest(row: typeof guardianActionRequests.$inferSelect): Guardian
     lateAnsweredAt: row.lateAnsweredAt ?? null,
     followupAction: (row.followupAction as FollowupAction) ?? null,
     followupCompletedAt: row.followupCompletedAt ?? null,
+    toolName: row.toolName ?? null,
+    inputDigest: row.inputDigest ?? null,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -137,6 +141,8 @@ export function createGuardianActionRequest(params: {
   pendingQuestionId: string;
   questionText: string;
   expiresAt: number;
+  toolName?: string;
+  inputDigest?: string;
 }): GuardianActionRequest {
   const db = getDb();
   const now = Date.now();
@@ -164,6 +170,8 @@ export function createGuardianActionRequest(params: {
     lateAnsweredAt: null,
     followupAction: null,
     followupCompletedAt: null,
+    toolName: params.toolName ?? null,
+    inputDigest: params.inputDigest ?? null,
     createdAt: now,
     updatedAt: now,
   };

--- a/assistant/src/memory/migrations/034-guardian-action-tool-metadata.ts
+++ b/assistant/src/memory/migrations/034-guardian-action-tool-metadata.ts
@@ -1,0 +1,12 @@
+import type { DrizzleDb } from '../db-connection.js';
+
+/**
+ * Add tool_name and input_digest columns to guardian_action_requests for
+ * structured tool-approval tracking. These are nullable — informational
+ * ASK_GUARDIAN requests leave them NULL while tool-approval requests
+ * carry the tool identity and canonical input digest.
+ */
+export function migrateGuardianActionToolMetadata(database: DrizzleDb): void {
+  try { database.run(/*sql*/ `ALTER TABLE guardian_action_requests ADD COLUMN tool_name TEXT`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE guardian_action_requests ADD COLUMN input_digest TEXT`); } catch { /* already exists */ }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -34,6 +34,7 @@ export { migrateGuardianVerificationPurpose } from './030-guardian-verification-
 export { migrateConversationsThreadTypeIndex } from './031-conversations-thread-type-index.js';
 export { migrateGuardianDeliveryConversationIndex } from './032-guardian-delivery-conversation-index.js';
 export { createScopedApprovalGrantsTable } from './033-scoped-approval-grants.js';
+export { migrateGuardianActionToolMetadata } from './034-guardian-action-tool-metadata.js';
 export { createCoreTables } from './100-core-tables.js';
 export { createWatchersAndLogsTables } from './101-watchers-and-logs.js';
 export { addCoreColumns } from './102-alter-table-columns.js';

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -843,6 +843,8 @@ export const guardianActionRequests = sqliteTable('guardian_action_requests', {
   lateAnsweredAt: integer('late_answered_at'),
   followupAction: text('followup_action'),                          // call_back | message_back | decline
   followupCompletedAt: integer('followup_completed_at'),
+  toolName: text('tool_name'),                                        // tool identity for tool-approval requests
+  inputDigest: text('input_digest'),                                  // canonical SHA-256 digest of tool input
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 });


### PR DESCRIPTION
Adds structured ASK_GUARDIAN_APPROVAL marker with tool identity metadata (toolName + inputDigest) to guardian dispatch for tool-approval requests. Preserves informational ASK_GUARDIAN unchanged. Part of #10011. Closes #10014.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
