### PR TITLE
M3: Add interaction-state indicator to active chat view

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -454,28 +454,37 @@ extension MainWindowView {
     var chatView: some View {
         if let viewModel = threadManager.activeViewModel {
             let activeThread = threadManager.activeThread
+            let interactionState: ThreadInteractionState = {
+                guard let id = threadManager.activeThreadId else { return .idle }
+                return threadManager.interactionState(for: id)
+            }()
 
-            ActiveChatViewWrapper(
-                viewModel: viewModel,
-                windowState: windowState,
-                daemonClient: daemonClient,
-                ambientAgent: ambientAgent,
-                settingsStore: settingsStore,
-                onMicrophoneToggle: onMicrophoneToggle,
-                isTemporaryChat: activeThread?.kind == .private,
-                threadId: threadManager.activeThreadId
-            )
-            .environment(\.conversationZoomScale, conversationZoomManager.zoomLevel)
-            .overlay(alignment: .top) {
-                if conversationZoomManager.showZoomIndicator {
-                    ZoomIndicatorView(percentage: conversationZoomManager.zoomPercentage, label: "Text")
-                        .transition(.move(edge: .top).combined(with: .opacity))
-                        .padding(.top, VSpacing.xl)
+            VStack(spacing: 0) {
+                ThreadStatusBar(state: interactionState)
+                    .animation(VAnimation.fast, value: interactionState)
+
+                ActiveChatViewWrapper(
+                    viewModel: viewModel,
+                    windowState: windowState,
+                    daemonClient: daemonClient,
+                    ambientAgent: ambientAgent,
+                    settingsStore: settingsStore,
+                    onMicrophoneToggle: onMicrophoneToggle,
+                    isTemporaryChat: activeThread?.kind == .private,
+                    threadId: threadManager.activeThreadId
+                )
+                .environment(\.conversationZoomScale, conversationZoomManager.zoomLevel)
+                .overlay(alignment: .top) {
+                    if conversationZoomManager.showZoomIndicator {
+                        ZoomIndicatorView(percentage: conversationZoomManager.zoomPercentage, label: "Text")
+                            .transition(.move(edge: .top).combined(with: .opacity))
+                            .padding(.top, VSpacing.xl)
+                    }
                 }
-            }
-            .animation(VAnimation.fast, value: conversationZoomManager.showZoomIndicator)
-            .overlay(alignment: .bottomTrailing) {
-                DemoOverlayView()
+                .animation(VAnimation.fast, value: conversationZoomManager.showZoomIndicator)
+                .overlay(alignment: .bottomTrailing) {
+                    DemoOverlayView()
+                }
             }
         }
     }

--- a/clients/shared/Features/Chat/ThreadStatusBar.swift
+++ b/clients/shared/Features/Chat/ThreadStatusBar.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+/// A compact, subtle status indicator that appears at the top of the active
+/// chat view when the thread is not idle. Shows a colored dot + label
+/// reflecting the current `ThreadInteractionState`.
+///
+/// Hidden when the state is `.idle` — slides in/out with `VAnimation.fast`.
+public struct ThreadStatusBar: View {
+    public let state: ThreadInteractionState
+
+    public init(state: ThreadInteractionState) {
+        self.state = state
+    }
+
+    public var body: some View {
+        if state != .idle {
+            HStack(spacing: VSpacing.xs) {
+                Circle()
+                    .fill(dotColor)
+                    .frame(width: 6, height: 6)
+
+                Text(label)
+                    .font(VFont.caption)
+                    .foregroundColor(labelColor)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(height: 24)
+            .padding(.horizontal, VSpacing.md)
+            .background(backgroundColor)
+            .transition(.opacity.combined(with: .move(edge: .top)))
+        }
+    }
+
+    // MARK: - Private
+
+    private var dotColor: Color {
+        switch state {
+        case .processing:
+            return VColor.accent
+        case .waitingForInput:
+            return VColor.warning
+        case .error:
+            return VColor.error
+        case .idle:
+            return .clear
+        }
+    }
+
+    private var labelColor: Color {
+        switch state {
+        case .processing:
+            return VColor.textSecondary
+        case .waitingForInput:
+            return VColor.warning
+        case .error:
+            return VColor.error
+        case .idle:
+            return .clear
+        }
+    }
+
+    private var label: String {
+        switch state {
+        case .processing:
+            return "Processing..."
+        case .waitingForInput:
+            return "Waiting for input"
+        case .error:
+            return "Error"
+        case .idle:
+            return ""
+        }
+    }
+
+    private var backgroundColor: Color {
+        switch state {
+        case .processing:
+            return VColor.accent.opacity(0.06)
+        case .waitingForInput:
+            return VColor.warning.opacity(0.06)
+        case .error:
+            return VColor.error.opacity(0.06)
+        case .idle:
+            return .clear
+        }
+    }
+}


### PR DESCRIPTION
Add a subtle status bar below the navigation toolbar that shows the current thread's interaction state: processing (accent dot), waiting for input (amber dot), or error (red dot). Hidden when idle. Complements existing TypingIndicator and error banner. Part of #10065.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
