### PR TITLE
Reorder channels and remove Clear All button from Mobile card

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -191,8 +191,8 @@ struct SettingsChannelsTab: View {
             mobileCard
             telegramCard
             slackChannelCard
-            twilioCard
             voiceCard
+            twilioCard
             emailCard
         }
     }
@@ -1555,13 +1555,6 @@ struct SettingsChannelsTab: View {
                         }
                     )
                 }
-
-                Button("Clear All") {
-                    store.clearAllApprovedDevices()
-                }
-                .font(VFont.caption)
-                .foregroundColor(VColor.error)
-                .buttonStyle(.borderless)
             }
 
             Divider().background(VColor.surfaceBorder)


### PR DESCRIPTION
## Summary
- Reorder channel cards to: Mobile, Telegram, Slack, Phone, SMS, Email
- Remove the "Clear All" button from the Mobile card (individual "Remove" buttons remain)

## Original prompt
lets update the Channels settings page so that the channels are in this order: Mobile, Telegram, Slack, Phone, SMS, Email. Lets also remove the "Clear All" button from mobile to simplify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
