### PR TITLE
Fix inconsistent fallback name in TaskInputView

### DIFF
--- a/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
+++ b/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
@@ -12,7 +12,7 @@ struct TaskInputView: View {
     @State private var hasAPIKey = APIKeyManager.hasAnyKey()
     @State private var attachments: [TaskAttachment] = []
     @State private var attachmentError: String?
-    @State private var assistantName: String = IdentityInfo.load()?.name ?? "Vellum"
+    @State private var assistantName: String = IdentityInfo.load()?.name ?? "Assistant"
     @State private var isDropTargeted = false
     @FocusState private var isTextFieldFocused: Bool
     // Use NSApp action instead of @Environment(\.openSettings) for Xcode 16.2 compatibility


### PR DESCRIPTION
## Summary
- Changed TaskInputView's fallback from "Vellum" to "Assistant" for consistency with MainWindowView

Addresses review feedback on #10111.
Part of #10103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
