### PR TITLE
fix: exempt command -v from high-risk and tighten rm rule scope

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -378,6 +378,42 @@ describe('Permission Checker', () => {
       test('wrapped pkill via nohup is high risk', async () => {
         expect(await classifyRisk('bash', { command: 'nohup pkill node' })).toBe(RiskLevel.High);
       });
+
+      test('command -v is low risk (read-only lookup)', async () => {
+        expect(await classifyRisk('bash', { command: 'command -v rm' })).toBe(RiskLevel.Low);
+      });
+
+      test('command -V is low risk (read-only lookup)', async () => {
+        expect(await classifyRisk('bash', { command: 'command -V sudo' })).toBe(RiskLevel.Low);
+      });
+
+      test('command without -v/-V flag escalates wrapped program', async () => {
+        expect(await classifyRisk('bash', { command: 'command rm file.txt' })).toBe(RiskLevel.High);
+      });
+
+      test('rm BOOTSTRAP.md (bare safe file) is medium risk', async () => {
+        expect(await classifyRisk('bash', { command: 'rm BOOTSTRAP.md' })).toBe(RiskLevel.Medium);
+      });
+
+      test('rm UPDATES.md (bare safe file) is medium risk', async () => {
+        expect(await classifyRisk('bash', { command: 'rm UPDATES.md' })).toBe(RiskLevel.Medium);
+      });
+
+      test('rm -rf BOOTSTRAP.md is still high risk (flags present)', async () => {
+        expect(await classifyRisk('bash', { command: 'rm -rf BOOTSTRAP.md' })).toBe(RiskLevel.High);
+      });
+
+      test('rm /path/to/BOOTSTRAP.md is still high risk (path separator)', async () => {
+        expect(await classifyRisk('bash', { command: 'rm /path/to/BOOTSTRAP.md' })).toBe(RiskLevel.High);
+      });
+
+      test('rm BOOTSTRAP.md other.txt is still high risk (multiple targets)', async () => {
+        expect(await classifyRisk('bash', { command: 'rm BOOTSTRAP.md other.txt' })).toBe(RiskLevel.High);
+      });
+
+      test('rm somefile.md is still high risk (not a known safe file)', async () => {
+        expect(await classifyRisk('bash', { command: 'rm somefile.md' })).toBe(RiskLevel.High);
+      });
     });
 
     // unknown tool

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -101,6 +101,19 @@ const WRAPPER_PROGRAMS = new Set([
 // value of -u) as the wrapped program instead of `echo`.
 const ENV_VALUE_FLAGS = new Set(['-u', '--unset', '-C', '--chdir']);
 
+// Bare filenames that `rm` is allowed to delete at Medium risk (instead of
+// High) so workspace-scoped allow rules can approve them without the
+// dangerous `allowHighRisk` flag. Only matches when the args contain no
+// flags and exactly one of these filenames.
+const RM_SAFE_BARE_FILES = new Set(['BOOTSTRAP.md', 'UPDATES.md']);
+
+function isRmOfKnownSafeFile(args: string[]): boolean {
+  if (args.length !== 1) return false;
+  const target = args[0];
+  if (target.startsWith('-') || target.includes('/')) return false;
+  return RM_SAFE_BARE_FILES.has(target);
+}
+
 /**
  * Given a segment whose program is a known wrapper, return the first
  * non-flag argument (i.e. the wrapped program name).  Returns `undefined`
@@ -385,6 +398,13 @@ async function classifyRiskUncached(toolName: string, input: Record<string, unkn
       if (HIGH_RISK_PROGRAMS.has(prog)) return RiskLevel.High;
 
       if (prog === 'rm') {
+        // `rm` of known safe workspace files (no flags, bare filename) is
+        // Medium rather than High so scope-limited allow rules can approve
+        // it without needing allowHighRisk, which would bypass path checks.
+        if (isRmOfKnownSafeFile(seg.args)) {
+          maxRisk = RiskLevel.Medium;
+          continue;
+        }
         return RiskLevel.High;
       }
 
@@ -402,6 +422,11 @@ async function classifyRiskUncached(toolName: string, input: Record<string, unkn
       }
 
       if (WRAPPER_PROGRAMS.has(prog)) {
+        // `command -v` and `command -V` are read-only lookups (print where
+        // a command lives) — don't escalate to high risk for those.
+        if (prog === 'command' && seg.args.length > 0 && (seg.args[0] === '-v' || seg.args[0] === '-V')) {
+          continue;
+        }
         const wrapped = getWrappedProgram(seg);
         if (wrapped === 'rm') return RiskLevel.High;
         if (wrapped && HIGH_RISK_PROGRAMS.has(wrapped)) return RiskLevel.High;

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -132,7 +132,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     scope: workspaceDir,
     decision: 'allow',
     priority: 100,
-    allowHighRisk: true,
   };
 
   const updatesDeleteRule: DefaultRuleTemplate = {
@@ -142,7 +141,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     scope: workspaceDir,
     decision: 'allow',
     priority: 100,
-    allowHighRisk: true,
   };
 
   // Skill source directories — writing or editing skill source files should


### PR DESCRIPTION
Address reviewer feedback from PR #10156:

- Skip high-risk escalation when wrapper is 'command' with -v/-V flag (read-only lookup)
- Tighten bootstrap/updates rm rules to avoid auto-allowing high-risk deletions outside workspace
  - Remove allowHighRisk: true from default rm BOOTSTRAP.md and rm UPDATES.md rules
  - Lower risk classification for rm of known safe bare filenames (BOOTSTRAP.md, UPDATES.md) to Medium
  - This ensures scope-scoped allow rules work for the legitimate case while preventing cd-prefix bypass attacks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
