### PR TITLE
Fix: skip wake word resume when voice mode is active

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1921,6 +1921,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         // Wire the audio monitor into LiveTranscriptManager so it can
         // pause/resume wake-word detection during live transcription.
         mainWindow.liveTranscriptManager.setAudioMonitor(audioMonitor)
+        mainWindow.liveTranscriptManager.setVoiceModeManager(mainWindow.voiceModeManager)
 
         if UserDefaults.standard.bool(forKey: "wakeWordEnabled") {
             audioMonitor.startMonitoring()

--- a/clients/macos/vellum-assistant/Features/Voice/LiveTranscriptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveTranscriptManager.swift
@@ -42,6 +42,9 @@ final class LiveTranscriptManager: ObservableObject {
     /// Reference to the wake word monitor so we can pause/resume it.
     private weak var audioMonitor: AlwaysOnAudioMonitor?
 
+    /// Reference to voice mode manager so we skip wake word resume while voice mode is active.
+    private weak var voiceModeManager: VoiceModeManager?
+
     /// Rolling buffer duration — discard segments older than this.
     private static let bufferDuration: TimeInterval = 10 * 60 // 10 minutes
 
@@ -62,6 +65,12 @@ final class LiveTranscriptManager: ObservableObject {
     /// (e.g. wake word coordinator is set up after the main window).
     func setAudioMonitor(_ monitor: AlwaysOnAudioMonitor) {
         self.audioMonitor = monitor
+    }
+
+    /// Late-bind the voice mode manager so we can check whether voice mode
+    /// is active before resuming the wake word monitor.
+    func setVoiceModeManager(_ manager: VoiceModeManager) {
+        self.voiceModeManager = manager
     }
 
     // MARK: - Public API
@@ -218,6 +227,14 @@ final class LiveTranscriptManager: ObservableObject {
     private func resumeWakeWordIfNeeded() {
         guard let monitor = audioMonitor else { return }
         guard UserDefaults.standard.bool(forKey: "wakeWordEnabled") else { return }
+
+        // Don't resume wake word if voice mode is active — it uses
+        // SFSpeechRecognizer too and macOS only allows one active
+        // recognition task per process.
+        if let voiceModeManager, voiceModeManager.state != .off {
+            log.info("Skipping wake word resume — voice mode is active")
+            return
+        }
 
         // Delay to let audio engine fully release
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak monitor] in


### PR DESCRIPTION
Prevents resumeWakeWordIfNeeded() from resuming the wake word monitor when voice mode is currently active, avoiding SFSpeechRecognizer conflict (macOS only allows one active recognition task per process).

Follow-up from PR #10109 review. Part of #10023.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
