### PR TITLE
M3: Wire Edit Avatar button to chat pre-fill (#10061)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -95,9 +95,14 @@ extension MainWindowView {
         case .intelligence:
             IntelligencePanel(
                 onClose: { windowState.selection = nil },
-                onCustomizeAvatar: {
-                    windowState.avatarCustomizationReturnPanel = .intelligence
-                    windowState.selection = .panel(.avatarCustomization)
+                onEditAvatar: {
+                    if threadManager.activeViewModel == nil {
+                        threadManager.createThread()
+                    }
+                    if let viewModel = threadManager.activeViewModel {
+                        viewModel.inputText = "I want to edit my avatar's looks"
+                    }
+                    windowState.selection = nil
                 },
                 onInvokeSkill: { skill in
                     if threadManager.activeViewModel == nil {
@@ -520,9 +525,14 @@ extension MainWindowView {
         case .intelligence:
             IntelligencePanel(
                 onClose: { windowState.dismissOverlay() },
-                onCustomizeAvatar: {
-                    windowState.avatarCustomizationReturnPanel = .intelligence
-                    windowState.selection = .panel(.avatarCustomization)
+                onEditAvatar: {
+                    if threadManager.activeViewModel == nil {
+                        threadManager.createThread()
+                    }
+                    if let viewModel = threadManager.activeViewModel {
+                        viewModel.inputText = "I want to edit my avatar's looks"
+                    }
+                    windowState.dismissOverlay()
                 },
                 onInvokeSkill: { skill in
                     if threadManager.activeViewModel == nil {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -3,7 +3,7 @@ import VellumAssistantShared
 
 struct IdentityPanel: View {
     let onClose: () -> Void
-    let onCustomizeAvatar: () -> Void
+    let onEditAvatar: () -> Void
     let daemonClient: DaemonClient
     @State private var appearance = AvatarAppearanceManager.shared
 
@@ -42,8 +42,8 @@ struct IdentityPanel: View {
                             .frame(maxWidth: .infinity, alignment: .center)
                             .padding(.top, VSpacing.lg)
 
-                        // Customize Avatar CTA — directly under avatar
-                        VButton(label: "Customize Avatar", style: .secondary, isFullWidth: true, action: onCustomizeAvatar)
+                        // Edit Avatar CTA — switches to chat and pre-fills composer
+                        VButton(label: "Edit Avatar", style: .secondary, isFullWidth: true, action: onEditAvatar)
                             .padding(.top, VSpacing.sm)
                             .padding(.horizontal, VSpacing.lg)
                             .padding(.bottom, VSpacing.lg)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -5,7 +5,7 @@ import VellumAssistantShared
 
 struct IntelligencePanel: View {
     var onClose: () -> Void
-    var onCustomizeAvatar: () -> Void
+    var onEditAvatar: () -> Void
     var onInvokeSkill: ((SkillInfo) -> Void)?
     let daemonClient: DaemonClient
 
@@ -90,7 +90,7 @@ struct IntelligencePanel: View {
         case .identity:
             IdentityPanel(
                 onClose: onClose,
-                onCustomizeAvatar: onCustomizeAvatar,
+                onEditAvatar: onEditAvatar,
                 daemonClient: daemonClient
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -126,5 +126,5 @@ struct IntelligencePanel: View {
 }
 
 #Preview {
-    IntelligencePanel(onClose: {}, onCustomizeAvatar: {}, daemonClient: DaemonClient())
+    IntelligencePanel(onClose: {}, onEditAvatar: {}, daemonClient: DaemonClient())
 }

--- a/clients/macos/vellum-assistantTests/MainWindowAvatarRoutingTests.swift
+++ b/clients/macos/vellum-assistantTests/MainWindowAvatarRoutingTests.swift
@@ -8,23 +8,22 @@ final class MainWindowAvatarRoutingTests: XCTestCase {
     // MARK: - Callback Wiring Tests
 
     /// Constructs an IdentityPanel with the same closure pattern used in IntelligencePanel,
-    /// then invokes the panel's onCustomizeAvatar callback and verifies it transitions state.
-    func testIdentityPanelOnCustomizeAvatarTransitionsState() {
+    /// then invokes the panel's onEditAvatar callback and verifies it clears selection
+    /// (navigating back to chat).
+    func testIdentityPanelOnEditAvatarClearsSelection() {
         let state = MainWindowState(hasAPIKey: false)
         state.selection = .panel(.intelligence)
         let daemonClient = DaemonClient()
 
         let panel = IdentityPanel(
             onClose: { state.selection = nil },
-            onCustomizeAvatar: { state.selection = .panel(.avatarCustomization) },
+            onEditAvatar: { state.selection = nil },
             daemonClient: daemonClient
         )
 
-        // Call the callback through the panel's stored property — this exercises
-        // the actual wiring, not a locally-defined closure.
-        panel.onCustomizeAvatar()
+        panel.onEditAvatar()
 
-        XCTAssertEqual(state.selection, .panel(.avatarCustomization))
+        XCTAssertNil(state.selection)
         daemonClient.disconnect()
     }
 
@@ -36,7 +35,7 @@ final class MainWindowAvatarRoutingTests: XCTestCase {
 
         let panel = IdentityPanel(
             onClose: { state.selection = nil },
-            onCustomizeAvatar: { state.selection = .panel(.avatarCustomization) },
+            onEditAvatar: { state.selection = nil },
             daemonClient: daemonClient
         )
 
@@ -48,25 +47,25 @@ final class MainWindowAvatarRoutingTests: XCTestCase {
 
     // MARK: - Callback Contract Tests
 
-    /// Verifies that IdentityPanel's init signature requires an onCustomizeAvatar callback.
+    /// Verifies that IdentityPanel's init signature requires an onEditAvatar callback.
     /// Instantiates a real IdentityPanel so the test fails to compile if the parameter is removed.
-    func testIdentityPanelRequiresCustomizeAvatarCallback() {
-        var customizeCalled = false
+    func testIdentityPanelRequiresEditAvatarCallback() {
+        var editCalled = false
         var closeCalled = false
         let daemonClient = DaemonClient()
 
         let panel = IdentityPanel(
             onClose: { closeCalled = true },
-            onCustomizeAvatar: { customizeCalled = true },
+            onEditAvatar: { editCalled = true },
             daemonClient: daemonClient
         )
 
         // Verify callbacks are wired — invoke them directly to confirm the closures passed through
         panel.onClose()
-        panel.onCustomizeAvatar()
+        panel.onEditAvatar()
 
         XCTAssertTrue(closeCalled)
-        XCTAssertTrue(customizeCalled)
+        XCTAssertTrue(editCalled)
         daemonClient.disconnect()
     }
 


### PR DESCRIPTION
Replace Customize Avatar with Edit Avatar button on Identity panel. Clicking it switches to Chat tab and pre-fills the composer with 'I want to edit my avatar'\''s looks'.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
