### PR TITLE
feat: enhance timezone picker search with aliases and tokenized matching

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TimezonePicker.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TimezonePicker.swift
@@ -13,12 +13,30 @@ struct TimezonePicker: View {
             let abbreviation = tz.abbreviation() ?? ""
             let offset = tz.formattedUTCOffset()
             let friendlyName = tz.friendlyName()
+
+            // Collect Apple's localized names for richer search coverage
+            let locale = Locale(identifier: "en_US")
+            let localizedNames = [
+                tz.localizedName(for: .standard, locale: locale),
+                tz.localizedName(for: .shortStandard, locale: locale),
+                tz.localizedName(for: .generic, locale: locale),
+                tz.localizedName(for: .shortGeneric, locale: locale),
+                tz.localizedName(for: .daylightSaving, locale: locale),
+                tz.localizedName(for: .shortDaylightSaving, locale: locale),
+            ].compactMap { $0 }
+
+            let aliases = timezoneAliases[identifier] ?? []
+
+            let searchParts = [identifier, friendlyName, abbreviation, offset]
+                + localizedNames + aliases
+            let searchText = searchParts.joined(separator: " ").lowercased()
+
             return TimezoneEntry(
                 identifier: identifier,
                 friendlyName: friendlyName,
                 abbreviation: abbreviation,
                 offset: offset,
-                searchText: "\(identifier) \(friendlyName) \(abbreviation)".lowercased()
+                searchText: searchText
             )
         }
     }()
@@ -28,7 +46,12 @@ struct TimezonePicker: View {
         if query.isEmpty {
             return Self.timezoneEntries
         }
-        return Self.timezoneEntries.filter { $0.searchText.contains(query) }
+        // Tokenized matching: every word in the query must appear somewhere in the search text.
+        // This lets queries like "hawaii time" or "eastern us" work naturally.
+        let tokens = query.split(separator: " ").map(String.init)
+        return Self.timezoneEntries.filter { entry in
+            tokens.allSatisfy { token in entry.searchText.contains(token) }
+        }
     }
 
     private var systemTimezoneIdentifier: String {
@@ -160,6 +183,124 @@ private struct TimezoneEntry {
     let offset: String
     let searchText: String
 }
+
+// MARK: - Timezone Search Aliases
+
+/// Maps IANA timezone identifiers to additional search terms that Apple's localized names don't cover.
+/// Covers country names, state/province names, common city aliases, and colloquial references.
+private let timezoneAliases: [String: [String]] = [
+    // United States
+    "America/New_York": ["usa", "united states", "new york", "nyc", "florida", "georgia", "virginia",
+                         "massachusetts", "boston", "miami", "atlanta", "philadelphia", "dc",
+                         "washington dc", "carolina", "connecticut", "maine", "vermont", "maryland"],
+    "America/Chicago": ["usa", "united states", "texas", "illinois", "dallas", "houston",
+                        "minneapolis", "milwaukee", "nashville", "memphis", "kansas city",
+                        "san antonio", "louisiana", "new orleans", "wisconsin", "minnesota",
+                        "iowa", "missouri", "tennessee", "alabama", "mississippi", "oklahoma",
+                        "nebraska", "arkansas"],
+    "America/Denver": ["usa", "united states", "colorado", "utah", "montana", "wyoming",
+                       "new mexico", "salt lake city", "albuquerque", "boise", "idaho"],
+    "America/Los_Angeles": ["usa", "united states", "california", "la", "san francisco",
+                            "sf", "seattle", "portland", "washington state", "oregon", "nevada",
+                            "las vegas", "san diego", "silicon valley", "hollywood", "pst", "pdt"],
+    "America/Anchorage": ["usa", "united states", "alaska"],
+    "Pacific/Honolulu": ["usa", "united states", "hawaii", "oahu", "maui", "kauai", "waikiki"],
+    "America/Phoenix": ["usa", "united states", "arizona"],
+
+    // Canada
+    "America/Toronto": ["canada", "ontario"],
+    "America/Vancouver": ["canada", "british columbia", "bc"],
+    "America/Edmonton": ["canada", "alberta", "calgary"],
+    "America/Winnipeg": ["canada", "manitoba"],
+    "America/Halifax": ["canada", "nova scotia", "new brunswick", "atlantic canada"],
+    "America/St_Johns": ["canada", "newfoundland"],
+
+    // Europe
+    "Europe/London": ["uk", "united kingdom", "england", "britain", "great britain", "scotland",
+                      "wales", "northern ireland"],
+    "Europe/Paris": ["france"],
+    "Europe/Berlin": ["germany", "deutschland"],
+    "Europe/Madrid": ["spain", "espana"],
+    "Europe/Rome": ["italy", "italia"],
+    "Europe/Amsterdam": ["netherlands", "holland"],
+    "Europe/Brussels": ["belgium"],
+    "Europe/Zurich": ["switzerland"],
+    "Europe/Vienna": ["austria"],
+    "Europe/Stockholm": ["sweden"],
+    "Europe/Oslo": ["norway"],
+    "Europe/Copenhagen": ["denmark"],
+    "Europe/Helsinki": ["finland"],
+    "Europe/Warsaw": ["poland"],
+    "Europe/Prague": ["czech republic", "czechia"],
+    "Europe/Dublin": ["ireland"],
+    "Europe/Lisbon": ["portugal"],
+    "Europe/Athens": ["greece"],
+    "Europe/Bucharest": ["romania"],
+    "Europe/Istanbul": ["turkey", "turkiye"],
+    "Europe/Moscow": ["russia"],
+    "Europe/Kiev": ["ukraine", "kyiv"],
+
+    // Asia
+    "Asia/Tokyo": ["japan"],
+    "Asia/Shanghai": ["china", "beijing", "prc"],
+    "Asia/Hong_Kong": ["hong kong", "hk"],
+    "Asia/Singapore": ["singapore"],
+    "Asia/Kolkata": ["india", "mumbai", "delhi", "bangalore", "chennai", "hyderabad"],
+    "Asia/Seoul": ["south korea", "korea"],
+    "Asia/Taipei": ["taiwan"],
+    "Asia/Bangkok": ["thailand"],
+    "Asia/Jakarta": ["indonesia"],
+    "Asia/Manila": ["philippines"],
+    "Asia/Ho_Chi_Minh": ["vietnam", "saigon"],
+    "Asia/Kuala_Lumpur": ["malaysia"],
+    "Asia/Dubai": ["uae", "united arab emirates", "abu dhabi"],
+    "Asia/Riyadh": ["saudi arabia"],
+    "Asia/Karachi": ["pakistan"],
+    "Asia/Dhaka": ["bangladesh"],
+    "Asia/Colombo": ["sri lanka"],
+    "Asia/Kathmandu": ["nepal"],
+    "Asia/Tashkent": ["uzbekistan"],
+    "Asia/Almaty": ["kazakhstan"],
+    "Asia/Tehran": ["iran"],
+    "Asia/Baghdad": ["iraq"],
+    "Asia/Beirut": ["lebanon"],
+    "Asia/Jerusalem": ["israel"],
+
+    // Oceania
+    "Australia/Sydney": ["australia", "aest", "new south wales", "nsw"],
+    "Australia/Melbourne": ["australia", "victoria"],
+    "Australia/Brisbane": ["australia", "queensland"],
+    "Australia/Perth": ["australia", "western australia"],
+    "Australia/Adelaide": ["australia", "south australia"],
+    "Australia/Darwin": ["australia", "northern territory"],
+    "Australia/Hobart": ["australia", "tasmania"],
+    "Pacific/Auckland": ["new zealand", "nz", "nzst"],
+    "Pacific/Fiji": ["fiji"],
+
+    // South America
+    "America/Sao_Paulo": ["brazil", "brasil"],
+    "America/Argentina/Buenos_Aires": ["argentina"],
+    "America/Santiago": ["chile"],
+    "America/Bogota": ["colombia"],
+    "America/Lima": ["peru"],
+    "America/Caracas": ["venezuela"],
+    "America/Montevideo": ["uruguay"],
+
+    // Central America & Caribbean
+    "America/Mexico_City": ["mexico"],
+    "America/Costa_Rica": ["costa rica"],
+    "America/Panama": ["panama"],
+
+    // Africa
+    "Africa/Cairo": ["egypt"],
+    "Africa/Lagos": ["nigeria"],
+    "Africa/Johannesburg": ["south africa"],
+    "Africa/Nairobi": ["kenya"],
+    "Africa/Casablanca": ["morocco"],
+    "Africa/Accra": ["ghana"],
+    "Africa/Addis_Ababa": ["ethiopia"],
+    "Africa/Dar_es_Salaam": ["tanzania"],
+]
 
 // MARK: - TimeZone Helpers
 


### PR DESCRIPTION
## Summary
- Add Apple's `localizedName(for:locale:)` variants (standard, generic, daylight saving) to the search index so terms like "Hawaii", "Eastern", "Greenwich" match automatically
- Add a static alias map (~80 entries) covering country names, US state names, common city nicknames, and colloquial references (e.g. "hawaii" → Pacific/Honolulu, "uk" → Europe/London, "california" → America/Los_Angeles)
- Switch from single-substring matching to tokenized matching — every word in the query must appear somewhere in the search text, enabling multi-word queries like "hawaii time" or "eastern us"

## Original prompt
it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
