### PR TITLE
fix: move buffered cert reads inside TLS renewal fallback

### DIFF
--- a/assistant/src/daemon/tls-certs.ts
+++ b/assistant/src/daemon/tls-certs.ts
@@ -152,20 +152,25 @@ export async function ensureTlsCert(): Promise<{ cert: string; key: string; fing
   }
 
   if (status === 'approaching_expiry') {
-    // Buffer existing cert/key/fingerprint before attempting renewal.
-    // generateNewCert() overwrites key.pem in-place, so if it fails mid-flight
-    // (e.g., key written but cert generation fails), reading from disk in the
-    // catch block would return a mismatched key/cert pair.
-    const [existingCert, existingKey, existingFp] = await Promise.all([
-      readFile(certPath, 'utf-8'),
-      readFile(keyPath, 'utf-8'),
-      readFile(fpPath, 'utf-8'),
-    ]);
     try {
-      return await generateNewCert(tlsDir, certPath, keyPath, fpPath);
+      // Buffer existing cert/key/fingerprint before attempting renewal.
+      // generateNewCert() overwrites key.pem in-place, so if it fails mid-flight
+      // (e.g., key written but cert generation fails), reading from disk in the
+      // catch block would return a mismatched key/cert pair.
+      const [existingCert, existingKey, existingFp] = await Promise.all([
+        readFile(certPath, 'utf-8'),
+        readFile(keyPath, 'utf-8'),
+        readFile(fpPath, 'utf-8'),
+      ]);
+      try {
+        return await generateNewCert(tlsDir, certPath, keyPath, fpPath);
+      } catch (err) {
+        log.warn({ err }, 'Proactive TLS renewal failed, continuing with existing certificate');
+        return { cert: existingCert, key: existingKey, fingerprint: existingFp.trim() };
+      }
     } catch (err) {
-      log.warn({ err }, 'Proactive TLS renewal failed, continuing with existing certificate');
-      return { cert: existingCert, key: existingKey, fingerprint: existingFp.trim() };
+      log.warn({ err }, 'Failed to read existing TLS cert for buffering, attempting regeneration');
+      return await generateNewCert(tlsDir, certPath, keyPath, fpPath);
     }
   }
 


### PR DESCRIPTION
Address review feedback from PR #9911. Move the buffered readFile calls for cert/key inside the try block so that a transient file-read failure doesn't prevent generateNewCert() from being attempted. If the buffered reads fail (e.g. concurrent delete/permission change), we now fall through to regeneration instead of throwing at startup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
