### PR TITLE
feat: bulk mark-all-threads-as-seen with undo

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -57,6 +57,15 @@ extension AppDelegate {
         newChatItem.target = self
         fileMenu.addItem(newChatItem)
 
+        let markAllSeenItem = NSMenuItem(
+            title: "Mark All Threads as Seen",
+            action: #selector(markAllThreadsSeen),
+            keyEquivalent: "\u{1b}" // Escape key
+        )
+        markAllSeenItem.keyEquivalentModifierMask = .shift
+        markAllSeenItem.target = self
+        fileMenu.addItem(markAllSeenItem)
+
         let fileMenuItem = NSMenuItem(title: "File", action: nil, keyEquivalent: "")
         fileMenuItem.submenu = fileMenu
         mainMenu.insertItem(fileMenuItem, at: 1)
@@ -207,6 +216,9 @@ extension AppDelegate {
         ]
         if conversationZoomSelectors.contains(action) {
             return mainWindow?.windowState.isConversationVisible ?? false
+        }
+        if action == #selector(markAllThreadsSeen) {
+            return (mainWindow?.threadManager.unseenVisibleConversationCount ?? 0) > 0
         }
         return true
     }
@@ -481,6 +493,39 @@ extension AppDelegate {
         menu.addItem(quitItem)
 
         menu.popUp(positioning: nil, at: NSPoint(x: 0, y: button.bounds.height + 2), in: button)
+    }
+
+    @objc func markAllThreadsSeen() {
+        guard let threadManager = mainWindow?.threadManager else { return }
+        let markedIds = threadManager.markAllThreadsSeen()
+        guard !markedIds.isEmpty else { return }
+        let count = markedIds.count
+        mainWindow?.windowState.showToast(
+            message: "Marked \(count) thread\(count == 1 ? "" : "s") as seen",
+            style: .success,
+            primaryAction: VToastAction(label: "Undo") { [weak self] in
+                self?.mainWindow?.threadManager.restoreUnseen(threadIds: markedIds)
+                self?.mainWindow?.windowState.dismissToast()
+            }
+        )
+    }
+
+    func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {
+        let menu = NSMenu()
+
+        let newChatItem = NSMenuItem(title: "New Chat", action: #selector(openNewChat), keyEquivalent: "")
+        newChatItem.target = self
+        menu.addItem(newChatItem)
+
+        let markAllSeenItem = NSMenuItem(
+            title: "Mark All Threads as Seen",
+            action: #selector(markAllThreadsSeen),
+            keyEquivalent: ""
+        )
+        markAllSeenItem.target = self
+        menu.addItem(markAllSeenItem)
+
+        return menu
     }
 
     @objc func openCurrentThread() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1177,10 +1177,26 @@ struct MainWindowView: View {
                 .padding(.horizontal, VSpacing.md)
 
             // MARK: Threads (scrollable)
-            SidebarThreadsHeader(onNewThread: {
-                windowState.selection = nil
-                threadManager.createThread()
-            })
+            SidebarThreadsHeader(
+                hasUnseenThreads: threadManager.unseenVisibleConversationCount > 0,
+                onMarkAllSeen: {
+                    let markedIds = threadManager.markAllThreadsSeen()
+                    guard !markedIds.isEmpty else { return }
+                    let count = markedIds.count
+                    windowState.showToast(
+                        message: "Marked \(count) thread\(count == 1 ? "" : "s") as seen",
+                        style: .success,
+                        primaryAction: VToastAction(label: "Undo") {
+                            threadManager.restoreUnseen(threadIds: markedIds)
+                            windowState.dismissToast()
+                        }
+                    )
+                },
+                onNewThread: {
+                    windowState.selection = nil
+                    threadManager.createThread()
+                }
+            )
 
             ScrollView {
                 VStack(spacing: 0) {
@@ -1493,6 +1509,8 @@ private struct SidebarNavRow: View {
 }
 
 private struct SidebarThreadsHeader: View {
+    let hasUnseenThreads: Bool
+    let onMarkAllSeen: () -> Void
     let onNewThread: () -> Void
 
     var body: some View {
@@ -1501,11 +1519,28 @@ private struct SidebarThreadsHeader: View {
                 .font(.system(size: 13, weight: .medium))
                 .foregroundColor(VColor.textPrimary)
             Spacer()
+            if hasUnseenThreads {
+                VIconButton(
+                    label: "Mark all as seen",
+                    icon: "checkmark.circle",
+                    iconOnly: true,
+                    tooltip: "Mark all as seen",
+                    action: onMarkAllSeen
+                )
+            }
             VIconButton(label: "New thread", icon: "plus", iconOnly: true, action: onNewThread)
         }
         .padding(.leading, 20)
         .padding(.trailing, VSpacing.md)
         .padding(.vertical, VSpacing.xs)
+        .contextMenu {
+            Button {
+                onMarkAllSeen()
+            } label: {
+                Label("Mark All as Seen", systemImage: "checkmark.circle")
+            }
+            .disabled(!hasUnseenThreads)
+        }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -736,6 +736,34 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
     }
 
+    /// Mark all visible (non-archived, non-private) threads as seen and emit
+    /// IPC signals for each. Returns the IDs of threads that were actually
+    /// marked, so the caller can offer an undo action.
+    @discardableResult
+    internal func markAllThreadsSeen() -> [UUID] {
+        var markedIds: [UUID] = []
+        for idx in threads.indices {
+            guard !threads[idx].isArchived,
+                  threads[idx].kind != .private,
+                  threads[idx].hasUnseenLatestAssistantMessage else { continue }
+            threads[idx].hasUnseenLatestAssistantMessage = false
+            markedIds.append(threads[idx].id)
+            if let sessionId = threads[idx].sessionId {
+                emitConversationSeenSignal(conversationId: sessionId)
+            }
+        }
+        return markedIds
+    }
+
+    /// Restore the unseen flag for the given thread IDs (used by undo).
+    internal func restoreUnseen(threadIds: [UUID]) {
+        for id in threadIds {
+            if let idx = threads.firstIndex(where: { $0.id == id }) {
+                threads[idx].hasUnseenLatestAssistantMessage = true
+            }
+        }
+    }
+
     // MARK: - Private
 
     /// Send a `conversation_seen_signal` IPC message to the daemon.


### PR DESCRIPTION
## Summary
- Adds a "Mark all as seen" icon button (checkmark.circle) to the Threads sidebar header, conditionally visible when unseen threads exist
- Adds right-click context menu on the Threads header with "Mark All as Seen" option
- Adds Shift+Escape keyboard shortcut (via File menu) and dock menu item
- Shows a success toast with "Undo" action that restores unseen state
- Menu/dock items auto-disable when no unseen threads exist

## Original prompt
Add a "Mark all as seen" button to the Threads sidebar header row, next to the existing "+" button.

**Behavior:**
- Conditionally visible — only appears when there are unseen threads
- On click: marks all threads as seen, shows a toast with undo
- Tooltip on hover: "Mark all as seen"

**Four access patterns:**
1. **Icon button** in the Threads header row (primary, for everyone)
2. **Keyboard shortcut** `⇧⎋` (power users)
3. **Right-click context menu** on the Threads header with "Mark all as seen" option
4. **Dock menu** item for quick access from the dock

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
