### PR TITLE
M2: Add reorder_threads IPC handler

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -1155,6 +1155,9 @@ export function handleReorderThreads(
   _socket: net.Socket,
   _ctx: HandlerContext,
 ): void {
+  if (!Array.isArray(msg.updates)) {
+    return;
+  }
   conversationStore.batchSetDisplayOrders(
     msg.updates.map((u) => ({ id: u.sessionId, displayOrder: u.displayOrder, isPinned: u.isPinned })),
   );

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -24,6 +24,7 @@ import type {
   HistoryRequest,
   MessageContentRequest,
   RegenerateRequest,
+  ReorderThreadsRequest,
   SandboxSetRequest,
   SecretResponse,
   ServerMessage,
@@ -1149,6 +1150,16 @@ export function handleMessageContentRequest(
   });
 }
 
+export function handleReorderThreads(
+  msg: ReorderThreadsRequest,
+  _socket: net.Socket,
+  _ctx: HandlerContext,
+): void {
+  conversationStore.batchSetDisplayOrders(
+    msg.updates.map((u) => ({ id: u.sessionId, displayOrder: u.displayOrder, isPinned: u.isPinned })),
+  );
+}
+
 export const sessionHandlers = defineHandlers({
   user_message: handleUserMessage,
   confirmation_response: handleConfirmationResponse,
@@ -1167,4 +1178,5 @@ export const sessionHandlers = defineHandlers({
   usage_request: handleUsageRequest,
   sandbox_set: handleSandboxSet,
   conversation_search: handleConversationSearch,
+  reorder_threads: handleReorderThreads,
 });

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -124,6 +124,7 @@
     "reminder_cancel",
     "reminders_list",
     "remove_trust_rule",
+    "reorder_threads",
     "ride_shotgun_start",
     "ride_shotgun_stop",
     "sandbox_set",

--- a/assistant/src/daemon/ipc-contract/sessions.ts
+++ b/assistant/src/daemon/ipc-contract/sessions.ts
@@ -156,6 +156,11 @@ export interface ConversationSearchRequest {
   maxMessagesPerConversation?: number;
 }
 
+export interface ReorderThreadsRequest {
+  type: 'reorder_threads';
+  updates: Array<{ sessionId: string; displayOrder: number; isPinned: boolean }>;
+}
+
 // === Server → Client ===
 
 export interface ConversationSearchMatchingMessage {
@@ -392,7 +397,8 @@ export type _SessionsClientMessages =
   | SessionRenameRequest
   | SessionsClearRequest
   | ConversationSearchRequest
-  | MessageContentRequest;
+  | MessageContentRequest
+  | ReorderThreadsRequest;
 
 export type _SessionsServerMessages =
   | AuthResult

--- a/assistant/src/daemon/ipc-contract/sessions.ts
+++ b/assistant/src/daemon/ipc-contract/sessions.ts
@@ -158,7 +158,7 @@ export interface ConversationSearchRequest {
 
 export interface ReorderThreadsRequest {
   type: 'reorder_threads';
-  updates: Array<{ sessionId: string; displayOrder: number; isPinned: boolean }>;
+  updates: Array<{ sessionId: string; displayOrder: number | null; isPinned: boolean }>;
 }
 
 // === Server → Client ===

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -3487,6 +3487,28 @@ public struct IPCRemoveTrustRule: Codable, Sendable {
     }
 }
 
+public struct IPCReorderThreadsRequest: Codable, Sendable {
+    public let type: String
+    public let updates: [IPCReorderThreadsRequestUpdate]
+
+    public init(type: String, updates: [IPCReorderThreadsRequestUpdate]) {
+        self.type = type
+        self.updates = updates
+    }
+}
+
+public struct IPCReorderThreadsRequestUpdate: Codable, Sendable {
+    public let sessionId: String
+    public let displayOrder: Double
+    public let isPinned: Bool
+
+    public init(sessionId: String, displayOrder: Double, isPinned: Bool) {
+        self.sessionId = sessionId
+        self.displayOrder = displayOrder
+        self.isPinned = isPinned
+    }
+}
+
 public struct IPCRideShotgunProgress: Codable, Sendable {
     public let type: String
     public let watchId: String

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -3499,10 +3499,10 @@ public struct IPCReorderThreadsRequest: Codable, Sendable {
 
 public struct IPCReorderThreadsRequestUpdate: Codable, Sendable {
     public let sessionId: String
-    public let displayOrder: Double
+    public let displayOrder: Double?
     public let isPinned: Bool
 
-    public init(sessionId: String, displayOrder: Double, isPinned: Bool) {
+    public init(sessionId: String, displayOrder: Double?, isPinned: Bool) {
         self.sessionId = sessionId
         self.displayOrder = displayOrder
         self.isPinned = isPinned


### PR DESCRIPTION
Add reorder_threads IPC message type and handler that calls batchSetDisplayOrders() to persist thread ordering. Part of #10077.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
