### PR TITLE
fix: correct pronoun in unapproved user reply message

### DIFF
--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -275,7 +275,7 @@ export async function handleChannelInbound(
 
         if (body.replyCallbackUrl) {
           const replyText = guardianNotified
-            ? "Hmm looks like you don't have access to talk to me. I'll let them know you tried talking to them and get back to you."
+            ? "Hmm looks like you don't have access to talk to me. I'll let them know you tried talking to me and get back to you."
             : "Sorry, you haven't been approved to message this assistant.";
           try {
             await deliverChannelReply(body.replyCallbackUrl, {
@@ -342,7 +342,7 @@ export async function handleChannelInbound(
 
           if (body.replyCallbackUrl) {
             const replyText = guardianNotified
-              ? "Hmm looks like you don't have access to talk to me. I'll let them know you tried talking to them and get back to you."
+              ? "Hmm looks like you don't have access to talk to me. I'll let them know you tried talking to me and get back to you."
               : "Sorry, you haven't been approved to message this assistant.";
             try {
               await deliverChannelReply(body.replyCallbackUrl, {


### PR DESCRIPTION
## Summary
- Fix "talking to them" → "talking to me" so the reply reads consistently from the assistant's perspective

## Test plan
- [ ] Send a message from an unapproved Telegram user and verify the reply says "talking to me"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
