### PR TITLE
M1: Add identity_changed IPC event and broadcast from daemon

### DIFF
--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -90,8 +90,9 @@ export class ConfigWatcher {
   /**
    * Start all file watchers. `onSessionEvict` is called when watched
    * files change and sessions need to be evicted for reload.
+   * `onIdentityChanged` is called when IDENTITY.md changes on disk.
    */
-  start(onSessionEvict: () => void): void {
+  start(onSessionEvict: () => void, onIdentityChanged?: () => void): void {
     const workspaceDir = getWorkspaceDir();
     const protectedDir = join(getRootDir(), 'protected');
 
@@ -106,7 +107,7 @@ export class ConfigWatcher {
         }
       },
       'SOUL.md': () => onSessionEvict(),
-      'IDENTITY.md': () => onSessionEvict(),
+      'IDENTITY.md': () => { onSessionEvict(); onIdentityChanged?.(); },
       'USER.md': () => onSessionEvict(),
       'LOOKS.md': () => onSessionEvict(),
       'UPDATES.md': () => onSessionEvict(),

--- a/assistant/src/daemon/handlers/identity.ts
+++ b/assistant/src/daemon/handlers/identity.ts
@@ -6,6 +6,45 @@ import { fileURLToPath } from 'node:url';
 import { getWorkspacePromptPath, readLockfile } from '../../util/platform.js';
 import { defineHandlers, type HandlerContext,log } from './shared.js';
 
+export interface IdentityFields {
+  name: string;
+  role: string;
+  personality: string;
+  emoji: string;
+  home: string;
+}
+
+/** Parse the core identity fields from IDENTITY.md content. */
+export function parseIdentityFields(content: string): IdentityFields {
+  const fields: Record<string, string> = {};
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    const lower = trimmed.toLowerCase();
+    const extract = (prefix: string): string | null => {
+      if (!lower.startsWith(prefix)) return null;
+      return trimmed.split(':**').pop()?.trim() ?? null;
+    };
+
+    const name = extract('- **name:**');
+    if (name) { fields.name = name; continue; }
+    const role = extract('- **role:**');
+    if (role) { fields.role = role; continue; }
+    const personality = extract('- **personality:**') ?? extract('- **vibe:**');
+    if (personality) { fields.personality = personality; continue; }
+    const emoji = extract('- **emoji:**');
+    if (emoji) { fields.emoji = emoji; continue; }
+    const home = extract('- **home:**');
+    if (home) { fields.home = home; continue; }
+  }
+  return {
+    name: fields.name ?? '',
+    role: fields.role ?? '',
+    personality: fields.personality ?? '',
+    emoji: fields.emoji ?? '',
+    home: fields.home ?? '',
+  };
+}
+
 function handleIdentityGet(socket: net.Socket, ctx: HandlerContext): void {
   const identityPath = getWorkspacePromptPath('IDENTITY.md');
 
@@ -24,26 +63,7 @@ function handleIdentityGet(socket: net.Socket, ctx: HandlerContext): void {
 
   try {
     const content = readFileSync(identityPath, 'utf-8');
-    const fields: Record<string, string> = {};
-    for (const line of content.split('\n')) {
-      const trimmed = line.trim();
-      const lower = trimmed.toLowerCase();
-      const extract = (prefix: string): string | null => {
-        if (!lower.startsWith(prefix)) return null;
-        return trimmed.split(':**').pop()?.trim() ?? null;
-      };
-
-      const name = extract('- **name:**');
-      if (name) { fields.name = name; continue; }
-      const role = extract('- **role:**');
-      if (role) { fields.role = role; continue; }
-      const personality = extract('- **personality:**') ?? extract('- **vibe:**');
-      if (personality) { fields.personality = personality; continue; }
-      const emoji = extract('- **emoji:**');
-      if (emoji) { fields.emoji = emoji; continue; }
-      const home = extract('- **home:**');
-      if (home) { fields.home = home; continue; }
-    }
+    const fields = parseIdentityFields(content);
 
     // Read version from package.json
     let version: string | undefined;
@@ -90,11 +110,11 @@ function handleIdentityGet(socket: net.Socket, ctx: HandlerContext): void {
     ctx.send(socket, {
       type: 'identity_get_response',
       found: true,
-      name: fields.name ?? '',
-      role: fields.role ?? '',
-      personality: fields.personality ?? '',
-      emoji: fields.emoji ?? '',
-      home: fields.home ?? '',
+      name: fields.name,
+      role: fields.role,
+      personality: fields.personality,
+      emoji: fields.emoji,
+      home: fields.home,
       version,
       assistantId,
       createdAt,

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -248,6 +248,7 @@
     "heartbeat_runs_list_response",
     "history_response",
     "home_base_get_response",
+    "identity_changed",
     "identity_get_response",
     "ingress_config_response",
     "ingress_invite_response",

--- a/assistant/src/daemon/ipc-contract/workspace.ts
+++ b/assistant/src/daemon/ipc-contract/workspace.ts
@@ -112,6 +112,16 @@ export interface ToolNamesListResponse {
   schemas?: Record<string, ToolInputSchema>;
 }
 
+/** Server push — broadcast when IDENTITY.md changes on disk. */
+export interface IdentityChanged {
+  type: 'identity_changed';
+  name: string;
+  role: string;
+  personality: string;
+  emoji: string;
+  home: string;
+}
+
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
 export type _WorkspaceClientMessages =
@@ -126,4 +136,5 @@ export type _WorkspaceServerMessages =
   | WorkspaceFileReadResponse
   | IdentityGetResponse
   | ToolPermissionSimulateResponse
-  | ToolNamesListResponse;
+  | ToolNamesListResponse
+  | IdentityChanged;

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1,4 +1,4 @@
-import { chmodSync, readFileSync,statSync } from 'node:fs';
+import { chmodSync, existsSync, readFileSync,statSync } from 'node:fs';
 import * as net from 'node:net';
 import { join } from 'node:path';
 import * as tls from 'node:tls';
@@ -20,12 +20,13 @@ import { getSubagentManager } from '../subagent/index.js';
 import { IngressBlockedError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
 import { getLocalIPv4 } from '../util/network-info.js';
-import { getSandboxWorkingDir, getSocketPath, getTCPHost, getTCPPort, isIOSPairingEnabled,isTCPEnabled, removeSocketFile } from '../util/platform.js';
+import { getSandboxWorkingDir, getSocketPath, getTCPHost, getTCPPort, getWorkspacePromptPath, isIOSPairingEnabled,isTCPEnabled, removeSocketFile } from '../util/platform.js';
 import { registerDaemonCallbacks } from '../work-items/work-item-runner.js';
 import { AuthManager } from './auth-manager.js';
 import { ComputerUseSession } from './computer-use-session.js';
 import { ConfigWatcher } from './config-watcher.js';
 import { handleMessage, type HandlerContext, type SessionCreateOptions } from './handlers.js';
+import { parseIdentityFields } from './handlers/identity.js';
 import { cleanupRecordingsOnDisconnect } from './handlers/recording.js';
 import { ensureBlobDir, sweepStaleBlobs } from './ipc-blob-store.js';
 import { IpcSender } from './ipc-handler.js';
@@ -226,6 +227,25 @@ export class DaemonServer {
     );
   }
 
+  private broadcastIdentityChanged(): void {
+    try {
+      const identityPath = getWorkspacePromptPath('IDENTITY.md');
+      if (!existsSync(identityPath)) return;
+      const content = readFileSync(identityPath, 'utf-8');
+      const fields = parseIdentityFields(content);
+      this.broadcast({
+        type: 'identity_changed',
+        name: fields.name,
+        role: fields.role,
+        personality: fields.personality,
+        emoji: fields.emoji,
+        home: fields.home,
+      });
+    } catch (err) {
+      log.error({ err }, 'Failed to broadcast identity change');
+    }
+  }
+
   // ── Server lifecycle ────────────────────────────────────────────────
 
   async start(): Promise<void> {
@@ -255,7 +275,10 @@ export class DaemonServer {
       });
     }, 5 * 60 * 1000);
 
-    this.configWatcher.start(() => this.evictSessionsForReload());
+    this.configWatcher.start(
+      () => this.evictSessionsForReload(),
+      () => this.broadcastIdentityChanged(),
+    );
     this.auth.initToken();
 
     let tlsCreds: { cert: string; key: string; fingerprint: string } | null = null;

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -2312,6 +2312,25 @@ public struct IPCHomeBaseGetResponseHomeBasePreviewMetric: Codable, Sendable {
     }
 }
 
+/// Server push — broadcast when IDENTITY.md changes on disk.
+public struct IPCIdentityChanged: Codable, Sendable {
+    public let type: String
+    public let name: String
+    public let role: String
+    public let personality: String
+    public let emoji: String
+    public let home: String
+
+    public init(type: String, name: String, role: String, personality: String, emoji: String, home: String) {
+        self.type = type
+        self.name = name
+        self.role = role
+        self.personality = personality
+        self.emoji = emoji
+        self.home = home
+    }
+}
+
 public struct IPCIdentityGetRequest: Codable, Sendable {
     public let type: String
 


### PR DESCRIPTION
## Summary
- Added `IdentityChanged` push event to the IPC workspace contract
- Updated ConfigWatcher to accept an `onIdentityChanged` callback, called when IDENTITY.md changes
- Wired the server to parse IDENTITY.md and broadcast `identity_changed` to all connected clients
- Regenerated IPC artifacts (Swift types + inventory)

Part of #10103
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
