### PR TITLE
M3: Implement full drag-and-drop reordering in Swift client

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -99,8 +99,10 @@ declare -a SAFE_LINE_PATTERNS=(
     "[Cc]lient[Ss]ecret:[[:space:]]*[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*$"
     # AWS well-known example key used in documentation
     "AKIAIOSFODNN7EXAMPLE"
-    # Swift let/var constants used as UserDefaults key names (not secrets)
-    "(private[[:space:]]+)?(let|var)[[:space:]]+[a-zA-Z_][a-zA-Z0-9_]*Key[[:space:]]*[:=][[:space:]]*['\"][a-zA-Z][a-zA-Z0-9_]*['\"]"
+    # Swift let/var constants used as UserDefaults key names (not secrets).
+    # Only whitelist specific known key-name constants — a broad `*Key` pattern
+    # would let real credentials like `let apiKey = "sk_live_..."` slip through.
+    "(private[[:space:]]+)?(let|var)[[:space:]]+(archivedSessionsKey)[[:space:]]*[:=][[:space:]]*['\"][a-zA-Z][a-zA-Z0-9_]*['\"]"
 )
 
 matches_safe_line_pattern() {

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -99,6 +99,8 @@ declare -a SAFE_LINE_PATTERNS=(
     "[Cc]lient[Ss]ecret:[[:space:]]*[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*$"
     # AWS well-known example key used in documentation
     "AKIAIOSFODNN7EXAMPLE"
+    # Swift let/var constants used as UserDefaults key names (not secrets)
+    "(private[[:space:]]+)?(let|var)[[:space:]]+[a-zA-Z_][a-zA-Z0-9_]*Key[[:space:]]*[:=][[:space:]]*['\"][a-zA-Z][a-zA-Z0-9_]*['\"]"
 )
 
 matches_safe_line_pattern() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1239,6 +1239,23 @@ struct MainWindowView: View {
                         ForEach(displayedScheduleThreads) { thread in
                             threadItem(thread)
                                 .padding(.bottom, VSpacing.xxs)
+                                .overlay(alignment: .top) {
+                                    if sidebar.dropTargetThreadId == thread.id {
+                                        Rectangle()
+                                            .fill(adaptiveColor(light: Forest._500, dark: Forest._400))
+                                            .frame(height: 2)
+                                            .transition(.opacity)
+                                    }
+                                }
+                                .dropDestination(for: String.self) { items, _ in
+                                    sidebar.dropTargetThreadId = nil
+                                    guard let droppedId = items.first,
+                                          let sourceUUID = UUID(uuidString: droppedId),
+                                          sourceUUID != thread.id else { return false }
+                                    return threadManager.moveThread(sourceId: sourceUUID, beforeId: thread.id)
+                                } isTargeted: { isTargeted in
+                                    sidebar.dropTargetThreadId = isTargeted ? thread.id : nil
+                                }
                         }
 
                         if scheduleThreads.count > 3 {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -32,6 +32,8 @@ final class SidebarInteractionState {
     var showAllScheduleThreads: Bool = false
     var showAllApps: Bool = false
     var showControlCenterDrawer: Bool = false
+    /// Thread ID that is currently the drop target during a drag-and-drop reorder.
+    var dropTargetThreadId: UUID?
 }
 
 /// Copy-thread confirmation state.
@@ -1187,12 +1189,23 @@ struct MainWindowView: View {
                     ForEach(displayedThreads) { thread in
                         threadItem(thread)
                             .padding(.bottom, VSpacing.xxs)
+                            .overlay(alignment: .top) {
+                                if sidebar.dropTargetThreadId == thread.id {
+                                    Rectangle()
+                                        .fill(adaptiveColor(light: Forest._500, dark: Forest._400))
+                                        .frame(height: 2)
+                                        .transition(.opacity)
+                                }
+                            }
                             .dropDestination(for: String.self) { items, _ in
+                                sidebar.dropTargetThreadId = nil
                                 guard let droppedId = items.first,
                                       let sourceUUID = UUID(uuidString: droppedId),
                                       sourceUUID != thread.id else { return false }
                                 return threadManager.moveThread(sourceId: sourceUUID, beforeId: thread.id)
-                            } isTargeted: { _ in }
+                            } isTargeted: { isTargeted in
+                                sidebar.dropTargetThreadId = isTargeted ? thread.id : nil
+                            }
                     }
 
                     if regularThreads.count > 5 {
@@ -1226,12 +1239,23 @@ struct MainWindowView: View {
                         ForEach(displayedScheduleThreads) { thread in
                             threadItem(thread)
                                 .padding(.bottom, VSpacing.xxs)
+                                .overlay(alignment: .top) {
+                                    if sidebar.dropTargetThreadId == thread.id {
+                                        Rectangle()
+                                            .fill(adaptiveColor(light: Forest._500, dark: Forest._400))
+                                            .frame(height: 2)
+                                            .transition(.opacity)
+                                    }
+                                }
                                 .dropDestination(for: String.self) { items, _ in
+                                    sidebar.dropTargetThreadId = nil
                                     guard let droppedId = items.first,
                                           let sourceUUID = UUID(uuidString: droppedId),
                                           sourceUUID != thread.id else { return false }
                                     return threadManager.moveThread(sourceId: sourceUUID, beforeId: thread.id)
-                                } isTargeted: { _ in }
+                                } isTargeted: { isTargeted in
+                                    sidebar.dropTargetThreadId = isTargeted ? thread.id : nil
+                                }
                         }
 
                         if scheduleThreads.count > 3 {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1239,23 +1239,6 @@ struct MainWindowView: View {
                         ForEach(displayedScheduleThreads) { thread in
                             threadItem(thread)
                                 .padding(.bottom, VSpacing.xxs)
-                                .overlay(alignment: .top) {
-                                    if sidebar.dropTargetThreadId == thread.id {
-                                        Rectangle()
-                                            .fill(adaptiveColor(light: Forest._500, dark: Forest._400))
-                                            .frame(height: 2)
-                                            .transition(.opacity)
-                                    }
-                                }
-                                .dropDestination(for: String.self) { items, _ in
-                                    sidebar.dropTargetThreadId = nil
-                                    guard let droppedId = items.first,
-                                          let sourceUUID = UUID(uuidString: droppedId),
-                                          sourceUUID != thread.id else { return false }
-                                    return threadManager.moveThread(sourceId: sourceUUID, beforeId: thread.id)
-                                } isTargeted: { isTargeted in
-                                    sidebar.dropTargetThreadId = isTargeted ? thread.id : nil
-                                }
                         }
 
                         if scheduleThreads.count > 3 {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -402,23 +402,30 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             $0.threadType != "private" && $0.channelBinding?.sourceChannel == nil
         }
 
+        // Compute the next pinnedOrder based on existing pinned threads so
+        // appended pinned threads don't collide with already-loaded ones.
+        var nextPinnedOrder = (threads.compactMap(\.pinnedOrder).max() ?? -1) + 1
+
         for session in recentSessions {
             // Skip sessions that already have a thread
             guard !threads.contains(where: { $0.sessionId == session.id }) else { continue }
 
+            let isPinned = session.isPinned ?? false
             let effectiveCreatedAt = session.createdAt ?? session.updatedAt
             let thread = ThreadModel(
                 title: session.title,
                 createdAt: Date(timeIntervalSince1970: TimeInterval(effectiveCreatedAt) / 1000.0),
                 sessionId: session.id,
                 isArchived: isSessionArchived(session.id),
-                isPinned: session.isPinned ?? false,
+                isPinned: isPinned,
+                pinnedOrder: isPinned ? nextPinnedOrder : nil,
                 displayOrder: session.displayOrder.map { Int($0) },
                 lastInteractedAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
                 kind: session.threadType == "private" ? .private : .standard,
                 source: session.source,
                 hasUnseenLatestAssistantMessage: session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false
             )
+            if isPinned { nextPinnedOrder += 1 }
             // VM creation is lazy — getOrCreateViewModel() will instantiate
             // when the thread is first accessed (e.g. selected by the user).
             threads.append(thread)
@@ -611,14 +618,18 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     /// Send the current thread ordering to the daemon so it persists across restarts.
+    /// Only sends explicit displayOrder for threads that have been user-reordered
+    /// (non-nil displayOrder) or are pinned. Threads without explicit ordering get
+    /// displayOrder: nil so the daemon clears any previously stored value, preserving
+    /// the default "new threads sort to top by recency" behavior.
     private func sendReorderThreads() {
         let visible = visibleThreads
         var updates: [IPCReorderThreadsRequestUpdate] = []
-        for (index, thread) in visible.enumerated() {
+        for thread in visible {
             guard let sessionId = thread.sessionId else { continue }
             updates.append(IPCReorderThreadsRequestUpdate(
                 sessionId: sessionId,
-                displayOrder: Double(index),
+                displayOrder: thread.displayOrder.map { Double($0) },
                 isPinned: thread.isPinned
             ))
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -560,7 +560,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// Move a thread to a new position in the visible list (for drag-and-drop reorder).
     /// Works for any thread: pinned-to-pinned reorders among pinned items,
     /// unpinned-to-pinned pins the source, and unpinned-to-unpinned reorders
-    /// using displayOrder.
+    /// using displayOrder. When the target is a schedule thread, the source is
+    /// inserted at the end of the unpinned regular threads list (the boundary
+    /// between regular and scheduled threads).
     @discardableResult
     func moveThread(sourceId: UUID, beforeId: UUID) -> Bool {
         guard let sourceIdx = threads.firstIndex(where: { $0.id == sourceId }),
@@ -589,8 +591,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 recompactPinnedOrders()
             }
 
-            // Build the current visible unpinned order and insert the source before the target
-            let unpinned = visibleThreads.filter { !$0.isPinned && !$0.isScheduleThread }
+            // Build the current visible unpinned order and insert the source before the target.
+            // Include schedule threads so that dropping on a schedule thread places the source
+            // at the boundary (end of regular threads, just before the first schedule thread).
+            let unpinned = visibleThreads.filter { !$0.isPinned }
             var reordered = unpinned.filter { $0.id != sourceId }
             let targetPos = reordered.firstIndex(where: { $0.id == beforeId }) ?? reordered.endIndex
             if let movedThread = unpinned.first(where: { $0.id == sourceId }) ?? [threads[sourceIdx]].first {
@@ -618,18 +622,26 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     /// Send the current thread ordering to the daemon so it persists across restarts.
-    /// Only sends explicit displayOrder for threads that have been user-reordered
-    /// (non-nil displayOrder) or are pinned. Threads without explicit ordering get
-    /// displayOrder: nil so the daemon clears any previously stored value, preserving
-    /// the default "new threads sort to top by recency" behavior.
+    /// For pinned threads, derives a deterministic displayOrder from pinnedOrder so
+    /// the pinned ordering survives restarts. For unpinned threads that have been
+    /// explicitly reordered (non-nil displayOrder), sends their displayOrder. For
+    /// unpinned threads without explicit ordering, sends nil so they sort by recency.
     private func sendReorderThreads() {
         let visible = visibleThreads
         var updates: [IPCReorderThreadsRequestUpdate] = []
         for thread in visible {
             guard let sessionId = thread.sessionId else { continue }
+            let order: Double?
+            if thread.isPinned {
+                // Pinned threads always need a persisted displayOrder derived from
+                // their pinnedOrder so their user-defined order survives restarts.
+                order = Double(thread.pinnedOrder ?? 0)
+            } else {
+                order = thread.displayOrder.map { Double($0) }
+            }
             updates.append(IPCReorderThreadsRequestUpdate(
                 sessionId: sessionId,
-                displayOrder: thread.displayOrder.map { Double($0) },
+                displayOrder: order,
                 isPinned: thread.isPinned
             ))
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -83,7 +83,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     @Published private(set) var busyThreadIds: Set<UUID> = []
 
     /// Threads that are not archived — used by the UI to populate the sidebar.
-    /// Sorted: pinned first (by pinnedOrder ascending), then unpinned by lastInteractedAt descending.
+    /// Sorted: pinned first (by pinnedOrder ascending), then threads with explicit
+    /// displayOrder ascending, then remaining threads by lastInteractedAt descending.
     /// Threads move to the top when messages are sent or received, but NOT when clicked/selected.
     var visibleThreads: [ThreadModel] {
         threads.filter { !$0.isArchived && $0.kind != .private }.sorted { a, b in
@@ -92,6 +93,12 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             }
             if a.isPinned { return true }
             if b.isPinned { return false }
+            // Threads with explicit displayOrder come before those without
+            if let aOrder = a.displayOrder, let bOrder = b.displayOrder {
+                return aOrder < bOrder
+            }
+            if a.displayOrder != nil { return true }
+            if b.displayOrder != nil { return false }
             return a.lastInteractedAt > b.lastInteractedAt
         }
     }
@@ -405,6 +412,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 createdAt: Date(timeIntervalSince1970: TimeInterval(effectiveCreatedAt) / 1000.0),
                 sessionId: session.id,
                 isArchived: isSessionArchived(session.id),
+                isPinned: session.isPinned ?? false,
+                displayOrder: session.displayOrder.map { Int($0) },
                 lastInteractedAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
                 kind: session.threadType == "private" ? .private : .standard,
                 source: session.source,
@@ -514,13 +523,16 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         let nextOrder = (threads.compactMap(\.pinnedOrder).max() ?? -1) + 1
         threads[index].isPinned = true
         threads[index].pinnedOrder = nextOrder
+        sendReorderThreads()
     }
 
     func unpinThread(id: UUID) {
         guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
         threads[index].isPinned = false
         threads[index].pinnedOrder = nil
+        threads[index].displayOrder = nil
         recompactPinnedOrders()
+        sendReorderThreads()
     }
 
     func reorderPinnedThreads(from source: IndexSet, to destination: Int) {
@@ -539,30 +551,53 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     /// Move a thread to a new position in the visible list (for drag-and-drop reorder).
-    /// If the source thread is pinned, reorder among pinned items.
-    /// If unpinned, pin it and insert at the target position.
+    /// Works for any thread: pinned-to-pinned reorders among pinned items,
+    /// unpinned-to-pinned pins the source, and unpinned-to-unpinned reorders
+    /// using displayOrder.
     @discardableResult
     func moveThread(sourceId: UUID, beforeId: UUID) -> Bool {
         guard let sourceIdx = threads.firstIndex(where: { $0.id == sourceId }),
               let targetIdx = threads.firstIndex(where: { $0.id == beforeId }) else { return false }
         let targetThread = threads[targetIdx]
 
-        // Only reorder when the drop target is pinned
-        guard targetThread.isPinned else { return false }
+        if targetThread.isPinned {
+            // Dropping onto a pinned thread — pin the source if needed and reorder
+            if !threads[sourceIdx].isPinned {
+                threads[sourceIdx].isPinned = true
+            }
+            let targetOrder = targetThread.pinnedOrder ?? 0
+            threads[sourceIdx].pinnedOrder = targetOrder
+            for i in threads.indices where threads[i].isPinned && threads[i].id != sourceId {
+                if let order = threads[i].pinnedOrder, order >= targetOrder {
+                    threads[i].pinnedOrder = order + 1
+                }
+            }
+            recompactPinnedOrders()
+        } else {
+            // Dropping onto an unpinned thread — reorder using displayOrder.
+            // If the source was pinned, unpin it first.
+            if threads[sourceIdx].isPinned {
+                threads[sourceIdx].isPinned = false
+                threads[sourceIdx].pinnedOrder = nil
+                recompactPinnedOrders()
+            }
 
-        if !threads[sourceIdx].isPinned {
-            threads[sourceIdx].isPinned = true
-        }
-        // Set pinnedOrder to place before the target
-        let targetOrder = targetThread.pinnedOrder ?? 0
-        threads[sourceIdx].pinnedOrder = targetOrder
-        // Bump all pinned items at or after targetOrder (except source)
-        for i in threads.indices where threads[i].isPinned && threads[i].id != sourceId {
-            if let order = threads[i].pinnedOrder, order >= targetOrder {
-                threads[i].pinnedOrder = order + 1
+            // Build the current visible unpinned order and insert the source before the target
+            let unpinned = visibleThreads.filter { !$0.isPinned && !$0.isScheduleThread }
+            var reordered = unpinned.filter { $0.id != sourceId }
+            let targetPos = reordered.firstIndex(where: { $0.id == beforeId }) ?? reordered.endIndex
+            if let movedThread = unpinned.first(where: { $0.id == sourceId }) ?? [threads[sourceIdx]].first {
+                reordered.insert(movedThread, at: targetPos)
+            }
+            // Assign sequential displayOrder to all reordered unpinned threads
+            for (order, item) in reordered.enumerated() {
+                if let idx = threads.firstIndex(where: { $0.id == item.id }) {
+                    threads[idx].displayOrder = order
+                }
             }
         }
-        recompactPinnedOrders()
+
+        sendReorderThreads()
         return true
     }
 
@@ -572,6 +607,29 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             .sorted { ($0.element.pinnedOrder ?? 0) < ($1.element.pinnedOrder ?? 0) }
         for (order, item) in pinned.enumerated() {
             threads[item.offset].pinnedOrder = order
+        }
+    }
+
+    /// Send the current thread ordering to the daemon so it persists across restarts.
+    private func sendReorderThreads() {
+        let visible = visibleThreads
+        var updates: [IPCReorderThreadsRequestUpdate] = []
+        for (index, thread) in visible.enumerated() {
+            guard let sessionId = thread.sessionId else { continue }
+            updates.append(IPCReorderThreadsRequestUpdate(
+                sessionId: sessionId,
+                displayOrder: Double(index),
+                isPinned: thread.isPinned
+            ))
+        }
+        guard !updates.isEmpty else { return }
+        do {
+            try daemonClient.send(IPCReorderThreadsRequest(
+                type: "reorder_threads",
+                updates: updates
+            ))
+        } catch {
+            log.error("Failed to send reorder_threads: \(error.localizedDescription)")
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
@@ -15,12 +15,15 @@ struct ThreadModel: Identifiable, Hashable {
     var isArchived: Bool
     var isPinned: Bool
     var pinnedOrder: Int?
+    /// Explicit display order set by the user via drag-and-drop reordering.
+    /// nil means no explicit order — thread is sorted by recency.
+    var displayOrder: Int?
     var lastInteractedAt: Date
     var kind: ThreadKind
     var source: String?
     var hasUnseenLatestAssistantMessage: Bool = false
 
-    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), sessionId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, pinnedOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ThreadKind = .standard, source: String? = nil, hasUnseenLatestAssistantMessage: Bool = false) {
+    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), sessionId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, pinnedOrder: Int? = nil, displayOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ThreadKind = .standard, source: String? = nil, hasUnseenLatestAssistantMessage: Bool = false) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -28,6 +31,7 @@ struct ThreadModel: Identifiable, Hashable {
         self.isArchived = isArchived
         self.isPinned = isPinned
         self.pinnedOrder = pinnedOrder
+        self.displayOrder = displayOrder
         self.lastInteractedAt = lastInteractedAt ?? createdAt
         self.kind = kind
         self.source = source

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -205,6 +205,8 @@ final class ThreadSessionRestorer {
                 createdAt: Date(timeIntervalSince1970: TimeInterval(effectiveCreatedAt) / 1000.0),
                 sessionId: session.id,
                 isArchived: delegate.isSessionArchived(session.id),
+                isPinned: session.isPinned ?? false,
+                displayOrder: session.displayOrder.map { Int($0) },
                 lastInteractedAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
                 kind: kind,
                 source: session.source,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -182,6 +182,7 @@ final class ThreadSessionRestorer {
             && delegate.chatViewModel(for: delegate.threads[0].id)?.sessionId == nil
 
         var restoredThreads: [ThreadModel] = []
+        var pinnedCount = 0
         for session in recentSessions {
             // Skip sessions that already have a local thread (e.g. created by
             // createNotificationThread before the session list response arrived).
@@ -199,19 +200,22 @@ final class ThreadSessionRestorer {
                 .title
             let title = existingTitle ?? session.title
 
+            let isPinned = session.isPinned ?? false
             let effectiveCreatedAt = session.createdAt ?? session.updatedAt
             let thread = ThreadModel(
                 title: title,
                 createdAt: Date(timeIntervalSince1970: TimeInterval(effectiveCreatedAt) / 1000.0),
                 sessionId: session.id,
                 isArchived: delegate.isSessionArchived(session.id),
-                isPinned: session.isPinned ?? false,
+                isPinned: isPinned,
+                pinnedOrder: isPinned ? pinnedCount : nil,
                 displayOrder: session.displayOrder.map { Int($0) },
                 lastInteractedAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
                 kind: kind,
                 source: session.source,
                 hasUnseenLatestAssistantMessage: session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false
             )
+            if isPinned { pinnedCount += 1 }
             // VM creation is lazy — only the active thread will get a VM via
             // getOrCreateViewModel() when it's first accessed.
             restoredThreads.append(thread)


### PR DESCRIPTION
Implement drag-and-drop reordering for all thread tabs in the macOS client. Adds displayOrder to ThreadModel, updates sorting, enables draggable/droppable tabs, and sends reorder_threads IPC messages to persist ordering. Part of #10077.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
