### PR TITLE
fix: wait for unresponsive daemon during startup before replacing

### DIFF
--- a/assistant/src/cli/core-commands.ts
+++ b/assistant/src/cli/core-commands.ts
@@ -12,7 +12,6 @@ import { loadRawConfig } from '../config/loader.js';
 import { getConfig } from '../config/loader.js';
 import { hasSocketOverride,shouldAutoStartDaemon } from '../daemon/connection-policy.js';
 import {
-  cleanupPidFile,
   ensureDaemonRunning,
   getDaemonStatus,
   startDaemon,
@@ -110,7 +109,7 @@ export function registerDevCommand(program: Command): void {
     .command('dev')
     .description('Run the daemon in dev mode with auto-restart on file changes')
     .action(async () => {
-      const status = await getDaemonStatus();
+      let status = await getDaemonStatus();
       if (status.running) {
         log.info('Stopping existing daemon...');
         const stopResult = await stopDaemon();
@@ -120,10 +119,44 @@ export function registerDevCommand(program: Command): void {
         }
       } else if (status.pid) {
         // PID file references a live process but the socket is unresponsive.
-        // The PID may have been reused by an unrelated process — only remove
-        // the stale PID file; never signal a process we cannot verify is ours.
-        log.info('Cleaning up stale PID file (socket unresponsive)...');
-        cleanupPidFile();
+        // This can happen during the daemon startup window before the socket
+        // is bound. Wait briefly for it to come up before replacing.
+        log.info('Daemon process alive but socket unresponsive — waiting for startup...');
+        const maxWait = 5000;
+        const interval = 500;
+        let waited = 0;
+        let resolved = false;
+        while (waited < maxWait) {
+          await new Promise((r) => setTimeout(r, interval));
+          waited += interval;
+          status = await getDaemonStatus();
+          if (status.running) {
+            // Socket came up — stop the daemon normally.
+            log.info('Daemon became responsive, stopping it...');
+            const stopResult = await stopDaemon();
+            if (!stopResult.stopped && stopResult.reason === 'stop_failed') {
+              log.error('Failed to stop existing daemon — process survived SIGKILL');
+              process.exit(1);
+            }
+            resolved = true;
+            break;
+          }
+          if (!status.pid) {
+            // Process exited on its own — PID file already cleaned up.
+            resolved = true;
+            break;
+          }
+        }
+        if (!resolved) {
+          // Still alive but unresponsive after waiting — stop it via stopDaemon()
+          // which handles SIGTERM → SIGKILL escalation and PID file cleanup.
+          log.info('Daemon still unresponsive after wait — stopping it...');
+          const stopResult = await stopDaemon();
+          if (!stopResult.stopped && stopResult.reason === 'stop_failed') {
+            log.error('Failed to stop existing daemon — process survived SIGKILL');
+            process.exit(1);
+          }
+        }
       }
 
       const mainPath = `${import.meta.dirname}/../daemon/main.ts`;


### PR DESCRIPTION
Address Codex P1 feedback on PR #10074: when a live PID exists but the socket is unresponsive, wait briefly for it to come up (startup window) before replacing. Only clean up the PID file if the process is actually dead.

Previously, `vellum dev` would delete the PID file and start a new daemon when the existing daemon's socket was unresponsive. This could happen during the normal startup window before the socket is bound, leading to two daemon processes running simultaneously.

Now the `dev` command:
1. Waits up to 5 seconds for the socket to become responsive (polling every 500ms)
2. If the socket comes up, stops the daemon normally via `stopDaemon()`
3. If the process exits on its own, proceeds without cleanup
4. If still unresponsive after the wait, stops it via `stopDaemon()` which handles SIGTERM/SIGKILL escalation and proper PID file cleanup
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
