### PR TITLE
feat: add automated review feedback loop to safe-execute-plan

### DIFF
--- a/.claude/commands/safe-execute-plan.md
+++ b/.claude/commands/safe-execute-plan.md
@@ -130,6 +130,9 @@ Use this aggregate status in the feedback loop below.
 The `check-pr-reviews` script reports **cumulative** review status — it counts all reviews ever posted, not just unresolved ones. After fixes are pushed and threads are resolved, old reviews still exist in the GitHub API, so `check-pr-reviews` may still return `changes_requested` even though the feedback has been addressed. To avoid infinite loops, use the `last_fix_push_time` timestamp and the `gh api` to check whether any reviews were posted **after** that timestamp before treating `changes_requested` as actionable.
 
 1. **Check for reviews**: Poll `.claude/check-pr-reviews $PR_NUMBER` to get per-reviewer statuses. Derive the aggregate status (see above).
+
+   Before the first fix cycle, this initial poll loop is bounded: if reviewers do not respond within **15 minutes**, stop polling, log `"Timed out after 15 minutes waiting for initial reviews on PR #$PR_NUMBER. Proceeding."`, and proceed to Step 7.
+
    - If aggregate status is `pending`, wait 60 seconds and poll again.
    - If aggregate status is `rate_limited`, wait 120 seconds and poll again.
    - If aggregate status is `approved`, proceed to Step 7 (done).
@@ -181,12 +184,12 @@ The `check-pr-reviews` script reports **cumulative** review status — it counts
      # Union all logins across endpoints and count unique bots
      all_responded_bots=$(echo -e "$review_bot_logins\n$comment_bot_logins\n$issue_comment_bot_logins\n$reaction_bot_logins" | sort -u | grep -c .)
      ```
-     A reviewer bot counts as "responded" if its login appears in any of the four queries above. Both bots must have posted something new to consider the poll complete.
-   - If `all_responded_bots` is **>= 2** (both reviewer bots have posted new activity after `last_fix_push_time`), run `.claude/check-pr-reviews $PR_NUMBER` and derive the aggregate status:
+     A reviewer bot counts as "responded" if its login appears in any of the four queries above.
+   - If `all_responded_bots` is **>= 1** (at least one reviewer bot has posted new activity after `last_fix_push_time`), run `.claude/check-pr-reviews $PR_NUMBER` and derive the aggregate status:
      - If aggregate status is `approved`, proceed to Step 7.
      - If aggregate status is `changes_requested`, return to step 2 (which checks the cycle limit).
      - If aggregate status is `pending` or `rate_limited`, continue polling.
-   - If `all_responded_bots` is **< 2**, **continue polling** — do not exit the loop. Old cumulative statuses from `check-pr-reviews` are unreliable after fixes have been pushed.
+   - If `all_responded_bots` is **< 1**, **continue polling** — do not exit the loop. Old cumulative statuses from `check-pr-reviews` are unreliable after fixes have been pushed.
    - If **10 minutes** pass without both reviewer bots posting new activity, proceed to Step 7. Log: `"Timed out after 10 minutes waiting for reviewer responses. Proceeding with pending reviews."`
 
 Repeat steps 1-5 until the exit condition: either `approved` aggregate status, both reviewers have posted fresh activity, 10-minute timeout after a fix push, or the cycle counter has reached 3.

--- a/.claude/commands/safe-execute-plan.md
+++ b/.claude/commands/safe-execute-plan.md
@@ -183,18 +183,19 @@ The `check-pr-reviews` script reports **cumulative** review status — it counts
      # Get reviewer bot logins with new reactions after last_fix_push_time (e.g., Codex +1 approval)
      reaction_bot_logins=$(gh api "repos/{owner}/{repo}/issues/$PR_NUMBER/reactions" \
        --jq '[.[] | select(.created_at > "'$last_fix_push_time'" and (.user.login == "chatgpt-codex-connector[bot]" or .user.login == "devin-ai-integration[bot]"))] | [.[].user.login] | unique | .[]')
-     # Union all logins across endpoints and count unique bots
-     all_responded_bots=$(echo -e "$review_bot_logins\n$comment_bot_logins\n$issue_comment_bot_logins\n$reaction_bot_logins" | sort -u | grep -c .)
+     # Union all logins across endpoints into a set of responding bots and count
+     responded_bot_logins=$(printf "%s\n%s\n%s\n%s\n" "$review_bot_logins" "$comment_bot_logins" "$issue_comment_bot_logins" "$reaction_bot_logins" | sort -u | grep .)
+     all_responded_bots=$(echo "$responded_bot_logins" | grep -c .)
      ```
-     A reviewer bot counts as "responded" if its login appears in any of the four queries above.
-   - If `all_responded_bots` is **>= 1** (at least one reviewer bot has posted new activity after `last_fix_push_time`), run `.claude/check-pr-reviews $PR_NUMBER` and derive the aggregate status:
+     A reviewer bot counts as "responded" if its login appears in any of the four queries above. Collect all unique responding logins into `responded_bot_logins` (the set of bots that have posted new activity), and also compute `all_responded_bots` (the count).
+   - If `all_responded_bots` is **>= 1** (at least one reviewer bot has posted new activity after `last_fix_push_time`), run `.claude/check-pr-reviews $PR_NUMBER` and derive the aggregate status. **Important:** when the aggregate status would be `changes_requested`, verify that the bot with `changes_requested` is in `responded_bot_logins` — if it is not (meaning the `changes_requested` comes from a bot that has not yet responded to the new commit), treat the status as `pending` instead and continue polling.
      - If aggregate status is `approved`, proceed to Step 7.
-     - If aggregate status is `changes_requested`, return to step 2 (which checks the cycle limit).
-     - If aggregate status is `pending` or `rate_limited`, continue polling.
+     - If aggregate status is `changes_requested` **and the bot with `changes_requested` is in `responded_bot_logins`**, return to step 2 (which checks the cycle limit).
+     - Otherwise (`pending`, `rate_limited`, or `changes_requested` from a non-responding bot), continue polling.
    - If `all_responded_bots` is **< 1**, **continue polling** — do not exit the loop. Old cumulative statuses from `check-pr-reviews` are unreliable after fixes have been pushed.
-   - If **10 minutes** pass without both reviewer bots posting new activity, proceed to Step 7. Log: `"Timed out after 10 minutes waiting for reviewer responses. Proceeding with pending reviews."`
+   - If **10 minutes** pass without any reviewer bot posting new activity, proceed to Step 7. Log: `"Timed out after 10 minutes waiting for reviewer responses. Proceeding with pending reviews."`
 
-Repeat steps 1-5 until the exit condition: either `approved` aggregate status, both reviewers have posted fresh activity, 10-minute timeout after a fix push, or the cycle counter has reached 3.
+Repeat steps 1-5 until the exit condition: either `approved` aggregate status, actionable `changes_requested` from a freshly-responding bot, 10-minute timeout after a fix push, or the cycle counter has reached 3.
 
 #### Feedback agent prompt
 

--- a/.claude/commands/safe-execute-plan.md
+++ b/.claude/commands/safe-execute-plan.md
@@ -117,11 +117,13 @@ Repeat the following until the exit condition is met:
 
 **Determining aggregate review status from `check-pr-reviews` output:**
 
-The `check-pr-reviews` script returns **per-reviewer** statuses at `codex.status` and `devin.status` — there is no top-level `status` field. Derive an aggregate status as follows:
+The `check-pr-reviews` script returns **per-reviewer** statuses at `codex.status` and `devin.status` — there is no top-level `status` field. Derive an aggregate status as follows (higher entries take priority):
+- **changes_requested**: Either reviewer has `changes_requested`.
+- **pending**: Either reviewer is `pending` (and neither has `changes_requested`).
+- **rate_limited**: Either reviewer is `rate_limited` (and neither has `changes_requested` or `pending`).
 - **approved**: Both `codex.status` and `devin.status` are `approved` (or `skipped` for Devin).
-- **pending**: Either reviewer is `pending`.
-- **rate_limited**: Either reviewer is `rate_limited` (and the other is not `changes_requested`).
-- **changes_requested**: Either reviewer has `changes_requested` (and neither is `pending`).
+
+`changes_requested` always takes priority so that actionable feedback is never masked by a slow/pending reviewer.
 
 Use this aggregate status in the feedback loop below.
 

--- a/.claude/commands/safe-execute-plan.md
+++ b/.claude/commands/safe-execute-plan.md
@@ -83,11 +83,164 @@ Part of plan: <plan filename> (PR <X> of <total>)
   --track-unreviewed
 ```
 
+Record the PR number and head branch name for the review loop:
+
+```bash
+PR_NUMBER=<number printed by .claude/ship>
+PR_BRANCH=$(gh pr view $PR_NUMBER --json headRefName --jq '.headRefName')
+```
+
 ### 5. Human Attention Comment (optional)
 
 If the PR contains areas that genuinely warrant focused human review, leave a comment highlighting them (see "Human Attention Comments on PRs" in AGENTS.md). Skip this for routine, low-risk changes.
 
-### 6. Save state
+### 6. Automated review feedback loop
+
+After shipping, trigger reviews from Codex and Devin, then automatically address their feedback. This loop runs up to **3 cycles**.
+
+Maintain an internal **cycle counter** starting at 0, a **fix counter** for worktree naming (e.g., `fix-1`, `fix-2`, ...), and a `last_fix_push_time` timestamp.
+
+#### 6a. Trigger initial reviews
+
+Post two separate comments on the PR to invoke Codex and Devin:
+
+```bash
+gh pr comment $PR_NUMBER --body "@codex review"
+gh pr comment $PR_NUMBER --body "@devin review"
+```
+
+Log: `"Requested reviews from Codex and Devin on PR #$PR_NUMBER."`
+
+#### 6b. Feedback loop
+
+Repeat the following until the exit condition is met:
+
+**Determining aggregate review status from `check-pr-reviews` output:**
+
+The `check-pr-reviews` script returns **per-reviewer** statuses at `codex.status` and `devin.status` — there is no top-level `status` field. Derive an aggregate status as follows:
+- **approved**: Both `codex.status` and `devin.status` are `approved` (or `skipped` for Devin).
+- **pending**: Either reviewer is `pending`.
+- **rate_limited**: Either reviewer is `rate_limited` (and the other is not `changes_requested`).
+- **changes_requested**: Either reviewer has `changes_requested` (and neither is `pending`).
+
+Use this aggregate status in the feedback loop below.
+
+**Handling stale `changes_requested` from old reviews:**
+
+The `check-pr-reviews` script reports **cumulative** review status — it counts all reviews ever posted, not just unresolved ones. After fixes are pushed and threads are resolved, old reviews still exist in the GitHub API, so `check-pr-reviews` may still return `changes_requested` even though the feedback has been addressed. To avoid infinite loops, use the `last_fix_push_time` timestamp and the `gh api` to check whether any reviews were posted **after** that timestamp before treating `changes_requested` as actionable.
+
+1. **Check for reviews**: Poll `.claude/check-pr-reviews $PR_NUMBER` to get per-reviewer statuses. Derive the aggregate status (see above).
+   - If aggregate status is `pending`, wait 60 seconds and poll again.
+   - If aggregate status is `rate_limited`, wait 120 seconds and poll again.
+   - If aggregate status is `approved`, proceed to Step 7 (done).
+   - If aggregate status is `changes_requested`, proceed to step 2.
+
+2. **Check cycle limit**: If the cycle counter has reached 3, log: `"Reached maximum feedback cycles (3) for PR #$PR_NUMBER. Proceeding."` and proceed to Step 7.
+
+3. **Address the feedback**: Increment the cycle counter by 1.
+   a. Read the review comments to understand what's requested.
+   b. Create a worktree from the PR branch:
+      ```bash
+      .claude/worktree create safe-plan/<plan-slug>/<pr-slug>-fix-<counter> origin/$PR_BRANCH
+      ```
+   c. Spawn a `general-purpose` agent using the **feedback agent prompt** (see below). The agent pushes fixes directly to `$PR_BRANCH` instead of creating a new PR.
+   d. When the agent finishes, clean up the worktree:
+      ```bash
+      .claude/worktree remove safe-plan/<plan-slug>/<pr-slug>-fix-<counter> --delete-branch
+      ```
+   e. Fetch the updated PR branch and get the latest commit SHA:
+      ```bash
+      git fetch origin $PR_BRANCH
+      LATEST_COMMIT=$(git rev-parse origin/$PR_BRANCH)
+      ```
+   f. Record the current UTC time as `last_fix_push_time` (e.g., `date -u +%Y-%m-%dT%H:%M:%SZ`).
+
+4. **Re-request reviews**: After fixes are pushed, explicitly tag both reviewers to re-request their review by posting two separate comments on the PR:
+   ```bash
+   gh pr comment $PR_NUMBER --body "@codex review this PR again — the previous issues have been fixed in commit $LATEST_COMMIT"
+   gh pr comment $PR_NUMBER --body "@devin review this PR again — the previous issues have been fixed in commit $LATEST_COMMIT"
+   ```
+   Log: `"Re-requested reviews from Codex and Devin on PR #$PR_NUMBER (cycle <cycle-counter>/3, commit $LATEST_COMMIT)."`
+
+5. **Wait for fresh reviews**: After fixes are pushed, poll for **new** reviewer activity from Codex and Devin posted after `last_fix_push_time`. Do NOT use `check-pr-reviews` cumulative statuses to determine whether reviewers have responded — old reviews persist in the GitHub API and will make cumulative status checks pass immediately on subsequent cycles.
+   - Poll every 60 seconds for up to **10 minutes**.
+   - On each poll, collect the **login names** of reviewer bots that have posted new activity (reviews, inline comments, issue comments, or reactions) after `last_fix_push_time`:
+     ```bash
+     # Get reviewer bot logins with new reviews after last_fix_push_time
+     review_bot_logins=$(gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/reviews" \
+       --jq '[.[] | select(.submitted_at > "'$last_fix_push_time'" and (.user.login == "chatgpt-codex-connector[bot]" or .user.login == "devin-ai-integration[bot]"))] | [.[].user.login] | unique | .[]')
+     # Get reviewer bot logins with new inline comments after last_fix_push_time
+     comment_bot_logins=$(gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/comments" \
+       --jq '[.[] | select(.created_at > "'$last_fix_push_time'" and (.user.login == "chatgpt-codex-connector[bot]" or .user.login == "devin-ai-integration[bot]"))] | [.[].user.login] | unique | .[]')
+     # Get reviewer bot logins with new issue comments after last_fix_push_time
+     issue_comment_bot_logins=$(gh api "repos/{owner}/{repo}/issues/$PR_NUMBER/comments" \
+       --jq '[.[] | select(.created_at > "'$last_fix_push_time'" and (.user.login == "chatgpt-codex-connector[bot]" or .user.login == "devin-ai-integration[bot]"))] | [.[].user.login] | unique | .[]')
+     # Get reviewer bot logins with new reactions after last_fix_push_time (e.g., Codex +1 approval)
+     reaction_bot_logins=$(gh api "repos/{owner}/{repo}/issues/$PR_NUMBER/reactions" \
+       --jq '[.[] | select(.created_at > "'$last_fix_push_time'" and (.user.login == "chatgpt-codex-connector[bot]" or .user.login == "devin-ai-integration[bot]"))] | [.[].user.login] | unique | .[]')
+     # Union all logins across endpoints and count unique bots
+     all_responded_bots=$(echo -e "$review_bot_logins\n$comment_bot_logins\n$issue_comment_bot_logins\n$reaction_bot_logins" | sort -u | grep -c .)
+     ```
+     A reviewer bot counts as "responded" if its login appears in any of the four queries above. Both bots must have posted something new to consider the poll complete.
+   - If `all_responded_bots` is **>= 2** (both reviewer bots have posted new activity after `last_fix_push_time`), run `.claude/check-pr-reviews $PR_NUMBER` and derive the aggregate status:
+     - If aggregate status is `approved`, proceed to Step 7.
+     - If aggregate status is `changes_requested`, return to step 2 (which checks the cycle limit).
+     - If aggregate status is `pending` or `rate_limited`, continue polling.
+   - If `all_responded_bots` is **< 2**, **continue polling** — do not exit the loop. Old cumulative statuses from `check-pr-reviews` are unreliable after fixes have been pushed.
+   - If **10 minutes** pass without both reviewer bots posting new activity, proceed to Step 7. Log: `"Timed out after 10 minutes waiting for reviewer responses. Proceeding with pending reviews."`
+
+Repeat steps 1-5 until the exit condition: either `approved` aggregate status, both reviewers have posted fresh activity, 10-minute timeout after a fix push, or the cycle counter has reached 3.
+
+#### Feedback agent prompt
+
+```
+You are working on a single task in an isolated git worktree.
+
+## Project context
+Read AGENTS.md in the repo root for project conventions and structure.
+
+## Repo-specific gotchas
+- `gh pr view` does NOT support a `merged` --json field. Use `state` and `mergedAt`: `gh pr view <N> --json state,mergedAt,title,url`
+- This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- Do NOT wait for CI checks to pass before merging. Merge immediately.
+- `tail` and `head` may not be available in the shell. Don't pipe to them.
+
+## Your worktree
+<absolute path to worktree>
+ALL work happens here. Do NOT touch the main repo.
+
+## Your task
+Address the review feedback on PR #<pr-number> (<pr-url>):
+<summary of changes requested>
+
+## Workflow
+1. Read the review comments on the PR to understand what changes are requested:
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/<pr-number>/reviews --jq '.[-1].body'
+   gh api repos/{owner}/{repo}/pulls/<pr-number>/comments --jq '.[] | {path: .path, body: .body, line: .line}'
+   ```
+2. Implement the requested fixes in your worktree.
+3. Do NOT run tests, type-checking (tsc), or linting unless the task specifically requires it.
+4. Commit and push directly to the PR branch:
+   ```bash
+   cd <worktree>
+   git add -A
+   git commit -m "<descriptive message about what feedback was addressed>"
+   git push origin HEAD:<pr-branch>
+   ```
+5. Resolve the addressed review threads:
+   ```bash
+   .claude/gh-review resolve-threads <pr-number> "Addressed in direct push to <pr-branch>"
+   ```
+6. Do NOT create a new PR. Do NOT use .claude/ship.
+7. Send a message to "lead" with:
+   - A summary of what feedback was addressed
+   - Which files were modified
+   - Any issues or concerns
+
+```
+
+### 7. Save state
 
 ```bash
 mkdir -p .private/safe-plan-state
@@ -104,9 +257,10 @@ Write `.private/safe-plan-state/<plan-slug>.md` with this format:
 - **PR Number**: <number>
 - **Branch**: <branch name>
 - **Worktree**: <absolute path to worktree>
+- **Review cycles completed**: <cycle-counter>/3
 ```
 
-### 7. Notify the user and stop
+### 8. Notify the user and stop
 
 Tell the user:
 
@@ -114,9 +268,10 @@ Tell the user:
 >
 > - <brief summary of what was implemented>
 > - Files changed: <list>
+> - **Review cycles completed:** <cycle-counter>/3
+> - **Final review status:** <approved / max cycles reached / timed out waiting for reviews>
 >
 > **Next steps:**
-> - `/safe-check-review <plan file>` — check for reviewer feedback and address it
 > - `/resume-plan <plan file>` — merge this PR and continue to the next one
 
 Then **stop**. Do NOT continue to the next PR.

--- a/README.md
+++ b/README.md
@@ -717,16 +717,17 @@ A three-command workflow for executing plans one PR at a time with human review 
 
 | Command | Purpose |
 |---------|---------|
-| `/safe-execute-plan <file>` | Start a plan from `.private/plans/` — implements the first PR, creates it (without merging), and stops to wait for review. |
+| `/safe-execute-plan <file>` | Start a plan from `.private/plans/` — implements the next PR, creates it (without merging), automatically runs an **automated review feedback loop** (up to 3 fix cycles with Codex/Devin), and stops to await human merge approval. |
 | `/safe-check-review [file]` | Check the active plan PR for feedback from codex/devin/humans. Addresses requested changes by pushing fixes. Waits if reviews are still pending — only recommends merging once all reviewers have responded. Auto-detects the plan if only one is active. |
 | `/resume-plan [file]` | Merge the current PR, implement the next one, create it, and stop again. Repeats until the plan is complete. Auto-detects the plan if only one is active. |
 
 **Typical flow:**
 
-1. **`/safe-execute-plan MY_PLAN.md`** — starts the plan, creates PR 1, stops
-2. **`/safe-check-review MY_PLAN.md`** — run periodically; waits for pending reviews, addresses feedback, or gives the all-clear to merge
-3. **`/resume-plan MY_PLAN.md`** — merge PR 1, create PR 2, stop (only after `/safe-check-review` confirms all reviews are in)
-4. Repeat steps 2–3 until the plan is complete
+1. **`/safe-execute-plan MY_PLAN.md`** — starts the plan, creates PR 1, automatically handles Codex/Devin review feedback (up to 3 cycles), then stops
+2. **`/resume-plan MY_PLAN.md`** — merge PR 1 (automated reviews already complete), create PR 2, stop
+3. Repeat step 2 until the plan is complete
+
+The automated review loop in `/safe-execute-plan` triggers Codex and Devin reviews, waits for their feedback (up to 15 minutes for initial reviews, 10 minutes for subsequent cycles), addresses any `changes_requested` feedback by pushing fixes directly to the PR branch, and re-requests reviews — repeating up to 3 cycles before handing off to you.
 
 Multiple plans can run in parallel — just specify the plan name to disambiguate.
 
@@ -754,7 +755,7 @@ Multiple plans can run in parallel — just specify the plan name to disambiguat
 
 Or for a focused feature: **`/blitz <feature>`** handles all of the above in one shot (plan, issues, swarm, sweep, report). Use **`/safe-blitz <feature>`** for the same workflow but with a feature branch and a final PR for manual review, then **`/safe-blitz-done`** to merge it when ready.
 
-For controlled, sequential plan execution with human review at every step: **`/safe-execute-plan <file>`** → **`/safe-check-review`** → **`/resume-plan`** → repeat.
+For controlled, sequential plan execution with automated bot reviews and human merge approval: **`/safe-execute-plan <file>`** (creates PR + auto-handles Codex/Devin feedback) → **`/resume-plan`** → repeat.
 
 All workflows use squash-merge (no merge commits), worktree isolation for parallel work, and track state in `.private/TODO.md` and `.private/UNREVIEWED_PRS.md`.
 


### PR DESCRIPTION
## Summary
- After shipping each plan PR, automatically trigger Codex and Devin reviews
- Implement up to 3 feedback cycles: address bot review comments, push fixes directly to the PR branch, re-request reviews, and poll for fresh responses
- Uses the same review loop pattern as safe-blitz (cycle counter, last_fix_push_time, 10-minute timeout waiting for both reviewer bots)

## Original prompt
update the safe-execute-plan to automatically review feedback up to 3 times in a loop like how we do in safe-blitz command

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
