### PR TITLE
fix: externalize @huggingface/transformers in daemon build to prevent startup crash

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -147,7 +147,7 @@ build_binaries() {
     command -v bun &>/dev/null || { echo "ERROR: bun is required but not found"; exit 1; }
 
     # Daemon
-    local daemon_flags=(--external electron --external "chromium-bidi/*" --external onnxruntime-node)
+    local daemon_flags=(--external electron --external "chromium-bidi/*" --external onnxruntime-node --external @huggingface/transformers)
     if [ -n "${DISPLAY_VERSION:-}" ] && [ "$DISPLAY_VERSION" != "0.1.0" ]; then
         daemon_flags+=(--define "process.env.APP_VERSION='$DISPLAY_VERSION'")
     fi
@@ -304,7 +304,7 @@ if [ -d "$ASSISTANT_SRC_DIR/src" ] && command -v bun &>/dev/null; then
     fi
 fi
 if [ "$DAEMON_BIN_NEEDS_BUILD" = true ]; then
-    local_daemon_flags=(--external electron --external "chromium-bidi/*" --external onnxruntime-node)
+    local_daemon_flags=(--external electron --external "chromium-bidi/*" --external onnxruntime-node --external @huggingface/transformers)
     if [ -n "${DISPLAY_VERSION:-}" ] && [ "$DISPLAY_VERSION" != "0.1.0" ]; then
         local_daemon_flags+=(--define "process.env.APP_VERSION='$DISPLAY_VERSION'")
     fi


### PR DESCRIPTION
## Summary

- Externalize `@huggingface/transformers` in the daemon binary build to prevent Bun from bundling its static `import * as ONNX_NODE from 'onnxruntime-node'` — which crashes the compiled binary at startup since onnxruntime-node resolves from the virtual `/$bunfs/root/` path
- The existing lazy loading mechanism in `embedding-backend.ts` already handles this case: local embeddings gracefully fall back to API-based backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
