### PR TITLE
M2: Integrate intent gate into checker and update defaults

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -417,8 +417,8 @@ describe('Permission Checker', () => {
 
     test('plain rm (without -rf) is high risk and prompts despite default allow rule', async () => {
       // Validates that ALL rm commands are escalated to High risk, not just rm -rf.
-      // The default allow rule for host_bash auto-approves Low/Medium risk but
-      // High risk always prompts.
+      // The default allow rule for host_bash auto-approves Low risk (Read intent) but
+      // High risk always prompts and Medium risk Write intent is gated.
       const result = await check('host_bash', { command: 'rm single-file.txt' }, '/tmp');
       expect(result.decision).toBe('prompt');
       expect(result.reason).toContain('High risk');
@@ -482,11 +482,10 @@ describe('Permission Checker', () => {
       expect(result.matchedRule?.pattern).toBe('npm *');
     });
 
-    test('host_file_read prompts by default via host ask rule', async () => {
+    test('host_file_read auto-allows by default via host allow rule', async () => {
       const result = await check('host_file_read', { path: '/etc/hosts' }, '/tmp');
-      expect(result.decision).toBe('prompt');
-      expect(result.reason).toContain('ask rule');
-      expect(result.matchedRule?.id).toBe('default:ask-host_file_read-global');
+      expect(result.decision).toBe('allow');
+      expect(result.matchedRule?.id).toBe('default:allow-host_file_read-global');
     });
 
     test('host_file_write prompts by default via host ask rule', async () => {
@@ -508,6 +507,20 @@ describe('Permission Checker', () => {
       expect(result.decision).toBe('allow');
       expect(result.reason).toContain('Matched trust rule');
       expect(result.matchedRule?.id).toBe('default:allow-host_bash-global');
+    });
+
+    test('intent gate: default allow + Write intent → prompt (host_bash curl)', async () => {
+      // curl is medium risk, Write intent — default allow rule should be gated
+      const result = await check('host_bash', { command: 'curl https://example.com' }, '/tmp');
+      expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('Write operation');
+    });
+
+    test('intent gate: user-created allow + Write intent → still allows', async () => {
+      // User explicitly created an allow rule — intent gate should NOT apply
+      addRule('host_bash', '**', 'everywhere', 'allow', 2000);
+      const result = await check('host_bash', { command: 'curl https://example.com' }, '/tmp');
+      expect(result.decision).toBe('allow');
     });
 
     test('scaffold_managed_skill prompts by default via managed skill ask rule', async () => {
@@ -2503,10 +2516,10 @@ describe('Permission Checker', () => {
         expect(result.matchedRule?.id).toBe('default:allow-host_bash-global');
       });
 
-      test('host_file_read prompts by default (no implicit allow)', async () => {
+      test('host_file_read auto-allows by default (Read intent)', async () => {
         const result = await check('host_file_read', { path: '/etc/hosts' }, '/tmp');
-        expect(result.decision).toBe('prompt');
-        expect(result.matchedRule?.id).toBe('default:ask-host_file_read-global');
+        expect(result.decision).toBe('allow');
+        expect(result.matchedRule?.id).toBe('default:allow-host_file_read-global');
       });
 
       test('host_file_write prompts by default (no implicit allow)', async () => {
@@ -2547,11 +2560,13 @@ describe('Permission Checker', () => {
         expect(matchResult.matchedRule?.id).toBe('inv4-target-scoped');
 
         // Different target — the target-scoped rule should NOT match;
-        // falls back to the default host_bash allow rule (auto-allows medium risk)
+        // falls back to default host_bash allow rule, but intent gate prompts
+        // for Write operations (unknown program = medium risk = Write intent)
         const noMatchResult = await check('host_bash', { command: 'run script.js' }, '/tmp', {
           executionTarget: '/usr/local/bin/bun',
         });
-        expect(noMatchResult.decision).toBe('allow');
+        expect(noMatchResult.decision).toBe('prompt');
+        expect(noMatchResult.reason).toContain('Write operation');
         expect(noMatchResult.matchedRule?.id).not.toBe('inv4-target-scoped');
       });
     });
@@ -3270,10 +3285,9 @@ describe('workspace mode — auto-allow workspace-scoped operations', () => {
 
   // ── host tools — default ask rules prompt ──
 
-  test('host_file_read → prompt (default ask rule matches)', async () => {
+  test('host_file_read → allow (default allow rule + Read intent)', async () => {
     const result = await check('host_file_read', { file_path: '/home/user/my-project/file.txt' }, workspaceDir);
-    expect(result.decision).toBe('prompt');
-    expect(result.reason).toContain('ask rule');
+    expect(result.decision).toBe('allow');
   });
 
   test('host_bash → allow (default allow rule matches)', async () => {

--- a/assistant/src/__tests__/intent.test.ts
+++ b/assistant/src/__tests__/intent.test.ts
@@ -82,16 +82,18 @@ describe('classifyIntent', () => {
     ).toBe(ToolIntent.Read);
   });
 
-  test('file_write (workspace-scoped) → Read', () => {
+  test('file_write → Read (sandboxed)', () => {
     expect(
       classifyIntent('file_write', { file_path: `${WORKSPACE_DIR}/bar.txt` }, WORKSPACE_DIR, RiskLevel.Low),
     ).toBe(ToolIntent.Read);
   });
 
-  test('file_write (outside workspace) → Write', () => {
+  test('file_write (outside workspace) → Read (sandboxed)', () => {
+    // Sandboxed tools are always Read regardless of target path — the sandbox
+    // provides isolation so writes cannot affect the host filesystem.
     expect(
       classifyIntent('file_write', { file_path: '/etc/shadow' }, WORKSPACE_DIR, RiskLevel.Low),
-    ).toBe(ToolIntent.Write);
+    ).toBe(ToolIntent.Read);
   });
 
   test('bash (sandbox enabled) → Read', () => {

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -298,14 +298,14 @@ describe('Trust Store', () => {
 
     test('returns null when tool does not match', () => {
       addRule('file_write', 'file_write:/tmp/*', '/tmp');
-      // host_file_read default is 'ask' so findMatchingRule (allow-only) won't find it
-      const match = findMatchingRule('host_file_read', 'host_file_read:/etc/hosts', '/tmp');
+      // host_file_write default is 'ask' so findMatchingRule (allow-only) won't find it
+      const match = findMatchingRule('host_file_write', 'host_file_write:/etc/hosts', '/tmp');
       expect(match).toBeNull();
     });
 
     test('returns null when pattern does not match', () => {
-      addRule('host_file_read', 'host_file_read:/etc/hosts', '/tmp');
-      const match = findMatchingRule('host_file_read', 'host_file_read:/var/log/syslog', '/tmp');
+      addRule('host_file_write', 'host_file_write:/etc/hosts', '/tmp');
+      const match = findMatchingRule('host_file_write', 'host_file_write:/var/log/syslog', '/tmp');
       expect(match).toBeNull();
     });
 
@@ -324,8 +324,8 @@ describe('Trust Store', () => {
       });
 
       test('does not match when scope is outside rule scope', () => {
-        addRule('host_file_read', 'host_file_read:/home/user/project/*', '/home/user/project');
-        const match = findMatchingRule('host_file_read', 'host_file_read:/home/user/project/file.txt', '/home/other');
+        addRule('host_file_write', 'host_file_write:/home/user/project/*', '/home/user/project');
+        const match = findMatchingRule('host_file_write', 'host_file_write:/home/user/project/file.txt', '/home/other');
         expect(match).toBeNull();
       });
 
@@ -342,8 +342,8 @@ describe('Trust Store', () => {
       });
 
       test('does not match sibling path with shared prefix', () => {
-        addRule('host_file_read', 'host_file_read:/home/user/project/*', '/home/user/project');
-        const match = findMatchingRule('host_file_read', 'host_file_read:/home/user/project/file.txt', '/home/user/project-evil');
+        addRule('host_file_write', 'host_file_write:/home/user/project/*', '/home/user/project');
+        const match = findMatchingRule('host_file_write', 'host_file_write:/home/user/project/file.txt', '/home/user/project-evil');
         expect(match).toBeNull();
       });
 
@@ -360,8 +360,8 @@ describe('Trust Store', () => {
       });
 
       test('does not match sibling with glob-suffixed scope', () => {
-        addRule('host_file_read', 'host_file_read:/home/user/project/*', '/home/user/project*');
-        const match = findMatchingRule('host_file_read', 'host_file_read:/home/user/project/file.txt', '/home/user/project-evil');
+        addRule('host_file_write', 'host_file_write:/home/user/project/*', '/home/user/project*');
+        const match = findMatchingRule('host_file_write', 'host_file_write:/home/user/project/file.txt', '/home/user/project-evil');
         expect(match).toBeNull();
       });
     });
@@ -375,9 +375,9 @@ describe('Trust Store', () => {
       });
 
       test('matches exact string', () => {
-        addRule('host_file_read', 'host_file_read:/etc/hosts', '/tmp');
-        expect(findMatchingRule('host_file_read', 'host_file_read:/etc/hosts', '/tmp')).not.toBeNull();
-        expect(findMatchingRule('host_file_read', 'host_file_read:/etc/passwd', '/tmp')).toBeNull();
+        addRule('host_file_write', 'host_file_write:/etc/hosts', '/tmp');
+        expect(findMatchingRule('host_file_write', 'host_file_write:/etc/hosts', '/tmp')).not.toBeNull();
+        expect(findMatchingRule('host_file_write', 'host_file_write:/etc/passwd', '/tmp')).toBeNull();
       });
 
       test('matches file path pattern', () => {
@@ -545,9 +545,9 @@ describe('Trust Store', () => {
     });
 
     test('findMatchingRule ignores deny rules', () => {
-      // Use host_file_read — it has an 'ask' default so findMatchingRule (allow-only) won't find it.
-      addRule('host_file_read', 'host_file_read:/etc/*', '/tmp', 'deny');
-      const match = findMatchingRule('host_file_read', 'host_file_read:/etc/hosts', '/tmp');
+      // Use host_file_write — it has an 'ask' default so findMatchingRule (allow-only) won't find it.
+      addRule('host_file_write', 'host_file_write:/etc/*', '/tmp', 'deny');
+      const match = findMatchingRule('host_file_write', 'host_file_write:/etc/hosts', '/tmp');
       expect(match).toBeNull();
     });
 
@@ -774,20 +774,20 @@ describe('Trust Store', () => {
       // Remove one default rule by editing trust.json directly on disk
       // (removeRule() throws for default rules, so we simulate external editing)
       const raw = JSON.parse(readFileSync(trustPath, 'utf-8'));
-      raw.rules = raw.rules.filter((r: { id: string }) => r.id !== 'default:ask-host_file_read-global');
+      raw.rules = raw.rules.filter((r: { id: string }) => r.id !== 'default:allow-host_file_read-global');
       writeFileSync(trustPath, JSON.stringify(raw, null, 2));
       // After reload, the rule is re-backfilled (defaults are always present)
       clearCache();
       const rules = getAllRules();
-      expect(rules.find((r) => r.id === 'default:ask-host_file_read-global')).toBeDefined();
+      expect(rules.find((r) => r.id === 'default:allow-host_file_read-global')).toBeDefined();
     });
 
-    test('findHighestPriorityRule matches default ask for host_file_read', () => {
+    test('findHighestPriorityRule matches default allow for host_file_read', () => {
       const match = findHighestPriorityRule('host_file_read', ['host_file_read:/etc/hosts'], '/tmp');
       expect(match).not.toBeNull();
-      expect(match!.id).toBe('default:ask-host_file_read-global');
-      expect(match!.decision).toBe('ask');
-      expect(match!.priority).toBe(DEFAULT_PRIORITY_BY_ID.get('default:ask-host_file_read-global')!);
+      expect(match!.id).toBe('default:allow-host_file_read-global');
+      expect(match!.decision).toBe('allow');
+      expect(match!.priority).toBe(DEFAULT_PRIORITY_BY_ID.get('default:allow-host_file_read-global')!);
     });
 
     test('findHighestPriorityRule matches default ask for host_file_write', () => {

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -10,6 +10,7 @@ import type { ManifestOverride } from '../tools/execution-target.js';
 import { looksLikeHostPortShorthand, looksLikePathOnlyInput } from '../tools/network/url-safety.js';
 import { getTool } from '../tools/registry.js';
 import { getLogger } from '../util/logger.js';
+import { classifyIntent, ToolIntent } from './intent.js';
 import { buildShellAllowlistOptions, buildShellCommandCandidates, cachedParse, type ParsedCommand } from './shell-identity.js';
 import { findHighestPriorityRule, onRulesChanged } from './trust-store.js';
 import { type AllowlistOption, type PermissionCheckResult, type PolicyContext,RiskLevel, type ScopeOption } from './types.js';
@@ -497,6 +498,17 @@ export async function check(
     if (matchedRule.decision === 'ask') {
       // Ask rules always prompt — never auto-allow or auto-deny
       return { decision: 'prompt', reason: `Matched ask rule: ${matchedRule.pattern}`, matchedRule };
+    }
+
+    // Intent gate — default/starter allow rules only auto-allow Read operations.
+    // User-created allow rules are always honored (they explicitly chose to allow).
+    const isExplicitUserRule = !matchedRule.id.startsWith('default:')
+                            && !matchedRule.id.startsWith('starter:');
+    if (!isExplicitUserRule && risk !== RiskLevel.High) {
+      const intent = classifyIntent(toolName, input, workingDir, risk);
+      if (intent === ToolIntent.Write) {
+        return { decision: 'prompt', reason: 'Write operation requires approval', matchedRule };
+      }
     }
 
     // Allow rule: auto-allow for non-High risk

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -14,7 +14,7 @@ export interface DefaultRuleTemplate {
   allowHighRisk?: boolean;
 }
 
-const HOST_FILE_TOOLS = ['host_file_read', 'host_file_write', 'host_file_edit'] as const;
+const HOST_FILE_WRITE_TOOLS = ['host_file_write', 'host_file_edit'] as const;
 const COMPUTER_USE_TOOLS = [
   'computer_use_click',
   'computer_use_double_click',
@@ -44,7 +44,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     skills?: { load?: { extraDirs?: unknown } };
   };
 
-  const hostFileRules = HOST_FILE_TOOLS.map((tool) => ({
+  const hostFileWriteRules = HOST_FILE_WRITE_TOOLS.map((tool) => ({
     id: `default:ask-${tool}-global`,
     tool,
     pattern: `${tool}:/**`,
@@ -52,6 +52,15 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     decision: 'ask' as const,
     priority: 50,
   }));
+
+  const hostFileReadRule: DefaultRuleTemplate = {
+    id: 'default:allow-host_file_read-global',
+    tool: 'host_file_read',
+    pattern: 'host_file_read:/**',
+    scope: 'everywhere',
+    decision: 'allow',
+    priority: 50,
+  };
 
   // host_bash command candidates are raw commands ("ls", "npm test"), so the
   // global default ask rule uses "**" (globstar) instead of a "tool:*" prefix
@@ -260,7 +269,8 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   };
 
   return [
-    ...hostFileRules,
+    hostFileReadRule,
+    ...hostFileWriteRules,
     hostShellRule,
     ...(sandboxShellRule ? [sandboxShellRule] : []),
     ...computerUseRules,

--- a/assistant/src/permissions/intent.ts
+++ b/assistant/src/permissions/intent.ts
@@ -1,4 +1,3 @@
-import { isWorkspaceScopedInvocation } from '../permissions/workspace-policy.js';
 import { isSideEffectTool } from '../tools/side-effects.js';
 import { RiskLevel } from '../permissions/types.js';
 
@@ -24,11 +23,12 @@ export function classifyIntent(
   workingDir: string,
   risk: RiskLevel,
 ): ToolIntent {
-  // 1. Workspace-scoped tools: sandbox provides isolation, so reads are safe.
+  // 1. Sandboxed tools: the sandbox provides isolation so all operations
+  //    (including writes) cannot affect the host filesystem.
   if (
     toolName === 'file_read' ||
-    (toolName === 'file_write' && isWorkspaceScopedInvocation(toolName, input, workingDir)) ||
-    (toolName === 'file_edit' && isWorkspaceScopedInvocation(toolName, input, workingDir)) ||
+    toolName === 'file_write' ||
+    toolName === 'file_edit' ||
     toolName === 'bash'
   ) {
     return ToolIntent.Read;


### PR DESCRIPTION
Insert ToolIntent gate in permission checker: default/starter allow rules only auto-allow Read operations, Write operations prompt. Change host_file_read default from ask to allow. Update tests. Part of #10092.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
