### PR TITLE
fix: remove stale DemoOverlayView reference

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -482,9 +482,6 @@ extension MainWindowView {
                     }
                 }
                 .animation(VAnimation.fast, value: conversationZoomManager.showZoomIndicator)
-                .overlay(alignment: .bottomTrailing) {
-                    DemoOverlayView()
-                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Remove reference to `DemoOverlayView()` in `PanelCoordinator.swift` that was left behind when the view file was deleted in #10183
- Fixes build failure: `cannot find 'DemoOverlayView' in scope`

## Original prompt
/update (build fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
