### PR TITLE
feat: add slack_delete_message tool

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/TOOLS.json
+++ b/assistant/src/config/bundled-skills/messaging/TOOLS.json
@@ -257,6 +257,36 @@
       "execution_target": "host"
     },
     {
+      "name": "slack_delete_message",
+      "description": "Delete a Slack message posted by the bot. Include a confidence score (0-1).",
+      "category": "messaging",
+      "risk": "high",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "channel": {
+            "type": "string",
+            "description": "Slack channel ID"
+          },
+          "timestamp": {
+            "type": "string",
+            "description": "Message timestamp (ts) to delete"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          }
+        },
+        "required": [
+          "channel",
+          "timestamp",
+          "confidence"
+        ]
+      },
+      "executor": "tools/slack-delete-message.ts",
+      "execution_target": "host"
+    },
+    {
       "name": "slack_leave_channel",
       "description": "Leave a Slack channel. Include a confidence score (0-1).",
       "category": "messaging",

--- a/assistant/src/config/bundled-skills/messaging/tools/slack-delete-message.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/slack-delete-message.ts
@@ -1,0 +1,24 @@
+import { deleteMessage } from '../../../../messaging/providers/slack/client.js';
+import { getMessagingProvider } from '../../../../messaging/registry.js';
+import { withValidToken } from '../../../../security/token-manager.js';
+import type { ToolContext, ToolExecutionResult } from '../../../../tools/types.js';
+import { err, ok } from './shared.js';
+
+export async function run(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  const channel = input.channel as string;
+  const timestamp = input.timestamp as string;
+
+  if (!channel || !timestamp) {
+    return err('channel and timestamp are both required.');
+  }
+
+  try {
+    const provider = getMessagingProvider('slack');
+    return withValidToken(provider.credentialService, async (token) => {
+      await deleteMessage(token, channel, timestamp);
+      return ok(`Message deleted.`);
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/messaging/providers/slack/client.ts
+++ b/assistant/src/messaging/providers/slack/client.ts
@@ -9,6 +9,7 @@ import type {
   SlackApiResponse,
   SlackAuthTestResponse,
   SlackConversationHistoryResponse,
+  SlackChatDeleteResponse,
   SlackConversationLeaveResponse,
   SlackConversationMarkResponse,
   SlackConversationRepliesResponse,
@@ -185,6 +186,17 @@ export async function addReaction(
     channel,
     timestamp,
     name,
+  });
+}
+
+export async function deleteMessage(
+  token: string,
+  channel: string,
+  ts: string,
+): Promise<SlackChatDeleteResponse> {
+  return request<SlackChatDeleteResponse>(token, 'chat.delete', undefined, {
+    channel,
+    ts,
   });
 }
 

--- a/assistant/src/messaging/providers/slack/types.ts
+++ b/assistant/src/messaging/providers/slack/types.ts
@@ -116,4 +116,9 @@ export type SlackReactionAddResponse = SlackApiResponse;
 
 export type SlackConversationLeaveResponse = SlackApiResponse;
 
+export interface SlackChatDeleteResponse extends SlackApiResponse {
+  channel: string;
+  ts: string;
+}
+
 export type SlackConversationMarkResponse = SlackApiResponse;


### PR DESCRIPTION
## Summary
- Adds `slack_delete_message` high-risk tool for deleting Slack messages
- Adds `deleteMessage` client method wrapping Slack's `chat.delete` API
- Adds `SlackChatDeleteResponse` type

## Test plan
- [ ] Verify tool is registered and appears in tool list
- [ ] Test deleting a message the bot/user sent
- [ ] Confirm Slack rejects attempts to delete others' messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
