### PR TITLE
fix: show screen recording permission prompt in quick chat from keyboard shortcut

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1607,11 +1607,15 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         fnVLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
     }
 
-    func toggleQuickInput(aboveDock: Bool = false, requestScreenPermission: Bool = false) {
+    func toggleQuickInput(aboveDock: Bool = false, requestScreenPermission: Bool? = nil) {
         if let window = quickInputWindow, window.isVisible {
             window.dismiss()
             return
         }
+
+        // Auto-detect screen recording permission if not explicitly specified
+        let shouldShowPermissionPrompt = requestScreenPermission
+            ?? (PermissionManager.screenRecordingStatus() != .granted)
 
         let window = QuickInputWindow()
         window.onSubmit = { [weak self, weak window] message, imageData in
@@ -1636,7 +1640,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 .prefix(3)
                 .map { QuickInputThread(id: $0.id, title: $0.title) }
         }
-        window.showScreenPermissionPrompt = requestScreenPermission
+        window.showScreenPermissionPrompt = shouldShowPermissionPrompt
         if aboveDock {
             window.showAboveDock()
         } else {


### PR DESCRIPTION
## Summary
- The "Allow screen recording" permission banner was only shown when opening quick input from the menu bar click, not from the Cmd+/ keyboard shortcut
- Changed `toggleQuickInput` to auto-detect screen recording permission status when not explicitly specified, so all entry points (menu bar, Cmd+/, Cmd+Shift+V) consistently show the banner when needed

## Test plan
- [ ] Open quick chat via Cmd+/ without screen recording permission granted — verify the permission banner appears
- [ ] Open quick chat via menu bar click without permission — verify banner still appears
- [ ] Grant screen recording permission — verify banner no longer appears from any entry point

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
