### PR TITLE
fix: add horizontal padding to apps grid view

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -40,6 +40,7 @@ struct AppsGridView: View {
             }
             .frame(maxWidth: 700)
             .frame(maxWidth: .infinity)
+            .padding(.horizontal, VSpacing.xl)
             .padding(.bottom, VSpacing.xxl)
         }
         .background(VColor.backgroundSubtle)


### PR DESCRIPTION
## Summary
- Add horizontal padding (`VSpacing.xl`) to the apps grid content so it doesn't sit flush against the panel edges

## Test plan
- [ ] Open the My Apps panel and verify the grid has consistent horizontal spacing
- [ ] Resize the window and confirm padding remains consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
