### PR TITLE
Fix: pre-wrap user instructions in pendingInstructions

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -384,7 +384,7 @@ export class CallController {
 
     // Queue the instruction when it cannot be safely appended right now
     if (this.state === 'processing' || this.state === 'speaking') {
-      this.pendingInstructions.push(instructionText);
+      this.pendingInstructions.push(`[USER_INSTRUCTION: ${instructionText}]`);
       return;
     }
 


### PR DESCRIPTION
Pre-wrap user instructions at the handleUserInstruction push site so flushPendingInstructions correctly identifies them as already-formatted. Fixes a bug where raw user text starting with [ would skip the USER_INSTRUCTION wrapper. Part of #10187.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
