### PR TITLE
docs: clarify notification threading uses semantic grouping, not title matching

### DIFF
--- a/assistant/src/config/bundled-skills/notifications/SKILL.md
+++ b/assistant/src/config/bundled-skills/notifications/SKILL.md
@@ -22,14 +22,9 @@ Use `send_notification` for user-facing alerts and notifications. This tool rout
 
 Thread grouping is handled by the LLM-powered decision engine, not by any parameter you pass. There is no explicit "post to thread X" parameter — thread reuse is inferred, not commanded.
 
-**How it works:** The engine evaluates recent notification thread candidates and chooses `reuse_existing` when a new signal looks like a continuation of an existing thread (same title, same `source_event_name`, related context).
+**How it works:** The engine evaluates recent notification thread candidates and decides whether a new signal is a continuation of an existing thread based on `source_event_name`, provenance metadata, and message content. Use natural, descriptive titles and bodies — the engine groups by semantic relatedness, not string matching.
 
-**To encourage thread reuse:**
-- Use a consistent `title` across related notifications.
-- Use a `source_event_name` that reflects the same event type (e.g. `dog.news.thread.reply` rather than a brand new name each time).
-
-**To force a new thread:**
-- Use a distinct `title` or a clearly different `source_event_name`.
+**`source_event_name` is the primary grouping signal.** Use a stable event name for notifications that belong to the same logical stream (e.g. `dog.news.thread.reply` for all replies in a thread). Use a distinct event name when the notification represents a genuinely different kind of event.
 
 **Practical constraints:**
 - Thread candidates are scoped to the **last 24 hours** (max 5 per channel). You cannot reuse an old thread from days ago.


### PR DESCRIPTION
## Summary
- Remove guidance to use consistent titles for thread reuse — the LLM groups by semantic relatedness using `source_event_name`, provenance metadata, and message content, not string matching
- Emphasize `source_event_name` as the primary grouping signal
- Encourage natural, descriptive titles and bodies instead of artificially repeating the same title

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
