### PR TITLE
fix: preserve symlink targets in bulletin atomic write

### DIFF
--- a/assistant/src/config/update-bulletin.ts
+++ b/assistant/src/config/update-bulletin.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, lstatSync, readFileSync, realpathSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { stripCommentLines } from './system-prompt.js';
@@ -21,7 +21,11 @@ function atomicWriteFileSync(filePath: string, content: string): void {
   const tmpPath = `${filePath}.tmp.${process.pid}`;
   try {
     writeFileSync(tmpPath, content, 'utf-8');
-    renameSync(tmpPath, filePath);
+    // Resolve symlinks so we rename to the real target, preserving the link
+    const targetPath = lstatSync(filePath, { throwIfNoEntry: false })?.isSymbolicLink()
+      ? realpathSync(filePath)
+      : filePath;
+    renameSync(tmpPath, targetPath);
   } catch (err) {
     try {
       unlinkSync(tmpPath);


### PR DESCRIPTION
Address review feedback from PR #9992. When atomically writing UPDATES.md, resolve symlinks before renaming so that symlinked workspace files are updated through the link rather than replacing it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
