### PR TITLE
fix: include build.sh in daemon staleness check

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -332,6 +332,8 @@ if [ -d "$ASSISTANT_SRC_DIR/src" ] && command -v bun &>/dev/null; then
     elif [ "$ASSISTANT_SRC_DIR/package.json" -nt "$SCRIPT_DIR/daemon-bin/vellum-daemon" ] || \
          [ "$ASSISTANT_SRC_DIR/bun.lock" -nt "$SCRIPT_DIR/daemon-bin/vellum-daemon" ]; then
         DAEMON_BIN_NEEDS_BUILD=true
+    elif [ "$SCRIPT_DIR/build.sh" -nt "$SCRIPT_DIR/daemon-bin/vellum-daemon" ]; then
+        DAEMON_BIN_NEEDS_BUILD=true
     fi
 fi
 if [ "$DAEMON_BIN_NEEDS_BUILD" = true ]; then


### PR DESCRIPTION
## Summary

- The incremental daemon build check (`DAEMON_BIN_NEEDS_BUILD`) only watched `assistant/src/` files and `package.json`/`bun.lock` for changes, missing changes to `build.sh` itself
- When build.sh added new node_modules staging steps (e.g. `@huggingface/transformers`), the staleness check didn't trigger a rebuild, leaving the staged artifacts incomplete
- Added `build.sh` as a staleness input so changes to the build script itself trigger a daemon rebuild and restaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
