### PR TITLE
fix: avoid killing unrelated processes via stale PID files in dev startup

### DIFF
--- a/assistant/src/cli/core-commands.ts
+++ b/assistant/src/cli/core-commands.ts
@@ -12,6 +12,7 @@ import { loadRawConfig } from '../config/loader.js';
 import { getConfig } from '../config/loader.js';
 import { hasSocketOverride,shouldAutoStartDaemon } from '../daemon/connection-policy.js';
 import {
+  cleanupPidFile,
   ensureDaemonRunning,
   getDaemonStatus,
   startDaemon,
@@ -110,13 +111,19 @@ export function registerDevCommand(program: Command): void {
     .description('Run the daemon in dev mode with auto-restart on file changes')
     .action(async () => {
       const status = await getDaemonStatus();
-      if (status.running || status.pid) {
+      if (status.running) {
         log.info('Stopping existing daemon...');
         const stopResult = await stopDaemon();
         if (!stopResult.stopped && stopResult.reason === 'stop_failed') {
           log.error('Failed to stop existing daemon — process survived SIGKILL');
           process.exit(1);
         }
+      } else if (status.pid) {
+        // PID file references a live process but the socket is unresponsive.
+        // The PID may have been reused by an unrelated process — only remove
+        // the stale PID file; never signal a process we cannot verify is ours.
+        log.info('Cleaning up stale PID file (socket unresponsive)...');
+        cleanupPidFile();
       }
 
       const mainPath = `${import.meta.dirname}/../daemon/main.ts`;

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -64,6 +64,7 @@ import { installShutdownHandlers } from './shutdown-handlers.js';
 // Re-export public API so existing consumers don't need to change imports
 export type { StopResult } from './daemon-control.js';
 export {
+  cleanupPidFile,
   ensureDaemonRunning,
   getDaemonStatus,
   isDaemonRunning,


### PR DESCRIPTION
Address Codex P1 feedback on PR #10049: only stop daemon when socket confirms it is running. When status.running is false but a stale PID exists, clean up the PID file instead of killing what may be an unrelated process.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
