### PR TITLE
M1: Assistant config + skill feature flag enforcement

### DIFF
--- a/assistant/src/__tests__/skill-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags-integration.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Integration tests for skill feature flag enforcement at system prompt,
+ * skill_load, and session-skill-tools projection layers.
+ */
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Test-scoped temp directory and config state
+// ---------------------------------------------------------------------------
+
+const TEST_DIR = join(tmpdir(), `vellum-skill-flags-test-${crypto.randomUUID()}`);
+
+let currentConfig: Record<string, unknown> = {
+  sandbox: { enabled: false, backend: 'native' },
+  featureFlags: {},
+};
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => TEST_DIR,
+  getDataDir: () => TEST_DIR,
+  getWorkspaceDir: () => TEST_DIR,
+  getWorkspaceConfigPath: () => join(TEST_DIR, 'config.json'),
+  getWorkspaceSkillsDir: () => join(TEST_DIR, 'skills'),
+  getWorkspaceHooksDir: () => join(TEST_DIR, 'hooks'),
+  getWorkspacePromptPath: (file: string) => join(TEST_DIR, file),
+  ensureDataDir: () => {},
+  getSocketPath: () => join(TEST_DIR, 'vellum.sock'),
+  getPidPath: () => join(TEST_DIR, 'vellum.pid'),
+  getDbPath: () => join(TEST_DIR, 'data', 'assistant.db'),
+  getLogPath: () => join(TEST_DIR, 'logs', 'vellum.log'),
+  getHistoryPath: () => join(TEST_DIR, 'history'),
+  getHooksDir: () => join(TEST_DIR, 'hooks'),
+  getIpcBlobDir: () => join(TEST_DIR, 'ipc-blobs'),
+  getSandboxRootDir: () => join(TEST_DIR, 'sandbox'),
+  getSandboxWorkingDir: () => TEST_DIR,
+  getInterfacesDir: () => join(TEST_DIR, 'interfaces'),
+  isMacOS: () => false,
+  isLinux: () => false,
+  isWindows: () => false,
+  getPlatformName: () => 'linux',
+  getClipboardCommand: () => null,
+  removeSocketFile: () => {},
+  migratePath: () => {},
+  migrateToWorkspaceLayout: () => {},
+  migrateToDataLayout: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+  isDebug: () => false,
+  truncateForLog: (v: string) => v,
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => currentConfig,
+}));
+
+mock.module('../config/user-reference.js', () => ({
+  resolveUserReference: () => 'TestUser',
+}));
+
+mock.module('../security/parental-control-store.js', () => ({
+  getParentalControlSettings: () => ({ enabled: false, contentRestrictions: [], blockedToolCategories: [] }),
+}));
+
+mock.module('../tools/credentials/metadata-store.js', () => ({
+  listCredentialMetadata: () => [],
+}));
+
+const { buildSystemPrompt } = await import('../config/system-prompt.js');
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+  // Reset config to defaults before each test
+  currentConfig = {
+    sandbox: { enabled: false, backend: 'native' },
+    featureFlags: {},
+  };
+});
+
+afterEach(() => {
+  if (existsSync(TEST_DIR)) {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createSkillOnDisk(id: string, name: string, description: string): void {
+  const skillsDir = join(TEST_DIR, 'skills');
+  mkdirSync(join(skillsDir, id), { recursive: true });
+  writeFileSync(
+    join(skillsDir, id, 'SKILL.md'),
+    `---\nname: "${name}"\ndescription: "${description}"\n---\n\nInstructions for ${id}.\n`,
+  );
+  // Ensure SKILLS.md index references the skill
+  const indexPath = join(skillsDir, 'SKILLS.md');
+  const existing = existsSync(indexPath) ? require('node:fs').readFileSync(indexPath, 'utf-8') : '';
+  writeFileSync(indexPath, existing + `- ${id}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// System prompt — feature flag filtering
+// ---------------------------------------------------------------------------
+
+describe('buildSystemPrompt feature flag filtering', () => {
+  test('flag OFF skill does not appear in <available_skills> section', () => {
+    createSkillOnDisk('browser', 'Browser', 'Web browsing automation');
+    createSkillOnDisk('twitter', 'Twitter', 'Post to X/Twitter');
+
+    currentConfig = {
+      sandbox: { enabled: false, backend: 'native' },
+      featureFlags: { 'skills.browser.enabled': false },
+    };
+
+    const result = buildSystemPrompt();
+
+    // twitter should be visible, browser should not
+    expect(result).toContain('id="twitter"');
+    expect(result).not.toContain('id="browser"');
+  });
+
+  test('all skills visible when featureFlags is empty', () => {
+    createSkillOnDisk('browser', 'Browser', 'Web browsing automation');
+    createSkillOnDisk('twitter', 'Twitter', 'Post to X/Twitter');
+
+    currentConfig = {
+      sandbox: { enabled: false, backend: 'native' },
+      featureFlags: {},
+    };
+
+    const result = buildSystemPrompt();
+
+    expect(result).toContain('id="browser"');
+    expect(result).toContain('id="twitter"');
+  });
+
+  test('all skills hidden when all flags are OFF', () => {
+    createSkillOnDisk('browser', 'Browser', 'Web browsing automation');
+    createSkillOnDisk('twitter', 'Twitter', 'Post to X/Twitter');
+
+    currentConfig = {
+      sandbox: { enabled: false, backend: 'native' },
+      featureFlags: {
+        'skills.browser.enabled': false,
+        'skills.twitter.enabled': false,
+      },
+    };
+
+    const result = buildSystemPrompt();
+
+    expect(result).not.toContain('<available_skills>');
+    expect(result).not.toContain('id="browser"');
+    expect(result).not.toContain('id="twitter"');
+  });
+});

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { AssistantConfig } from '../config/schema.js';
+import { isSkillFeatureEnabled, resolveSkillStates } from '../config/skill-state.js';
+import type { SkillSummary } from '../config/skills.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a minimal AssistantConfig with optional featureFlags. */
+function makeConfig(overrides: Partial<AssistantConfig> = {}): AssistantConfig {
+  return {
+    featureFlags: {},
+    skills: {
+      entries: {},
+      load: { extraDirs: [], watch: true, watchDebounceMs: 250 },
+      install: { nodeManager: 'npm' },
+      allowBundled: null,
+    },
+    ...overrides,
+  } as AssistantConfig;
+}
+
+/** Create a minimal SkillSummary for testing. */
+function makeSkill(id: string, source: 'bundled' | 'managed' = 'bundled'): SkillSummary {
+  return {
+    id,
+    name: `${id} skill`,
+    description: `Description for ${id}`,
+    directoryPath: `/fake/skills/${id}`,
+    skillFilePath: `/fake/skills/${id}/SKILL.md`,
+    bundled: source === 'bundled',
+    userInvocable: true,
+    disableModelInvocation: false,
+    source,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// isSkillFeatureEnabled
+// ---------------------------------------------------------------------------
+
+describe('isSkillFeatureEnabled', () => {
+  test('returns true when featureFlags section is empty', () => {
+    const config = makeConfig({ featureFlags: {} });
+    expect(isSkillFeatureEnabled('browser', config)).toBe(true);
+  });
+
+  test('returns true when skill key is missing (default enabled)', () => {
+    const config = makeConfig({
+      featureFlags: { 'skills.other.enabled': true },
+    });
+    expect(isSkillFeatureEnabled('browser', config)).toBe(true);
+  });
+
+  test('returns true when skill key is explicitly true', () => {
+    const config = makeConfig({
+      featureFlags: { 'skills.browser.enabled': true },
+    });
+    expect(isSkillFeatureEnabled('browser', config)).toBe(true);
+  });
+
+  test('returns false when skill key is explicitly false', () => {
+    const config = makeConfig({
+      featureFlags: { 'skills.browser.enabled': false },
+    });
+    expect(isSkillFeatureEnabled('browser', config)).toBe(false);
+  });
+
+  test('returns true when featureFlags is undefined', () => {
+    const config = makeConfig();
+    // Simulate a config that somehow has no featureFlags key
+    delete (config as Record<string, unknown>).featureFlags;
+    expect(isSkillFeatureEnabled('browser', config)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveSkillStates — feature flag filtering
+// ---------------------------------------------------------------------------
+
+describe('resolveSkillStates with feature flags', () => {
+  test('flag OFF skill does not appear in resolved list', () => {
+    const catalog = [makeSkill('browser'), makeSkill('twitter')];
+    const config = makeConfig({
+      featureFlags: { 'skills.browser.enabled': false },
+    });
+
+    const resolved = resolveSkillStates(catalog, config);
+    const ids = resolved.map((r) => r.summary.id);
+
+    expect(ids).not.toContain('browser');
+    expect(ids).toContain('twitter');
+  });
+
+  test('flag ON skill appears normally', () => {
+    const catalog = [makeSkill('browser'), makeSkill('twitter')];
+    const config = makeConfig({
+      featureFlags: { 'skills.browser.enabled': true, 'skills.twitter.enabled': true },
+    });
+
+    const resolved = resolveSkillStates(catalog, config);
+    const ids = resolved.map((r) => r.summary.id);
+
+    expect(ids).toContain('browser');
+    expect(ids).toContain('twitter');
+  });
+
+  test('missing flag key defaults to enabled', () => {
+    const catalog = [makeSkill('browser')];
+    const config = makeConfig({ featureFlags: {} });
+
+    const resolved = resolveSkillStates(catalog, config);
+    expect(resolved.length).toBe(1);
+    expect(resolved[0].summary.id).toBe('browser');
+  });
+
+  test('feature flag OFF takes precedence over user-enabled config entry', () => {
+    const catalog = [makeSkill('browser')];
+    const config = makeConfig({
+      featureFlags: { 'skills.browser.enabled': false },
+      skills: {
+        entries: { browser: { enabled: true } },
+        load: { extraDirs: [], watch: true, watchDebounceMs: 250 },
+        install: { nodeManager: 'npm' },
+        allowBundled: null,
+      },
+    });
+
+    const resolved = resolveSkillStates(catalog, config);
+    // The skill should not appear at all — feature flag is a higher-priority gate
+    expect(resolved.length).toBe(0);
+  });
+
+  test('multiple skills with mixed flags', () => {
+    const catalog = [
+      makeSkill('browser'),
+      makeSkill('twitter'),
+      makeSkill('deploy'),
+    ];
+    const config = makeConfig({
+      featureFlags: {
+        'skills.browser.enabled': false,
+        'skills.deploy.enabled': false,
+      },
+    });
+
+    const resolved = resolveSkillStates(catalog, config);
+    const ids = resolved.map((r) => r.summary.id);
+
+    expect(ids).toEqual(['twitter']);
+  });
+});

--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests that skill_load rejects loading a skill whose feature flag is OFF
+ * with a deterministic error message.
+ */
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const TEST_DIR = join(tmpdir(), `vellum-skill-load-flag-test-${crypto.randomUUID()}`);
+
+let currentConfig: Record<string, unknown> = {
+  featureFlags: {},
+};
+
+const platformOverrides: Record<string, (...args: unknown[]) => unknown> = {
+  getRootDir: () => TEST_DIR,
+  getDataDir: () => TEST_DIR,
+  ensureDataDir: () => {},
+  getSocketPath: () => join(TEST_DIR, 'vellum.sock'),
+  getPidPath: () => join(TEST_DIR, 'vellum.pid'),
+  getDbPath: () => join(TEST_DIR, 'data', 'assistant.db'),
+  getLogPath: () => join(TEST_DIR, 'logs', 'vellum.log'),
+  getWorkspaceDir: () => join(TEST_DIR, 'workspace'),
+  getWorkspaceSkillsDir: () => join(TEST_DIR, 'skills'),
+  getWorkspaceConfigPath: () => join(TEST_DIR, 'workspace', 'config.json'),
+  getWorkspaceHooksDir: () => join(TEST_DIR, 'workspace', 'hooks'),
+  getWorkspacePromptPath: (f: unknown) => join(TEST_DIR, 'workspace', String(f)),
+  getInterfacesDir: () => join(TEST_DIR, 'interfaces'),
+  getHooksDir: () => join(TEST_DIR, 'hooks'),
+  getIpcBlobDir: () => join(TEST_DIR, 'blobs'),
+  getSandboxRootDir: () => join(TEST_DIR, 'sandbox'),
+  getSandboxWorkingDir: () => join(TEST_DIR, 'sandbox', 'work'),
+  getHistoryPath: () => join(TEST_DIR, 'history'),
+  getSessionTokenPath: () => join(TEST_DIR, 'session-token'),
+  readSessionToken: () => null,
+  getClipboardCommand: () => null,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getPlatformName: () => process.platform,
+  migratePath: () => {},
+  migrateToWorkspaceLayout: () => {},
+  migrateToDataLayout: () => {},
+  removeSocketFile: () => {},
+};
+mock.module('../util/platform.js', () => platformOverrides);
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => currentConfig,
+}));
+
+await import('../tools/skills/load.js');
+const { getTool } = await import('../tools/registry.js');
+
+function writeSkill(skillId: string, name: string, description: string, body: string): void {
+  const skillDir = join(TEST_DIR, 'skills', skillId);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, 'SKILL.md'),
+    `---\nname: "${name}"\ndescription: "${description}"\n---\n\n${body}\n`,
+  );
+}
+
+async function executeSkillLoad(input: Record<string, unknown>): Promise<{ content: string; isError: boolean }> {
+  const tool = getTool('skill_load');
+  if (!tool) throw new Error('skill_load tool was not registered');
+
+  const result = await tool.execute(input, {
+    workingDir: '/tmp',
+    sessionId: 'session-1',
+    conversationId: 'conversation-1',
+  });
+  return { content: result.content, isError: result.isError };
+}
+
+describe('skill_load feature flag enforcement', () => {
+  beforeEach(() => {
+    mkdirSync(join(TEST_DIR, 'skills'), { recursive: true });
+    currentConfig = { featureFlags: {} };
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  test('returns deterministic error for flag OFF skill', async () => {
+    writeSkill('browser', 'Browser', 'Web browsing', 'Use the browser.');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- browser\n');
+
+    currentConfig = {
+      featureFlags: { 'skills.browser.enabled': false },
+    };
+
+    const result = await executeSkillLoad({ skill: 'browser' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('disabled by feature flag');
+    expect(result.content).toContain('browser');
+  });
+
+  test('loads skill normally when flag is ON', async () => {
+    writeSkill('browser', 'Browser', 'Web browsing', 'Use the browser.');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- browser\n');
+
+    currentConfig = {
+      featureFlags: { 'skills.browser.enabled': true },
+    };
+
+    const result = await executeSkillLoad({ skill: 'browser' });
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Skill: Browser');
+  });
+
+  test('loads skill normally when flag key is absent (defaults to enabled)', async () => {
+    writeSkill('browser', 'Browser', 'Web browsing', 'Use the browser.');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- browser\n');
+
+    currentConfig = {
+      featureFlags: {},
+    };
+
+    const result = await executeSkillLoad({ skill: 'browser' });
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Skill: Browser');
+  });
+});

--- a/assistant/src/__tests__/skill-projection-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-projection-feature-flag.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Tests that projectSkillTools drops flag-OFF active skills from projected
+ * tools, even when conversation history contains old markers for those skills.
+ */
+import * as realFs from 'node:fs';
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+import type { SkillSummary, SkillToolManifest } from '../config/skills.js';
+import { RiskLevel } from '../permissions/types.js';
+import type { Message } from '../providers/types.js';
+import type { Tool } from '../tools/types.js';
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockCatalog: SkillSummary[] = [];
+let mockManifests: Record<string, SkillToolManifest | null> = {};
+let mockRegisteredTools: Map<string, Tool[]> = new Map();
+let mockUnregisteredSkillIds: string[] = [];
+let mockSkillRefCount: Map<string, number> = new Map();
+
+let currentConfig: Record<string, unknown> = { featureFlags: {} };
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module('../config/skills.js', () => ({
+  loadSkillCatalog: () => mockCatalog,
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => currentConfig,
+}));
+
+mock.module('../skills/active-skill-tools.js', () => {
+  const parseMarkers = (messages: Message[]) => {
+    const skillLoadUseIds = new Set<string>();
+    for (const msg of messages) {
+      for (const block of msg.content) {
+        if (block.type === 'tool_use' && block.name === 'skill_load') {
+          skillLoadUseIds.add(block.id);
+        }
+      }
+    }
+    const re = /<loaded_skill\s+id="([^"]+)"(?:\s+version="([^"]+)")?\s*\/>/g;
+    const seen = new Set<string>();
+    const entries: Array<{ id: string; version?: string }> = [];
+    for (const msg of messages) {
+      for (const block of msg.content) {
+        if (block.type !== 'tool_result') continue;
+        if (!skillLoadUseIds.has(block.tool_use_id)) continue;
+        const text = block.content;
+        if (!text) continue;
+        for (const m of text.matchAll(re)) {
+          if (!seen.has(m[1])) {
+            seen.add(m[1]);
+            const entry: { id: string; version?: string } = { id: m[1] };
+            if (m[2]) entry.version = m[2];
+            entries.push(entry);
+          }
+        }
+      }
+    }
+    return entries;
+  };
+
+  return {
+    deriveActiveSkills: (messages: Message[]) => parseMarkers(messages),
+    deriveActiveSkillIds: (messages: Message[]) => parseMarkers(messages).map((e) => e.id),
+  };
+});
+
+mock.module('../skills/tool-manifest.js', () => ({
+  parseToolManifestFile: (filePath: string) => {
+    const parts = filePath.split('/');
+    const skillId = parts[parts.length - 2];
+    const manifest = mockManifests[skillId];
+    if (!manifest) throw new Error(`Mock: no manifest for skill "${skillId}"`);
+    return manifest;
+  },
+}));
+
+mock.module('../tools/skills/skill-tool-factory.js', () => ({
+  createSkillToolsFromManifest: (
+    entries: SkillToolManifest['tools'],
+    skillId: string,
+    _skillDir: string,
+    versionHash: string,
+    bundled?: boolean,
+  ): Tool[] => {
+    return entries.map((entry) => ({
+      name: entry.name,
+      description: entry.description,
+      category: entry.category,
+      defaultRiskLevel: RiskLevel.Medium,
+      origin: 'skill' as const,
+      ownerSkillId: skillId,
+      ownerSkillVersionHash: versionHash,
+      ownerSkillBundled: bundled ?? undefined,
+      getDefinition: () => ({
+        name: entry.name,
+        description: entry.description,
+        input_schema: entry.input_schema as object,
+      }),
+      execute: async () => ({ content: '', isError: false }),
+    }));
+  },
+}));
+
+mock.module('../tools/registry.js', () => ({
+  registerSkillTools: (tools: Tool[]) => {
+    const skillIds = new Set<string>();
+    for (const tool of tools) {
+      const skillId = tool.ownerSkillId!;
+      skillIds.add(skillId);
+      const existing = mockRegisteredTools.get(skillId) ?? [];
+      existing.push(tool);
+      mockRegisteredTools.set(skillId, existing);
+    }
+    for (const id of skillIds) {
+      mockSkillRefCount.set(id, (mockSkillRefCount.get(id) ?? 0) + 1);
+    }
+    return tools;
+  },
+  unregisterSkillTools: (skillId: string) => {
+    mockUnregisteredSkillIds.push(skillId);
+    const current = mockSkillRefCount.get(skillId) ?? 0;
+    if (current > 1) {
+      mockSkillRefCount.set(skillId, current - 1);
+      return;
+    }
+    mockSkillRefCount.delete(skillId);
+    mockRegisteredTools.delete(skillId);
+  },
+  getTool: (name: string): Tool | undefined => {
+    let found: Tool | undefined;
+    for (const tools of mockRegisteredTools.values()) {
+      for (const tool of tools) {
+        if (tool.name === name) found = tool;
+      }
+    }
+    return found;
+  },
+  getSkillToolNames: () => {
+    const names: string[] = [];
+    for (const tools of mockRegisteredTools.values()) {
+      for (const tool of tools) {
+        names.push(tool.name);
+      }
+    }
+    return names;
+  },
+}));
+
+mock.module('node:fs', () => ({
+  ...realFs,
+  existsSync: (p: string) => {
+    if (typeof p === 'string' && p.endsWith('TOOLS.json')) {
+      const parts = p.split('/');
+      const skillId = parts[parts.length - 2];
+      return skillId in mockManifests;
+    }
+    return realFs.existsSync(p);
+  },
+}));
+
+mock.module('../skills/version-hash.js', () => ({
+  computeSkillVersionHash: (skillDir: string) => {
+    const parts = skillDir.split('/');
+    const skillId = parts[parts.length - 1];
+    return `v1:default-hash-${skillId}`;
+  },
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    debug: () => {},
+    error: () => {},
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { projectSkillTools, resetSkillToolProjection } = await import(
+  '../daemon/session-skill-tools.js'
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSkill(id: string): SkillSummary {
+  return {
+    id,
+    name: id,
+    description: `Skill ${id}`,
+    directoryPath: `/skills/${id}`,
+    skillFilePath: `/skills/${id}/SKILL.md`,
+    userInvocable: true,
+    disableModelInvocation: false,
+    source: 'managed',
+  };
+}
+
+function makeManifest(toolNames: string[]): SkillToolManifest {
+  return {
+    version: 1,
+    tools: toolNames.map((name) => ({
+      name,
+      description: `Tool ${name}`,
+      category: 'test',
+      risk: 'medium' as const,
+      input_schema: { type: 'object', properties: {} },
+      executor: 'run.ts',
+      execution_target: 'host' as const,
+    })),
+  };
+}
+
+/** Build conversation history with a loaded_skill marker. */
+function buildHistoryWithMarker(skillId: string): Message[] {
+  return [
+    {
+      role: 'assistant',
+      content: [{ type: 'tool_use', id: 'tu-1', name: 'skill_load', input: { skill: skillId } }],
+    },
+    {
+      role: 'user',
+      content: [{
+        type: 'tool_result',
+        tool_use_id: 'tu-1',
+        content: `Loaded.\n\n<loaded_skill id="${skillId}" version="v1:default-hash-${skillId}" />`,
+      }],
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('projectSkillTools feature flag enforcement', () => {
+  beforeEach(() => {
+    mockCatalog = [];
+    mockManifests = {};
+    mockRegisteredTools = new Map();
+    mockUnregisteredSkillIds = [];
+    mockSkillRefCount = new Map();
+    currentConfig = { featureFlags: {} };
+    resetSkillToolProjection();
+  });
+
+  test('no skill tools projected for flag OFF skill even with old markers', () => {
+    mockCatalog = [makeSkill('browser')];
+    mockManifests = { browser: makeManifest(['browser_navigate', 'browser_click']) };
+
+    // History contains a marker from before the flag was turned off
+    const history = buildHistoryWithMarker('browser');
+    const prevActive = new Map<string, string>();
+
+    // Feature flag is OFF
+    currentConfig = { featureFlags: { 'skills.browser.enabled': false } };
+
+    const result = projectSkillTools(history, { previouslyActiveSkillIds: prevActive });
+
+    // No tools should be projected
+    expect(result.toolDefinitions).toHaveLength(0);
+    expect(result.allowedToolNames.size).toBe(0);
+  });
+
+  test('skill tools projected normally when flag is ON', () => {
+    mockCatalog = [makeSkill('browser')];
+    mockManifests = { browser: makeManifest(['browser_navigate', 'browser_click']) };
+
+    const history = buildHistoryWithMarker('browser');
+    const prevActive = new Map<string, string>();
+
+    // Feature flag is ON
+    currentConfig = { featureFlags: { 'skills.browser.enabled': true } };
+
+    const result = projectSkillTools(history, { previouslyActiveSkillIds: prevActive });
+
+    expect(result.toolDefinitions).toHaveLength(2);
+    expect(result.allowedToolNames.has('browser_navigate')).toBe(true);
+    expect(result.allowedToolNames.has('browser_click')).toBe(true);
+  });
+
+  test('skill tools projected normally when flag key is absent (defaults to enabled)', () => {
+    mockCatalog = [makeSkill('browser')];
+    mockManifests = { browser: makeManifest(['browser_navigate']) };
+
+    const history = buildHistoryWithMarker('browser');
+    const prevActive = new Map<string, string>();
+
+    // featureFlags is empty — should default to enabled
+    currentConfig = { featureFlags: {} };
+
+    const result = projectSkillTools(history, { previouslyActiveSkillIds: prevActive });
+
+    expect(result.toolDefinitions).toHaveLength(1);
+    expect(result.allowedToolNames.has('browser_navigate')).toBe(true);
+  });
+
+  test('mixed flag-on and flag-off skills — only flag-on tools projected', () => {
+    mockCatalog = [makeSkill('browser'), makeSkill('twitter')];
+    mockManifests = {
+      browser: makeManifest(['browser_navigate']),
+      twitter: makeManifest(['twitter_post']),
+    };
+
+    const history: Message[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'tu-1', name: 'skill_load', input: { skill: 'browser' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{
+          type: 'tool_result',
+          tool_use_id: 'tu-1',
+          content: '<loaded_skill id="browser" version="v1:default-hash-browser" />',
+        }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'tu-2', name: 'skill_load', input: { skill: 'twitter' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{
+          type: 'tool_result',
+          tool_use_id: 'tu-2',
+          content: '<loaded_skill id="twitter" version="v1:default-hash-twitter" />',
+        }],
+      },
+    ];
+    const prevActive = new Map<string, string>();
+
+    // browser is OFF, twitter is ON
+    currentConfig = {
+      featureFlags: { 'skills.browser.enabled': false },
+    };
+
+    const result = projectSkillTools(history, { previouslyActiveSkillIds: prevActive });
+
+    const toolNames = result.toolDefinitions.map((t) => t.name);
+    expect(toolNames).toContain('twitter_post');
+    expect(toolNames).not.toContain('browser_navigate');
+  });
+});

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -218,6 +218,9 @@ export const AssistantConfigSchema = z.object({
   daemon: DaemonConfigSchema.default({} as any),
   notifications: NotificationsConfigSchema.default({} as any),
   ui: UiConfigSchema.default({} as any),
+  featureFlags: z
+    .record(z.string(), z.boolean({ error: 'featureFlags values must be booleans' }))
+    .default({} as any),
 }).superRefine((config, ctx) => {
   if (config.contextWindow?.targetInputTokens != null && config.contextWindow?.maxInputTokens != null &&
       config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {

--- a/assistant/src/config/skill-state.ts
+++ b/assistant/src/config/skill-state.ts
@@ -12,6 +12,20 @@ export interface ResolvedSkill {
   configEntry?: SkillEntryConfig;
 }
 
+/**
+ * Check whether a skill's feature flag is enabled.
+ * Feature flag key format: `skills.<skillId>.enabled`.
+ * Missing key defaults to `true` (enabled); explicit `false` means disabled.
+ */
+export function isSkillFeatureEnabled(skillId: string, config: AssistantConfig): boolean {
+  const flags = config.featureFlags;
+  if (!flags) return true;
+  const key = `skills.${skillId}.enabled`;
+  const value = flags[key];
+  if (value === undefined) return true;
+  return value !== false;
+}
+
 export function resolveSkillStates(
   catalog: SkillSummary[],
   config: AssistantConfig,
@@ -20,6 +34,11 @@ export function resolveSkillStates(
   const { entries, allowBundled } = config.skills ?? { entries: {}, allowBundled: null };
 
   for (const skill of catalog) {
+    // Feature flag gate: if the flag is explicitly OFF, skip this skill entirely
+    if (!isSkillFeatureEnabled(skill.id, config)) {
+      continue;
+    }
+
     // Filter bundled skills by allowlist
     if (skill.source === 'bundled' && allowBundled != null && !allowBundled.includes(skill.id)) {
       continue;

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -7,6 +7,7 @@ import { listCredentialMetadata } from '../tools/credentials/metadata-store.js';
 import { getLogger } from '../util/logger.js';
 import { getWorkspaceDir, getWorkspacePromptPath, isMacOS } from '../util/platform.js';
 import { getConfig } from './loader.js';
+import { isSkillFeatureEnabled } from './skill-state.js';
 import { loadSkillCatalog, type SkillSummary } from './skills.js';
 import { resolveUserReference } from './user-reference.js';
 
@@ -721,10 +722,14 @@ function readPromptFile(path: string): string | null {
 
 function appendSkillsCatalog(basePrompt: string): string {
   const skills = loadSkillCatalog();
+  const config = getConfig();
+
+  // Filter out skills whose feature flag is explicitly OFF
+  const flagFiltered = skills.filter(s => isSkillFeatureEnabled(s.id, config));
 
   const sections: string[] = [basePrompt];
 
-  const catalog = formatSkillsCatalog(skills);
+  const catalog = formatSkillsCatalog(flagFiltered);
   if (catalog) sections.push(catalog);
 
   sections.push(buildDynamicSkillWorkflowSection());

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -732,13 +732,13 @@ function appendSkillsCatalog(basePrompt: string): string {
   const catalog = formatSkillsCatalog(flagFiltered);
   if (catalog) sections.push(catalog);
 
-  sections.push(buildDynamicSkillWorkflowSection());
+  sections.push(buildDynamicSkillWorkflowSection(config));
 
   return sections.join('\n\n');
 }
 
-function buildDynamicSkillWorkflowSection(): string {
-  return [
+function buildDynamicSkillWorkflowSection(config: import('./schema.js').AssistantConfig): string {
+  const lines = [
     '## Dynamic Skill Authoring Workflow',
     '',
     'When no existing tool or skill can satisfy a request:',
@@ -750,13 +750,25 @@ function buildDynamicSkillWorkflowSection(): string {
     '',
     '**Never persist or delete skills without explicit user confirmation.** To remove: `delete_managed_skill`.',
     'After a skill is written or deleted, the next turn may run in a recreated session due to file-watcher eviction. Continue normally.',
-    '',
-    '### Browser Skill Prerequisite',
-    'If you need browser capabilities (navigating web pages, clicking elements, extracting content) and `browser_*` tools are not available, load the "browser" skill first using `skill_load`.',
-    '',
-    '### X (Twitter) Skill',
-    'When the user asks to post, reply, or interact with X/Twitter, load the "twitter" skill using `skill_load`. Do NOT use computer-use or the browser skill for X — the X skill provides CLI commands (`vellum x post`, `vellum x reply`) that are faster and more reliable.',
-  ].join('\n');
+  ];
+
+  if (isSkillFeatureEnabled('browser', config)) {
+    lines.push(
+      '',
+      '### Browser Skill Prerequisite',
+      'If you need browser capabilities (navigating web pages, clicking elements, extracting content) and `browser_*` tools are not available, load the "browser" skill first using `skill_load`.',
+    );
+  }
+
+  if (isSkillFeatureEnabled('twitter', config)) {
+    lines.push(
+      '',
+      '### X (Twitter) Skill',
+      'When the user asks to post, reply, or interact with X/Twitter, load the "twitter" skill using `skill_load`. Do NOT use computer-use or the browser skill for X — the X skill provides CLI commands (`vellum x post`, `vellum x reply`) that are faster and more reliable.',
+    );
+  }
+
+  return lines.join('\n');
 }
 
 function escapeXml(str: string): string {

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -43,3 +43,11 @@ export type {
   UiConfig,
   WorkspaceGitConfig,
 } from './schema.js';
+
+/**
+ * Feature flags are a top-level config section (Record<string, boolean>).
+ * Skill feature flags use the key format `skills.<skillId>.enabled`.
+ * Missing key defaults to `true` (enabled); explicit `false` disables everywhere.
+ */
+export type FeatureFlags = Record<string, boolean>;
+

--- a/assistant/src/daemon/session-skill-tools.ts
+++ b/assistant/src/daemon/session-skill-tools.ts
@@ -11,6 +11,8 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { getConfig } from '../config/loader.js';
+import { isSkillFeatureEnabled } from '../config/skill-state.js';
 import type { SkillSummary, SkillToolManifest } from '../config/skills.js';
 import { loadSkillCatalog } from '../config/skills.js';
 import type { Message, ToolDefinition } from '../providers/types.js';
@@ -215,7 +217,17 @@ export function projectSkillTools(
 
   // Union of context-derived and preactivated IDs
   const contextIds = contextEntries.map((e) => e.id);
-  const activeIds = new Set<string>([...contextIds, ...preactivated]);
+  const allCandidateIds = new Set<string>([...contextIds, ...preactivated]);
+
+  // Feature flag gate: drop skills whose feature flag is explicitly OFF,
+  // even if they have markers in conversation history from before the flag was turned off.
+  const config = getConfig();
+  const activeIds = new Set<string>();
+  for (const id of allCandidateIds) {
+    if (isSkillFeatureEnabled(id, config)) {
+      activeIds.add(id);
+    }
+  }
 
   // Determine which skills were removed since last projection
   const removedIds = new Set<string>();

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -94,14 +94,15 @@ export class SkillLoadTool implements Tool {
       const childLines: string[] = [];
       for (const childId of skill.includes) {
         const child = catalogIndex.get(childId);
-        if (child) {
-          childLines.push(`  - ${child.id}: ${child.name} — ${child.description} (${child.skillFilePath})`);
+        if (!child) continue;
+        if (!isSkillFeatureEnabled(childId, config)) continue;
 
-          // Load the included skill's body content
-          const childLoaded = loadSkillBySelector(childId);
-          if (childLoaded.skill && childLoaded.skill.body.length > 0) {
-            includedBodies.push(`--- Included Skill: ${childLoaded.skill.name} (${childId}) ---\n${childLoaded.skill.body}`);
-          }
+        childLines.push(`  - ${child.id}: ${child.name} — ${child.description} (${child.skillFilePath})`);
+
+        // Load the included skill's body content
+        const childLoaded = loadSkillBySelector(childId);
+        if (childLoaded.skill && childLoaded.skill.body.length > 0) {
+          includedBodies.push(`--- Included Skill: ${childLoaded.skill.name} (${childId}) ---\n${childLoaded.skill.body}`);
         }
       }
       immediateChildrenSection = `Included Skills (immediate):\n${childLines.join('\n')}`;
@@ -124,6 +125,7 @@ export class SkillLoadTool implements Tool {
       for (const childId of skill.includes) {
         const child = catalogIndex.get(childId);
         if (!child) continue;
+        if (!isSkillFeatureEnabled(childId, config)) continue;
         let childHash: string | undefined;
         try {
           childHash = computeSkillVersionHash(child.directoryPath);

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -1,3 +1,5 @@
+import { getConfig } from '../../config/loader.js';
+import { isSkillFeatureEnabled } from '../../config/skill-state.js';
 import type { SkillSummary } from '../../config/skills.js';
 import { loadSkillBySelector, loadSkillCatalog } from '../../config/skills.js';
 import { RiskLevel } from '../../permissions/types.js';
@@ -45,6 +47,15 @@ export class SkillLoadTool implements Tool {
     }
 
     const skill = loaded.skill;
+
+    // Feature flag gate: reject loading if the skill's feature flag is OFF
+    const config = getConfig();
+    if (!isSkillFeatureEnabled(skill.id, config)) {
+      return {
+        content: `Error: skill "${skill.id}" is currently unavailable (disabled by feature flag)`,
+        isError: true,
+      };
+    }
 
     // Load catalog for include validation and child metadata output
     let catalogIndex: Map<string, SkillSummary> | undefined;


### PR DESCRIPTION
Add featureFlags config section to assistant and enforce feature flags at all skill exposure code paths. When a skill flag is OFF, the skill is hidden from UI lists, model prompts, skill_load, and active tool projection. Part of #10145.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
