### PR TITLE
fix: default sandbox to enabled when config is missing

### DIFF
--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -69,7 +69,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   // them (including high-risk) so the user is never prompted for sandbox work.
   // Only emit this rule when the sandbox is actually enabled; otherwise bash
   // commands execute on the host and must go through normal permission checks.
-  const sandboxEnabled = config.sandbox?.enabled === true;
+  const sandboxEnabled = config.sandbox?.enabled !== false;
   const sandboxShellRule: DefaultRuleTemplate | null = sandboxEnabled
     ? {
         id: 'default:allow-bash-global',


### PR DESCRIPTION
Address review feedback from PR #10031. Default sandboxEnabled to true when config.sandbox is undefined, matching the production runtime default and preventing the allow-bash-global rule from being dropped in partial-config scenarios.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
