### PR TITLE
Fix browser-relay host-header spoof bypass

### DIFF
--- a/gateway/src/__tests__/browser-relay-websocket.test.ts
+++ b/gateway/src/__tests__/browser-relay-websocket.test.ts
@@ -107,7 +107,10 @@ describe("createBrowserRelayWebsocketHandler", () => {
       `http://localhost:7830/v1/browser-relay?token=${TEST_TOKEN}`,
       { headers: { upgrade: "websocket" } },
     );
-    const fakeServer = { upgrade: mock(() => true) } as unknown as import("bun").Server<any>;
+    const fakeServer = {
+      requestIP: mock(() => ({ address: "127.0.0.1", family: "IPv4", port: 54000 })),
+      upgrade: mock(() => true),
+    } as unknown as import("bun").Server<any>;
     const res = handler(req, fakeServer);
 
     expect(res).toBeUndefined();
@@ -120,7 +123,10 @@ describe("createBrowserRelayWebsocketHandler", () => {
     const req = new Request("http://localhost:7830/v1/browser-relay", {
       headers: { upgrade: "websocket" },
     });
-    const fakeServer = { upgrade: mock(() => true) } as unknown as import("bun").Server<any>;
+    const fakeServer = {
+      requestIP: mock(() => ({ address: "127.0.0.1", family: "IPv4", port: 54000 })),
+      upgrade: mock(() => true),
+    } as unknown as import("bun").Server<any>;
     const res = handler(req, fakeServer);
 
     expect(res).toBeInstanceOf(Response);
@@ -134,7 +140,10 @@ describe("createBrowserRelayWebsocketHandler", () => {
     const req = new Request("http://localhost:7830/v1/browser-relay", {
       headers: { upgrade: "websocket" },
     });
-    const fakeServer = { upgrade: mock(() => true) } as unknown as import("bun").Server<any>;
+    const fakeServer = {
+      requestIP: mock(() => ({ address: "127.0.0.1", family: "IPv4", port: 54000 })),
+      upgrade: mock(() => true),
+    } as unknown as import("bun").Server<any>;
     const res = handler(req, fakeServer);
 
     expect(res).toBeUndefined();
@@ -146,6 +155,25 @@ describe("createBrowserRelayWebsocketHandler", () => {
     const handler = createBrowserRelayWebsocketHandler(config);
     const req = new Request(
       `http://gateway.example.com:7830/v1/browser-relay?token=${TEST_TOKEN}`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const fakeServer = {
+      requestIP: mock(() => ({ address: "8.8.8.8", family: "IPv4", port: 54000 })),
+      upgrade: mock(() => true),
+    } as unknown as import("bun").Server<any>;
+
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(403);
+    expect(fakeServer.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("returns 403 for localhost host when peer is public (host spoof prevention)", () => {
+    const config = makeConfig({ runtimeProxyBearerToken: TEST_TOKEN });
+    const handler = createBrowserRelayWebsocketHandler(config);
+    const req = new Request(
+      `http://localhost:7830/v1/browser-relay?token=${TEST_TOKEN}`,
       { headers: { upgrade: "websocket" } },
     );
     const fakeServer = {

--- a/gateway/src/http/routes/browser-relay-websocket.ts
+++ b/gateway/src/http/routes/browser-relay-websocket.ts
@@ -7,10 +7,6 @@ const log = getLogger("browser-relay-ws");
 // Cap buffered messages to prevent unbounded memory growth if upstream stalls
 const MAX_PENDING_MESSAGES = 100;
 
-function isLoopbackHost(hostname: string): boolean {
-  return hostname === "127.0.0.1" || hostname === "::1" || hostname === "localhost";
-}
-
 function isPrivateAddress(addr: string): boolean {
   const v4Mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
   const normalized = v4Mapped ? v4Mapped[1] : addr;
@@ -65,8 +61,8 @@ export function createBrowserRelayWebsocketHandler(config: GatewayConfig) {
 
     const url = new URL(req.url);
 
-    // Match runtime policy: browser relay is local/private-network only.
-    if (!isLoopbackHost(url.hostname) && !isPrivateNetworkPeer(server, req)) {
+    // Trust actual peer IP, not request host headers, for local/private gating.
+    if (!isPrivateNetworkPeer(server, req)) {
       return new Response("Browser relay only accepts connections from localhost", { status: 403 });
     }
 


### PR DESCRIPTION
## Summary
- enforce browser-relay local/private gating by always checking the actual peer IP (`server.requestIP(req)`)
- remove conditional trust in URL hostname (`localhost`/`127.0.0.1`) for access control
- add regression coverage for localhost-host spoof attempts from a public peer

## Why
The previous guard could be bypassed by sending a loopback Host header while connecting from a public IP, because hostname-based allow logic ran before peer-IP enforcement.

## Validation
- `cd gateway && bun test src/__tests__/browser-relay-websocket.test.ts src/__tests__/telegram-only-default.test.ts` (pass)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
