### PR TITLE
M1: Add ToolIntent classification

### DIFF
--- a/assistant/src/__tests__/intent.test.ts
+++ b/assistant/src/__tests__/intent.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'bun:test';
+
+import { classifyIntent, ToolIntent } from '../permissions/intent.js';
+import { RiskLevel } from '../permissions/types.js';
+
+const WORKSPACE_DIR = '/tmp/test-workspace';
+
+describe('classifyIntent', () => {
+  // ── host_bash: risk-dependent ─────────────────────────────────────
+
+  test('host_bash + RiskLevel.Low → Read', () => {
+    expect(classifyIntent('host_bash', { command: 'ls' }, WORKSPACE_DIR, RiskLevel.Low)).toBe(ToolIntent.Read);
+  });
+
+  test('host_bash + RiskLevel.Medium → Write', () => {
+    expect(classifyIntent('host_bash', { command: 'rm -rf /' }, WORKSPACE_DIR, RiskLevel.Medium)).toBe(ToolIntent.Write);
+  });
+
+  test('host_bash + RiskLevel.High → Write', () => {
+    expect(classifyIntent('host_bash', { command: 'rm -rf /' }, WORKSPACE_DIR, RiskLevel.High)).toBe(ToolIntent.Write);
+  });
+
+  // ── Host file tools ───────────────────────────────────────────────
+
+  test('host_file_read → Read', () => {
+    expect(classifyIntent('host_file_read', {}, WORKSPACE_DIR, RiskLevel.Low)).toBe(ToolIntent.Read);
+  });
+
+  test('host_file_write → Write', () => {
+    expect(classifyIntent('host_file_write', {}, WORKSPACE_DIR, RiskLevel.Low)).toBe(ToolIntent.Write);
+  });
+
+  test('host_file_edit → Write', () => {
+    expect(classifyIntent('host_file_edit', {}, WORKSPACE_DIR, RiskLevel.Low)).toBe(ToolIntent.Write);
+  });
+
+  // ── Information retrieval ─────────────────────────────────────────
+
+  test('web_search → Read', () => {
+    expect(classifyIntent('web_search', {}, WORKSPACE_DIR, RiskLevel.Low)).toBe(ToolIntent.Read);
+  });
+
+  test('web_fetch → Read', () => {
+    expect(classifyIntent('web_fetch', {}, WORKSPACE_DIR, RiskLevel.Low)).toBe(ToolIntent.Read);
+  });
+
+  // ── Browser tools ─────────────────────────────────────────────────
+
+  test('browser_navigate → Read', () => {
+    expect(classifyIntent('browser_navigate', {}, WORKSPACE_DIR, RiskLevel.Low)).toBe(ToolIntent.Read);
+  });
+
+  test('browser_click → Read', () => {
+    expect(classifyIntent('browser_click', {}, WORKSPACE_DIR, RiskLevel.Low)).toBe(ToolIntent.Read);
+  });
+
+  // ── Network request ───────────────────────────────────────────────
+
+  test('network_request → Write', () => {
+    expect(classifyIntent('network_request', {}, WORKSPACE_DIR, RiskLevel.Low)).toBe(ToolIntent.Write);
+  });
+
+  // ── Scheduling tools ──────────────────────────────────────────────
+
+  test('schedule_create → Write', () => {
+    expect(classifyIntent('schedule_create', {}, WORKSPACE_DIR, RiskLevel.Low)).toBe(ToolIntent.Write);
+  });
+
+  test('schedule_update → Write', () => {
+    expect(classifyIntent('schedule_update', {}, WORKSPACE_DIR, RiskLevel.Low)).toBe(ToolIntent.Write);
+  });
+
+  test('schedule_delete → Write', () => {
+    expect(classifyIntent('schedule_delete', {}, WORKSPACE_DIR, RiskLevel.Low)).toBe(ToolIntent.Write);
+  });
+
+  // ── Workspace-scoped tools ────────────────────────────────────────
+
+  test('file_read (workspace-scoped) → Read', () => {
+    expect(
+      classifyIntent('file_read', { file_path: `${WORKSPACE_DIR}/foo.txt` }, WORKSPACE_DIR, RiskLevel.Low),
+    ).toBe(ToolIntent.Read);
+  });
+
+  test('bash (sandbox enabled) → Read', () => {
+    expect(classifyIntent('bash', { command: 'echo hello' }, WORKSPACE_DIR, RiskLevel.Low)).toBe(ToolIntent.Read);
+  });
+
+  // ── External communication ────────────────────────────────────────
+
+  test('send_notification → Write', () => {
+    expect(classifyIntent('send_notification', {}, WORKSPACE_DIR, RiskLevel.Low)).toBe(ToolIntent.Write);
+  });
+
+  test('call_start → Write', () => {
+    expect(classifyIntent('call_start', {}, WORKSPACE_DIR, RiskLevel.Low)).toBe(ToolIntent.Write);
+  });
+
+  // ── Default ───────────────────────────────────────────────────────
+
+  test('unknown tool → Read (default)', () => {
+    expect(classifyIntent('some_unknown_tool', {}, WORKSPACE_DIR, RiskLevel.Low)).toBe(ToolIntent.Read);
+  });
+});

--- a/assistant/src/__tests__/intent.test.ts
+++ b/assistant/src/__tests__/intent.test.ts
@@ -82,6 +82,18 @@ describe('classifyIntent', () => {
     ).toBe(ToolIntent.Read);
   });
 
+  test('file_write (workspace-scoped) → Read', () => {
+    expect(
+      classifyIntent('file_write', { file_path: `${WORKSPACE_DIR}/bar.txt` }, WORKSPACE_DIR, RiskLevel.Low),
+    ).toBe(ToolIntent.Read);
+  });
+
+  test('file_write (outside workspace) → Write', () => {
+    expect(
+      classifyIntent('file_write', { file_path: '/etc/shadow' }, WORKSPACE_DIR, RiskLevel.Low),
+    ).toBe(ToolIntent.Write);
+  });
+
   test('bash (sandbox enabled) → Read', () => {
     expect(classifyIntent('bash', { command: 'echo hello' }, WORKSPACE_DIR, RiskLevel.Low)).toBe(ToolIntent.Read);
   });

--- a/assistant/src/permissions/intent.ts
+++ b/assistant/src/permissions/intent.ts
@@ -1,0 +1,71 @@
+import { isWorkspaceScopedInvocation } from '../permissions/workspace-policy.js';
+import { isSideEffectTool } from '../tools/side-effects.js';
+import { RiskLevel } from '../permissions/types.js';
+
+export enum ToolIntent {
+  Read = 'read',
+  Write = 'write',
+}
+
+// Tools whose invocations are always classified as Write regardless of other signals.
+const EXTERNAL_COMMUNICATION_PREFIXES = ['messaging_send', 'gmail_send'] as const;
+const EXTERNAL_COMMUNICATION_EXACT = new Set(['gmail_forward', 'call_start', 'send_notification']);
+const SCHEDULING_TOOLS = new Set(['schedule_create', 'schedule_update', 'schedule_delete']);
+
+/**
+ * Classify a tool invocation as Read or Write based on its name, inputs,
+ * working directory, and risk level. This is orthogonal to risk — a tool
+ * can be low-risk but still Write (e.g. scheduling), or high-risk but
+ * still Read (e.g. host_file_read on a sensitive path).
+ */
+export function classifyIntent(
+  toolName: string,
+  input: Record<string, unknown>,
+  workingDir: string,
+  risk: RiskLevel,
+): ToolIntent {
+  // 1. Workspace-scoped tools: sandbox provides isolation, so reads are safe.
+  if (
+    toolName === 'file_read' ||
+    toolName === 'file_write' ||
+    (toolName === 'file_edit' && isWorkspaceScopedInvocation(toolName, input, workingDir)) ||
+    toolName === 'bash'
+  ) {
+    return ToolIntent.Read;
+  }
+
+  // 2. Host reads are unrestricted.
+  if (toolName === 'host_file_read') return ToolIntent.Read;
+
+  // 3. Information retrieval.
+  if (toolName === 'web_search' || toolName === 'web_fetch') return ToolIntent.Read;
+
+  // 4. Browser tools — sandboxed and user-visible.
+  if (toolName.startsWith('browser_')) return ToolIntent.Read;
+
+  // 5. Host mutations.
+  if (toolName === 'host_file_write' || toolName === 'host_file_edit') return ToolIntent.Write;
+
+  // 6. Host bash — risk-dependent.
+  if (toolName === 'host_bash') {
+    return risk === RiskLevel.Low ? ToolIntent.Read : ToolIntent.Write;
+  }
+
+  // 7. External communication.
+  if (EXTERNAL_COMMUNICATION_EXACT.has(toolName)) return ToolIntent.Write;
+  for (const prefix of EXTERNAL_COMMUNICATION_PREFIXES) {
+    if (toolName.startsWith(prefix)) return ToolIntent.Write;
+  }
+
+  // 8. Scheduling.
+  if (SCHEDULING_TOOLS.has(toolName)) return ToolIntent.Write;
+
+  // 9. Network requests (proxy-authenticated, carries credentials).
+  if (toolName === 'network_request') return ToolIntent.Write;
+
+  // 10. Catch-all side-effect check for tools not already classified as Read.
+  if (isSideEffectTool(toolName, input)) return ToolIntent.Write;
+
+  // 11. Default: don't over-prompt.
+  return ToolIntent.Read;
+}

--- a/assistant/src/permissions/intent.ts
+++ b/assistant/src/permissions/intent.ts
@@ -27,7 +27,7 @@ export function classifyIntent(
   // 1. Workspace-scoped tools: sandbox provides isolation, so reads are safe.
   if (
     toolName === 'file_read' ||
-    toolName === 'file_write' ||
+    (toolName === 'file_write' && isWorkspaceScopedInvocation(toolName, input, workingDir)) ||
     (toolName === 'file_edit' && isWorkspaceScopedInvocation(toolName, input, workingDir)) ||
     toolName === 'bash'
   ) {


### PR DESCRIPTION
Add ToolIntent enum (Read/Write) and classifyIntent() function in assistant/src/permissions/intent.ts. This classifies tool invocations by their intent (read-only vs write/mutation) orthogonal to risk level. Part of #10091.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
