### PR TITLE
feat: auto-initiate /safe-check-review after 60s in safe-execute-plan

### DIFF
--- a/.claude/commands/safe-execute-plan.md
+++ b/.claude/commands/safe-execute-plan.md
@@ -266,7 +266,7 @@ Write `.private/safe-plan-state/<plan-slug>.md` with this format:
 - **Review cycles completed**: <cycle-counter>/3
 ```
 
-### 8. Notify the user and stop
+### 8. Notify the user and auto-initiate review check
 
 Tell the user:
 
@@ -279,8 +279,14 @@ Tell the user:
 >
 > **Next steps:**
 > - `/resume-plan <plan file>` — merge this PR and continue to the next one
+>
+> Waiting 60 seconds, then automatically running `/safe-check-review <plan file>`...
+> To skip the wait and check reviews immediately, send any message now.
+> To skip and resume the plan directly without checking reviews, run `/resume-plan <plan file>`.
 
-Then **stop**. Do NOT continue to the next PR.
+Wait 60 seconds (`sleep 60`), then automatically invoke `/safe-check-review <plan file>`.
+
+Do NOT continue to the next PR directly — let `/safe-check-review` handle merging and continuing the plan.
 
 ## Important
 

--- a/.claude/commands/safe-execute-plan.md
+++ b/.claude/commands/safe-execute-plan.md
@@ -281,8 +281,8 @@ Tell the user:
 > - `/resume-plan <plan file>` — merge this PR and continue to the next one
 >
 > Waiting 60 seconds, then automatically running `/safe-check-review <plan file>`...
-> To skip the wait and check reviews immediately, send any message now.
-> To skip and resume the plan directly without checking reviews, run `/resume-plan <plan file>`.
+> To skip the wait: interrupt the agent (Ctrl+C), then run `/safe-check-review <plan file>` manually.
+> To skip and resume the plan directly without checking reviews: interrupt the agent (Ctrl+C), then run `/resume-plan <plan file>`.
 
 Wait 60 seconds (`sleep 60`), then automatically invoke `/safe-check-review <plan file>`.
 

--- a/.claude/commands/safe-execute-plan.md
+++ b/.claude/commands/safe-execute-plan.md
@@ -286,7 +286,7 @@ Tell the user:
 
 Wait 60 seconds (`sleep 60`), then automatically invoke `/safe-check-review <plan file>`.
 
-Do NOT continue to the next PR directly — let `/safe-check-review` handle merging and continuing the plan.
+Do NOT continue to the next PR directly — `/safe-check-review` will check for and address review feedback, then prompt the user to run `/resume-plan` when ready to merge.
 
 ## Important
 

--- a/README.md
+++ b/README.md
@@ -717,17 +717,17 @@ A three-command workflow for executing plans one PR at a time with human review 
 
 | Command | Purpose |
 |---------|---------|
-| `/safe-execute-plan <file>` | Start a plan from `.private/plans/` — implements the next PR, creates it (without merging), automatically runs an **automated review feedback loop** (up to 3 fix cycles with Codex/Devin), and stops to await human merge approval. |
+| `/safe-execute-plan <file>` | Start a plan from `.private/plans/` — implements the next PR, creates it (without merging), automatically runs an **automated review feedback loop** (up to 3 fix cycles with Codex/Devin), then auto-initiates `/safe-check-review` after 60 seconds to await human merge approval. |
 | `/safe-check-review [file]` | Check the active plan PR for feedback from codex/devin/humans and CI. Runs an **automated feedback loop** (up to 3 fix cycles): fetches full review data (reviews, inline comments, review threads, reactions, CI checks), determines aggregate status including CI state and human unresolved threads, addresses `changes_requested` by pushing fixes, re-requests reviews, and polls for fresh responses — only concluding approved once all reviewers (bots and humans) and CI are green. Auto-detects the plan if only one is active. |
 | `/resume-plan [file]` | Merge the current PR, implement the next one, create it, and stop again. Repeats until the plan is complete. Auto-detects the plan if only one is active. |
 
 **Typical flow:**
 
-1. **`/safe-execute-plan MY_PLAN.md`** — starts the plan, creates PR 1, automatically handles Codex/Devin review feedback (up to 3 cycles), then stops
+1. **`/safe-execute-plan MY_PLAN.md`** — starts the plan, creates PR 1, automatically handles Codex/Devin review feedback (up to 3 cycles), then auto-initiates `/safe-check-review` after 60 seconds
 2. **`/resume-plan MY_PLAN.md`** — merge PR 1 (automated reviews already complete), create PR 2, stop
 3. Repeat step 2 until the plan is complete
 
-The automated review loop in `/safe-execute-plan` triggers Codex and Devin reviews, waits for their feedback (up to 15 minutes for initial reviews, 10 minutes for subsequent cycles), addresses any `changes_requested` feedback by pushing fixes directly to the PR branch, and re-requests reviews — repeating up to 3 cycles before handing off to you.
+The automated review loop in `/safe-execute-plan` triggers Codex and Devin reviews, waits for their feedback (up to 15 minutes for initial reviews, 10 minutes for subsequent cycles), addresses any `changes_requested` feedback by pushing fixes directly to the PR branch, and re-requests reviews — repeating up to 3 cycles. After the review loop completes, it waits 60 seconds then automatically invokes `/safe-check-review` to hand off to you for merge approval.
 
 Multiple plans can run in parallel — just specify the plan name to disambiguate.
 
@@ -755,7 +755,7 @@ Multiple plans can run in parallel — just specify the plan name to disambiguat
 
 Or for a focused feature: **`/blitz <feature>`** handles all of the above in one shot (plan, issues, swarm, sweep, report). Use **`/safe-blitz <feature>`** for the same workflow but with a feature branch and a final PR for manual review, then **`/safe-blitz-done`** to merge it when ready.
 
-For controlled, sequential plan execution with automated bot reviews and human merge approval: **`/safe-execute-plan <file>`** (creates PR + auto-handles Codex/Devin feedback) → **`/resume-plan`** → repeat.
+For controlled, sequential plan execution with automated bot reviews and human merge approval: **`/safe-execute-plan <file>`** (creates PR + auto-handles Codex/Devin feedback + auto-initiates `/safe-check-review` after 60s) → **`/resume-plan`** → repeat.
 
 All workflows use squash-merge (no merge commits), worktree isolation for parallel work, and track state in `.private/TODO.md` and `.private/UNREVIEWED_PRS.md`.
 


### PR DESCRIPTION
## Summary
- After notifying the user that a PR is ready, wait 60 seconds then automatically invoke `/safe-check-review`
- Kept existing `/resume-plan` next-step instruction
- Added instructions to skip the 60s wait (send any message) or skip directly to resuming the plan

## Original prompt
update safe-execute-plan to automatically initiate /safe-check-review plan after waiting 60 seconds. Keep the existing instructions about resumeing the plan though and a new instruction about how to skip the sleep and to resume the plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
