### PR TITLE
Fix missing import in ConnectionStatusRow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ConnectionStatusRow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ConnectionStatusRow.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import VellumAssistantShared
 
 /// Describes the current state of a connection check.
 struct ConnectionStatusInfo {


### PR DESCRIPTION
## Summary
- Add missing `import VellumAssistantShared` to `ConnectionStatusRow.swift` so VFont, VColor, and VSpacing resolve at build time

🤖 Generated with [Claude Code](https://claude.com/claude-code)