### PR TITLE
M2: Gateway feature-flags API + persistence

### DIFF
--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -1,0 +1,354 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+
+// Use an isolated temp directory so tests don't touch the real workspace config
+const testDir = join(tmpdir(), `vellum-ff-test-${randomBytes(6).toString("hex")}`);
+const vellumRoot = join(testDir, ".vellum");
+const workspaceDir = join(vellumRoot, "workspace");
+const configPath = join(workspaceDir, "config.json");
+
+const savedBaseDataDir = process.env.BASE_DATA_DIR;
+
+beforeEach(() => {
+  process.env.BASE_DATA_DIR = testDir;
+  mkdirSync(workspaceDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (savedBaseDataDir === undefined) {
+    delete process.env.BASE_DATA_DIR;
+  } else {
+    process.env.BASE_DATA_DIR = savedBaseDataDir;
+  }
+  try {
+    rmSync(testDir, { recursive: true, force: true });
+  } catch {
+    // best effort cleanup
+  }
+});
+
+const { createFeatureFlagsGetHandler, createFeatureFlagsPatchHandler } = await import(
+  "../http/routes/feature-flags.js"
+);
+
+describe("GET /v1/feature-flags handler", () => {
+  test("returns empty flags array when config file does not exist", async () => {
+    // Don't create the config file
+    if (existsSync(configPath)) {
+      rmSync(configPath);
+    }
+
+    const handler = createFeatureFlagsGetHandler();
+    const res = await handler(new Request("http://gateway.test/v1/feature-flags"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.flags).toEqual([]);
+  });
+
+  test("returns empty flags array when config has no featureFlags key", async () => {
+    writeFileSync(configPath, JSON.stringify({ sms: { phoneNumber: "+1234" } }));
+
+    const handler = createFeatureFlagsGetHandler();
+    const res = await handler(new Request("http://gateway.test/v1/feature-flags"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.flags).toEqual([]);
+  });
+
+  test("returns stored feature flags", async () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        featureFlags: {
+          "skills.browser.enabled": true,
+          "skills.twitter.enabled": false,
+        },
+      }),
+    );
+
+    const handler = createFeatureFlagsGetHandler();
+    const res = await handler(new Request("http://gateway.test/v1/feature-flags"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.flags).toEqual([
+      { key: "skills.browser.enabled", enabled: true },
+      { key: "skills.twitter.enabled", enabled: false },
+    ]);
+  });
+
+  test("ignores non-boolean values in featureFlags", async () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        featureFlags: {
+          "skills.browser.enabled": true,
+          "skills.bad.enabled": "yes",
+          "skills.number.enabled": 1,
+        },
+      }),
+    );
+
+    const handler = createFeatureFlagsGetHandler();
+    const res = await handler(new Request("http://gateway.test/v1/feature-flags"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.flags).toEqual([{ key: "skills.browser.enabled", enabled: true }]);
+  });
+});
+
+describe("PATCH /v1/feature-flags/:flagKey handler", () => {
+  test("creates a new feature flag", async () => {
+    writeFileSync(configPath, JSON.stringify({}));
+
+    const handler = createFeatureFlagsPatchHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags/skills.browser.enabled", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      }),
+      "skills.browser.enabled",
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ key: "skills.browser.enabled", enabled: true });
+
+    // Verify persistence
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    expect(config.featureFlags["skills.browser.enabled"]).toBe(true);
+  });
+
+  test("updates an existing feature flag", async () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        featureFlags: { "skills.browser.enabled": true },
+      }),
+    );
+
+    const handler = createFeatureFlagsPatchHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags/skills.browser.enabled", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: false }),
+      }),
+      "skills.browser.enabled",
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ key: "skills.browser.enabled", enabled: false });
+
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    expect(config.featureFlags["skills.browser.enabled"]).toBe(false);
+  });
+
+  test("preserves unknown config keys when writing", async () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        sms: { phoneNumber: "+1234567890" },
+        email: { address: "test@example.com" },
+        featureFlags: { "skills.existing.enabled": true },
+      }),
+    );
+
+    const handler = createFeatureFlagsPatchHandler();
+    await handler(
+      new Request("http://gateway.test/v1/feature-flags/skills.new.enabled", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      }),
+      "skills.new.enabled",
+    );
+
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    expect(config.sms).toEqual({ phoneNumber: "+1234567890" });
+    expect(config.email).toEqual({ address: "test@example.com" });
+    expect(config.featureFlags["skills.existing.enabled"]).toBe(true);
+    expect(config.featureFlags["skills.new.enabled"]).toBe(true);
+  });
+
+  test("creates config file and directories when they do not exist", async () => {
+    // Remove the workspace dir to test directory creation
+    rmSync(workspaceDir, { recursive: true, force: true });
+
+    const handler = createFeatureFlagsPatchHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags/skills.test.enabled", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      }),
+      "skills.test.enabled",
+    );
+
+    expect(res.status).toBe(200);
+    expect(existsSync(configPath)).toBe(true);
+
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    expect(config.featureFlags["skills.test.enabled"]).toBe(true);
+  });
+
+  // Validation tests
+  test("rejects empty flag key", async () => {
+    const handler = createFeatureFlagsPatchHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags/", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      }),
+      "",
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("non-empty");
+  });
+
+  test("rejects key not matching skills.<id>.enabled format", async () => {
+    const handler = createFeatureFlagsPatchHandler();
+
+    const invalidKeys = [
+      "random.key",
+      "skills.enabled",
+      "skills..enabled",
+      "skills.UPPERCASE.enabled",
+      "skills.browser.disabled",
+      "other.browser.enabled",
+      "skills.browser.enabled.extra",
+    ];
+
+    for (const key of invalidKeys) {
+      const res = await handler(
+        new Request(`http://gateway.test/v1/feature-flags/${key}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ enabled: true }),
+        }),
+        key,
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain("Invalid flag key format");
+    }
+  });
+
+  test("accepts valid skill key formats", async () => {
+    writeFileSync(configPath, JSON.stringify({}));
+    const handler = createFeatureFlagsPatchHandler();
+
+    const validKeys = [
+      "skills.browser.enabled",
+      "skills.twitter.enabled",
+      "skills.my-skill.enabled",
+      "skills.my_skill.enabled",
+      "skills.skill123.enabled",
+    ];
+
+    for (const key of validKeys) {
+      const res = await handler(
+        new Request(`http://gateway.test/v1/feature-flags/${key}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ enabled: true }),
+        }),
+        key,
+      );
+
+      expect(res.status).toBe(200);
+    }
+  });
+
+  test("rejects non-boolean enabled value", async () => {
+    const handler = createFeatureFlagsPatchHandler();
+
+    const invalidValues = ["true", 1, null, undefined];
+    for (const value of invalidValues) {
+      const res = await handler(
+        new Request("http://gateway.test/v1/feature-flags/skills.test.enabled", {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ enabled: value }),
+        }),
+        "skills.test.enabled",
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain("boolean");
+    }
+  });
+
+  test("rejects invalid JSON body", async () => {
+    const handler = createFeatureFlagsPatchHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags/skills.test.enabled", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: "not json",
+      }),
+      "skills.test.enabled",
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("valid JSON");
+  });
+
+  test("rejects missing body", async () => {
+    const handler = createFeatureFlagsPatchHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags/skills.test.enabled", {
+        method: "PATCH",
+      }),
+      "skills.test.enabled",
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  test("atomic write does not corrupt config on successful write", async () => {
+    // Write initial config
+    const initial = {
+      sms: { phoneNumber: "+1234" },
+      featureFlags: { "skills.a.enabled": true },
+    };
+    writeFileSync(configPath, JSON.stringify(initial));
+
+    const handler = createFeatureFlagsPatchHandler();
+    await handler(
+      new Request("http://gateway.test/v1/feature-flags/skills.b.enabled", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: false }),
+      }),
+      "skills.b.enabled",
+    );
+
+    // Verify the file is valid JSON and contains all expected data
+    const raw = readFileSync(configPath, "utf-8");
+    const config = JSON.parse(raw);
+    expect(config.sms).toEqual({ phoneNumber: "+1234" });
+    expect(config.featureFlags["skills.a.enabled"]).toBe(true);
+    expect(config.featureFlags["skills.b.enabled"]).toBe(false);
+
+    // Verify no temp files left behind
+    const { readdirSync } = await import("node:fs");
+    const files = readdirSync(workspaceDir);
+    const tmpFiles = files.filter((f: string) => f.endsWith(".tmp"));
+    expect(tmpFiles.length).toBe(0);
+  });
+});

--- a/gateway/src/http/routes/feature-flags.ts
+++ b/gateway/src/http/routes/feature-flags.ts
@@ -29,7 +29,11 @@ function readConfigFile(): ConfigReadResult {
   }
   try {
     const raw = readFileSync(cfgPath, "utf-8");
-    return { ok: true, data: JSON.parse(raw) };
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { ok: false, reason: "malformed", detail: "Config file is not a JSON object" };
+    }
+    return { ok: true, data: parsed };
   } catch (err) {
     return { ok: false, reason: "malformed", detail: String(err) };
   }

--- a/gateway/src/http/routes/feature-flags.ts
+++ b/gateway/src/http/routes/feature-flags.ts
@@ -1,0 +1,140 @@
+import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { randomBytes } from "node:crypto";
+import { getRootDir } from "../../credential-reader.js";
+import { getLogger } from "../../logger.js";
+
+const log = getLogger("feature-flags");
+
+/**
+ * Only allow keys matching `skills.<skillId>.enabled` for the initial rollout.
+ * The skillId segment must be a non-empty string of lowercase alphanumeric chars,
+ * hyphens, and underscores.
+ */
+const ALLOWED_KEY_RE = /^skills\.[a-z0-9_-]+\.enabled$/;
+
+function getConfigPath(): string {
+  return join(getRootDir(), "workspace", "config.json");
+}
+
+function readConfigFile(): Record<string, unknown> {
+  const cfgPath = getConfigPath();
+  try {
+    const raw = readFileSync(cfgPath, "utf-8");
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Atomically write the config file: write to a temporary file in the same
+ * directory, then rename. This avoids partial-file corruption if the process
+ * crashes mid-write.
+ */
+function writeConfigFileAtomic(data: Record<string, unknown>): void {
+  const cfgPath = getConfigPath();
+  const dir = dirname(cfgPath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const tmpPath = join(dir, `.config.${randomBytes(6).toString("hex")}.tmp`);
+  writeFileSync(tmpPath, JSON.stringify(data, null, 2) + "\n", "utf-8");
+  renameSync(tmpPath, cfgPath);
+}
+
+export type FeatureFlagEntry = {
+  key: string;
+  enabled: boolean;
+};
+
+export function createFeatureFlagsGetHandler() {
+  return async (_req: Request): Promise<Response> => {
+    try {
+      const config = readConfigFile();
+      const flags: Record<string, boolean> = {};
+      const raw = config.featureFlags;
+      if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+        for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+          if (typeof v === "boolean") {
+            flags[k] = v;
+          }
+        }
+      }
+
+      const entries: FeatureFlagEntry[] = Object.entries(flags).map(
+        ([key, enabled]) => ({ key, enabled }),
+      );
+
+      return Response.json({ flags: entries });
+    } catch (err) {
+      log.error({ err }, "Failed to read feature flags");
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
+  };
+}
+
+export function createFeatureFlagsPatchHandler() {
+  return async (req: Request, flagKey: string): Promise<Response> => {
+    // Validate flagKey is non-empty and matches allowed key charset
+    if (!flagKey) {
+      return Response.json(
+        { error: "Flag key must be non-empty" },
+        { status: 400 },
+      );
+    }
+
+    if (!ALLOWED_KEY_RE.test(flagKey)) {
+      return Response.json(
+        { error: "Invalid flag key format. Must match: skills.<skillId>.enabled" },
+        { status: 400 },
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return Response.json(
+        { error: "Request body must be valid JSON" },
+        { status: 400 },
+      );
+    }
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return Response.json(
+        { error: "Request body must be a JSON object" },
+        { status: 400 },
+      );
+    }
+
+    const { enabled } = body as { enabled?: unknown };
+    if (typeof enabled !== "boolean") {
+      return Response.json(
+        { error: "\"enabled\" must be a boolean" },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const config = readConfigFile();
+
+      // Preserve existing config keys; only update featureFlags
+      const existingFlags =
+        config.featureFlags && typeof config.featureFlags === "object" && !Array.isArray(config.featureFlags)
+          ? (config.featureFlags as Record<string, unknown>)
+          : {};
+
+      config.featureFlags = { ...existingFlags, [flagKey]: enabled };
+
+      writeConfigFileAtomic(config);
+
+      log.info({ flagKey, enabled }, "Feature flag updated");
+
+      return Response.json({ key: flagKey, enabled });
+    } catch (err) {
+      log.error({ err, flagKey }, "Failed to update feature flag");
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
+  };
+}

--- a/gateway/src/http/routes/feature-flags.ts
+++ b/gateway/src/http/routes/feature-flags.ts
@@ -17,13 +17,21 @@ function getConfigPath(): string {
   return join(getRootDir(), "workspace", "config.json");
 }
 
-function readConfigFile(): Record<string, unknown> {
+type ConfigReadResult =
+  | { ok: true; data: Record<string, unknown> }
+  | { ok: false; reason: "not_found" }
+  | { ok: false; reason: "malformed"; detail: string };
+
+function readConfigFile(): ConfigReadResult {
   const cfgPath = getConfigPath();
+  if (!existsSync(cfgPath)) {
+    return { ok: true, data: {} };
+  }
   try {
     const raw = readFileSync(cfgPath, "utf-8");
-    return JSON.parse(raw);
-  } catch {
-    return {};
+    return { ok: true, data: JSON.parse(raw) };
+  } catch (err) {
+    return { ok: false, reason: "malformed", detail: String(err) };
   }
 }
 
@@ -51,7 +59,9 @@ export type FeatureFlagEntry = {
 export function createFeatureFlagsGetHandler() {
   return async (_req: Request): Promise<Response> => {
     try {
-      const config = readConfigFile();
+      const result = readConfigFile();
+      // For GET, a malformed config degrades gracefully to empty flags
+      const config = result.ok ? result.data : {};
       const flags: Record<string, boolean> = {};
       const raw = config.featureFlags;
       if (raw && typeof raw === "object" && !Array.isArray(raw)) {
@@ -117,7 +127,16 @@ export function createFeatureFlagsPatchHandler() {
     }
 
     try {
-      const config = readConfigFile();
+      const result = readConfigFile();
+      if (!result.ok) {
+        log.error({ reason: result.reason, detail: result.detail }, "Config file is malformed, refusing to overwrite");
+        return Response.json(
+          { error: "Config file is malformed, cannot safely write" },
+          { status: 500 },
+        );
+      }
+
+      const config = result.data;
 
       // Preserve existing config keys; only update featureFlags
       const existingFlags =

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -435,7 +435,12 @@ function main() {
           authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
           return Response.json({ error: "Unauthorized" }, { status: 401 });
         }
-        const flagKey = decodeURIComponent(featureFlagPatchMatch[1]);
+        let flagKey: string;
+        try {
+          flagKey = decodeURIComponent(featureFlagPatchMatch[1]);
+        } catch {
+          return Response.json({ error: "Invalid flag key encoding" }, { status: 400 });
+        }
         return handleFeatureFlagsPatch(tracedReq, flagKey);
       }
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -26,6 +26,7 @@ import { createWhatsAppDeliverHandler } from "./http/routes/whatsapp-deliver.js"
 import { createSlackDeliverHandler } from "./http/routes/slack-deliver.js";
 import { createOAuthCallbackHandler } from "./http/routes/oauth-callback.js";
 import { createPairingProxyHandler } from "./http/routes/pairing-proxy.js";
+import { createFeatureFlagsGetHandler, createFeatureFlagsPatchHandler } from "./http/routes/feature-flags.js";
 import { validateBearerToken } from "./http/auth/bearer.js";
 import { getLogger, initLogger } from "./logger.js";
 import { CircuitBreakerOpenError } from "./runtime/client.js";
@@ -145,6 +146,8 @@ function main() {
   const handleSlackDeliver = createSlackDeliverHandler(config);
   const handleOAuthCallback = createOAuthCallbackHandler(config);
   const pairingProxy = createPairingProxyHandler(config);
+  const handleFeatureFlagsGet = createFeatureFlagsGetHandler();
+  const handleFeatureFlagsPatch = createFeatureFlagsPatchHandler();
 
   const handleRuntimeProxy = config.runtimeProxyEnabled
     ? createRuntimeProxyHandler(config)
@@ -395,6 +398,45 @@ function main() {
           authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
         }
         return res;
+      }
+
+      // ── Feature flags API ──
+      if (url.pathname === "/v1/feature-flags" && req.method === "GET") {
+        if (!config.runtimeBearerToken) {
+          return Response.json(
+            { error: "Service not configured: bearer token required" },
+            { status: 503 },
+          );
+        }
+        const authResult = validateBearerToken(
+          tracedReq.headers.get("authorization"),
+          config.runtimeBearerToken,
+        );
+        if (!authResult.authorized) {
+          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+          return Response.json({ error: "Unauthorized" }, { status: 401 });
+        }
+        return handleFeatureFlagsGet(tracedReq);
+      }
+
+      const featureFlagPatchMatch = url.pathname.match(/^\/v1\/feature-flags\/(.+)$/);
+      if (featureFlagPatchMatch && req.method === "PATCH") {
+        if (!config.runtimeBearerToken) {
+          return Response.json(
+            { error: "Service not configured: bearer token required" },
+            { status: 503 },
+          );
+        }
+        const authResult = validateBearerToken(
+          tracedReq.headers.get("authorization"),
+          config.runtimeBearerToken,
+        );
+        if (!authResult.authorized) {
+          authRateLimiter.recordFailure(getClientIp(req, svr, config.trustProxy));
+          return Response.json({ error: "Unauthorized" }, { status: 401 });
+        }
+        const flagKey = decodeURIComponent(featureFlagPatchMatch[1]);
+        return handleFeatureFlagsPatch(tracedReq, flagKey);
       }
 
       if (handleRuntimeProxy) {


### PR DESCRIPTION
Add GET /v1/feature-flags and PATCH /v1/feature-flags/:flagKey endpoints to gateway with workspace config file persistence. Atomic writes and key validation included. Part of #10145.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
