### PR TITLE
M2: Add avatar generation daemon tool (set_avatar) (#10060)

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -322,6 +322,10 @@ function buildInChatConfigurationSection(): string {
     '**After saving a value**, confirm success with a message like: "Great, saved! You can always update this from the Settings page."',
     '',
     '**Never tell the user to go to Settings to enter a value.** The Settings page is for reviewing and updating existing configuration, not for initial setup. Always prefer the in-chat flow for first-time configuration.',
+    '',
+    '### Avatar Customisation',
+    '',
+    'You can change your avatar appearance using the `set_avatar` tool. When the user asks to change, update, or customise your avatar, use `set_avatar` with a `description` parameter describing the desired appearance (e.g. "a friendly purple cat with green eyes wearing a tiny hat"). The tool generates an avatar image via DALL-E and updates all connected clients automatically. Requires an OpenAI API key.',
   ].join('\n');
 }
 

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -210,6 +210,7 @@
     "assistant_text_delta",
     "assistant_thinking_delta",
     "auth_result",
+    "avatar_updated",
     "browser_cdp_request",
     "browser_frame",
     "browser_handoff_request",

--- a/assistant/src/daemon/ipc-contract/settings.ts
+++ b/assistant/src/daemon/ipc-contract/settings.ts
@@ -20,7 +20,14 @@ export interface ClientSettingsUpdate {
   value: string;
 }
 
+/** Sent by the daemon after the avatar image has been regenerated and saved to disk. */
+export interface AvatarUpdated {
+  type: 'avatar_updated';
+  /** Absolute path to the updated avatar image file. */
+  avatarPath: string;
+}
+
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
 export type _SettingsClientMessages = VoiceConfigUpdateRequest;
-export type _SettingsServerMessages = ClientSettingsUpdate;
+export type _SettingsServerMessages = ClientSettingsUpdate | AvatarUpdated;

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -7,10 +7,13 @@
  * registry entry instead of another if/else branch.
  */
 
+import { join } from 'node:path';
+
 import { normalizeActivationKey } from './handlers/config-voice.js';
 import { updatePublishedAppDeployment } from '../services/published-app-updater.js';
 import { openAppViaSurface } from '../tools/apps/open-proxy.js';
 import type { ToolExecutionResult } from '../tools/types.js';
+import { getWorkspaceDir } from '../util/platform.js';
 import { isDoordashCommand, updateDoordashProgress } from './doordash-steps.js';
 import type { ServerMessage } from './ipc-protocol.js';
 import {
@@ -96,6 +99,13 @@ registerHook(
     }
   },
 );
+
+// Broadcast avatar change to all connected clients so every
+// macOS/iOS instance reloads the avatar image.
+registerHook('set_avatar', (_name, _input, _result, { broadcastToAllClients }) => {
+  const avatarPath = join(getWorkspaceDir(), 'data', 'avatar', 'custom-avatar.png');
+  broadcastToAllClients?.({ type: 'avatar_updated', avatarPath });
+});
 
 // Broadcast activation key change to all connected clients so every
 // macOS/iOS instance picks up the new setting immediately.

--- a/assistant/src/tools/system/avatar-generator.ts
+++ b/assistant/src/tools/system/avatar-generator.ts
@@ -1,0 +1,136 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import OpenAI from 'openai';
+
+import { getConfig } from '../../config/loader.js';
+import { RiskLevel } from '../../permissions/types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { getLogger } from '../../util/logger.js';
+import { getWorkspaceDir } from '../../util/platform.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+
+const log = getLogger('avatar-generator');
+
+const TOOL_NAME = 'set_avatar';
+
+/** Canonical path where the custom avatar PNG is stored. */
+function getAvatarPath(): string {
+  return join(getWorkspaceDir(), 'data', 'avatar', 'custom-avatar.png');
+}
+
+export const setAvatarTool: Tool = {
+  name: TOOL_NAME,
+  description:
+    'Generate a custom avatar image from a text description using DALL-E. ' +
+    'Saves the result as the assistant\'s avatar.',
+  category: 'system',
+  defaultRiskLevel: RiskLevel.Low,
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: TOOL_NAME,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          description: {
+            type: 'string',
+            description:
+              'A text description of the desired avatar appearance, ' +
+              'e.g. "a friendly purple cat with green eyes wearing a tiny hat".',
+          },
+        },
+        required: ['description'],
+      },
+    };
+  },
+
+  async execute(
+    input: Record<string, unknown>,
+    context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    const description = input.description;
+    if (typeof description !== 'string' || description.trim() === '') {
+      return {
+        content: 'Error: description is required and must be a non-empty string.',
+        isError: true,
+      };
+    }
+
+    // Retrieve the OpenAI API key from the daemon config
+    const config = getConfig();
+    const apiKey = config.apiKeys.openai;
+
+    if (!apiKey) {
+      return {
+        content:
+          'No OpenAI API key configured. Please set your OpenAI API key ' +
+          '(via Settings or the credential_store tool) to use avatar generation.',
+        isError: true,
+      };
+    }
+
+    // Wrap the user description with prompt engineering for safe, avatar-appropriate output
+    const prompt =
+      'Cute, friendly, work-safe avatar character illustration. ' +
+      'Round, simple design with soft colors. ' +
+      `${description.trim()}. ` +
+      'White or light background, digital art style.';
+
+    try {
+      const client = new OpenAI({ apiKey });
+
+      log.info({ description: description.trim() }, 'Generating avatar via DALL-E');
+
+      const response = await client.images.generate({
+        model: 'dall-e-3',
+        prompt,
+        n: 1,
+        size: '1024x1024',
+        response_format: 'b64_json',
+      });
+
+      const b64Data = response.data[0]?.b64_json;
+      if (!b64Data) {
+        log.error('DALL-E response contained no image data');
+        return {
+          content: 'Error: the image generation API returned no image data. Please try again.',
+          isError: true,
+        };
+      }
+
+      // Decode and save the PNG
+      const avatarPath = getAvatarPath();
+      const avatarDir = dirname(avatarPath);
+
+      mkdirSync(avatarDir, { recursive: true });
+      writeFileSync(avatarPath, Buffer.from(b64Data, 'base64'));
+
+      log.info({ avatarPath }, 'Avatar saved successfully');
+
+      // Notify connected clients that the avatar has changed
+      context.sendToClient?.({ type: 'avatar_updated', avatarPath });
+
+      return {
+        content: 'Avatar updated! Your new avatar will appear shortly.',
+        isError: false,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log.error({ error: message }, 'Avatar generation failed');
+
+      if (error instanceof OpenAI.APIError) {
+        return {
+          content: `Avatar generation failed (API error ${error.status}): ${error.message}`,
+          isError: true,
+        };
+      }
+
+      return {
+        content: `Avatar generation failed: ${message}`,
+        isError: true,
+      };
+    }
+  },
+};

--- a/assistant/src/tools/system/avatar-generator.ts
+++ b/assistant/src/tools/system/avatar-generator.ts
@@ -109,8 +109,7 @@ export const setAvatarTool: Tool = {
 
       log.info({ avatarPath }, 'Avatar saved successfully');
 
-      // Notify connected clients that the avatar has changed
-      context.sendToClient?.({ type: 'avatar_updated', avatarPath });
+      // Side-effect hook in tool-side-effects.ts broadcasts avatar_updated to all clients.
 
       return {
         content: 'Avatar updated! Your new avatar will appear shortly.',

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -12,6 +12,7 @@ import { credentialStoreTool } from './credentials/vault.js';
 import { memorySaveTool, memorySearchTool, memoryUpdateTool } from './memory/register.js';
 import type { LazyToolDescriptor } from './registry.js';
 import { vellumSkillsCatalogTool } from './skills/vellum-catalog.js';
+import { setAvatarTool } from './system/avatar-generator.js';
 import { voiceConfigUpdateTool } from './system/voice-config.js';
 import type { Tool } from './types.js';
 import { screenWatchTool } from './watch/screen-watch.js';
@@ -68,6 +69,7 @@ export const explicitTools: Tool[] = [
   screenWatchTool,
   vellumSkillsCatalogTool,
   voiceConfigUpdateTool,
+  setAvatarTool,
 ];
 
 // ── Lazy tool descriptors ───────────────────────────────────────────

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1111,6 +1111,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             }
         }
 
+        // Handle avatar_updated from daemon: reload the avatar image from disk
+        daemonClient.onAvatarUpdated = { _ in
+            AvatarAppearanceManager.shared.reloadAvatar()
+        }
+
         // Restart DaemonClient connection when the health monitor relaunches
         // the daemon process so we don't wait for the backoff timer to expire.
         assistantCli.onDaemonRestarted = { [weak self] in

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -106,6 +106,12 @@ final class AvatarAppearanceManager {
         customAvatarImage = image
     }
 
+    /// Reloads the custom avatar from disk. Called when the daemon notifies
+    /// that the avatar image has been regenerated (via `avatar_updated` IPC).
+    func reloadAvatar() {
+        loadCustomAvatar()
+    }
+
     func clearCustomAvatar() {
         try? FileManager.default.removeItem(at: customAvatarURL)
         try? FileManager.default.removeItem(at: Self.legacyAppSupportCustomAvatarURL())

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -476,6 +476,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `client_settings_update` message.
     public var onClientSettingsUpdate: ((IPCClientSettingsUpdate) -> Void)?
 
+    /// Called when the daemon sends an `avatar_updated` message after regenerating the avatar.
+    public var onAvatarUpdated: ((IPCAvatarUpdated) -> Void)?
+
     // MARK: - Broadcast Subscribers
 
     /// Creates a new message stream for the caller. Each subscriber receives all messages

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -278,6 +278,8 @@ extension DaemonClient {
             onRecordingStop?(msg)
         case .clientSettingsUpdate(let msg):
             onClientSettingsUpdate?(msg)
+        case .avatarUpdated(let msg):
+            onAvatarUpdated?(msg)
         default:
             break
         }

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -513,6 +513,18 @@ public struct IPCAuthResult: Codable, Sendable {
     }
 }
 
+/// Sent by the daemon after the avatar image has been regenerated and saved to disk.
+public struct IPCAvatarUpdated: Codable, Sendable {
+    public let type: String
+    /// Absolute path to the updated avatar image file.
+    public let avatarPath: String
+
+    public init(type: String, avatarPath: String) {
+        self.type = type
+        self.avatarPath = avatarPath
+    }
+}
+
 public struct IPCBrowserCDPRequest: Codable, Sendable {
     public let type: String
     public let sessionId: String

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2332,6 +2332,7 @@ public enum ServerMessage: Decodable, Sendable {
     case recordingStart(IPCRecordingStart)
     case recordingStop(IPCRecordingStop)
     case clientSettingsUpdate(IPCClientSettingsUpdate)
+    case avatarUpdated(IPCAvatarUpdated)
     case heartbeatConfigResponse(IPCHeartbeatConfigResponse)
     case heartbeatRunsListResponse(IPCHeartbeatRunsListResponse)
     case heartbeatRunNowResponse(IPCHeartbeatRunNowResponse)
@@ -2756,6 +2757,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "client_settings_update":
             let message = try IPCClientSettingsUpdate(from: decoder)
             self = .clientSettingsUpdate(message)
+        case "avatar_updated":
+            let message = try IPCAvatarUpdated(from: decoder)
+            self = .avatarUpdated(message)
         case "heartbeat_config_response":
             let message = try IPCHeartbeatConfigResponse(from: decoder)
             self = .heartbeatConfigResponse(message)


### PR DESCRIPTION
Adds a set_avatar tool that generates avatar images via OpenAI DALL-E, saves them to the workspace avatar path, and notifies connected clients via a new avatar_updated IPC message. Updates system prompt to tell the AI about the tool.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
