### PR TITLE
fix: handle re-install rename and use collision-safe namespace encoding

### DIFF
--- a/assistant/src/__tests__/skillssh-install.test.ts
+++ b/assistant/src/__tests__/skillssh-install.test.ts
@@ -135,6 +135,18 @@ describe('namespacedSkillDir', () => {
   test('handles deeply nested source paths', () => {
     expect(namespacedSkillDir('a/b/c', 'x')).toBe('a--b--c--x');
   });
+
+  test('escapes literal double-hyphens in source to prevent collisions', () => {
+    // Without escaping, "foo/bar--baz" and "foo--bar/baz" would both produce
+    // "foo--bar--baz--skill". The encoding must be injective.
+    const nsA = namespacedSkillDir('foo/bar--baz', 'skill');
+    const nsB = namespacedSkillDir('foo--bar/baz', 'skill');
+    expect(nsA).not.toBe(nsB);
+  });
+
+  test('round-trips sources containing literal double-hyphens', () => {
+    expect(namespacedSkillDir('org--team/repo', 'x')).toBe('org-_-team--repo--x');
+  });
 });
 
 // ─── Security gate tests ─────────────────────────────────────────────────────────
@@ -301,6 +313,31 @@ describe('skillsshInstall namespacing', () => {
     expect(nsA).toBe('orgA--repoA--shared-skill');
     expect(nsB).toBe('orgB--repoB--shared-skill');
     expect(nsA).not.toBe(nsB);
+  });
+
+  test('re-install succeeds when namespaced directory already exists', async () => {
+    const mockSpawn = mockSuccessfulSpawn();
+    try {
+      // First install
+      const firstResult = await skillsshInstall({
+        candidate: makeCandidate(),
+        securityDecision: makeProceedDecision(),
+      });
+      expect(firstResult.success).toBe(true);
+
+      const namespacedDir = join(TEST_DIR, 'skills', 'test-org--test-repo--my-skill');
+      expect(existsSync(join(namespacedDir, 'SKILL.md'))).toBe(true);
+
+      // Second install (re-install) -- should not throw ENOTEMPTY
+      const secondResult = await skillsshInstall({
+        candidate: makeCandidate(),
+        securityDecision: makeProceedDecision(),
+      });
+      expect(secondResult.success).toBe(true);
+      expect(existsSync(join(namespacedDir, 'SKILL.md'))).toBe(true);
+    } finally {
+      mockSpawn.mockRestore();
+    }
   });
 });
 

--- a/assistant/src/skills/skillssh-install.ts
+++ b/assistant/src/skills/skillssh-install.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import { getLogger } from '../util/logger.js';
@@ -66,11 +66,13 @@ function getSkillsShProjectRoot(): string {
 
 /**
  * Derive a source-namespaced directory name from source and skillId.
- * Replaces slashes with double-hyphens so the result is a flat, safe directory name.
+ * Uses collision-safe encoding: literal `--` in the source is escaped to `-_-`
+ * before `/` is replaced with `--`, making the mapping injective.
  * Example: source="org/repo", skillId="my-skill" -> "org--repo--my-skill"
+ * Example: source="foo--bar/baz", skillId="x" -> "foo-_-bar--baz--x"
  */
 export function namespacedSkillDir(source: string, skillId: string): string {
-  const sanitized = source.replace(/\//g, '--');
+  const sanitized = source.replace(/--/g, '-_-').replace(/\//g, '--');
   return `${sanitized}--${skillId}`;
 }
 
@@ -227,9 +229,14 @@ export async function skillsshInstall(
       };
     }
 
-    // Relocate to namespaced directory when the raw and namespaced paths differ
+    // Relocate to namespaced directory when the raw and namespaced paths differ.
+    // On re-install the namespaced dir may already exist from a previous install,
+    // so remove it first to prevent ENOTEMPTY from renameSync.
     if (rawInstalledDir !== namespacedDir) {
       mkdirSync(dirname(namespacedDir), { recursive: true });
+      if (existsSync(namespacedDir)) {
+        rmSync(namespacedDir, { recursive: true });
+      }
       renameSync(rawInstalledDir, namespacedDir);
     }
 


### PR DESCRIPTION
Address reviewer feedback from PR #10160:

- Remove existing namespaced directory before renameSync to prevent ENOTEMPTY on re-install
- Use collision-safe encoding for source namespaces (escape literal `--` as `-_-` before replacing `/` with `--`) to prevent directory collisions between sources like `foo/bar--baz` and `foo--bar/baz`
- Add tests for both fixes: re-install scenario and collision-safe encoding injectivity
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
