### PR TITLE
fix: address review feedback on heartbeat config modal PR #10178

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/HeartbeatConfigView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/HeartbeatConfigView.swift
@@ -234,7 +234,11 @@ struct HeartbeatConfigView: View {
                     self.activeHoursEnabled = false
                 }
                 self.nextRunAt = response.nextRunAt
-                self.isApplyingFromServer = false
+                // Defer reset to the next run-loop tick so SwiftUI's onChange
+                // closures fire while the flag is still true.
+                DispatchQueue.main.async {
+                    self.isApplyingFromServer = false
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/HeartbeatConfigView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/HeartbeatConfigView.swift
@@ -14,6 +14,7 @@ struct HeartbeatConfigView: View {
     @State private var activeHoursEnd: Int = 17
     @State private var nextRunAt: Int?
     @State private var isApplyingFromServer = false
+    @State private var saveErrorMessage: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -175,6 +176,18 @@ struct HeartbeatConfigView: View {
                                     .foregroundColor(VColor.textSecondary)
                             }
                         }
+
+                        // Inline save error
+                        if let saveError = saveErrorMessage {
+                            HStack(spacing: VSpacing.sm) {
+                                Image(systemName: "exclamationmark.triangle")
+                                    .font(.system(size: 11))
+                                    .foregroundColor(VColor.error)
+                                Text(saveError)
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.error)
+                            }
+                        }
                     }
                     .padding(VSpacing.lg)
                 }
@@ -269,8 +282,9 @@ struct HeartbeatConfigView: View {
             )
             // Refresh to get updated nextRunAt
             try daemonClient.sendHeartbeatConfigGet()
+            saveErrorMessage = nil
         } catch {
-            errorMessage = "Failed to save: \(error.localizedDescription)"
+            saveErrorMessage = "Failed to save: \(error.localizedDescription)"
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/HeartbeatConfigView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/HeartbeatConfigView.swift
@@ -13,6 +13,7 @@ struct HeartbeatConfigView: View {
     @State private var activeHoursStart: Int = 9
     @State private var activeHoursEnd: Int = 17
     @State private var nextRunAt: Int?
+    @State private var isApplyingFromServer = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -64,6 +65,7 @@ struct HeartbeatConfigView: View {
                                 .toggleStyle(.switch)
                                 .labelsHidden()
                                 .onChange(of: enabled) { _, newValue in
+                                    guard !isApplyingFromServer else { return }
                                     saveConfig(enabled: newValue)
                                 }
                         }
@@ -92,6 +94,7 @@ struct HeartbeatConfigView: View {
                             .labelsHidden()
                             .fixedSize()
                             .onChange(of: intervalMinutes) { _, newValue in
+                                guard !isApplyingFromServer else { return }
                                 saveConfig(intervalMs: newValue * 60 * 1000)
                             }
                         }
@@ -114,6 +117,7 @@ struct HeartbeatConfigView: View {
                                     .toggleStyle(.switch)
                                     .labelsHidden()
                                     .onChange(of: activeHoursEnabled) { _, newValue in
+                                        guard !isApplyingFromServer else { return }
                                         if newValue {
                                             saveConfig(activeHoursStart: Double(activeHoursStart), activeHoursEnd: Double(activeHoursEnd))
                                         } else {
@@ -135,6 +139,7 @@ struct HeartbeatConfigView: View {
                                     .labelsHidden()
                                     .fixedSize()
                                     .onChange(of: activeHoursStart) { _, newValue in
+                                        guard !isApplyingFromServer else { return }
                                         saveConfig(activeHoursStart: Double(newValue))
                                     }
 
@@ -149,6 +154,7 @@ struct HeartbeatConfigView: View {
                                     .labelsHidden()
                                     .fixedSize()
                                     .onChange(of: activeHoursEnd) { _, newValue in
+                                        guard !isApplyingFromServer else { return }
                                         saveConfig(activeHoursEnd: Double(newValue))
                                     }
                                 }
@@ -215,6 +221,8 @@ struct HeartbeatConfigView: View {
                     self.errorMessage = response.error ?? "Unknown error"
                     return
                 }
+                self.errorMessage = nil
+                self.isApplyingFromServer = true
                 self.enabled = response.enabled
                 self.intervalMinutes = response.intervalMs / 60.0 / 1000.0
                 if let start = response.activeHoursStart, let end = response.activeHoursEnd,
@@ -226,6 +234,7 @@ struct HeartbeatConfigView: View {
                     self.activeHoursEnabled = false
                 }
                 self.nextRunAt = response.nextRunAt
+                self.isApplyingFromServer = false
             }
         }
     }
@@ -247,13 +256,17 @@ struct HeartbeatConfigView: View {
         activeHoursStart: Double? = nil,
         activeHoursEnd: Double? = nil
     ) {
-        try? daemonClient.sendHeartbeatConfigSet(
-            enabled: enabled,
-            intervalMs: intervalMs,
-            activeHoursStart: activeHoursStart,
-            activeHoursEnd: activeHoursEnd
-        )
-        // Refresh to get updated nextRunAt
-        try? daemonClient.sendHeartbeatConfigGet()
+        do {
+            try daemonClient.sendHeartbeatConfigSet(
+                enabled: enabled,
+                intervalMs: intervalMs,
+                activeHoursStart: activeHoursStart,
+                activeHoursEnd: activeHoursEnd
+            )
+            // Refresh to get updated nextRunAt
+            try daemonClient.sendHeartbeatConfigGet()
+        } catch {
+            errorMessage = "Failed to save: \(error.localizedDescription)"
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `isApplyingFromServer` guard to prevent onChange handlers from firing spurious save-back IPC calls during initial config load
- Clear `errorMessage` on successful config responses so transient failures don't permanently block the modal
- Replace `try?` with do/catch in `saveConfig()` to surface send failures when daemon is disconnected

## Original prompt
Addresses review feedback from #10178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
