### PR TITLE
fix: add missing test helper overload for channel binding tests

### DIFF
--- a/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
@@ -94,6 +94,11 @@ private func makeSessionListResponse(sessions: [(id: String, title: String, crea
     return try! JSONDecoder().decode(SessionListResponseMessage.self, from: data)
 }
 
+/// Convenience overload with threadType and optional channelBinding.
+private func makeSessionListResponse(sessions: [(id: String, title: String, updatedAt: Int, threadType: String?, channelBinding: [String: Any]?)]) -> SessionListResponseMessage {
+    makeSessionListResponse(sessions: sessions.map { ($0.id, $0.title, $0.updatedAt, $0.updatedAt, $0.threadType, $0.channelBinding) })
+}
+
 /// Convenience overload with threadType but no channelBinding.
 private func makeSessionListResponse(sessions: [(id: String, title: String, updatedAt: Int, threadType: String?)]) -> SessionListResponseMessage {
     makeSessionListResponse(sessions: sessions.map { ($0.id, $0.title, $0.updatedAt, $0.updatedAt, $0.threadType, nil) })


### PR DESCRIPTION
## Summary
- Added a missing `makeSessionListResponse` convenience overload accepting `(id, title, updatedAt, threadType, channelBinding)` tuples
- The channel binding filter tests used this 5-parameter tuple shape, but only 3, 4, and 6-parameter overloads existed, causing Swift compiler errors (`'nil' requires a contextual type`)

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22466926244

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
