### PR TITLE
M2: Handle identity_changed in macOS client and make identity reactive

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -230,8 +230,7 @@ export class DaemonServer {
   private broadcastIdentityChanged(): void {
     try {
       const identityPath = getWorkspacePromptPath('IDENTITY.md');
-      if (!existsSync(identityPath)) return;
-      const content = readFileSync(identityPath, 'utf-8');
+      const content = existsSync(identityPath) ? readFileSync(identityPath, 'utf-8') : '';
       const fields = parseIdentityFields(content);
       this.broadcast({
         type: 'identity_changed',

--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -9,6 +9,7 @@ extension Notification.Name {
     static let openDocumentEditor = Notification.Name("MainWindow.openDocumentEditor")
     static let navigateToSettingsTab = Notification.Name("MainWindow.navigateToSettingsTab")
     static let activationKeyChanged = Notification.Name("activationKeyChanged")
+    static let identityChanged = Notification.Name("identityChanged")
 }
 
 /// Manages API keys in the macOS login keychain.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1111,6 +1111,22 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             }
         }
 
+        daemonClient.onIdentityChanged = { msg in
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(
+                    name: .identityChanged,
+                    object: nil,
+                    userInfo: [
+                        "name": msg.name,
+                        "role": msg.role,
+                        "personality": msg.personality,
+                        "emoji": msg.emoji,
+                        "home": msg.home
+                    ]
+                )
+            }
+        }
+
         // Restart DaemonClient connection when the health monitor relaunches
         // the daemon process so we don't wait for the backoff timer to expire.
         assistantCli.onDaemonRestarted = { [weak self] in

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -476,6 +476,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `client_settings_update` message.
     public var onClientSettingsUpdate: ((IPCClientSettingsUpdate) -> Void)?
 
+    /// Called when the daemon broadcasts an `identity_changed` event (IDENTITY.md changed on disk).
+    public var onIdentityChanged: ((IPCIdentityChanged) -> Void)?
+
     // MARK: - Broadcast Subscribers
 
     /// Creates a new message stream for the caller. Each subscriber receives all messages

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -278,6 +278,8 @@ extension DaemonClient {
             onRecordingStop?(msg)
         case .clientSettingsUpdate(let msg):
             onClientSettingsUpdate?(msg)
+        case .identityChanged(let msg):
+            onIdentityChanged?(msg)
         default:
             break
         }

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2339,6 +2339,7 @@ public enum ServerMessage: Decodable, Sendable {
     case heartbeatChecklistWriteResponse(IPCHeartbeatChecklistWriteResponse)
     case messageContentResponse(IPCMessageContentResponse)
     case tokenRotated(TokenRotatedMessage)
+    case identityChanged(IPCIdentityChanged)
     case pong
     case unknown(String)
 
@@ -2777,6 +2778,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "token_rotated":
             let message = try TokenRotatedMessage(from: decoder)
             self = .tokenRotated(message)
+        case "identity_changed":
+            let message = try IPCIdentityChanged(from: decoder)
+            self = .identityChanged(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Added `identityChanged` case to ServerMessage enum in IPCMessages.swift with decoder for `identity_changed` type
- Added `onIdentityChanged` callback to DaemonClient for the `identity_changed` broadcast
- Added router dispatch in DaemonMessageRouter.swift to forward `identityChanged` messages to the callback
- Wired identity change notifications in AppDelegate via `NotificationCenter` so views can reactively observe daemon identity updates
- Added `.identityChanged` Notification.Name extension alongside existing notification names

Part of #10103
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
