### PR TITLE
Wire live listening into production UI

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1918,6 +1918,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             voiceInputManager: voiceInput
         )
 
+        // Wire the audio monitor into LiveTranscriptManager so it can
+        // pause/resume wake-word detection during live transcription.
+        mainWindow.liveTranscriptManager.setAudioMonitor(audioMonitor)
+
         if UserDefaults.standard.bool(forKey: "wakeWordEnabled") {
             audioMonitor.startMonitoring()
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -140,6 +140,7 @@ public final class MainWindow {
     let avatarEvolutionState: AvatarEvolutionState?
     var onMicrophoneToggle: (() -> Void)?
     let voiceModeManager = VoiceModeManager()
+    let liveTranscriptManager = LiveTranscriptManager()
 
     /// Wake-up greeting to auto-send after the "coming alive" transition completes.
     /// Set by AppDelegate on first launch; consumed by MainWindowView.
@@ -296,7 +297,7 @@ public final class MainWindow {
             }
         } : nil
 
-        let rootView = MainWindowView(threadManager: threadManager, appListManager: appListManager, zoomManager: zoomManager, conversationZoomManager: services.conversationZoomManager, traceStore: traceStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, documentManager: documentManager, avatarEvolutionState: avatarEvolutionState, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, onSendWakeUp: wakeUpCallback)
+        let rootView = MainWindowView(threadManager: threadManager, appListManager: appListManager, zoomManager: zoomManager, conversationZoomManager: services.conversationZoomManager, traceStore: traceStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, documentManager: documentManager, avatarEvolutionState: avatarEvolutionState, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, liveTranscriptManager: liveTranscriptManager, onSendWakeUp: wakeUpCallback)
         let hostingController = NonDraggableHostingController(rootView: rootView)
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -86,6 +86,7 @@ struct MainWindowView: View {
     @State private var lastAppliedBootstrapTurn: Int = 0
     let onMicrophoneToggle: () -> Void
     @ObservedObject var voiceModeManager: VoiceModeManager
+    @ObservedObject var liveTranscriptManager: LiveTranscriptManager
 
     /// Callback to send the wake-up greeting after the "coming alive" transition.
     /// Nil for returning users (no transition).
@@ -94,7 +95,7 @@ struct MainWindowView: View {
     /// Whether the "coming alive" overlay is currently showing.
     @State private var showComingAlive: Bool
 
-    init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, conversationZoomManager: ConversationZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, avatarEvolutionState: AvatarEvolutionState? = nil, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager = VoiceModeManager(), onSendWakeUp: (() -> Void)? = nil) {
+    init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, conversationZoomManager: ConversationZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, avatarEvolutionState: AvatarEvolutionState? = nil, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager = VoiceModeManager(), liveTranscriptManager: LiveTranscriptManager = LiveTranscriptManager(), onSendWakeUp: (() -> Void)? = nil) {
         self.threadManager = threadManager
         self.appListManager = appListManager
         self.zoomManager = zoomManager
@@ -110,6 +111,7 @@ struct MainWindowView: View {
         self.avatarEvolutionState = avatarEvolutionState
         self.onMicrophoneToggle = onMicrophoneToggle
         self.voiceModeManager = voiceModeManager
+        self.liveTranscriptManager = liveTranscriptManager
         self.onSendWakeUp = onSendWakeUp
         self._showComingAlive = State(initialValue: onSendWakeUp != nil)
     }
@@ -527,6 +529,9 @@ struct MainWindowView: View {
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: timer)
                     }
                 }
+
+                // Live listening toggle
+                LiveListeningIndicator(manager: liveTranscriptManager)
 
                 // Voice mode toggle
                 VIconButton(

--- a/clients/macos/vellum-assistant/Features/Voice/LiveTranscriptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveTranscriptManager.swift
@@ -58,6 +58,12 @@ final class LiveTranscriptManager: ObservableObject {
         setupCallbacks()
     }
 
+    /// Late-bind the audio monitor when it isn't available at init time
+    /// (e.g. wake word coordinator is set up after the main window).
+    func setAudioMonitor(_ monitor: AlwaysOnAudioMonitor) {
+        self.audioMonitor = monitor
+    }
+
     // MARK: - Public API
 
     func startListening() {


### PR DESCRIPTION
## Summary
- Adds `LiveTranscriptManager` as a property on `MainWindow`, following the same pattern as `VoiceModeManager`
- Passes `LiveTranscriptManager` through to `MainWindowView` via dependency injection
- Places `LiveListeningIndicator` in the top bar alongside the voice mode toggle button

Users can now start/stop live audio transcription directly from the toolbar.

Part of #10023.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
