### PR TITLE
feat: active blitz registry for check-reviews coordination

### DIFF
--- a/.claude/commands/blitz.md
+++ b/.claude/commands/blitz.md
@@ -23,6 +23,17 @@ Read and follow `.claude/phases/repo-gotchas.md`. Include these gotchas in every
 
 Read and follow `.claude/phases/project-setup.md`.
 
+### Register active blitz
+
+Register this blitz run in `.private/ACTIVE_BLITZ.md` so that standalone `/check-reviews` runs (without `--namespace`) will automatically skip PRs owned by this blitz. This prevents duplicate work when check-reviews runs as a periodic cronjob while this blitz is active.
+
+1. Read `.private/ACTIVE_BLITZ.md` (create it if it doesn't exist). This file is gitignored.
+2. Remove any existing line starting with `<namespace> ` (in case of a stale entry from a previous crashed run).
+3. Append a new entry:
+   ```bash
+   echo "<namespace> blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md
+   ```
+
 ## Phase 2: Plan & Spec
 
 Read and follow `.claude/phases/plan-and-spec.md`. For blitz mode, remove the `<EXTRA_EPIC_FIELDS>` placeholder entirely (no feature branch field).
@@ -253,6 +264,14 @@ After all PRs are merged, proceed to Phase 5.
 
 ## Phase 5: Recursive Sweep
 
+**Update the blitz heartbeat** at the start of each sweep loop iteration to prevent the entry from going stale. Replace the line starting with `<namespace> ` in `.private/ACTIVE_BLITZ.md` with a fresh timestamp:
+```bash
+# Read, filter out old entry, append fresh entry
+grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp 2>/dev/null || true
+echo "<namespace> blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp
+mv .private/ACTIVE_BLITZ.md.tmp .private/ACTIVE_BLITZ.md
+```
+
 Read and follow `.claude/phases/sweep.md`. When it says "back to the Swarm phase", return to Phase 4 above (with the same `--skip-reviews` behavior). When it says "final phase", proceed to Phase 6.
 
 This phase runs a recursive loop: check reviews → swarm to address feedback → review and merge feedback PRs → check reviews on the merged feedback PRs → repeat. PRs created to address feedback are themselves tracked in UNREVIEWED_PRS.md and must be reviewed before the blitz is considered done. The blitz only exits the sweep when there are no namespaced TODO items AND no namespaced PRs pending review.
@@ -262,6 +281,15 @@ This phase runs a recursive loop: check reviews → swarm to address feedback �
 **When `--skip-reviews` is set**: Feedback PRs are merged immediately by swarm agents (current behavior). The sweep continues as before.
 
 ## Phase 6: Report
+
+### Deregister active blitz
+
+Remove this blitz's entry from `.private/ACTIVE_BLITZ.md`:
+```bash
+grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp 2>/dev/null || true
+mv .private/ACTIVE_BLITZ.md.tmp .private/ACTIVE_BLITZ.md
+```
+If the file is now empty (only blank lines), delete it: `rm -f .private/ACTIVE_BLITZ.md`
 
 1. Update the project-level issue status to "Done" and close it:
 

--- a/.claude/commands/check-reviews.md
+++ b/.claude/commands/check-reviews.md
@@ -5,9 +5,42 @@ Arguments (optional): $ARGUMENTS
 Parse optional flags from `$ARGUMENTS`:
 
 - **`--namespace NAME`** (optional): when provided, only process PRs whose head branch starts with `swarm/<NAME>/`. Any TODO items added will be prefixed with `[<NAME>]` (e.g., `- [<NAME>] Address the feedback on <link>`). When omitted, process all PRs. TODO items will still be namespaced if the PR's branch name matches `swarm/<NAME>/...` (the namespace is inferred from the branch).
+- **`--force`** (optional): skip active blitz filtering (see below). Process all PRs regardless of whether they're owned by a running blitz.
+
 To check a PR's head branch name, include `headRefName` in the `--json` fields when fetching PR data.
 
 <instructions>
+
+## Active blitz detection
+
+Before processing PRs, check if any blitz or safe-blitz runs are actively managing their own review cycles. This prevents standalone check-reviews from picking up work that's already being handled by an in-process blitz.
+
+**Skip this section entirely if `--namespace` was explicitly provided or `--force` was passed.** When `--namespace` is provided, the caller is explicitly claiming ownership of that namespace (this is how the blitz sweep itself calls check-reviews). When `--force` is passed, the caller wants to process everything regardless.
+
+If neither `--namespace` nor `--force` was provided:
+
+1. Check if `.private/ACTIVE_BLITZ.md` exists. If not, skip to the main processing below.
+2. Read `.private/ACTIVE_BLITZ.md`. Each non-empty, non-comment line (lines not starting with `#`) represents an active blitz run in the format:
+   ```
+   <namespace> <type> <heartbeat-ISO-timestamp>
+   ```
+   Example: `approval-conv-flow safe-blitz 2026-02-26T10:00:00Z`
+
+3. For each entry, check if the heartbeat is stale (older than 30 minutes):
+   ```bash
+   HEARTBEAT="<heartbeat-timestamp>"
+   HEARTBEAT_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$HEARTBEAT" "+%s" 2>/dev/null)
+   NOW_EPOCH=$(date "+%s")
+   AGE=$(( NOW_EPOCH - HEARTBEAT_EPOCH ))
+   ```
+   - If `AGE > 1800` (30 minutes): the entry is stale. Remove it from the file and log: `"Removing stale blitz entry '<namespace>' (last heartbeat <AGE>s ago)"`. Do not add this namespace to the exclusion list.
+   - If `AGE <= 1800`: add the namespace to an internal **exclusion list**.
+
+4. When building the list of PRs to process from UNREVIEWED_PRS.md, exclude any PR whose head branch starts with `swarm/<excluded-namespace>/` for any namespace in the exclusion list. Log: `"Skipping <N> PRs owned by active <type> '<namespace>' (heartbeat <AGE>s ago)"`
+
+5. Include the skipped PRs in the output table with a new verdict: `🔒 Owned` and a note indicating which blitz owns them. Do NOT remove these PRs from UNREVIEWED_PRS.md.
+
+---
 
 Look at every item in .private/UNREVIEWED_PRS.md. Each line is a PR URL like `https://github.com/<owner>/<repo>/pull/123`.
 
@@ -94,6 +127,7 @@ Display a table with these columns:
   - 📝 Valid feedback
   - ⚠️ Regression risk
   - ⏳ Pending
+  - 🔒 Owned (PR belongs to an active blitz — skipped)
 - **TODO / Removed**: Use ✅ for yes, — for no.
 
 ### Regression risk flagging

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -45,6 +45,17 @@ This keeps your current branch unchanged so safe-blitz doesn't block your main w
 
 3. Store the feature branch name for later phases. Milestone agents will use `--base <feature-branch-name>`. Per-milestone feedback agents will push directly to the milestone PR branch (see Phase 4c).
 
+### Register active blitz
+
+Register this safe-blitz run in `.private/ACTIVE_BLITZ.md` so that standalone `/check-reviews` runs (without `--namespace`) will automatically skip PRs owned by this blitz. This prevents duplicate work when check-reviews runs as a periodic cronjob while this safe-blitz is active.
+
+1. Read `.private/ACTIVE_BLITZ.md` (create it if it doesn't exist). This file is gitignored.
+2. Remove any existing line starting with `<namespace> ` (in case of a stale entry from a previous crashed run).
+3. Append a new entry:
+   ```bash
+   echo "<namespace> safe-blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md
+   ```
+
 ## Phase 2: Plan & Spec
 
 Read and follow `.claude/phases/plan-and-spec.md`. For safe-blitz mode, replace `<EXTRA_EPIC_FIELDS>` with:
@@ -208,6 +219,13 @@ Address the review feedback on PR #<milestone-pr-number> (<milestone-pr-url>):
    ```
 
 #### 4c. Per-milestone feedback loop
+
+**Update the blitz heartbeat** before entering the feedback loop (and at the start of each feedback cycle) to prevent the entry from going stale:
+```bash
+grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp 2>/dev/null || true
+echo "<namespace> safe-blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp
+mv .private/ACTIVE_BLITZ.md.tmp .private/ACTIVE_BLITZ.md
+```
 
 Instead of using the full sweep+swarm machinery (which creates new PRs), per-milestone feedback is handled by pushing fixes directly to the milestone PR branch. This is faster and avoids the overhead of creating, reviewing, and merging intermediate feedback PRs.
 
@@ -442,6 +460,13 @@ Proceed to step 4d.
 
 ## Phase 5: Final Feature Branch Sweep
 
+**Update the blitz heartbeat** at the start of each sweep loop iteration to prevent the entry from going stale:
+```bash
+grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp 2>/dev/null || true
+echo "<namespace> safe-blitz $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .private/ACTIVE_BLITZ.md.tmp
+mv .private/ACTIVE_BLITZ.md.tmp .private/ACTIVE_BLITZ.md
+```
+
 After all milestones are merged and their individual reviews are clean, run one final recursive sweep on the entire feature branch.
 
 Read and follow `.claude/phases/sweep.md` with `--namespace <namespace>` and `--auto`. Safe-blitz already has review gates on every milestone, so an extra pause before the final sweep is unnecessary.
@@ -653,6 +678,15 @@ gh pr checks <final-pr-number> --json name,state,conclusion --jq '.[] | {name: .
 - If all checks pass (or there are no required checks), proceed to Phase 8.
 
 ## Phase 8: Final Summary & Merge Prompt
+
+### Deregister active blitz
+
+Remove this safe-blitz's entry from `.private/ACTIVE_BLITZ.md`:
+```bash
+grep -v "^<namespace> " .private/ACTIVE_BLITZ.md > .private/ACTIVE_BLITZ.md.tmp 2>/dev/null || true
+mv .private/ACTIVE_BLITZ.md.tmp .private/ACTIVE_BLITZ.md
+```
+If the file is now empty (only blank lines), delete it: `rm -f .private/ACTIVE_BLITZ.md`
 
 1. If the final PR warrants focused human review, leave a Human Attention Comment (see "Human Attention Comments on PRs" in AGENTS.md). Skip for routine changes.
 

--- a/.claude/phases/blitz-important.md
+++ b/.claude/phases/blitz-important.md
@@ -1,6 +1,6 @@
 ## Important
 
-- `.private/TODO.md` and `.private/UNREVIEWED_PRS.md` are written to by other processes. Always read before writing, verify after writing. These files are gitignored.
+- `.private/TODO.md`, `.private/UNREVIEWED_PRS.md`, and `.private/ACTIVE_BLITZ.md` are written to by other processes. Always read before writing, verify after writing. These files are gitignored.
 - Don't sleep for more than 15 seconds at a time while waiting for agents to finish.
 - If an agent reports failure, put the item back in TODO.md and note the failure.
 - Use `.claude/worktree` for isolation (same as swarm).


### PR DESCRIPTION
## Summary
- Adds `.private/ACTIVE_BLITZ.md` as a heartbeat-based registry for active blitz/safe-blitz runs
- `check-reviews` now auto-skips PRs owned by active blitz namespaces when run without `--namespace` (the blitz sweep passes `--namespace`, so it's unaffected)
- Blitz and safe-blitz register on start, update heartbeat during sweep/feedback loops, and deregister on completion. Stale entries (>30 min without heartbeat) are auto-cleaned
- New `--force` flag on `check-reviews` as an escape hatch to bypass filtering

## Original prompt
go ahead and implement your recommendation

🤖 Generated with [Claude Code](https://claude.com/claude-code)