### PR TITLE
feat: add first-party vs third-party provenance to skills UI

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1748,6 +1748,10 @@ exports[`IPC message snapshots ServerMessage types skills_list_response serializ
       "emoji": "🔧",
       "id": "my-skill",
       "name": "My Skill",
+      "provenance": {
+        "kind": "first-party",
+        "provider": "Vellum",
+      },
       "source": "bundled",
       "state": "enabled",
       "updateAvailable": false,

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -1081,6 +1081,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
         degraded: false,
         updateAvailable: false,
         userInvocable: true,
+        provenance: { kind: 'first-party', provider: 'Vellum' },
       },
     ],
   },

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 
 import { getConfig, invalidateConfigCache,loadRawConfig, saveRawConfig } from '../../config/loader.js';
 import { resolveSkillStates } from '../../config/skill-state.js';
-import { ensureSkillIcon,loadSkillBySelector, loadSkillCatalog } from '../../config/skills.js';
+import { ensureSkillIcon,loadSkillBySelector, loadSkillCatalog, type SkillSummary } from '../../config/skills.js';
 import { createTimeout,extractText, getConfiguredProvider, userMessage } from '../../providers/provider-send-message.js';
 import { clawhubCheckUpdates, clawhubInspect, clawhubInstall, clawhubSearch, type ClawhubSearchResultItem,clawhubUpdate } from '../../skills/clawhub.js';
 import { createManagedSkill,deleteManagedSkill, removeSkillsIndexEntry, validateManagedSkillId } from '../../skills/managed-store.js';
@@ -26,6 +26,57 @@ import type {
 } from '../ipc-protocol.js';
 import { CONFIG_RELOAD_DEBOUNCE_MS, defineHandlers, ensureSkillEntry, type HandlerContext,log } from './shared.js';
 
+// ─── Provenance resolution ──────────────────────────────────────────────────
+
+interface SkillProvenance {
+  kind: 'first-party' | 'third-party';
+  provider?: string;
+  originId?: string;
+  sourceUrl?: string;
+}
+
+const CLAWHUB_BASE_URL = 'https://skills.sh';
+
+function resolveProvenance(summary: SkillSummary): SkillProvenance {
+  // Bundled skills are always first-party (shipped with Vellum)
+  if (summary.source === 'bundled') {
+    return { kind: 'first-party', provider: 'Vellum' };
+  }
+
+  // Clawhub-sourced skills are third-party community skills
+  if (summary.source === 'clawhub') {
+    return {
+      kind: 'third-party',
+      provider: 'skills.sh',
+      originId: summary.id,
+      sourceUrl: `${CLAWHUB_BASE_URL}/skills/${encodeURIComponent(summary.id)}`,
+    };
+  }
+
+  // Managed skills could be either first-party (installed from Vellum catalog)
+  // or third-party (installed from clawhub). The homepage field serves as a
+  // heuristic: Vellum catalog skills don't typically have a clawhub homepage.
+  if (summary.source === 'managed') {
+    if (summary.homepage?.includes('skills.sh') || summary.homepage?.includes('clawhub')) {
+      return {
+        kind: 'third-party',
+        provider: 'skills.sh',
+        originId: summary.id,
+        sourceUrl: summary.homepage ?? `${CLAWHUB_BASE_URL}/skills/${encodeURIComponent(summary.id)}`,
+      };
+    }
+    // Default managed skills to first-party (most are installed from Vellum catalog)
+    return { kind: 'first-party', provider: 'Vellum' };
+  }
+
+  // Workspace and extra skills are user-provided
+  if (summary.source === 'workspace' || summary.source === 'extra') {
+    return { kind: 'third-party', provider: 'local' };
+  }
+
+  return { kind: 'third-party' };
+}
+
 export function handleSkillsList(socket: net.Socket, ctx: HandlerContext): void {
   const config = getConfig();
   const catalog = loadSkillCatalog();
@@ -43,6 +94,7 @@ export function handleSkillsList(socket: net.Socket, ctx: HandlerContext): void 
     missingRequirements: r.missingRequirements,
     updateAvailable: false,
     userInvocable: r.summary.userInvocable,
+    provenance: resolveProvenance(r.summary),
   }));
 
   ctx.send(socket, { type: 'skills_list_response', skills });

--- a/assistant/src/daemon/ipc-contract/skills.ts
+++ b/assistant/src/daemon/ipc-contract/skills.ts
@@ -95,6 +95,7 @@ export interface SkillsListResponse {
     updateAvailable: boolean;
     userInvocable: boolean;
     clawhub?: { author: string; stars: number; installs: number; reports: number; publishedAt: string };
+    provenance?: { kind: 'first-party' | 'third-party'; provider?: string; originId?: string; sourceUrl?: string };
   }>;
 }
 

--- a/clients/ios/Views/IdentityView.swift
+++ b/clients/ios/Views/IdentityView.swift
@@ -258,9 +258,23 @@ struct IdentityView: View {
                     .accessibilityHidden(true)
 
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(skill.name)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
+                    HStack(spacing: 4) {
+                        Text(skill.name)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+
+                        if let provenance = skill.provenance {
+                            Text(provenance.kind == "first-party" ? (provenance.provider ?? "Vellum") : (provenance.provider ?? "Third-party"))
+                                .font(.caption2)
+                                .padding(.horizontal, 5)
+                                .padding(.vertical, 1)
+                                .background(
+                                    Capsule()
+                                        .fill(provenance.kind == "first-party" ? Color.blue.opacity(0.15) : Color.orange.opacity(0.15))
+                                )
+                                .foregroundColor(provenance.kind == "first-party" ? .blue : .orange)
+                        }
+                    }
 
                     if !skill.description.isEmpty {
                         Text(skill.description)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -919,6 +919,19 @@ struct AgentPanelContent: View {
                                     .fill(sourceBadgeColor(skill.source).opacity(0.15))
                             )
 
+                        // Provenance badge
+                        if let label = provenanceLabel(skill) {
+                            Text(label)
+                                .font(VFont.small)
+                                .foregroundColor(provenanceBadgeColor(skill))
+                                .padding(.horizontal, VSpacing.sm)
+                                .padding(.vertical, 2)
+                                .background(
+                                    Capsule()
+                                        .fill(provenanceBadgeColor(skill).opacity(0.15))
+                                )
+                        }
+
                         if skill.updateAvailable {
                             Text("UPDATE")
                                 .font(VFont.small)
@@ -930,6 +943,23 @@ struct AgentPanelContent: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.textMuted)
                         .lineLimit(2)
+
+                    // Source link for third-party skills
+                    if let provenance = skill.provenance,
+                       provenance.kind == "third-party",
+                       let urlString = provenance.sourceUrl,
+                       let url = URL(string: urlString) {
+                        Link(destination: url) {
+                            HStack(spacing: 3) {
+                                Image(systemName: "arrow.up.right.square")
+                                    .font(.system(size: 9))
+                                Text("View on \(provenance.provider ?? "source")")
+                                    .font(VFont.small)
+                            }
+                            .foregroundColor(VColor.textMuted)
+                        }
+                        .buttonStyle(.plain)
+                    }
                 }
 
                 Spacer(minLength: VSpacing.lg)
@@ -1036,6 +1066,19 @@ struct AgentPanelContent: View {
                             .fill(sourceBadgeColor(skill.source).opacity(0.15))
                     )
 
+                // Provenance badge
+                if let label = provenanceLabel(skill) {
+                    Text(label)
+                        .font(VFont.small)
+                        .foregroundColor(provenanceBadgeColor(skill))
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, 2)
+                        .background(
+                            Capsule()
+                                .fill(provenanceBadgeColor(skill).opacity(0.15))
+                        )
+                }
+
                 Spacer()
 
                 if skill.source == "managed" {
@@ -1065,6 +1108,23 @@ struct AgentPanelContent: View {
                     } else {
                         skillMetaItem(icon: "arrow.up.circle", value: "Update available", color: Amber._500)
                     }
+                }
+
+                // Source link for third-party skills
+                if let provenance = skill.provenance,
+                   provenance.kind == "third-party",
+                   let urlString = provenance.sourceUrl,
+                   let url = URL(string: urlString) {
+                    Link(destination: url) {
+                        HStack(spacing: VSpacing.xs) {
+                            Image(systemName: "arrow.up.right.square")
+                                .font(.system(size: 9))
+                            Text("View on \(provenance.provider ?? "source")")
+                                .font(VFont.small)
+                        }
+                        .foregroundColor(VColor.textMuted)
+                    }
+                    .buttonStyle(.plain)
                 }
             }
 
@@ -1102,6 +1162,16 @@ struct AgentPanelContent: View {
         }
     }
 
+    private func provenanceLabel(_ skill: SkillInfo) -> String? {
+        guard let provenance = skill.provenance else { return nil }
+        if provenance.kind == "first-party" {
+            return provenance.provider ?? "Vellum"
+        } else if provenance.kind == "third-party" {
+            return provenance.provider ?? "Third-party"
+        }
+        return nil
+    }
+
     private func sourceBadgeColor(_ source: String) -> Color {
         switch source {
         case "bundled":
@@ -1113,6 +1183,11 @@ struct AgentPanelContent: View {
         default:
             return VColor.textMuted
         }
+    }
+
+    private func provenanceBadgeColor(_ skill: SkillInfo) -> Color {
+        guard let provenance = skill.provenance else { return VColor.textMuted }
+        return provenance.kind == "first-party" ? VColor.accent : Amber._500
     }
 
     private func skillMetaItem(icon: String, value: String, color: Color = VColor.textMuted) -> some View {

--- a/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
@@ -406,12 +406,17 @@ private struct SkillRow: View {
                 .frame(width: 28)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(skill.name)
-                    .font(VFont.headline)
+                HStack(spacing: 6) {
+                    Text(skill.name)
+                        .font(VFont.headline)
+                    provenanceBadge
+                }
                 Text(skill.description)
                     .font(VFont.body)
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
+
+                provenanceSourceLink
 
                 if skill.degraded, let missing = skill.missingRequirements {
                     degradedWarning(missing)
@@ -447,6 +452,48 @@ private struct SkillRow: View {
                 .labelsHidden()
         }
         .padding(.vertical, 2)
+    }
+
+    @ViewBuilder
+    private var provenanceBadge: some View {
+        if let provenance = skill.provenance {
+            if provenance.kind == "first-party" {
+                Text(provenance.provider ?? "Vellum")
+                    .font(.caption2)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1)
+                    .background(Color.blue.opacity(0.15))
+                    .foregroundStyle(.blue)
+                    .clipShape(Capsule())
+            } else if provenance.kind == "third-party" {
+                Text(provenance.provider ?? "Third-party")
+                    .font(.caption2)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1)
+                    .background(Color.orange.opacity(0.15))
+                    .foregroundStyle(.orange)
+                    .clipShape(Capsule())
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var provenanceSourceLink: some View {
+        if let provenance = skill.provenance,
+           provenance.kind == "third-party",
+           let urlString = provenance.sourceUrl,
+           let url = URL(string: urlString) {
+            Link(destination: url) {
+                HStack(spacing: 3) {
+                    Image(systemName: "arrow.up.right.square")
+                        .font(.caption2)
+                    Text("View on \(provenance.provider ?? "source")")
+                        .font(.caption)
+                }
+                .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+        }
     }
 
     @ViewBuilder

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -4342,8 +4342,9 @@ public struct IPCSkillsListResponseSkill: Codable, Sendable {
     public let updateAvailable: Bool
     public let userInvocable: Bool
     public let clawhub: IPCSkillsListResponseSkillClawhub?
+    public let provenance: IPCSkillsListResponseSkillProvenance?
 
-    public init(id: String, name: String, description: String, emoji: String? = nil, homepage: String? = nil, source: String, state: String, degraded: Bool, missingRequirements: IPCSkillsListResponseSkillMissingRequirements? = nil, installedVersion: String? = nil, latestVersion: String? = nil, updateAvailable: Bool, userInvocable: Bool, clawhub: IPCSkillsListResponseSkillClawhub? = nil) {
+    public init(id: String, name: String, description: String, emoji: String? = nil, homepage: String? = nil, source: String, state: String, degraded: Bool, missingRequirements: IPCSkillsListResponseSkillMissingRequirements? = nil, installedVersion: String? = nil, latestVersion: String? = nil, updateAvailable: Bool, userInvocable: Bool, clawhub: IPCSkillsListResponseSkillClawhub? = nil, provenance: IPCSkillsListResponseSkillProvenance? = nil) {
         self.id = id
         self.name = name
         self.description = description
@@ -4358,6 +4359,7 @@ public struct IPCSkillsListResponseSkill: Codable, Sendable {
         self.updateAvailable = updateAvailable
         self.userInvocable = userInvocable
         self.clawhub = clawhub
+        self.provenance = provenance
     }
 }
 
@@ -4386,6 +4388,20 @@ public struct IPCSkillsListResponseSkillMissingRequirements: Codable, Sendable {
         self.bins = bins
         self.env = env
         self.permissions = permissions
+    }
+}
+
+public struct IPCSkillsListResponseSkillProvenance: Codable, Sendable {
+    public let kind: String
+    public let provider: String?
+    public let originId: String?
+    public let sourceUrl: String?
+
+    public init(kind: String, provider: String? = nil, originId: String? = nil, sourceUrl: String? = nil) {
+        self.kind = kind
+        self.provider = provider
+        self.originId = originId
+        self.sourceUrl = sourceUrl
     }
 }
 

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1045,6 +1045,10 @@ public typealias ClawhubInfo = IPCSkillsListResponseSkillClawhub
 /// Backed by generated `IPCSkillsListResponseSkillMissingRequirements`.
 public typealias MissingRequirements = IPCSkillsListResponseSkillMissingRequirements
 
+/// Provenance metadata indicating whether a skill is first-party or third-party.
+/// Backed by generated `IPCSkillsListResponseSkillProvenance`.
+public typealias SkillProvenance = IPCSkillsListResponseSkillProvenance
+
 /// Full skill info from the daemon's resolved skill list.
 /// Backed by generated `IPCSkillsListResponseSkill`.
 public typealias SkillInfo = IPCSkillsListResponseSkill
@@ -1054,12 +1058,12 @@ extension IPCSkillsListResponseSkill: Identifiable {}
 extension IPCSkillsListResponseSkill {
     /// Backward-compatible init that defaults `id` to `name`.
     public init(name: String, description: String, emoji: String?, homepage: String?, source: String, state: String, degraded: Bool, missingRequirements: IPCSkillsListResponseSkillMissingRequirements?, installedVersion: String?, latestVersion: String?, updateAvailable: Bool, userInvocable: Bool, clawhub: IPCSkillsListResponseSkillClawhub?) {
-        self.init(id: name, name: name, description: description, emoji: emoji, homepage: homepage, source: source, state: state, degraded: degraded, missingRequirements: missingRequirements, installedVersion: installedVersion, latestVersion: latestVersion, updateAvailable: updateAvailable, userInvocable: userInvocable, clawhub: clawhub)
+        self.init(id: name, name: name, description: description, emoji: emoji, homepage: homepage, source: source, state: state, degraded: degraded, missingRequirements: missingRequirements, installedVersion: installedVersion, latestVersion: latestVersion, updateAvailable: updateAvailable, userInvocable: userInvocable, clawhub: clawhub, provenance: nil)
     }
 
     /// Returns a copy with a different `state`, preserving all other fields including `id`.
     public func withState(_ newState: String) -> Self {
-        Self(id: id, name: name, description: description, emoji: emoji, homepage: homepage, source: source, state: newState, degraded: degraded, missingRequirements: missingRequirements, installedVersion: installedVersion, latestVersion: latestVersion, updateAvailable: updateAvailable, userInvocable: userInvocable, clawhub: clawhub)
+        Self(id: id, name: name, description: description, emoji: emoji, homepage: homepage, source: source, state: newState, degraded: degraded, missingRequirements: missingRequirements, installedVersion: installedVersion, latestVersion: latestVersion, updateAvailable: updateAvailable, userInvocable: userInvocable, clawhub: clawhub, provenance: provenance)
     }
 }
 


### PR DESCRIPTION
Implement M7 from #9784 (skills.sh-First Third-Party Skill Fallback):

- Add provenance metadata (source, origin, links) to skills listing endpoint
- Label skills as first-party or third-party in UI data
- Surface source metadata for third-party skills
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
