### PR TITLE
fix: improve guardian notification fallback copy

### DIFF
--- a/assistant/src/__tests__/notification-decision-fallback.test.ts
+++ b/assistant/src/__tests__/notification-decision-fallback.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression tests for notification decision fallback copy.
+ *
+ * Ensures fallback decisions still produce human-friendly copy when the
+ * decision-model call is unavailable.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+
+mock.module('../channels/config.js', () => ({
+  getDeliverableChannels: () => ['vellum', 'telegram', 'sms'],
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    notifications: {
+      decisionModelIntent: 'latency-optimized',
+    },
+  }),
+}));
+
+mock.module('../notifications/decisions-store.js', () => ({
+  createDecision: () => {},
+}));
+
+mock.module('../notifications/preference-summary.js', () => ({
+  getPreferenceSummary: () => undefined,
+}));
+
+mock.module('../notifications/thread-candidates.js', () => ({
+  buildThreadCandidates: () => undefined,
+  serializeCandidatesForPrompt: () => undefined,
+}));
+
+mock.module('../providers/provider-send-message.js', () => ({
+  getConfiguredProvider: () => null,
+  createTimeout: () => ({
+    signal: new AbortController().signal,
+    cleanup: () => {},
+  }),
+  extractToolUse: () => null,
+  userMessage: (text: string) => ({ role: 'user', content: text }),
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { evaluateSignal } from '../notifications/decision-engine.js';
+import type { NotificationSignal } from '../notifications/signal.js';
+import type { NotificationChannel } from '../notifications/types.js';
+
+function makeSignal(overrides?: Partial<NotificationSignal>): NotificationSignal {
+  return {
+    signalId: 'sig-fallback-guardian-1',
+    assistantId: 'self',
+    createdAt: Date.now(),
+    sourceChannel: 'voice',
+    sourceSessionId: 'call-session-1',
+    sourceEventName: 'guardian.question',
+    contextPayload: {
+      questionText: 'What is the gate code?',
+    },
+    attentionHints: {
+      requiresAction: true,
+      urgency: 'high',
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
+    ...overrides,
+  };
+}
+
+describe('notification decision fallback copy', () => {
+  test('uses human-friendly template copy for guardian.question', async () => {
+    const signal = makeSignal();
+    const decision = await evaluateSignal(signal, ['vellum'] as NotificationChannel[]);
+
+    expect(decision.fallbackUsed).toBe(true);
+    expect(decision.renderedCopy.vellum?.title).toBe('Guardian Question');
+    expect(decision.renderedCopy.vellum?.body).toBe('What is the gate code?');
+    expect(decision.renderedCopy.vellum?.title).not.toBe('guardian.question');
+    expect(decision.renderedCopy.vellum?.body).not.toContain('Action required: guardian.question');
+  });
+});

--- a/assistant/src/__tests__/thread-seed-composer.test.ts
+++ b/assistant/src/__tests__/thread-seed-composer.test.ts
@@ -175,6 +175,24 @@ describe('composeThreadSeed', () => {
       expect(seed).toContain('Action required');
     });
 
+    test('does not duplicate "Action required" when copy already includes it', () => {
+      const signal = makeSignal({
+        attentionHints: {
+          requiresAction: true,
+          urgency: 'high',
+          isAsyncBackground: false,
+          visibleInSourceNow: false,
+        },
+      });
+      const copy = makeCopy({
+        title: 'Guardian Question',
+        body: 'Action required: What is the gate code?',
+      });
+      const seed = composeThreadSeed(signal, 'vellum' as NotificationChannel, copy);
+      const markerCount = (seed.match(/action required/gi) ?? []).length;
+      expect(markerCount).toBe(1);
+    });
+
     test('omits "Notification" generic title', () => {
       const signal = makeSignal();
       const copy = makeCopy({ title: 'Notification', body: 'Something new.' });

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -16,6 +16,7 @@ import { getConfig } from '../config/loader.js';
 import { createTimeout, extractToolUse, getConfiguredProvider, userMessage } from '../providers/provider-send-message.js';
 import type { ModelIntent } from '../providers/types.js';
 import { getLogger } from '../util/logger.js';
+import { composeFallbackCopy } from './copy-composer.js';
 import { createDecision } from './decisions-store.js';
 import { getPreferenceSummary } from './preference-summary.js';
 import type { NotificationSignal, RoutingIntent } from './signal.js';
@@ -251,17 +252,7 @@ function buildFallbackDecision(
     };
   }
 
-  const copy: Partial<Record<NotificationChannel, RenderedChannelCopy>> = {};
-  for (const ch of selectedChannels) {
-    const fallbackBody = isHighUrgencyAction
-      ? `Action required: ${signal.sourceEventName}`
-      : signal.sourceEventName;
-    copy[ch] = {
-      title: signal.sourceEventName,
-      body: fallbackBody,
-      ...(ch === 'telegram' ? { deliveryText: fallbackBody } : {}),
-    };
-  }
+  const copy = composeFallbackCopy(signal, selectedChannels);
 
   return {
     shouldNotify: true,

--- a/assistant/src/notifications/thread-seed-composer.ts
+++ b/assistant/src/notifications/thread-seed-composer.ts
@@ -140,7 +140,8 @@ export function composeThreadSeed(
     const parts: string[] = [];
     if (copy.title && copy.title !== 'Notification') parts.push(copy.title);
     if (copy.body) parts.push(copy.body);
-    if (signal.attentionHints.requiresAction && parts.length > 0) {
+    const alreadyMentionsAction = parts.some((part) => /\baction required\b/i.test(part));
+    if (signal.attentionHints.requiresAction && parts.length > 0 && !alreadyMentionsAction) {
       parts.push('Action required.');
     }
     if (parts.length > 0) {


### PR DESCRIPTION
## Summary\n- use notification fallback templates in decision-engine fallback output instead of raw source event names\n- avoid duplicating "Action required" in rich thread seed composition when copy already includes that marker\n- add regression coverage for guardian.question fallback decisions and action-marker dedupe\n\n## Validation\n- export PATH="$HOME/.bun/bin:$PATH"\n- cd assistant && bun test src/__tests__/notification-decision-fallback.test.ts src/__tests__/thread-seed-composer.test.ts\n- cd assistant && bunx tsc --noEmit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
