### PR TITLE
Left-align Platform connection status indicator

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -180,7 +180,6 @@ struct SettingsAccountTab: View {
                 Text("Platform")
                     .font(VFont.caption)
                     .foregroundColor(VColor.textMuted)
-                Spacer()
                 if store.isCheckingVellumPlatform {
                     ProgressView().controlSize(.small)
                 } else if let reachable = store.vellumPlatformReachable {


### PR DESCRIPTION
## Summary
- Remove `Spacer()` from the Platform status row so the connection indicator and refresh button sit left-aligned next to the "Platform" label, matching the Gateway and Tunnel rows

## Original prompt
move the connection status indicator and refresh button so that it's left-aligned and just to the right of "Platform" subtext (just like we do for Gateway and Tunnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
