### PR TITLE
Fix ThreadManager history guard dropping live updates for task-run and notification threads

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -201,6 +201,11 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         let thread = ThreadModel(title: title, sessionId: conversationId)
         let viewModel = makeViewModel()
         viewModel.sessionId = conversationId
+        // Mark history as loaded since this thread streams live — there is no
+        // prior history to fetch. Without this, handleAssistantMessageArrival
+        // would drop all live updates (unseen indicators, recency bumps) because
+        // the !isHistoryLoaded guard returns early.
+        viewModel.isHistoryLoaded = true
         // Start the message loop so the view model receives streamed messages
         viewModel.startMessageLoop()
 
@@ -228,6 +233,11 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         thread.hasUnseenLatestAssistantMessage = true
         let viewModel = makeViewModel()
         viewModel.sessionId = conversationId
+        // Mark history as loaded since this thread streams live — there is no
+        // prior history to fetch. Without this, handleAssistantMessageArrival
+        // would drop all live updates (unseen indicators, recency bumps) because
+        // the !isHistoryLoaded guard returns early.
+        viewModel.isHistoryLoaded = true
         // Start the message loop so the view model receives streamed messages
         viewModel.startMessageLoop()
 


### PR DESCRIPTION
## Summary
- Set `isHistoryLoaded = true` on ChatViewModels for task-run and notification threads at creation time
- These threads stream live via startMessageLoop() and have no prior history to fetch from the daemon
- Without this, the `!vm.isHistoryLoaded` guard in `handleAssistantMessageArrival` silently drops all live assistant updates, causing missed unread indicators and stale thread ordering

Note: The browser-relay Host header bypass (P2 #1) was already addressed by #10037 which is merged.

Addresses review feedback on #10038
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
