### PR TITLE
fix: strip codesign-breaking dirs recursively from bundled node_modules

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -186,7 +186,6 @@ build_binaries() {
     # Strip non-runtime files (source, types, sourcemaps, web/browser bundles, WASM, model cache)
     rm -rf "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/src"
     rm -rf "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/types"
-    rm -rf "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/.cache"
     rm -f  "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/README.md"
     rm -f  "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/dist/"*.map
     rm -f  "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/dist/"*.min.*
@@ -201,8 +200,11 @@ build_binaries() {
     for img_pkg in "$ASSISTANT_SRC_DIR/node_modules/@img/"*; do
         [ -d "$img_pkg" ] && cp -R "$img_pkg" "$SCRIPT_DIR/daemon-bin/node_modules/@img/"
     done
-    # Strip build-time include dirs that codesign misinterprets as bundles
-    find "$SCRIPT_DIR/daemon-bin/node_modules/@img" -type d -name "glib-2.0" -exec rm -rf {} + 2>/dev/null || true
+    # Strip dirs that codesign misinterprets as bundles (recursive across
+    # all staged node_modules to catch nested copies like sharp/sharp/ and
+    # transformers/transformers/.cache)
+    find "$SCRIPT_DIR/daemon-bin/node_modules" -type d -name "glib-2.0" -exec rm -rf {} + 2>/dev/null || true
+    find "$SCRIPT_DIR/daemon-bin/node_modules" -type d -name ".cache" -exec rm -rf {} + 2>/dev/null || true
     # Stage sharp's JS dependencies
     for dep in detect-libc semver; do
         if [ -d "$ASSISTANT_SRC_DIR/node_modules/$dep" ]; then
@@ -371,7 +373,6 @@ if [ "$DAEMON_BIN_NEEDS_BUILD" = true ]; then
     cp -R "$ASSISTANT_SRC_DIR/node_modules/@huggingface/transformers" "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers"
     rm -rf "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/src"
     rm -rf "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/types"
-    rm -rf "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/.cache"
     rm -f  "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/README.md"
     rm -f  "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/dist/"*.map
     rm -f  "$SCRIPT_DIR/daemon-bin/node_modules/@huggingface/transformers/dist/"*.min.*
@@ -385,8 +386,10 @@ if [ "$DAEMON_BIN_NEEDS_BUILD" = true ]; then
     for img_pkg in "$ASSISTANT_SRC_DIR/node_modules/@img/"*; do
         [ -d "$img_pkg" ] && cp -R "$img_pkg" "$SCRIPT_DIR/daemon-bin/node_modules/@img/"
     done
-    # Strip build-time include dirs that codesign misinterprets as bundles
-    find "$SCRIPT_DIR/daemon-bin/node_modules/@img" -type d -name "glib-2.0" -exec rm -rf {} + 2>/dev/null || true
+    # Strip dirs that codesign misinterprets as bundles (recursive across
+    # all staged node_modules to catch nested copies)
+    find "$SCRIPT_DIR/daemon-bin/node_modules" -type d -name "glib-2.0" -exec rm -rf {} + 2>/dev/null || true
+    find "$SCRIPT_DIR/daemon-bin/node_modules" -type d -name ".cache" -exec rm -rf {} + 2>/dev/null || true
     for dep in detect-libc semver; do
         if [ -d "$ASSISTANT_SRC_DIR/node_modules/$dep" ]; then
             cp -R "$ASSISTANT_SRC_DIR/node_modules/$dep" "$SCRIPT_DIR/daemon-bin/node_modules/$dep"


### PR DESCRIPTION
## Summary
- Replace targeted `find` strips on `@img` and `sharp` with a single recursive `find` across all of `daemon-bin/node_modules` for both `glib-2.0` and `.cache` dirs
- Fixes codesign failure from `sharp/sharp/node_modules/@img/*/lib/glib-2.0` and `transformers/transformers/.cache` that were missed by previous per-directory strips
- Applied to both debug and release build paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
