### PR TITLE
fix: preserve 0.0.0-dev fallback for local development

### DIFF
--- a/assistant/src/version.ts
+++ b/assistant/src/version.ts
@@ -3,20 +3,28 @@ import { join } from 'node:path';
 
 function resolveVersion(): string {
   const envVersion = process.env.APP_VERSION;
-  if (envVersion && envVersion !== '0.0.0-dev') return envVersion;
 
-  // Fall back to package.json version when env var is not set or is the dev placeholder.
-  try {
-    const pkgPath = join(import.meta.dirname ?? __dirname, '..', 'package.json');
-    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-    if (pkg.version && typeof pkg.version === 'string') return pkg.version;
-  } catch {
-    // package.json missing or unreadable
+  // When APP_VERSION is not set, we're in local development — return the dev
+  // sentinel so Sentry (and similar) classify the session as "development".
+  if (!envVersion) return '0.0.0-dev';
+
+  // CI sets APP_VERSION to the dev placeholder during builds; resolve it to
+  // the package.json release version so Sentry gets a meaningful release tag.
+  if (envVersion === '0.0.0-dev') {
+    try {
+      const pkgPath = join(import.meta.dirname ?? __dirname, '..', 'package.json');
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+      if (pkg.version && typeof pkg.version === 'string') return pkg.version;
+    } catch {
+      // package.json missing or unreadable
+    }
+    return '0.0.0-dev';
   }
 
-  return '0.0.0-dev';
+  return envVersion;
 }
 
 // Version is embedded at compile time via --define in CI.
-// Falls back to package.json version, then "0.0.0-dev" for local development.
+// Falls back to "0.0.0-dev" for local development, or resolves the dev
+// placeholder to package.json version when explicitly set in CI.
 export const APP_VERSION: string = resolveVersion();


### PR DESCRIPTION
Address review feedback from PR #10018. Restore 0.0.0-dev as the default APP_VERSION when the env var is unset, preventing local dev sessions from polluting production Sentry telemetry.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
