### PR TITLE
M1: Add display_order column and extend SessionListResponse

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -547,6 +547,7 @@ export function handleSessionList(socket: net.Socket, ctx: HandlerContext, offse
   const conversationIds = conversations.map((c) => c.id);
   const bindings = externalConversationStore.getBindingsForConversations(conversationIds);
   const attentionStates = getAttentionStateByConversationIds(conversationIds);
+  const displayMetas = conversationStore.getDisplayMetaForConversations(conversationIds);
   ctx.send(socket, {
     type: 'session_list_response',
     sessions: conversations.map((c) => {
@@ -554,6 +555,7 @@ export function handleSessionList(socket: net.Socket, ctx: HandlerContext, offse
       const originChannel = parseChannelId(c.originChannel);
       const originInterface = parseInterfaceId(c.originInterface);
       const attn = attentionStates.get(c.id);
+      const displayMeta = displayMetas.get(c.id);
       const assistantAttention = attn ? {
         hasUnseenLatestAssistantMessage: attn.latestAssistantMessageAt != null &&
           (attn.lastSeenAssistantMessageAt == null || attn.lastSeenAssistantMessageAt < attn.latestAssistantMessageAt),
@@ -581,6 +583,8 @@ export function handleSessionList(socket: net.Socket, ctx: HandlerContext, offse
         ...(originChannel ? { conversationOriginChannel: originChannel } : {}),
         ...(originInterface ? { conversationOriginInterface: originInterface } : {}),
         ...(assistantAttention ? { assistantAttention } : {}),
+        ...(displayMeta?.displayOrder != null ? { displayOrder: displayMeta.displayOrder } : {}),
+        ...(displayMeta?.isPinned ? { isPinned: displayMeta.isPinned } : {}),
       };
     }),
     hasMore: offset + conversations.length < totalCount,

--- a/assistant/src/daemon/ipc-contract/sessions.ts
+++ b/assistant/src/daemon/ipc-contract/sessions.ts
@@ -213,7 +213,7 @@ export interface AssistantAttention {
 
 export interface SessionListResponse {
   type: 'session_list_response';
-  sessions: Array<{ id: string; title: string; createdAt?: number; updatedAt: number; threadType?: ThreadType; source?: string; channelBinding?: ChannelBinding; conversationOriginChannel?: ChannelId; conversationOriginInterface?: InterfaceId; assistantAttention?: AssistantAttention }>;
+  sessions: Array<{ id: string; title: string; createdAt?: number; updatedAt: number; threadType?: ThreadType; source?: string; channelBinding?: ChannelBinding; conversationOriginChannel?: ChannelId; conversationOriginInterface?: InterfaceId; assistantAttention?: AssistantAttention; displayOrder?: number; isPinned?: boolean }>;
   /** Whether more sessions exist beyond the returned page. */
   hasMore?: boolean;
 }

--- a/assistant/src/memory/conversation-display-order-migration.ts
+++ b/assistant/src/memory/conversation-display-order-migration.ts
@@ -1,0 +1,44 @@
+/**
+ * Runtime migration for display_order and is_pinned columns on the
+ * conversations table. Extracted into its own module to avoid circular
+ * dependencies between conversation-store.ts (which re-exports from
+ * conversation-queries.ts) and conversation-queries.ts (which needs
+ * the migration to run before ORDER BY display_order).
+ */
+
+import { getLogger } from '../util/logger.js';
+import { rawRun } from './db.js';
+
+const log = getLogger('conversation-store');
+
+function isDuplicateColumnError(err: unknown): boolean {
+  return err instanceof Error && /duplicate column name:/i.test(err.message);
+}
+
+function ensureDisplayOrderColumns(): void {
+  try {
+    rawRun('ALTER TABLE conversations ADD COLUMN display_order INTEGER');
+  } catch (err) {
+    if (!isDuplicateColumnError(err)) {
+      log.error({ err }, 'Failed to add display_order column');
+      throw err;
+    }
+  }
+  try {
+    rawRun('ALTER TABLE conversations ADD COLUMN is_pinned INTEGER DEFAULT 0');
+  } catch (err) {
+    if (!isDuplicateColumnError(err)) {
+      log.error({ err }, 'Failed to add is_pinned column');
+      throw err;
+    }
+  }
+}
+
+let displayOrderColumnsEnsured = false;
+
+export function ensureDisplayOrderMigration(): void {
+  if (!displayOrderColumnsEnsured) {
+    ensureDisplayOrderColumns();
+    displayOrderColumnsEnsured = true;
+  }
+}

--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -16,7 +16,7 @@ export function listConversations(limit?: number, includeBackground = false, off
     .select()
     .from(conversations)
     .where(where)
-    .orderBy(desc(conversations.updatedAt))
+    .orderBy(sql`display_order ASC NULLS LAST`, desc(conversations.updatedAt))
     .limit(limit ?? 100)
     .offset(offset);
   return query.all().map(parseConversation);

--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -4,12 +4,14 @@ import { getLogger } from '../util/logger.js';
 import { getDb, rawAll } from './db.js';
 import { parseConversation, parseMessage } from './conversation-crud.js';
 import type { ConversationRow, MessageRow } from './conversation-crud.js';
+import { ensureDisplayOrderMigration } from './conversation-display-order-migration.js';
 import { conversations, messages } from './schema.js';
 import { buildFtsMatchQuery } from './search/lexical.js';
 
 const log = getLogger('conversation-store');
 
 export function listConversations(limit?: number, includeBackground = false, offset = 0): ConversationRow[] {
+  ensureDisplayOrderMigration();
   const db = getDb();
   const where = includeBackground ? undefined : sql`${conversations.threadType} != 'background'`;
   const query = db

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -1,6 +1,8 @@
 // Re-export all conversation store functionality from focused sub-modules.
 // Existing imports from this file continue to work without changes.
 
+import { rawGet, rawRun } from './db.js';
+
 export {
   messageMetadataSchema,
   type MessageMetadata,
@@ -43,3 +45,107 @@ export {
   type ConversationSearchResult,
   searchConversations,
 } from './conversation-queries.js';
+
+// ---------------------------------------------------------------------------
+// Runtime migration: display_order and is_pinned columns
+// ---------------------------------------------------------------------------
+
+function ensureDisplayOrderColumns(): void {
+  try {
+    rawRun('ALTER TABLE conversations ADD COLUMN display_order INTEGER');
+  } catch {
+    // Column already exists — ignore the error
+  }
+  try {
+    rawRun('ALTER TABLE conversations ADD COLUMN is_pinned INTEGER DEFAULT 0');
+  } catch {
+    // Column already exists — ignore the error
+  }
+}
+
+let displayOrderColumnsEnsured = false;
+
+function ensureColumns(): void {
+  if (!displayOrderColumnsEnsured) {
+    ensureDisplayOrderColumns();
+    displayOrderColumnsEnsured = true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CRUD functions for display_order and is_pinned
+// ---------------------------------------------------------------------------
+
+export function getDisplayOrder(conversationId: string): number | null {
+  ensureColumns();
+  const row = rawGet<{ display_order: number | null }>(
+    'SELECT display_order FROM conversations WHERE id = ?',
+    conversationId,
+  );
+  return row?.display_order ?? null;
+}
+
+export function setDisplayOrder(conversationId: string, order: number | null): void {
+  ensureColumns();
+  rawRun(
+    'UPDATE conversations SET display_order = ? WHERE id = ?',
+    order,
+    conversationId,
+  );
+}
+
+export function batchSetDisplayOrders(
+  updates: Array<{ id: string; displayOrder: number | null; isPinned: boolean }>,
+): void {
+  ensureColumns();
+  for (const update of updates) {
+    rawRun(
+      'UPDATE conversations SET display_order = ?, is_pinned = ? WHERE id = ?',
+      update.displayOrder,
+      update.isPinned ? 1 : 0,
+      update.id,
+    );
+  }
+}
+
+export function setConversationPinned(conversationId: string, isPinned: boolean): void {
+  ensureColumns();
+  rawRun(
+    'UPDATE conversations SET is_pinned = ? WHERE id = ?',
+    isPinned ? 1 : 0,
+    conversationId,
+  );
+}
+
+export function getConversationDisplayMeta(
+  conversationId: string,
+): { displayOrder: number | null; isPinned: boolean } {
+  ensureColumns();
+  const row = rawGet<{ display_order: number | null; is_pinned: number | null }>(
+    'SELECT display_order, is_pinned FROM conversations WHERE id = ?',
+    conversationId,
+  );
+  return {
+    displayOrder: row?.display_order ?? null,
+    isPinned: (row?.is_pinned ?? 0) === 1,
+  };
+}
+
+export function getDisplayMetaForConversations(
+  conversationIds: string[],
+): Map<string, { displayOrder: number | null; isPinned: boolean }> {
+  ensureColumns();
+  const result = new Map<string, { displayOrder: number | null; isPinned: boolean }>();
+  if (conversationIds.length === 0) return result;
+  for (const id of conversationIds) {
+    const row = rawGet<{ display_order: number | null; is_pinned: number | null }>(
+      'SELECT display_order, is_pinned FROM conversations WHERE id = ?',
+      id,
+    );
+    result.set(id, {
+      displayOrder: row?.display_order ?? null,
+      isPinned: (row?.is_pinned ?? 0) === 1,
+    });
+  }
+  return result;
+}

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -2,6 +2,7 @@
 // Existing imports from this file continue to work without changes.
 
 import { rawGet, rawRun } from './db.js';
+import { ensureDisplayOrderMigration } from './conversation-display-order-migration.js';
 
 export {
   messageMetadataSchema,
@@ -46,38 +47,15 @@ export {
   searchConversations,
 } from './conversation-queries.js';
 
-// ---------------------------------------------------------------------------
-// Runtime migration: display_order and is_pinned columns
-// ---------------------------------------------------------------------------
-
-function ensureDisplayOrderColumns(): void {
-  try {
-    rawRun('ALTER TABLE conversations ADD COLUMN display_order INTEGER');
-  } catch {
-    // Column already exists — ignore the error
-  }
-  try {
-    rawRun('ALTER TABLE conversations ADD COLUMN is_pinned INTEGER DEFAULT 0');
-  } catch {
-    // Column already exists — ignore the error
-  }
-}
-
-let displayOrderColumnsEnsured = false;
-
-function ensureColumns(): void {
-  if (!displayOrderColumnsEnsured) {
-    ensureDisplayOrderColumns();
-    displayOrderColumnsEnsured = true;
-  }
-}
+// Re-export for backward compat — callers that imported ensureColumns from here
+export { ensureDisplayOrderMigration as ensureColumns } from './conversation-display-order-migration.js';
 
 // ---------------------------------------------------------------------------
 // CRUD functions for display_order and is_pinned
 // ---------------------------------------------------------------------------
 
 export function getDisplayOrder(conversationId: string): number | null {
-  ensureColumns();
+  ensureDisplayOrderMigration();
   const row = rawGet<{ display_order: number | null }>(
     'SELECT display_order FROM conversations WHERE id = ?',
     conversationId,
@@ -86,7 +64,7 @@ export function getDisplayOrder(conversationId: string): number | null {
 }
 
 export function setDisplayOrder(conversationId: string, order: number | null): void {
-  ensureColumns();
+  ensureDisplayOrderMigration();
   rawRun(
     'UPDATE conversations SET display_order = ? WHERE id = ?',
     order,
@@ -97,7 +75,7 @@ export function setDisplayOrder(conversationId: string, order: number | null): v
 export function batchSetDisplayOrders(
   updates: Array<{ id: string; displayOrder: number | null; isPinned: boolean }>,
 ): void {
-  ensureColumns();
+  ensureDisplayOrderMigration();
   for (const update of updates) {
     rawRun(
       'UPDATE conversations SET display_order = ?, is_pinned = ? WHERE id = ?',
@@ -109,7 +87,7 @@ export function batchSetDisplayOrders(
 }
 
 export function setConversationPinned(conversationId: string, isPinned: boolean): void {
-  ensureColumns();
+  ensureDisplayOrderMigration();
   rawRun(
     'UPDATE conversations SET is_pinned = ? WHERE id = ?',
     isPinned ? 1 : 0,
@@ -120,7 +98,7 @@ export function setConversationPinned(conversationId: string, isPinned: boolean)
 export function getConversationDisplayMeta(
   conversationId: string,
 ): { displayOrder: number | null; isPinned: boolean } {
-  ensureColumns();
+  ensureDisplayOrderMigration();
   const row = rawGet<{ display_order: number | null; is_pinned: number | null }>(
     'SELECT display_order, is_pinned FROM conversations WHERE id = ?',
     conversationId,
@@ -134,7 +112,7 @@ export function getConversationDisplayMeta(
 export function getDisplayMetaForConversations(
   conversationIds: string[],
 ): Map<string, { displayOrder: number | null; isPinned: boolean }> {
-  ensureColumns();
+  ensureDisplayOrderMigration();
   const result = new Map<string, { displayOrder: number | null; isPinned: boolean }>();
   if (conversationIds.length === 0) return result;
   for (const id of conversationIds) {

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -3802,8 +3802,10 @@ public struct IPCSessionListResponseSession: Codable, Sendable {
     public let conversationOriginInterface: String?
     /// Attention state metadata for a conversation's latest assistant message.
     public let assistantAttention: IPCAssistantAttention?
+    public let displayOrder: Double?
+    public let isPinned: Bool?
 
-    public init(id: String, title: String, createdAt: Int? = nil, updatedAt: Int, threadType: String? = nil, source: String? = nil, channelBinding: IPCChannelBinding? = nil, conversationOriginChannel: String? = nil, conversationOriginInterface: String? = nil, assistantAttention: IPCAssistantAttention? = nil) {
+    public init(id: String, title: String, createdAt: Int? = nil, updatedAt: Int, threadType: String? = nil, source: String? = nil, channelBinding: IPCChannelBinding? = nil, conversationOriginChannel: String? = nil, conversationOriginInterface: String? = nil, assistantAttention: IPCAssistantAttention? = nil, displayOrder: Double? = nil, isPinned: Bool? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -3814,6 +3816,8 @@ public struct IPCSessionListResponseSession: Codable, Sendable {
         self.conversationOriginChannel = conversationOriginChannel
         self.conversationOriginInterface = conversationOriginInterface
         self.assistantAttention = assistantAttention
+        self.displayOrder = displayOrder
+        self.isPinned = isPinned
     }
 }
 


### PR DESCRIPTION
Part of #10077. Adds display_order and is_pinned columns to conversations table via runtime migration, updates listConversations ordering, and extends SessionListResponse IPC type with displayOrder and isPinned fields.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
