### PR TITLE
M4: Voice Consumer + Bug Closure

### DIFF
--- a/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
+++ b/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
@@ -482,4 +482,90 @@ describe('voice scoped grant consumer', () => {
       .all();
     expect(otherActive.length).toBe(1);
   });
+
+  test('grants with null callSessionId are revoked by conversationId', () => {
+    const db = getDb();
+    const testConversationId = 'conv-revoke-by-conversation';
+
+    // Simulate the guardian-approval-interception minting path which sets
+    // callSessionId: null but always sets conversationId
+    createScopedApprovalGrant(grantParams({
+      callSessionId: null,
+      conversationId: testConversationId,
+    }));
+    createScopedApprovalGrant(grantParams({
+      callSessionId: null,
+      conversationId: 'other-conversation',
+    }));
+
+    // Verify both grants are active
+    const allActive = db.select()
+      .from(scopedApprovalGrants)
+      .where(eq(scopedApprovalGrants.status, 'active'))
+      .all();
+    expect(allActive.length).toBe(2);
+
+    // callSessionId-based revocation should miss grants with null callSessionId
+    // because the filter matches on the column value, not NULL
+    const revokedByCallSession = revokeScopedApprovalGrantsForContext({ callSessionId: CALL_SESSION_ID });
+    expect(revokedByCallSession).toBe(0);
+
+    // conversationId-based revocation catches the grant
+    const revokedByConversation = revokeScopedApprovalGrantsForContext({ conversationId: testConversationId });
+    expect(revokedByConversation).toBe(1);
+
+    // The target conversation's grant should be revoked
+    const revokedAfter = db.select()
+      .from(scopedApprovalGrants)
+      .where(and(
+        eq(scopedApprovalGrants.conversationId, testConversationId),
+        eq(scopedApprovalGrants.status, 'revoked'),
+      ))
+      .all();
+    expect(revokedAfter.length).toBe(1);
+
+    // The other conversation's grant should still be active
+    const otherActive = db.select()
+      .from(scopedApprovalGrants)
+      .where(and(
+        eq(scopedApprovalGrants.conversationId, 'other-conversation'),
+        eq(scopedApprovalGrants.status, 'active'),
+      ))
+      .all();
+    expect(otherActive.length).toBe(1);
+  });
+
+  test('non-guardian with grant for different assistantId: auto-denied', async () => {
+    // Create a grant scoped to a different assistant
+    createScopedApprovalGrant(grantParams({
+      assistantId: 'other-assistant',
+    }));
+
+    const mockData = createMockSession();
+    setupBridgeDeps(() => mockData.session);
+
+    const guardianContext: GuardianRuntimeContext = {
+      sourceChannel: 'voice',
+      actorRole: 'non-guardian',
+      requesterExternalUserId: 'caller-123',
+    };
+
+    await startVoiceTurn({
+      conversationId: CONVERSATION_ID,
+      callSessionId: CALL_SESSION_ID,
+      content: 'test utterance',
+      assistantId: ASSISTANT_ID,
+      guardianContext,
+      isInbound: true,
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    const decision = mockData.getConfirmationDecision();
+    expect(decision).not.toBeNull();
+    expect(decision!.decision).toBe('deny');
+  });
 });

--- a/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
+++ b/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
@@ -1,0 +1,485 @@
+/**
+ * Tests for M4: voice consumer checks scoped grants before auto-denying
+ * non-guardian confirmation requests.
+ *
+ * Verifies:
+ *   1. A matching grant allows a non-guardian voice confirmation (exactly once).
+ *   2. No grant or mismatched grant still auto-denies.
+ *   3. Guardian auto-allow path remains unchanged.
+ *   4. Grants are revoked on call end (controller.destroy).
+ *   5. Second identical invocation after consume is denied (one-time use).
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, type Mock, mock, test } from 'bun:test';
+
+const testDir = mkdtempSync(join(tmpdir(), 'voice-scoped-grant-consumer-test-'));
+
+// ── Platform + logger mocks (must come before any source imports) ────
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  readHttpToken: () => null,
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  isDebug: () => false,
+  truncateForLog: (value: string) => value,
+}));
+
+// ── Config mock ─────────────────────────────────────────────────────
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    provider: 'anthropic',
+    providerOrder: ['anthropic'],
+    apiKeys: { anthropic: 'test-key' },
+    calls: {
+      enabled: true,
+      provider: 'twilio',
+      maxDurationSeconds: 12 * 60,
+      userConsultTimeoutSeconds: 90,
+      userConsultationTimeoutSeconds: 90,
+      silenceTimeoutSeconds: 30,
+      disclosure: { enabled: false, text: '' },
+      safety: { denyCategories: [] },
+      model: undefined,
+    },
+    memory: { enabled: false },
+  }),
+}));
+
+// ── Secret ingress mock ────────────────────────────────────────────
+
+mock.module('../security/secret-ingress.js', () => ({
+  checkIngressForSecrets: () => ({ blocked: false }),
+}));
+
+// ── Assistant event hub mock ───────────────────────────────────────
+
+mock.module('../runtime/assistant-event-hub.js', () => ({
+  assistantEventHub: {
+    publish: async () => {},
+  },
+}));
+
+mock.module('../runtime/assistant-event.js', () => ({
+  buildAssistantEvent: () => ({}),
+}));
+
+// ── Session runtime assembly mock ──────────────────────────────────
+
+mock.module('../daemon/session-runtime-assembly.js', () => ({
+  resolveChannelCapabilities: () => ({
+    supportsRichText: false,
+    supportsDynamicUi: false,
+    supportsVoiceInput: true,
+  }),
+}));
+
+
+// ── Import source modules after all mocks are registered ────────────
+
+import { and, eq } from 'drizzle-orm';
+
+import {
+  createScopedApprovalGrant,
+  type CreateScopedApprovalGrantParams,
+  revokeScopedApprovalGrantsForContext,
+} from '../memory/scoped-approval-grants.js';
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { conversations, scopedApprovalGrants } from '../memory/schema.js';
+import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
+import type { ServerMessage } from '../daemon/ipc-protocol.js';
+import { setVoiceBridgeDeps, startVoiceTurn } from '../calls/voice-session-bridge.js';
+import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+// ---------------------------------------------------------------------------
+// Mock session that triggers a confirmation_request on processMessage
+// ---------------------------------------------------------------------------
+
+const TOOL_NAME = 'execute_shell';
+const TOOL_INPUT = { command: 'rm -rf /tmp/test' };
+const ASSISTANT_ID = 'self';
+const CONVERSATION_ID = 'conv-voice-grant-test';
+const CALL_SESSION_ID = 'call-session-voice-grant-test';
+
+/**
+ * Create a mock session that, when runAgentLoop is called, emits a
+ * confirmation_request through the updateClient callback before completing.
+ */
+function createMockSession(opts?: {
+  confirmationRequestId?: string;
+  toolName?: string;
+  toolInput?: Record<string, unknown>;
+}) {
+  const requestId = opts?.confirmationRequestId ?? `req-${crypto.randomUUID()}`;
+  const toolName = opts?.toolName ?? TOOL_NAME;
+  const toolInput = opts?.toolInput ?? TOOL_INPUT;
+
+  let clientCallback: ((msg: ServerMessage) => void) | null = null;
+  let confirmationDecision: { requestId: string; decision: string; reason?: string } | null = null;
+
+  const session = {
+    isProcessing: () => false,
+    memoryPolicy: {},
+    setAssistantId: () => {},
+    setGuardianContext: () => {},
+    setCommandIntent: () => {},
+    setTurnChannelContext: () => {},
+    setChannelCapabilities: () => {},
+    setVoiceCallControlPrompt: () => {},
+    currentRequestId: requestId,
+    abort: () => {},
+    persistUserMessage: async () => 'msg-1',
+    updateClient: (cb: (msg: ServerMessage) => void, _reset?: boolean) => {
+      clientCallback = cb;
+    },
+    handleConfirmationResponse: (
+      reqId: string,
+      decision: string,
+      _pattern?: string,
+      _scope?: string,
+      reason?: string,
+    ) => {
+      confirmationDecision = { requestId: reqId, decision, reason };
+    },
+    handleSecretResponse: () => {},
+    runAgentLoop: async (
+      _content: string,
+      _messageId: string,
+      broadcastFn: (msg: ServerMessage) => void,
+    ) => {
+      // Emit a confirmation_request through the client callback
+      if (clientCallback) {
+        clientCallback({
+          type: 'confirmation_request',
+          requestId,
+          toolName,
+          input: toolInput,
+          riskLevel: 'medium',
+          allowlistOptions: [],
+          scopeOptions: [],
+        } as ServerMessage);
+      }
+      // Then complete the turn
+      broadcastFn({ type: 'message_complete' } as ServerMessage);
+    },
+  };
+
+  return {
+    session,
+    requestId,
+    getConfirmationDecision: () => confirmationDecision,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup: inject mock deps into voice-session-bridge
+// ---------------------------------------------------------------------------
+
+function setupBridgeDeps(sessionFactory: () => ReturnType<typeof createMockSession>['session']) {
+  let currentSession: ReturnType<typeof createMockSession>['session'] | null = null;
+  setVoiceBridgeDeps({
+    getOrCreateSession: async () => {
+      currentSession = sessionFactory();
+      return currentSession as any;
+    },
+    resolveAttachments: () => [],
+    deriveDefaultStrictSideEffects: () => true,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function clearTables(): void {
+  const db = getDb();
+  try { db.run('DELETE FROM scoped_approval_grants'); } catch { /* table may not exist */ }
+}
+
+function grantParams(overrides: Partial<CreateScopedApprovalGrantParams> = {}): CreateScopedApprovalGrantParams {
+  const futureExpiry = new Date(Date.now() + 60_000).toISOString();
+  return {
+    assistantId: ASSISTANT_ID,
+    scopeMode: 'tool_signature',
+    toolName: TOOL_NAME,
+    inputDigest: computeToolApprovalDigest(TOOL_NAME, TOOL_INPUT),
+    requestChannel: 'voice',
+    decisionChannel: 'telegram',
+    executionChannel: 'voice',
+    conversationId: CONVERSATION_ID,
+    callSessionId: CALL_SESSION_ID,
+    expiresAt: futureExpiry,
+    ...overrides,
+  };
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+describe('voice scoped grant consumer', () => {
+  beforeEach(() => {
+    clearTables();
+  });
+
+  test('non-guardian with matching grant: consumed and allowed', async () => {
+    // Create a matching grant
+    createScopedApprovalGrant(grantParams());
+
+    const mockData = createMockSession();
+    setupBridgeDeps(() => mockData.session);
+
+    const guardianContext: GuardianRuntimeContext = {
+      sourceChannel: 'voice',
+      actorRole: 'non-guardian',
+      requesterExternalUserId: 'caller-123',
+    };
+
+    const handle = await startVoiceTurn({
+      conversationId: CONVERSATION_ID,
+      callSessionId: CALL_SESSION_ID,
+      content: 'test utterance',
+      assistantId: ASSISTANT_ID,
+      guardianContext,
+      isInbound: true,
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    // Wait for the async agent loop to finish
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    const decision = mockData.getConfirmationDecision();
+    expect(decision).not.toBeNull();
+    expect(decision!.decision).toBe('allow');
+    expect(decision!.reason).toContain('scoped grant');
+  });
+
+  test('non-guardian without grant: auto-denied', async () => {
+    // No grant created
+
+    const mockData = createMockSession();
+    setupBridgeDeps(() => mockData.session);
+
+    const guardianContext: GuardianRuntimeContext = {
+      sourceChannel: 'voice',
+      actorRole: 'non-guardian',
+      requesterExternalUserId: 'caller-123',
+    };
+
+    const handle = await startVoiceTurn({
+      conversationId: CONVERSATION_ID,
+      callSessionId: CALL_SESSION_ID,
+      content: 'test utterance',
+      assistantId: ASSISTANT_ID,
+      guardianContext,
+      isInbound: true,
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    const decision = mockData.getConfirmationDecision();
+    expect(decision).not.toBeNull();
+    expect(decision!.decision).toBe('deny');
+    expect(decision!.reason).toContain('Permission denied');
+  });
+
+  test('non-guardian with mismatched tool name: auto-denied', async () => {
+    // Create a grant for a different tool
+    createScopedApprovalGrant(grantParams({
+      toolName: 'read_file',
+      inputDigest: computeToolApprovalDigest('read_file', TOOL_INPUT),
+    }));
+
+    const mockData = createMockSession();
+    setupBridgeDeps(() => mockData.session);
+
+    const guardianContext: GuardianRuntimeContext = {
+      sourceChannel: 'voice',
+      actorRole: 'non-guardian',
+    };
+
+    await startVoiceTurn({
+      conversationId: CONVERSATION_ID,
+      callSessionId: CALL_SESSION_ID,
+      content: 'test utterance',
+      assistantId: ASSISTANT_ID,
+      guardianContext,
+      isInbound: true,
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    const decision = mockData.getConfirmationDecision();
+    expect(decision).not.toBeNull();
+    expect(decision!.decision).toBe('deny');
+  });
+
+  test('guardian caller: auto-allowed regardless of grants', async () => {
+    // No grant needed — guardian should auto-allow
+
+    const mockData = createMockSession();
+    setupBridgeDeps(() => mockData.session);
+
+    const guardianContext: GuardianRuntimeContext = {
+      sourceChannel: 'voice',
+      actorRole: 'guardian',
+    };
+
+    await startVoiceTurn({
+      conversationId: CONVERSATION_ID,
+      callSessionId: CALL_SESSION_ID,
+      content: 'test utterance',
+      assistantId: ASSISTANT_ID,
+      guardianContext,
+      isInbound: true,
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    const decision = mockData.getConfirmationDecision();
+    expect(decision).not.toBeNull();
+    expect(decision!.decision).toBe('allow');
+    expect(decision!.reason).toContain('guardian voice call');
+  });
+
+  test('one-time use: second identical invocation after consume is denied', async () => {
+    // Create a single grant
+    createScopedApprovalGrant(grantParams());
+
+    // First invocation — should consume the grant and allow
+    const mockData1 = createMockSession({ confirmationRequestId: 'req-first' });
+    setupBridgeDeps(() => mockData1.session);
+
+    const guardianContext: GuardianRuntimeContext = {
+      sourceChannel: 'voice',
+      actorRole: 'non-guardian',
+      requesterExternalUserId: 'caller-123',
+    };
+
+    await startVoiceTurn({
+      conversationId: CONVERSATION_ID,
+      callSessionId: CALL_SESSION_ID,
+      content: 'first utterance',
+      assistantId: ASSISTANT_ID,
+      guardianContext,
+      isInbound: true,
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    const decision1 = mockData1.getConfirmationDecision();
+    expect(decision1).not.toBeNull();
+    expect(decision1!.decision).toBe('allow');
+
+    // Second invocation — grant already consumed, should deny
+    const mockData2 = createMockSession({ confirmationRequestId: 'req-second' });
+    setupBridgeDeps(() => mockData2.session);
+
+    await startVoiceTurn({
+      conversationId: CONVERSATION_ID,
+      callSessionId: CALL_SESSION_ID,
+      content: 'second utterance',
+      assistantId: ASSISTANT_ID,
+      guardianContext,
+      isInbound: true,
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    const decision2 = mockData2.getConfirmationDecision();
+    expect(decision2).not.toBeNull();
+    expect(decision2!.decision).toBe('deny');
+  });
+
+  test('grants revoked when revokeScopedApprovalGrantsForContext is called with callSessionId', () => {
+    const db = getDb();
+    const testCallSessionId = 'call-session-revoke-test';
+
+    // Create two grants: one for our call session, one for another
+    createScopedApprovalGrant(grantParams({ callSessionId: testCallSessionId }));
+    createScopedApprovalGrant(grantParams({ callSessionId: 'other-call-session' }));
+
+    // Verify both grants are active
+    const allActive = db.select()
+      .from(scopedApprovalGrants)
+      .where(eq(scopedApprovalGrants.status, 'active'))
+      .all();
+    expect(allActive.length).toBe(2);
+
+    // Revoke grants for the specific call session (simulates call end)
+    const revokedCount = revokeScopedApprovalGrantsForContext({ callSessionId: testCallSessionId });
+    expect(revokedCount).toBe(1);
+
+    // Only the target call session's grant should be revoked
+    const activeAfter = db.select()
+      .from(scopedApprovalGrants)
+      .where(and(
+        eq(scopedApprovalGrants.callSessionId, testCallSessionId),
+        eq(scopedApprovalGrants.status, 'active'),
+      ))
+      .all();
+    expect(activeAfter.length).toBe(0);
+
+    const revokedAfter = db.select()
+      .from(scopedApprovalGrants)
+      .where(and(
+        eq(scopedApprovalGrants.callSessionId, testCallSessionId),
+        eq(scopedApprovalGrants.status, 'revoked'),
+      ))
+      .all();
+    expect(revokedAfter.length).toBe(1);
+
+    // The other call session's grant should still be active
+    const otherActive = db.select()
+      .from(scopedApprovalGrants)
+      .where(and(
+        eq(scopedApprovalGrants.callSessionId, 'other-call-session'),
+        eq(scopedApprovalGrants.status, 'active'),
+      ))
+      .all();
+    expect(otherActive.length).toBe(1);
+  });
+});

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -15,6 +15,7 @@ import {
   getPendingRequestByCallSessionId,
   markTimedOutWithReason,
 } from '../memory/guardian-action-store.js';
+import { revokeScopedApprovalGrantsForContext } from '../memory/scoped-approval-grants.js';
 import { getLogger } from '../util/logger.js';
 import { getMaxCallDurationMs, getUserConsultationTimeoutMs, SILENCE_TIMEOUT_MS } from './call-constants.js';
 import { persistCallCompletionMessage } from './call-conversation-messages.js';
@@ -430,6 +431,17 @@ export class CallController {
     this.abortCurrentTurn();
     this.currentTurnPromise = null;
     unregisterCallController(this.callSessionId);
+
+    // Revoke any scoped approval grants bound to this call session
+    try {
+      const revoked = revokeScopedApprovalGrantsForContext({ callSessionId: this.callSessionId });
+      if (revoked > 0) {
+        log.info({ callSessionId: this.callSessionId, revokedCount: revoked }, 'Revoked scoped grants on call end');
+      }
+    } catch (err) {
+      log.warn({ err, callSessionId: this.callSessionId }, 'Failed to revoke scoped grants on call end');
+    }
+
     log.info({ callSessionId: this.callSessionId }, 'CallController destroyed');
   }
 
@@ -568,6 +580,7 @@ export class CallController {
         // Start the voice turn through the session bridge
         startVoiceTurn({
           conversationId: this.conversationId,
+          callSessionId: this.callSessionId,
           content,
           assistantId: this.assistantId,
           guardianContext: this.guardianContext ?? undefined,

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -432,11 +432,15 @@ export class CallController {
     this.currentTurnPromise = null;
     unregisterCallController(this.callSessionId);
 
-    // Revoke any scoped approval grants bound to this call session
+    // Revoke any scoped approval grants bound to this call session.
+    // Revoke by both callSessionId and conversationId because the
+    // guardian-approval-interception minting path sets callSessionId: null
+    // but always sets conversationId.
     try {
-      const revoked = revokeScopedApprovalGrantsForContext({ callSessionId: this.callSessionId });
+      let revoked = revokeScopedApprovalGrantsForContext({ callSessionId: this.callSessionId });
+      revoked += revokeScopedApprovalGrantsForContext({ conversationId: this.conversationId });
       if (revoked > 0) {
-        log.info({ callSessionId: this.callSessionId, revokedCount: revoked }, 'Revoked scoped grants on call end');
+        log.info({ callSessionId: this.callSessionId, conversationId: this.conversationId, revokedCount: revoked }, 'Revoked scoped grants on call end');
       }
     } catch (err) {
       log.warn({ err, callSessionId: this.callSessionId }, 'Failed to revoke scoped grants on call end');

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -490,9 +490,13 @@ export async function cancelCall(input: CancelCallInput): Promise<{ ok: true; se
   // Expire any pending questions so they don't linger
   expirePendingQuestions(callSessionId);
 
-  // Revoke any scoped approval grants bound to this call session
+  // Revoke any scoped approval grants bound to this call session.
+  // Revoke by both callSessionId and conversationId because the
+  // guardian-approval-interception minting path sets callSessionId: null
+  // but always sets conversationId.
   try {
     revokeScopedApprovalGrantsForContext({ callSessionId });
+    revokeScopedApprovalGrantsForContext({ conversationId: session.conversationId });
   } catch (err) {
     log.warn({ err, callSessionId }, 'Failed to revoke scoped grants on call cancel');
   }

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -13,6 +13,7 @@ import { getTwilioStatusCallbackUrl,getTwilioVoiceWebhookUrl } from '../inbound/
 import { getOrCreateConversation } from '../memory/conversation-key-store.js';
 import { queueGenerateConversationTitle } from '../memory/conversation-title-service.js';
 import { upsertBinding } from '../memory/external-conversation-store.js';
+import { revokeScopedApprovalGrantsForContext } from '../memory/scoped-approval-grants.js';
 import { isGuardian } from '../runtime/channel-guardian-service.js';
 import { getSecureKey } from '../security/secure-keys.js';
 import { getLogger } from '../util/logger.js';
@@ -488,6 +489,13 @@ export async function cancelCall(input: CancelCallInput): Promise<{ ok: true; se
 
   // Expire any pending questions so they don't linger
   expirePendingQuestions(callSessionId);
+
+  // Revoke any scoped approval grants bound to this call session
+  try {
+    revokeScopedApprovalGrantsForContext({ callSessionId });
+  } catch (err) {
+    log.warn({ err, callSessionId }, 'Failed to revoke scoped grants on call cancel');
+  }
 
   // Re-check final status: a concurrent transition (e.g. Twilio callback) may have
   // moved the session to a terminal state before our update, causing it to be skipped.

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -12,6 +12,7 @@ import type { ServerWebSocket } from 'bun';
 
 import { getConfig } from '../config/loader.js';
 import * as conversationStore from '../memory/conversation-store.js';
+import { revokeScopedApprovalGrantsForContext } from '../memory/scoped-approval-grants.js';
 import {
   getPendingChallenge,
   validateAndConsumeChallenge,
@@ -351,6 +352,14 @@ export class RelayConnection {
     }
 
     expirePendingQuestions(this.callSessionId);
+
+    // Revoke any scoped approval grants bound to this call session
+    try {
+      revokeScopedApprovalGrantsForContext({ callSessionId: this.callSessionId });
+    } catch (err) {
+      log.warn({ err, callSessionId: this.callSessionId }, 'Failed to revoke scoped grants on transport close');
+    }
+
     persistCallCompletionMessage(session.conversationId, this.callSessionId).catch((err) => {
       log.error({ err, conversationId: session.conversationId, callSessionId: this.callSessionId }, 'Failed to persist call completion message');
     });

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -353,9 +353,13 @@ export class RelayConnection {
 
     expirePendingQuestions(this.callSessionId);
 
-    // Revoke any scoped approval grants bound to this call session
+    // Revoke any scoped approval grants bound to this call session.
+    // Revoke by both callSessionId and conversationId because the
+    // guardian-approval-interception minting path sets callSessionId: null
+    // but always sets conversationId.
     try {
       revokeScopedApprovalGrantsForContext({ callSessionId: this.callSessionId });
+      revokeScopedApprovalGrantsForContext({ conversationId: session.conversationId });
     } catch (err) {
       log.warn({ err, callSessionId: this.callSessionId }, 'Failed to revoke scoped grants on transport close');
     }

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -350,6 +350,7 @@ export async function startVoiceTurn(opts: VoiceTurnOptions): Promise<VoiceTurnH
           toolName: msg.toolName,
           inputDigest,
           consumingRequestId: msg.requestId,
+          assistantId: opts.assistantId,
           executionChannel: 'voice',
           conversationId: opts.conversationId,
           callSessionId: opts.callSessionId,

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -18,7 +18,9 @@ import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.
 import { resolveChannelCapabilities } from '../daemon/session-runtime-assembly.js';
 import { buildAssistantEvent } from '../runtime/assistant-event.js';
 import { assistantEventHub } from '../runtime/assistant-event-hub.js';
+import { consumeScopedApprovalGrantByToolSignature } from '../memory/scoped-approval-grants.js';
 import { checkIngressForSecrets } from '../security/secret-ingress.js';
+import { computeToolApprovalDigest } from '../security/tool-approval-digest.js';
 import { IngressBlockedError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
 
@@ -81,6 +83,8 @@ export interface VoiceRunEventSink {
 export interface VoiceTurnOptions {
   /** The conversation ID for this voice call's session. */
   conversationId: string;
+  /** The call session ID for scoped grant matching. */
+  callSessionId?: string;
   /** The transcribed caller utterance or synthetic marker. */
   content: string;
   /** Assistant scope for multi-assistant channels. */
@@ -339,9 +343,38 @@ export async function startVoiceTurn(opts: VoiceTurnOptions): Promise<VoiceTurnH
   session.updateClient((msg: ServerMessage) => {
     if (msg.type === 'confirmation_request') {
       if (autoDeny) {
+        // Before auto-denying, check if a guardian from another channel
+        // has pre-approved this exact tool invocation via a scoped grant.
+        const inputDigest = computeToolApprovalDigest(msg.toolName, msg.input);
+        const consumeResult = consumeScopedApprovalGrantByToolSignature({
+          toolName: msg.toolName,
+          inputDigest,
+          consumingRequestId: msg.requestId,
+          executionChannel: 'voice',
+          conversationId: opts.conversationId,
+          callSessionId: opts.callSessionId,
+          requesterExternalUserId: opts.guardianContext?.requesterExternalUserId,
+        });
+
+        if (consumeResult.ok) {
+          log.info(
+            { turnId, toolName: msg.toolName, grantId: consumeResult.grant?.id },
+            'Consumed scoped grant — allowing non-guardian voice confirmation',
+          );
+          session.handleConfirmationResponse(
+            msg.requestId,
+            'allow',
+            undefined,
+            undefined,
+            `Permission approved for "${msg.toolName}": guardian pre-approved via scoped grant.`,
+          );
+          publishToHub(msg);
+          return;
+        }
+
         log.info(
           { turnId, toolName: msg.toolName },
-          'Auto-denying confirmation request for voice turn (forceStrictSideEffects)',
+          'Auto-denying confirmation request for voice turn (no matching scoped grant)',
         );
         session.handleConfirmationResponse(
           msg.requestId,

--- a/assistant/src/memory/scoped-approval-grants.ts
+++ b/assistant/src/memory/scoped-approval-grants.ts
@@ -202,6 +202,7 @@ export interface ConsumeByToolSignatureParams {
   inputDigest: string;
   consumingRequestId: string;
   /** Optional context constraints — only matched when the grant has a non-null value */
+  assistantId?: string;
   executionChannel?: string;
   conversationId?: string;
   callSessionId?: string;
@@ -239,6 +240,12 @@ export function consumeScopedApprovalGrantByToolSignature(
     eq(scopedApprovalGrants.status, 'active'),
     sql`${scopedApprovalGrants.expiresAt} > ${currentTime}`,
   ];
+
+  // assistantId is always set on grants — scope consumption to the current
+  // assistant so grants minted for one assistant cannot be consumed by another.
+  if (params.assistantId !== undefined) {
+    conditions.push(eq(scopedApprovalGrants.assistantId, params.assistantId));
+  }
 
   // Context constraints: grant field must be NULL (any) or match exactly
   if (params.executionChannel !== undefined) {


### PR DESCRIPTION
Implements voice consumer grant check: before auto-denying non-guardian confirmation requests, checks for and consumes matching scoped grants. Adds grant revocation on call end/cancel. Fixes the core bug where guardian approval from another channel was not honored in voice. Part of #10011. Closes #10016.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
