### PR TITLE
M2: Update thread sidebar with distinct state icons

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -785,7 +785,7 @@ struct MainWindowView: View {
             }
         }()
         let isHovered = sidebar.isHoveredThread == thread.id
-        let isBusy = threadManager.isThreadBusy(thread.id)
+        let interactionState = threadManager.interactionState(for: thread.id)
         // Reserve trailing space when hovered for archive button overlay.
         let hasTrailingIcon = isHovered || sidebar.threadPendingDeletion == thread.id
         // Always reserve 20pt leading slot so text never shifts.
@@ -801,32 +801,44 @@ struct MainWindowView: View {
             }
         }) {
             HStack(spacing: VSpacing.xs) {
-                // Leading icon: spinner (busy) > amber unread dot > pin icon > spacer
+                // Leading icon: interaction state > idle fallback (unread dot > pin > spacer).
                 // The interactive pin button is in .overlay(alignment: .leading) below
                 // to avoid nesting a Button inside this outer Button's label.
                 // When hovered, the amber dot swaps to the pin icon (and back on hover-out).
-                if isBusy {
-                    ProgressView()
-                        .controlSize(.small)
+                switch interactionState {
+                case .processing:
+                    VBusyIndicator()
                         .frame(width: 20, height: 20)
-                } else if thread.hasUnseenLatestAssistantMessage && !isHovered {
-                    Circle()
-                        .fill(Color(hex: 0xE86B40))
-                        .frame(width: 6, height: 6)
+                case .waitingForInput:
+                    Image(systemName: "questionmark.circle.fill")
+                        .font(.system(size: 12))
+                        .foregroundColor(VColor.warning)
                         .frame(width: 20, height: 20)
-                        .transition(.opacity)
-                } else if isHovered || thread.isPinned {
-                    Image(systemName: thread.isPinned ? "pin.fill" : "pin")
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundColor(VColor.textMuted)
-                        .rotationEffect(.degrees(-45))
+                case .error:
+                    Image(systemName: "exclamationmark.circle.fill")
+                        .font(.system(size: 12))
+                        .foregroundColor(VColor.error)
                         .frame(width: 20, height: 20)
-                        .background(VColor.backgroundSubtle)
-                        .clipShape(Circle())
-                        .transition(.opacity)
-                } else {
-                    Color.clear
-                        .frame(width: 20, height: 20)
+                case .idle:
+                    if thread.hasUnseenLatestAssistantMessage && !isHovered {
+                        Circle()
+                            .fill(Color(hex: 0xE86B40))
+                            .frame(width: 6, height: 6)
+                            .frame(width: 20, height: 20)
+                            .transition(.opacity)
+                    } else if isHovered || thread.isPinned {
+                        Image(systemName: thread.isPinned ? "pin.fill" : "pin")
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundColor(VColor.textMuted)
+                            .rotationEffect(.degrees(-45))
+                            .frame(width: 20, height: 20)
+                            .background(VColor.backgroundSubtle)
+                            .clipShape(Circle())
+                            .transition(.opacity)
+                    } else {
+                        Color.clear
+                            .frame(width: 20, height: 20)
+                    }
                 }
                 if thread.kind == .private {
                     Image(systemName: "lock.fill")

--- a/clients/shared/DesignSystem/Core/Feedback/VBusyIndicator.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VBusyIndicator.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+/// A subtle pulsing indicator for busy/processing state.
+/// Displays a gentle opacity pulse when the assistant is actively working,
+/// and falls back to a static indicator when reduced motion is enabled.
+public struct VBusyIndicator: View {
+    public var size: CGFloat = 10
+    public var color: Color = VColor.accent
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isPulsing = false
+
+    public init(size: CGFloat = 10, color: Color = VColor.accent) {
+        self.size = size
+        self.color = color
+    }
+
+    public var body: some View {
+        Circle()
+            .fill(color)
+            .frame(width: size, height: size)
+            .opacity(reduceMotion ? 1.0 : (isPulsing ? 0.3 : 1.0))
+            .scaleEffect(reduceMotion ? 1.0 : (isPulsing ? 0.85 : 1.0))
+            .animation(
+                reduceMotion
+                    ? nil
+                    : .easeInOut(duration: 1.0).repeatForever(autoreverses: true),
+                value: isPulsing
+            )
+            .onAppear {
+                if !reduceMotion {
+                    isPulsing = true
+                }
+            }
+            .onDisappear {
+                isPulsing = false
+            }
+            .onChange(of: reduceMotion) {
+                isPulsing = !reduceMotion
+            }
+    }
+}
+
+#Preview("VBusyIndicator") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VStack(spacing: 24) {
+            HStack(spacing: 24) {
+                VBusyIndicator(size: 8)
+                VBusyIndicator()
+                VBusyIndicator(size: 14)
+                VBusyIndicator(color: VColor.success)
+            }
+            HStack(spacing: 24) {
+                Text("Reduced motion:")
+                    .foregroundColor(VColor.textPrimary)
+                Text("(reads @Environment automatically)")
+                    .foregroundColor(VColor.textSecondary)
+                    .font(VFont.caption)
+            }
+        }
+        .padding()
+    }
+    .frame(width: 450, height: 150)
+}


### PR DESCRIPTION
Replace the generic ProgressView spinner in the thread sidebar with state-specific icons: VBusyIndicator pulse for processing, question-mark for waiting-for-input, exclamation for error. Idle keeps existing behavior (unread dot/pin/spacer). Part of #10065.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
