### PR TITLE
feat: add IS_CONTAINERIZED env var for containerized deployments

### DIFF
--- a/assistant/src/config/env-registry.ts
+++ b/assistant/src/config/env-registry.ts
@@ -124,6 +124,16 @@ export function getEnableMonitoring(): boolean {
   return flag('VELLUM_ENABLE_MONITORING');
 }
 
+/**
+ * IS_CONTAINERIZED — boolean, default: false
+ * When true, indicates the assistant is running inside a container (e.g. Docker).
+ * Any new data that needs to survive restarts must be written to BASE_DATA_DIR,
+ * which is mapped to a persistent volume.
+ */
+export function getIsContainerized(): boolean {
+  return flag('IS_CONTAINERIZED');
+}
+
 // ── Known env var names ──────────────────────────────────────────────────────
 
 /**

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -6,7 +6,7 @@ import { getParentalControlSettings } from '../security/parental-control-store.j
 import { listCredentialMetadata } from '../tools/credentials/metadata-store.js';
 import { getLogger } from '../util/logger.js';
 import { getWorkspaceDir, getWorkspacePromptPath, isMacOS } from '../util/platform.js';
-import { getIsContainerized } from './env-registry.js';
+import { getBaseDataDir, getIsContainerized } from './env-registry.js';
 import { getConfig } from './loader.js';
 import { loadSkillCatalog, type SkillSummary } from './skills.js';
 import { resolveUserReference } from './user-reference.js';
@@ -628,7 +628,7 @@ function buildLearningMemorySection(): string {
 }
 
 function buildContainerizedSection(): string {
-  const baseDataDir = process.env['BASE_DATA_DIR'] ?? '$BASE_DATA_DIR';
+  const baseDataDir = getBaseDataDir() ?? '$BASE_DATA_DIR';
   return [
     '## Running in a Container — Data Persistence',
     '',
@@ -638,7 +638,6 @@ function buildContainerizedSection(): string {
     '',
     'Rules:',
     `- Always store new data, notes, memories, configs, and downloads under \`${baseDataDir}\``,
-    `- When tools write to paths like \`~/.vellum\` or \`/tmp\`, those paths are already mapped through \`${baseDataDir}\` — do not write to other locations`,
     '- Never write persistent data to system directories, `/tmp`, or paths outside the mounted volume',
     '- When in doubt, prefer paths nested under the data directory',
   ].join('\n');

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -640,6 +640,7 @@ function buildContainerizedSection(): string {
     `- Always store new data, notes, memories, configs, and downloads under \`${baseDataDir}\``,
     '- Never write persistent data to system directories, `/tmp`, or paths outside the mounted volume',
     '- When in doubt, prefer paths nested under the data directory',
+    '- If you create a file that is only needed temporarily (scratch files, intermediate outputs, download staging), delete it when you are done — disk space on the persistent volume is finite and will grow unboundedly if temp files are not cleaned up',
   ].join('\n');
 }
 

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -6,6 +6,7 @@ import { getParentalControlSettings } from '../security/parental-control-store.j
 import { listCredentialMetadata } from '../tools/credentials/metadata-store.js';
 import { getLogger } from '../util/logger.js';
 import { getWorkspaceDir, getWorkspacePromptPath, isMacOS } from '../util/platform.js';
+import { getIsContainerized } from './env-registry.js';
 import { getConfig } from './loader.js';
 import { loadSkillCatalog, type SkillSummary } from './skills.js';
 import { resolveUserReference } from './user-reference.js';
@@ -130,6 +131,7 @@ export function buildSystemPrompt(tier: ResponseTier = 'high'): string {
       '- When you are satisfied all updates have been actioned or communicated, delete `UPDATES.md` to signal completion.',
     ].join('\n'));
   }
+  if (getIsContainerized()) parts.push(buildContainerizedSection());
   parts.push(buildConfigSection());
   parts.push(buildPostToolResponseSection());
   parts.push(buildExternalCommsIdentitySection());
@@ -622,6 +624,23 @@ function buildLearningMemorySection(): string {
     '- `memory_save({ kind: "learning", subject: "Gmail API pagination", statement: "Gmail search returns max 100 results per page. Always check nextPageToken and loop if the user asks for \'all\' messages." })`',
     '',
     'Don\'t overthink it. If you catch yourself thinking "I\'ll remember that for next time," save it.',
+  ].join('\n');
+}
+
+function buildContainerizedSection(): string {
+  const baseDataDir = process.env['BASE_DATA_DIR'] ?? '$BASE_DATA_DIR';
+  return [
+    '## Running in a Container — Data Persistence',
+    '',
+    `This assistant is running inside a container. Only the directory \`${baseDataDir}\` is mounted to a persistent volume.`,
+    '',
+    '**Any new files or data you create MUST be written inside that directory, or they will be lost when the container restarts.**',
+    '',
+    'Rules:',
+    `- Always store new data, notes, memories, configs, and downloads under \`${baseDataDir}\``,
+    `- When tools write to paths like \`~/.vellum\` or \`/tmp\`, those paths are already mapped through \`${baseDataDir}\` — do not write to other locations`,
+    '- Never write persistent data to system directories, `/tmp`, or paths outside the mounted volume',
+    '- When in doubt, prefer paths nested under the data directory',
   ].join('\n');
 }
 


### PR DESCRIPTION
## Summary
- Adds `IS_CONTAINERIZED` boolean env var (reads `IS_CONTAINERIZED=true/1`) to `env-registry.ts`
- When set, injects a new system prompt section reminding the assistant that only `BASE_DATA_DIR` is on a persistent volume and all new data must be written there to survive restarts
- The injected section dynamically shows the actual `BASE_DATA_DIR` value (or the placeholder `$BASE_DATA_DIR`) so the assistant knows the exact path

## Original prompt
add a new IS_CONTAINERIZED env var for the assistant if this env var is set it should add in the system prompt to always write any new data to the BASE_DATA_DIR or it won't get persisted on restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
