### PR TITLE
fix: make release version bump idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,15 +122,19 @@ jobs:
           sed -i "s/^let appVersion = .*/let appVersion = \"$VERSION\"/" clients/Package.swift
 
           git add -A
-          git commit -m "Release v$VERSION"
-          git push origin "$BRANCH"
+          if git diff --cached --quiet; then
+            echo "Version files already at $VERSION — skipping bump PR"
+          else
+            git commit -m "Release v$VERSION"
+            git push origin "$BRANCH"
 
-          PR_URL=$(gh pr create \
-            --title "Release v$VERSION" \
-            --body "Automated version bump to $VERSION." \
-            --base main \
-            --head "$BRANCH")
-          gh pr merge "$PR_URL" --squash --admin
+            PR_URL=$(gh pr create \
+              --title "Release v$VERSION" \
+              --body "Automated version bump to $VERSION." \
+              --base main \
+              --head "$BRANCH")
+            gh pr merge "$PR_URL" --squash --admin
+          fi
 
       - name: Tag release
         env:


### PR DESCRIPTION
## Summary
- Skip the version bump PR when files already contain the target version (e.g. from a previous partial release run)
- Prevents the "nothing to commit" failure that blocks tagging and downstream release steps

## Original prompt
fix: make release version bump idempotent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
