### PR TITLE
Remove defunct --auto flag from safe-blitz

### DIFF
--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -10,7 +10,6 @@ If `$ARGUMENTS` is empty, stop and tell the user to provide a feature descriptio
 
 Extract these flags from `$ARGUMENTS` before treating the remainder as the feature description:
 
-- `--auto` — skip the pause between rounds (default: pause and ask before sweep)
 - `--workers N` — parallel worker count for swarm phases (default: 12)
 - `--skip-plan` — skip planning; use issues already in the "Ready" column of the GH project
 - `--branch NAME` — custom feature branch name (default: auto-generated from feature description as `feature/<kebab-case-summary>`)
@@ -444,7 +443,7 @@ Proceed to step 4d.
 
 After all milestones are merged and their individual reviews are clean, run one final recursive sweep on the entire feature branch.
 
-Read and follow `.claude/phases/sweep.md` with `--namespace <namespace>`. **Always skip the approval prompt** — safe-blitz already has review gates on every milestone, so an extra pause before the final sweep is unnecessary. Behave as if `--auto` was always passed for this step, regardless of whether the user passed `--auto`.
+Read and follow `.claude/phases/sweep.md` with `--namespace <namespace>` and `--auto`. Safe-blitz already has review gates on every milestone, so an extra pause before the final sweep is unnecessary.
 
 This final sweep catches:
 - Any cross-milestone issues that individual per-milestone feedback loops missed


### PR DESCRIPTION
## Summary
- Remove `--auto` from safe-blitz's parsed flags since it's now a no-op
- The final sweep approval prompt was removed in #10056, so `--auto` no longer controls anything
- Phase 5 now passes `--auto` directly to sweep.md instead of relying on a user-facing flag

## Original prompt
Remove the --auto flag from safe-blitz.md. It's now a no-op since the final sweep approval prompt was removed. Remove the flag from the parsing section and any remaining references to it in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
