### PR TITLE
fix: harden daemon startup lock and dev command cleanup

### DIFF
--- a/assistant/src/cli/core-commands.ts
+++ b/assistant/src/cli/core-commands.ts
@@ -110,7 +110,7 @@ export function registerDevCommand(program: Command): void {
     .description('Run the daemon in dev mode with auto-restart on file changes')
     .action(async () => {
       const status = await getDaemonStatus();
-      if (status.running) {
+      if (status.running || status.pid) {
         log.info('Stopping existing daemon...');
         const stopResult = await stopDaemon();
         if (!stopResult.stopped && stopResult.reason === 'stop_failed') {

--- a/assistant/src/daemon/daemon-control.ts
+++ b/assistant/src/daemon/daemon-control.ts
@@ -188,6 +188,11 @@ function getStartupLockPath(): string {
 function acquireStartupLock(): boolean {
   const lockPath = getStartupLockPath();
   try {
+    // Ensure the root directory exists before attempting the lock file write.
+    // On a first-time run, getRootDir() may not exist yet, and writeFileSync
+    // with 'wx' would throw ENOENT — which the catch block misinterprets as
+    // "lock already held."
+    mkdirSync(getRootDir(), { recursive: true });
     // O_CREAT | O_EXCL — fails atomically if the file already exists.
     writeFileSync(lockPath, String(Date.now()), { flag: 'wx' });
     return true;
@@ -226,12 +231,16 @@ export async function startDaemon(): Promise<{
     const lockWaitMs = 10_000;
     const lockInterval = 200;
     let lockWaited = 0;
+    let lockAcquired = false;
     while (lockWaited < lockWaitMs) {
       await new Promise((r) => setTimeout(r, lockInterval));
       lockWaited += lockInterval;
-      if (acquireStartupLock()) break;
+      if (acquireStartupLock()) {
+        lockAcquired = true;
+        break;
+      }
     }
-    if (lockWaited >= lockWaitMs) {
+    if (!lockAcquired) {
       // Timed out waiting for the lock — re-check status in case the
       // other caller succeeded.
       const recheck = await getDaemonStatus();


### PR DESCRIPTION
Address review feedback from PR #9962. Ensure root dir exists before lock acquisition, distinguish lock timeout from last-iteration success, and fix dev command to stop alive-but-unresponsive daemons.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
