### PR TITLE
fix: match custom socket check with resolveSocketPath semantics

### DIFF
--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -46,7 +46,10 @@ extension DaemonClient {
             //
             // Skip this check for custom socket transports (VELLUM_DAEMON_SOCKET) —
             // SSH-forwarded or external sockets have no local PID file.
-            let isCustomSocket = ProcessInfo.processInfo.environment["VELLUM_DAEMON_SOCKET"] != nil
+            let isCustomSocket: Bool = {
+                guard let v = ProcessInfo.processInfo.environment["VELLUM_DAEMON_SOCKET"] else { return false }
+                return !v.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            }()
             if !isCustomSocket, FileManager.default.fileExists(atPath: path), !Self.isDaemonProcessAlive() {
                 log.warning("Stale daemon socket detected — PID is dead, removing socket at \(path, privacy: .public)")
                 // Only remove the path if it is actually a Unix socket, not a regular file.


### PR DESCRIPTION
Address review feedback from PR #9957. Update isCustomSocket to treat empty/whitespace VELLUM_DAEMON_SOCKET as default mode, matching resolveSocketPath's trimmed/non-empty check.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
