### PR TITLE
Move Gateway card to Account settings page

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -1,0 +1,448 @@
+import Foundation
+import SwiftUI
+import VellumAssistantShared
+
+/// Standalone gateway configuration card — local gateway target, gateway URL,
+/// connection status, and bearer token management. Designed to be embedded
+/// in any settings tab.
+@MainActor
+struct GatewaySettingsCard: View {
+    @ObservedObject var store: SettingsStore
+    var daemonClient: DaemonClient?
+
+    @State private var gatewayUrlText: String = ""
+    @FocusState private var isGatewayUrlFocused: Bool
+    @State private var bearerToken: String = ""
+    @State private var tokenRevealed: Bool = false
+    @State private var tokenCopied: Bool = false
+    @State private var gatewayTargetCopied: Bool = false
+    @State private var showingRegenerateConfirmation: Bool = false
+    @State private var isRegeneratingToken: Bool = false
+    @State private var refreshSpinning: Set<String> = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("Gateway")
+                .font(VFont.sectionTitle)
+                .foregroundColor(VColor.textPrimary)
+
+            gatewayContent
+        }
+        .padding(VSpacing.lg)
+        .vCard(background: VColor.surfaceSubtle)
+        .onAppear {
+            store.refreshIngressConfig()
+            gatewayUrlText = store.ingressPublicBaseUrl
+            refreshBearerToken()
+        }
+        .onChange(of: store.ingressPublicBaseUrl) { _, newValue in
+            if !isGatewayUrlFocused {
+                gatewayUrlText = newValue
+            }
+        }
+        .onChange(of: isGatewayUrlFocused) { _, focused in
+            if !focused {
+                gatewayUrlText = store.ingressPublicBaseUrl
+            }
+        }
+        .onChange(of: store.ingressConfigLoaded) { _, loaded in
+            guard loaded else { return }
+            Task { await store.testGatewayOnly() }
+            Task { await store.testTunnelOnly() }
+        }
+        .alert("Regenerate Bearer Token", isPresented: $showingRegenerateConfirmation) {
+            Button("Cancel", role: .cancel) {}
+            Button("Regenerate", role: .destructive) {
+                regenerateHttpToken()
+            }
+        } message: {
+            Text("This will generate a new security token and restart your assistant. Any paired devices will need to reconnect.")
+        }
+    }
+
+    // MARK: - Gateway Content
+
+    private var gatewayContent: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            // Local Gateway Target (read-only)
+            HStack(spacing: VSpacing.xs) {
+                Text("Local Gateway Target")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+            }
+
+            HStack(spacing: VSpacing.sm) {
+                Text(store.localGatewayTarget)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.textPrimary)
+                    .textSelection(.enabled)
+                    .padding(VSpacing.md)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(VColor.surface.opacity(0.5))
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.surfaceBorder.opacity(0.3), lineWidth: 1)
+                    )
+
+                Button {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(store.localGatewayTarget, forType: .string)
+                    gatewayTargetCopied = true
+                    Task {
+                        try? await Task.sleep(nanoseconds: 2_000_000_000)
+                        gatewayTargetCopied = false
+                    }
+                } label: {
+                    Image(systemName: gatewayTargetCopied ? "checkmark" : "doc.on.doc")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(gatewayTargetCopied ? VColor.success : VColor.textSecondary)
+                        .frame(width: 28, height: 28)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Copy gateway address")
+                .help("Copy address")
+            }
+
+            Text("Point your tunnel (ngrok, Cloudflare, etc.) to this address.")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+
+            // Gateway connection status (checks local daemon)
+            connectionStatusRow(
+                label: "Gateway",
+                status: gatewayStatusInfo,
+                isRefreshing: store.isCheckingGateway,
+                lastChecked: store.gatewayLastChecked
+            ) {
+                Task { await store.testGatewayOnly() }
+            }
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            // Gateway URL field
+            HStack(spacing: VSpacing.xs) {
+                Text("Gateway URL")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+            }
+
+            HStack(spacing: VSpacing.sm) {
+                TextField("https://your-tunnel.example.com", text: $gatewayUrlText)
+                    .focused($isGatewayUrlFocused)
+                    .vInputStyle()
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+
+                VButton(label: "Save", style: .primary) {
+                    store.saveIngressPublicBaseUrl(gatewayUrlText)
+                }
+            }
+
+            // Tunnel connection status (checks public URL)
+            connectionStatusRow(
+                label: "Tunnel",
+                status: tunnelStatusInfo,
+                isRefreshing: store.isCheckingTunnel,
+                lastChecked: store.tunnelLastChecked
+            ) {
+                Task { await store.testTunnelOnly() }
+            }
+
+            // Diagnostic message when gateway is up but tunnel is down
+            if store.gatewayReachable == true,
+               !store.ingressPublicBaseUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+               store.ingressReachable == false {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(VColor.warning)
+                        .font(.system(size: 12))
+                    Text("Gateway is running but tunnel is unreachable. Check your tunnel configuration.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.warning)
+                }
+            }
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            bearerTokenContent
+        }
+    }
+
+    // MARK: - Bearer Token Content
+
+    private var bearerTokenContent: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Bearer Token")
+                .font(VFont.bodyMedium)
+                .foregroundColor(VColor.textSecondary)
+
+            if bearerToken.isEmpty {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(VColor.warning)
+                        .font(.system(size: 12))
+                    Text("Bearer token not found. Restart the daemon to generate it.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                }
+            } else {
+                HStack(spacing: VSpacing.sm) {
+                    // Masked or revealed token
+                    if tokenRevealed {
+                        Text(bearerToken)
+                            .font(VFont.mono)
+                            .foregroundColor(VColor.textPrimary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    } else {
+                        Text(String(repeating: "\u{2022}", count: min(bearerToken.count, 24)))
+                            .font(VFont.mono)
+                            .foregroundColor(VColor.textPrimary)
+                            .lineLimit(1)
+                    }
+
+                    Spacer()
+
+                    // Reveal/hide toggle
+                    Button {
+                        tokenRevealed.toggle()
+                    } label: {
+                        Image(systemName: tokenRevealed ? "eye.slash" : "eye")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(VColor.textSecondary)
+                            .frame(width: 28, height: 28)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(tokenRevealed ? "Hide token" : "Reveal token")
+                    .help(tokenRevealed ? "Hide token" : "Reveal token")
+
+                    // Copy button
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(bearerToken, forType: .string)
+                        tokenCopied = true
+                        Task {
+                            try? await Task.sleep(nanoseconds: 2_000_000_000)
+                            tokenCopied = false
+                        }
+                    } label: {
+                        Image(systemName: tokenCopied ? "checkmark" : "doc.on.doc")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(tokenCopied ? VColor.success : VColor.textSecondary)
+                            .frame(width: 28, height: 28)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Copy bearer token")
+                    .help("Copy token")
+
+                    // Regenerate button
+                    Button("Regenerate") {
+                        showingRegenerateConfirmation = true
+                    }
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.accent)
+                }
+            }
+        }
+    }
+
+    // MARK: - Connection Status Helpers
+
+    private struct ConnectionStatusInfo {
+        let label: String
+        let color: Color
+        let icon: String
+    }
+
+    private var gatewayStatusInfo: ConnectionStatusInfo {
+        guard let reachable = store.gatewayReachable else {
+            return ConnectionStatusInfo(label: "Unknown", color: VColor.textMuted, icon: "questionmark.circle.fill")
+        }
+        if reachable {
+            return ConnectionStatusInfo(label: "Running", color: VColor.success, icon: "checkmark.circle.fill")
+        } else {
+            return ConnectionStatusInfo(label: "Stopped", color: VColor.error, icon: "xmark.circle.fill")
+        }
+    }
+
+    private var tunnelStatusInfo: ConnectionStatusInfo {
+        let trimmedUrl = store.ingressPublicBaseUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // No URL configured
+        if trimmedUrl.isEmpty {
+            return ConnectionStatusInfo(label: "Not configured", color: VColor.textMuted, icon: "minus.circle.fill")
+        }
+
+        // URL is non-empty but not a valid absolute HTTP(S) URL
+        if let parsed = URL(string: trimmedUrl), let scheme = parsed.scheme, ["http", "https"].contains(scheme.lowercased()) {
+            // valid — fall through to further checks below
+        } else {
+            return ConnectionStatusInfo(label: "Invalid URL format", color: VColor.error, icon: "exclamationmark.circle.fill")
+        }
+
+        // URL is set but ingress is disabled
+        if !store.ingressEnabled {
+            return ConnectionStatusInfo(label: "URL set but gateway not active", color: VColor.warning, icon: "exclamationmark.triangle.fill")
+        }
+
+        // Haven't tested yet
+        guard let reachable = store.ingressReachable else {
+            return ConnectionStatusInfo(label: "Unknown", color: VColor.textMuted, icon: "questionmark.circle.fill")
+        }
+
+        if reachable {
+            return ConnectionStatusInfo(label: "Reachable", color: VColor.success, icon: "checkmark.circle.fill")
+        } else {
+            return ConnectionStatusInfo(label: "Unreachable", color: VColor.error, icon: "xmark.circle.fill")
+        }
+    }
+
+    private func connectionStatusRow(
+        label: String,
+        status: ConnectionStatusInfo,
+        isRefreshing: Bool = false,
+        lastChecked: Date? = nil,
+        onRefresh: (() -> Void)? = nil
+    ) -> some View {
+        let spinning = isRefreshing || refreshSpinning.contains(label)
+
+        return HStack(spacing: VSpacing.sm) {
+            Text(label)
+                .font(VFont.bodyMedium)
+                .foregroundColor(VColor.textSecondary)
+                .frame(width: 60, alignment: .leading)
+
+            Image(systemName: status.icon)
+                .foregroundColor(status.color)
+                .font(.system(size: 12))
+
+            Text(status.label)
+                .font(VFont.body)
+                .foregroundColor(status.color)
+
+            if let onRefresh {
+                let tooltipText: String = {
+                    if spinning { return "Checking..." }
+                    if let lastChecked { return "Last verified: \(relativeTimeString(from: lastChecked))" }
+                    return "Test connection"
+                }()
+
+                Button {
+                    guard !spinning else { return }
+                    refreshSpinning.insert(label)
+                    onRefresh()
+                    Task {
+                        try? await Task.sleep(nanoseconds: 500_000_000)
+                        refreshSpinning.remove(label)
+                    }
+                } label: {
+                    SpinningRefreshIcon(isSpinning: spinning)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Refresh \(label) status")
+                .help(tooltipText)
+            }
+
+            Spacer()
+        }
+    }
+
+    /// Returns a human-readable relative time string (e.g. "just now", "2 minutes ago").
+    private func relativeTimeString(from date: Date) -> String {
+        let seconds = Int(-date.timeIntervalSinceNow)
+        if seconds < 5 { return "just now" }
+        if seconds < 60 { return "\(seconds) seconds ago" }
+        let minutes = seconds / 60
+        if minutes == 1 { return "1 minute ago" }
+        if minutes < 60 { return "\(minutes) minutes ago" }
+        let hours = minutes / 60
+        if hours == 1 { return "1 hour ago" }
+        return "\(hours) hours ago"
+    }
+
+    // MARK: - Spinning Refresh Icon
+
+    private struct SpinningRefreshIcon: View {
+        let isSpinning: Bool
+
+        @State private var angle: Double = 0
+
+        var body: some View {
+            Image(systemName: "arrow.triangle.2.circlepath")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(isSpinning ? VColor.accent : VColor.textMuted)
+                .rotationEffect(.degrees(angle))
+                .frame(width: 24, height: 24)
+                .contentShape(Rectangle())
+                .task(id: isSpinning) {
+                    if isSpinning {
+                        angle = 0
+                        while !Task.isCancelled {
+                            withAnimation(.linear(duration: 1)) {
+                                angle += 360
+                            }
+                            try? await Task.sleep(nanoseconds: 1_000_000_000)
+                        }
+                    } else {
+                        angle = 0
+                    }
+                }
+        }
+    }
+
+    // MARK: - Token Helpers
+
+    private func refreshBearerToken() {
+        bearerToken = readHttpToken() ?? ""
+    }
+
+    private func regenerateHttpToken() {
+        let tokenPath = resolveHttpTokenPath()
+        // Generate new random bytes before deleting the old file so a
+        // SecRandomCopyBytes failure doesn't leave us with no token at all.
+        var bytes = [UInt8](repeating: 0, count: 32)
+        guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else { return }
+        let newToken = bytes.map { String(format: "%02x", $0) }.joined()
+        try? FileManager.default.removeItem(atPath: tokenPath)
+        let dir = (tokenPath as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: tokenPath, contents: Data(newToken.utf8), attributes: [.posixPermissions: 0o600])
+        bearerToken = newToken
+        // Kill the daemon so the health monitor restarts it with the new token.
+        // The daemon only reads the token at startup, so a restart is required.
+        isRegeneratingToken = true
+        let pidPath = resolvePidPath()
+        if let pidStr = try? String(contentsOfFile: pidPath, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines),
+           let pid = Int32(pidStr) {
+            kill(pid, SIGTERM)
+        }
+        // Wait for the daemon to restart and become reachable with the new token.
+        Task {
+            let base = store.localGatewayTarget.hasSuffix("/")
+                ? String(store.localGatewayTarget.dropLast())
+                : store.localGatewayTarget
+            guard let url = URL(string: "\(base)/v1/health") else {
+                isRegeneratingToken = false
+                return
+            }
+            var request = URLRequest(url: url)
+            request.setValue("Bearer \(newToken)", forHTTPHeaderField: "Authorization")
+            request.timeoutInterval = 2
+            for _ in 0..<30 { // up to ~30s
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                if let (_, response) = try? await URLSession.shared.data(for: request),
+                   let http = response as? HTTPURLResponse, http.statusCode == 200 {
+                    isRegeneratingToken = false
+                    return
+                }
+            }
+            isRegeneratingToken = false
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -29,6 +29,7 @@ struct SettingsAccountTab: View {
             accountSection
             assistantInfoSection
             switchAssistantSection
+            GatewaySettingsCard(store: store, daemonClient: daemonClient)
             retireAssistantSection
             hatchNewAssistantSection
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -2,23 +2,19 @@ import Foundation
 import SwiftUI
 import VellumAssistantShared
 
-/// Channels settings tab — Gateway URL, Bearer Token, channel configuration,
-/// and QR pairing UI. This is the single source of truth for configuring how devices
+/// Channels settings tab — channel configuration and QR pairing UI.
+/// This is the single source of truth for configuring how devices
 /// and integrations reach this Mac.
 @MainActor
 struct SettingsChannelsTab: View {
     @ObservedObject var store: SettingsStore
     var daemonClient: DaemonClient?
 
-    @State private var gatewayUrlText: String = ""
-    @FocusState private var isGatewayUrlFocused: Bool
     @State private var bearerToken: String = ""
     @State private var tokenRevealed: Bool = false
     @State private var tokenCopied: Bool = false
-    @State private var gatewayTargetCopied: Bool = false
     @State private var showingPairingQR: Bool = false
     @State private var showingRegenerateConfirmation: Bool = false
-    @State private var gatewayExpanded: Bool = true
     @State private var advancedExpanded: Bool = false
 
     // Telegram credential entry
@@ -64,9 +60,6 @@ struct SettingsChannelsTab: View {
     @State private var countdownTimer: Timer?
     @State private var countdownTimerRefCount: Int = 0
 
-    // Refresh button minimum-spin state (keyed by row label)
-    @State private var refreshSpinning: Set<String> = []
-
     // Shared label column width for channelStatusRow and guardianLabel alignment
     private let labelColumnWidth: CGFloat = 140
 
@@ -76,30 +69,16 @@ struct SettingsChannelsTab: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
-            gatewaySection
             connectionsSection
         }
         .onAppear {
-            store.refreshIngressConfig()
             store.refreshAssistantEmail()
             store.refreshApprovedDevices()
-            gatewayUrlText = store.ingressPublicBaseUrl
             refreshBearerToken()
             store.refreshChannelGuardianStatus(channel: "telegram")
             store.refreshChannelGuardianStatus(channel: "sms")
             store.refreshChannelGuardianStatus(channel: "voice")
             store.fetchSlackChannelConfig()
-            gatewayExpanded = store.ingressPublicBaseUrl.isEmpty
-        }
-        .onChange(of: store.ingressPublicBaseUrl) { _, newValue in
-            if !isGatewayUrlFocused {
-                gatewayUrlText = newValue
-            }
-        }
-        .onChange(of: isGatewayUrlFocused) { _, focused in
-            if !focused {
-                gatewayUrlText = store.ingressPublicBaseUrl
-            }
         }
         .onChange(of: store.twilioHasCredentials) { _, hasCredentials in
             if !hasCredentials {
@@ -108,11 +87,6 @@ struct SettingsChannelsTab: View {
                 voiceSetupExpanded = false
                 voiceNumberPickerExpanded = false
             }
-        }
-        .onChange(of: store.ingressConfigLoaded) { _, loaded in
-            guard loaded else { return }
-            Task { await store.testGatewayOnly() }
-            Task { await store.testTunnelOnly() }
         }
         .alert("Regenerate Bearer Token", isPresented: $showingRegenerateConfirmation) {
             Button("Cancel", role: .cancel) {}
@@ -128,127 +102,6 @@ struct SettingsChannelsTab: View {
                 daemonClient: daemonClient
             )
         }
-    }
-
-    // MARK: - Gateway Section
-
-    private var gatewaySection: some View {
-        VDisclosureSection(
-            title: "Gateway",
-            icon: "network",
-            subtitle: !gatewayExpanded && !store.ingressPublicBaseUrl.isEmpty ? store.ingressPublicBaseUrl : nil,
-            isExpanded: $gatewayExpanded
-        ) {
-            VStack(alignment: .leading, spacing: VSpacing.md) {
-                // Local Gateway Target (read-only)
-                HStack(spacing: VSpacing.xs) {
-                    Text("Local Gateway Target")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                }
-
-                HStack(spacing: VSpacing.sm) {
-                    Text(store.localGatewayTarget)
-                        .font(VFont.mono)
-                        .foregroundColor(VColor.textPrimary)
-                        .textSelection(.enabled)
-                        .padding(VSpacing.md)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(VColor.surface.opacity(0.5))
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.surfaceBorder.opacity(0.3), lineWidth: 1)
-                        )
-
-                    Button {
-                        NSPasteboard.general.clearContents()
-                        NSPasteboard.general.setString(store.localGatewayTarget, forType: .string)
-                        gatewayTargetCopied = true
-                        Task {
-                            try? await Task.sleep(nanoseconds: 2_000_000_000)
-                            gatewayTargetCopied = false
-                        }
-                    } label: {
-                        Image(systemName: gatewayTargetCopied ? "checkmark" : "doc.on.doc")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundColor(gatewayTargetCopied ? VColor.success : VColor.textSecondary)
-                            .frame(width: 28, height: 28)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Copy gateway address")
-                    .help("Copy address")
-                }
-
-                Text("Point your tunnel (ngrok, Cloudflare, etc.) to this address.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textSecondary)
-
-                // Gateway connection status (checks local daemon)
-                connectionStatusRow(
-                    label: "Gateway",
-                    status: gatewayStatusInfo,
-                    isRefreshing: store.isCheckingGateway,
-                    lastChecked: store.gatewayLastChecked
-                ) {
-                    Task { await store.testGatewayOnly() }
-                }
-
-                Divider()
-                    .background(VColor.surfaceBorder)
-
-                // Gateway URL field
-                HStack(spacing: VSpacing.xs) {
-                    Text("Gateway URL")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                }
-
-                HStack(spacing: VSpacing.sm) {
-                    TextField("https://your-tunnel.example.com", text: $gatewayUrlText)
-                        .focused($isGatewayUrlFocused)
-                        .vInputStyle()
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
-
-                    VButton(label: "Save", style: .primary) {
-                        store.saveIngressPublicBaseUrl(gatewayUrlText)
-                    }
-                }
-
-                // Tunnel connection status (checks public URL)
-                connectionStatusRow(
-                    label: "Tunnel",
-                    status: tunnelStatusInfo,
-                    isRefreshing: store.isCheckingTunnel,
-                    lastChecked: store.tunnelLastChecked
-                ) {
-                    Task { await store.testTunnelOnly() }
-                }
-
-                // Diagnostic message when gateway is up but tunnel is down
-                if store.gatewayReachable == true,
-                   !store.ingressPublicBaseUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-                   store.ingressReachable == false {
-                    HStack(spacing: VSpacing.sm) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundColor(VColor.warning)
-                            .font(.system(size: 12))
-                        Text("Gateway is running but tunnel is unreachable. Check your tunnel configuration.")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.warning)
-                    }
-                }
-
-                Divider()
-                    .background(VColor.surfaceBorder)
-
-                bearerTokenContent
-            }
-        }
-        .padding(VSpacing.lg)
-        .vCard(background: VColor.surfaceSubtle)
     }
 
     // MARK: - Bearer Token Content
@@ -1801,159 +1654,6 @@ struct SettingsChannelsTab: View {
         }
     }
 
-
-    // MARK: - Spinning Refresh Icon
-
-    /// Standalone view for a continuously-rotating refresh icon.
-    ///
-    /// Uses `.task(id:)` to drive the rotation loop so that stopping
-    /// the animation is reliable (the task is cancelled when `isSpinning`
-    /// changes, which cleanly exits the animation loop).  The previous
-    /// `.animation(.repeatForever, value:)` + `nil` pattern has a known
-    /// SwiftUI bug where the repeating animation can persist after the
-    /// driving value becomes false.
-    private struct SpinningRefreshIcon: View {
-        let isSpinning: Bool
-
-        @State private var angle: Double = 0
-
-        var body: some View {
-            Image(systemName: "arrow.triangle.2.circlepath")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(isSpinning ? VColor.accent : VColor.textMuted)
-                .rotationEffect(.degrees(angle))
-                .frame(width: 24, height: 24)
-                .contentShape(Rectangle())
-                .task(id: isSpinning) {
-                    if isSpinning {
-                        angle = 0
-                        while !Task.isCancelled {
-                            withAnimation(.linear(duration: 1)) {
-                                angle += 360
-                            }
-                            try? await Task.sleep(nanoseconds: 1_000_000_000)
-                        }
-                    } else {
-                        angle = 0
-                    }
-                }
-        }
-    }
-
-    // MARK: - Connection Status Helpers
-
-    private struct ConnectionStatusInfo {
-        let label: String
-        let color: Color
-        let icon: String
-    }
-
-    private var gatewayStatusInfo: ConnectionStatusInfo {
-        guard let reachable = store.gatewayReachable else {
-            return ConnectionStatusInfo(label: "Unknown", color: VColor.textMuted, icon: "questionmark.circle.fill")
-        }
-        if reachable {
-            return ConnectionStatusInfo(label: "Running", color: VColor.success, icon: "checkmark.circle.fill")
-        } else {
-            return ConnectionStatusInfo(label: "Stopped", color: VColor.error, icon: "xmark.circle.fill")
-        }
-    }
-
-    private var tunnelStatusInfo: ConnectionStatusInfo {
-        let trimmedUrl = store.ingressPublicBaseUrl.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        // No URL configured
-        if trimmedUrl.isEmpty {
-            return ConnectionStatusInfo(label: "Not configured", color: VColor.textMuted, icon: "minus.circle.fill")
-        }
-
-        // URL is non-empty but not a valid absolute HTTP(S) URL
-        if let parsed = URL(string: trimmedUrl), let scheme = parsed.scheme, ["http", "https"].contains(scheme.lowercased()) {
-            // valid — fall through to further checks below
-        } else {
-            return ConnectionStatusInfo(label: "Invalid URL format", color: VColor.error, icon: "exclamationmark.circle.fill")
-        }
-
-        // URL is set but ingress is disabled — the backend ignores the URL when
-        // ingress.enabled is false, so public callbacks are effectively off.
-        if !store.ingressEnabled {
-            return ConnectionStatusInfo(label: "URL set but gateway not active", color: VColor.warning, icon: "exclamationmark.triangle.fill")
-        }
-
-        // Haven't tested yet
-        guard let reachable = store.ingressReachable else {
-            return ConnectionStatusInfo(label: "Unknown", color: VColor.textMuted, icon: "questionmark.circle.fill")
-        }
-
-        if reachable {
-            return ConnectionStatusInfo(label: "Reachable", color: VColor.success, icon: "checkmark.circle.fill")
-        } else {
-            return ConnectionStatusInfo(label: "Unreachable", color: VColor.error, icon: "xmark.circle.fill")
-        }
-    }
-
-    private func connectionStatusRow(
-        label: String,
-        status: ConnectionStatusInfo,
-        isRefreshing: Bool = false,
-        lastChecked: Date? = nil,
-        onRefresh: (() -> Void)? = nil
-    ) -> some View {
-        let spinning = isRefreshing || refreshSpinning.contains(label)
-
-        return HStack(spacing: VSpacing.sm) {
-            Text(label)
-                .font(VFont.bodyMedium)
-                .foregroundColor(VColor.textSecondary)
-                .frame(width: 60, alignment: .leading)
-
-            Image(systemName: status.icon)
-                .foregroundColor(status.color)
-                .font(.system(size: 12))
-
-            Text(status.label)
-                .font(VFont.body)
-                .foregroundColor(status.color)
-
-            if let onRefresh {
-                let tooltipText: String = {
-                    if spinning { return "Checking..." }
-                    if let lastChecked { return "Last verified: \(relativeTimeString(from: lastChecked))" }
-                    return "Test connection"
-                }()
-
-                Button {
-                    guard !spinning else { return }
-                    refreshSpinning.insert(label)
-                    onRefresh()
-                    Task {
-                        try? await Task.sleep(nanoseconds: 500_000_000)
-                        refreshSpinning.remove(label)
-                    }
-                } label: {
-                    SpinningRefreshIcon(isSpinning: spinning)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Refresh \(label) status")
-                .help(tooltipText)
-            }
-
-            Spacer()
-        }
-    }
-
-    /// Returns a human-readable relative time string (e.g. "just now", "2 minutes ago").
-    private func relativeTimeString(from date: Date) -> String {
-        let seconds = Int(-date.timeIntervalSinceNow)
-        if seconds < 5 { return "just now" }
-        if seconds < 60 { return "\(seconds) seconds ago" }
-        let minutes = seconds / 60
-        if minutes == 1 { return "1 minute ago" }
-        if minutes < 60 { return "\(minutes) minutes ago" }
-        let hours = minutes / 60
-        if hours == 1 { return "1 hour ago" }
-        return "\(hours) hours ago"
-    }
 
     // MARK: - Token Helpers
 


### PR DESCRIPTION
## Summary
- Extracted Gateway section into standalone `GatewaySettingsCard.swift` with all its state, views, and helpers
- Added `GatewaySettingsCard` to the Account tab above "Retire Assistant"
- Removed gateway section from Channels tab (bearer token + mobile pairing code remains since it's used by the mobile card)
- Restyled the Gateway header to use `VFont.sectionTitle` + `VColor.textPrimary`, consistent with other Account page card headers

## Original prompt
lets move the "Gateway" card to the "Account" page above "Retire Assistant" and make the header consistent with the other card headers on that page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
