### PR TITLE
fix: revoke guardian ingress member record when guardian binding is revoked

### DIFF
--- a/assistant/.claude/commands/blitz.md
+++ b/assistant/.claude/commands/blitz.md
@@ -1,0 +1,1 @@
+../../scripts/commands/blitz.md

--- a/assistant/.claude/commands/brainstorm.md
+++ b/assistant/.claude/commands/brainstorm.md
@@ -1,0 +1,1 @@
+../../scripts/commands/brainstorm.md

--- a/assistant/.claude/commands/check-reviews.md
+++ b/assistant/.claude/commands/check-reviews.md
@@ -1,0 +1,1 @@
+../../scripts/commands/check-reviews.md

--- a/assistant/.claude/commands/do.md
+++ b/assistant/.claude/commands/do.md
@@ -1,0 +1,1 @@
+../../scripts/commands/do.md

--- a/assistant/.claude/commands/execute-plan.md
+++ b/assistant/.claude/commands/execute-plan.md
@@ -1,0 +1,1 @@
+../../scripts/commands/execute-plan.md

--- a/assistant/.claude/commands/mainline.md
+++ b/assistant/.claude/commands/mainline.md
@@ -1,0 +1,1 @@
+../../scripts/commands/mainline.md

--- a/assistant/.claude/commands/swarm.md
+++ b/assistant/.claude/commands/swarm.md
@@ -1,0 +1,1 @@
+../../scripts/commands/swarm.md

--- a/assistant/.claude/commands/work.md
+++ b/assistant/.claude/commands/work.md
@@ -1,0 +1,1 @@
+../../scripts/commands/work.md

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -2,6 +2,7 @@ import * as net from 'node:net';
 
 import type { ChannelId } from '../../channels/types.js';
 import * as externalConversationStore from '../../memory/external-conversation-store.js';
+import { findMember, revokeMember } from '../../memory/ingress-member-store.js';
 import {
   createVerificationChallenge,
   findActiveSession,
@@ -173,8 +174,25 @@ export function handleGuardianVerification(
       const result = getGuardianStatus(channel, assistantId);
       ctx.send(socket, { type: 'guardian_verification_response', ...result });
     } else if (msg.action === 'revoke') {
+      // Capture binding before revoking so we can revoke the guardian's
+      // ingress member record — without this, the guardian would still pass
+      // the ACL check after unbinding.
+      const bindingBeforeRevoke = getGuardianBinding(assistantId, channel);
       revokeGuardianBinding(assistantId, channel);
       revokePendingChallenges(assistantId, channel);
+
+      if (bindingBeforeRevoke) {
+        const member = findMember({
+          assistantId,
+          sourceChannel: channel,
+          externalUserId: bindingBeforeRevoke.guardianExternalUserId,
+          externalChatId: bindingBeforeRevoke.guardianDeliveryChatId,
+        });
+        if (member) {
+          revokeMember(member.id, 'guardian_binding_revoked');
+        }
+      }
+
       ctx.send(socket, {
         type: 'guardian_verification_response',
         success: true,

--- a/assistant/src/memory/guardian-verification.ts
+++ b/assistant/src/memory/guardian-verification.ts
@@ -131,8 +131,8 @@ export function createChallenge(params: {
     nextResendAt: null,
     codeDigits: 6,
     maxAttempts: 3,
-    bootstrapTokenHash: null,
     verificationPurpose: 'guardian' as const,
+    bootstrapTokenHash: null,
     createdAt: now,
     updatedAt: now,
   };


### PR DESCRIPTION
## Summary
- When revoking a guardian binding via settings, capture the guardian's identity beforehand and revoke their `assistant_ingress_members` record
- Fixes bug where revoking guardian access still allowed the guardian to message the bot (member record stayed `status: active`)
- Minor field reorder in `createChallenge` (move `verificationPurpose` before `bootstrapTokenHash` for consistency)

## Original prompt
fix: revoke guardian ingress member record when guardian binding is revoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
