### PR TITLE
Fix Slack deliver error response format

### DIFF
--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -39,7 +39,7 @@ export function createSlackDeliverHandler(config: GatewayConfig) {
     }
 
     if (typeof body !== 'object' || body === null) {
-      return Response.json({ ok: false, error: "Invalid request body" }, { status: 400 });
+      return Response.json({ error: "Invalid request body" }, { status: 400 });
     }
 
     if (body.attachments && Array.isArray(body.attachments) && body.attachments.length > 0) {


### PR DESCRIPTION
Remove ok:false from non-object body error response to match the consistent { error: '...' } pattern used by all other gateway deliver handlers.

Addresses review feedback on #9919.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
