### PR TITLE
fix: restrict symlink fallback to ENOENT only in bulletin write

### DIFF
--- a/assistant/src/config/update-bulletin.ts
+++ b/assistant/src/config/update-bulletin.ts
@@ -29,8 +29,12 @@ function atomicWriteFileSync(filePath: string, content: string): void {
       if (lstatSync(filePath, { throwIfNoEntry: false })?.isSymbolicLink()) {
         targetPath = realpathSync(filePath);
       }
-    } catch {
-      // Dangling symlink — fall back to writing through the symlink path
+    } catch (err: unknown) {
+      // Dangling symlink — fall back to writing through the symlink path.
+      // Only swallow ENOENT (dangling target); re-throw ELOOP, EACCES, I/O faults, etc.
+      if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw err;
+      }
     }
     renameSync(tmpPath, targetPath);
   } catch (err) {


### PR DESCRIPTION
Address Codex P2 feedback on PR #10071: gate the dangling-symlink fallback on err.code === ENOENT and re-throw all other errors (ELOOP, EACCES, I/O faults) to avoid silently masking failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10097" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
