### PR TITLE
fix: menu bar click opens centered quick input instead of screen capture

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -331,10 +331,8 @@ extension AppDelegate {
         }
         if event.type == .rightMouseUp || event.modifierFlags.contains(.control) {
             showStatusMenu()
-        } else if PermissionManager.screenRecordingStatus() == .granted {
-            startScreenCapture()
         } else {
-            toggleQuickInput(aboveDock: true, requestScreenPermission: true)
+            toggleQuickInput()
         }
     }
 


### PR DESCRIPTION
## Summary
- Left-clicking the menu bar icon now opens the same centered quick input panel as Cmd+/, instead of jumping directly to screen capture or showing the panel docked above the dock
- Right-click / ctrl-click still opens the status menu

## Test plan
- [ ] Left-click the menu bar icon — verify the quick input appears centered on screen (Spotlight-style)
- [ ] Press Cmd+/ — verify same centered quick input appears
- [ ] Right-click the menu bar icon — verify the status menu still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
