### PR TITLE
fix: strip glib-2.0 dirs from sharp-libvips to fix codesign CI failure

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -200,6 +200,8 @@ build_binaries() {
     for img_pkg in "$ASSISTANT_SRC_DIR/node_modules/@img/"*; do
         [ -d "$img_pkg" ] && cp -R "$img_pkg" "$SCRIPT_DIR/daemon-bin/node_modules/@img/"
     done
+    # Strip build-time include dirs that codesign misinterprets as bundles
+    find "$SCRIPT_DIR/daemon-bin/node_modules/@img" -type d -name "glib-2.0" -exec rm -rf {} + 2>/dev/null || true
     # Stage sharp's JS dependencies
     for dep in detect-libc semver; do
         if [ -d "$ASSISTANT_SRC_DIR/node_modules/$dep" ]; then
@@ -379,6 +381,8 @@ if [ "$DAEMON_BIN_NEEDS_BUILD" = true ]; then
     for img_pkg in "$ASSISTANT_SRC_DIR/node_modules/@img/"*; do
         [ -d "$img_pkg" ] && cp -R "$img_pkg" "$SCRIPT_DIR/daemon-bin/node_modules/@img/"
     done
+    # Strip build-time include dirs that codesign misinterprets as bundles
+    find "$SCRIPT_DIR/daemon-bin/node_modules/@img" -type d -name "glib-2.0" -exec rm -rf {} + 2>/dev/null || true
     for dep in detect-libc semver; do
         if [ -d "$ASSISTANT_SRC_DIR/node_modules/$dep" ]; then
             cp -R "$ASSISTANT_SRC_DIR/node_modules/$dep" "$SCRIPT_DIR/daemon-bin/node_modules/$dep"


### PR DESCRIPTION
## Summary
- The `@img/sharp-libvips-darwin-arm64` package ships a `lib/glib-2.0/` directory containing a build-time header (`glibconfig.h`) not needed at runtime
- `codesign --verify --deep --strict` treats this directory as a malformed bundle, failing CI with: `bundle format unrecognized, invalid, or unsuitable`
- Strip `glib-2.0` directories from staged `@img` packages in both build paths (full `build_binaries` and incremental daemon rebuild)

## Original prompt
fix: strip glib-2.0 build-time include dirs from @img/sharp-libvips during macOS build — codesign misinterprets them as malformed bundles, breaking CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
