### PR TITLE
fix: add safety guards to scoped approval grant operations

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -218,7 +218,7 @@ The app token is validated by format only — it must start with `xapp-`.
 
 **Connection status:**
 
-The `GET` endpoint reports `connected: true` only when both `hasBotToken` and `hasAppToken` are true. If only one token is stored, a `warning` field describes which token is missing.
+Both `GET` and `POST` endpoints report `connected: true` only when both `hasBotToken` and `hasAppToken` are true. The `POST` endpoint additionally returns a `warning` field when only one token is stored, describing which token is missing.
 
 **Key source files:**
 

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -2724,11 +2724,26 @@ describe('Permission Checker', () => {
     );
 
     test('getDefaultRuleTemplates has no extra rules when extraDirs is empty', () => {
-      // Default testConfig has no skills property → getConfig returns default
-      // with extraDirs: []
       const templates = getDefaultRuleTemplates();
       const extraRules = templates.filter((t) => t.id.includes('extra-'));
       expect(extraRules.length).toBe(0);
+    });
+
+    test('getDefaultRuleTemplates tolerates partial config mocks', () => {
+      const originalSkills = testConfig.skills;
+      const originalSandbox = testConfig.sandbox;
+      try {
+        testConfig.skills = {} as any;
+        testConfig.sandbox = {} as any;
+
+        const templates = getDefaultRuleTemplates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.some((t) => t.id.includes('extra-'))).toBe(false);
+        expect(templates.some((t) => t.id === 'default:allow-bash-global')).toBe(false);
+      } finally {
+        testConfig.skills = originalSkills;
+        testConfig.sandbox = originalSandbox;
+      }
     });
   });
 

--- a/assistant/src/__tests__/update-bulletin.test.ts
+++ b/assistant/src/__tests__/update-bulletin.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -255,6 +255,30 @@ describe('syncUpdateBulletinOnStartup', () => {
 
     const entries = readdirSync(tempDir);
     const tmpFiles = entries.filter((e) => e.includes('.tmp.'));
+    expect(tmpFiles).toHaveLength(0);
+  });
+
+  it('preserves existing file when atomic write fails', () => {
+    const workspacePath = join(tempDir, 'UPDATES.md');
+    const originalContent = '<!-- vellum-update-release:0.9.0 -->\nOriginal content.\n';
+    writeFileSync(workspacePath, originalContent, 'utf-8');
+
+    // Make tempDir read-only so the temp file creation fails.
+    // On macOS/Linux, 0o555 prevents new file creation inside the directory.
+    chmodSync(tempDir, 0o555);
+    try {
+      expect(() => syncUpdateBulletinOnStartup()).toThrow();
+    } finally {
+      chmodSync(tempDir, 0o755);
+    }
+
+    // Original content should be preserved (atomic write never renamed over it)
+    const content = readFileSync(workspacePath, 'utf-8');
+    expect(content).toBe(originalContent);
+
+    // No temp file leftovers
+    const entries = readdirSync(tempDir);
+    const tmpFiles = entries.filter((e: string) => e.includes('.tmp.'));
     expect(tmpFiles).toHaveLength(0);
   });
 });

--- a/assistant/src/__tests__/update-bulletin.test.ts
+++ b/assistant/src/__tests__/update-bulletin.test.ts
@@ -94,15 +94,26 @@ mock.module('../version.js', () => ({
 
 const { syncUpdateBulletinOnStartup } = await import('../config/update-bulletin.js');
 
+// The real template is now comment-only (no materialized content). Tests that
+// exercise materialization need a template with real content, so we swap in a
+// test template before each test and restore the original afterwards.
+const TEMPLATE_PATH = join(import.meta.dirname, '..', 'config', 'templates', 'UPDATES.md');
+const originalTemplate = readFileSync(TEMPLATE_PATH, 'utf-8');
+const TEST_TEMPLATE = '## What\'s New\n\nTest release notes.\n';
+
 describe('syncUpdateBulletinOnStartup', () => {
   beforeEach(() => {
     store.clear();
     tempDir = join(tmpdir(), `update-bulletin-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     mkdirSync(tempDir, { recursive: true });
+    // Write a test template with real content so materialization proceeds
+    writeFileSync(TEMPLATE_PATH, TEST_TEMPLATE, 'utf-8');
   });
 
   afterEach(() => {
     rmSync(tempDir, { recursive: true, force: true });
+    // Restore the original comment-only template
+    writeFileSync(TEMPLATE_PATH, originalTemplate, 'utf-8');
   });
 
   it('creates workspace file on first eligible run', () => {
@@ -256,6 +267,16 @@ describe('syncUpdateBulletinOnStartup', () => {
     const entries = readdirSync(tempDir);
     const tmpFiles = entries.filter((e) => e.includes('.tmp.'));
     expect(tmpFiles).toHaveLength(0);
+  });
+
+  it('skips materialization when template is comment-only', () => {
+    // Restore the real comment-only template for this test
+    writeFileSync(TEMPLATE_PATH, originalTemplate, 'utf-8');
+
+    const workspacePath = join(tempDir, 'UPDATES.md');
+    syncUpdateBulletinOnStartup();
+
+    expect(existsSync(workspacePath)).toBe(false);
   });
 
   it('preserves existing file when atomic write fails', () => {

--- a/assistant/src/__tests__/update-template-contract.test.ts
+++ b/assistant/src/__tests__/update-template-contract.test.ts
@@ -1,9 +1,8 @@
 /**
- * Contract test: ensures the bundled UPDATES.md template exists and meets
- * the format expectations that the bulletin system depends on at runtime.
+ * Contract test: ensures the bundled UPDATES.md template exists and is readable.
  *
- * The "## What's New" heading is a structural contract — bulletin rendering
- * logic expects this section to be present in the template.
+ * The template may be comment-only (no real content) for no-op releases —
+ * the bulletin system treats an empty-after-stripping template as a skip signal.
  */
 
 import { existsSync, readFileSync } from 'node:fs';
@@ -17,13 +16,8 @@ describe('UPDATES.md template contract', () => {
     expect(existsSync(TEMPLATE_PATH)).toBe(true);
   });
 
-  test('template contains non-whitespace content', () => {
+  test('template is a readable UTF-8 file', () => {
     const content = readFileSync(TEMPLATE_PATH, 'utf-8');
-    expect(content.trim().length).toBeGreaterThan(0);
-  });
-
-  test('template contains the "## What\'s New" heading', () => {
-    const content = readFileSync(TEMPLATE_PATH, 'utf-8');
-    expect(content).toContain("## What's New");
+    expect(typeof content).toBe('string');
   });
 });

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -462,6 +462,8 @@ describe('voice-session-bridge', () => {
     const prompt: string = capturedPrompt;
 
     expect(prompt).toContain('this is an inbound call you are answering (not a call you initiated)');
+    expect(prompt).toContain('Introduce yourself once at the start using your assistant name if you know it');
+    expect(prompt).toContain('If your assistant name is not known, skip the name and just identify yourself as the guardian\'s assistant.');
     expect(prompt).toContain('Do NOT say "I\'m calling" or "I\'m calling on behalf of".');
   });
 

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -176,7 +176,7 @@ function buildVoiceCallControlPrompt(opts: {
       );
     } else {
       lines.push(
-        '7. If the latest user turn is "(call connected — deliver opening greeting)", this is an inbound call you are answering (not a call you initiated). Greet the caller warmly and ask how you can help. Do NOT say "I\'m calling" or "I\'m calling on behalf of". If you need to identify your role, use pickup framing like "I\'m [name]\'s assistant." Vary the wording; do not use a fixed template.',
+        '7. If the latest user turn is "(call connected — deliver opening greeting)", this is an inbound call you are answering (not a call you initiated). Greet the caller warmly and ask how you can help. Introduce yourself once at the start using your assistant name if you know it (for example: "Hey there, this is Ava, Sam\'s assistant. How can I help?"). If your assistant name is not known, skip the name and just identify yourself as the guardian\'s assistant. Do NOT say "I\'m calling" or "I\'m calling on behalf of". Vary the wording; do not use a fixed template.',
       );
     }
     lines.push(

--- a/assistant/src/config/templates/UPDATES.md
+++ b/assistant/src/config/templates/UPDATES.md
@@ -1,7 +1,5 @@
 _ Lines starting with _ are comments — they won't appear in the system prompt
-
-# UPDATES.md
-
+_
 _ This file contains release update notes for the assistant.
 _ Each release block is wrapped with HTML comment markers:
 _   <!-- vellum-update-release:<version> -->
@@ -11,6 +9,7 @@ _
 _ Format is freeform markdown. Write notes that help the assistant
 _ understand what changed and how it affects behavior, capabilities,
 _ or available tools. Focus on what matters to the user experience.
-
-## What's New
-
+_
+_ To add release notes, replace this content with real markdown
+_ describing what changed. The sync will only materialize a bulletin
+_ when non-comment content is present.

--- a/assistant/src/memory/scoped-approval-grants.ts
+++ b/assistant/src/memory/scoped-approval-grants.ts
@@ -47,6 +47,13 @@ export interface ScopedApprovalGrant {
 }
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Max CAS retry attempts when a concurrent consumer steals the selected candidate. */
+const MAX_CAS_RETRIES = 3;
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -213,6 +220,11 @@ export interface ConsumeByToolSignatureResult {
  * All non-null scope fields on the grant must match the provided context.
  * This is enforced via SQL conditions that check: either the grant field is
  * NULL (wildcard), or it equals the provided value.
+ *
+ * If a CAS contention miss occurs (another consumer races and wins the
+ * selected candidate), re-selects and retries up to {@link MAX_CAS_RETRIES}
+ * times before giving up. This prevents false denials when multiple matching
+ * grants exist but a concurrent consumer steals the first pick.
  */
 export function consumeScopedApprovalGrantByToolSignature(
   params: ConsumeByToolSignatureParams,
@@ -262,54 +274,60 @@ export function consumeScopedApprovalGrantByToolSignature(
     conditions.push(sql`${scopedApprovalGrants.requesterExternalUserId} IS NULL`);
   }
 
-  // Select a single matching grant to consume (prefer most specific: fewest NULL scope fields).
-  // This avoids burning multiple grants when a wildcard grant and a specific grant both match.
-  const candidate = db
-    .select({ id: scopedApprovalGrants.id })
-    .from(scopedApprovalGrants)
-    .where(and(...conditions))
-    .orderBy(
-      // Prefer grants with more non-null context fields (most specific first)
-      sql`(CASE WHEN ${scopedApprovalGrants.executionChannel} IS NOT NULL THEN 1 ELSE 0 END
+  const specificityOrder = sql`(CASE WHEN ${scopedApprovalGrants.executionChannel} IS NOT NULL THEN 1 ELSE 0 END
          + CASE WHEN ${scopedApprovalGrants.conversationId} IS NOT NULL THEN 1 ELSE 0 END
          + CASE WHEN ${scopedApprovalGrants.callSessionId} IS NOT NULL THEN 1 ELSE 0 END
-         + CASE WHEN ${scopedApprovalGrants.requesterExternalUserId} IS NOT NULL THEN 1 ELSE 0 END) DESC`,
-    )
-    .limit(1)
-    .get();
+         + CASE WHEN ${scopedApprovalGrants.requesterExternalUserId} IS NOT NULL THEN 1 ELSE 0 END) DESC`;
 
-  if (!candidate) {
-    return { ok: false, grant: null };
+  // Retry loop: if CAS fails because another consumer stole our candidate,
+  // re-select and try again — another matching active grant may still exist.
+  for (let attempt = 0; attempt <= MAX_CAS_RETRIES; attempt++) {
+    // Select a single matching grant to consume (prefer most specific: fewest NULL scope fields).
+    // This avoids burning multiple grants when a wildcard grant and a specific grant both match.
+    const candidate = db
+      .select({ id: scopedApprovalGrants.id })
+      .from(scopedApprovalGrants)
+      .where(and(...conditions))
+      .orderBy(specificityOrder)
+      .limit(1)
+      .get();
+
+    if (!candidate) {
+      return { ok: false, grant: null };
+    }
+
+    db.update(scopedApprovalGrants)
+      .set({
+        status: 'consumed',
+        consumedAt: currentTime,
+        consumedByRequestId: params.consumingRequestId,
+        updatedAt: currentTime,
+      })
+      .where(
+        and(
+          eq(scopedApprovalGrants.id, candidate.id),
+          eq(scopedApprovalGrants.status, 'active'),
+        ),
+      )
+      .run();
+
+    if (rawChanges() === 0) {
+      // CAS failed — another consumer raced and won this candidate; retry with next match
+      continue;
+    }
+
+    // Fetch the consumed grant
+    const row = db
+      .select()
+      .from(scopedApprovalGrants)
+      .where(eq(scopedApprovalGrants.id, candidate.id))
+      .get();
+
+    return { ok: true, grant: row ? rowToGrant(row) : null };
   }
 
-  db.update(scopedApprovalGrants)
-    .set({
-      status: 'consumed',
-      consumedAt: currentTime,
-      consumedByRequestId: params.consumingRequestId,
-      updatedAt: currentTime,
-    })
-    .where(
-      and(
-        eq(scopedApprovalGrants.id, candidate.id),
-        eq(scopedApprovalGrants.status, 'active'),
-      ),
-    )
-    .run();
-
-  if (rawChanges() === 0) {
-    // CAS failed — another consumer raced and won
-    return { ok: false, grant: null };
-  }
-
-  // Fetch the consumed grant
-  const row = db
-    .select()
-    .from(scopedApprovalGrants)
-    .where(eq(scopedApprovalGrants.id, candidate.id))
-    .get();
-
-  return { ok: true, grant: row ? rowToGrant(row) : null };
+  // All retry attempts exhausted — every candidate was stolen by concurrent consumers
+  return { ok: false, grant: null };
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -37,6 +37,13 @@ const COMPUTER_USE_TOOLS = [
  * Computed at runtime so paths reflect the configured root directory.
  */
 export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
+  // Some test suites mock getConfig() with partial objects; treat missing
+  // branches as defaults so rule generation remains deterministic.
+  const config = getConfig() as {
+    sandbox?: { enabled?: boolean };
+    skills?: { load?: { extraDirs?: unknown } };
+  };
+
   const hostFileRules = HOST_FILE_TOOLS.map((tool) => ({
     id: `default:ask-${tool}-global`,
     tool,
@@ -62,7 +69,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   // them (including high-risk) so the user is never prompted for sandbox work.
   // Only emit this rule when the sandbox is actually enabled; otherwise bash
   // commands execute on the host and must go through normal permission checks.
-  const sandboxEnabled = getConfig().sandbox.enabled;
+  const sandboxEnabled = config.sandbox?.enabled === true;
   const sandboxShellRule: DefaultRuleTemplate | null = sandboxEnabled
     ? {
         id: 'default:allow-bash-global',
@@ -149,7 +156,10 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
 
   // Append any user-configured extra skill directories so they get the
   // same default ask rules as managed and bundled dirs.
-  const extraDirs = getConfig().skills.load.extraDirs;
+  const rawExtraDirs = config.skills?.load?.extraDirs;
+  const extraDirs = Array.isArray(rawExtraDirs)
+    ? rawExtraDirs.filter((dir): dir is string => typeof dir === 'string')
+    : [];
   for (let i = 0; i < extraDirs.length; i++) {
     skillDirs.push({ dir: extraDirs[i].replaceAll('\\', '/'), label: `extra-${i}` });
   }

--- a/assistant/src/version.ts
+++ b/assistant/src/version.ts
@@ -1,3 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+function resolveVersion(): string {
+  const envVersion = process.env.APP_VERSION;
+  if (envVersion && envVersion !== '0.0.0-dev') return envVersion;
+
+  // Fall back to package.json version when env var is not set or is the dev placeholder.
+  try {
+    const pkgPath = join(import.meta.dirname ?? __dirname, '..', 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    if (pkg.version && typeof pkg.version === 'string') return pkg.version;
+  } catch {
+    // package.json missing or unreadable
+  }
+
+  return '0.0.0-dev';
+}
+
 // Version is embedded at compile time via --define in CI.
-// Falls back to "0.0.0-dev" for local development.
-export const APP_VERSION: string = process.env.APP_VERSION ?? "0.0.0-dev";
+// Falls back to package.json version, then "0.0.0-dev" for local development.
+export const APP_VERSION: string = resolveVersion();

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -8,7 +8,7 @@
 
 import type { ExtensionCommand, ExtensionResponse, ExtensionHeartbeat } from '../../../assistant/src/browser-extension-relay/protocol.js';
 
-const DEFAULT_RELAY_PORT = 7821;
+const DEFAULT_RELAY_PORT = 7830;
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const RECONNECT_BASE_MS = 1_000;
 const RECONNECT_MAX_MS = 30_000;

--- a/clients/chrome-extension/popup/popup.html
+++ b/clients/chrome-extension/popup/popup.html
@@ -124,7 +124,7 @@
   <input
     type="text"
     id="port-input"
-    placeholder="7821"
+    placeholder="7830"
     autocomplete="off"
     spellcheck="false"
   />
@@ -134,7 +134,7 @@
     <button id="btn-disconnect" disabled>Disconnect</button>
   </div>
 
-  <p class="hint">Token is stored locally in your browser. Find it at <code>~/.vellum/http-token</code>. Port defaults to 7821.</p>
+  <p class="hint">Token is stored locally in your browser. Find it at <code>~/.vellum/http-token</code>. Port defaults to 7830.</p>
 
   <script type="module" src="popup.js"></script>
 </body>

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -2015,23 +2015,20 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
     // MARK: - Wake-Up Greeting
 
-    /// Generates a time-aware, name-aware greeting for the assistant's first message.
+    /// Generates a time-aware greeting for the assistant's first message.
+    /// Intentionally unnamed — the assistant has no identity yet at hatch.
     private func wakeUpGreeting() -> String {
-        let name = IdentityInfo.load()?.name
-            ?? UserDefaults.standard.string(forKey: "assistantName")
-            ?? "friend"
-
         let hour = Calendar.current.component(.hour, from: Date())
         switch hour {
         case 5..<12:
-            return "Good morning, \(name). Time to wake up."
+            return "Good morning. Time to wake up."
         case 12..<18:
             return "Wake up, my friend."
         case 18..<22:
-            return "Evening, \(name). Ready when you are."
+            return "Evening. Ready when you are."
         default:
             // 22–4 (late night)
-            return "Burning the midnight oil? Let's go, \(name)."
+            return "Burning the midnight oil? Let's go."
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -979,11 +979,16 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// avoids O(n) IPC calls per streaming response (one per text delta) while
     /// still advancing the server-side seen cursor.
     private func handleAssistantMessageArrival(threadId: UUID, previousSnapshot: AssistantActivitySnapshot?, currentSnapshot: AssistantActivitySnapshot) {
-        // Skip during thread restoration — loadHistoryIfNeeded populates
-        // messages which triggers the Combine publisher, but those are
-        // historical messages, not fresh assistant replies. Without this
-        // guard the handler would clear real unread state on app launch.
+        // Skip during thread restoration or history re-hydration —
+        // loadHistoryIfNeeded populates messages which triggers the Combine
+        // publisher, but those are historical messages, not fresh assistant
+        // replies. Without this guard the handler would clear real unread
+        // state on app launch, or bump threads to the top when clicking on
+        // them causes an evicted ViewModel to reload its history.
         guard !isRestoringThreads else { return }
+        if let vm = chatViewModels[threadId], vm.isLoadingHistory || !vm.isHistoryLoaded {
+            return
+        }
         guard let index = threads.firstIndex(where: { $0.id == threadId }) else { return }
         updateLastInteracted(threadId: threadId)
         if threadId == activeThreadId {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift
@@ -2099,9 +2099,13 @@ struct SettingsConnectTab: View {
         }
         // Wait for the daemon to restart and become reachable with the new token.
         Task {
-            let port = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"]
-                .flatMap(Int.init) ?? 7821
-            let url = URL(string: "http://localhost:\(port)/healthz")!
+            let base = store.localGatewayTarget.hasSuffix("/")
+                ? String(store.localGatewayTarget.dropLast())
+                : store.localGatewayTarget
+            guard let url = URL(string: "\(base)/v1/health") else {
+                isRegeneratingToken = false
+                return
+            }
             var request = URLRequest(url: url)
             request.setValue("Bearer \(newToken)", forHTTPHeaderField: "Authorization")
             request.timeoutInterval = 2

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -664,7 +664,12 @@ public final class ChatViewModel: ObservableObject {
             messages[i].stripHeavyContent()
         }
         displayedMessageCount = Self.messagePageSize
-        isHistoryLoaded = false
+        // Only mark history as unloaded if there's a session to reload from.
+        // Threads without a session (new, empty) have nothing to fetch —
+        // resetting the flag would leave the UI stuck on a loading spinner.
+        if sessionId != nil {
+            isHistoryLoaded = false
+        }
     }
 
     /// Surface the user is currently viewing in workspace mode.

--- a/gateway/src/__tests__/browser-relay-websocket.test.ts
+++ b/gateway/src/__tests__/browser-relay-websocket.test.ts
@@ -1,0 +1,226 @@
+import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+import type { GatewayConfig } from "../config.js";
+import {
+  createBrowserRelayWebsocketHandler,
+  getBrowserRelayWebsocketHandlers,
+} from "../http/routes/browser-relay-websocket.js";
+
+const WS_CONNECTING = WebSocket.CONNECTING; // 0
+const WS_OPEN = WebSocket.OPEN; // 1
+const WS_CLOSED = WebSocket.CLOSED; // 3
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  const merged: GatewayConfig = {
+    telegramBotToken: "tok",
+    telegramWebhookSecret: "wh-ver",
+    telegramApiBaseUrl: "https://api.telegram.org",
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeBearerToken: undefined,
+    runtimeGatewayOriginSecret: undefined,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    runtimeProxyBearerToken: undefined,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
+    twilioAuthToken: undefined,
+    twilioAccountSid: undefined,
+    twilioPhoneNumber: undefined,
+    smsDeliverAuthBypass: false,
+    ingressPublicBaseUrl: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    whatsappPhoneNumberId: undefined,
+    whatsappAccessToken: undefined,
+    whatsappAppSecret: undefined,
+    whatsappWebhookVerifyToken: undefined,
+    whatsappDeliverAuthBypass: false,
+    whatsappTimeoutMs: 15000,
+    whatsappMaxRetries: 3,
+    whatsappInitialBackoffMs: 1000,
+    trustProxy: false,
+    ...overrides,
+  };
+  if (merged.runtimeGatewayOriginSecret === undefined) {
+    merged.runtimeGatewayOriginSecret = merged.runtimeBearerToken;
+  }
+  return merged;
+}
+
+function createFakeDownstreamWs(data: Record<string, unknown> = {}) {
+  const sent: (string | Uint8Array)[] = [];
+  const closes: { code: number; reason: string }[] = [];
+  return {
+    data,
+    sent,
+    closes,
+    send: mock((msg: string | Uint8Array) => {
+      sent.push(msg);
+    }),
+    close: mock((code?: number, reason?: string) => {
+      closes.push({ code: code ?? 1000, reason: reason ?? "" });
+    }),
+  };
+}
+
+function createFakeUpstreamWs() {
+  const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+  const sent: unknown[] = [];
+  return {
+    readyState: WS_CONNECTING as number,
+    sent,
+    listeners,
+    addEventListener: mock((event: string, cb: (...args: unknown[]) => void) => {
+      (listeners[event] ??= []).push(cb);
+    }),
+    send: mock((msg: unknown) => {
+      sent.push(msg);
+    }),
+    close: mock(() => {}),
+    emit(event: string, detail: unknown = {}) {
+      for (const cb of listeners[event] ?? []) {
+        cb(detail);
+      }
+    },
+  };
+}
+
+describe("createBrowserRelayWebsocketHandler", () => {
+  const TEST_TOKEN = "relay-token-abc123";
+
+  test("upgrades when token query parameter is valid", () => {
+    const config = makeConfig({ runtimeProxyBearerToken: TEST_TOKEN });
+    const handler = createBrowserRelayWebsocketHandler(config);
+    const req = new Request(
+      `http://localhost:7830/v1/browser-relay?token=${TEST_TOKEN}`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const fakeServer = { upgrade: mock(() => true) } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeUndefined();
+    expect(fakeServer.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns 401 when token is missing", () => {
+    const config = makeConfig({ runtimeProxyBearerToken: TEST_TOKEN });
+    const handler = createBrowserRelayWebsocketHandler(config);
+    const req = new Request("http://localhost:7830/v1/browser-relay", {
+      headers: { upgrade: "websocket" },
+    });
+    const fakeServer = { upgrade: mock(() => true) } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(401);
+    expect(fakeServer.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("allows unauthenticated upgrade when runtime proxy auth is disabled", () => {
+    const config = makeConfig({ runtimeProxyRequireAuth: false, runtimeProxyBearerToken: undefined });
+    const handler = createBrowserRelayWebsocketHandler(config);
+    const req = new Request("http://localhost:7830/v1/browser-relay", {
+      headers: { upgrade: "websocket" },
+    });
+    const fakeServer = { upgrade: mock(() => true) } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeUndefined();
+    expect(fakeServer.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns 403 when non-loopback host is requested from a public peer", () => {
+    const config = makeConfig({ runtimeProxyBearerToken: TEST_TOKEN });
+    const handler = createBrowserRelayWebsocketHandler(config);
+    const req = new Request(
+      `http://gateway.example.com:7830/v1/browser-relay?token=${TEST_TOKEN}`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const fakeServer = {
+      requestIP: mock(() => ({ address: "8.8.8.8", family: "IPv4", port: 54000 })),
+      upgrade: mock(() => true),
+    } as unknown as import("bun").Server<any>;
+
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(403);
+    expect(fakeServer.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("allows non-loopback host when peer is private network", () => {
+    const config = makeConfig({ runtimeProxyBearerToken: TEST_TOKEN });
+    const handler = createBrowserRelayWebsocketHandler(config);
+    const req = new Request(
+      `http://gateway.example.com:7830/v1/browser-relay?token=${TEST_TOKEN}`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const fakeServer = {
+      requestIP: mock(() => ({ address: "10.42.0.8", family: "IPv4", port: 54000 })),
+      upgrade: mock(() => true),
+    } as unknown as import("bun").Server<any>;
+
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeUndefined();
+    expect(fakeServer.upgrade).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("getBrowserRelayWebsocketHandlers", () => {
+  const OriginalWebSocket = globalThis.WebSocket;
+  let fakeUpstream: ReturnType<typeof createFakeUpstreamWs>;
+  let handlers: ReturnType<typeof getBrowserRelayWebsocketHandlers>;
+
+  beforeEach(() => {
+    fakeUpstream = createFakeUpstreamWs();
+    const MockWS = mock(() => fakeUpstream);
+    Object.assign(MockWS, {
+      CONNECTING: WS_CONNECTING,
+      OPEN: WS_OPEN,
+      CLOSING: 2,
+      CLOSED: WS_CLOSED,
+    });
+    globalThis.WebSocket = MockWS as unknown as typeof WebSocket;
+    handlers = getBrowserRelayWebsocketHandlers();
+  });
+
+  afterAll(() => {
+    globalThis.WebSocket = OriginalWebSocket;
+  });
+
+  test("open targets runtime browser-relay websocket and flushes buffered messages", () => {
+    const ws = createFakeDownstreamWs({
+      wsType: "browser-relay",
+      config: makeConfig({
+        assistantRuntimeBaseUrl: "http://runtime.internal:7821",
+        runtimeBearerToken: "runtime-token",
+      }),
+    });
+
+    handlers.open(ws as never);
+    handlers.message(ws as never, "hello-before-open");
+
+    const MockWS = globalThis.WebSocket as unknown as ReturnType<typeof mock>;
+    expect(MockWS).toHaveBeenCalledWith("ws://runtime.internal:7821/v1/browser-relay?token=runtime-token");
+
+    fakeUpstream.readyState = WS_OPEN;
+    fakeUpstream.emit("open");
+    expect(fakeUpstream.sent).toEqual(["hello-before-open"]);
+
+    fakeUpstream.emit("message", { data: "runtime-message" });
+    expect(ws.sent).toEqual(["runtime-message"]);
+  });
+});

--- a/gateway/src/http/routes/browser-relay-websocket.ts
+++ b/gateway/src/http/routes/browser-relay-websocket.ts
@@ -1,0 +1,199 @@
+import type { GatewayConfig } from "../../config.js";
+import { getLogger } from "../../logger.js";
+import { validateBearerToken } from "../auth/bearer.js";
+
+const log = getLogger("browser-relay-ws");
+
+// Cap buffered messages to prevent unbounded memory growth if upstream stalls
+const MAX_PENDING_MESSAGES = 100;
+
+function isLoopbackHost(hostname: string): boolean {
+  return hostname === "127.0.0.1" || hostname === "::1" || hostname === "localhost";
+}
+
+function isPrivateAddress(addr: string): boolean {
+  const v4Mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
+  const normalized = v4Mapped ? v4Mapped[1] : addr;
+
+  if (normalized.includes(".")) {
+    const parts = normalized.split(".").map(Number);
+    if (parts.length !== 4 || parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)) return false;
+
+    if (parts[0] === 127) return true;
+    if (parts[0] === 10) return true;
+    if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true;
+    if (parts[0] === 192 && parts[1] === 168) return true;
+    if (parts[0] === 169 && parts[1] === 254) return true;
+
+    return false;
+  }
+
+  const lower = normalized.toLowerCase();
+  if (lower === "::1") return true;
+  if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
+  if (lower.startsWith("fe80")) return true;
+
+  return false;
+}
+
+function isPrivateNetworkPeer(server: import("bun").Server<unknown>, req: Request): boolean {
+  const ip = server.requestIP(req);
+  if (!ip) return false;
+  return isPrivateAddress(ip.address);
+}
+
+export type BrowserRelaySocketData = {
+  wsType: "browser-relay";
+  config: GatewayConfig;
+  clientToken?: string;
+  upstream?: WebSocket;
+  pendingMessages?: (string | ArrayBuffer | Uint8Array)[];
+};
+
+/**
+ * Create a WebSocket upgrade handler that proxies browser-relay frames between
+ * the local Chrome extension and the runtime's /v1/browser-relay endpoint.
+ */
+export function createBrowserRelayWebsocketHandler(config: GatewayConfig) {
+  return function handleUpgrade(
+    req: Request,
+    server: import("bun").Server<unknown>,
+  ): Response | undefined {
+    if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+      return new Response("Upgrade Required", { status: 426 });
+    }
+
+    const url = new URL(req.url);
+
+    // Match runtime policy: browser relay is local/private-network only.
+    if (!isLoopbackHost(url.hostname) && !isPrivateNetworkPeer(server, req)) {
+      return new Response("Browser relay only accepts connections from localhost", { status: 403 });
+    }
+
+    const authResponse = checkBrowserRelayAuth(req, url, config);
+    if (authResponse) return authResponse;
+
+    const upgraded = server.upgrade(req, {
+      data: {
+        wsType: "browser-relay",
+        config,
+        clientToken: url.searchParams.get("token") ?? undefined,
+      },
+    });
+
+    if (!upgraded) {
+      return new Response("WebSocket upgrade failed", { status: 500 });
+    }
+
+    // Return undefined to indicate upgrade was handled
+    return undefined;
+  };
+}
+
+function checkBrowserRelayAuth(
+  req: Request,
+  url: URL,
+  config: GatewayConfig,
+): Response | null {
+  if (!config.runtimeProxyRequireAuth) return null;
+
+  if (!config.runtimeProxyBearerToken) {
+    log.error("Browser relay WS: no bearer token configured — rejecting (fail-closed)");
+    return new Response("Service not configured: bearer token required", { status: 503 });
+  }
+
+  const authHeader = req.headers.get("authorization");
+  const queryToken = url.searchParams.get("token");
+  const tokenSource = authHeader ?? (queryToken ? `Bearer ${queryToken}` : null);
+
+  const result = validateBearerToken(tokenSource, config.runtimeProxyBearerToken);
+  if (!result.authorized) {
+    log.warn({ reason: result.reason }, "Browser relay WS: authentication failed");
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  return null;
+}
+
+/**
+ * WebSocket handler config for Bun.serve() that proxies frames to runtime.
+ */
+export function getBrowserRelayWebsocketHandlers() {
+  return {
+    open(ws: import("bun").ServerWebSocket<BrowserRelaySocketData>) {
+      const { config } = ws.data;
+
+      // Initialize message buffer for frames arriving before upstream connects
+      ws.data.pendingMessages = [];
+
+      const runtimeBase = config.assistantRuntimeBaseUrl.replace(/^http/, "ws");
+      const upstreamToken = config.runtimeBearerToken || config.runtimeProxyBearerToken || ws.data.clientToken;
+      const query = upstreamToken ? `?token=${encodeURIComponent(upstreamToken)}` : "";
+      const upstreamUrl = `${runtimeBase}/v1/browser-relay${query}`;
+      const logSafeUpstreamUrl = `${runtimeBase}/v1/browser-relay${upstreamToken ? "?token=<redacted>" : ""}`;
+
+      log.info({ upstreamUrl: logSafeUpstreamUrl }, "Opening upstream browser relay WS to runtime");
+
+      const upstream = new WebSocket(upstreamUrl);
+      ws.data.upstream = upstream;
+
+      upstream.addEventListener("open", () => {
+        log.info("Upstream browser relay WS connected");
+        const pending = ws.data.pendingMessages;
+        if (pending) {
+          for (const msg of pending) {
+            upstream.send(msg);
+          }
+          ws.data.pendingMessages = undefined;
+        }
+      });
+
+      upstream.addEventListener("message", (event) => {
+        const data = typeof event.data === "string"
+          ? event.data
+          : new Uint8Array(event.data as ArrayBuffer);
+        ws.send(data);
+      });
+
+      upstream.addEventListener("close", (event) => {
+        log.info({ code: event.code }, "Upstream browser relay WS closed");
+        ws.close(event.code, event.reason);
+      });
+
+      upstream.addEventListener("error", (event) => {
+        log.error({ error: event }, "Upstream browser relay WS error");
+        ws.close(1011, "Upstream error");
+      });
+    },
+
+    message(
+      ws: import("bun").ServerWebSocket<BrowserRelaySocketData>,
+      message: string | ArrayBuffer | Uint8Array,
+    ) {
+      const upstream = ws.data.upstream;
+      if (upstream && upstream.readyState === WebSocket.OPEN) {
+        upstream.send(message);
+      } else if (ws.data.pendingMessages) {
+        if (ws.data.pendingMessages.length >= MAX_PENDING_MESSAGES) {
+          log.warn("Browser relay pending message buffer overflow — closing connection");
+          ws.close(1008, "Buffer overflow");
+          return;
+        }
+        ws.data.pendingMessages.push(message);
+      }
+    },
+
+    close(
+      ws: import("bun").ServerWebSocket<BrowserRelaySocketData>,
+      code: number,
+      reason: string,
+    ) {
+      const { upstream } = ws.data;
+      log.info({ code, reason }, "Browser relay downstream WS closed");
+      ws.data.pendingMessages = undefined;
+      if (upstream && (upstream.readyState === WebSocket.OPEN || upstream.readyState === WebSocket.CONNECTING)) {
+        upstream.close(code, reason);
+      }
+    },
+  };
+}

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -39,7 +39,7 @@ export function createSlackDeliverHandler(config: GatewayConfig) {
     }
 
     if (typeof body !== 'object' || body === null) {
-      return Response.json({ ok: false, error: "Invalid request body" }, { status: 400 });
+      return Response.json({ error: "Invalid request body" }, { status: 400 });
     }
 
     if (body.attachments && Array.isArray(body.attachments) && body.attachments.length > 0) {

--- a/gateway/src/http/routes/twilio-relay-websocket.ts
+++ b/gateway/src/http/routes/twilio-relay-websocket.ts
@@ -19,7 +19,7 @@ type RelaySocketData = {
  * frames between Twilio and the runtime's /v1/calls/relay endpoint.
  */
 export function createTwilioRelayWebsocketHandler(config: GatewayConfig) {
-  return function handleUpgrade(req: Request, server: import("bun").Server<RelaySocketData>): Response | undefined {
+  return function handleUpgrade(req: Request, server: import("bun").Server<unknown>): Response | undefined {
     const url = new URL(req.url);
     const callSessionId = url.searchParams.get("callSessionId");
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -7,6 +7,11 @@ import { ConfigFileWatcher } from "./config-file-watcher.js";
 import { loadConfig, isSlackChannelConfigured, type GatewayConfig } from "./config.js";
 import { CredentialWatcher } from "./credential-watcher.js";
 import { createRuntimeProxyHandler } from "./http/routes/runtime-proxy.js";
+import {
+  createBrowserRelayWebsocketHandler,
+  getBrowserRelayWebsocketHandlers,
+  type BrowserRelaySocketData,
+} from "./http/routes/browser-relay-websocket.js";
 import { createTelegramDeliverHandler } from "./http/routes/telegram-deliver.js";
 import { createTelegramReconcileHandler } from "./http/routes/telegram-reconcile.js";
 import { createTelegramWebhookHandler } from "./http/routes/telegram-webhook.js";
@@ -40,6 +45,10 @@ let draining = false;
 
 // Shared rate limiter for auth failures and unauthenticated endpoints
 const authRateLimiter = new AuthRateLimiter();
+
+function isBrowserRelaySocketData(data: unknown): data is BrowserRelaySocketData {
+  return !!data && typeof data === "object" && (data as { wsType?: unknown }).wsType === "browser-relay";
+}
 
 function getClientIp(req: Request, server: ReturnType<typeof Bun.serve>, trustProxy: boolean): string {
   if (trustProxy) {
@@ -126,6 +135,9 @@ function main() {
   const handleTwilioStatusWebhook = createTwilioStatusWebhookHandler(config);
   const handleTwilioConnectActionWebhook = createTwilioConnectActionWebhookHandler(config);
   const handleTwilioRelayWs = createTwilioRelayWebsocketHandler(config);
+  const handleBrowserRelayWs = createBrowserRelayWebsocketHandler(config);
+  const twilioRelayWebsocketHandlers = getRelayWebsocketHandlers();
+  const browserRelayWebsocketHandlers = getBrowserRelayWebsocketHandlers();
   const { handler: handleTwilioSmsWebhook, dedupCache: smsDedupCache } = createTwilioSmsWebhookHandler(config);
   const handleSmsDeliver = createSmsDeliverHandler(config);
   const { handler: handleWhatsAppWebhook, dedupCache: whatsappDedupCache } = createWhatsAppWebhookHandler(config);
@@ -140,7 +152,29 @@ function main() {
 
   const server = Bun.serve({
     port: config.port,
-    websocket: getRelayWebsocketHandlers(),
+    websocket: {
+      open(ws) {
+        if (isBrowserRelaySocketData(ws.data)) {
+          browserRelayWebsocketHandlers.open(ws as never);
+          return;
+        }
+        twilioRelayWebsocketHandlers.open(ws as never);
+      },
+      message(ws, message) {
+        if (isBrowserRelaySocketData(ws.data)) {
+          browserRelayWebsocketHandlers.message(ws as never, message);
+          return;
+        }
+        twilioRelayWebsocketHandlers.message(ws as never, message);
+      },
+      close(ws, code, reason) {
+        if (isBrowserRelaySocketData(ws.data)) {
+          browserRelayWebsocketHandlers.close(ws as never, code, reason);
+          return;
+        }
+        twilioRelayWebsocketHandlers.close(ws as never, code, reason);
+      },
+    },
     error(err) {
       if (err instanceof CircuitBreakerOpenError) {
         return Response.json(
@@ -183,6 +217,7 @@ function main() {
           url.pathname !== "/v1/calls/twilio/voice-webhook" &&
           url.pathname !== "/v1/calls/twilio/status" &&
           url.pathname !== "/v1/calls/twilio/connect-action" &&
+          url.pathname !== "/v1/browser-relay" &&
           url.pathname !== "/v1/calls/relay");
       if (isRateLimitedRoute) {
         const clientIp = getClientIp(req, svr, config.trustProxy);
@@ -303,6 +338,13 @@ function main() {
 
       if (url.pathname === "/webhooks/twilio/relay" || url.pathname === "/v1/calls/relay") {
         const upgradeResult = handleTwilioRelayWs(req, server);
+        if (upgradeResult !== undefined) return upgradeResult;
+        // If upgrade was handled, Bun doesn't need a response
+        return undefined as unknown as Response;
+      }
+
+      if (config.runtimeProxyEnabled && url.pathname === "/v1/browser-relay") {
+        const upgradeResult = handleBrowserRelayWs(req, server);
         if (upgradeResult !== undefined) return upgradeResult;
         // If upgrade was handled, Bun doesn't need a response
         return undefined as unknown as Response;


### PR DESCRIPTION
Address review feedback from PR #10021:

- Add runtime guard in revokeScopedApprovalGrantsForContext to require at least one context filter (prevents accidental revocation of all active grants)
- Limit tool-signature grant consumption to a single matching row (prevents burning unrelated approvals when wildcard and specific grants coexist)
- Add retry logic after CAS contention miss in consumeScopedApprovalGrant (re-selects another matching grant before failing)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10038" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
