### PR TITLE
M4: Guardian Notification Path Integration + Regression Lock

### DIFF
--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -335,4 +335,124 @@ describe('guardian-dispatch', () => {
     expect(vellumDelivery).toBeDefined();
     expect(vellumDelivery!.destination_conversation_id).toBe('conv-from-thread-created');
   });
+
+  test('includes activeGuardianRequestCount in context payload', async () => {
+    const convId = 'conv-dispatch-5';
+    ensureConversation(convId);
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15550002222',
+    });
+    const pq = createPendingQuestion(session.id, 'First question');
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: 'self',
+      pendingQuestion: pq,
+    });
+
+    const signalParams = emitCalls[0] as Record<string, unknown>;
+    const payload = signalParams.contextPayload as Record<string, unknown>;
+    // The request was just created so there is 1 pending request for this session
+    expect(payload.activeGuardianRequestCount).toBe(1);
+    expect(payload.callSessionId).toBe(session.id);
+  });
+
+  test('repeated guardian questions in the same call each create per-request delivery rows even when sharing a conversation', async () => {
+    const convId = 'conv-dispatch-reuse-1';
+    ensureConversation(convId);
+
+    // Both dispatches deliver to the same vellum conversation (simulating thread reuse)
+    const sharedConversationId = 'conv-shared-guardian';
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15550002222',
+    });
+
+    // First dispatch
+    const pq1 = createPendingQuestion(session.id, 'What is the gate code?');
+    mockEmitResult = {
+      signalId: 'sig-reuse-1',
+      deduplicated: false,
+      dispatched: true,
+      reason: 'ok',
+      deliveryResults: [
+        {
+          channel: 'vellum',
+          destination: 'vellum',
+          status: 'sent',
+          conversationId: sharedConversationId,
+        },
+      ],
+    };
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: 'self',
+      pendingQuestion: pq1,
+    });
+
+    // Second dispatch (same call session, same shared conversation)
+    emitCalls.length = 0;
+    const pq2 = createPendingQuestion(session.id, 'Should I let them in?');
+    mockEmitResult = {
+      signalId: 'sig-reuse-2',
+      deduplicated: false,
+      dispatched: true,
+      reason: 'ok',
+      deliveryResults: [
+        {
+          channel: 'vellum',
+          destination: 'vellum',
+          status: 'sent',
+          conversationId: sharedConversationId,
+        },
+      ],
+    };
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: 'self',
+      pendingQuestion: pq2,
+    });
+
+    // Both dispatches should have created separate action requests
+    const db = getDb();
+    const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const requests = raw.query(
+      'SELECT * FROM guardian_action_requests WHERE call_session_id = ? ORDER BY created_at ASC',
+    ).all(session.id) as Array<{ id: string; question_text: string }>;
+    expect(requests).toHaveLength(2);
+    expect(requests[0].question_text).toBe('What is the gate code?');
+    expect(requests[1].question_text).toBe('Should I let them in?');
+
+    // Each request should have its own delivery row, both pointing to the shared conversation
+    for (const req of requests) {
+      const delivery = raw.query(
+        'SELECT * FROM guardian_action_deliveries WHERE request_id = ? AND destination_channel = ?',
+      ).get(req.id, 'vellum') as { status: string; destination_conversation_id: string | null } | undefined;
+      expect(delivery).toBeDefined();
+      expect(delivery!.status).toBe('sent');
+      expect(delivery!.destination_conversation_id).toBe(sharedConversationId);
+    }
+
+    // Total delivery rows should be 2 (one per request), not 1
+    const allDeliveries = raw.query(
+      'SELECT * FROM guardian_action_deliveries WHERE destination_conversation_id = ?',
+    ).all(sharedConversationId) as Array<{ request_id: string }>;
+    expect(allDeliveries).toHaveLength(2);
+
+    // Second dispatch should report a higher activeGuardianRequestCount
+    const secondPayload = (emitCalls[0] as Record<string, unknown>).contextPayload as Record<string, unknown>;
+    expect(secondPayload.activeGuardianRequestCount).toBe(2);
+  });
 });

--- a/assistant/src/__tests__/notification-guardian-path.test.ts
+++ b/assistant/src/__tests__/notification-guardian-path.test.ts
@@ -333,4 +333,161 @@ describe('ASK_GUARDIAN canonical notification path', () => {
     expect(vellumDelivery!.status).toBe('failed');
     expect(vellumDelivery!.last_error).toContain('No vellum delivery result');
   });
+
+  test('context payload includes callSessionId and activeGuardianRequestCount for candidate-affinity', async () => {
+    const convId = 'conv-guardian-notif-affinity';
+    ensureConversation(convId);
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15550002222',
+    });
+    const pq = createPendingQuestion(session.id, 'Affinity test question');
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: 'self',
+      pendingQuestion: pq,
+    });
+
+    expect(emitCalls.length).toBe(1);
+    const signalParams = emitCalls[0] as Record<string, unknown>;
+    const payload = signalParams.contextPayload as Record<string, unknown>;
+
+    // callSessionId is present for the decision engine to match candidates to the current call
+    expect(payload.callSessionId).toBe(session.id);
+    // activeGuardianRequestCount provides a hint about whether to reuse an existing thread
+    expect(typeof payload.activeGuardianRequestCount).toBe('number');
+    expect(payload.activeGuardianRequestCount).toBeGreaterThanOrEqual(1);
+  });
+
+  test('repeated guardian questions retain per-request delivery records when sharing a conversation', async () => {
+    const convId = 'conv-guardian-notif-reuse';
+    ensureConversation(convId);
+
+    const sharedConvId = 'conv-guardian-shared-thread';
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15550002222',
+    });
+
+    // First guardian question
+    const pq1 = createPendingQuestion(session.id, 'Can they enter through the side gate?');
+    mockEmitResult = {
+      signalId: 'sig-reuse-a',
+      deduplicated: false,
+      dispatched: true,
+      reason: 'ok',
+      deliveryResults: [
+        {
+          channel: 'vellum',
+          destination: 'vellum',
+          status: 'sent',
+          conversationId: sharedConvId,
+        },
+      ],
+    };
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: 'self',
+      pendingQuestion: pq1,
+    });
+
+    // Second guardian question (same call, pipeline reuses the same conversation)
+    emitCalls.length = 0;
+    const pq2 = createPendingQuestion(session.id, 'What about the back door?');
+    mockEmitResult = {
+      signalId: 'sig-reuse-b',
+      deduplicated: false,
+      dispatched: true,
+      reason: 'ok',
+      deliveryResults: [
+        {
+          channel: 'vellum',
+          destination: 'vellum',
+          status: 'sent',
+          conversationId: sharedConvId,
+        },
+      ],
+    };
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: 'self',
+      pendingQuestion: pq2,
+    });
+
+    // Verify: two distinct guardian_action_requests exist
+    const db = getDb();
+    const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const requests = raw.query(
+      'SELECT id, question_text FROM guardian_action_requests WHERE call_session_id = ? ORDER BY created_at ASC',
+    ).all(session.id) as Array<{ id: string; question_text: string }>;
+    expect(requests).toHaveLength(2);
+    expect(requests[0].question_text).toBe('Can they enter through the side gate?');
+    expect(requests[1].question_text).toBe('What about the back door?');
+
+    // Verify: each request has its own delivery row pointing to the shared conversation
+    const deliveries = raw.query(
+      'SELECT request_id, destination_conversation_id, status FROM guardian_action_deliveries WHERE destination_conversation_id = ? ORDER BY created_at ASC',
+    ).all(sharedConvId) as Array<{ request_id: string; destination_conversation_id: string; status: string }>;
+    expect(deliveries).toHaveLength(2);
+    expect(deliveries[0].request_id).toBe(requests[0].id);
+    expect(deliveries[1].request_id).toBe(requests[1].id);
+    expect(deliveries[0].status).toBe('sent');
+    expect(deliveries[1].status).toBe('sent');
+  });
+
+  test('follow-up/timeout flow is unchanged — expired request still gets fallback delivery on no pipeline result', async () => {
+    const convId = 'conv-guardian-notif-timeout';
+    ensureConversation(convId);
+
+    // Simulate a scenario where the pipeline returns no delivery results (e.g. blocked)
+    mockEmitResult = {
+      signalId: 'sig-timeout',
+      deduplicated: false,
+      dispatched: false,
+      reason: 'blocked by deterministic checks',
+      deliveryResults: [],
+    };
+
+    const session = createCallSession({
+      conversationId: convId,
+      provider: 'twilio',
+      fromNumber: '+15550001111',
+      toNumber: '+15550002222',
+    });
+    const pq = createPendingQuestion(session.id, 'Timeout scenario');
+
+    await dispatchGuardianQuestion({
+      callSessionId: session.id,
+      conversationId: convId,
+      assistantId: 'self',
+      pendingQuestion: pq,
+    });
+
+    // The dispatch should still create a failed fallback delivery row
+    const db = getDb();
+    const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const request = raw.query('SELECT id FROM guardian_action_requests WHERE call_session_id = ?').get(session.id) as
+      | { id: string }
+      | undefined;
+    expect(request).toBeDefined();
+
+    const delivery = raw.query(
+      'SELECT status, last_error FROM guardian_action_deliveries WHERE request_id = ? AND destination_channel = ?',
+    ).get(request!.id, 'vellum') as { status: string; last_error: string | null } | undefined;
+    expect(delivery).toBeDefined();
+    expect(delivery!.status).toBe('failed');
+    expect(delivery!.last_error).toContain('No vellum delivery result');
+  });
 });

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -9,6 +9,7 @@
 
 import { getActiveBinding } from '../memory/channel-guardian-store.js';
 import {
+  countPendingRequestsByCallSessionId,
   createGuardianActionDelivery,
   createGuardianActionRequest,
   updateDeliveryStatus,
@@ -69,6 +70,12 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
       'Created guardian action request',
     );
 
+    // Count how many guardian requests are already pending for this call.
+    // This count is a candidate-affinity hint: the decision engine uses it
+    // to prefer reusing an existing thread when multiple questions arise
+    // in the same call session.
+    const activeGuardianRequestCount = countPendingRequestsByCallSessionId(callSessionId);
+
     // Route through the canonical notification pipeline. The paired vellum
     // conversation from this pipeline is the canonical guardian thread.
     let vellumDeliveryId: string | null = null;
@@ -90,6 +97,7 @@ export async function dispatchGuardianQuestion(params: GuardianDispatchParams): 
         callSessionId,
         questionText: pendingQuestion.questionText,
         pendingQuestionId: pendingQuestion.id,
+        activeGuardianRequestCount,
       },
       dedupeKey: `guardian:${request.id}`,
       onThreadCreated: (info) => {

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -7,7 +7,7 @@
  * answer resolves the request and all other deliveries are marked answered.
  */
 
-import { and, desc, eq, inArray, lt } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, lt } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 
 import { getLogger } from '../util/logger.js';
@@ -210,6 +210,26 @@ export function getPendingRequestByCallSessionId(callSessionId: string): Guardia
     .orderBy(desc(guardianActionRequests.createdAt))
     .get();
   return row ? rowToRequest(row) : null;
+}
+
+/**
+ * Count pending guardian action requests for a given call session.
+ * Used as a candidate-affinity hint so the decision engine knows how many
+ * active guardian requests already exist for the current call.
+ */
+export function countPendingRequestsByCallSessionId(callSessionId: string): number {
+  const db = getDb();
+  const row = db
+    .select({ count: count() })
+    .from(guardianActionRequests)
+    .where(
+      and(
+        eq(guardianActionRequests.callSessionId, callSessionId),
+        eq(guardianActionRequests.status, 'pending'),
+      ),
+    )
+    .get();
+  return row?.count ?? 0;
 }
 
 /**


### PR DESCRIPTION
Ensures guardian dispatch provides candidate-affinity hints (callSessionId, guardian request context) for thread decision making. Adds regression tests locking that repeated guardian questions can share a conversation while retaining per-request delivery records. Part of #9946.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
