### PR TITLE
feat: add pulse animation to busy thread indicator with reduced-motion support

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -79,7 +79,7 @@ struct MainWindowView: View {
     let daemonClient: DaemonClient
     let surfaceManager: SurfaceManager
     let ambientAgent: AmbientAgent
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     let settingsStore: SettingsStore
     let authManager: AuthManager
     @ObservedObject var documentManager: DocumentManager
@@ -807,7 +807,7 @@ struct MainWindowView: View {
                 // to avoid nesting a Button inside this outer Button's label.
                 // When hovered, the amber dot swaps to the pin icon (and back on hover-out).
                 if isBusy {
-                    VBusyIndicator(reduceMotion: reduceMotion)
+                    VBusyIndicator()
                         .frame(width: 20, height: 20)
                 } else if thread.hasUnseenLatestAssistantMessage && !isHovered {
                     Circle()

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -79,6 +79,7 @@ struct MainWindowView: View {
     let daemonClient: DaemonClient
     let surfaceManager: SurfaceManager
     let ambientAgent: AmbientAgent
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let settingsStore: SettingsStore
     let authManager: AuthManager
     @ObservedObject var documentManager: DocumentManager
@@ -806,8 +807,7 @@ struct MainWindowView: View {
                 // to avoid nesting a Button inside this outer Button's label.
                 // When hovered, the amber dot swaps to the pin icon (and back on hover-out).
                 if isBusy {
-                    ProgressView()
-                        .controlSize(.small)
+                    VBusyIndicator(reduceMotion: reduceMotion)
                         .frame(width: 20, height: 20)
                 } else if thread.hasUnseenLatestAssistantMessage && !isHovered {
                     Circle()

--- a/clients/shared/DesignSystem/Core/Feedback/VBusyIndicator.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VBusyIndicator.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// A subtle pulsing indicator for busy/processing state.
+/// Displays a gentle opacity pulse when the assistant is actively working,
+/// and falls back to a static indicator when reduced motion is enabled.
+public struct VBusyIndicator: View {
+    public var size: CGFloat = 10
+    public var color: Color = VColor.accent
+    public var reduceMotion: Bool = false
+
+    @State private var isPulsing = false
+
+    public init(size: CGFloat = 10, color: Color = VColor.accent, reduceMotion: Bool = false) {
+        self.size = size
+        self.color = color
+        self.reduceMotion = reduceMotion
+    }
+
+    public var body: some View {
+        Circle()
+            .fill(color)
+            .frame(width: size, height: size)
+            .opacity(reduceMotion ? 1.0 : (isPulsing ? 0.3 : 1.0))
+            .scaleEffect(reduceMotion ? 1.0 : (isPulsing ? 0.85 : 1.0))
+            .animation(
+                reduceMotion
+                    ? nil
+                    : .easeInOut(duration: 1.0).repeatForever(autoreverses: true),
+                value: isPulsing
+            )
+            .onAppear {
+                if !reduceMotion {
+                    isPulsing = true
+                }
+            }
+            .onDisappear {
+                isPulsing = false
+            }
+    }
+}
+
+#Preview("VBusyIndicator") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VStack(spacing: 24) {
+            HStack(spacing: 24) {
+                VBusyIndicator(size: 8)
+                VBusyIndicator()
+                VBusyIndicator(size: 14)
+                VBusyIndicator(color: VColor.success)
+            }
+            HStack(spacing: 24) {
+                Text("Reduced motion:")
+                    .foregroundColor(VColor.textPrimary)
+                VBusyIndicator(reduceMotion: true)
+            }
+        }
+        .padding()
+    }
+    .frame(width: 350, height: 150)
+}

--- a/clients/shared/DesignSystem/Core/Feedback/VBusyIndicator.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VBusyIndicator.swift
@@ -6,14 +6,13 @@ import SwiftUI
 public struct VBusyIndicator: View {
     public var size: CGFloat = 10
     public var color: Color = VColor.accent
-    public var reduceMotion: Bool = false
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isPulsing = false
 
-    public init(size: CGFloat = 10, color: Color = VColor.accent, reduceMotion: Bool = false) {
+    public init(size: CGFloat = 10, color: Color = VColor.accent) {
         self.size = size
         self.color = color
-        self.reduceMotion = reduceMotion
     }
 
     public var body: some View {
@@ -36,6 +35,9 @@ public struct VBusyIndicator: View {
             .onDisappear {
                 isPulsing = false
             }
+            .onChange(of: reduceMotion) {
+                isPulsing = !reduceMotion
+            }
     }
 }
 
@@ -52,10 +54,12 @@ public struct VBusyIndicator: View {
             HStack(spacing: 24) {
                 Text("Reduced motion:")
                     .foregroundColor(VColor.textPrimary)
-                VBusyIndicator(reduceMotion: true)
+                Text("(reads @Environment automatically)")
+                    .foregroundColor(VColor.textSecondary)
+                    .font(VFont.caption)
             }
         }
         .padding()
     }
-    .frame(width: 350, height: 150)
+    .frame(width: 450, height: 150)
 }

--- a/clients/shared/DesignSystem/Core/Feedback/VLoadingIndicator.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VLoadingIndicator.swift
@@ -5,6 +5,7 @@ public struct VLoadingIndicator: View {
     public var color: Color = VColor.accent
 
     @State private var isAnimating = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     public init(size: CGFloat = 20, color: Color = VColor.accent) {
         self.size = size
@@ -16,13 +17,17 @@ public struct VLoadingIndicator: View {
             .trim(from: 0, to: 0.7)
             .stroke(color, lineWidth: 2)
             .frame(width: size, height: size)
-            .rotationEffect(Angle(degrees: isAnimating ? 360 : 0))
+            .rotationEffect(Angle(degrees: reduceMotion ? 0 : (isAnimating ? 360 : 0)))
             .animation(
-                .linear(duration: 0.8).repeatForever(autoreverses: false),
+                reduceMotion
+                    ? nil
+                    : .linear(duration: 0.8).repeatForever(autoreverses: false),
                 value: isAnimating
             )
             .onAppear {
-                isAnimating = true
+                if !reduceMotion {
+                    isAnimating = true
+                }
             }
             .onDisappear {
                 isAnimating = false

--- a/clients/shared/DesignSystem/Core/Feedback/VLoadingIndicator.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VLoadingIndicator.swift
@@ -32,6 +32,9 @@ public struct VLoadingIndicator: View {
             .onDisappear {
                 isAnimating = false
             }
+            .onChange(of: reduceMotion) {
+                isAnimating = !reduceMotion
+            }
     }
 }
 

--- a/clients/shared/Features/Chat/TypingIndicatorView.swift
+++ b/clients/shared/Features/Chat/TypingIndicatorView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// (before the first token or tool call arrives).
 public struct TypingIndicatorView: View {
     @State private var animate = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     public init() {}
 
@@ -13,11 +14,13 @@ public struct TypingIndicatorView: View {
                 Circle()
                     .fill(VColor.textMuted)
                     .frame(width: 8, height: 8)
-                    .scaleEffect(animate ? 1.0 : 0.5)
+                    .scaleEffect(reduceMotion ? 1.0 : (animate ? 1.0 : 0.5))
                     .animation(
-                        .easeInOut(duration: 0.5)
-                            .repeatForever(autoreverses: true)
-                            .delay(Double(index) * 0.18),
+                        reduceMotion
+                            ? nil
+                            : .easeInOut(duration: 0.5)
+                                .repeatForever(autoreverses: true)
+                                .delay(Double(index) * 0.18),
                         value: animate
                     )
             }
@@ -29,7 +32,9 @@ public struct TypingIndicatorView: View {
                 .fill(VColor.surface)
         )
         .onAppear {
-            animate = true
+            if !reduceMotion {
+                animate = true
+            }
         }
         .onDisappear {
             animate = false

--- a/clients/shared/Features/Chat/TypingIndicatorView.swift
+++ b/clients/shared/Features/Chat/TypingIndicatorView.swift
@@ -39,6 +39,9 @@ public struct TypingIndicatorView: View {
         .onDisappear {
             animate = false
         }
+        .onChange(of: reduceMotion) {
+            animate = !reduceMotion
+        }
     }
 }
 


### PR DESCRIPTION
Add a subtle pulse animation to the thread sidebar busy indicator. When the assistant is actively processing, the indicator gently pulses. When reduced motion is enabled in accessibility settings, a static indicator is shown instead. Stops automatically when idle.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
