### PR TITLE
fix: remove stale 'clawhub' source references causing type check failure

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -43,16 +43,6 @@ function resolveProvenance(summary: SkillSummary): SkillProvenance {
     return { kind: 'first-party', provider: 'Vellum' };
   }
 
-  // Clawhub-sourced skills are third-party community skills
-  if (summary.source === 'clawhub') {
-    return {
-      kind: 'third-party',
-      provider: 'skills.sh',
-      originId: summary.id,
-      sourceUrl: `${CLAWHUB_BASE_URL}/skills/${encodeURIComponent(summary.id)}`,
-    };
-  }
-
   // Managed skills could be either first-party (installed from Vellum catalog)
   // or third-party (installed from clawhub). The homepage field serves as a
   // heuristic: Vellum catalog skills don't typically have a clawhub homepage.
@@ -89,7 +79,7 @@ export function handleSkillsList(socket: net.Socket, ctx: HandlerContext): void 
     description: r.summary.description,
     emoji: r.summary.emoji,
     homepage: r.summary.homepage,
-    source: r.summary.source as 'bundled' | 'managed' | 'workspace' | 'clawhub' | 'extra',
+    source: r.summary.source,
     state: (r.state === 'degraded' ? 'enabled' : r.state) as 'enabled' | 'disabled' | 'available',
     degraded: r.degraded,
     missingRequirements: r.missingRequirements,


### PR DESCRIPTION
## Summary
- Remove dead `'clawhub'` branch from `resolveProvenance()` — clawhub-installed skills are now classified as `'managed'` source, so this branch was unreachable and caused a TS2367 type error.
- Remove unnecessary type cast on `source` field in `handleSkillsList` that included the now-invalid `'clawhub'` literal.

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22467747845

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
