### PR TITLE
M5: Two-size avatar display polish (#10063)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -14,10 +14,21 @@ final class AvatarAppearanceManager {
     private var cachedFallbackAvatar: NSImage?
     /// The name used to build the cached fallback, so we can invalidate when identity changes.
     private var cachedFallbackName: String?
+    /// Cached chat-size avatar (56pt for 2x Retina).
+    private var cachedChatAvatar: NSImage?
+    /// Cached full-size fallback avatar for larger displays (identity panel, constellation).
+    private var cachedFullFallbackAvatar: NSImage?
+    private var cachedFullFallbackName: String?
 
-    /// Returns the custom avatar if set, otherwise an initial-letter placeholder (cached).
+    /// Returns the custom avatar resized for chat (56pt for 2x Retina) if available,
+    /// otherwise an initial-letter placeholder (cached).
     var chatAvatarImage: NSImage {
-        if let custom = customAvatarImage { return custom }
+        if let custom = customAvatarImage {
+            if let cached = cachedChatAvatar { return cached }
+            let resized = Self.resizedImage(custom, to: 56)
+            cachedChatAvatar = resized
+            return resized
+        }
 
         let name = assistantName
         if let cached = cachedFallbackAvatar, cachedFallbackName == name {
@@ -27,6 +38,22 @@ final class AvatarAppearanceManager {
         let avatar = Self.buildInitialLetterAvatar(name: name)
         cachedFallbackAvatar = avatar
         cachedFallbackName = name
+        return avatar
+    }
+
+    /// Returns the full-size custom avatar for large displays (identity panel, constellation node),
+    /// or falls back to a larger initial-letter circle.
+    var fullAvatarImage: NSImage {
+        if let custom = customAvatarImage { return custom }
+
+        let name = assistantName
+        if let cached = cachedFullFallbackAvatar, cachedFullFallbackName == name {
+            return cached
+        }
+
+        let avatar = Self.buildInitialLetterAvatar(name: name, size: 240)
+        cachedFullFallbackAvatar = avatar
+        cachedFullFallbackName = name
         return avatar
     }
 
@@ -89,7 +116,12 @@ final class AvatarAppearanceManager {
         guard let url = Self.resolveCustomAvatarURL(
             workspaceURL: customAvatarURL,
             legacyURL: Self.legacyAppSupportCustomAvatarURL()
-        ) else { return }
+        ) else {
+            customAvatarImage = nil
+            cachedChatAvatar = nil
+            return
+        }
+        cachedChatAvatar = nil
         customAvatarImage = NSImage(contentsOf: url)
     }
 
@@ -103,12 +135,17 @@ final class AvatarAppearanceManager {
               let pngData = bitmap.representation(using: .png, properties: [:]) else { return }
 
         try? pngData.write(to: url)
+        cachedChatAvatar = nil
         customAvatarImage = image
     }
 
     /// Reloads the custom avatar from disk. Called when the daemon notifies
     /// that the avatar image has been regenerated (via `avatar_updated` IPC).
+    /// Invalidates all cached images so SwiftUI views pick up the new avatar.
     func reloadAvatar() {
+        cachedChatAvatar = nil
+        cachedFallbackAvatar = nil
+        cachedFullFallbackAvatar = nil
         loadCustomAvatar()
     }
 
@@ -116,7 +153,9 @@ final class AvatarAppearanceManager {
         try? FileManager.default.removeItem(at: customAvatarURL)
         try? FileManager.default.removeItem(at: Self.legacyAppSupportCustomAvatarURL())
         customAvatarImage = nil
+        cachedChatAvatar = nil
         cachedFallbackAvatar = nil
+        cachedFullFallbackAvatar = nil
     }
 
     // MARK: - File Watching
@@ -188,9 +227,27 @@ final class AvatarAppearanceManager {
         source.resume()
     }
 
+    // MARK: - Image Utilities
+
+    /// Resize an NSImage to the given point size (produces a 1x bitmap; callers rely on
+    /// SwiftUI's `.resizable()` + `.aspectRatio(contentMode: .fill)` for Retina scaling).
+    static func resizedImage(_ source: NSImage, to size: CGFloat) -> NSImage {
+        let targetSize = NSSize(width: size, height: size)
+        let resized = NSImage(size: targetSize)
+        resized.lockFocus()
+        source.draw(
+            in: NSRect(origin: .zero, size: targetSize),
+            from: NSRect(origin: .zero, size: source.size),
+            operation: .copy,
+            fraction: 1.0
+        )
+        resized.unlockFocus()
+        return resized
+    }
+
     // MARK: - Initial Letter Avatar
 
-    /// Build a 56px NSImage with a colored circle and white initial letter as fallback avatar.
+    /// Build a colored-circle NSImage with the assistant's initial letter as fallback avatar.
     static func buildInitialLetterAvatar(name: String, size: CGFloat = 56) -> NSImage {
         let image = NSImage(size: NSSize(width: size, height: size))
         image.lockFocus()

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -229,15 +229,34 @@ final class AvatarAppearanceManager {
 
     // MARK: - Image Utilities
 
-    /// Resize an NSImage to the given point size (produces a 1x bitmap; callers rely on
-    /// SwiftUI's `.resizable()` + `.aspectRatio(contentMode: .fill)` for Retina scaling).
+    /// Resize an NSImage to a square of the given point size using aspect-fill:
+    /// scales the source to fully cover the target square, then crops the excess
+    /// so non-square images are centered rather than stretched.
     static func resizedImage(_ source: NSImage, to size: CGFloat) -> NSImage {
         let targetSize = NSSize(width: size, height: size)
+        let srcW = source.size.width
+        let srcH = source.size.height
+
+        // Determine crop rect: scale so the smaller dimension fills `size`,
+        // then center-crop the larger dimension.
+        let cropRect: NSRect
+        if srcW / srcH > 1 {
+            // Wider than tall -- crop horizontal excess
+            let cropW = srcH // square side in source coords
+            let originX = (srcW - cropW) / 2
+            cropRect = NSRect(x: originX, y: 0, width: cropW, height: srcH)
+        } else {
+            // Taller than wide (or square) -- crop vertical excess
+            let cropH = srcW // square side in source coords
+            let originY = (srcH - cropH) / 2
+            cropRect = NSRect(x: 0, y: originY, width: srcW, height: cropH)
+        }
+
         let resized = NSImage(size: targetSize)
         resized.lockFocus()
         source.draw(
             in: NSRect(origin: .zero, size: targetSize),
-            from: NSRect(origin: .zero, size: source.size),
+            from: cropRect,
             operation: .copy,
             fraction: 1.0
         )

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarCustomizationPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarCustomizationPanel.swift
@@ -37,7 +37,7 @@ struct AvatarCustomizationPanel: View {
                     // Avatar preview
                     HStack {
                         Spacer()
-                        Image(nsImage: appearance.chatAvatarImage)
+                        Image(nsImage: appearance.fullAvatarImage)
                             .resizable()
                             .aspectRatio(contentMode: .fill)
                             .frame(width: 120, height: 120)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -204,11 +204,14 @@ struct ChatBubble: View {
                 .overlay(alignment: .topLeading) {
                     if !isUser && showAvatar {
                         Image(nsImage: appearance.chatAvatarImage)
-                            .interpolation(.none)
                             .resizable()
                             .aspectRatio(contentMode: .fill)
                             .frame(width: 28, height: 28)
                             .clipShape(Circle())
+                            .overlay(
+                                Circle()
+                                    .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
+                            )
                             .offset(x: -(28 + VSpacing.sm), y: 2)
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ComingAliveOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ComingAliveOverlay.swift
@@ -46,7 +46,7 @@ struct ComingAliveOverlay: View {
                 .allowsHitTesting(false)
 
             // Avatar image
-            Image(nsImage: appearance.chatAvatarImage)
+            Image(nsImage: appearance.fullAvatarImage)
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .frame(width: 200, height: 200)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -1129,8 +1129,8 @@ struct ConstellationView: View {
                 }
             }
 
-            // Center avatar on top of everything
-            Image(nsImage: appearance.chatAvatarImage)
+            // Center avatar on top of everything (full-size for constellation display)
+            Image(nsImage: appearance.fullAvatarImage)
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .frame(width: centerAvatarSize, height: centerAvatarSize)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -33,12 +33,16 @@ struct IdentityPanel: View {
 
                     // Card wrapping avatar + ID fields
                     VStack(spacing: 0) {
-                        // Avatar image or initial-letter fallback
-                        Image(nsImage: appearance.chatAvatarImage)
+                        // Avatar image or initial-letter fallback (full-size for identity display)
+                        Image(nsImage: appearance.fullAvatarImage)
                             .resizable()
                             .aspectRatio(contentMode: .fill)
-                            .frame(width: 80, height: 80)
+                            .frame(width: 120, height: 120)
                             .clipShape(Circle())
+                            .overlay(
+                                Circle()
+                                    .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
+                            )
                             .frame(maxWidth: .infinity, alignment: .center)
                             .padding(.top, VSpacing.lg)
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/AvatarRevealStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/AvatarRevealStepView.swift
@@ -215,7 +215,7 @@ struct AvatarRevealStepView: View {
                 if success {
                     // Reload avatar from disk
                     AvatarAppearanceManager.shared.reloadAvatar()
-                    avatarImage = AvatarAppearanceManager.shared.chatAvatarImage
+                    avatarImage = AvatarAppearanceManager.shared.fullAvatarImage
                     generationFailed = false
                 } else {
                     // Use fallback initial-letter avatar

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/CreatureView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/CreatureView.swift
@@ -50,7 +50,7 @@ struct CreatureView: View {
     }
 
     private var avatarImage: some View {
-        Image(nsImage: appearance.chatAvatarImage)
+        Image(nsImage: appearance.fullAvatarImage)
             .resizable()
             .aspectRatio(contentMode: .fill)
             .frame(width: 200, height: 200)


### PR DESCRIPTION
Polish avatar display at two sizes from a single PNG: 28pt circular avatar in chat bubbles, full-size on identity panel. AvatarAppearanceManager provides chatAvatarImage and fullAvatarImage, both reactive to avatar_updated IPC. Falls back to initial-letter circle when no custom avatar exists.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
