### PR TITLE
fix: include workspace files in constellation view groups

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -741,7 +741,7 @@ struct ConstellationView: View {
             )
         }
 
-        var categoryMap: [SkillCategory: [OrbitItem]] = [:]
+        var categoryMap: [SkillCategory: [OrbitItem]] = [.knowledge: fileItems]
         for skill in skills {
             let cat = inferCategory(skill)
             let item = OrbitItem(


### PR DESCRIPTION
## Summary
- `fileItems` (workspace knowledge files) was computed but never added to `categoryMap`, so they were silently dropped from the constellation view
- Seed `categoryMap` with `[.knowledge: fileItems]` so workspace files appear in the knowledge category group

## Original prompt
fix: unused `fileItems` variable in ConstellationView.swift causing build warning — workspace files were never included in the constellation groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
