### PR TITLE
fix: harden skillssh install with validation, wiring, and hash ordering

### DIFF
--- a/assistant/src/__tests__/skillssh-install.test.ts
+++ b/assistant/src/__tests__/skillssh-install.test.ts
@@ -18,8 +18,8 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
-import { skillsshInstall } from '../skills/skillssh-install.js';
-import type { SkillsShInstallOptions, SkillsShProvenance } from '../skills/skillssh-install.js';
+import { namespacedSkillDir, skillsshInstall } from '../skills/skillssh-install.js';
+import type { SkillsShProvenance } from '../skills/skillssh-install.js';
 import type { SecurityDecision } from '../skills/security-decision.js';
 import type { SkillsShSearchWithAuditItem } from '../skills/skillssh.js';
 import { readSkillProvenance } from '../skills/managed-store.js';
@@ -79,11 +79,33 @@ function makeDoNotRecommendDecision(): SecurityDecision {
 /**
  * Simulate a successful `npx skills add` by creating the expected
  * skill directory and SKILL.md file in the managed skills dir.
+ * The CLI installs into skills/<skillId>/ (not namespaced).
  */
 function simulateSuccessfulInstall(skillId: string): void {
   const skillDir = join(TEST_DIR, 'skills', skillId);
   mkdirSync(skillDir, { recursive: true });
   writeFileSync(join(skillDir, 'SKILL.md'), `---\nname: "${skillId}"\ndescription: "A test skill"\n---\n\n# ${skillId}\n`, 'utf-8');
+}
+
+function mockSuccessfulSpawn(): ReturnType<typeof spyOn> {
+  const originalSpawn = Bun.spawn;
+  return spyOn(Bun, 'spawn').mockImplementation((..._args: unknown[]) => {
+    simulateSuccessfulInstall('my-skill');
+    return {
+      stdout: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('OK'));
+          controller.close();
+        },
+      }),
+      stderr: new ReadableStream({
+        start(controller) { controller.close(); },
+      }),
+      exited: Promise.resolve(0),
+      pid: 12345,
+      kill: () => {},
+    } as unknown as ReturnType<typeof originalSpawn>;
+  });
 }
 
 // ─── Setup / Teardown ────────────────────────────────────────────────────────────
@@ -99,6 +121,22 @@ afterEach(() => {
   mock.restore();
 });
 
+// ─── namespacedSkillDir unit tests ───────────────────────────────────────────────
+
+describe('namespacedSkillDir', () => {
+  test('replaces slashes with double hyphens', () => {
+    expect(namespacedSkillDir('org/repo', 'my-skill')).toBe('org--repo--my-skill');
+  });
+
+  test('handles source without slashes', () => {
+    expect(namespacedSkillDir('single', 'skill')).toBe('single--skill');
+  });
+
+  test('handles deeply nested source paths', () => {
+    expect(namespacedSkillDir('a/b/c', 'x')).toBe('a--b--c--x');
+  });
+});
+
 // ─── Security gate tests ─────────────────────────────────────────────────────────
 
 describe('skillsshInstall security gate', () => {
@@ -111,6 +149,7 @@ describe('skillsshInstall security gate', () => {
 
     expect(result.success).toBe(false);
     expect(result.skillId).toBe('my-skill');
+    expect(result.namespacedId).toBe('test-org--test-repo--my-skill');
     expect(result.installedVia).toBe('policy');
     expect(result.error).toContain('Installation blocked');
     expect(result.error).toContain('do_not_recommend');
@@ -128,28 +167,7 @@ describe('skillsshInstall security gate', () => {
   });
 
   test('allows install when decision is do_not_recommend but override is true', async () => {
-    // Mock Bun.spawn to simulate a successful subprocess
-    const originalSpawn = Bun.spawn;
-    const mockSpawn = spyOn(Bun, 'spawn').mockImplementation((..._args: unknown[]) => {
-      const candidate = makeCandidate({ overallRisk: 'high' });
-      simulateSuccessfulInstall(candidate.skillId);
-
-      return {
-        stdout: new ReadableStream({
-          start(controller) {
-            controller.enqueue(new TextEncoder().encode('Skill installed successfully'));
-            controller.close();
-          },
-        }),
-        stderr: new ReadableStream({
-          start(controller) { controller.close(); },
-        }),
-        exited: Promise.resolve(0),
-        pid: 12345,
-        kill: () => {},
-      } as unknown as ReturnType<typeof originalSpawn>;
-    });
-
+    const mockSpawn = mockSuccessfulSpawn();
     try {
       const result = await skillsshInstall({
         candidate: makeCandidate({ overallRisk: 'high' }),
@@ -160,6 +178,7 @@ describe('skillsshInstall security gate', () => {
       expect(result.success).toBe(true);
       expect(result.installedVia).toBe('override');
       expect(result.skillId).toBe('my-skill');
+      expect(result.namespacedId).toBe('test-org--test-repo--my-skill');
       expect(result.installedPath).toBeDefined();
     } finally {
       mockSpawn.mockRestore();
@@ -167,26 +186,7 @@ describe('skillsshInstall security gate', () => {
   });
 
   test('allows install when decision is proceed', async () => {
-    const originalSpawn = Bun.spawn;
-    const mockSpawn = spyOn(Bun, 'spawn').mockImplementation((..._args: unknown[]) => {
-      simulateSuccessfulInstall('my-skill');
-
-      return {
-        stdout: new ReadableStream({
-          start(controller) {
-            controller.enqueue(new TextEncoder().encode('Skill installed successfully'));
-            controller.close();
-          },
-        }),
-        stderr: new ReadableStream({
-          start(controller) { controller.close(); },
-        }),
-        exited: Promise.resolve(0),
-        pid: 12345,
-        kill: () => {},
-      } as unknown as ReturnType<typeof originalSpawn>;
-    });
-
+    const mockSpawn = mockSuccessfulSpawn();
     try {
       const result = await skillsshInstall({
         candidate: makeCandidate(),
@@ -196,32 +196,14 @@ describe('skillsshInstall security gate', () => {
       expect(result.success).toBe(true);
       expect(result.installedVia).toBe('policy');
       expect(result.skillId).toBe('my-skill');
+      expect(result.namespacedId).toBe('test-org--test-repo--my-skill');
     } finally {
       mockSpawn.mockRestore();
     }
   });
 
   test('allows install when decision is proceed_with_caution', async () => {
-    const originalSpawn = Bun.spawn;
-    const mockSpawn = spyOn(Bun, 'spawn').mockImplementation((..._args: unknown[]) => {
-      simulateSuccessfulInstall('my-skill');
-
-      return {
-        stdout: new ReadableStream({
-          start(controller) {
-            controller.enqueue(new TextEncoder().encode('Skill installed successfully'));
-            controller.close();
-          },
-        }),
-        stderr: new ReadableStream({
-          start(controller) { controller.close(); },
-        }),
-        exited: Promise.resolve(0),
-        pid: 12345,
-        kill: () => {},
-      } as unknown as ReturnType<typeof originalSpawn>;
-    });
-
+    const mockSpawn = mockSuccessfulSpawn();
     try {
       const result = await skillsshInstall({
         candidate: makeCandidate({ overallRisk: 'medium' }),
@@ -236,30 +218,132 @@ describe('skillsshInstall security gate', () => {
   });
 });
 
+// ─── Validation tests ────────────────────────────────────────────────────────────
+
+describe('skillsshInstall validation', () => {
+  test('rejects empty skill ID', async () => {
+    const result = await skillsshInstall({
+      candidate: makeCandidate({ skillId: '' }),
+      securityDecision: makeProceedDecision(),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid skill ID');
+  });
+
+  test('rejects skill ID with path traversal', async () => {
+    const result = await skillsshInstall({
+      candidate: makeCandidate({ skillId: '../escape' }),
+      securityDecision: makeProceedDecision(),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid skill ID');
+  });
+
+  test('rejects empty source', async () => {
+    const result = await skillsshInstall({
+      candidate: makeCandidate({ source: '' }),
+      securityDecision: makeProceedDecision(),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid source');
+  });
+
+  test('rejects source with path traversal', async () => {
+    const result = await skillsshInstall({
+      candidate: makeCandidate({ source: '../../../etc' }),
+      securityDecision: makeProceedDecision(),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid source');
+  });
+
+  test('rejects source with backslashes', async () => {
+    const result = await skillsshInstall({
+      candidate: makeCandidate({ source: 'org\\repo' }),
+      securityDecision: makeProceedDecision(),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid source');
+  });
+});
+
+// ─── Namespacing tests ───────────────────────────────────────────────────────────
+
+describe('skillsshInstall namespacing', () => {
+  test('installs into source-namespaced directory', async () => {
+    const mockSpawn = mockSuccessfulSpawn();
+    try {
+      const result = await skillsshInstall({
+        candidate: makeCandidate(),
+        securityDecision: makeProceedDecision(),
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.namespacedId).toBe('test-org--test-repo--my-skill');
+
+      // The namespaced directory should exist, the raw one should have been moved
+      const namespacedDir = join(TEST_DIR, 'skills', 'test-org--test-repo--my-skill');
+      expect(existsSync(join(namespacedDir, 'SKILL.md'))).toBe(true);
+      expect(result.installedPath).toBe(namespacedDir);
+    } finally {
+      mockSpawn.mockRestore();
+    }
+  });
+
+  test('different sources with same skillId get different directories', () => {
+    const nsA = namespacedSkillDir('orgA/repoA', 'shared-skill');
+    const nsB = namespacedSkillDir('orgB/repoB', 'shared-skill');
+    expect(nsA).toBe('orgA--repoA--shared-skill');
+    expect(nsB).toBe('orgB--repoB--shared-skill');
+    expect(nsA).not.toBe(nsB);
+  });
+});
+
+// ─── SKILLS.md index tests ───────────────────────────────────────────────────────
+
+describe('skillsshInstall SKILLS.md index', () => {
+  test('adds entry to SKILLS.md index on successful install', async () => {
+    const mockSpawn = mockSuccessfulSpawn();
+    try {
+      const result = await skillsshInstall({
+        candidate: makeCandidate(),
+        securityDecision: makeProceedDecision(),
+      });
+
+      expect(result.success).toBe(true);
+
+      const indexPath = join(TEST_DIR, 'skills', 'SKILLS.md');
+      expect(existsSync(indexPath)).toBe(true);
+      const indexContent = readFileSync(indexPath, 'utf-8');
+      expect(indexContent).toContain('test-org--test-repo--my-skill');
+    } finally {
+      mockSpawn.mockRestore();
+    }
+  });
+
+  test('does not add entry to SKILLS.md on failed install', async () => {
+    const result = await skillsshInstall({
+      candidate: makeCandidate(),
+      securityDecision: makeDoNotRecommendDecision(),
+      userOverride: false,
+    });
+
+    expect(result.success).toBe(false);
+    const indexPath = join(TEST_DIR, 'skills', 'SKILLS.md');
+    expect(existsSync(indexPath)).toBe(false);
+  });
+});
+
 // ─── Provenance metadata tests ───────────────────────────────────────────────────
 
 describe('skillsshInstall provenance', () => {
   test('stores provenance metadata on successful install', async () => {
-    const originalSpawn = Bun.spawn;
-    const mockSpawn = spyOn(Bun, 'spawn').mockImplementation((..._args: unknown[]) => {
-      simulateSuccessfulInstall('my-skill');
-
-      return {
-        stdout: new ReadableStream({
-          start(controller) {
-            controller.enqueue(new TextEncoder().encode('OK'));
-            controller.close();
-          },
-        }),
-        stderr: new ReadableStream({
-          start(controller) { controller.close(); },
-        }),
-        exited: Promise.resolve(0),
-        pid: 12345,
-        kill: () => {},
-      } as unknown as ReturnType<typeof originalSpawn>;
-    });
-
+    const mockSpawn = mockSuccessfulSpawn();
     try {
       const candidate = makeCandidate();
       const result = await skillsshInstall({
@@ -282,8 +366,8 @@ describe('skillsshInstall provenance', () => {
       });
       expect(result.provenance!.auditSnapshot.capturedAt).toBeDefined();
 
-      // Verify the file was actually written
-      const provenancePath = join(TEST_DIR, 'skills', 'my-skill', '.provenance.json');
+      // Verify the file is in the namespaced directory
+      const provenancePath = join(TEST_DIR, 'skills', 'test-org--test-repo--my-skill', '.provenance.json');
       expect(existsSync(provenancePath)).toBe(true);
 
       const storedProvenance = JSON.parse(readFileSync(provenancePath, 'utf-8'));
@@ -294,29 +378,30 @@ describe('skillsshInstall provenance', () => {
     }
   });
 
-  test('provenance includes only dimensions present in the audit', async () => {
-    const originalSpawn = Bun.spawn;
-    const mockSpawn = spyOn(Bun, 'spawn').mockImplementation((..._args: unknown[]) => {
-      simulateSuccessfulInstall('my-skill');
-
-      return {
-        stdout: new ReadableStream({
-          start(controller) {
-            controller.enqueue(new TextEncoder().encode('OK'));
-            controller.close();
-          },
-        }),
-        stderr: new ReadableStream({
-          start(controller) { controller.close(); },
-        }),
-        exited: Promise.resolve(0),
-        pid: 12345,
-        kill: () => {},
-      } as unknown as ReturnType<typeof originalSpawn>;
-    });
-
+  test('provenance is written before integrity hash to prevent false tampering warnings', async () => {
+    const mockSpawn = mockSuccessfulSpawn();
     try {
-      // Only snyk dimension present
+      const result = await skillsshInstall({
+        candidate: makeCandidate(),
+        securityDecision: makeProceedDecision(),
+      });
+
+      expect(result.success).toBe(true);
+
+      // Both provenance and integrity should exist
+      const namespacedDir = join(TEST_DIR, 'skills', 'test-org--test-repo--my-skill');
+      expect(existsSync(join(namespacedDir, '.provenance.json'))).toBe(true);
+
+      const integrityPath = join(TEST_DIR, 'skills', '.integrity.json');
+      expect(existsSync(integrityPath)).toBe(true);
+    } finally {
+      mockSpawn.mockRestore();
+    }
+  });
+
+  test('provenance includes only dimensions present in the audit', async () => {
+    const mockSpawn = mockSuccessfulSpawn();
+    try {
       const candidate = makeCandidate({
         audit: {
           snyk: { risk: 'safe', analyzedAt: '2025-06-01T00:00:00Z' },
@@ -347,7 +432,7 @@ describe('skillsshInstall provenance', () => {
     expect(result.success).toBe(false);
     expect(result.provenance).toBeUndefined();
 
-    const provenancePath = join(TEST_DIR, 'skills', 'my-skill', '.provenance.json');
+    const provenancePath = join(TEST_DIR, 'skills', 'test-org--test-repo--my-skill', '.provenance.json');
     expect(existsSync(provenancePath)).toBe(false);
   });
 });
@@ -389,7 +474,6 @@ describe('skillsshInstall error handling', () => {
 
   test('returns error when SKILL.md is not found after install', async () => {
     const originalSpawn = Bun.spawn;
-    // Simulate subprocess success but without creating SKILL.md
     const mockSpawn = spyOn(Bun, 'spawn').mockImplementation((..._args: unknown[]) => {
       return {
         stdout: new ReadableStream({

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -8,6 +8,9 @@ import { ensureSkillIcon,loadSkillBySelector, loadSkillCatalog } from '../../con
 import { createTimeout,extractText, getConfiguredProvider, userMessage } from '../../providers/provider-send-message.js';
 import { clawhubCheckUpdates, clawhubInspect, clawhubInstall, clawhubSearch, type ClawhubSearchResultItem,clawhubUpdate } from '../../skills/clawhub.js';
 import { createManagedSkill,deleteManagedSkill, removeSkillsIndexEntry, validateManagedSkillId } from '../../skills/managed-store.js';
+import { makeSecurityDecision } from '../../skills/security-decision.js';
+import { skillsshInstall } from '../../skills/skillssh-install.js';
+import { skillsshSearchWithAudit } from '../../skills/skillssh.js';
 import { checkVellumSkill,installFromVellumCatalog, listCatalogEntries } from '../../tools/skills/vellum-catalog.js';
 import { getWorkspaceSkillsDir } from '../../util/platform.js';
 import type {
@@ -210,19 +213,26 @@ export async function handleSkillsInstall(
       }
       skillId = result.skillName ?? msg.slug;
     } else {
-      // Install from clawhub (community)
-      const result = await clawhubInstall(msg.slug, { version: msg.version });
-      if (!result.success) {
-        ctx.send(socket, {
-          type: 'skills_operation_response',
-          operation: 'install',
-          success: false,
-          error: result.error ?? 'Unknown error',
-        });
-        return;
+      // Try clawhub first, then fall back to skills.sh
+      const clawhubResult = await clawhubInstall(msg.slug, { version: msg.version });
+
+      if (clawhubResult.success) {
+        const rawId = clawhubResult.skillName ?? msg.slug;
+        skillId = rawId.includes('/') ? rawId.split('/').pop()! : rawId;
+      } else {
+        // Fallback: search skills.sh by the slug, audit, and install
+        const skillsshResult = await trySkillsShInstall(msg.slug);
+        if (!skillsshResult.success) {
+          ctx.send(socket, {
+            type: 'skills_operation_response',
+            operation: 'install',
+            success: false,
+            error: skillsshResult.error ?? clawhubResult.error ?? 'Unknown error',
+          });
+          return;
+        }
+        skillId = skillsshResult.namespacedId;
       }
-      const rawId = result.skillName ?? msg.slug;
-      skillId = rawId.includes('/') ? rawId.split('/').pop()! : rawId;
     }
 
     // Reload skill catalog so the newly installed skill is picked up
@@ -265,6 +275,31 @@ export async function handleSkillsInstall(
       success: false,
       error: message,
     });
+  }
+}
+
+/**
+ * Attempt to install a skill via skills.sh: search by slug, fetch audit data,
+ * make a security decision, and invoke the installer.
+ */
+async function trySkillsShInstall(slug: string): Promise<{ success: boolean; namespacedId: string; error?: string }> {
+  try {
+    const searchResult = await skillsshSearchWithAudit(slug, { limit: 1 });
+    const match = searchResult.skills[0];
+    if (!match) {
+      return { success: false, namespacedId: '', error: `No skills.sh skill found for "${slug}"` };
+    }
+
+    const decision = makeSecurityDecision(match.audit);
+    const installResult = await skillsshInstall({ candidate: match, securityDecision: decision });
+    return {
+      success: installResult.success,
+      namespacedId: installResult.namespacedId,
+      error: installResult.error,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { success: false, namespacedId: '', error: message };
   }
 }
 

--- a/assistant/src/skills/skillssh-install.ts
+++ b/assistant/src/skills/skillssh-install.ts
@@ -1,9 +1,10 @@
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import { getLogger } from '../util/logger.js';
 import { getWorkspaceSkillsDir } from '../util/platform.js';
 import { validateSlug, verifyAndRecordSkillHash } from './clawhub.js';
+import { upsertSkillsIndexEntry } from './managed-store.js';
 import type { SecurityDecision } from './security-decision.js';
 import type { SkillsShSearchWithAuditItem } from './skillssh.js';
 
@@ -23,6 +24,8 @@ export interface SkillsShInstallOptions {
 export interface SkillsShInstallResult {
   success: boolean;
   skillId: string;
+  /** Source-namespaced ID used for the install directory (e.g. "org--repo--my-skill") */
+  namespacedId: string;
   /** The managed skill directory path */
   installedPath?: string;
   /** Error message if install failed */
@@ -59,6 +62,16 @@ function getManagedSkillsDir(): string {
 // so we use the parent of the managed skills dir as the project root.
 function getSkillsShProjectRoot(): string {
   return dirname(getWorkspaceSkillsDir());
+}
+
+/**
+ * Derive a source-namespaced directory name from source and skillId.
+ * Replaces slashes with double-hyphens so the result is a flat, safe directory name.
+ * Example: source="org/repo", skillId="my-skill" -> "org--repo--my-skill"
+ */
+export function namespacedSkillDir(source: string, skillId: string): string {
+  const sanitized = source.replace(/\//g, '--');
+  return `${sanitized}--${skillId}`;
 }
 
 // ─── Subprocess runner ───────────────────────────────────────────────────────────
@@ -149,15 +162,27 @@ export async function skillsshInstall(
   const { candidate, securityDecision, userOverride } = options;
   const { skillId, source } = candidate;
 
-  // Reject invalid skill IDs before computing install paths — prevents empty
-  // strings, path traversal segments, or other malformed identifiers from
-  // targeting unexpected directories.
+  const nsId = namespacedSkillDir(source, skillId);
+
+  // Reject invalid skill IDs and source identifiers before computing install
+  // paths -- prevents empty strings, path traversal segments, or other malformed
+  // identifiers from targeting unexpected directories.
   if (!validateSlug(skillId)) {
     return {
       success: false,
       skillId,
+      namespacedId: nsId,
       installedVia: 'policy',
       error: `Invalid skill ID: ${skillId}`,
+    };
+  }
+  if (!source || source.includes('..') || /[\\]/.test(source)) {
+    return {
+      success: false,
+      skillId,
+      namespacedId: nsId,
+      installedVia: 'policy',
+      error: `Invalid source: ${source}`,
     };
   }
 
@@ -166,6 +191,7 @@ export async function skillsshInstall(
     return {
       success: false,
       skillId,
+      namespacedId: nsId,
       installedVia: 'policy',
       error:
         `Installation blocked: security assessment is "${securityDecision.recommendation}" ` +
@@ -181,46 +207,66 @@ export async function skillsshInstall(
 
     if (result.exitCode !== 0) {
       const error = result.stderr.trim() || result.stdout.trim() || 'Unknown error';
-      return { success: false, skillId, installedVia, error };
+      return { success: false, skillId, namespacedId: nsId, installedVia, error };
     }
 
-    // `npx skills add` installs into skills/<skillId>/SKILL.md relative to the project root.
-    // The project root is the parent of the managed skills dir, so the installed
-    // path lands inside the managed skills dir.
-    const installedDir = join(getManagedSkillsDir(), skillId);
-    const skillFile = join(installedDir, 'SKILL.md');
+    // `npx skills add` installs into skills/<skillId>/SKILL.md relative to the
+    // project root. We then relocate it to a source-namespaced directory to
+    // prevent ID collisions between different repos publishing the same skillId.
+    const rawInstalledDir = join(getManagedSkillsDir(), skillId);
+    const namespacedDir = join(getManagedSkillsDir(), nsId);
+    const rawSkillFile = join(rawInstalledDir, 'SKILL.md');
 
-    if (!existsSync(skillFile)) {
+    if (!existsSync(rawSkillFile)) {
       return {
         success: false,
         skillId,
+        namespacedId: nsId,
         installedVia,
-        error: `Installation completed but SKILL.md not found at expected path: ${skillFile}`,
+        error: `Installation completed but SKILL.md not found at expected path: ${rawSkillFile}`,
       };
     }
 
-    // Record content integrity hash (trust-on-first-use)
-    verifyAndRecordSkillHash(skillId);
+    // Relocate to namespaced directory when the raw and namespaced paths differ
+    if (rawInstalledDir !== namespacedDir) {
+      mkdirSync(dirname(namespacedDir), { recursive: true });
+      renameSync(rawInstalledDir, namespacedDir);
+    }
 
-    // Store provenance metadata alongside the skill
+    const installedDir = namespacedDir;
+
+    // Write provenance metadata before computing the integrity hash so the
+    // hash is stable on re-install. collectFileContents already excludes
+    // .provenance.json, but writing it first avoids any ordering ambiguity.
     const provenance = buildProvenance(candidate);
     const provenancePath = join(installedDir, '.provenance.json');
     writeFileSync(provenancePath, JSON.stringify(provenance, null, 2) + '\n', 'utf-8');
 
+    // Record content integrity hash (trust-on-first-use)
+    verifyAndRecordSkillHash(nsId);
+
+    // Add to SKILLS.md index so the skill is discoverable
+    try {
+      upsertSkillsIndexEntry(nsId);
+    } catch (err) {
+      log.warn({ err, nsId }, 'Failed to update SKILLS.md index after install');
+    }
+
     log.info(
-      { skillId, source, installedVia, installedDir },
+      { skillId, namespacedId: nsId, source, installedVia, installedDir },
       'skills.sh skill installed successfully',
     );
 
     return {
       success: true,
       skillId,
+      namespacedId: nsId,
       installedPath: installedDir,
       installedVia,
       provenance,
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    return { success: false, skillId, installedVia, error: message };
+    return { success: false, skillId, namespacedId: nsId, installedVia, error: message };
   }
 }


### PR DESCRIPTION
Address reviewer feedback from PR #9870:

## Changes

- **Validate skill IDs and source** (Codex P1): Added source validation (empty, path traversal, backslash) alongside existing skillId validation before computing install paths
- **Wire skillssh installer into runtime install flow** (Codex P1): Added skills.sh as a fallback in `handleSkillsInstall` -- when both vellum catalog and clawhub fail, searches skills.sh by slug, fetches audit data, makes a security decision, and installs
- **Update SKILLS.md index after successful install** (Codex P1): Calls `upsertSkillsIndexEntry` after successful install so the skill is discoverable in workspaces with an index
- **Namespace stored skills by source** (Codex P2): Install directory is now keyed by `source--skillId` (e.g., `org--repo--my-skill`) to prevent ID collisions between different repos publishing the same skillId. The raw `skills add` output is relocated via `renameSync`
- **Fix provenance/hash ordering** (Devin): Provenance metadata is now written before computing the integrity hash, eliminating any ordering ambiguity (the `.provenance.json` exclusion in `collectFileContents` was already in place)

## Test plan
- [ ] Verify tests pass for source validation (empty, traversal, backslash)
- [ ] Verify namespaced directory creation and relocation
- [ ] Verify SKILLS.md index updated on successful install
- [ ] Verify provenance written before hash computation
- [ ] Verify different sources with same skillId get different directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
