### PR TITLE
fix: classify managed skills as local instead of first-party by default

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -29,7 +29,7 @@ import { CONFIG_RELOAD_DEBOUNCE_MS, defineHandlers, ensureSkillEntry, type Handl
 // ─── Provenance resolution ──────────────────────────────────────────────────
 
 interface SkillProvenance {
-  kind: 'first-party' | 'third-party';
+  kind: 'first-party' | 'third-party' | 'local';
   provider?: string;
   originId?: string;
   sourceUrl?: string;
@@ -65,16 +65,17 @@ function resolveProvenance(summary: SkillSummary): SkillProvenance {
         sourceUrl: summary.homepage ?? `${CLAWHUB_BASE_URL}/skills/${encodeURIComponent(summary.id)}`,
       };
     }
-    // Default managed skills to first-party (most are installed from Vellum catalog)
-    return { kind: 'first-party', provider: 'Vellum' };
+    // No positive evidence of origin -- could be user-authored or from Vellum catalog.
+    // Default to "local" to avoid mislabeling user-created skills as first-party.
+    return { kind: 'local' };
   }
 
   // Workspace and extra skills are user-provided
   if (summary.source === 'workspace' || summary.source === 'extra') {
-    return { kind: 'third-party', provider: 'local' };
+    return { kind: 'local' };
   }
 
-  return { kind: 'third-party' };
+  return { kind: 'local' };
 }
 
 export function handleSkillsList(socket: net.Socket, ctx: HandlerContext): void {

--- a/assistant/src/daemon/ipc-contract/skills.ts
+++ b/assistant/src/daemon/ipc-contract/skills.ts
@@ -95,7 +95,7 @@ export interface SkillsListResponse {
     updateAvailable: boolean;
     userInvocable: boolean;
     clawhub?: { author: string; stars: number; installs: number; reports: number; publishedAt: string };
-    provenance?: { kind: 'first-party' | 'third-party'; provider?: string; originId?: string; sourceUrl?: string };
+    provenance?: { kind: 'first-party' | 'third-party' | 'local'; provider?: string; originId?: string; sourceUrl?: string };
   }>;
 }
 

--- a/clients/ios/Views/IdentityView.swift
+++ b/clients/ios/Views/IdentityView.swift
@@ -264,15 +264,17 @@ struct IdentityView: View {
                             .foregroundColor(VColor.textPrimary)
 
                         if let provenance = skill.provenance {
-                            Text(provenance.kind == "first-party" ? (provenance.provider ?? "Vellum") : (provenance.provider ?? "Third-party"))
+                            let label = provenance.kind == "first-party" ? (provenance.provider ?? "Vellum") : provenance.kind == "local" ? "Local" : (provenance.provider ?? "Third-party")
+                            let badgeColor: Color = provenance.kind == "first-party" ? .blue : provenance.kind == "local" ? .secondary : .orange
+                            Text(label)
                                 .font(.caption2)
                                 .padding(.horizontal, 5)
                                 .padding(.vertical, 1)
                                 .background(
                                     Capsule()
-                                        .fill(provenance.kind == "first-party" ? Color.blue.opacity(0.15) : Color.orange.opacity(0.15))
+                                        .fill(badgeColor.opacity(0.15))
                                 )
-                                .foregroundColor(provenance.kind == "first-party" ? .blue : .orange)
+                                .foregroundColor(badgeColor)
                         }
                     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -1168,6 +1168,8 @@ struct AgentPanelContent: View {
             return provenance.provider ?? "Vellum"
         } else if provenance.kind == "third-party" {
             return provenance.provider ?? "Third-party"
+        } else if provenance.kind == "local" {
+            return "Local"
         }
         return nil
     }
@@ -1187,7 +1189,14 @@ struct AgentPanelContent: View {
 
     private func provenanceBadgeColor(_ skill: SkillInfo) -> Color {
         guard let provenance = skill.provenance else { return VColor.textMuted }
-        return provenance.kind == "first-party" ? VColor.accent : Amber._500
+        switch provenance.kind {
+        case "first-party":
+            return VColor.accent
+        case "third-party":
+            return Amber._500
+        default:
+            return VColor.textMuted
+        }
     }
 
     private func skillMetaItem(icon: String, value: String, color: Color = VColor.textMuted) -> some View {

--- a/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
@@ -473,6 +473,14 @@ private struct SkillRow: View {
                     .background(Color.orange.opacity(0.15))
                     .foregroundStyle(.orange)
                     .clipShape(Capsule())
+            } else if provenance.kind == "local" {
+                Text("Local")
+                    .font(.caption2)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1)
+                    .background(Color.secondary.opacity(0.15))
+                    .foregroundStyle(.secondary)
+                    .clipShape(Capsule())
             }
         }
     }

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1045,7 +1045,7 @@ public typealias ClawhubInfo = IPCSkillsListResponseSkillClawhub
 /// Backed by generated `IPCSkillsListResponseSkillMissingRequirements`.
 public typealias MissingRequirements = IPCSkillsListResponseSkillMissingRequirements
 
-/// Provenance metadata indicating whether a skill is first-party or third-party.
+/// Provenance metadata indicating whether a skill is first-party, third-party, or local.
 /// Backed by generated `IPCSkillsListResponseSkillProvenance`.
 public typealias SkillProvenance = IPCSkillsListResponseSkillProvenance
 


### PR DESCRIPTION
Address reviewer feedback from PR #10162:

- Default managed skills without provenance markers to kind 'local' instead of misleading 'first-party'
- Update provenance type and UI code to handle the new 'local' kind
- Workspace/extra skills also now use 'local' instead of 'third-party' with provider 'local'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
