### PR TITLE
Fix lifecycle race conditions in live transcription

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/LiveTranscriptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveTranscriptManager.swift
@@ -98,7 +98,7 @@ final class LiveTranscriptManager: ObservableObject {
                 log.info("Live transcription active")
             } catch {
                 // If stopListening() was called while we were awaiting, bail out
-                guard self.startGeneration == currentGeneration else { return }
+                guard self.status == .starting, self.startGeneration == currentGeneration else { return }
 
                 log.error("Failed to start audio capture: \(error.localizedDescription, privacy: .public)")
                 status = .error(error.localizedDescription)

--- a/clients/macos/vellum-assistant/Features/Voice/LiveTranscriptionEngine.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveTranscriptionEngine.swift
@@ -50,10 +50,10 @@ final class LiveTranscriptionEngine {
         switch authStatus {
         case .notDetermined:
             log.info("Speech recognition authorization not determined — requesting")
-            SFSpeechRecognizer.requestAuthorization { [weak self] status in
+            SFSpeechRecognizer.requestAuthorization { status in
                 DispatchQueue.main.async {
                     if status == .authorized {
-                        self?.start()
+                        log.info("Speech recognition authorization granted — user can retry")
                     } else {
                         log.warning("Speech recognition authorization denied")
                     }


### PR DESCRIPTION
Fixes two issues from PR #10028 review:
1. Catch block in startListening() now checks status == .starting before setting error, preventing stale error from overwriting idle after stopListening()
2. Removed auto-start from speech authorization callback to prevent engine running without manager awareness

Part of #10023.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
