### PR TITLE
Extract shared ConnectionStatusRow component for connection status indicators

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ConnectionStatusRow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ConnectionStatusRow.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+/// Describes the current state of a connection check.
+struct ConnectionStatusInfo {
+    let label: String
+    let color: Color
+    let icon: String
+}
+
+/// A reusable row that displays a labelled connection status with an animated
+/// refresh button. Used for Platform, Gateway, and Tunnel status indicators.
+struct ConnectionStatusRow: View {
+    let label: String
+    let status: ConnectionStatusInfo
+    var isRefreshing: Bool = false
+    var lastChecked: Date? = nil
+    var onRefresh: (() -> Void)? = nil
+
+    /// Label font — defaults to `VFont.bodyMedium` to match Gateway/Tunnel.
+    var labelFont: Font = VFont.bodyMedium
+
+    /// Fixed width for the label column so icons line up across rows.
+    var labelWidth: CGFloat = 60
+
+    @State private var spinning: Bool = false
+
+    var body: some View {
+        let isSpinning = isRefreshing || spinning
+
+        HStack(spacing: VSpacing.sm) {
+            Text(label)
+                .font(labelFont)
+                .foregroundColor(VColor.textSecondary)
+                .frame(width: labelWidth, alignment: .leading)
+
+            Image(systemName: status.icon)
+                .foregroundColor(status.color)
+                .font(.system(size: 12))
+
+            Text(status.label)
+                .font(VFont.body)
+                .foregroundColor(status.color)
+
+            if let onRefresh {
+                let tooltipText: String = {
+                    if isSpinning { return "Checking..." }
+                    if let lastChecked { return "Last verified: \(relativeTimeString(from: lastChecked))" }
+                    return "Test connection"
+                }()
+
+                Button {
+                    guard !isSpinning else { return }
+                    spinning = true
+                    onRefresh()
+                    Task {
+                        try? await Task.sleep(nanoseconds: 500_000_000)
+                        spinning = false
+                    }
+                } label: {
+                    SpinningRefreshIcon(isSpinning: isSpinning)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Refresh \(label) status")
+                .help(tooltipText)
+            }
+
+            Spacer()
+        }
+    }
+
+    /// Returns a human-readable relative time string (e.g. "just now", "2 minutes ago").
+    private func relativeTimeString(from date: Date) -> String {
+        let seconds = Int(-date.timeIntervalSinceNow)
+        if seconds < 5 { return "just now" }
+        if seconds < 60 { return "\(seconds) seconds ago" }
+        let minutes = seconds / 60
+        if minutes == 1 { return "1 minute ago" }
+        if minutes < 60 { return "\(minutes) minutes ago" }
+        let hours = minutes / 60
+        if hours == 1 { return "1 hour ago" }
+        return "\(hours) hours ago"
+    }
+}
+
+// MARK: - Spinning Refresh Icon
+
+struct SpinningRefreshIcon: View {
+    let isSpinning: Bool
+
+    @State private var angle: Double = 0
+
+    var body: some View {
+        Image(systemName: "arrow.triangle.2.circlepath")
+            .font(.system(size: 11, weight: .medium))
+            .foregroundColor(isSpinning ? VColor.accent : VColor.textMuted)
+            .rotationEffect(.degrees(angle))
+            .frame(width: 24, height: 24)
+            .contentShape(Rectangle())
+            .task(id: isSpinning) {
+                if isSpinning {
+                    angle = 0
+                    while !Task.isCancelled {
+                        withAnimation(.linear(duration: 1)) {
+                            angle += 360
+                        }
+                        try? await Task.sleep(nanoseconds: 1_000_000_000)
+                    }
+                } else {
+                    angle = 0
+                }
+            }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -18,7 +18,6 @@ struct GatewaySettingsCard: View {
     @State private var gatewayTargetCopied: Bool = false
     @State private var showingRegenerateConfirmation: Bool = false
     @State private var isRegeneratingToken: Bool = false
-    @State private var refreshSpinning: Set<String> = []
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -110,7 +109,7 @@ struct GatewaySettingsCard: View {
                 .foregroundColor(VColor.textSecondary)
 
             // Gateway connection status (checks local daemon)
-            connectionStatusRow(
+            ConnectionStatusRow(
                 label: "Gateway",
                 status: gatewayStatusInfo,
                 isRefreshing: store.isCheckingGateway,
@@ -142,7 +141,7 @@ struct GatewaySettingsCard: View {
             }
 
             // Tunnel connection status (checks public URL)
-            connectionStatusRow(
+            ConnectionStatusRow(
                 label: "Tunnel",
                 status: tunnelStatusInfo,
                 isRefreshing: store.isCheckingTunnel,
@@ -254,12 +253,6 @@ struct GatewaySettingsCard: View {
 
     // MARK: - Connection Status Helpers
 
-    private struct ConnectionStatusInfo {
-        let label: String
-        let color: Color
-        let icon: String
-    }
-
     private var gatewayStatusInfo: ConnectionStatusInfo {
         guard let reachable = store.gatewayReachable else {
             return ConnectionStatusInfo(label: "Unknown", color: VColor.textMuted, icon: "questionmark.circle.fill")
@@ -300,99 +293,6 @@ struct GatewaySettingsCard: View {
             return ConnectionStatusInfo(label: "Reachable", color: VColor.success, icon: "checkmark.circle.fill")
         } else {
             return ConnectionStatusInfo(label: "Unreachable", color: VColor.error, icon: "xmark.circle.fill")
-        }
-    }
-
-    private func connectionStatusRow(
-        label: String,
-        status: ConnectionStatusInfo,
-        isRefreshing: Bool = false,
-        lastChecked: Date? = nil,
-        onRefresh: (() -> Void)? = nil
-    ) -> some View {
-        let spinning = isRefreshing || refreshSpinning.contains(label)
-
-        return HStack(spacing: VSpacing.sm) {
-            Text(label)
-                .font(VFont.bodyMedium)
-                .foregroundColor(VColor.textSecondary)
-                .frame(width: 60, alignment: .leading)
-
-            Image(systemName: status.icon)
-                .foregroundColor(status.color)
-                .font(.system(size: 12))
-
-            Text(status.label)
-                .font(VFont.body)
-                .foregroundColor(status.color)
-
-            if let onRefresh {
-                let tooltipText: String = {
-                    if spinning { return "Checking..." }
-                    if let lastChecked { return "Last verified: \(relativeTimeString(from: lastChecked))" }
-                    return "Test connection"
-                }()
-
-                Button {
-                    guard !spinning else { return }
-                    refreshSpinning.insert(label)
-                    onRefresh()
-                    Task {
-                        try? await Task.sleep(nanoseconds: 500_000_000)
-                        refreshSpinning.remove(label)
-                    }
-                } label: {
-                    SpinningRefreshIcon(isSpinning: spinning)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Refresh \(label) status")
-                .help(tooltipText)
-            }
-
-            Spacer()
-        }
-    }
-
-    /// Returns a human-readable relative time string (e.g. "just now", "2 minutes ago").
-    private func relativeTimeString(from date: Date) -> String {
-        let seconds = Int(-date.timeIntervalSinceNow)
-        if seconds < 5 { return "just now" }
-        if seconds < 60 { return "\(seconds) seconds ago" }
-        let minutes = seconds / 60
-        if minutes == 1 { return "1 minute ago" }
-        if minutes < 60 { return "\(minutes) minutes ago" }
-        let hours = minutes / 60
-        if hours == 1 { return "1 hour ago" }
-        return "\(hours) hours ago"
-    }
-
-    // MARK: - Spinning Refresh Icon
-
-    private struct SpinningRefreshIcon: View {
-        let isSpinning: Bool
-
-        @State private var angle: Double = 0
-
-        var body: some View {
-            Image(systemName: "arrow.triangle.2.circlepath")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(isSpinning ? VColor.accent : VColor.textMuted)
-                .rotationEffect(.degrees(angle))
-                .frame(width: 24, height: 24)
-                .contentShape(Rectangle())
-                .task(id: isSpinning) {
-                    if isSpinning {
-                        angle = 0
-                        while !Task.isCancelled {
-                            withAnimation(.linear(duration: 1)) {
-                                angle += 360
-                            }
-                            try? await Task.sleep(nanoseconds: 1_000_000_000)
-                        }
-                    } else {
-                        angle = 0
-                    }
-                }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -176,33 +176,31 @@ struct SettingsAccountTab: View {
             Divider().background(VColor.surfaceBorder)
 
             // Platform connection status
-            HStack(spacing: VSpacing.sm) {
-                Text("Platform")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
-                if store.isCheckingVellumPlatform {
-                    ProgressView().controlSize(.small)
-                } else if let reachable = store.vellumPlatformReachable {
-                    Image(systemName: reachable ? "checkmark.circle.fill" : "xmark.circle.fill")
-                        .foregroundColor(reachable ? VColor.success : VColor.error)
-                        .font(.system(size: 12))
-                    Text(reachable ? "Reachable" : (store.vellumPlatformError ?? "Unreachable"))
-                        .font(VFont.caption)
-                        .foregroundColor(reachable ? VColor.success : VColor.error)
-                }
-                Button {
-                    Task { await store.checkVellumPlatform() }
-                } label: {
-                    Image(systemName: "arrow.clockwise")
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundColor(VColor.textSecondary)
-                }
-                .buttonStyle(.plain)
+            ConnectionStatusRow(
+                label: "Platform",
+                status: platformStatusInfo,
+                isRefreshing: store.isCheckingVellumPlatform,
+                lastChecked: store.platformLastChecked
+            ) {
+                Task { await store.checkVellumPlatform() }
             }
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
+    }
+
+    // MARK: - Platform Status
+
+    private var platformStatusInfo: ConnectionStatusInfo {
+        guard let reachable = store.vellumPlatformReachable else {
+            return ConnectionStatusInfo(label: "Unknown", color: VColor.textMuted, icon: "questionmark.circle.fill")
+        }
+        if reachable {
+            return ConnectionStatusInfo(label: "Reachable", color: VColor.success, icon: "checkmark.circle.fill")
+        } else {
+            return ConnectionStatusInfo(label: store.vellumPlatformError ?? "Unreachable", color: VColor.error, icon: "xmark.circle.fill")
+        }
     }
 
     // MARK: - Assistant Info


### PR DESCRIPTION
## Summary
- Extract `ConnectionStatusRow`, `ConnectionStatusInfo`, and `SpinningRefreshIcon` into a shared `ConnectionStatusRow.swift` file
- Replace the inline Platform status in `SettingsAccountTab` with the shared component (gains spinning refresh icon, tooltip with last-checked time, and consistent styling)
- Update `GatewaySettingsCard` to use the shared component, removing ~100 lines of duplicated code

## Original prompt
we should use the same refresh icon and loading behavior and general styling for the Platform check as we have for Gateway and Tunnel. Maybe introduce a shared component to use across all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
