### PR TITLE
fix: strip .cache and glib-2.0 dirs from bundled node_modules to fix codesigning

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -183,9 +183,10 @@ build_binaries() {
     # so the externalized import('@huggingface/transformers') resolves at runtime
     mkdir -p "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface"
     cp -R "$ASSISTANT_SRC_DIR/node_modules/@huggingface/transformers" "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers"
-    # Strip non-runtime files (source, types, sourcemaps, web/browser bundles, WASM)
+    # Strip non-runtime files (source, types, sourcemaps, web/browser bundles, WASM, model cache)
     rm -rf "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/src"
     rm -rf "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/types"
+    rm -rf "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/.cache"
     rm -f  "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/README.md"
     rm -f  "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/dist/"*.map
     rm -f  "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/dist/"*.min.*
@@ -200,6 +201,8 @@ build_binaries() {
     for img_pkg in "$ASSISTANT_SRC_DIR/node_modules/@img/"*; do
         [ -d "$img_pkg" ] && cp -R "$img_pkg" "$SCRIPT_DIR/daemon-bin/node_modules/@img/"
     done
+    # Strip build-time include dirs that codesign misinterprets as bundles
+    find "$SCRIPT_DIR/daemon-bin/node_modules/@img" -type d -name "glib-2.0" -exec rm -rf {} + 2>/dev/null || true
     # Stage sharp's JS dependencies
     for dep in detect-libc semver; do
         if [ -d "$ASSISTANT_SRC_DIR/node_modules/$dep" ]; then
@@ -366,6 +369,7 @@ if [ "$DAEMON_BIN_NEEDS_BUILD" = true ]; then
     cp -R "$ASSISTANT_SRC_DIR/node_modules/@huggingface/transformers" "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers"
     rm -rf "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/src"
     rm -rf "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/types"
+    rm -rf "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/.cache"
     rm -f  "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/README.md"
     rm -f  "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/dist/"*.map
     rm -f  "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/dist/"*.min.*
@@ -379,6 +383,8 @@ if [ "$DAEMON_BIN_NEEDS_BUILD" = true ]; then
     for img_pkg in "$ASSISTANT_SRC_DIR/node_modules/@img/"*; do
         [ -d "$img_pkg" ] && cp -R "$img_pkg" "$SCRIPT_DIR/daemon-bin/node_modules/@img/"
     done
+    # Strip build-time include dirs that codesign misinterprets as bundles
+    find "$SCRIPT_DIR/daemon-bin/node_modules/@img" -type d -name "glib-2.0" -exec rm -rf {} + 2>/dev/null || true
     for dep in detect-libc semver; do
         if [ -d "$ASSISTANT_SRC_DIR/node_modules/$dep" ]; then
             cp -R "$ASSISTANT_SRC_DIR/node_modules/$dep" "$SCRIPT_DIR/daemon-bin/node_modules/$dep"


### PR DESCRIPTION
## Summary
- Strip `.cache` directory from `@huggingface/transformers` in both build paths to prevent codesign failures (model cache dirs are misinterpreted as malformed bundles)
- Strip `glib-2.0` include directories from `@img/*` packages in both build paths (same codesign issue)

## Original prompt
Fix codesigning failure: `bundle format unrecognized, invalid, or unsuitable` caused by `.cache` directory in bundled `@huggingface/transformers` node_modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
