### PR TITLE
fix: resolve @huggingface/transformers from executable path in compiled binaries

### DIFF
--- a/assistant/src/memory/embedding-local.ts
+++ b/assistant/src/memory/embedding-local.ts
@@ -1,3 +1,5 @@
+import { dirname, join } from 'node:path';
+
 import { getLogger } from '../util/logger.js';
 import { PromiseGuard } from '../util/promise-guard.js';
 import type { EmbeddingBackend, EmbeddingRequestOptions } from './embedding-backend.js';
@@ -59,13 +61,20 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
     let transformers: typeof import('@huggingface/transformers');
     try {
       transformers = await import('@huggingface/transformers');
-    } catch (err) {
-      // onnxruntime-node is not bundled in compiled binaries, so the import
-      // fails at runtime. Surface a clear error so callers can fall back to
-      // another embedding backend.
-      throw new Error(
-        `Local embedding backend unavailable: failed to load @huggingface/transformers (${err instanceof Error ? err.message : String(err)})`,
-      );
+    } catch {
+      // In compiled Bun binaries, bare specifier resolution starts from the
+      // virtual /$bunfs/root/ filesystem and can't find externalized packages.
+      // Fall back to resolving from the executable's real disk location where
+      // node_modules/ is co-located.
+      try {
+        const execDir = dirname(process.execPath);
+        const modulePath = join(execDir, 'node_modules', '@huggingface', 'transformers');
+        transformers = await import(modulePath);
+      } catch (err) {
+        throw new Error(
+          `Local embedding backend unavailable: failed to load @huggingface/transformers (${err instanceof Error ? err.message : String(err)})`,
+        );
+      }
     }
     this.extractor = await transformers.pipeline('feature-extraction', this.model, {
       dtype: 'fp32',


### PR DESCRIPTION
## Summary

- Compiled Bun binaries resolve bare specifiers from the virtual `/$bunfs/root/` filesystem, so `import('@huggingface/transformers')` fails even when the package is staged in `node_modules/` next to the binary
- Added a fallback that resolves the module from `dirname(process.execPath)` — the executable's real disk location where `node_modules/` is co-located
- Fixes the "No embedding backend configured" error in the macOS app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
