### PR TITLE
Skip approval prompt before final sweep in safe-blitz

### DIFF
--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -444,7 +444,7 @@ Proceed to step 4d.
 
 After all milestones are merged and their individual reviews are clean, run one final recursive sweep on the entire feature branch.
 
-Read and follow `.claude/phases/sweep.md` with `--namespace <namespace>`. Unless `--auto` was passed, this is where the user-facing pause happens: **"All milestones complete. Run final sweep for review feedback?"**
+Read and follow `.claude/phases/sweep.md` with `--namespace <namespace>`. **Always skip the approval prompt** — safe-blitz already has review gates on every milestone, so an extra pause before the final sweep is unnecessary. Behave as if `--auto` was always passed for this step, regardless of whether the user passed `--auto`.
 
 This final sweep catches:
 - Any cross-milestone issues that individual per-milestone feedback loops missed


### PR DESCRIPTION
## Summary
- Remove the approval pause before the final sweep in safe-blitz Phase 5
- Safe-blitz already has review gates on every milestone PR, so the extra "All milestones complete. Run final sweep for review feedback?" prompt is unnecessary friction
- The sweep now always runs automatically, behaving as if `--auto` was passed for this step

## Original prompt
in our safe-blitz command, do not bother asking for approval before performing the sweep for reviews on the feature branch towards the end. This one: "All milestones complete. Run final sweep for review feedback?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
