### PR TITLE
Fix notification thread history loading regression

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -233,11 +233,16 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         thread.hasUnseenLatestAssistantMessage = true
         let viewModel = makeViewModel()
         viewModel.sessionId = conversationId
-        // Mark history as loaded since this thread streams live — there is no
-        // prior history to fetch. Without this, handleAssistantMessageArrival
-        // would drop all live updates (unseen indicators, recency bumps) because
-        // the !isHistoryLoaded guard returns early.
-        viewModel.isHistoryLoaded = true
+        // Do NOT set isHistoryLoaded here — notification threads have a
+        // pre-existing seed message persisted by conversation-pairing before
+        // the notification_thread_created event is emitted. Leaving
+        // isHistoryLoaded false allows ThreadSessionRestorer.loadHistoryIfNeeded
+        // to fetch that seed message when the thread is first selected.
+        // The handleAssistantMessageArrival guard dropping updates is correct
+        // for notification threads because their content arrives via history
+        // load, not live streaming. Unread state is already set explicitly
+        // above (hasUnseenLatestAssistantMessage = true).
+
         // Start the message loop so the view model receives streamed messages
         viewModel.startMessageLoop()
 


### PR DESCRIPTION
## Summary
- Remove isHistoryLoaded=true from createNotificationThread — notification threads have a pre-existing seed message that must be loaded via history
- Keep isHistoryLoaded=true in createTaskRunThread — task-run threads stream live with no prior history

Addresses review feedback on #10086
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
