### PR TITLE
feat: add Telegram approved users list with revoke UI

### DIFF
--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -275,7 +275,7 @@ export async function handleChannelInbound(
 
         if (body.replyCallbackUrl) {
           const replyText = guardianNotified
-            ? "I've let my guardian know you'd like access. They'll send you a verification code if they approve your request."
+            ? "Hmm looks like you don't have access to talk to me. I'll let them know you tried talking to them and get back to you."
             : "Sorry, you haven't been approved to message this assistant.";
           try {
             await deliverChannelReply(body.replyCallbackUrl, {
@@ -342,7 +342,7 @@ export async function handleChannelInbound(
 
           if (body.replyCallbackUrl) {
             const replyText = guardianNotified
-              ? "I've let my guardian know you'd like access. They'll send you a verification code if they approve your request."
+              ? "Hmm looks like you don't have access to talk to me. I'll let them know you tried talking to them and get back to you."
               : "Sorry, you haven't been approved to message this assistant.";
             try {
               await deliverChannelReply(body.replyCallbackUrl, {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -78,6 +78,7 @@ struct SettingsChannelsTab: View {
             store.refreshChannelGuardianStatus(channel: "telegram")
             store.refreshChannelGuardianStatus(channel: "sms")
             store.refreshChannelGuardianStatus(channel: "voice")
+            store.refreshTelegramApprovedMembers()
             store.fetchSlackChannelConfig()
         }
         .onChange(of: store.twilioHasCredentials) { _, hasCredentials in
@@ -308,9 +309,70 @@ struct SettingsChannelsTab: View {
                 Divider().background(VColor.surfaceBorder)
                 guardianStatusRow(channel: "telegram")
             }
+
+            // Approved users (only when bot token exists and guardian is verified)
+            if store.telegramHasBotToken && store.telegramGuardianVerified {
+                Divider().background(VColor.surfaceBorder)
+                telegramApprovedUsersSection
+            }
         }
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)
+    }
+
+    // MARK: - Telegram Approved Users
+
+    private var telegramApprovedUsersSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack(spacing: VSpacing.xs) {
+                Text("Approved Users")
+                VInfoTooltip("Users who have been granted access to interact with your assistant via Telegram.")
+            }
+            .font(VFont.caption)
+            .foregroundColor(VColor.textSecondary)
+
+            if store.telegramApprovedMembersLoading {
+                HStack(spacing: VSpacing.sm) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Loading...")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+            } else if store.telegramApprovedMembers.isEmpty {
+                Text("No approved users.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            } else {
+                ForEach(store.telegramApprovedMembers) { member in
+                    HStack(spacing: VSpacing.sm) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(member.displayName ?? member.username ?? member.externalUserId ?? member.id)
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textPrimary)
+                                .lineLimit(1)
+                            if let username = member.username, member.displayName != nil {
+                                Text("@\(username)")
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.textMuted)
+                                    .lineLimit(1)
+                            }
+                        }
+                        Spacer()
+                        VButton(label: "Revoke", style: .danger) {
+                            store.revokeTelegramApprovedMember(memberId: member.id)
+                        }
+                        .disabled(store.telegramRevokingMemberIds.contains(member.id))
+                    }
+                }
+            }
+
+            if let error = store.telegramApprovedMembersError {
+                Text(error)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
+            }
+        }
     }
 
     // MARK: - Telegram Credential Entry

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -162,6 +162,20 @@ public final class SettingsStore: ObservableObject {
     @Published var voiceOutboundSendCount: Int = 0
     @Published var voiceOutboundCode: String?
 
+    // MARK: - Approved Ingress Members (Telegram)
+
+    struct ApprovedMember: Identifiable, Equatable {
+        let id: String
+        let displayName: String?
+        let username: String?
+        let externalUserId: String?
+    }
+
+    @Published var telegramApprovedMembers: [ApprovedMember] = []
+    @Published var telegramApprovedMembersLoading: Bool = false
+    @Published var telegramApprovedMembersError: String?
+    @Published var telegramRevokingMemberIds: Set<String> = []
+
     // MARK: - Slack Channel Integration State
 
     @Published var slackChannelHasBotToken: Bool = false
@@ -1276,6 +1290,80 @@ public final class SettingsStore: ObservableObject {
             try daemonClient?.sendGuardianVerification(action: "revoke", channel: channel, assistantId: guardianAssistantScope)
         } catch {
             log.error("Failed to revoke \(channel) guardian: \(error)")
+        }
+    }
+
+    // MARK: - Approved Ingress Members Actions
+
+    func refreshTelegramApprovedMembers() {
+        guard let http = resolveRuntimeHTTP() else { return }
+        guard let url = URL(string: "\(http.baseURL)/v1/ingress/members?sourceChannel=telegram&status=active") else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+        telegramApprovedMembersLoading = true
+        telegramApprovedMembersError = nil
+        Task {
+            do {
+                let (data, response) = try await URLSession.shared.data(for: request)
+                self.telegramApprovedMembersLoading = false
+                guard let httpResp = response as? HTTPURLResponse else { return }
+                if httpResp.statusCode == 200 {
+                    if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                       let members = json["members"] as? [[String: Any]] {
+                        let guardianId = self.telegramGuardianIdentity
+                        self.telegramApprovedMembers = members.compactMap { m in
+                            guard let id = m["id"] as? String else { return nil }
+                            let externalUserId = m["externalUserId"] as? String
+                            // Skip the guardian — they're already shown in the Guardian Verification row
+                            if let guardianId, let externalUserId, externalUserId == guardianId {
+                                return nil
+                            }
+                            return ApprovedMember(
+                                id: id,
+                                displayName: m["displayName"] as? String,
+                                username: m["username"] as? String,
+                                externalUserId: externalUserId
+                            )
+                        }
+                        self.telegramApprovedMembersError = nil
+                    }
+                } else {
+                    self.telegramApprovedMembersError = "Failed to load (HTTP \(httpResp.statusCode))"
+                }
+            } catch {
+                self.telegramApprovedMembersLoading = false
+                self.telegramApprovedMembersError = "Failed to load: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    func revokeTelegramApprovedMember(memberId: String) {
+        guard let http = resolveRuntimeHTTP() else { return }
+        guard let url = URL(string: "\(http.baseURL)/v1/ingress/members/\(memberId)") else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+        telegramRevokingMemberIds.insert(memberId)
+        let removed = telegramApprovedMembers.filter { $0.id == memberId }
+        telegramApprovedMembers.removeAll { $0.id == memberId }
+        Task {
+            do {
+                let (_, response) = try await URLSession.shared.data(for: request)
+                self.telegramRevokingMemberIds.remove(memberId)
+                guard let httpResp = response as? HTTPURLResponse else { return }
+                if !(200..<300).contains(httpResp.statusCode) {
+                    // Rollback on failure
+                    self.telegramApprovedMembers.append(contentsOf: removed)
+                    self.telegramApprovedMembersError = "Failed to revoke (HTTP \(httpResp.statusCode))"
+                }
+            } catch {
+                self.telegramRevokingMemberIds.remove(memberId)
+                self.telegramApprovedMembers.append(contentsOf: removed)
+                self.telegramApprovedMembersError = "Failed to revoke: \(error.localizedDescription)"
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add an "Approved Users" section to the Telegram card in Settings > Channels, showing active ingress members with per-user revoke buttons
- Filter out the guardian from the approved users list (they already appear in the Guardian Verification row)
- Update the unapproved-user reply message to be more conversational

## Test plan
- [ ] Open Settings > Channels > Telegram card with a verified guardian and approved users
- [ ] Verify the guardian does not appear in the Approved Users list
- [ ] Click "Revoke" on an approved user and verify they are removed
- [ ] Send a message from an unapproved user and verify the new reply text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
