### PR TITLE
fix: add public modifier to applicationDockMenu

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -510,7 +510,7 @@ extension AppDelegate {
         )
     }
 
-    func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {
+    public func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {
         let menu = NSMenu()
 
         let newChatItem = NSMenuItem(title: "New Chat", action: #selector(openNewChat), keyEquivalent: "")


### PR DESCRIPTION
## Summary

- `applicationDockMenu` in `AppDelegate+MenuBar.swift` must be `public` because `AppDelegate` is a `public final class` conforming to `NSApplicationDelegate`. The Swift compiler enforces that protocol requirement implementations match the access level of the conforming type.

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22467770817

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
