### PR TITLE
M3: Clean up vestigial Velly default and UserDefaults assistantName persistence

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1958,12 +1958,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             OnboardingState.clearPersistedState()
             UserDefaults.standard.set(state.chosenKey.rawValue, forKey: "activationKey")
 
-            // Persist the assistant name in case it was changed during replay.
-            let trimmedName = state.assistantName.trimmingCharacters(in: .whitespaces)
-            if !trimmedName.isEmpty {
-                UserDefaults.standard.set(trimmedName, forKey: "assistantName")
-            }
-
             onboarding.close()
             self?.onboardingWindow = nil
 
@@ -1992,13 +1986,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         onboarding.onComplete = { [weak self] state in
             OnboardingState.clearPersistedState()
             UserDefaults.standard.set(state.chosenKey.rawValue, forKey: "activationKey")
-
-            // Persist the assistant name chosen during onboarding so the
-            // wake-up greeting can use it (IDENTITY.md may not be written yet).
-            let trimmedName = state.assistantName.trimmingCharacters(in: .whitespaces)
-            if !trimmedName.isEmpty {
-                UserDefaults.standard.set(trimmedName, forKey: "assistantName")
-            }
 
             onboarding.close()
             self?.onboardingWindow = nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -293,9 +293,7 @@ struct MainWindowView: View {
     /// Resolve display names for thread export.
     private func resolveParticipantNames() -> ChatTranscriptFormatter.ParticipantNames {
         // Assistant name: IdentityInfo → UserDefaults → fallback
-        let assistantName = IdentityInfo.load()?.name
-            ?? UserDefaults.standard.string(forKey: "assistantName")
-            ?? "Assistant"
+        let assistantName = IdentityInfo.load()?.name ?? "Assistant"
 
         // User name: stored profile → system name → fallback
         let userName: String = {

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/CapabilitiesBriefingView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/CapabilitiesBriefingView.swift
@@ -93,7 +93,7 @@ struct CapabilitiesBriefingView: View {
             state: {
                 let s = OnboardingState()
                 s.currentStep = 3
-                s.assistantName = "Velly"
+                s.assistantName = "Assistant"
                 return s
             }(),
             onComplete: {}

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/ObservationModeView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/ObservationModeView.swift
@@ -137,7 +137,7 @@ struct ObservationModeView: View {
             state: {
                 let s = OnboardingState()
                 s.currentStep = 4
-                s.assistantName = "Velly"
+                s.assistantName = "Assistant"
                 s.firstTaskCandidate = "organizing my project files"
                 return s
             }(),

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/ObservationSessionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/ObservationSessionView.swift
@@ -257,7 +257,7 @@ private struct NarrationBubble: View {
             state: {
                 let s = OnboardingState()
                 s.currentStep = 4
-                s.assistantName = "Velly"
+                s.assistantName = "Assistant"
                 s.observationDurationMinutes = 1
                 return s
             }(),

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/ObservationSummaryView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/ObservationSummaryView.swift
@@ -160,7 +160,7 @@ private struct InsightRow: View {
             state: {
                 let s = OnboardingState()
                 s.currentStep = 4
-                s.assistantName = "Velly"
+                s.assistantName = "Assistant"
                 s.firstTaskCandidate = "organizing my project files"
                 s.observationInsights = [
                     "You switch between VS Code and Terminal frequently.",

--- a/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
@@ -306,7 +306,7 @@ struct FnKeyStepView: View {
                 .padding(.bottom, VSpacing.xxl)
             FnKeyStepView(state: {
                 let s = OnboardingState()
-                s.assistantName = "Velly"
+                s.assistantName = "Assistant"
                 s.currentStep = 4
                 return s
             }())

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
@@ -167,7 +167,7 @@ struct InterviewStepView: View {
             state: {
                 let s = OnboardingState()
                 s.currentStep = 7
-                s.assistantName = "Velly"
+                s.assistantName = "Assistant"
                 return s
             }(),
             daemonClient: DaemonClient(),

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -30,7 +30,7 @@ final class OnboardingState {
     private static let currentFlowVersion = 8
 
     var currentStep: Int = 0
-    var assistantName: String = "Velly"
+    var assistantName: String = ""
     var chosenKey: ActivationKey = .fn
     var speechGranted: Bool = false
     var accessibilityGranted: Bool = false
@@ -116,7 +116,7 @@ final class OnboardingState {
             } else {
                 currentStep = saved
             }
-            assistantName = UserDefaults.standard.string(forKey: "onboarding.name") ?? "Velly"
+            assistantName = UserDefaults.standard.string(forKey: "onboarding.name") ?? ""
             if let raw = UserDefaults.standard.string(forKey: "onboarding.key"),
                let key = ActivationKey(rawValue: raw) {
                 chosenKey = key

--- a/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
+++ b/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
@@ -12,6 +12,7 @@ struct TaskInputView: View {
     @State private var hasAPIKey = APIKeyManager.hasAnyKey()
     @State private var attachments: [TaskAttachment] = []
     @State private var attachmentError: String?
+    @State private var assistantName: String = IdentityInfo.load()?.name ?? "Vellum"
     @State private var isDropTargeted = false
     @FocusState private var isTextFieldFocused: Bool
     // Use NSApp action instead of @Environment(\.openSettings) for Xcode 16.2 compatibility
@@ -27,7 +28,7 @@ struct TaskInputView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             HStack {
-                Text(IdentityInfo.load()?.name ?? "Vellum")
+                Text(assistantName)
                     .font(VFont.headline)
                     .foregroundStyle(.primary)
                 Spacer()

--- a/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
+++ b/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
@@ -27,7 +27,7 @@ struct TaskInputView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             HStack {
-                Text(UserDefaults.standard.string(forKey: "assistantName") ?? "Vellum")
+                Text(IdentityInfo.load()?.name ?? "Vellum")
                     .font(VFont.headline)
                     .foregroundStyle(.primary)
                 Spacer()


### PR DESCRIPTION
## Summary
- Removed hardcoded 'Velly' default from OnboardingState (changed to empty string)
- Removed UserDefaults persistence of assistantName from AppDelegate (naming step was already removed)
- Updated TaskInputView and MainWindowView to use IdentityInfo instead of UserDefaults
- Updated preview blocks to use generic 'Assistant' instead of 'Velly'

Part of #10103
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
