### PR TITLE
fix: accept whitespace before ASK_GUARDIAN_APPROVAL closing bracket

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -101,13 +101,20 @@ function extractBalancedJson(
       if (depth === 0) {
         const jsonEnd = i + 1;
         const json = text.slice(jsonStart, jsonEnd);
+        // Skip any whitespace between the closing '}' and the expected ']'.
+        // Models sometimes emit formatted markers with spaces or newlines
+        // before the bracket (e.g. `{ ... }\n]` or `{ ... } ]`).
+        let bracketIdx = jsonEnd;
+        while (bracketIdx < text.length && /\s/.test(text[bracketIdx])) {
+          bracketIdx++;
+        }
         // Require the closing ']' to be present before considering this
         // a complete match. If it hasn't arrived yet (streaming), return
         // null so the caller keeps buffering.
-        if (jsonEnd >= text.length || text[jsonEnd] !== ']') {
+        if (bracketIdx >= text.length || text[bracketIdx] !== ']') {
           return null;
         }
-        const fullMatchEnd = jsonEnd + 1;
+        const fullMatchEnd = bracketIdx + 1;
         const fullMatch = text.slice(prefixIdx, fullMatchEnd);
         return { json, fullMatch, startIndex: prefixIdx };
       }


### PR DESCRIPTION
Addresses Codex review feedback on #10088. The balanced-marker parser in extractBalancedJson now skips whitespace between the closing } of the JSON payload and the closing ] of the marker, so markers like [ASK_GUARDIAN_APPROVAL: {"question":"..."} ] are correctly parsed instead of returning null.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
