### PR TITLE
fix: handle dangling symlinks in bulletin atomic write

### DIFF
--- a/assistant/src/config/update-bulletin.ts
+++ b/assistant/src/config/update-bulletin.ts
@@ -21,10 +21,17 @@ function atomicWriteFileSync(filePath: string, content: string): void {
   const tmpPath = `${filePath}.tmp.${process.pid}`;
   try {
     writeFileSync(tmpPath, content, 'utf-8');
-    // Resolve symlinks so we rename to the real target, preserving the link
-    const targetPath = lstatSync(filePath, { throwIfNoEntry: false })?.isSymbolicLink()
-      ? realpathSync(filePath)
-      : filePath;
+    // Resolve symlinks so we rename to the real target, preserving the link.
+    // If the symlink is dangling (target doesn't exist), fall back to writing
+    // through the symlink path directly — realpathSync throws ENOENT for dangling links.
+    let targetPath = filePath;
+    try {
+      if (lstatSync(filePath, { throwIfNoEntry: false })?.isSymbolicLink()) {
+        targetPath = realpathSync(filePath);
+      }
+    } catch {
+      // Dangling symlink — fall back to writing through the symlink path
+    }
     renameSync(tmpPath, targetPath);
   } catch (err) {
     try {


### PR DESCRIPTION
Address Codex P2 + Devin feedback on PR #10042: wrap realpathSync in try/catch so dangling symlinks fall back to writing through the symlink path instead of crashing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
