### PR TITLE
fix: handle wrapped destructive commands and fix rm rule priorities

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -354,6 +354,30 @@ describe('Permission Checker', () => {
       test('env injection is high risk', async () => {
         expect(await classifyRisk('bash', { command: 'LD_PRELOAD=evil.so cmd' })).toBe(RiskLevel.High);
       });
+
+      test('wrapped rm via env is high risk', async () => {
+        expect(await classifyRisk('bash', { command: 'env rm -rf /tmp/x' })).toBe(RiskLevel.High);
+      });
+
+      test('wrapped rm via time is high risk', async () => {
+        expect(await classifyRisk('bash', { command: 'time rm file.txt' })).toBe(RiskLevel.High);
+      });
+
+      test('wrapped kill via env is high risk', async () => {
+        expect(await classifyRisk('bash', { command: 'env kill -9 1234' })).toBe(RiskLevel.High);
+      });
+
+      test('wrapped sudo via env is high risk', async () => {
+        expect(await classifyRisk('bash', { command: 'env sudo apt-get install foo' })).toBe(RiskLevel.High);
+      });
+
+      test('wrapped reboot via nice is high risk', async () => {
+        expect(await classifyRisk('bash', { command: 'nice reboot' })).toBe(RiskLevel.High);
+      });
+
+      test('wrapped pkill via nohup is high risk', async () => {
+        expect(await classifyRisk('bash', { command: 'nohup pkill node' })).toBe(RiskLevel.High);
+      });
     });
 
     // unknown tool

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -838,6 +838,7 @@ describe('Trust Store', () => {
       expect(match).not.toBeNull();
       expect(match!.id).toBe('default:allow-bash-rm-bootstrap');
       expect(match!.decision).toBe('allow');
+      expect(match!.allowHighRisk).toBe(true);
       // Outside workspace, the bootstrap rule doesn't match — the global
       // default:allow-bash-global rule matches instead (not the bootstrap rule).
       const other = findHighestPriorityRule('bash', ['rm BOOTSTRAP.md'], '/tmp/other-project');
@@ -852,6 +853,7 @@ describe('Trust Store', () => {
       expect(match).not.toBeNull();
       expect(match!.id).toBe('default:allow-bash-rm-updates');
       expect(match!.decision).toBe('allow');
+      expect(match!.allowHighRisk).toBe(true);
       // Outside workspace, should NOT match the updates rule
       const other = findHighestPriorityRule('bash', ['rm UPDATES.md'], '/tmp/other-project');
       expect(other).not.toBeNull();

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -403,6 +403,8 @@ async function classifyRiskUncached(toolName: string, input: Record<string, unkn
 
       if (WRAPPER_PROGRAMS.has(prog)) {
         const wrapped = getWrappedProgram(seg);
+        if (wrapped === 'rm') return RiskLevel.High;
+        if (wrapped && HIGH_RISK_PROGRAMS.has(wrapped)) return RiskLevel.High;
         if (wrapped === 'curl' || wrapped === 'wget') {
           maxRisk = RiskLevel.Medium;
           continue;

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -132,6 +132,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     scope: workspaceDir,
     decision: 'allow',
     priority: 100,
+    allowHighRisk: true,
   };
 
   const updatesDeleteRule: DefaultRuleTemplate = {
@@ -141,6 +142,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     scope: workspaceDir,
     decision: 'allow',
     priority: 100,
+    allowHighRisk: true,
   };
 
   // Skill source directories — writing or editing skill source files should


### PR DESCRIPTION
Address reviewer feedback from PR #10057:\n\n- Extend destructive command detection to handle wrapper programs (env, sudo, time, etc.) so that commands like `env rm -rf /tmp/x`, `time kill -9 1234`, or `nohup pkill node` are correctly classified as High risk\n- Add `allowHighRisk: true` to bootstrap/updates rm default rules so they can auto-approve `rm BOOTSTRAP.md` and `rm UPDATES.md` which are now always High risk\n- Add tests for wrapped destructive commands in checker.test.ts\n- Add allowHighRisk assertions to trust-store.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
