### PR TITLE
feat: add heartbeat config button and modal

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -65,6 +65,7 @@ struct SettingsPanel: View {
     @State private var showingTrustRules = false
     @State private var showingReminders = false
     @State private var showingScheduledTasks = false
+    @State private var showingHeartbeatConfig = false
     @State private var twitterClientId: String = ""
     @State private var twitterClientSecret: String = ""
     @State private var integrations: [IPCIntegrationListResponseIntegration] = []
@@ -207,6 +208,11 @@ struct SettingsPanel: View {
                 ScheduledTasksView(daemonClient: daemonClient)
             }
         }
+        .sheet(isPresented: $showingHeartbeatConfig) {
+            if let daemonClient {
+                HeartbeatConfigView(daemonClient: daemonClient)
+            }
+        }
     }
 
     // MARK: - Nav Sidebar
@@ -239,7 +245,7 @@ struct SettingsPanel: View {
         case .permissions:
             permissionsContent
         case .automation:
-            SettingsAutomationTab(daemonClient: daemonClient, showingReminders: $showingReminders, showingScheduledTasks: $showingScheduledTasks)
+            SettingsAutomationTab(daemonClient: daemonClient, showingReminders: $showingReminders, showingScheduledTasks: $showingScheduledTasks, showingHeartbeatConfig: $showingHeartbeatConfig)
         case .appearance:
             SettingsAppearanceTab(store: store)
         case .parental:

--- a/clients/macos/vellum-assistant/Features/Settings/HeartbeatConfigView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/HeartbeatConfigView.swift
@@ -1,0 +1,259 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct HeartbeatConfigView: View {
+    let daemonClient: DaemonClient
+    @Environment(\.dismiss) var dismiss
+
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+    @State private var enabled: Bool = true
+    @State private var intervalMinutes: Double = 60
+    @State private var activeHoursEnabled: Bool = false
+    @State private var activeHoursStart: Int = 9
+    @State private var activeHoursEnd: Int = 17
+    @State private var nextRunAt: Int?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("Heartbeat Configuration")
+                    .font(VFont.headline)
+                    .foregroundColor(VColor.textPrimary)
+                Spacer()
+                VButton(label: "Done", style: .tertiary) { dismiss() }
+            }
+            .padding(VSpacing.lg)
+
+            Divider().background(VColor.surfaceBorder)
+
+            if isLoading {
+                Spacer()
+                ProgressView()
+                Spacer()
+            } else if let errorMessage {
+                Spacer()
+                VStack(spacing: VSpacing.sm) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.largeTitle)
+                        .foregroundColor(VColor.textMuted)
+                    Text("Failed to load configuration")
+                        .foregroundColor(VColor.textSecondary)
+                    Text(errorMessage)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    VButton(label: "Retry", style: .tertiary) { loadConfig() }
+                }
+                Spacer()
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: VSpacing.xl) {
+                        // Enabled toggle
+                        HStack {
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Enabled")
+                                    .font(VFont.body)
+                                    .foregroundColor(VColor.textPrimary)
+                                Text("Run heartbeat checks on a schedule")
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.textMuted)
+                            }
+                            Spacer()
+                            Toggle("", isOn: $enabled)
+                                .toggleStyle(.switch)
+                                .labelsHidden()
+                                .onChange(of: enabled) { _, newValue in
+                                    saveConfig(enabled: newValue)
+                                }
+                        }
+
+                        Divider().background(VColor.surfaceBorder)
+
+                        // Interval picker
+                        VStack(alignment: .leading, spacing: VSpacing.sm) {
+                            Text("Check Interval")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textPrimary)
+                            Text("How often the heartbeat runs")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+
+                            Picker("", selection: $intervalMinutes) {
+                                Text("15 minutes").tag(15.0)
+                                Text("30 minutes").tag(30.0)
+                                Text("1 hour").tag(60.0)
+                                Text("2 hours").tag(120.0)
+                                Text("4 hours").tag(240.0)
+                                Text("8 hours").tag(480.0)
+                                Text("12 hours").tag(720.0)
+                                Text("24 hours").tag(1440.0)
+                            }
+                            .labelsHidden()
+                            .fixedSize()
+                            .onChange(of: intervalMinutes) { _, newValue in
+                                saveConfig(intervalMs: newValue * 60 * 1000)
+                            }
+                        }
+
+                        Divider().background(VColor.surfaceBorder)
+
+                        // Active hours
+                        VStack(alignment: .leading, spacing: VSpacing.sm) {
+                            HStack {
+                                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                    Text("Active Hours")
+                                        .font(VFont.body)
+                                        .foregroundColor(VColor.textPrimary)
+                                    Text("Only run heartbeat during these hours")
+                                        .font(VFont.caption)
+                                        .foregroundColor(VColor.textMuted)
+                                }
+                                Spacer()
+                                Toggle("", isOn: $activeHoursEnabled)
+                                    .toggleStyle(.switch)
+                                    .labelsHidden()
+                                    .onChange(of: activeHoursEnabled) { _, newValue in
+                                        if newValue {
+                                            saveConfig(activeHoursStart: Double(activeHoursStart), activeHoursEnd: Double(activeHoursEnd))
+                                        } else {
+                                            saveConfig(activeHoursStart: -1, activeHoursEnd: -1)
+                                        }
+                                    }
+                            }
+
+                            if activeHoursEnabled {
+                                HStack(spacing: VSpacing.md) {
+                                    Text("From")
+                                        .font(VFont.caption)
+                                        .foregroundColor(VColor.textSecondary)
+                                    Picker("", selection: $activeHoursStart) {
+                                        ForEach(0..<24, id: \.self) { hour in
+                                            Text(formatHour(hour)).tag(hour)
+                                        }
+                                    }
+                                    .labelsHidden()
+                                    .fixedSize()
+                                    .onChange(of: activeHoursStart) { _, newValue in
+                                        saveConfig(activeHoursStart: Double(newValue))
+                                    }
+
+                                    Text("to")
+                                        .font(VFont.caption)
+                                        .foregroundColor(VColor.textSecondary)
+                                    Picker("", selection: $activeHoursEnd) {
+                                        ForEach(0..<24, id: \.self) { hour in
+                                            Text(formatHour(hour)).tag(hour)
+                                        }
+                                    }
+                                    .labelsHidden()
+                                    .fixedSize()
+                                    .onChange(of: activeHoursEnd) { _, newValue in
+                                        saveConfig(activeHoursEnd: Double(newValue))
+                                    }
+                                }
+                            }
+                        }
+
+                        Divider().background(VColor.surfaceBorder)
+
+                        // Next run display
+                        if let nextRun = nextRunAt {
+                            HStack {
+                                Text("Next Run")
+                                    .font(VFont.body)
+                                    .foregroundColor(VColor.textPrimary)
+                                Spacer()
+                                Text(formatTimestamp(nextRun))
+                                    .font(VFont.mono)
+                                    .foregroundColor(VColor.textSecondary)
+                            }
+                        }
+                    }
+                    .padding(VSpacing.lg)
+                }
+            }
+        }
+        .frame(width: 450, height: 400)
+        .background(VColor.background)
+        .onAppear {
+            setupCallback()
+            loadConfig()
+        }
+        .onDisappear {
+            daemonClient.onHeartbeatConfigResponse = nil
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func formatHour(_ hour: Int) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "h a"
+        var components = DateComponents()
+        components.hour = hour
+        let calendar = Calendar.current
+        let date = calendar.date(from: components) ?? Date()
+        return formatter.string(from: date)
+    }
+
+    private func formatTimestamp(_ ms: Int) -> String {
+        let date = Date(timeIntervalSince1970: Double(ms) / 1000.0)
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+
+    // MARK: - Data
+
+    private func setupCallback() {
+        daemonClient.onHeartbeatConfigResponse = { response in
+            Task { @MainActor in
+                self.isLoading = false
+                if !response.success {
+                    self.errorMessage = response.error ?? "Unknown error"
+                    return
+                }
+                self.enabled = response.enabled
+                self.intervalMinutes = response.intervalMs / 60.0 / 1000.0
+                if let start = response.activeHoursStart, let end = response.activeHoursEnd,
+                   start >= 0, end >= 0 {
+                    self.activeHoursEnabled = true
+                    self.activeHoursStart = Int(start)
+                    self.activeHoursEnd = Int(end)
+                } else {
+                    self.activeHoursEnabled = false
+                }
+                self.nextRunAt = response.nextRunAt
+            }
+        }
+    }
+
+    private func loadConfig() {
+        isLoading = true
+        errorMessage = nil
+        do {
+            try daemonClient.sendHeartbeatConfigGet()
+        } catch {
+            isLoading = false
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func saveConfig(
+        enabled: Bool? = nil,
+        intervalMs: Double? = nil,
+        activeHoursStart: Double? = nil,
+        activeHoursEnd: Double? = nil
+    ) {
+        try? daemonClient.sendHeartbeatConfigSet(
+            enabled: enabled,
+            intervalMs: intervalMs,
+            activeHoursStart: activeHoursStart,
+            activeHoursEnd: activeHoursEnd
+        )
+        // Refresh to get updated nextRunAt
+        try? daemonClient.sendHeartbeatConfigGet()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAutomationTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAutomationTab.swift
@@ -7,6 +7,7 @@ struct SettingsAutomationTab: View {
     var daemonClient: DaemonClient?
     @Binding var showingReminders: Bool
     @Binding var showingScheduledTasks: Bool
+    @Binding var showingHeartbeatConfig: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
@@ -60,7 +61,7 @@ struct SettingsAutomationTab: View {
             }
 
             // Heartbeat section (checklist + runs, minus configCard)
-            HeartbeatAutomationSection(daemonClient: daemonClient)
+            HeartbeatAutomationSection(daemonClient: daemonClient, showingHeartbeatConfig: $showingHeartbeatConfig)
         }
     }
 }
@@ -73,6 +74,7 @@ struct SettingsAutomationTab: View {
 @MainActor
 struct HeartbeatAutomationSection: View {
     var daemonClient: DaemonClient?
+    @Binding var showingHeartbeatConfig: Bool
 
     // -- Checklist state --
     @State private var checklistContent: String = ""
@@ -108,6 +110,9 @@ struct HeartbeatAutomationSection: View {
                     Text("Using default")
                         .font(VFont.caption)
                         .foregroundColor(VColor.textMuted)
+                }
+                VIconButton(label: "Config", icon: "gearshape", iconOnly: true) {
+                    showingHeartbeatConfig = true
                 }
             }
 


### PR DESCRIPTION
## Summary
- Adds a gear icon button to the Heartbeat Checklist card header in Settings > Automation
- Opens a configuration modal for heartbeat settings: enabled toggle, interval picker, active hours, and next run display
- Uses existing IPC infrastructure (`sendHeartbeatConfigGet`/`sendHeartbeatConfigSet`)

## Test plan
- [ ] Build: `./build.sh`
- [ ] Open Settings > Automation, verify gear icon appears in Heartbeat Checklist card header
- [ ] Click gear icon, verify config modal opens with current settings loaded
- [ ] Toggle enabled, change interval, set active hours — verify changes persist after closing and reopening

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
