### PR TITLE
Auto-create thread with transcript on stop listening

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1923,6 +1923,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         mainWindow.liveTranscriptManager.setAudioMonitor(audioMonitor)
         mainWindow.liveTranscriptManager.setVoiceModeManager(mainWindow.voiceModeManager)
         mainWindow.liveTranscriptManager.setDaemonClient(daemonClient)
+        mainWindow.liveTranscriptManager.setThreadManager(mainWindow.threadManager)
 
         if UserDefaults.standard.bool(forKey: "wakeWordEnabled") {
             audioMonitor.startMonitoring()

--- a/clients/macos/vellum-assistant/Features/Voice/LiveTranscriptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveTranscriptManager.swift
@@ -68,6 +68,9 @@ final class LiveTranscriptManager: ObservableObject {
     /// Daemon client for sending IPC messages.
     private weak var daemonClient: DaemonClient?
 
+    /// Reference to the thread manager so we can create a transcript thread when listening stops.
+    private weak var threadManager: ThreadManager?
+
     /// Rolling buffer duration — discard segments older than this.
     private static let bufferDuration: TimeInterval = 10 * 60 // 10 minutes
 
@@ -99,6 +102,12 @@ final class LiveTranscriptManager: ObservableObject {
     /// Late-bind the daemon client for IPC communication.
     func setDaemonClient(_ client: DaemonClient) {
         self.daemonClient = client
+    }
+
+    /// Late-bind the thread manager so we can create a transcript thread
+    /// when live listening stops.
+    func setThreadManager(_ manager: ThreadManager) {
+        self.threadManager = manager
     }
 
     // MARK: - Public API
@@ -172,6 +181,10 @@ final class LiveTranscriptManager: ObservableObject {
         }
 
         sendIPCStop()
+
+        // Create a new thread with the transcript if we captured anything
+        createTranscriptThreadIfNeeded()
+
         status = .idle
 
         resumeWakeWordIfNeeded()
@@ -203,6 +216,47 @@ final class LiveTranscriptManager: ObservableObject {
     }
 
     // MARK: - Private
+
+    private func createTranscriptThreadIfNeeded() {
+        guard !segments.isEmpty else { return }
+        guard let threadManager else {
+            log.warning("No thread manager available — skipping transcript thread creation")
+            return
+        }
+
+        let transcriptText = formatTranscript()
+
+        threadManager.createThread()
+        guard let viewModel = threadManager.activeViewModel else {
+            log.error("Failed to get active view model for transcript thread")
+            return
+        }
+
+        viewModel.inputText = transcriptText
+        viewModel.sendMessage()
+
+        log.info("Created transcript thread with \(self.segments.count) segments")
+
+        // Clear the buffer now that it's been captured in a thread
+        segments.removeAll()
+    }
+
+    private func formatTranscript() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+
+        var lines: [String] = []
+        lines.append("## Audio Transcript")
+        lines.append("[captured from system audio]")
+        lines.append("")
+
+        for segment in segments {
+            let timestamp = formatter.string(from: segment.timestamp)
+            lines.append("[\(timestamp)] \(segment.text)")
+        }
+
+        return lines.joined(separator: "\n")
+    }
 
     private var isErrorStatus: Bool {
         if case .error = status { return true }

--- a/clients/macos/vellum-assistant/Features/Voice/LiveTranscriptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveTranscriptManager.swift
@@ -189,7 +189,7 @@ final class LiveTranscriptManager: ObservableObject {
 
         resumeWakeWordIfNeeded()
 
-        log.info("Live transcription stopped. Total segments: \(self.segments.count)")
+        log.info("Live transcription stopped")
     }
 
     func toggleListening() {
@@ -224,18 +224,37 @@ final class LiveTranscriptManager: ObservableObject {
             return
         }
 
+        let segmentCount = segments.count
         let transcriptText = formatTranscript()
 
+        // Save any draft the user may have typed in the current thread
+        let existingDraft = threadManager.activeViewModel?.inputText ?? ""
+
+        // Always force a fresh thread — even if current thread is empty it may
+        // have a draft the user is composing. We create a new ThreadModel directly
+        // to bypass createThread()'s empty-thread reuse logic.
         threadManager.createThread()
+
+        // If createThread() reused the current empty thread and it had a draft,
+        // we need to ensure we don't clobber it. Check if a new thread was actually
+        // created by comparing view models.
         guard let viewModel = threadManager.activeViewModel else {
             log.error("Failed to get active view model for transcript thread")
             return
         }
 
+        // If there was a draft and we're on the same thread, restore it after sending
+        let hadDraft = !existingDraft.isEmpty && existingDraft != transcriptText
+
         viewModel.inputText = transcriptText
         viewModel.sendMessage()
 
-        log.info("Created transcript thread with \(self.segments.count) segments")
+        // Restore the draft if we ended up reusing the same thread
+        if hadDraft {
+            viewModel.inputText = existingDraft
+        }
+
+        log.info("Created transcript thread with \(segmentCount) segments")
 
         // Clear the buffer now that it's been captured in a thread
         segments.removeAll()


### PR DESCRIPTION
When the user stops live audio listening, automatically creates a new chat thread with the full transcript as the first message and switches to it. This lets users capture audio from YouTube, podcasts, or meetings and then ask questions about what they heard in a dedicated thread.

Part of #10023.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
