### PR TITLE
Rename Permissions section to macOS System Permissions and reorder nav

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -16,7 +16,7 @@ enum SettingsTab: String {
     static func visibleTabs(isDevMode: Bool) -> [SettingsTab] {
         var tabs: [SettingsTab] = [
             .account, .channels, .modelsAndServices, .voice,
-            .permissions, .automation, .appearance
+            .automation, .appearance, .permissions
         ]
         if isDevMode {
             tabs.append(.advanced)
@@ -675,7 +675,7 @@ struct SettingsPanel: View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
             // PERMISSIONS section (OS permissions)
             VStack(alignment: .leading, spacing: VSpacing.md) {
-                Text("Permissions")
+                Text("macOS System Permissions")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
 


### PR DESCRIPTION
## Summary
- Rename the "Permissions" section heading to "macOS System Permissions" for clarity
- Move the Permissions nav item from between Voice and Automation to between Appearance and Advanced

## Original prompt
lets rename this section from "Permissions" to something like "MacOS System Permissions". Lets also move the "Permissions" nav item to be between "Appearance" and "Advanced"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
