### PR TITLE
fix: point assistant command symlinks to correct .claude/commands/ path

### DIFF
--- a/assistant/.claude/commands/blitz.md
+++ b/assistant/.claude/commands/blitz.md
@@ -1,1 +1,1 @@
-../../scripts/commands/blitz.md
+../../../.claude/commands/blitz.md

--- a/assistant/.claude/commands/brainstorm.md
+++ b/assistant/.claude/commands/brainstorm.md
@@ -1,1 +1,1 @@
-../../scripts/commands/brainstorm.md
+../../../.claude/commands/brainstorm.md

--- a/assistant/.claude/commands/check-reviews.md
+++ b/assistant/.claude/commands/check-reviews.md
@@ -1,1 +1,1 @@
-../../scripts/commands/check-reviews.md
+../../../.claude/commands/check-reviews.md

--- a/assistant/.claude/commands/do.md
+++ b/assistant/.claude/commands/do.md
@@ -1,1 +1,1 @@
-../../scripts/commands/do.md
+../../../.claude/commands/do.md

--- a/assistant/.claude/commands/execute-plan.md
+++ b/assistant/.claude/commands/execute-plan.md
@@ -1,1 +1,1 @@
-../../scripts/commands/execute-plan.md
+../../../.claude/commands/execute-plan.md

--- a/assistant/.claude/commands/mainline.md
+++ b/assistant/.claude/commands/mainline.md
@@ -1,1 +1,1 @@
-../../scripts/commands/mainline.md
+../../../.claude/commands/mainline.md

--- a/assistant/.claude/commands/swarm.md
+++ b/assistant/.claude/commands/swarm.md
@@ -1,1 +1,1 @@
-../../scripts/commands/swarm.md
+../../../.claude/commands/swarm.md

--- a/assistant/.claude/commands/work.md
+++ b/assistant/.claude/commands/work.md
@@ -1,1 +1,1 @@
-../../scripts/commands/work.md
+../../../.claude/commands/work.md


### PR DESCRIPTION
## Summary
- Fix 8 broken symlinks in `assistant/.claude/commands/` that pointed to non-existent `../../scripts/commands/`
- Corrected target to `../../../.claude/commands/` which resolves to the repo-root `.claude/commands/` directory
- Fixes ENOENT when slash commands are resolved from `assistant/.claude/commands/` first

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
