### PR TITLE
fix: harden remote skill policy security gates

### DIFF
--- a/assistant/src/__tests__/remote-skill-policy.test.ts
+++ b/assistant/src/__tests__/remote-skill-policy.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  evaluateRemoteSkillInstall,
+  filterInstallableRemoteSkills,
+  type RemoteSkillPolicy,
+} from '../skills/remote-skill-policy.js';
+
+describe('remote skill policy — clawhub', () => {
+  const policy: RemoteSkillPolicy = {
+    blockSuspicious: true,
+    blockMalware: true,
+    maxSkillsShRisk: 'medium',
+  };
+
+  test('suspicious skills are excluded from installable list', () => {
+    const candidates = [
+      {
+        provider: 'clawhub' as const,
+        slug: 'safe-skill',
+        moderation: { isSuspicious: false, isMalwareBlocked: false },
+      },
+      {
+        provider: 'clawhub' as const,
+        slug: 'suspicious-skill',
+        moderation: { isSuspicious: true, isMalwareBlocked: false },
+      },
+    ];
+
+    const installable = filterInstallableRemoteSkills(candidates, policy);
+    expect(installable.map((skill) => skill.slug)).toEqual(['safe-skill']);
+  });
+
+  test('suspicious skills are not installable when installation is attempted', () => {
+    const decision = evaluateRemoteSkillInstall(
+      {
+        provider: 'clawhub',
+        slug: 'suspicious-skill',
+        moderation: { isSuspicious: true, isMalwareBlocked: false },
+      },
+      policy,
+    );
+
+    expect(decision).toEqual({ ok: false, reason: 'clawhub_suspicious' });
+  });
+
+  test('malware-blocked skills are excluded from installable list and blocked on install', () => {
+    const candidates = [
+      {
+        provider: 'clawhub' as const,
+        slug: 'malware-skill',
+        moderation: { isSuspicious: false, isMalwareBlocked: true },
+      },
+    ];
+
+    expect(filterInstallableRemoteSkills(candidates, policy)).toEqual([]);
+
+    const decision = evaluateRemoteSkillInstall(candidates[0], policy);
+    expect(decision).toEqual({ ok: false, reason: 'clawhub_malware_blocked' });
+  });
+
+  test('clawhub skill with undefined moderation is blocked (fail-closed)', () => {
+    const decision = evaluateRemoteSkillInstall(
+      {
+        provider: 'clawhub',
+        slug: 'no-moderation-skill',
+        moderation: undefined,
+      },
+      policy,
+    );
+
+    expect(decision).toEqual({ ok: false, reason: 'clawhub_moderation_missing' });
+  });
+
+  test('clawhub skill with null moderation is blocked (fail-closed)', () => {
+    const decision = evaluateRemoteSkillInstall(
+      {
+        provider: 'clawhub',
+        slug: 'null-moderation-skill',
+        moderation: null,
+      },
+      policy,
+    );
+
+    expect(decision).toEqual({ ok: false, reason: 'clawhub_moderation_missing' });
+  });
+
+  test('clawhub skill without moderation property is blocked (fail-closed)', () => {
+    const decision = evaluateRemoteSkillInstall(
+      {
+        provider: 'clawhub',
+        slug: 'missing-moderation-skill',
+      },
+      policy,
+    );
+
+    expect(decision).toEqual({ ok: false, reason: 'clawhub_moderation_missing' });
+  });
+
+  test('clawhub skills with missing moderation are excluded from installable list', () => {
+    const candidates = [
+      {
+        provider: 'clawhub' as const,
+        slug: 'safe-skill',
+        moderation: { isSuspicious: false, isMalwareBlocked: false },
+      },
+      {
+        provider: 'clawhub' as const,
+        slug: 'no-moderation-skill',
+      },
+    ];
+
+    const installable = filterInstallableRemoteSkills(candidates, policy);
+    expect(installable.map((skill) => skill.slug)).toEqual(['safe-skill']);
+  });
+});
+
+describe('remote skill policy — skills.sh', () => {
+  const policy: RemoteSkillPolicy = {
+    blockSuspicious: true,
+    blockMalware: true,
+    maxSkillsShRisk: 'medium',
+  };
+
+  test('high-risk skills are excluded from installable list', () => {
+    const candidates = [
+      {
+        provider: 'skillssh' as const,
+        slug: 'safe-skill',
+        audit: { risk: 'low' as const },
+      },
+      {
+        provider: 'skillssh' as const,
+        slug: 'suspicious-skill',
+        audit: { risk: 'high' as const },
+      },
+    ];
+
+    const installable = filterInstallableRemoteSkills(candidates, policy);
+    expect(installable.map((skill) => skill.slug)).toEqual(['safe-skill']);
+  });
+
+  test('high-risk skills are not installable when installation is attempted', () => {
+    const decision = evaluateRemoteSkillInstall(
+      {
+        provider: 'skillssh',
+        slug: 'suspicious-skill',
+        audit: { risk: 'high' },
+      },
+      policy,
+    );
+
+    expect(decision).toEqual({ ok: false, reason: 'skillssh_risk_exceeds_threshold' });
+  });
+
+  test('unknown risk is treated as suspicious and blocked by default', () => {
+    const decision = evaluateRemoteSkillInstall(
+      {
+        provider: 'skillssh',
+        slug: 'unknown-risk-skill',
+        audit: { risk: 'unknown' },
+      },
+      policy,
+    );
+
+    expect(decision).toEqual({ ok: false, reason: 'skillssh_risk_exceeds_threshold' });
+  });
+
+  test('risk threshold is enforced even when blockSuspicious is false', () => {
+    const permissivePolicy: RemoteSkillPolicy = {
+      blockSuspicious: false,
+      blockMalware: false,
+      maxSkillsShRisk: 'medium',
+    };
+
+    const decision = evaluateRemoteSkillInstall(
+      {
+        provider: 'skillssh',
+        slug: 'high-risk-skill',
+        audit: { risk: 'high' },
+      },
+      permissivePolicy,
+    );
+
+    expect(decision).toEqual({ ok: false, reason: 'skillssh_risk_exceeds_threshold' });
+  });
+
+  test('prototype property risk label is treated as unknown and blocked', () => {
+    const decision = evaluateRemoteSkillInstall(
+      {
+        provider: 'skillssh',
+        slug: 'proto-risk-skill',
+        // "toString" exists on Object.prototype — must not be treated as a known risk label
+        audit: { risk: 'toString' as never },
+      },
+      policy,
+    );
+
+    expect(decision).toEqual({ ok: false, reason: 'skillssh_risk_exceeds_threshold' });
+  });
+
+  test('unrecognized risk string is coerced to unknown and blocked', () => {
+    const decision = evaluateRemoteSkillInstall(
+      {
+        provider: 'skillssh',
+        slug: 'bogus-risk-skill',
+        // Cast to bypass type checking — simulates a provider returning a novel risk label
+        audit: { risk: 'super-duper-risky' as never },
+      },
+      policy,
+    );
+
+    expect(decision).toEqual({ ok: false, reason: 'skillssh_risk_exceeds_threshold' });
+  });
+});

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -117,12 +117,18 @@ export {
   SandboxConfigSchema,
 } from './sandbox-schema.js';
 export type {
+  RemotePolicyConfig,
+  RemoteProviderConfig,
+  RemoteProvidersConfig,
   SkillEntryConfig,
   SkillsConfig,
   SkillsInstallConfig,
   SkillsLoadConfig,
 } from './skills-schema.js';
 export {
+  RemotePolicyConfigSchema,
+  RemoteProviderConfigSchema,
+  RemoteProvidersConfigSchema,
   SkillEntryConfigSchema,
   SkillsConfigSchema,
   SkillsInstallConfigSchema,

--- a/assistant/src/config/skills-schema.ts
+++ b/assistant/src/config/skills-schema.ts
@@ -19,14 +19,41 @@ export const SkillsInstallConfigSchema = z.object({
   }).default('npm'),
 });
 
+export const RemoteProviderConfigSchema = z.object({
+  enabled: z.boolean({ error: 'skills.remoteProviders.<provider>.enabled must be a boolean' }).default(true),
+});
+
+export const RemoteProvidersConfigSchema = z.object({
+  skillssh: RemoteProviderConfigSchema.default({} as any),
+  clawhub: RemoteProviderConfigSchema.default({} as any),
+});
+
+const VALID_SKILLS_SH_RISK_LEVELS = ['safe', 'low', 'medium', 'high', 'critical', 'unknown'] as const;
+// 'unknown' is valid as a risk label on a skill but not as a threshold — setting the threshold
+// to 'unknown' would silently disable fail-closed behavior since nothing can exceed it.
+const VALID_MAX_RISK_LEVELS = ['safe', 'low', 'medium', 'high', 'critical'] as const;
+
+export const RemotePolicyConfigSchema = z.object({
+  blockSuspicious: z.boolean({ error: 'skills.remotePolicy.blockSuspicious must be a boolean' }).default(true),
+  blockMalware: z.boolean({ error: 'skills.remotePolicy.blockMalware must be a boolean' }).default(true),
+  maxSkillsShRisk: z.enum(VALID_MAX_RISK_LEVELS, {
+    error: `skills.remotePolicy.maxSkillsShRisk must be one of: ${VALID_MAX_RISK_LEVELS.join(', ')}`,
+  }).default('medium'),
+});
+
 export const SkillsConfigSchema = z.object({
   entries: z.record(z.string(), SkillEntryConfigSchema).default({} as any),
   load: SkillsLoadConfigSchema.default({} as any),
   install: SkillsInstallConfigSchema.default({} as any),
   allowBundled: z.array(z.string()).nullable().default(null),
+  remoteProviders: RemoteProvidersConfigSchema.default({} as any),
+  remotePolicy: RemotePolicyConfigSchema.default({} as any),
 });
 
 export type SkillEntryConfig = z.infer<typeof SkillEntryConfigSchema>;
 export type SkillsLoadConfig = z.infer<typeof SkillsLoadConfigSchema>;
 export type SkillsInstallConfig = z.infer<typeof SkillsInstallConfigSchema>;
+export type RemoteProviderConfig = z.infer<typeof RemoteProviderConfigSchema>;
+export type RemoteProvidersConfig = z.infer<typeof RemoteProvidersConfigSchema>;
+export type RemotePolicyConfig = z.infer<typeof RemotePolicyConfigSchema>;
 export type SkillsConfig = z.infer<typeof SkillsConfigSchema>;

--- a/assistant/src/skills/remote-skill-policy.ts
+++ b/assistant/src/skills/remote-skill-policy.ts
@@ -1,0 +1,131 @@
+export type RemoteSkillProvider = 'clawhub' | 'skillssh';
+
+export type SkillsShRisk = 'safe' | 'low' | 'medium' | 'high' | 'critical' | 'unknown';
+export type SkillsShRiskThreshold = Exclude<SkillsShRisk, 'unknown'>;
+
+export interface RemoteSkillPolicy {
+  /**
+   * When true, suspicious skills are excluded from installable lists
+   * and blocked from installation.
+   */
+  blockSuspicious: boolean;
+  /**
+   * When true, malware-blocked skills are excluded from installable lists
+   * and blocked from installation.
+   */
+  blockMalware: boolean;
+  /**
+   * Maximum allowed Skills.sh audit risk. Anything above this threshold is blocked.
+   */
+  maxSkillsShRisk: SkillsShRiskThreshold;
+}
+
+export interface ClawhubModerationState {
+  isSuspicious?: boolean;
+  isMalwareBlocked?: boolean;
+}
+
+export interface SkillsShAuditState {
+  risk?: SkillsShRisk | null;
+}
+
+interface RemoteSkillCandidateBase {
+  provider: RemoteSkillProvider;
+  slug: string;
+}
+
+export interface ClawhubRemoteSkillCandidate extends RemoteSkillCandidateBase {
+  provider: 'clawhub';
+  moderation?: ClawhubModerationState | null;
+}
+
+export interface SkillsShRemoteSkillCandidate extends RemoteSkillCandidateBase {
+  provider: 'skillssh';
+  audit?: SkillsShAuditState | null;
+}
+
+export type RemoteSkillCandidate =
+  | ClawhubRemoteSkillCandidate
+  | SkillsShRemoteSkillCandidate;
+
+export type RemoteSkillDenyReason =
+  | 'clawhub_suspicious'
+  | 'clawhub_malware_blocked'
+  | 'clawhub_moderation_missing'
+  | 'skillssh_risk_exceeds_threshold';
+
+export type RemoteSkillInstallDecision =
+  | { ok: true }
+  | { ok: false; reason: RemoteSkillDenyReason };
+
+export const DEFAULT_REMOTE_SKILL_POLICY: Readonly<RemoteSkillPolicy> = Object.freeze({
+  blockSuspicious: true,
+  blockMalware: true,
+  maxSkillsShRisk: 'medium',
+});
+
+const SKILLS_SH_RISK_RANK: Record<SkillsShRisk, number> = {
+  safe: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+  // Fail closed when risk is unknown.
+  unknown: 5,
+};
+
+function normalizeSkillsShRisk(audit: SkillsShAuditState | null | undefined): SkillsShRisk {
+  const risk = audit?.risk;
+  if (risk == null) return 'unknown';
+  // Coerce unrecognized risk labels to 'unknown' so we fail closed.
+  if (!Object.hasOwn(SKILLS_SH_RISK_RANK, risk)) return 'unknown';
+  return risk;
+}
+
+function exceedsSkillsShRiskThreshold(
+  audit: SkillsShAuditState | null | undefined,
+  threshold: SkillsShRiskThreshold,
+): boolean {
+  const actualRisk = normalizeSkillsShRisk(audit);
+  return SKILLS_SH_RISK_RANK[actualRisk] > SKILLS_SH_RISK_RANK[threshold];
+}
+
+export function evaluateRemoteSkillInstall(
+  candidate: RemoteSkillCandidate,
+  policy: RemoteSkillPolicy = DEFAULT_REMOTE_SKILL_POLICY,
+): RemoteSkillInstallDecision {
+  if (candidate.provider === 'clawhub') {
+    // Fail closed: block Clawhub skills when moderation data is missing.
+    if (candidate.moderation == null) {
+      return { ok: false, reason: 'clawhub_moderation_missing' };
+    }
+
+    if (policy.blockMalware && candidate.moderation.isMalwareBlocked === true) {
+      return { ok: false, reason: 'clawhub_malware_blocked' };
+    }
+    if (policy.blockSuspicious && candidate.moderation.isSuspicious === true) {
+      return { ok: false, reason: 'clawhub_suspicious' };
+    }
+    return { ok: true };
+  }
+
+  if (exceedsSkillsShRiskThreshold(candidate.audit, policy.maxSkillsShRisk)) {
+    return { ok: false, reason: 'skillssh_risk_exceeds_threshold' };
+  }
+
+  return { ok: true };
+}
+
+export function isRemoteSkillInstallable(
+  candidate: RemoteSkillCandidate,
+  policy: RemoteSkillPolicy = DEFAULT_REMOTE_SKILL_POLICY,
+): boolean {
+  return evaluateRemoteSkillInstall(candidate, policy).ok;
+}
+
+export function filterInstallableRemoteSkills<T extends RemoteSkillCandidate>(
+  skills: T[],
+  policy: RemoteSkillPolicy = DEFAULT_REMOTE_SKILL_POLICY,
+): T[] {
+  return skills.filter((skill) => isRemoteSkillInstallable(skill, policy));
+}


### PR DESCRIPTION
Address reviewer feedback from PR #9789:

- Use Object.hasOwn for risk label validation instead of 'in' operator
- Coerce unrecognized risk labels to 'unknown'
- Decouple skills.sh risk check from blockSuspicious flag
- Remove 'unknown' from valid maxSkillsShRisk threshold values
- Add fail-closed behavior for Clawhub skills with missing moderation data
- Update tests for new security behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
