### PR TITLE
Widen settings sidenav and add text truncation with tooltips

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -104,7 +104,7 @@ struct SettingsPanel: View {
             HStack(spacing: 0) {
                 // Left: nav sidebar
                 settingsNav
-                    .frame(width: 160)
+                    .frame(width: 200)
 
                 Divider()
 
@@ -1004,6 +1004,8 @@ private struct SettingsNavRow: View {
     var body: some View {
         Button(action: action) {
             Text(tab.rawValue)
+                .lineLimit(1)
+                .truncationMode(.tail)
                 .font(isSelected ? VFont.bodyMedium : VFont.body)
                 .foregroundColor(isSelected ? VColor.textPrimary : VColor.textSecondary)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -1014,6 +1016,7 @@ private struct SettingsNavRow: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .help(tab.rawValue)
         .onHover { hovering in
             isHovered = hovering
             if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }


### PR DESCRIPTION
## Summary
- Increased settings sidebar width from 160pt to 200pt so no nav item wraps to two lines
- Added single-line truncation (`.lineLimit(1)` + `.truncationMode(.tail)`) to nav row text
- Added `.help()` tooltip on hover showing the full tab name for any truncated text

## Original prompt
 lets increase the width of this side nav so that no item spans two lines. We should also use text truncation and tooltips on hover for long text that would span two lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
