### PR TITLE
Voice ASK_GUARDIAN Non-Blocking Flow

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -351,7 +351,7 @@ describe('call-controller', () => {
 
   // ── ASK_GUARDIAN pattern ──────────────────────────────────────────
 
-  test('ASK_GUARDIAN pattern: detects pattern, creates pending question, enters waiting_on_user', async () => {
+  test('ASK_GUARDIAN pattern: detects pattern, creates pending question, sets session to waiting_on_user', async () => {
     mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
       ['Let me check on that. ', '[ASK_GUARDIAN: What date works best?]'],
     ));
@@ -365,9 +365,17 @@ describe('call-controller', () => {
     expect(question!.questionText).toBe('What date works best?');
     expect(question!.status).toBe('pending');
 
-    // Verify session status was updated to waiting_on_user
+    // Controller state returns to idle (non-blocking); consultation is
+    // tracked separately via pendingConsultation.
+    expect(controller.getState()).toBe('idle');
+
+    // Session status in the store is still set to waiting_on_user for
+    // external consumers (e.g. the answer route).
     const updatedSession = getCallSession(session.id);
     expect(updatedSession!.status).toBe('waiting_on_user');
+
+    // A pending consultation should be active
+    expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
 
     // The ASK_GUARDIAN marker text should NOT appear in the relay tokens
     const allText = relay.sentTokens.map((t) => t.token).join('');
@@ -474,13 +482,14 @@ describe('call-controller', () => {
 
     await controller.handleCallerUtterance('Can I book for 7:30?');
 
-    // Verify we're in waiting_on_user state
-    expect(controller.getState()).toBe('waiting_on_user');
+    // Controller returns to idle (non-blocking); consultation tracked separately
+    expect(controller.getState()).toBe('idle');
+    expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
     const question = getPendingQuestion(session.id);
     expect(question).not.toBeNull();
     expect(question!.questionText).toBe('Is 8:00 okay instead?');
 
-    // Verify session status
+    // Session status in store reflects consultation state
     const midSession = getCallSession(session.id);
     expect(midSession!.status).toBe('waiting_on_user');
 
@@ -530,10 +539,10 @@ describe('call-controller', () => {
     controller.destroy();
   });
 
-  test('handleUserAnswer: returns false when not in waiting_on_user state', async () => {
+  test('handleUserAnswer: returns false when no pending consultation exists', async () => {
     const { controller } = setupController();
 
-    // Controller starts in idle state
+    // No consultation is pending — answer should be rejected
     const result = await controller.handleUserAnswer('some answer');
     expect(result).toBe(false);
 
@@ -818,55 +827,54 @@ describe('call-controller', () => {
     controller.destroy();
   });
 
-  // ── waiting_on_user re-entry guard ────────────────────────────────
+  // ── Non-blocking consultation: caller follow-up during pending consultation ──
 
-  test('handleCallerUtterance: does NOT trigger startVoiceTurn when waiting_on_user', async () => {
-    // Trigger ASK_GUARDIAN to enter waiting_on_user state
+  test('handleCallerUtterance: triggers normal turn while consultation is pending (non-blocking)', async () => {
+    // Trigger ASK_GUARDIAN to start a consultation
     mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
       ['Hold on. [ASK_GUARDIAN: What time works?]'],
     ));
     const { controller } = setupController();
     await controller.handleCallerUtterance('Book me in');
-    expect(controller.getState()).toBe('waiting_on_user');
+    // Controller returns to idle; consultation tracked separately
+    expect(controller.getState()).toBe('idle');
+    expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
 
     // Track calls to startVoiceTurn from this point
     let turnCallCount = 0;
     mockStartVoiceTurn.mockImplementation(async (opts: { onTextDelta: (t: string) => void; onComplete: () => void }) => {
       turnCallCount++;
-      opts.onTextDelta('Should not appear.');
+      opts.onTextDelta('Sure, let me help with that.');
       opts.onComplete();
-      return { turnId: 'run-blocked', abort: () => {} };
+      return { turnId: 'run-followup', abort: () => {} };
     });
 
-    // Caller speaks while waiting — should be queued, not processed
+    // Caller speaks while consultation is pending — should trigger a normal turn
     await controller.handleCallerUtterance('Hello? Are you still there?');
-    expect(turnCallCount).toBe(0);
-    expect(controller.getState()).toBe('waiting_on_user');
+    expect(turnCallCount).toBe(1);
+    // Controller returns to idle after the turn completes
+    expect(controller.getState()).toBe('idle');
+    // Consultation should still be pending
+    expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
 
     controller.destroy();
   });
 
-  test('queued caller utterance IS processed after handleUserAnswer resolves', async () => {
-    // Trigger ASK_GUARDIAN to enter waiting_on_user state
+  test('guardian answer arriving while controller idle: queued as instruction and flushed immediately', async () => {
+    // Trigger ASK_GUARDIAN to start a consultation
     mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
       ['Checking. [ASK_GUARDIAN: Confirm appointment?]'],
     ));
     const { controller } = setupController();
     await controller.handleCallerUtterance('I want to schedule');
-    expect(controller.getState()).toBe('waiting_on_user');
+    expect(controller.getState()).toBe('idle');
+    expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
 
-    // Caller speaks while waiting — queued
-    await controller.handleCallerUtterance('Actually make it 4pm');
-
-    // Set up mocks for the answer turn and subsequent queued utterance turn
+    // Set up mock for the answer turn
     const turnContents: string[] = [];
     mockStartVoiceTurn.mockImplementation(async (opts: { content: string; onTextDelta: (t: string) => void; onComplete: () => void }) => {
       turnContents.push(opts.content);
-      if (opts.content.includes('[USER_ANSWERED:')) {
-        opts.onTextDelta('Confirmed.');
-      } else {
-        opts.onTextDelta('Got it, 4pm.');
-      }
+      opts.onTextDelta('Confirmed.');
       opts.onComplete();
       return { turnId: `run-${turnContents.length}`, abort: () => {} };
     });
@@ -877,62 +885,59 @@ describe('call-controller', () => {
     // Give fire-and-forget turns time to complete
     await new Promise((r) => setTimeout(r, 100));
 
-    // The answer turn should have fired
+    // The answer turn should have fired with the USER_ANSWERED marker
     expect(turnContents.some((c) => c.includes('[USER_ANSWERED: Yes, confirmed]'))).toBe(true);
-    // The queued caller utterance should also have been processed
-    expect(turnContents.some((c) => c.includes('Actually make it 4pm'))).toBe(true);
+    // Consultation should now be cleared
+    expect(controller.getPendingConsultationQuestionId()).toBeNull();
 
     controller.destroy();
   });
 
-  test('no duplicate guardian dispatch: subsequent handleCallerUtterance during waiting_on_user does not produce another ASK_GUARDIAN', async () => {
-    // Trigger ASK_GUARDIAN to enter waiting_on_user
+  test('no duplicate guardian dispatch: second ASK_GUARDIAN supersedes the first consultation', async () => {
+    // Trigger ASK_GUARDIAN to start first consultation
     mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
       ['Let me ask. [ASK_GUARDIAN: Preferred date?]'],
     ));
-    const { controller } = setupController();
+    const { session, controller } = setupController();
     await controller.handleCallerUtterance('Schedule please');
-    expect(controller.getState()).toBe('waiting_on_user');
+    expect(controller.getState()).toBe('idle');
+    const firstQuestionId = controller.getPendingConsultationQuestionId();
+    expect(firstQuestionId).not.toBeNull();
 
-    // Count how many times startVoiceTurn is invoked after this point
-    let postGuardianTurnCount = 0;
-    mockStartVoiceTurn.mockImplementation(async (opts: { onTextDelta: (t: string) => void; onComplete: () => void }) => {
-      postGuardianTurnCount++;
-      // Simulate the model trying to emit another ASK_GUARDIAN
-      opts.onTextDelta('[ASK_GUARDIAN: Preferred date again?]');
-      opts.onComplete();
-      return { turnId: 'run-dup', abort: () => {} };
-    });
-
-    // Multiple caller utterances during waiting_on_user — all should be queued
+    // Model emits another ASK_GUARDIAN in a subsequent turn — supersedes
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Actually let me re-check. [ASK_GUARDIAN: Preferred date again?]'],
+    ));
     await controller.handleCallerUtterance('Hello?');
-    await controller.handleCallerUtterance('Anyone there?');
 
-    // No turns should have started
-    expect(postGuardianTurnCount).toBe(0);
-    // State should still be waiting_on_user
-    expect(controller.getState()).toBe('waiting_on_user');
+    // New consultation should replace the old one
+    const secondQuestionId = controller.getPendingConsultationQuestionId();
+    expect(secondQuestionId).not.toBeNull();
+    expect(secondQuestionId).not.toBe(firstQuestionId);
+
+    // The session status should still be waiting_on_user
+    const updatedSession = getCallSession(session.id);
+    expect(updatedSession!.status).toBe('waiting_on_user');
 
     controller.destroy();
   });
 
-  test('handleUserAnswer: returns false when not in waiting_on_user state (stale/duplicate guard)', async () => {
+  test('handleUserAnswer: returns false when no pending consultation (stale/duplicate guard)', async () => {
     const { controller } = setupController();
 
-    // idle state
+    // No consultation pending — idle state, answer rejected
     expect(await controller.handleUserAnswer('some answer')).toBe(false);
 
-    // processing state — trigger a turn first
+    // Start a turn to enter processing state — still no consultation
     mockStartVoiceTurn.mockImplementation(async (opts: { onTextDelta: (t: string) => void; onComplete: () => void }) => {
-      // Slow turn — give time to call handleUserAnswer while processing
       await new Promise((r) => setTimeout(r, 200));
       opts.onTextDelta('Response.');
       opts.onComplete();
       return { turnId: 'run-proc', abort: () => {} };
     });
     const turnPromise = controller.handleCallerUtterance('Test');
-    // Give it a moment to enter processing state
     await new Promise((r) => setTimeout(r, 10));
+    // No consultation → answer rejected regardless of controller state
     expect(await controller.handleUserAnswer('stale answer')).toBe(false);
 
     // Clean up
@@ -940,52 +945,98 @@ describe('call-controller', () => {
     controller.destroy();
   });
 
-  test('handleUserInstruction: does not trigger turn when controller is not idle', async () => {
-    // First, trigger ASK_GUARDIAN so controller enters waiting_on_user
+  test('duplicate answer to same consultation: first accepted, second rejected', async () => {
+    // Trigger ASK_GUARDIAN consultation
     mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
       ['Hold on. [ASK_GUARDIAN: What time?]'],
     ));
+    const { controller } = setupController();
+    await controller.handleCallerUtterance('Book me');
+    expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
 
-    const { session, controller } = setupController();
-    await controller.handleCallerUtterance('I need an appointment');
-    expect(controller.getState()).toBe('waiting_on_user');
-
-    // Track how many times startVoiceTurn is called
-    let turnCallCount = 0;
-    mockStartVoiceTurn.mockImplementation(async (opts: { onTextDelta: (t: string) => void; onComplete: () => void }) => {
-      turnCallCount++;
-      opts.onTextDelta('Response after instruction.');
+    // Set up mock for the answer turn
+    mockStartVoiceTurn.mockImplementation(async (opts: { content: string; onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      opts.onTextDelta('Got it.');
       opts.onComplete();
-      return { turnId: 'run-2', abort: () => {} };
+      return { turnId: 'run-answer', abort: () => {} };
     });
 
-    // Inject instruction while in waiting_on_user state
+    // First answer is accepted
+    const first = await controller.handleUserAnswer('3pm');
+    expect(first).toBe(true);
+    expect(controller.getPendingConsultationQuestionId()).toBeNull();
+
+    // Second answer is rejected — consultation already consumed
+    const second = await controller.handleUserAnswer('4pm');
+    expect(second).toBe(false);
+
+    await new Promise((r) => setTimeout(r, 50));
+    controller.destroy();
+  });
+
+  test('handleUserInstruction: queues when processing, but triggers when idle', async () => {
+    // Track content passed to each voice turn invocation
+    const turnContents: string[] = [];
+    let turnCount = 0;
+
+    // Start a slow turn to put controller in processing/speaking state.
+    // After the first turn completes, the mock switches to a fast handler
+    // that captures content so we can verify the flushed instruction.
+    mockStartVoiceTurn.mockImplementation(async (opts: { content: string; onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      turnCount++;
+      if (turnCount === 1) {
+        // First turn: slow, simulates processing state
+        await new Promise((r) => setTimeout(r, 100));
+        opts.onTextDelta('Response.');
+        opts.onComplete();
+        return { turnId: 'run-1', abort: () => {} };
+      }
+      // Subsequent turns: capture content and complete immediately
+      turnContents.push(opts.content);
+      opts.onTextDelta('Noted.');
+      opts.onComplete();
+      return { turnId: `run-${turnCount}`, abort: () => {} };
+    });
+
+    const { session, controller } = setupController();
+    const turnPromise = controller.handleCallerUtterance('Hello');
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Inject instruction while processing — should be queued
     await controller.handleUserInstruction('Suggest morning slots');
 
-    // The turn should NOT have been triggered since we're not idle
-    expect(turnCallCount).toBe(0);
-
-    // But the event should still be recorded
+    // Event should be recorded even when queued
     const events = getCallEvents(session.id);
     const instructionEvents = events.filter((e) => e.eventType === 'user_instruction_relayed');
     expect(instructionEvents.length).toBe(1);
+
+    // Wait for the first turn to finish (instructions flushed at turn boundary)
+    await turnPromise;
+
+    // Allow the fire-and-forget flush turn to execute
+    await new Promise((r) => setTimeout(r, 50));
+
+    // The queued instruction should have been flushed into a new turn
+    expect(turnContents.length).toBeGreaterThanOrEqual(1);
+    expect(turnContents.some((c) => c.includes('[USER_INSTRUCTION: Suggest morning slots]'))).toBe(true);
+
+    // Controller should return to idle after the flush turn completes
+    expect(controller.getState()).toBe('idle');
 
     controller.destroy();
   });
 
   // ── Post-end-call drain guard ───────────────────────────────────
 
-  test('handleUserAnswer: queued caller utterances are discarded (not processed) when answer turn ends the call', async () => {
-    // Trigger ASK_GUARDIAN to enter waiting_on_user state
+  test('handleUserAnswer: answer turn ends call with END_CALL, no further turns after completion', async () => {
+    // Trigger ASK_GUARDIAN to start a consultation
     mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
       ['Checking. [ASK_GUARDIAN: Confirm cancellation?]'],
     ));
     const { session, relay, controller } = setupController();
     await controller.handleCallerUtterance('I want to cancel');
-    expect(controller.getState()).toBe('waiting_on_user');
-
-    // Queue a caller utterance while waiting
-    await controller.handleCallerUtterance('Never mind, just cancel it');
+    expect(controller.getState()).toBe('idle');
+    expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
 
     // Set up mock so the answer turn ends the call with [END_CALL]
     const turnContents: string[] = [];
@@ -1004,8 +1055,6 @@ describe('call-controller', () => {
 
     // The answer turn should have fired
     expect(turnContents.some((c) => c.includes('[USER_ANSWERED: Yes, cancel it]'))).toBe(true);
-    // The queued caller utterance should NOT have been processed — only the answer turn
-    expect(turnContents.length).toBe(1);
 
     // Call should be completed
     const updatedSession = getCallSession(session.id);
@@ -1021,13 +1070,14 @@ describe('call-controller', () => {
     // Use a short consultation timeout so we can wait for it in the test
     mockConsultationTimeoutMs = 50;
 
-    // Trigger ASK_GUARDIAN to enter waiting_on_user state
+    // Trigger ASK_GUARDIAN to start a consultation
     mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
       ['Let me check. [ASK_GUARDIAN: What time works?]'],
     ));
     const { session, relay, controller } = setupController();
     await controller.handleCallerUtterance('Book me in');
-    expect(controller.getState()).toBe('waiting_on_user');
+    expect(controller.getState()).toBe('idle');
+    expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
 
     // Set up mock to capture what content the timeout turn receives
     const turnContents: string[] = [];
@@ -1041,11 +1091,12 @@ describe('call-controller', () => {
     // Wait for the short consultation timeout to fire
     await new Promise((r) => setTimeout(r, 200));
 
-    // A generated turn should have been fired with the GUARDIAN_TIMEOUT instruction
+    // A generated turn should have been fired with the GUARDIAN_TIMEOUT instruction.
+    // The instruction starts with '[' so flushPendingInstructions passes it through
+    // without wrapping it in [USER_INSTRUCTION:].
     expect(turnContents.length).toBe(1);
     expect(turnContents[0]).toContain('[GUARDIAN_TIMEOUT]');
     expect(turnContents[0]).toContain('What time works?');
-    expect(turnContents[0]).toContain('[USER_INSTRUCTION:');
 
     // No hardcoded timeout text should appear in relay tokens
     const allText = relay.sentTokens.map((t) => t.token).join('');
@@ -1059,27 +1110,24 @@ describe('call-controller', () => {
     controller.destroy();
   });
 
-  test('consultation timeout: merges pending instructions and caller utterances into the timeout turn', async () => {
+  test('consultation timeout: timeout instruction fires even when controller is idle', async () => {
     // Use a short consultation timeout so we can wait for it in the test
     mockConsultationTimeoutMs = 50;
 
-    // Trigger ASK_GUARDIAN to enter waiting_on_user state
+    // Trigger ASK_GUARDIAN to start a consultation
     mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
       ['Let me check. [ASK_GUARDIAN: What time works?]'],
     ));
     const { controller } = setupController();
     await controller.handleCallerUtterance('Book me in');
-    expect(controller.getState()).toBe('waiting_on_user');
+    expect(controller.getState()).toBe('idle');
+    expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
 
-    // Queue an instruction and a caller utterance while waiting
-    await controller.handleUserInstruction('Suggest morning slots');
-    await controller.handleCallerUtterance('Actually, I prefer 10am');
-
-    // Set up mock to capture what content the merged turn receives
+    // Set up mock to capture what content the timeout turn receives
     const turnContents: string[] = [];
     mockStartVoiceTurn.mockImplementation(async (opts: { content: string; onTextDelta: (t: string) => void; onComplete: () => void }) => {
       turnContents.push(opts.content);
-      opts.onTextDelta('Got it, let me check 10am availability.');
+      opts.onTextDelta('Got it, I was unable to reach them.');
       opts.onComplete();
       return { turnId: `run-${turnContents.length}`, abort: () => {} };
     });
@@ -1087,12 +1135,13 @@ describe('call-controller', () => {
     // Wait for the short consultation timeout to fire
     await new Promise((r) => setTimeout(r, 200));
 
-    // A single merged turn should have been fired containing instructions,
-    // the timeout instruction, and the caller utterance
-    expect(turnContents.length).toBe(1);
-    expect(turnContents[0]).toContain('[USER_INSTRUCTION: Suggest morning slots]');
-    expect(turnContents[0]).toContain('[GUARDIAN_TIMEOUT]');
-    expect(turnContents[0]).toContain('Actually, I prefer 10am');
+    // The timeout instruction turn should have fired
+    const timeoutTurns = turnContents.filter((c) => c.includes('[GUARDIAN_TIMEOUT]'));
+    expect(timeoutTurns.length).toBe(1);
+    expect(timeoutTurns[0]).toContain('What time works?');
+
+    // Consultation should be cleared after timeout
+    expect(controller.getPendingConsultationQuestionId()).toBeNull();
 
     controller.destroy();
   });
@@ -1100,13 +1149,14 @@ describe('call-controller', () => {
   test('consultation timeout: marks linked guardian action request as timed out', async () => {
     mockConsultationTimeoutMs = 50;
 
-    // Trigger ASK_GUARDIAN to enter waiting_on_user state
+    // Trigger ASK_GUARDIAN to start a consultation
     mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
       ['Let me check. [ASK_GUARDIAN: What time works?]'],
     ));
     const { session, controller } = setupController();
     await controller.handleCallerUtterance('Book me in');
-    expect(controller.getState()).toBe('waiting_on_user');
+    expect(controller.getState()).toBe('idle');
+    expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
 
     // Give the async dispatchGuardianQuestion a tick to create the request
     await new Promise((r) => setTimeout(r, 10));
@@ -1143,13 +1193,14 @@ describe('call-controller', () => {
   test('ASK_GUARDIAN after timeout: skips wait and injects GUARDIAN_UNAVAILABLE instruction', async () => {
     mockConsultationTimeoutMs = 50;
 
-    // Step 1: Trigger ASK_GUARDIAN to enter waiting_on_user state
+    // Step 1: Trigger ASK_GUARDIAN to start a consultation
     mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
       ['Let me check. [ASK_GUARDIAN: What time works?]'],
     ));
     const { session, controller } = setupController();
     await controller.handleCallerUtterance('Book me in');
-    expect(controller.getState()).toBe('waiting_on_user');
+    expect(controller.getState()).toBe('idle');
+    expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
 
     // Step 2: Set up mock for timeout-generated turn
     mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
@@ -1185,8 +1236,9 @@ describe('call-controller', () => {
     // The second turn should contain the GUARDIAN_UNAVAILABLE instruction
     expect(turnCount).toBeGreaterThanOrEqual(2);
     expect(turnContents.some((c) => c.includes('[GUARDIAN_UNAVAILABLE]'))).toBe(true);
-    // Should NOT have entered waiting_on_user state
+    // Controller remains idle; no new consultation created
     expect(controller.getState()).toBe('idle');
+    expect(controller.getPendingConsultationQuestionId()).toBeNull();
 
     // The skip should be recorded as an event
     const events = getCallEvents(session.id);
@@ -1214,8 +1266,9 @@ describe('call-controller', () => {
     // Give the async dispatchGuardianQuestion a tick to create the request
     await new Promise((r) => setTimeout(r, 50));
 
-    // Verify controller entered waiting_on_user
-    expect(controller.getState()).toBe('waiting_on_user');
+    // Controller returns to idle (non-blocking); consultation tracked separately
+    expect(controller.getState()).toBe('idle');
+    expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
 
     // Verify a pending question was created with the correct text
     const question = getPendingQuestion(session.id);
@@ -1322,8 +1375,9 @@ describe('call-controller', () => {
     await controller.handleCallerUtterance('Send it');
     await new Promise((r) => setTimeout(r, 50));
 
-    // Verify controller entered waiting_on_user with the correct question
-    expect(controller.getState()).toBe('waiting_on_user');
+    // Controller returns to idle (non-blocking); consultation tracked separately
+    expect(controller.getState()).toBe('idle');
+    expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
     const question = getPendingQuestion(session.id);
     expect(question).not.toBeNull();
     expect(question!.questionText).toBe('Allow send_message?');
@@ -1362,6 +1416,119 @@ describe('call-controller', () => {
     // Tool metadata should be null since the approval marker was malformed
     expect(pendingRequest!.toolName).toBeNull();
     expect(pendingRequest!.inputDigest).toBeNull();
+
+    controller.destroy();
+  });
+
+  // ── Non-blocking race safety ───────────────────────────────────────
+
+  test('guardian answer during processing/speaking: queued in pendingInstructions and applied at next turn boundary', async () => {
+    // Trigger ASK_GUARDIAN to start a consultation
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Checking. [ASK_GUARDIAN: Confirm appointment?]'],
+    ));
+    const { controller } = setupController();
+    await controller.handleCallerUtterance('I want to schedule');
+    expect(controller.getState()).toBe('idle');
+    expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
+
+    // Start a new turn (caller follow-up) to put controller in processing state
+    let firstTurnResolve: (() => void) | null = null;
+    const turnContents: string[] = [];
+    mockStartVoiceTurn.mockImplementation(async (opts: { content: string; onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      turnContents.push(opts.content);
+      if (!firstTurnResolve) {
+        // First turn: pause to simulate processing state
+        await new Promise<void>((resolve) => { firstTurnResolve = resolve; });
+      }
+      opts.onTextDelta('Response.');
+      opts.onComplete();
+      return { turnId: `run-${turnContents.length}`, abort: () => {} };
+    });
+
+    // Start a caller turn that will pause mid-processing
+    const callerTurnPromise = controller.handleCallerUtterance('Are you still there?');
+    await new Promise((r) => setTimeout(r, 10));
+    expect(controller.getState()).toBe('speaking');
+
+    // Answer arrives while the controller is processing/speaking
+    const accepted = await controller.handleUserAnswer('3pm works');
+    expect(accepted).toBe(true);
+    // Consultation is consumed immediately
+    expect(controller.getPendingConsultationQuestionId()).toBeNull();
+
+    // Complete the first turn so the answer instruction flushes
+    firstTurnResolve!();
+    await callerTurnPromise;
+
+    // Give the flushed instruction turn time to complete
+    await new Promise((r) => setTimeout(r, 100));
+
+    // The queued USER_ANSWERED instruction should have been applied
+    expect(turnContents.some((c) => c.includes('[USER_ANSWERED: 3pm works]'))).toBe(true);
+
+    controller.destroy();
+  });
+
+  test('timeout + late answer: after timeout, a late answer is rejected as stale', async () => {
+    mockConsultationTimeoutMs = 50;
+
+    // Trigger ASK_GUARDIAN to start a consultation
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Let me check. [ASK_GUARDIAN: What time works?]'],
+    ));
+    const { controller } = setupController();
+    await controller.handleCallerUtterance('Book me in');
+    expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
+
+    // Set up mock for the timeout-generated turn
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Sorry, I could not reach them.'],
+    ));
+
+    // Wait for the consultation timeout to expire the consultation
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Consultation should be cleared by the timeout
+    expect(controller.getPendingConsultationQuestionId()).toBeNull();
+
+    // A late answer should be rejected
+    const lateResult = await controller.handleUserAnswer('3pm is fine');
+    expect(lateResult).toBe(false);
+
+    controller.destroy();
+  });
+
+  test('caller follow-up processed normally while consultation pending', async () => {
+    // Trigger ASK_GUARDIAN to start a consultation
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(
+      ['Let me check. [ASK_GUARDIAN: What date?]'],
+    ));
+    const { relay, controller } = setupController();
+    await controller.handleCallerUtterance('Schedule something');
+    expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
+
+    // Caller follows up while consultation is pending
+    const turnContents: string[] = [];
+    mockStartVoiceTurn.mockImplementation(async (opts: { content: string; onTextDelta: (t: string) => void; onComplete: () => void }) => {
+      turnContents.push(opts.content);
+      opts.onTextDelta('Of course, what else can I help with?');
+      opts.onComplete();
+      return { turnId: `run-${turnContents.length}`, abort: () => {} };
+    });
+
+    await controller.handleCallerUtterance('Can you also check availability?');
+
+    // The follow-up should trigger a normal turn (non-blocking)
+    expect(turnContents.length).toBe(1);
+    expect(turnContents[0]).toContain('Can you also check availability?');
+
+    // Consultation should still be pending
+    expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
+
+    // Response should appear in relay
+    const allText = relay.sentTokens.map((t) => t.token).join('');
+    expect(allText).toContain('what else can I help with');
 
     controller.destroy();
   });

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -680,6 +680,17 @@ export class CallController {
             + `The unanswered question was: "${questionText}"`,
           );
           // Fall through to normal turn completion (idle + flushPendingInstructions)
+        } else if (this.pendingInstructions.some((instr) => instr.startsWith('[USER_ANSWERED:'))) {
+          // A guardian answer arrived mid-turn and is queued in
+          // pendingInstructions but hasn't been flushed yet. The in-flight
+          // LLM response was generated without knowledge of this answer, so
+          // creating a new consultation now would supersede the old one and
+          // desynchronize the flow. Skip this consultation — the answer will
+          // be flushed on the next turn, and if the model still needs to
+          // consult a guardian, it will emit another ASK_GUARDIAN then.
+          log.info({ callSessionId: this.callSessionId }, 'Deferring ASK_GUARDIAN — queued USER_ANSWERED pending');
+          recordCallEvent(this.callSessionId, 'guardian_consult_deferred', { question: questionText });
+          // Fall through to normal turn completion (idle + flushPendingInstructions)
         } else {
           // Cancel any prior pending consultation (superseded by this new one)
           if (this.pendingConsultation) {
@@ -791,6 +802,17 @@ export class CallController {
 
       // Check for END_CALL marker
       if (responseText.includes(END_CALL_MARKER)) {
+        // Clear any pending consultation before completing the call.
+        // Without this, the consultation timeout can fire on an already-ended
+        // call, overwriting 'completed' status back to 'in_progress' and
+        // starting a new LLM turn on a dead session. Similarly, a late
+        // handleUserAnswer could be accepted since pendingConsultation is
+        // still non-null.
+        if (this.pendingConsultation) {
+          clearTimeout(this.pendingConsultation.timer);
+          this.pendingConsultation = null;
+        }
+
         const currentSession = getCallSession(this.callSessionId);
         const shouldNotifyCompletion = currentSession
           ? currentSession.status !== 'completed' && currentSession.status !== 'failed' && currentSession.status !== 'cancelled'

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -12,6 +12,7 @@ import { getGatewayInternalBaseUrl } from '../config/env.js';
 import type { ServerMessage } from '../daemon/ipc-contract.js';
 import type { GuardianRuntimeContext } from '../daemon/session-runtime-assembly.js';
 import {
+  expireGuardianActionRequest,
   getDeliveriesByRequestId,
   getPendingRequestByCallSessionId,
   markTimedOutWithReason,
@@ -39,7 +40,19 @@ import { startVoiceTurn, type VoiceTurnHandle } from './voice-session-bridge.js'
 
 const log = getLogger('call-controller');
 
-type ControllerState = 'idle' | 'processing' | 'waiting_on_user' | 'speaking';
+type ControllerState = 'idle' | 'processing' | 'speaking';
+
+/**
+ * Tracks a pending guardian consultation independently of the controller's
+ * turn state. This allows the call to continue normal turn processing
+ * (idle -> processing -> speaking) while a consultation is outstanding.
+ */
+interface PendingConsultation {
+  questionText: string;
+  questionId: string;
+  toolApprovalMeta: { toolName: string; inputDigest: string } | null;
+  timer: ReturnType<typeof setTimeout>;
+}
 
 const ASK_GUARDIAN_CAPTURE_REGEX = /\[ASK_GUARDIAN:\s*(.+?)\]/;
 const ASK_GUARDIAN_MARKER_REGEX = /\[ASK_GUARDIAN:\s*.+?\]/g;
@@ -176,15 +189,18 @@ export class CallController {
   private silenceTimer: ReturnType<typeof setTimeout> | null = null;
   private durationTimer: ReturnType<typeof setTimeout> | null = null;
   private durationWarningTimer: ReturnType<typeof setTimeout> | null = null;
-  private consultationTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * Tracks the currently pending guardian consultation, if any. Decoupled
+   * from the controller's turn state so callers can continue to trigger
+   * normal turns while consultation is outstanding.
+   */
+  private pendingConsultation: PendingConsultation | null = null;
   private durationEndTimer: ReturnType<typeof setTimeout> | null = null;
   private task: string | null;
   /** True when the call session was created via the inbound path (no outbound task). */
   private isInbound: boolean;
-  /** Instructions queued while an LLM turn is in-flight or during waiting_on_user */
+  /** Instructions queued while an LLM turn is in-flight or during pending consultation */
   private pendingInstructions: string[] = [];
-  /** Caller utterances queued while waiting_on_user to prevent re-entrant turns */
-  private pendingCallerUtterances: Array<{transcript: string, speaker?: PromptSpeakerContext}> = [];
   /** Ensures the call opener is triggered at most once per call. */
   private initialGreetingStarted = false;
   /** Marks that the next caller turn should be treated as an opening acknowledgment. */
@@ -270,19 +286,10 @@ export class CallController {
 
   /**
    * Handle a final caller utterance from the ConversationRelay.
+   * Caller utterances always trigger normal turns, even when a guardian
+   * consultation is pending — the consultation is tracked separately.
    */
   async handleCallerUtterance(transcript: string, speaker?: PromptSpeakerContext): Promise<void> {
-    // Do not start a new turn while waiting for guardian input — queue
-    // the utterance so it can be processed after the answer arrives.
-    if (this.state === 'waiting_on_user') {
-      log.warn(
-        { callSessionId: this.callSessionId },
-        'Caller utterance received while waiting_on_user — queued for after answer.',
-      );
-      this.pendingCallerUtterances.push({ transcript, speaker });
-      return;
-    }
-
     const interruptedInFlight = this.state === 'processing' || this.state === 'speaking';
     // If we're already processing or speaking, abort the in-flight generation
     if (interruptedInFlight) {
@@ -318,66 +325,39 @@ export class CallController {
   }
 
   /**
-   * Called when the user (in the chat UI) answers a pending question.
+   * Called when the guardian (via chat UI or channel) answers a pending
+   * consultation question. Acceptance is gated on having an active
+   * pending consultation record, not on controller turn state — so
+   * answers can arrive while the controller is idle, processing, or
+   * speaking.
    */
   async handleUserAnswer(answerText: string): Promise<boolean> {
-    if (this.state !== 'waiting_on_user') {
+    if (!this.pendingConsultation) {
       log.warn(
         { callSessionId: this.callSessionId, state: this.state },
-        'handleUserAnswer called but controller is not in waiting_on_user state',
+        'handleUserAnswer called but no pending consultation exists',
       );
       return false;
     }
 
-    // Clear the consultation timeout
-    if (this.consultationTimer) {
-      clearTimeout(this.consultationTimer);
-      this.consultationTimer = null;
-    }
+    // Clear the consultation timeout and record
+    clearTimeout(this.pendingConsultation.timer);
+    this.pendingConsultation = null;
 
-    // Defensive: await any lingering turn promise before starting a new one.
-    if (this.currentTurnPromise) {
-      const teardownPromise = this.currentTurnPromise;
-      this.currentTurnPromise = null;
-      await Promise.race([
-        teardownPromise.catch(() => {}),
-        new Promise<void>(resolve => setTimeout(resolve, 2000)),
-      ]);
-    }
-
-    this.state = 'processing';
     updateCallSession(this.callSessionId, { status: 'in_progress' });
 
-    // Merge any instructions that were queued during the waiting_on_user
-    // state into a single user message alongside the answer to avoid
-    // consecutive user-role messages (which violate API role-alternation
-    // requirements).
-    const parts: string[] = [];
-    for (const instr of this.pendingInstructions) {
-      parts.push(`[USER_INSTRUCTION: ${instr}]`);
+    // Inject the answer as a queued instruction so it merges into the
+    // next turn naturally, respecting role-alternation. If the controller
+    // is idle the instruction flush will fire a turn immediately.
+    this.pendingInstructions.push(`[USER_ANSWERED: ${answerText}]`);
+
+    // If the controller is idle, flush instructions immediately to
+    // deliver the answer. If processing/speaking, the answer will be
+    // delivered when the current turn completes via flushPendingInstructions.
+    if (this.state === 'idle') {
+      this.flushPendingInstructions();
     }
-    this.pendingInstructions = [];
-    parts.push(`[USER_ANSWERED: ${answerText}]`);
 
-    const content = parts.join('\n');
-
-    // Fire-and-forget: unblock the caller so the HTTP response and answer
-    // persistence happen immediately, before LLM streaming begins.
-    this.runTurn(content)
-      .then(() => {
-        // If the answer turn ended the call (e.g. [END_CALL]), don't drain
-        // queued utterances — just discard them to avoid starting a fresh
-        // turn on a dead session.
-        if (this.state === 'idle' && this.isCallCompleted()) {
-          this.pendingCallerUtterances = [];
-          return;
-        }
-        this.drainPendingCallerUtterances();
-      })
-      .catch((err) => {
-        this.pendingCallerUtterances = [];
-        log.error({ err, callSessionId: this.callSessionId }, 'runTurn failed after user answer');
-      });
     return true;
   }
 
@@ -386,16 +366,15 @@ export class CallController {
    * The instruction is formatted as a dedicated marker that the system prompt
    * tells the model to treat as high-priority steering input.
    *
-   * When the LLM is actively processing or speaking, or when the controller
-   * is waiting on a user answer, the instruction is queued and spliced into
-   * the conversation at the correct chronological position once the current
-   * turn completes.
+   * When the LLM is actively processing or speaking, the instruction is
+   * queued and spliced into the conversation at the correct chronological
+   * position once the current turn completes.
    */
   async handleUserInstruction(instructionText: string): Promise<void> {
     recordCallEvent(this.callSessionId, 'user_instruction_relayed', { instruction: instructionText });
 
     // Queue the instruction when it cannot be safely appended right now
-    if (this.state === 'processing' || this.state === 'speaking' || this.state === 'waiting_on_user') {
+    if (this.state === 'processing' || this.state === 'speaking') {
       this.pendingInstructions.push(instructionText);
       return;
     }
@@ -432,7 +411,7 @@ export class CallController {
     if (this.silenceTimer) clearTimeout(this.silenceTimer);
     if (this.durationTimer) clearTimeout(this.durationTimer);
     if (this.durationWarningTimer) clearTimeout(this.durationWarningTimer);
-    if (this.consultationTimer) clearTimeout(this.consultationTimer);
+    if (this.pendingConsultation) { clearTimeout(this.pendingConsultation.timer); this.pendingConsultation = null; }
     if (this.durationEndTimer) { clearTimeout(this.durationEndTimer); this.durationEndTimer = null; }
     this.llmRunVersion++;
     this.abortCurrentTurn();
@@ -693,8 +672,26 @@ export class CallController {
           );
           // Fall through to normal turn completion (idle + flushPendingInstructions)
         } else {
+          // Cancel any prior pending consultation (superseded by this new one)
+          if (this.pendingConsultation) {
+            clearTimeout(this.pendingConsultation.timer);
+
+            // Expire the previous consultation's storage records so stale
+            // guardian answers cannot match the old request.
+            expirePendingQuestions(this.callSessionId);
+            const previousRequest = getPendingRequestByCallSessionId(this.callSessionId);
+            if (previousRequest) {
+              expireGuardianActionRequest(previousRequest.id, 'cancelled');
+              log.info(
+                { callSessionId: this.callSessionId, requestId: previousRequest.id },
+                'Expired superseded guardian action request',
+              );
+            }
+
+            this.pendingConsultation = null;
+          }
+
           const pendingQuestion = createPendingQuestion(this.callSessionId, questionText);
-          this.state = 'waiting_on_user';
           updateCallSession(this.callSessionId, { status: 'waiting_on_user' });
           recordCallEvent(this.callSessionId, 'user_question_asked', { question: questionText });
 
@@ -714,11 +711,13 @@ export class CallController {
             });
           }
 
-          // Set a consultation timeout
-          this.consultationTimer = setTimeout(() => {
-            if (this.state !== 'waiting_on_user') return;
+          // Set a consultation timeout tied to this specific consultation
+          // record, not the global controller state.
+          const consultationTimer = setTimeout(() => {
+            // Only fire if this consultation is still the active one
+            if (!this.pendingConsultation || this.pendingConsultation.questionId !== pendingQuestion.id) return;
 
-            log.info({ callSessionId: this.callSessionId }, 'User consultation timed out');
+            log.info({ callSessionId: this.callSessionId }, 'Guardian consultation timed out');
 
             // Mark the linked guardian action request as timed out and
             // send expiry notices to guardian destinations. Deliveries
@@ -747,45 +746,37 @@ export class CallController {
 
             // Expire pending questions and update call state
             expirePendingQuestions(this.callSessionId);
-            this.state = 'idle';
+            this.pendingConsultation = null;
             updateCallSession(this.callSessionId, { status: 'in_progress' });
             this.guardianUnavailableForCall = true;
             recordCallEvent(this.callSessionId, 'guardian_consultation_timed_out', { question: questionText });
 
-            // Restart silence detection before firing the generated turn
-            this.resetSilenceTimer();
-
-            // Build a generated turn instruction instead of hardcoded text.
-            // Merge any queued instructions and caller utterances into the
-            // timeout turn to avoid concurrent-turn races.
+            // Inject timeout instruction so the model addresses it on the
+            // next turn. If idle, flush immediately; otherwise it merges
+            // into the next turn completion.
             const timeoutInstruction =
               `[GUARDIAN_TIMEOUT] Your guardian did not respond in time to your question: "${questionText}". `
               + `Apologize to the caller for the delay, let them know you were unable to reach your guardian, `
               + `ask if they would like to leave a message or receive a callback, `
               + `and ask if there are any other questions you can help with right now.`;
 
-            const parts: string[] = [];
-            for (const instr of this.pendingInstructions) {
-              parts.push(`[USER_INSTRUCTION: ${instr}]`);
-            }
-            this.pendingInstructions = [];
-            parts.push(`[USER_INSTRUCTION: ${timeoutInstruction}]`);
+            this.pendingInstructions.push(timeoutInstruction);
 
-            if (this.pendingCallerUtterances.length > 0) {
-              const latest = this.pendingCallerUtterances[this.pendingCallerUtterances.length - 1];
-              this.pendingCallerUtterances = [];
-              const callerContent = this.formatCallerUtterance(latest.transcript, latest.speaker);
-              if (callerContent.length > 0) {
-                parts.push(callerContent);
-              }
+            if (this.state === 'idle') {
+              this.resetSilenceTimer();
+              this.flushPendingInstructions();
             }
-
-            const content = parts.join('\n');
-            this.runTurn(content).catch((err) =>
-              log.error({ err, callSessionId: this.callSessionId }, 'runTurn failed after guardian consultation timeout'),
-            );
           }, getUserConsultationTimeoutMs());
-          return;
+
+          this.pendingConsultation = {
+            questionText,
+            questionId: pendingQuestion.id,
+            toolApprovalMeta: toolApprovalMeta
+              ? { toolName: toolApprovalMeta.toolName, inputDigest: toolApprovalMeta.inputDigest }
+              : null,
+            timer: consultationTimer,
+          };
+          // Fall through to normal turn completion (idle + flushPendingInstructions)
         }
       }
 
@@ -875,24 +866,13 @@ export class CallController {
   }
 
   /**
-   * Check whether the underlying call session has already ended.
-   * Used to guard against post-completion work (e.g. draining queued
-   * utterances after an [END_CALL] turn).
-   */
-  private isCallCompleted(): boolean {
-    const session = getCallSession(this.callSessionId);
-    if (!session) return true;
-    return session.status === 'completed' || session.status === 'failed' || session.status === 'cancelled';
-  }
-
-  /**
    * Drain any instructions that were queued while the LLM was active.
    */
   private flushPendingInstructions(): void {
     if (this.pendingInstructions.length === 0) return;
 
     const parts = this.pendingInstructions.map(
-      (instr) => `[USER_INSTRUCTION: ${instr}]`,
+      (instr) => instr.startsWith('[') ? instr : `[USER_INSTRUCTION: ${instr}]`,
     );
     this.pendingInstructions = [];
 
@@ -903,49 +883,6 @@ export class CallController {
     // Fire-and-forget so we don't block the current turn's cleanup.
     this.runTurn(content).catch((err) =>
       log.error({ err, callSessionId: this.callSessionId }, 'runTurn failed after flushing queued instructions'),
-    );
-  }
-
-  /**
-   * Drain caller utterances that were queued while waiting_on_user.
-   * Only the most recent utterance is processed — older ones are discarded
-   * as stale since the caller likely moved on.
-   *
-   * @param contentPrefix — optional string (e.g. instruction markers) to
-   *   prepend to the turn content so instructions and the caller utterance
-   *   are sent as a single turn, avoiding concurrent-turn races.
-   */
-  private drainPendingCallerUtterances(contentPrefix?: string): void {
-    if (this.pendingCallerUtterances.length === 0) return;
-
-    // Keep only the most recent utterance; discard stale older ones
-    const latest = this.pendingCallerUtterances[this.pendingCallerUtterances.length - 1];
-    this.pendingCallerUtterances = [];
-
-    if (contentPrefix) {
-      // Merge prefix content with the caller utterance into a single turn
-      let callerContent = this.formatCallerUtterance(latest.transcript, latest.speaker);
-
-      // Preserve opening-ack semantics when draining bypasses handleCallerUtterance
-      if (this.awaitingOpeningAck) {
-        callerContent = callerContent.length > 0
-          ? `${CALL_OPENING_ACK_MARKER}\n${callerContent}`
-          : CALL_OPENING_ACK_MARKER;
-        this.awaitingOpeningAck = false;
-        this.lastSentWasOpener = false;
-      }
-
-      const combined = `${contentPrefix}\n${callerContent}`;
-      this.resetSilenceTimer();
-      this.runTurn(combined).catch((err) =>
-        log.error({ err, callSessionId: this.callSessionId }, 'runTurn failed after draining queued caller utterance with prefix'),
-      );
-      return;
-    }
-
-    // Fire-and-forget so we don't block the current turn's cleanup.
-    this.handleCallerUtterance(latest.transcript, latest.speaker).catch((err) =>
-      log.error({ err, callSessionId: this.callSessionId }, 'runTurn failed after draining queued caller utterance'),
     );
   }
 

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -265,6 +265,15 @@ export class CallController {
   }
 
   /**
+   * Returns the question ID of the currently pending guardian consultation,
+   * or null if no consultation is active. Used by answerCall to match
+   * incoming answers to the correct consultation record.
+   */
+  getPendingConsultationQuestionId(): string | null {
+    return this.pendingConsultation?.questionId ?? null;
+  }
+
+  /**
    * Update guardian trust context for subsequent LLM turns.
    */
   setGuardianContext(ctx: GuardianRuntimeContext | null): void {

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -384,7 +384,7 @@ export class CallController {
 
     // Queue the instruction when it cannot be safely appended right now
     if (this.state === 'processing' || this.state === 'speaking') {
-      this.pendingInstructions.push(instructionText);
+      this.pendingInstructions.push(`[USER_INSTRUCTION: ${instructionText}]`);
       return;
     }
 

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -810,6 +810,16 @@ export class CallController {
         // still non-null.
         if (this.pendingConsultation) {
           clearTimeout(this.pendingConsultation.timer);
+
+          // Expire store-side consultation records so clients don't observe
+          // a completed call with a dangling pendingQuestion, and guardian
+          // replies are cleanly rejected instead of hitting answerCall failures.
+          expirePendingQuestions(this.callSessionId);
+          const previousRequest = getPendingRequestByCallSessionId(this.callSessionId);
+          if (previousRequest) {
+            expireGuardianActionRequest(previousRequest.id, 'cancelled');
+          }
+
           this.pendingConsultation = null;
         }
 

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -539,7 +539,7 @@ export async function answerCall(input: AnswerCallInput): Promise<{ ok: true; qu
   if (!accepted) {
     log.warn(
       { callSessionId },
-      'answerCall: controller rejected the answer (not in waiting_on_user state)',
+      'answerCall: controller rejected the answer (no pending consultation)',
     );
     return { ok: false, error: 'Controller is not waiting for an answer', status: 409 };
   }

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -72,6 +72,8 @@ export type CancelCallInput = {
 export type AnswerCallInput = {
   callSessionId: string;
   answer: string;
+  /** When provided, the answer is matched to this specific pending question/consultation. */
+  pendingQuestionId?: string;
 };
 
 export type RelayInstructionInput = {
@@ -516,23 +518,59 @@ export async function cancelCall(input: CancelCallInput): Promise<{ ok: true; se
 
 /**
  * Answer a pending question for an active call.
+ *
+ * When `pendingQuestionId` is provided, the answer is matched to that specific
+ * pending question/consultation rather than relying on transient controller
+ * state. This allows answers to arrive while the call is active and not paused,
+ * as long as the referenced question is still pending.
  */
 export async function answerCall(input: AnswerCallInput): Promise<{ ok: true; questionId: string } | CallError> {
-  const { callSessionId, answer } = input;
+  const { callSessionId, answer, pendingQuestionId } = input;
 
   if (!answer || typeof answer !== 'string') {
     return { ok: false, error: 'Missing answer', status: 400 };
-  }
-
-  const question = getPendingQuestion(callSessionId);
-  if (!question) {
-    return { ok: false, error: 'No pending question found', status: 404 };
   }
 
   const controller = getCallController(callSessionId);
   if (!controller) {
     log.warn({ callSessionId }, 'answerCall: no active controller for call session');
     return { ok: false, error: 'No active controller for this call', status: 409 };
+  }
+
+  // When a specific question is targeted, validate it matches the active
+  // consultation. This prevents stale or duplicate answers from being
+  // applied to the wrong consultation.
+  if (pendingQuestionId) {
+    const activeQuestionId = controller.getPendingConsultationQuestionId();
+    if (!activeQuestionId) {
+      log.warn(
+        { callSessionId, pendingQuestionId },
+        'answerCall: pendingQuestionId provided but no consultation is active',
+      );
+      return { ok: false, error: 'Referenced question is no longer pending', status: 409 };
+    }
+    if (activeQuestionId !== pendingQuestionId) {
+      log.warn(
+        { callSessionId, pendingQuestionId, activeQuestionId },
+        'answerCall: pendingQuestionId does not match active consultation',
+      );
+      return { ok: false, error: 'Referenced question is stale — a newer consultation has superseded it', status: 409 };
+    }
+  }
+
+  // Look up the pending question in the store for record-keeping
+  const question = getPendingQuestion(callSessionId);
+  if (!question) {
+    return { ok: false, error: 'No pending question found', status: 404 };
+  }
+
+  // When pendingQuestionId is given, double-check it matches the store record
+  if (pendingQuestionId && question.id !== pendingQuestionId) {
+    log.warn(
+      { callSessionId, pendingQuestionId, storeQuestionId: question.id },
+      'answerCall: store pending question does not match requested pendingQuestionId',
+    );
+    return { ok: false, error: 'Referenced question is stale', status: 409 };
   }
 
   const accepted = await controller.handleUserAnswer(answer);

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -488,7 +488,7 @@ export async function processMessage(
         // the guardian action request if answerCall succeeds, so that a
         // failed delivery leaves the request pending for retry from
         // another channel.
-        const answerResult = await answerCall({ callSessionId: guardianRequest.callSessionId, answer: answerText });
+        const answerResult = await answerCall({ callSessionId: guardianRequest.callSessionId, answer: answerText, pendingQuestionId: guardianRequest.pendingQuestionId });
 
         if ('ok' in answerResult && answerResult.ok) {
           const resolved = resolveGuardianActionRequest(guardianRequest.id, answerText, 'vellum');

--- a/assistant/src/runtime/routes/call-routes.ts
+++ b/assistant/src/runtime/routes/call-routes.ts
@@ -179,7 +179,7 @@ export async function handleCancelCall(req: Request, callSessionId: string): Pro
  * Body: { answer: string }
  */
 export async function handleAnswerCall(req: Request, callSessionId: string): Promise<Response> {
-  let body: { answer?: string };
+  let body: { answer?: string; pendingQuestionId?: string };
   try {
     body = await req.json() as typeof body;
   } catch {
@@ -193,6 +193,7 @@ export async function handleAnswerCall(req: Request, callSessionId: string): Pro
   const result = await answerCall({
     callSessionId,
     answer: body.answer ?? '',
+    pendingQuestionId: typeof body.pendingQuestionId === 'string' ? body.pendingQuestionId : undefined,
   });
 
   if (!result.ok) {

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -875,7 +875,7 @@ export async function handleChannelInbound(
             // the guardian action request if answerCall succeeds, so that a
             // failed delivery (e.g. pending question timed out) leaves the
             // request pending for retry from another channel.
-            const answerResult = await answerCall({ callSessionId: request.callSessionId, answer: answerText });
+            const answerResult = await answerCall({ callSessionId: request.callSessionId, answer: answerText, pendingQuestionId: request.pendingQuestionId });
 
             if (!('ok' in answerResult) || !answerResult.ok) {
               const errorMsg = 'error' in answerResult ? answerResult.error : 'Unknown error';


### PR DESCRIPTION
## Summary
Fix the voice-call behavior where `ASK_GUARDIAN` / `ASK_GUARDIAN_APPROVAL` pauses the call and ignores caller follow-up until guardian response or timeout. Guardian consultations are now non-blocking — the caller continues speaking naturally while consultation is pending, and guardian answers are applied asynchronously at safe turn boundaries.

## Changes
- Decoupled consultation state from turn processing — removed `waiting_on_user` from `ControllerState`, added separate `PendingConsultation` tracking
- Made guardian answer acceptance request-scoped via `pendingQuestionId` validation, not state-scoped
- Pre-wrapped user instructions at push site to prevent `startsWith('[')` false positives in `flushPendingInstructions`
- Expired superseded consultations in storage when new ones are created
- Realigned test suite: replaced blocking-wait assertions with non-blocking expectations, added tests for mid-turn answer delivery, timeout + late answer rejection, and duplicate answer safety

## Milestone PRs (merged into feature branch)
- #10191: M1: Non-Blocking Controller Refactor
- #10197: M2: Request-Scoped Answer Plumbing
- #10204: M3: Test Realignment + Regression Coverage
- #10210: Fix: pre-wrap user instructions in pendingInstructions

## Project issue
Closes #10187

## Test plan
- [ ] Verify caller utterances during pending guardian consultation trigger normal assistant turns
- [ ] Verify guardian answer can be applied while call is active and not paused
- [ ] Verify duplicate/late answers are safely rejected
- [ ] Verify timeout behavior for unanswered consultations
- [ ] Run `cd assistant && bun test src/__tests__/call-controller.test.ts` — all 43 tests pass

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
