### PR TITLE
Make vellum ps reliable with process titles + multi-tier detection

### DIFF
--- a/assistant/src/daemon/main.ts
+++ b/assistant/src/daemon/main.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+process.title = 'vellum-daemon';
 import * as Sentry from '@sentry/node';
 
 import { getLogger } from '../util/logger.js';

--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -7,9 +7,15 @@ import {
   loadAllAssistants,
   type AssistantEntry,
 } from "../lib/assistant-config";
+import { GATEWAY_PORT } from "../lib/constants";
 import { checkHealth } from "../lib/health-check";
+import { pgrepExact } from "../lib/pgrep";
+import { probePort } from "../lib/port-probe";
 import { withStatusEmoji } from "../lib/status-emoji";
 import { execOutput } from "../lib/step-runner";
+
+const DAEMON_HTTP_PORT = Number(process.env.DAEMON_HTTP_PORT) || 7821;
+const QDRANT_PORT = 6333;
 
 // ── Table formatting helpers ────────────────────────────────────
 
@@ -149,62 +155,86 @@ async function getRemoteProcessesCustom(
   ]);
 }
 
-function checkPidFile(pidFile: string): { status: string; pid: string | null } {
-  if (!existsSync(pidFile)) {
-    return { status: "not running", pid: null };
-  }
+interface ProcessSpec {
+  name: string;
+  pgrepName: string;
+  port: number;
+  pidFile: string;
+}
+
+function readPidFile(pidFile: string): string | null {
+  if (!existsSync(pidFile)) return null;
   const pid = readFileSync(pidFile, "utf-8").trim();
+  return pid || null;
+}
+
+function isProcessAlive(pid: string): boolean {
   try {
     process.kill(parseInt(pid, 10), 0);
-    return { status: "running", pid };
+    return true;
   } catch {
-    return { status: "not running", pid };
+    return false;
   }
+}
+
+interface DetectedProcess {
+  name: string;
+  pid: string | null;
+  port: number;
+  running: boolean;
+}
+
+async function detectProcess(spec: ProcessSpec): Promise<DetectedProcess> {
+  // Tier 1: pgrep by process title
+  const pids = await pgrepExact(spec.pgrepName);
+  if (pids.length > 0) {
+    return { name: spec.name, pid: pids[0], port: spec.port, running: true };
+  }
+
+  // Tier 2: TCP port probe
+  const listening = await probePort(spec.port);
+  if (listening) {
+    const filePid = readPidFile(spec.pidFile);
+    return {
+      name: spec.name,
+      pid: filePid,
+      port: spec.port,
+      running: true,
+    };
+  }
+
+  // Tier 3: PID file fallback
+  const filePid = readPidFile(spec.pidFile);
+  if (filePid && isProcessAlive(filePid)) {
+    return { name: spec.name, pid: filePid, port: spec.port, running: true };
+  }
+
+  return { name: spec.name, pid: null, port: spec.port, running: false };
+}
+
+function formatDetectionInfo(proc: DetectedProcess): string {
+  const parts: string[] = [];
+  if (proc.pid) parts.push(`PID ${proc.pid}`);
+  parts.push(`port ${proc.port}`);
+  return parts.join(" | ");
 }
 
 async function getLocalProcesses(entry: AssistantEntry): Promise<TableRow[]> {
   const vellumDir = entry.baseDataDir ?? join(homedir(), ".vellum");
-  const rows: TableRow[] = [];
 
-  // Check daemon PID
-  const daemon = checkPidFile(join(vellumDir, "vellum.pid"));
-  rows.push({
-    name: "daemon",
-    status: withStatusEmoji(daemon.status),
-    info: daemon.pid ? `PID ${daemon.pid}` : "no PID file",
-  });
+  const specs: ProcessSpec[] = [
+    { name: "daemon", pgrepName: "vellum-daemon", port: DAEMON_HTTP_PORT, pidFile: join(vellumDir, "vellum.pid") },
+    { name: "qdrant", pgrepName: "qdrant", port: QDRANT_PORT, pidFile: join(vellumDir, "workspace", "data", "qdrant", "qdrant.pid") },
+    { name: "gateway", pgrepName: "vellum-gateway", port: GATEWAY_PORT, pidFile: join(vellumDir, "gateway.pid") },
+  ];
 
-  // Check qdrant PID
-  const qdrant = checkPidFile(join(vellumDir, "workspace", "data", "qdrant", "qdrant.pid"));
-  rows.push({
-    name: "qdrant",
-    status: withStatusEmoji(qdrant.status),
-    info: qdrant.pid ? `PID ${qdrant.pid} | port 6333` : "no PID file",
-  });
+  const results = await Promise.all(specs.map(detectProcess));
 
-  // Check gateway PID
-  const gateway = checkPidFile(join(vellumDir, "gateway.pid"));
-  rows.push({
-    name: "gateway",
-    status: withStatusEmoji(gateway.status),
-    info: gateway.pid ? `PID ${gateway.pid} | port 7830` : "no PID file",
-  });
-
-  // If no PID files found, fall back to health check
-  const allMissingPid = !daemon.pid && !qdrant.pid && !gateway.pid;
-  if (allMissingPid) {
-    const health = await checkHealth(entry.runtimeUrl);
-    if (health.status === "healthy" || health.status === "ok") {
-      rows.length = 0;
-      rows.push({
-        name: "daemon",
-        status: withStatusEmoji("running"),
-        info: "no PID file (detected via health check)",
-      });
-    }
-  }
-
-  return rows;
+  return results.map((proc) => ({
+    name: proc.name,
+    status: withStatusEmoji(proc.running ? "running" : "not running"),
+    info: proc.running ? formatDetectionInfo(proc) : "not detected",
+  }));
 }
 
 async function showAssistantProcesses(entry: AssistantEntry): Promise<void> {
@@ -270,10 +300,10 @@ async function detectOrphanedProcesses(): Promise<OrphanedProcess[]> {
   ];
 
   for (const { file, name } of pidFiles) {
-    const result = checkPidFile(file);
-    if (result.status === "running" && result.pid) {
-      results.push({ name, pid: result.pid, source: "pid file" });
-      seenPids.add(result.pid);
+    const pid = readPidFile(file);
+    if (pid && isProcessAlive(pid)) {
+      results.push({ name, pid, source: "pid file" });
+      seenPids.add(pid);
     }
   }
 

--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -14,7 +14,7 @@ import { probePort } from "../lib/port-probe";
 import { withStatusEmoji } from "../lib/status-emoji";
 import { execOutput } from "../lib/step-runner";
 
-const DAEMON_HTTP_PORT = Number(process.env.DAEMON_HTTP_PORT) || 7821;
+const RUNTIME_HTTP_PORT = Number(process.env.RUNTIME_HTTP_PORT) || 7821;
 const QDRANT_PORT = 6333;
 
 // ── Table formatting helpers ────────────────────────────────────
@@ -223,7 +223,7 @@ async function getLocalProcesses(entry: AssistantEntry): Promise<TableRow[]> {
   const vellumDir = entry.baseDataDir ?? join(homedir(), ".vellum");
 
   const specs: ProcessSpec[] = [
-    { name: "daemon", pgrepName: "vellum-daemon", port: DAEMON_HTTP_PORT, pidFile: join(vellumDir, "vellum.pid") },
+    { name: "daemon", pgrepName: "vellum-daemon", port: RUNTIME_HTTP_PORT, pidFile: join(vellumDir, "vellum.pid") },
     { name: "qdrant", pgrepName: "qdrant", port: QDRANT_PORT, pidFile: join(vellumDir, "workspace", "data", "qdrant", "qdrant.pid") },
     { name: "gateway", pgrepName: "vellum-gateway", port: GATEWAY_PORT, pidFile: join(vellumDir, "gateway.pid") },
   ];

--- a/cli/src/lib/pgrep.ts
+++ b/cli/src/lib/pgrep.ts
@@ -1,0 +1,10 @@
+import { execOutput } from "./step-runner";
+
+export async function pgrepExact(name: string): Promise<string[]> {
+  try {
+    const output = await execOutput("pgrep", ["-x", name]);
+    return output.trim().split("\n").filter(Boolean);
+  } catch {
+    return [];
+  }
+}

--- a/cli/src/lib/port-probe.ts
+++ b/cli/src/lib/port-probe.ts
@@ -1,0 +1,23 @@
+import { Socket } from "node:net";
+
+const PROBE_TIMEOUT_MS = 750;
+
+export function probePort(port: number, host = "127.0.0.1"): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = new Socket();
+    socket.setTimeout(PROBE_TIMEOUT_MS);
+    socket.once("connect", () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.once("timeout", () => {
+      socket.destroy();
+      resolve(false);
+    });
+    socket.once("error", () => {
+      socket.destroy();
+      resolve(false);
+    });
+    socket.connect(port, host);
+  });
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,3 +1,5 @@
+process.title = "vellum-gateway";
+
 import { randomBytes } from "node:crypto";
 import { readFileSync, watch, existsSync, mkdirSync, type FSWatcher } from "node:fs";
 import { join, dirname } from "node:path";


### PR DESCRIPTION
## Summary
- Set `process.title` on daemon (`vellum-daemon`) and gateway (`vellum-gateway`) so `pgrep -x` can find them reliably
- Replace PID-file-only detection in `getLocalProcesses()` with a three-tier chain: `pgrep` → TCP port probe → PID file fallback
- Detect daemon (port 7821), qdrant (port 6333), and gateway (port 7830) in parallel via `Promise.all`
- Remove the old "all missing PID → health check" fallback (subsumed by port probing)

## Test plan
- [ ] Hatch an assistant, run `vellum ps <name>` — all three show running with PIDs and ports
- [ ] `ps aux | grep vellum` — daemon shows as `vellum-daemon`, gateway as `vellum-gateway`
- [ ] Kill gateway, verify `vellum ps` shows it as not running
- [ ] Create stale PID file, verify port probe still detects running service
- [ ] Stop all processes, verify all show "not detected"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
