### PR TITLE
fix: update sandbox default test to match new enabled-by-default behavior

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -2739,7 +2739,7 @@ describe('Permission Checker', () => {
         const templates = getDefaultRuleTemplates();
         expect(Array.isArray(templates)).toBe(true);
         expect(templates.some((t) => t.id.includes('extra-'))).toBe(false);
-        expect(templates.some((t) => t.id === 'default:allow-bash-global')).toBe(false);
+        expect(templates.some((t) => t.id === 'default:allow-bash-global')).toBe(true);
       } finally {
         testConfig.skills = originalSkills;
         testConfig.sandbox = originalSandbox;


### PR DESCRIPTION
Address Devin feedback on PR #10044: update test assertion at checker.test.ts:2742 to expect sandbox rule present when sandbox config is {} (enabled defaults to true with !== false check).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
