### PR TITLE
fix: resolve actor isolation warnings in activation key observer

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1894,7 +1894,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.voiceInput?.restartKeyMonitors()
+            Task { @MainActor in
+                self?.voiceInput?.restartKeyMonitors()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Wrap `restartKeyMonitors()` call in `Task { @MainActor in }` to satisfy Swift strict concurrency checks for accessing `@MainActor`-isolated property and method from a `Sendable` closure.

## Original prompt
fix: resolve Swift actor isolation warnings in AppDelegate.swift activation key observer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
