### PR TITLE
M2: Request-Scoped Answer Plumbing

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -265,6 +265,15 @@ export class CallController {
   }
 
   /**
+   * Returns the question ID of the currently pending guardian consultation,
+   * or null if no consultation is active. Used by answerCall to match
+   * incoming answers to the correct consultation record.
+   */
+  getPendingConsultationQuestionId(): string | null {
+    return this.pendingConsultation?.questionId ?? null;
+  }
+
+  /**
    * Update guardian trust context for subsequent LLM turns.
    */
   setGuardianContext(ctx: GuardianRuntimeContext | null): void {

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -72,6 +72,8 @@ export type CancelCallInput = {
 export type AnswerCallInput = {
   callSessionId: string;
   answer: string;
+  /** When provided, the answer is matched to this specific pending question/consultation. */
+  pendingQuestionId?: string;
 };
 
 export type RelayInstructionInput = {
@@ -516,23 +518,59 @@ export async function cancelCall(input: CancelCallInput): Promise<{ ok: true; se
 
 /**
  * Answer a pending question for an active call.
+ *
+ * When `pendingQuestionId` is provided, the answer is matched to that specific
+ * pending question/consultation rather than relying on transient controller
+ * state. This allows answers to arrive while the call is active and not paused,
+ * as long as the referenced question is still pending.
  */
 export async function answerCall(input: AnswerCallInput): Promise<{ ok: true; questionId: string } | CallError> {
-  const { callSessionId, answer } = input;
+  const { callSessionId, answer, pendingQuestionId } = input;
 
   if (!answer || typeof answer !== 'string') {
     return { ok: false, error: 'Missing answer', status: 400 };
-  }
-
-  const question = getPendingQuestion(callSessionId);
-  if (!question) {
-    return { ok: false, error: 'No pending question found', status: 404 };
   }
 
   const controller = getCallController(callSessionId);
   if (!controller) {
     log.warn({ callSessionId }, 'answerCall: no active controller for call session');
     return { ok: false, error: 'No active controller for this call', status: 409 };
+  }
+
+  // When a specific question is targeted, validate it matches the active
+  // consultation. This prevents stale or duplicate answers from being
+  // applied to the wrong consultation.
+  if (pendingQuestionId) {
+    const activeQuestionId = controller.getPendingConsultationQuestionId();
+    if (!activeQuestionId) {
+      log.warn(
+        { callSessionId, pendingQuestionId },
+        'answerCall: pendingQuestionId provided but no consultation is active',
+      );
+      return { ok: false, error: 'Referenced question is no longer pending', status: 409 };
+    }
+    if (activeQuestionId !== pendingQuestionId) {
+      log.warn(
+        { callSessionId, pendingQuestionId, activeQuestionId },
+        'answerCall: pendingQuestionId does not match active consultation',
+      );
+      return { ok: false, error: 'Referenced question is stale — a newer consultation has superseded it', status: 409 };
+    }
+  }
+
+  // Look up the pending question in the store for record-keeping
+  const question = getPendingQuestion(callSessionId);
+  if (!question) {
+    return { ok: false, error: 'No pending question found', status: 404 };
+  }
+
+  // When pendingQuestionId is given, double-check it matches the store record
+  if (pendingQuestionId && question.id !== pendingQuestionId) {
+    log.warn(
+      { callSessionId, pendingQuestionId, storeQuestionId: question.id },
+      'answerCall: store pending question does not match requested pendingQuestionId',
+    );
+    return { ok: false, error: 'Referenced question is stale', status: 409 };
   }
 
   const accepted = await controller.handleUserAnswer(answer);

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -488,7 +488,7 @@ export async function processMessage(
         // the guardian action request if answerCall succeeds, so that a
         // failed delivery leaves the request pending for retry from
         // another channel.
-        const answerResult = await answerCall({ callSessionId: guardianRequest.callSessionId, answer: answerText });
+        const answerResult = await answerCall({ callSessionId: guardianRequest.callSessionId, answer: answerText, pendingQuestionId: guardianRequest.pendingQuestionId });
 
         if ('ok' in answerResult && answerResult.ok) {
           const resolved = resolveGuardianActionRequest(guardianRequest.id, answerText, 'vellum');

--- a/assistant/src/runtime/routes/call-routes.ts
+++ b/assistant/src/runtime/routes/call-routes.ts
@@ -179,7 +179,7 @@ export async function handleCancelCall(req: Request, callSessionId: string): Pro
  * Body: { answer: string }
  */
 export async function handleAnswerCall(req: Request, callSessionId: string): Promise<Response> {
-  let body: { answer?: string };
+  let body: { answer?: string; pendingQuestionId?: string };
   try {
     body = await req.json() as typeof body;
   } catch {
@@ -193,6 +193,7 @@ export async function handleAnswerCall(req: Request, callSessionId: string): Pro
   const result = await answerCall({
     callSessionId,
     answer: body.answer ?? '',
+    pendingQuestionId: typeof body.pendingQuestionId === 'string' ? body.pendingQuestionId : undefined,
   });
 
   if (!result.ok) {

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -875,7 +875,7 @@ export async function handleChannelInbound(
             // the guardian action request if answerCall succeeds, so that a
             // failed delivery (e.g. pending question timed out) leaves the
             // request pending for retry from another channel.
-            const answerResult = await answerCall({ callSessionId: request.callSessionId, answer: answerText });
+            const answerResult = await answerCall({ callSessionId: request.callSessionId, answer: answerText, pendingQuestionId: request.pendingQuestionId });
 
             if (!('ok' in answerResult) || !answerResult.ok) {
               const errorMsg = 'error' in answerResult ? answerResult.error : 'Unknown error';


### PR DESCRIPTION
Extend answerCall to accept answers based on pending question/consultation identity rather than controller state. Guardian answers can now be applied while the call is active. Stale/expired answers are cleanly rejected. Part of #10187.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
