### PR TITLE
refactor: reorganize Settings panel tabs for clearer navigation

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -2203,7 +2203,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
     /// Opens the settings panel and navigates to a specific tab.
     public func showSettingsTab(_ tab: String) {
-        if let settingsTab = SettingsTab.fromLegacyRawValue(tab) {
+        if let settingsTab = SettingsTab.fromLegacyRawValue(tab, isDevMode: services.settingsStore.isDevMode) {
             services.settingsStore.pendingSettingsTab = settingsTab
         }
         showSettingsWindow(nil)

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -2203,7 +2203,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
     /// Opens the settings panel and navigates to a specific tab.
     public func showSettingsTab(_ tab: String) {
-        if let settingsTab = SettingsTab(rawValue: tab) {
+        if let settingsTab = SettingsTab.fromLegacyRawValue(tab) {
             services.settingsStore.pendingSettingsTab = settingsTab
         }
         showSettingsWindow(nil)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -1,16 +1,44 @@
 import SwiftUI
 import VellumAssistantShared
 
-enum SettingsTab: String, CaseIterable {
-    case connect = "Connect"
-    case integrations = "Integrations"
-    case trust = "Trust"
-    case reminders = "Schedules"
-    case heartbeat = "Heartbeat"
+enum SettingsTab: String {
+    case account = "Account"
+    case channels = "Channels"
+    case modelsAndServices = "Models & Services"
     case voice = "Voice"
+    case permissions = "Permissions"
+    case automation = "Automation"
     case appearance = "Appearance"
-    case advanced = "Advanced"
     case parental = "Parental"
+    case advanced = "Advanced"
+
+    /// Tabs shown in the sidebar. Advanced is only visible in dev mode.
+    static func visibleTabs(isDevMode: Bool) -> [SettingsTab] {
+        var tabs: [SettingsTab] = [
+            .account, .channels, .modelsAndServices, .voice,
+            .permissions, .automation, .appearance, .parental
+        ]
+        if isDevMode {
+            tabs.append(.advanced)
+        }
+        return tabs
+    }
+
+    /// Maps legacy tab names (from IPC or saved state) to current tabs.
+    static func fromLegacyRawValue(_ value: String) -> SettingsTab? {
+        // Try current values first
+        if let tab = SettingsTab(rawValue: value) { return tab }
+        // Map legacy names
+        switch value {
+        case "Connect": return .account
+        case "Integrations": return .modelsAndServices
+        case "Trust": return .permissions
+        case "Schedules": return .automation
+        case "Heartbeat": return .automation
+        case "Advanced": return .advanced
+        default: return nil
+        }
+    }
 }
 
 @MainActor
@@ -45,8 +73,7 @@ struct SettingsPanel: View {
     @State private var showModelDropdown = false
     @State private var mouseDownMonitor: Any?
     @State private var modelDropdownFrame: CGRect = .zero
-    @State private var selectedTab: SettingsTab = .connect
-    @State private var testerModel: ToolPermissionTesterModel?
+    @State private var selectedTab: SettingsTab = .account
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -92,9 +119,6 @@ struct SettingsPanel: View {
             store.refreshIngressConfig()
             setupIntegrationCallbacks()
             try? daemonClient?.sendIntegrationList()
-            if testerModel == nil, let dc = daemonClient {
-                testerModel = ToolPermissionTesterModel(daemonClient: dc)
-            }
             if let pending = store.pendingSettingsTab {
                 selectedTab = pending
                 store.pendingSettingsTab = nil
@@ -180,7 +204,7 @@ struct SettingsPanel: View {
 
     private var settingsNav: some View {
         VStack(alignment: .leading, spacing: VSpacing.xxs) {
-            ForEach(SettingsTab.allCases, id: \.self) { tab in
+            ForEach(SettingsTab.visibleTabs(isDevMode: store.isDevMode), id: \.self) { tab in
                 SettingsNavRow(tab: tab, isSelected: selectedTab == tab) {
                     selectedTab = tab
                 }
@@ -195,29 +219,24 @@ struct SettingsPanel: View {
     @ViewBuilder
     private var selectedTabContent: some View {
         switch selectedTab {
-        case .connect:
-            SettingsConnectTab(store: store, daemonClient: daemonClient, authManager: authManager)
-        case .integrations:
+        case .account:
+            SettingsAccountTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose)
+        case .channels:
+            SettingsChannelsTab(store: store, daemonClient: daemonClient)
+        case .modelsAndServices:
             integrationsContent
-        case .trust:
-            trustContent
-        case .reminders:
-            remindersContent
-        case .heartbeat:
-            HeartbeatSettingsTab(daemonClient: daemonClient)
         case .voice:
             VoiceSettingsView(store: store)
+        case .permissions:
+            permissionsContent
+        case .automation:
+            SettingsAutomationTab(daemonClient: daemonClient, showingReminders: $showingReminders, showingScheduledTasks: $showingScheduledTasks)
         case .appearance:
             SettingsAppearanceTab(store: store)
-        case .advanced:
-            SettingsAdvancedTab(
-                store: store,
-                threadManager: threadManager,
-                onClose: onClose,
-                daemonClient: daemonClient
-            )
         case .parental:
             SettingsParentalTab(daemonClient: daemonClient)
+        case .advanced:
+            SettingsAdvancedDevTab(store: store, daemonClient: daemonClient)
         }
     }
 
@@ -640,11 +659,11 @@ struct SettingsPanel: View {
         .vCard(background: VColor.surfaceSubtle)
     }
 
-    // MARK: - Trust Tab
+    // MARK: - Permissions Tab
 
-    private var trustContent: some View {
+    private var permissionsContent: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
-            // PERMISSIONS section
+            // PERMISSIONS section (OS permissions)
             VStack(alignment: .leading, spacing: VSpacing.md) {
                 Text("Permissions")
                     .font(VFont.sectionTitle)
@@ -735,83 +754,27 @@ struct SettingsPanel: View {
                 .vCard(background: VColor.surfaceSubtle)
             }
 
-            // PERMISSION SIMULATOR section
-            if let model = testerModel {
-                ToolPermissionTesterView(model: model)
-            }
-
-            // PRIVACY & SECURITY section
+            // COMPUTER USAGE section (moved from Advanced)
             VStack(alignment: .leading, spacing: VSpacing.md) {
-                Text("Privacy & Security")
+                Text("Computer Usage")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
 
-                VStack(alignment: .leading, spacing: 0) {
-                    privacyBullet(icon: "eye.slash", text: "AI only runs when you explicitly trigger it")
-                    Divider().background(VColor.surfaceBorder)
-                    privacyBullet(icon: "lock.shield", text: "API key stored in macOS Keychain")
-                    Divider().background(VColor.surfaceBorder)
-                    privacyBullet(icon: "xmark.shield", text: "Your data is not used to train AI models")
-                    Divider().background(VColor.surfaceBorder)
-                    privacyBullet(icon: "internaldrive", text: "Session logs and knowledge stored locally on your Mac")
+                HStack {
+                    Text("Max Steps per Session")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    VInfoTooltip("Maximum number of tool-use steps the assistant can take in a single session")
+                    Spacer()
+                    Text("\(Int(store.maxSteps))")
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textSecondary)
                 }
+
+                VSlider(value: $store.maxSteps, range: 1...100, step: 10, showTickMarks: true)
             }
             .padding(VSpacing.lg)
             .vCard(background: VColor.surfaceSubtle)
-        }
-    }
-
-    // MARK: - Reminders Tab
-
-    private var remindersContent: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xl) {
-            if daemonClient != nil {
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    Text("Reminders")
-                        .font(VFont.sectionTitle)
-                        .foregroundColor(VColor.textPrimary)
-
-                    HStack {
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Manage Reminders")
-                                .font(VFont.body)
-                                .foregroundColor(VColor.textSecondary)
-                            Text("View and manage one-shot reminders created by the assistant")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textMuted)
-                        }
-                        Spacer()
-                        VButton(label: "Manage...", style: .tertiary) {
-                            showingReminders = true
-                        }
-                    }
-                }
-                .padding(VSpacing.lg)
-                .vCard(background: VColor.surfaceSubtle)
-
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    Text("Scheduled Tasks")
-                        .font(VFont.sectionTitle)
-                        .foregroundColor(VColor.textPrimary)
-
-                    HStack {
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Manage Scheduled Tasks")
-                                .font(VFont.body)
-                                .foregroundColor(VColor.textSecondary)
-                            Text("View and manage recurring tasks (cron and RRULE schedules)")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textMuted)
-                        }
-                        Spacer()
-                        VButton(label: "Manage...", style: .tertiary) {
-                            showingScheduledTasks = true
-                        }
-                    }
-                }
-                .padding(VSpacing.lg)
-                .vCard(background: VColor.surfaceSubtle)
-            }
         }
     }
 
@@ -1017,21 +980,6 @@ struct SettingsPanel: View {
                 await refreshPermissionStatus()
             }
         }
-    }
-
-    // MARK: - Privacy Bullet
-
-    private func privacyBullet(icon: String, text: String) -> some View {
-        HStack(alignment: .top, spacing: VSpacing.sm) {
-            Image(systemName: icon)
-                .font(.system(size: 12))
-                .foregroundColor(VColor.textMuted)
-                .frame(width: 16)
-            Text(text)
-                .font(VFont.caption)
-                .foregroundColor(VColor.textSecondary)
-        }
-        .padding(.vertical, VSpacing.md)
     }
 
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -25,19 +25,28 @@ enum SettingsTab: String {
     }
 
     /// Maps legacy tab names (from IPC or saved state) to current tabs.
-    static func fromLegacyRawValue(_ value: String) -> SettingsTab? {
+    /// The `isDevMode` parameter gates dev-only tabs so external callers
+    /// (e.g. daemon IPC) cannot navigate to them when dev mode is off.
+    static func fromLegacyRawValue(_ value: String, isDevMode: Bool = false) -> SettingsTab? {
+        let tab: SettingsTab?
         // Try current values first
-        if let tab = SettingsTab(rawValue: value) { return tab }
-        // Map legacy names
-        switch value {
-        case "Connect": return .account
-        case "Integrations": return .modelsAndServices
-        case "Trust": return .permissions
-        case "Schedules": return .automation
-        case "Heartbeat": return .automation
-        case "Advanced": return .advanced
-        default: return nil
+        if let direct = SettingsTab(rawValue: value) {
+            tab = direct
+        } else {
+            // Map legacy names
+            switch value {
+            case "Connect": tab = .account
+            case "Integrations": tab = .modelsAndServices
+            case "Trust": tab = .permissions
+            case "Schedules": tab = .automation
+            case "Heartbeat": tab = .automation
+            case "Advanced": tab = .advanced
+            default: tab = nil
+            }
         }
+        // Block dev-only tabs when dev mode is disabled
+        if tab == .advanced && !isDevMode { return nil }
+        return tab
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -2,56 +2,60 @@ import Foundation
 import SwiftUI
 import VellumAssistantShared
 
-/// Advanced settings tab — computer usage limits, archived threads,
-/// and developer tools.
+/// Account settings tab — sign-in/out, assistant identity, switch/retire/hatch.
 @MainActor
-struct SettingsAdvancedTab: View {
+struct SettingsAccountTab: View {
     @ObservedObject var store: SettingsStore
-    @ObservedObject var threadManager: ThreadManager
-    var onClose: () -> Void
     var daemonClient: DaemonClient?
+    var authManager: AuthManager
+    var onClose: () -> Void
 
+    // -- Account / Vellum section state --
+    @State private var platformUrlText: String = ""
+    @FocusState private var isPlatformUrlFocused: Bool
+
+    // -- Assistant Info state (from SettingsAdvancedTab) --
     @State private var showingRetireConfirmation: Bool = false
     @State private var isRetiring: Bool = false
     @State private var lockfileAssistants: [LockfileAssistant] = []
     @State private var selectedAssistantId: String = ""
     @State private var identity: IdentityInfo?
     @State private var remoteIdentity: RemoteIdentityInfo?
-    @State private var flagStates: [(flag: FeatureFlag, enabled: Bool)] = []
-
     @State private var devModeTapCount: Int = 0
     @State private var devModeMessage: String?
 
-    @State private var showingEnvVars = false
-    @State private var appEnvVars: [(String, String)] = []
-    @State private var daemonEnvVars: [(String, String)] = []
-
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
+            accountSection
             assistantInfoSection
-            computerUsageSection
-            archivedThreadsSection
             switchAssistantSection
             retireAssistantSection
             hatchNewAssistantSection
-            featureFlagSection
-
-            if store.isDevMode {
-                developerSection
-            }
         }
         .onAppear {
+            Task { await authManager.checkSession() }
+            store.refreshPlatformConfig()
+            Task { await store.checkVellumPlatform() }
+            platformUrlText = store.platformBaseUrl
             lockfileAssistants = LockfileAssistant.loadAll()
             selectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
             identity = IdentityInfo.load()
-            flagStates = FeatureFlag.allCases.map { flag in
-                (flag: flag, enabled: FeatureFlagManager.shared.isEnabled(flag))
-            }
-
-            if identity == nil, let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }), assistant.isRemote {
+            if identity == nil,
+               let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }),
+               assistant.isRemote {
                 Task {
                     remoteIdentity = await daemonClient?.fetchRemoteIdentity()
                 }
+            }
+        }
+        .onChange(of: store.platformBaseUrl) { _, newValue in
+            if !isPlatformUrlFocused {
+                platformUrlText = newValue
+            }
+        }
+        .onChange(of: isPlatformUrlFocused) { _, focused in
+            if !focused {
+                platformUrlText = store.platformBaseUrl
             }
         }
         .alert("Retire Assistant", isPresented: $showingRetireConfirmation) {
@@ -88,12 +92,117 @@ struct SettingsAdvancedTab: View {
             .frame(minWidth: 260)
             .interactiveDismissDisabled()
         }
-        .sheet(isPresented: $showingEnvVars) {
-            SettingsPanelEnvVarsSheet(appEnvVars: appEnvVars, daemonEnvVars: daemonEnvVars)
+    }
+
+    // MARK: - Account Section
+
+    private var accountSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("Account")
+                .font(VFont.sectionTitle)
+                .foregroundColor(VColor.textPrimary)
+
+            if authManager.isLoading {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .foregroundColor(VColor.textMuted)
+                        .font(.system(size: 14))
+                    Text("Checking...")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                }
+            } else if let user = authManager.currentUser {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(VColor.success)
+                        .font(.system(size: 14))
+                    Text(user.email ?? user.display ?? "Signed in")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Spacer()
+                    VButton(label: "Log Out", style: .danger) {
+                        Task { await authManager.logout() }
+                    }
+                }
+            } else {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "xmark.circle")
+                        .foregroundColor(VColor.textMuted)
+                        .font(.system(size: 14))
+                    Text("Not signed in")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Spacer()
+                    VButton(
+                        label: authManager.isSubmitting ? "Signing in..." : "Log In",
+                        style: .primary
+                    ) {
+                        Task { await authManager.startWorkOSLogin() }
+                    }
+                    .disabled(authManager.isSubmitting)
+                }
+            }
+
+            if let error = authManager.errorMessage {
+                Text(error)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
+            }
+
+            if store.isDevMode {
+                Divider().background(VColor.surfaceBorder)
+
+                Text("Platform URL")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+
+                HStack(spacing: VSpacing.sm) {
+                    TextField("https://platform.vellum.ai", text: $platformUrlText)
+                        .focused($isPlatformUrlFocused)
+                        .vInputStyle()
+                        .font(VFont.mono)
+                        .onSubmit {
+                            store.savePlatformBaseUrl(platformUrlText)
+                            Task { await store.checkVellumPlatform() }
+                        }
+                    VButton(label: "Save", style: .primary) {
+                        store.savePlatformBaseUrl(platformUrlText)
+                        Task { await store.checkVellumPlatform() }
+                    }
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder)
+
+            // Platform connection status
+            HStack(spacing: VSpacing.sm) {
+                Text("Platform")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                Spacer()
+                if store.isCheckingVellumPlatform {
+                    ProgressView().controlSize(.small)
+                } else if let reachable = store.vellumPlatformReachable {
+                    Image(systemName: reachable ? "checkmark.circle.fill" : "xmark.circle.fill")
+                        .foregroundColor(reachable ? VColor.success : VColor.error)
+                        .font(.system(size: 12))
+                    Text(reachable ? "Reachable" : (store.vellumPlatformError ?? "Unreachable"))
+                        .font(VFont.caption)
+                        .foregroundColor(reachable ? VColor.success : VColor.error)
+                }
+                Button {
+                    Task { await store.checkVellumPlatform() }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(VColor.textSecondary)
+                }
+                .buttonStyle(.plain)
+            }
         }
-        .onDisappear {
-            daemonClient?.onEnvVarsResponse = nil
-        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard(background: VColor.surfaceSubtle)
     }
 
     // MARK: - Assistant Info
@@ -134,7 +243,7 @@ struct SettingsAdvancedTab: View {
 
             // Process status (child view observes @Published changes)
             if let daemonClient {
-                DaemonStatusRows(daemonClient: daemonClient)
+                AccountDaemonStatusRows(daemonClient: daemonClient)
             }
         }
         .padding(VSpacing.lg)
@@ -184,64 +293,6 @@ struct SettingsAdvancedTab: View {
             }
 
             Spacer()
-        }
-    }
-
-    // MARK: - Computer Usage
-
-    private var computerUsageSection: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Computer Usage")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.textPrimary)
-
-            HStack {
-                Text("Max Steps per Session")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textSecondary)
-                VInfoTooltip("Maximum number of tool-use steps the assistant can take in a single session")
-                Spacer()
-                Text("\(Int(store.maxSteps))")
-                    .font(VFont.mono)
-                    .foregroundColor(VColor.textSecondary)
-            }
-
-            VSlider(value: $store.maxSteps, range: 1...100, step: 10, showTickMarks: true)
-        }
-        .padding(VSpacing.lg)
-        .vCard(background: VColor.surfaceSubtle)
-    }
-
-    // MARK: - Archived Threads
-
-    @ViewBuilder
-    private var archivedThreadsSection: some View {
-        if !threadManager.archivedThreads.isEmpty {
-            VStack(alignment: .leading, spacing: VSpacing.md) {
-                Text("Archived Threads")
-                    .font(VFont.sectionTitle)
-                    .foregroundColor(VColor.textPrimary)
-
-                ForEach(threadManager.archivedThreads) { thread in
-                    HStack {
-                        Text(thread.title)
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textSecondary)
-                            .lineLimit(1)
-                        Spacer()
-                        Button(action: { threadManager.unarchiveThread(id: thread.id) }) {
-                            Text("Unarchive")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.accent)
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel("Unarchive \(thread.title)")
-                    }
-                    .padding(.vertical, VSpacing.xs)
-                }
-            }
-            .padding(VSpacing.lg)
-            .vCard(background: VColor.surfaceSubtle)
         }
     }
 
@@ -360,83 +411,13 @@ struct SettingsAdvancedTab: View {
             .vCard(background: VColor.surfaceSubtle)
         }
     }
-
-    // MARK: - Feature Flags
-
-    @ViewBuilder
-    private var featureFlagSection: some View {
-        if store.isDevMode {
-            VStack(alignment: .leading, spacing: VSpacing.md) {
-                Text("Feature Flags")
-                    .font(VFont.sectionTitle)
-                    .foregroundColor(VColor.textPrimary)
-
-                ForEach(Array(flagStates.enumerated()), id: \.element.flag) { index, entry in
-                    Toggle(entry.flag.displayName, isOn: Binding(
-                        get: { flagStates[index].enabled },
-                        set: { newValue in
-                            flagStates[index].enabled = newValue
-                            FeatureFlagManager.shared.setOverride(entry.flag, enabled: newValue)
-                        }
-                    ))
-                    .toggleStyle(.switch)
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textSecondary)
-                }
-            }
-            .padding(VSpacing.lg)
-            .vCard(background: VColor.surfaceSubtle)
-        }
-    }
-
-    // MARK: - Developer
-
-    @ViewBuilder
-    private var developerSection: some View {
-        if daemonClient != nil {
-            VStack(alignment: .leading, spacing: VSpacing.md) {
-                Text("Developer")
-                    .font(VFont.sectionTitle)
-                    .foregroundColor(VColor.textPrimary)
-
-                HStack {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        Text("Environment Variables")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textSecondary)
-                        Text("View env vars for both the app and daemon processes")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-                    }
-                    Spacer()
-                    VButton(label: "View...", style: .tertiary) {
-                        appEnvVars = ProcessInfo.processInfo.environment
-                            .sorted(by: { $0.key < $1.key })
-                            .map { ($0.key, $0.value) }
-                        daemonEnvVars = []
-                        daemonClient?.onEnvVarsResponse = { response in
-                            Task { @MainActor in
-                                self.daemonEnvVars = response.vars
-                                    .sorted(by: { $0.key < $1.key })
-                                    .map { ($0.key, $0.value) }
-                            }
-                        }
-                        try? daemonClient?.sendEnvVarsRequest()
-                        showingEnvVars = true
-                    }
-                }
-            }
-            .padding(VSpacing.lg)
-            .vCard(background: VColor.surfaceSubtle)
-        }
-    }
 }
 
 // MARK: - Daemon Status Rows
 
 /// Extracted child view so SwiftUI observes `DaemonClient`'s `@Published`
 /// properties and re-renders when connection or memory status changes.
-private struct DaemonStatusRows: View {
+private struct AccountDaemonStatusRows: View {
     @ObservedObject var daemonClient: DaemonClient
 
     var body: some View {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Advanced / Developer settings tab — permission simulator, feature flags,
+/// and environment variables. Only visible when dev mode is enabled.
+@MainActor
+struct SettingsAdvancedDevTab: View {
+    @ObservedObject var store: SettingsStore
+    var daemonClient: DaemonClient?
+
+    @State private var flagStates: [(flag: FeatureFlag, enabled: Bool)] = []
+    @State private var showingEnvVars = false
+    @State private var appEnvVars: [(String, String)] = []
+    @State private var daemonEnvVars: [(String, String)] = []
+    @State private var testerModel: ToolPermissionTesterModel?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xl) {
+            // Permission Simulator
+            if let model = testerModel {
+                ToolPermissionTesterView(model: model)
+            }
+
+            // Feature Flags
+            featureFlagSection
+
+            // Developer section (env vars)
+            developerSection
+        }
+        .onAppear {
+            flagStates = FeatureFlag.allCases.map { flag in
+                (flag: flag, enabled: FeatureFlagManager.shared.isEnabled(flag))
+            }
+            if testerModel == nil, let dc = daemonClient {
+                testerModel = ToolPermissionTesterModel(daemonClient: dc)
+            }
+        }
+        .sheet(isPresented: $showingEnvVars) {
+            SettingsPanelEnvVarsSheet(appEnvVars: appEnvVars, daemonEnvVars: daemonEnvVars)
+        }
+        .onDisappear {
+            daemonClient?.onEnvVarsResponse = nil
+        }
+    }
+
+    // MARK: - Feature Flags
+
+    private var featureFlagSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("Feature Flags")
+                .font(VFont.sectionTitle)
+                .foregroundColor(VColor.textPrimary)
+
+            ForEach(Array(flagStates.enumerated()), id: \.element.flag) { index, entry in
+                Toggle(entry.flag.displayName, isOn: Binding(
+                    get: { flagStates[index].enabled },
+                    set: { newValue in
+                        flagStates[index].enabled = newValue
+                        FeatureFlagManager.shared.setOverride(entry.flag, enabled: newValue)
+                    }
+                ))
+                .toggleStyle(.switch)
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+            }
+        }
+        .padding(VSpacing.lg)
+        .vCard(background: VColor.surfaceSubtle)
+    }
+
+    // MARK: - Developer
+
+    @ViewBuilder
+    private var developerSection: some View {
+        if daemonClient != nil {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("Developer")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                HStack {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Environment Variables")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                        Text("View env vars for both the app and daemon processes")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    Spacer()
+                    VButton(label: "View...", style: .tertiary) {
+                        appEnvVars = ProcessInfo.processInfo.environment
+                            .sorted(by: { $0.key < $1.key })
+                            .map { ($0.key, $0.value) }
+                        daemonEnvVars = []
+                        daemonClient?.onEnvVarsResponse = { response in
+                            Task { @MainActor in
+                                self.daemonEnvVars = response.vars
+                                    .sorted(by: { $0.key < $1.key })
+                                    .map { ($0.key, $0.value) }
+                            }
+                        }
+                        try? daemonClient?.sendEnvVarsRequest()
+                        showingEnvVars = true
+                    }
+                }
+            }
+            .padding(VSpacing.lg)
+            .vCard(background: VColor.surfaceSubtle)
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAutomationTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAutomationTab.swift
@@ -1,18 +1,78 @@
 import SwiftUI
 import VellumAssistantShared
 
-// MARK: - Heartbeat Settings Tab
-
+/// Automation settings tab — reminders, scheduled tasks, and heartbeat monitoring.
 @MainActor
-struct HeartbeatSettingsTab: View {
+struct SettingsAutomationTab: View {
     var daemonClient: DaemonClient?
+    @Binding var showingReminders: Bool
+    @Binding var showingScheduledTasks: Bool
 
-    // -- Config state --
-    @State private var isEnabled: Bool = false
-    @State private var intervalMs: Double = 3_600_000
-    @State private var activeHoursStart: Double? = nil
-    @State private var activeHoursEnd: Double? = nil
-    @State private var nextRunAt: Int? = nil
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xl) {
+            // Reminders section (from old Schedules tab)
+            if daemonClient != nil {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text("Reminders")
+                        .font(VFont.sectionTitle)
+                        .foregroundColor(VColor.textPrimary)
+
+                    HStack {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Manage Reminders")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textSecondary)
+                            Text("View and manage one-shot reminders created by the assistant")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                        Spacer()
+                        VButton(label: "Manage...", style: .tertiary) {
+                            showingReminders = true
+                        }
+                    }
+                }
+                .padding(VSpacing.lg)
+                .vCard(background: VColor.surfaceSubtle)
+
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text("Scheduled Tasks")
+                        .font(VFont.sectionTitle)
+                        .foregroundColor(VColor.textPrimary)
+
+                    HStack {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Manage Scheduled Tasks")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textSecondary)
+                            Text("View and manage recurring tasks (cron and RRULE schedules)")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                        Spacer()
+                        VButton(label: "Manage...", style: .tertiary) {
+                            showingScheduledTasks = true
+                        }
+                    }
+                }
+                .padding(VSpacing.lg)
+                .vCard(background: VColor.surfaceSubtle)
+            }
+
+            // Heartbeat section (checklist + runs, minus configCard)
+            HeartbeatAutomationSection(daemonClient: daemonClient)
+        }
+    }
+}
+
+// MARK: - Heartbeat Automation Section
+
+/// Heartbeat monitoring section for the Automation tab.
+/// Shows the checklist and recent runs (excludes the configuration card
+/// which is managed via conversation with the assistant).
+@MainActor
+struct HeartbeatAutomationSection: View {
+    var daemonClient: DaemonClient?
 
     // -- Checklist state --
     @State private var checklistContent: String = ""
@@ -26,12 +86,8 @@ struct HeartbeatSettingsTab: View {
     // -- Expansion state --
     @State private var expandedRunId: String?
 
-    // -- Loading --
-    @State private var isLoading: Bool = true
-
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
-            configCard
             checklistCard
             runsCard
         }
@@ -39,83 +95,12 @@ struct HeartbeatSettingsTab: View {
         .onDisappear { clearCallbacks() }
     }
 
-    // MARK: - Configuration Card (read-only)
-
-    private var configCard: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Configuration")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.textPrimary)
-
-            // Status
-            HStack {
-                Text("Status")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textSecondary)
-                Spacer()
-                Text(isEnabled ? "Enabled" : "Disabled")
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(isEnabled ? VColor.success : VColor.textMuted)
-            }
-
-            if isEnabled {
-                Divider().background(VColor.surfaceBorder)
-
-                // Interval
-                HStack {
-                    Text("Check every")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textSecondary)
-                    Spacer()
-                    Text(formatInterval(intervalMs))
-                        .font(VFont.bodyMedium)
-                        .foregroundColor(VColor.textPrimary)
-                }
-
-                // Active hours
-                if let start = activeHoursStart, let end = activeHoursEnd {
-                    Divider().background(VColor.surfaceBorder)
-                    HStack {
-                        Text("Active hours")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textSecondary)
-                        Spacer()
-                        Text("\(formatHour(Int(start))) – \(formatHour(Int(end)))")
-                            .font(VFont.bodyMedium)
-                            .foregroundColor(VColor.textPrimary)
-                    }
-                }
-
-                // Next run status
-                if let nextRun = nextRunAt, nextRun > 0 {
-                    Divider().background(VColor.surfaceBorder)
-                    HStack(spacing: VSpacing.sm) {
-                        Image(systemName: "clock")
-                            .font(.system(size: 12))
-                            .foregroundColor(VColor.textMuted)
-                        Text("Next run ~\(formatTimestamp(nextRun))")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-                    }
-                }
-            }
-
-            Divider().background(VColor.surfaceBorder)
-
-            Text("Ask the assistant to change heartbeat settings.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
-        }
-        .padding(VSpacing.lg)
-        .vCard(background: VColor.surfaceSubtle)
-    }
-
     // MARK: - Checklist Card
 
     private var checklistCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
             HStack {
-                Text("Checklist")
+                Text("Heartbeat Checklist")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
                 Spacer()
@@ -155,7 +140,7 @@ struct HeartbeatSettingsTab: View {
     private var runsCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
             HStack {
-                Text("Recent Runs")
+                Text("Heartbeat Runs")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
                 Spacer()
@@ -287,27 +272,6 @@ struct HeartbeatSettingsTab: View {
         .frame(width: 70, alignment: .leading)
     }
 
-    private func formatInterval(_ ms: Double) -> String {
-        let minutes = Int(ms / 60_000)
-        if minutes < 60 {
-            return "\(minutes) min"
-        }
-        let hours = minutes / 60
-        let remainingMinutes = minutes % 60
-        if remainingMinutes == 0 {
-            return hours == 1 ? "1 hour" : "\(hours) hours"
-        }
-        return "\(hours)h \(remainingMinutes)m"
-    }
-
-    private func formatHour(_ hour: Int) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "h a"
-        let calendar = Calendar.current
-        let date = calendar.date(from: DateComponents(hour: hour)) ?? Date()
-        return formatter.string(from: date)
-    }
-
     private func formatTimestamp(_ ms: Int) -> String {
         let date = Date(timeIntervalSince1970: Double(ms) / 1000.0)
         let formatter = DateFormatter()
@@ -319,22 +283,11 @@ struct HeartbeatSettingsTab: View {
     // MARK: - Data Loading
 
     private func loadAll() {
-        try? daemonClient?.sendHeartbeatConfigGet()
         try? daemonClient?.sendHeartbeatChecklistRead()
         try? daemonClient?.sendHeartbeatRunsList(limit: 20)
     }
 
     private func setupCallbacks() {
-        daemonClient?.onHeartbeatConfigResponse = { response in
-            Task { @MainActor in
-                self.isEnabled = response.enabled
-                self.intervalMs = response.intervalMs
-                self.activeHoursStart = response.activeHoursStart
-                self.activeHoursEnd = response.activeHoursEnd
-                self.nextRunAt = response.nextRunAt
-                self.isLoading = false
-            }
-        }
         daemonClient?.onHeartbeatChecklistResponse = { response in
             Task { @MainActor in
                 self.checklistContent = response.content
@@ -360,7 +313,6 @@ struct HeartbeatSettingsTab: View {
     }
 
     private func clearCallbacks() {
-        daemonClient?.onHeartbeatConfigResponse = nil
         daemonClient?.onHeartbeatChecklistResponse = nil
         daemonClient?.onHeartbeatRunsListResponse = nil
         daemonClient?.onHeartbeatRunNowResponse = nil

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -2,19 +2,16 @@ import Foundation
 import SwiftUI
 import VellumAssistantShared
 
-/// Connect settings tab — centralized Gateway URL, Bearer Token, channel configuration,
+/// Channels settings tab — Gateway URL, Bearer Token, channel configuration,
 /// and QR pairing UI. This is the single source of truth for configuring how devices
 /// and integrations reach this Mac.
 @MainActor
-struct SettingsConnectTab: View {
+struct SettingsChannelsTab: View {
     @ObservedObject var store: SettingsStore
     var daemonClient: DaemonClient?
-    var authManager: AuthManager
 
     @State private var gatewayUrlText: String = ""
     @FocusState private var isGatewayUrlFocused: Bool
-    @State private var platformUrlText: String = ""
-    @FocusState private var isPlatformUrlFocused: Bool
     @State private var bearerToken: String = ""
     @State private var tokenRevealed: Bool = false
     @State private var tokenCopied: Bool = false
@@ -79,19 +76,14 @@ struct SettingsConnectTab: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
-            vellumSection
             gatewaySection
             connectionsSection
         }
         .onAppear {
-            Task { await authManager.checkSession() }
-            store.refreshPlatformConfig()
-            Task { await store.checkVellumPlatform() }
             store.refreshIngressConfig()
             store.refreshAssistantEmail()
             store.refreshApprovedDevices()
             gatewayUrlText = store.ingressPublicBaseUrl
-            platformUrlText = store.platformBaseUrl
             refreshBearerToken()
             store.refreshChannelGuardianStatus(channel: "telegram")
             store.refreshChannelGuardianStatus(channel: "sms")
@@ -107,16 +99,6 @@ struct SettingsConnectTab: View {
         .onChange(of: isGatewayUrlFocused) { _, focused in
             if !focused {
                 gatewayUrlText = store.ingressPublicBaseUrl
-            }
-        }
-        .onChange(of: store.platformBaseUrl) { _, newValue in
-            if !isPlatformUrlFocused {
-                platformUrlText = newValue
-            }
-        }
-        .onChange(of: isPlatformUrlFocused) { _, focused in
-            if !focused {
-                platformUrlText = store.platformBaseUrl
             }
         }
         .onChange(of: store.twilioHasCredentials) { _, hasCredentials in
@@ -146,92 +128,6 @@ struct SettingsConnectTab: View {
                 daemonClient: daemonClient
             )
         }
-    }
-
-    // MARK: - Vellum Section
-
-    private var vellumSection: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Vellum")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.textPrimary)
-
-            if authManager.isLoading {
-                channelStatusRow(
-                    label: "Account",
-                    icon: "arrow.triangle.2.circlepath",
-                    iconColor: VColor.textMuted,
-                    value: "Checking..."
-                )
-            } else if let user = authManager.currentUser {
-                channelStatusRow(
-                    label: "Account",
-                    icon: "checkmark.circle.fill",
-                    iconColor: VColor.success,
-                    value: user.email ?? user.display ?? "Signed in",
-                    action: .init(label: "Log Out", style: .danger) {
-                        Task { await authManager.logout() }
-                    }
-                )
-            } else {
-                channelStatusRow(
-                    label: "Account",
-                    icon: "xmark.circle",
-                    iconColor: VColor.textMuted,
-                    value: "Not signed in",
-                    action: .init(
-                        label: authManager.isSubmitting ? "Signing in..." : "Log In",
-                        style: .primary,
-                        disabled: authManager.isSubmitting
-                    ) {
-                        Task { await authManager.startWorkOSLogin() }
-                    }
-                )
-            }
-
-            if let error = authManager.errorMessage {
-                Text(error)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.error)
-            }
-
-            if store.isDevMode {
-                Divider().background(VColor.surfaceBorder)
-
-                Text("Platform URL")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textSecondary)
-
-                HStack(spacing: VSpacing.sm) {
-                    TextField("https://platform.vellum.ai", text: $platformUrlText)
-                        .focused($isPlatformUrlFocused)
-                        .vInputStyle()
-                        .font(VFont.mono)
-                        .onSubmit {
-                            store.savePlatformBaseUrl(platformUrlText)
-                            Task { await store.checkVellumPlatform() }
-                        }
-                    VButton(label: "Save", style: .primary) {
-                        store.savePlatformBaseUrl(platformUrlText)
-                        Task { await store.checkVellumPlatform() }
-                    }
-                }
-            }
-
-            Divider().background(VColor.surfaceBorder)
-
-            connectionStatusRow(
-                label: "Platform",
-                status: platformUrlStatusInfo,
-                isRefreshing: store.isCheckingVellumPlatform,
-                lastChecked: store.platformLastChecked
-            ) {
-                Task { await store.checkVellumPlatform() }
-            }
-        }
-        .padding(VSpacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceSubtle)
     }
 
     // MARK: - Gateway Section
@@ -1960,18 +1856,6 @@ struct SettingsConnectTab: View {
             return ConnectionStatusInfo(label: "Running", color: VColor.success, icon: "checkmark.circle.fill")
         } else {
             return ConnectionStatusInfo(label: "Stopped", color: VColor.error, icon: "xmark.circle.fill")
-        }
-    }
-
-    private var platformUrlStatusInfo: ConnectionStatusInfo {
-        guard let reachable = store.vellumPlatformReachable else {
-            return ConnectionStatusInfo(label: "Unknown", color: VColor.textMuted, icon: "questionmark.circle.fill")
-        }
-        if reachable {
-            return ConnectionStatusInfo(label: "Reachable", color: VColor.success, icon: "checkmark.circle.fill")
-        } else {
-            let detail = store.vellumPlatformError ?? "Unreachable"
-            return ConnectionStatusInfo(label: detail, color: VColor.error, icon: "xmark.circle.fill")
         }
     }
 


### PR DESCRIPTION
## Summary
- Reorganize the 9 Settings tabs into 8 user-facing tabs + a dev-mode-only Advanced tab
- **Account** (new): sign-in/out, assistant identity, switch/retire/hatch — split from Connect + Advanced
- **Channels** (new): gateway config + all channel connections (Mobile, Telegram, Slack, SMS, Voice, Email) — split from Connect
- **Models & Services** (renamed): same content as Integrations, clearer name
- **Permissions** (renamed): OS permissions + trust rules + computer usage slider — streamlined from Trust
- **Automation** (new): reminders + scheduled tasks + heartbeat checklist/runs — merges Schedules + Heartbeat
- **Advanced** (dev-mode only): permission simulator, feature flags, env vars
- Removes: Privacy & Security bullets, Archived Threads section, read-only Heartbeat config card
- Adds backward-compatible IPC tab name mapping via `fromLegacyRawValue`

## Original prompt
Reorganize the Settings panel in the macOS app from 9 tabs to 8 tabs (plus a dev-mode-only Advanced tab) for clearer, more intentional navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
