### PR TITLE
fix: reset global regex lastIndex before extractReleaseIds loop

### DIFF
--- a/assistant/src/config/update-bulletin-format.ts
+++ b/assistant/src/config/update-bulletin-format.ts
@@ -44,6 +44,7 @@ export function appendReleaseBlock(
 /** Extracts all version strings from release markers found in `content`. */
 export function extractReleaseIds(content: string): string[] {
   const ids: string[] = [];
+  MARKER_REGEX.lastIndex = 0;
   let match: RegExpExecArray | null;
   while ((match = MARKER_REGEX.exec(content)) !== null) {
     ids.push(match[1]);


### PR DESCRIPTION
Address review feedback from PR #9976. Reset MARKER_REGEX.lastIndex to 0 before the while loop in extractReleaseIds to prevent stale state from previous invocations.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
