### PR TITLE
M3: Channel-Agnostic Decision->Grant Bridge

### DIFF
--- a/assistant/src/__tests__/guardian-grant-minting.test.ts
+++ b/assistant/src/__tests__/guardian-grant-minting.test.ts
@@ -236,11 +236,12 @@ describe('guardian grant minting on tool-approval decisions', () => {
 
   // ── 2. approve_once for non-tool-approval does NOT mint a grant ──
 
-  test('approve_once for informational request (empty input) does NOT mint a grant', async () => {
+  test('approve_once for informational request (no toolName) does NOT mint a grant', async () => {
     const requestId = 'req-no-grant-1';
-    createTestGuardianApproval(requestId, { toolName: 'ask_guardian_question' });
-    // Register with empty input to simulate informational ASK_GUARDIAN
-    registerPendingInteraction(requestId, CONVERSATION_ID, 'ask_guardian_question', {});
+    // Informational requests have no meaningful tool name — the empty string
+    // signals that this is not a tool-approval request.
+    createTestGuardianApproval(requestId, { toolName: '' });
+    registerPendingInteraction(requestId, CONVERSATION_ID, '', {});
 
     const result = await handleApprovalInterception({
       conversationId: 'guardian-conv-2',
@@ -259,6 +260,47 @@ describe('guardian grant minting on tool-approval decisions', () => {
 
     // No grant should have been minted
     expect(countGrants()).toBe(0);
+
+    deliverSpy.mockRestore();
+    composeSpy.mockRestore();
+  });
+
+  // ── 2b. approve_once for zero-argument tool call DOES mint a grant ──
+
+  test('approve_once for zero-argument tool call mints a scoped grant', async () => {
+    const requestId = 'req-grant-zero-arg';
+    const zeroArgTool = 'get_system_status';
+    createTestGuardianApproval(requestId, { toolName: zeroArgTool });
+    // Register with empty input object to simulate a zero-argument tool call
+    registerPendingInteraction(requestId, CONVERSATION_ID, zeroArgTool, {});
+
+    const result = await handleApprovalInterception({
+      conversationId: 'guardian-conv-2b',
+      callbackData: `apr:${requestId}:approve_once`,
+      content: '',
+      externalChatId: GUARDIAN_CHAT,
+      sourceChannel: 'telegram',
+      senderExternalUserId: GUARDIAN_USER,
+      replyCallbackUrl: 'https://gateway.test/deliver',
+      guardianCtx: makeGuardianContext(),
+      assistantId: ASSISTANT_ID,
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.type).toBe('guardian_decision_applied');
+
+    // A grant MUST be minted even though input is {}
+    expect(countGrants()).toBe(1);
+
+    const grant = getLatestGrant();
+    expect(grant).not.toBeNull();
+    expect(grant!.scope_mode).toBe('tool_signature');
+    expect(grant!.tool_name).toBe(zeroArgTool);
+    expect(grant!.status).toBe('active');
+
+    // Verify the input digest matches what computeToolApprovalDigest produces for empty input
+    const expectedDigest = computeToolApprovalDigest(zeroArgTool, {});
+    expect(grant!.input_digest).toBe(expectedDigest);
 
     deliverSpy.mockRestore();
     composeSpy.mockRestore();

--- a/assistant/src/__tests__/guardian-grant-minting.test.ts
+++ b/assistant/src/__tests__/guardian-grant-minting.test.ts
@@ -1,0 +1,501 @@
+/**
+ * Tests for M3: scoped grant minting on guardian tool-approval decisions.
+ *
+ * When a guardian approves a tool-approval request (one with toolName + input),
+ * the approval interception flow should mint a `tool_signature` scoped grant.
+ * Non-tool-approval requests and rejections must NOT mint grants.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Test isolation: in-memory SQLite via temp directory
+// ---------------------------------------------------------------------------
+
+const testDir = mkdtempSync(join(tmpdir(), 'guardian-grant-minting-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import type { Session } from '../daemon/session.js';
+import {
+  createApprovalRequest,
+  createBinding,
+  getAllPendingApprovalsByGuardianChat,
+  type GuardianApprovalRequest,
+} from '../memory/channel-guardian-store.js';
+import { initializeDb, resetDb } from '../memory/db.js';
+import * as scopedGrantStore from '../memory/scoped-approval-grants.js';
+import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
+import * as approvalMessageComposer from '../runtime/approval-message-composer.js';
+import * as gatewayClient from '../runtime/gateway-client.js';
+import * as pendingInteractions from '../runtime/pending-interactions.js';
+import {
+  handleApprovalInterception,
+  GRANT_TTL_MS,
+} from '../runtime/routes/guardian-approval-interception.js';
+import type { GuardianContext } from '../runtime/routes/channel-route-shared.js';
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ASSISTANT_ID = 'self';
+const GUARDIAN_USER = 'guardian-user-1';
+const GUARDIAN_CHAT = 'guardian-chat-1';
+const REQUESTER_USER = 'requester-user-1';
+const REQUESTER_CHAT = 'requester-chat-1';
+const CONVERSATION_ID = 'conv-1';
+const TOOL_NAME = 'execute_shell';
+const TOOL_INPUT = { command: 'rm -rf /tmp/test' };
+
+function resetTables(): void {
+  try {
+    const { getDb } = require('../memory/db.js');
+    const db = getDb();
+    db.run('DELETE FROM channel_guardian_approval_requests');
+    db.run('DELETE FROM scoped_approval_grants');
+  } catch { /* tables may not exist yet */ }
+  pendingInteractions.clear();
+}
+
+function createTestGuardianApproval(
+  requestId: string,
+  overrides: Partial<Parameters<typeof createApprovalRequest>[0]> = {},
+): GuardianApprovalRequest {
+  return createApprovalRequest({
+    runId: `run-${requestId}`,
+    requestId,
+    conversationId: CONVERSATION_ID,
+    assistantId: ASSISTANT_ID,
+    channel: 'telegram',
+    requesterExternalUserId: REQUESTER_USER,
+    requesterChatId: REQUESTER_CHAT,
+    guardianExternalUserId: GUARDIAN_USER,
+    guardianChatId: GUARDIAN_CHAT,
+    toolName: TOOL_NAME,
+    expiresAt: Date.now() + 300_000,
+    ...overrides,
+  });
+}
+
+function registerPendingInteraction(
+  requestId: string,
+  conversationId: string,
+  toolName: string,
+  input: Record<string, unknown> = TOOL_INPUT,
+): ReturnType<typeof mock> {
+  const handleConfirmationResponse = mock(() => {});
+  const mockSession = {
+    handleConfirmationResponse,
+  } as unknown as Session;
+
+  pendingInteractions.register(requestId, {
+    session: mockSession,
+    conversationId,
+    kind: 'confirmation',
+    confirmationDetails: {
+      toolName,
+      input,
+      riskLevel: 'high',
+      allowlistOptions: [
+        { label: 'test', description: 'test', pattern: 'test' },
+      ],
+      scopeOptions: [
+        { label: 'everywhere', scope: 'everywhere' },
+      ],
+    },
+  });
+
+  return handleConfirmationResponse;
+}
+
+function makeGuardianContext(): GuardianContext {
+  return {
+    actorRole: 'guardian',
+    denialReason: undefined,
+  };
+}
+
+function makeNonGuardianContext(): GuardianContext {
+  return {
+    actorRole: 'non-guardian',
+    denialReason: undefined,
+  };
+}
+
+function countGrants(): number {
+  try {
+    const { getDb } = require('../memory/db.js');
+    const db = getDb();
+    const row = db.$client.prepare('SELECT count(*) as cnt FROM scoped_approval_grants').get() as { cnt: number };
+    return row.cnt;
+  } catch {
+    return 0;
+  }
+}
+
+function getLatestGrant(): Record<string, unknown> | null {
+  try {
+    const { getDb } = require('../memory/db.js');
+    const db = getDb();
+    const row = db.$client.prepare('SELECT * FROM scoped_approval_grants ORDER BY created_at DESC LIMIT 1').get();
+    return (row as Record<string, unknown>) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('guardian grant minting on tool-approval decisions', () => {
+  let deliverSpy: ReturnType<typeof spyOn>;
+  let composeSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    resetTables();
+    deliverSpy = spyOn(gatewayClient, 'deliverChannelReply').mockResolvedValue(undefined);
+    composeSpy = spyOn(approvalMessageComposer, 'composeApprovalMessageGenerative')
+      .mockResolvedValue('test message');
+  });
+
+  // ── 1. approve_once via callback mints a grant ──
+
+  test('approve_once via callback for tool-approval request mints a scoped grant', async () => {
+    const requestId = 'req-grant-cb-1';
+    createTestGuardianApproval(requestId);
+    registerPendingInteraction(requestId, CONVERSATION_ID, TOOL_NAME, TOOL_INPUT);
+
+    const result = await handleApprovalInterception({
+      conversationId: 'guardian-conv-1',
+      callbackData: `apr:${requestId}:approve_once`,
+      content: '',
+      externalChatId: GUARDIAN_CHAT,
+      sourceChannel: 'telegram',
+      senderExternalUserId: GUARDIAN_USER,
+      replyCallbackUrl: 'https://gateway.test/deliver',
+      guardianCtx: makeGuardianContext(),
+      assistantId: ASSISTANT_ID,
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.type).toBe('guardian_decision_applied');
+
+    // Verify a grant was minted
+    expect(countGrants()).toBe(1);
+
+    const grant = getLatestGrant();
+    expect(grant).not.toBeNull();
+    expect(grant!.scope_mode).toBe('tool_signature');
+    expect(grant!.tool_name).toBe(TOOL_NAME);
+    expect(grant!.status).toBe('active');
+    expect(grant!.request_channel).toBe('telegram');
+    expect(grant!.decision_channel).toBe('telegram');
+    expect(grant!.guardian_external_user_id).toBe(GUARDIAN_USER);
+    expect(grant!.requester_external_user_id).toBe(REQUESTER_USER);
+    expect(grant!.conversation_id).toBe(CONVERSATION_ID);
+    expect(grant!.execution_channel).toBeNull();
+    expect(grant!.call_session_id).toBeNull();
+
+    // Verify the input digest matches what computeToolApprovalDigest produces
+    const expectedDigest = computeToolApprovalDigest(TOOL_NAME, TOOL_INPUT);
+    expect(grant!.input_digest).toBe(expectedDigest);
+
+    deliverSpy.mockRestore();
+    composeSpy.mockRestore();
+  });
+
+  // ── 2. approve_once for non-tool-approval does NOT mint a grant ──
+
+  test('approve_once for informational request (empty input) does NOT mint a grant', async () => {
+    const requestId = 'req-no-grant-1';
+    createTestGuardianApproval(requestId, { toolName: 'ask_guardian_question' });
+    // Register with empty input to simulate informational ASK_GUARDIAN
+    registerPendingInteraction(requestId, CONVERSATION_ID, 'ask_guardian_question', {});
+
+    const result = await handleApprovalInterception({
+      conversationId: 'guardian-conv-2',
+      callbackData: `apr:${requestId}:approve_once`,
+      content: '',
+      externalChatId: GUARDIAN_CHAT,
+      sourceChannel: 'telegram',
+      senderExternalUserId: GUARDIAN_USER,
+      replyCallbackUrl: 'https://gateway.test/deliver',
+      guardianCtx: makeGuardianContext(),
+      assistantId: ASSISTANT_ID,
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.type).toBe('guardian_decision_applied');
+
+    // No grant should have been minted
+    expect(countGrants()).toBe(0);
+
+    deliverSpy.mockRestore();
+    composeSpy.mockRestore();
+  });
+
+  // ── 3. reject does NOT mint a grant ──
+
+  test('reject decision does NOT mint a scoped grant', async () => {
+    const requestId = 'req-no-grant-rej';
+    createTestGuardianApproval(requestId);
+    registerPendingInteraction(requestId, CONVERSATION_ID, TOOL_NAME, TOOL_INPUT);
+
+    const result = await handleApprovalInterception({
+      conversationId: 'guardian-conv-3',
+      callbackData: `apr:${requestId}:reject`,
+      content: '',
+      externalChatId: GUARDIAN_CHAT,
+      sourceChannel: 'telegram',
+      senderExternalUserId: GUARDIAN_USER,
+      replyCallbackUrl: 'https://gateway.test/deliver',
+      guardianCtx: makeGuardianContext(),
+      assistantId: ASSISTANT_ID,
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.type).toBe('guardian_decision_applied');
+
+    // No grant should have been minted
+    expect(countGrants()).toBe(0);
+
+    deliverSpy.mockRestore();
+    composeSpy.mockRestore();
+  });
+
+  // ── 4. Identity mismatch remains fail-closed (no grant minted) ──
+
+  test('identity mismatch does NOT mint a grant and fails closed', async () => {
+    const requestId = 'req-mismatch-1';
+    createTestGuardianApproval(requestId);
+    registerPendingInteraction(requestId, CONVERSATION_ID, TOOL_NAME, TOOL_INPUT);
+
+    const result = await handleApprovalInterception({
+      conversationId: 'guardian-conv-4',
+      callbackData: `apr:${requestId}:approve_once`,
+      content: '',
+      externalChatId: GUARDIAN_CHAT,
+      sourceChannel: 'telegram',
+      senderExternalUserId: 'wrong-guardian-user',
+      replyCallbackUrl: 'https://gateway.test/deliver',
+      guardianCtx: makeGuardianContext(),
+      assistantId: ASSISTANT_ID,
+    });
+
+    expect(result.handled).toBe(true);
+    // Identity mismatch results in guardian_decision_applied (fail-closed, no actual decision applied)
+    expect(result.type).toBe('guardian_decision_applied');
+
+    // No grant should have been minted
+    expect(countGrants()).toBe(0);
+
+    deliverSpy.mockRestore();
+    composeSpy.mockRestore();
+  });
+
+  // ── 5. Stale/already-resolved request does NOT mint a grant ──
+
+  test('stale request (already resolved) does NOT mint a grant', async () => {
+    const requestId = 'req-stale-1';
+    // Create guardian approval but do NOT register a pending interaction
+    // This simulates the pending interaction being already resolved
+    createTestGuardianApproval(requestId);
+
+    const result = await handleApprovalInterception({
+      conversationId: 'guardian-conv-5',
+      callbackData: `apr:${requestId}:approve_once`,
+      content: '',
+      externalChatId: GUARDIAN_CHAT,
+      sourceChannel: 'telegram',
+      senderExternalUserId: GUARDIAN_USER,
+      replyCallbackUrl: 'https://gateway.test/deliver',
+      guardianCtx: makeGuardianContext(),
+      assistantId: ASSISTANT_ID,
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.type).toBe('stale_ignored');
+
+    // No grant should have been minted
+    expect(countGrants()).toBe(0);
+
+    deliverSpy.mockRestore();
+    composeSpy.mockRestore();
+  });
+
+  // ── 6. approve_once via conversation engine mints a grant ──
+
+  test('approve_once via conversation engine mints a scoped grant', async () => {
+    const requestId = 'req-grant-eng-1';
+    createTestGuardianApproval(requestId);
+    registerPendingInteraction(requestId, CONVERSATION_ID, TOOL_NAME, TOOL_INPUT);
+
+    const mockGenerator = async () => ({
+      disposition: 'approve_once' as const,
+      replyText: 'Approved!',
+      targetRequestId: requestId,
+    });
+
+    const result = await handleApprovalInterception({
+      conversationId: 'guardian-conv-6',
+      content: 'yes, approve it',
+      externalChatId: GUARDIAN_CHAT,
+      sourceChannel: 'telegram',
+      senderExternalUserId: GUARDIAN_USER,
+      replyCallbackUrl: 'https://gateway.test/deliver',
+      guardianCtx: makeGuardianContext(),
+      assistantId: ASSISTANT_ID,
+      approvalConversationGenerator: mockGenerator,
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.type).toBe('guardian_decision_applied');
+
+    // Verify a grant was minted
+    expect(countGrants()).toBe(1);
+
+    const grant = getLatestGrant();
+    expect(grant).not.toBeNull();
+    expect(grant!.scope_mode).toBe('tool_signature');
+    expect(grant!.tool_name).toBe(TOOL_NAME);
+    expect(grant!.status).toBe('active');
+
+    deliverSpy.mockRestore();
+    composeSpy.mockRestore();
+  });
+
+  // ── 7. reject via conversation engine does NOT mint a grant ──
+
+  test('reject via conversation engine does NOT mint a grant', async () => {
+    const requestId = 'req-no-grant-eng-rej';
+    createTestGuardianApproval(requestId);
+    registerPendingInteraction(requestId, CONVERSATION_ID, TOOL_NAME, TOOL_INPUT);
+
+    const mockGenerator = async () => ({
+      disposition: 'reject' as const,
+      replyText: 'Denied.',
+      targetRequestId: requestId,
+    });
+
+    const result = await handleApprovalInterception({
+      conversationId: 'guardian-conv-7',
+      content: 'no, deny it',
+      externalChatId: GUARDIAN_CHAT,
+      sourceChannel: 'telegram',
+      senderExternalUserId: GUARDIAN_USER,
+      replyCallbackUrl: 'https://gateway.test/deliver',
+      guardianCtx: makeGuardianContext(),
+      assistantId: ASSISTANT_ID,
+      approvalConversationGenerator: mockGenerator,
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.type).toBe('guardian_decision_applied');
+
+    // No grant should have been minted
+    expect(countGrants()).toBe(0);
+
+    deliverSpy.mockRestore();
+    composeSpy.mockRestore();
+  });
+
+  // ── 8. approve_once via legacy parser mints a grant ──
+
+  test('approve_once via legacy parser mints a scoped grant', async () => {
+    const requestId = 'req-grant-leg-1';
+    createTestGuardianApproval(requestId);
+    registerPendingInteraction(requestId, CONVERSATION_ID, TOOL_NAME, TOOL_INPUT);
+
+    // No approvalConversationGenerator => legacy parser path
+    const result = await handleApprovalInterception({
+      conversationId: 'guardian-conv-8',
+      content: 'yes',
+      externalChatId: GUARDIAN_CHAT,
+      sourceChannel: 'telegram',
+      senderExternalUserId: GUARDIAN_USER,
+      replyCallbackUrl: 'https://gateway.test/deliver',
+      guardianCtx: makeGuardianContext(),
+      assistantId: ASSISTANT_ID,
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.type).toBe('guardian_decision_applied');
+
+    // Verify a grant was minted
+    expect(countGrants()).toBe(1);
+
+    const grant = getLatestGrant();
+    expect(grant).not.toBeNull();
+    expect(grant!.scope_mode).toBe('tool_signature');
+    expect(grant!.tool_name).toBe(TOOL_NAME);
+
+    deliverSpy.mockRestore();
+    composeSpy.mockRestore();
+  });
+
+  // ── 9. Grant TTL is approximately 5 minutes ──
+
+  test('minted grant has approximately 5-minute TTL', async () => {
+    const requestId = 'req-grant-ttl-1';
+    createTestGuardianApproval(requestId);
+    registerPendingInteraction(requestId, CONVERSATION_ID, TOOL_NAME, TOOL_INPUT);
+
+    const beforeTime = Date.now();
+
+    const result = await handleApprovalInterception({
+      conversationId: 'guardian-conv-9',
+      callbackData: `apr:${requestId}:approve_once`,
+      content: '',
+      externalChatId: GUARDIAN_CHAT,
+      sourceChannel: 'telegram',
+      senderExternalUserId: GUARDIAN_USER,
+      replyCallbackUrl: 'https://gateway.test/deliver',
+      guardianCtx: makeGuardianContext(),
+      assistantId: ASSISTANT_ID,
+    });
+
+    expect(result.type).toBe('guardian_decision_applied');
+
+    const grant = getLatestGrant();
+    expect(grant).not.toBeNull();
+
+    const expiresAt = new Date(grant!.expires_at as string).getTime();
+    const expectedMin = beforeTime + GRANT_TTL_MS - 1000; // 1s tolerance
+    const expectedMax = beforeTime + GRANT_TTL_MS + 5000;  // 5s tolerance
+    expect(expiresAt).toBeGreaterThanOrEqual(expectedMin);
+    expect(expiresAt).toBeLessThanOrEqual(expectedMax);
+
+    deliverSpy.mockRestore();
+    composeSpy.mockRestore();
+  });
+});

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -73,9 +73,11 @@ function tryMintToolApprovalGrant(params: {
 }): void {
   const { approvalInfo, approval, decisionChannel, guardianExternalUserId } = params;
 
-  // Only mint for tool-approval requests that have invocation input.
-  // Informational ASK_GUARDIAN requests won't have meaningful input to digest.
-  if (!approvalInfo.toolName || !approvalInfo.input || Object.keys(approvalInfo.input).length === 0) {
+  // Only mint for requests that carry a tool name — the presence of toolName
+  // distinguishes tool-approval requests from informational ones.
+  // computeToolApprovalDigest can deterministically hash {} so zero-argument
+  // tool invocations must still receive a grant.
+  if (!approvalInfo.toolName) {
     return;
   }
 

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -11,7 +11,9 @@ import {
   updateApprovalDecision,
   type GuardianApprovalRequest,
 } from '../../memory/channel-guardian-store.js';
+import { createScopedApprovalGrant } from '../../memory/scoped-approval-grants.js';
 import { emitNotificationSignal } from '../../notifications/emit-signal.js';
+import { computeToolApprovalDigest } from '../../security/tool-approval-digest.js';
 import { getLogger } from '../../util/logger.js';
 import { runApprovalConversationTurn } from '../approval-conversation-turn.js';
 import { composeApprovalMessageGenerative } from '../approval-message-composer.js';
@@ -23,6 +25,7 @@ import {
   getApprovalInfoByConversation,
   getChannelApprovalPrompt,
   handleChannelDecision,
+  type PendingApprovalInfo,
 } from '../channel-approvals.js';
 import { deliverChannelReply } from '../gateway-client.js';
 import type {
@@ -45,6 +48,66 @@ import {
 } from './channel-route-shared.js';
 
 const log = getLogger('runtime-http');
+
+/** TTL for scoped approval grants minted on guardian approve_once decisions. */
+export const GRANT_TTL_MS = 5 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Scoped grant minting on guardian tool-approval decisions
+// ---------------------------------------------------------------------------
+
+/**
+ * Mint a `tool_signature` scoped grant when a guardian approves a tool-approval
+ * request.  Only mints when the approval info contains a tool invocation with
+ * input (so we can compute the input digest).  Informational ASK_GUARDIAN
+ * requests that lack tool input are skipped.
+ *
+ * Fails silently on error — grant minting is best-effort and must never block
+ * the approval flow.
+ */
+function tryMintToolApprovalGrant(params: {
+  approvalInfo: PendingApprovalInfo;
+  approval: GuardianApprovalRequest;
+  decisionChannel: ChannelId;
+  guardianExternalUserId: string;
+}): void {
+  const { approvalInfo, approval, decisionChannel, guardianExternalUserId } = params;
+
+  // Only mint for tool-approval requests that have invocation input.
+  // Informational ASK_GUARDIAN requests won't have meaningful input to digest.
+  if (!approvalInfo.toolName || !approvalInfo.input || Object.keys(approvalInfo.input).length === 0) {
+    return;
+  }
+
+  try {
+    const inputDigest = computeToolApprovalDigest(approvalInfo.toolName, approvalInfo.input);
+
+    createScopedApprovalGrant({
+      assistantId: approval.assistantId,
+      scopeMode: 'tool_signature',
+      toolName: approvalInfo.toolName,
+      inputDigest,
+      requestChannel: approval.channel,
+      decisionChannel,
+      executionChannel: null,
+      conversationId: approval.conversationId,
+      callSessionId: null,
+      guardianExternalUserId,
+      requesterExternalUserId: approval.requesterExternalUserId,
+      expiresAt: new Date(Date.now() + GRANT_TTL_MS).toISOString(),
+    });
+
+    log.info(
+      { toolName: approvalInfo.toolName, conversationId: approval.conversationId },
+      'Minted scoped approval grant for guardian tool-approval decision',
+    );
+  } catch (err) {
+    log.error(
+      { err, toolName: approvalInfo.toolName, conversationId: approval.conversationId },
+      'Failed to mint scoped approval grant (non-fatal)',
+    );
+  }
+}
 
 export interface ApprovalInterceptionParams {
   conversationId: string;
@@ -207,6 +270,13 @@ export async function handleApprovalInterception(
           return accessResult;
         }
 
+        // Capture pending approval info before handleChannelDecision resolves
+        // (and removes) the pending interaction. Needed for grant minting.
+        const cbApprovalInfo = getApprovalInfoByConversation(guardianApproval.conversationId);
+        const cbMatchedInfo = callbackDecision.requestId
+          ? cbApprovalInfo.find(a => a.requestId === callbackDecision!.requestId)
+          : cbApprovalInfo[0];
+
         // Apply the decision to the underlying session using the requester's
         // conversation context
         const result = handleChannelDecision(
@@ -223,6 +293,16 @@ export async function handleApprovalInterception(
             status: approvalStatus,
             decidedByExternalUserId: senderExternalUserId,
           });
+
+          // Mint a scoped grant when a guardian approves a tool-approval request
+          if (callbackDecision.action !== 'reject' && cbMatchedInfo) {
+            tryMintToolApprovalGrant({
+              approvalInfo: cbMatchedInfo,
+              approval: guardianApproval,
+              decisionChannel: sourceChannel,
+              guardianExternalUserId: senderExternalUserId,
+            });
+          }
 
           // Notify the requester's chat about the outcome with the tool name
           const outcomeText = await composeApprovalMessageGenerative({
@@ -346,6 +426,13 @@ export async function handleApprovalInterception(
           ...(engineResult.targetRequestId ? { requestId: engineResult.targetRequestId } : {}),
         };
 
+        // Capture pending approval info before handleChannelDecision resolves
+        // (and removes) the pending interaction. Needed for grant minting.
+        const engineApprovalInfo = getApprovalInfoByConversation(targetApproval.conversationId);
+        const engineMatchedInfo = engineDecision.requestId
+          ? engineApprovalInfo.find(a => a.requestId === engineDecision.requestId)
+          : engineApprovalInfo[0];
+
         const result = handleChannelDecision(
           targetApproval.conversationId,
           engineDecision,
@@ -360,6 +447,16 @@ export async function handleApprovalInterception(
             status: approvalStatus,
             decidedByExternalUserId: senderExternalUserId,
           });
+
+          // Mint a scoped grant when a guardian approves a tool-approval request
+          if (decisionAction !== 'reject' && engineMatchedInfo) {
+            tryMintToolApprovalGrant({
+              approvalInfo: engineMatchedInfo,
+              approval: targetApproval,
+              decisionChannel: sourceChannel,
+              guardianExternalUserId: senderExternalUserId,
+            });
+          }
 
           // Notify the requester's chat about the outcome
           const outcomeText = await composeApprovalMessageGenerative({
@@ -492,6 +589,13 @@ export async function handleApprovalInterception(
             return accessResult;
           }
 
+          // Capture pending approval info before handleChannelDecision resolves
+          // (and removes) the pending interaction. Needed for grant minting.
+          const legacyApprovalInfo = getApprovalInfoByConversation(targetLegacyApproval.conversationId);
+          const legacyMatchedInfo = legacyGuardianDecision.requestId
+            ? legacyApprovalInfo.find(a => a.requestId === legacyGuardianDecision.requestId)
+            : legacyApprovalInfo[0];
+
           const result = handleChannelDecision(
             targetLegacyApproval.conversationId,
             legacyGuardianDecision,
@@ -503,6 +607,16 @@ export async function handleApprovalInterception(
               status: approvalStatus,
               decidedByExternalUserId: senderExternalUserId,
             });
+
+            // Mint a scoped grant when a guardian approves a tool-approval request
+            if (legacyGuardianDecision.action !== 'reject' && legacyMatchedInfo) {
+              tryMintToolApprovalGrant({
+                approvalInfo: legacyMatchedInfo,
+                approval: targetLegacyApproval,
+                decisionChannel: sourceChannel,
+                guardianExternalUserId: senderExternalUserId,
+              });
+            }
 
             // Notify the requester's chat about the outcome
             const outcomeText = await composeApprovalMessageGenerative({


### PR DESCRIPTION
Bridges channel-agnostic guardian approval decisions to scoped grant minting. When a guardian approves a tool-approval request (one with toolName+inputDigest metadata), a tool_signature scoped grant is minted. Non-tool-approval requests and rejections do not mint grants. Part of #10011. Closes #10015.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
