### PR TITLE
fix: re-throw aggregate FTS reconciliation failures

### DIFF
--- a/assistant/src/memory/fts-reconciler.ts
+++ b/assistant/src/memory/fts-reconciler.ts
@@ -84,6 +84,7 @@ function reconcileTable(opts: {
  */
 export function reconcileFtsIndexes(): FtsReconciliationResult[] {
   const results: FtsReconciliationResult[] = [];
+  const errors: unknown[] = [];
 
   // memory_segment_fts tracks memory_segments
   try {
@@ -103,6 +104,7 @@ export function reconcileFtsIndexes(): FtsReconciliationResult[] {
     }
   } catch (err) {
     log.error({ err }, 'Failed to reconcile memory_segment_fts');
+    errors.push(err);
   }
 
   // messages_fts tracks messages
@@ -123,6 +125,11 @@ export function reconcileFtsIndexes(): FtsReconciliationResult[] {
     }
   } catch (err) {
     log.error({ err }, 'Failed to reconcile messages_fts');
+    errors.push(err);
+  }
+
+  if (errors.length > 0) {
+    throw new AggregateError(errors, `FTS reconciliation failed for ${errors.length} table(s)`);
   }
 
   return results;


### PR DESCRIPTION
Address Codex P2 feedback on PR #10039: preserve per-table isolation in reconcileFtsIndexes() but re-throw an aggregate error after both tables are attempted so the job worker sees a failure and can retry.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
