### PR TITLE
fix: suppress premature guardian approved signal during verification

### DIFF
--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -276,7 +276,9 @@ describe('trusted contact lifecycle notification signals', () => {
 
     await handleChannelInbound(guardianReq, undefined, TEST_BEARER_TOKEN);
 
-    // Should emit guardian_decision (approved) and verification_sent signals
+    // guardian_decision should NOT fire at approval time when verification
+    // is still pending — it would cause the notification pipeline to send a
+    // premature "approved" message to the guardian's chat.
     const guardianDecisionSignals = emitSignalCalls.filter(
       (c) => c.sourceEventName === 'ingress.trusted_contact.guardian_decision',
     );
@@ -284,14 +286,8 @@ describe('trusted contact lifecycle notification signals', () => {
       (c) => c.sourceEventName === 'ingress.trusted_contact.verification_sent',
     );
 
-    expect(guardianDecisionSignals.length).toBe(1);
+    expect(guardianDecisionSignals.length).toBe(0);
     expect(verificationSentSignals.length).toBe(1);
-
-    // Verify guardian_decision payload
-    const gdPayload = guardianDecisionSignals[0].contextPayload as Record<string, unknown>;
-    expect(gdPayload.decision).toBe('approved');
-    expect(gdPayload.requesterExternalUserId).toBe('requester-user-456');
-    expect(gdPayload.decidedByExternalUserId).toBe('guardian-user-789');
 
     // Verify verification_sent payload
     const vsPayload = verificationSentSignals[0].contextPayload as Record<string, unknown>;

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -1152,27 +1152,34 @@ async function handleAccessRequestApproval(
     });
   }
 
-  // Emit guardian_decision (approved) signal
-  void emitNotificationSignal({
-    sourceEventName: 'ingress.trusted_contact.guardian_decision',
-    sourceChannel: approval.channel,
-    sourceSessionId: approval.conversationId,
-    assistantId,
-    attentionHints: {
-      requiresAction: false,
-      urgency: 'medium',
-      isAsyncBackground: false,
-      visibleInSourceNow: false,
-    },
-    contextPayload: {
+  // Don't emit guardian_decision for approvals that still require code
+  // verification — the guardian already received the code, and emitting
+  // this signal prematurely causes the notification pipeline to deliver
+  // a confusing "approved" message before the requester has verified.
+  // The guardian_decision signal should only fire once access is fully granted
+  // (i.e. after code consumption), which is handled in the verification path.
+  if (!decisionResult.verificationSessionId) {
+    void emitNotificationSignal({
+      sourceEventName: 'ingress.trusted_contact.guardian_decision',
       sourceChannel: approval.channel,
-      requesterExternalUserId: approval.requesterExternalUserId,
-      requesterChatId: approval.requesterChatId,
-      decidedByExternalUserId,
-      decision: 'approved',
-    },
-    dedupeKey: `trusted-contact:guardian-decision:${approval.id}`,
-  });
+      sourceSessionId: approval.conversationId,
+      assistantId,
+      attentionHints: {
+        requiresAction: false,
+        urgency: 'medium',
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
+      contextPayload: {
+        sourceChannel: approval.channel,
+        requesterExternalUserId: approval.requesterExternalUserId,
+        requesterChatId: approval.requesterChatId,
+        decidedByExternalUserId,
+        decision: 'approved',
+      },
+      dedupeKey: `trusted-contact:guardian-decision:${approval.id}`,
+    });
+  }
 
   // Only emit verification_sent when the code was actually delivered to the guardian.
   if (decisionResult.verificationSessionId && codeDelivered) {


### PR DESCRIPTION
## Summary
- Suppress the `ingress.trusted_contact.guardian_decision` notification signal when the guardian approves an access request that still requires code verification
- Previously, this signal fired immediately on approval, causing the notification pipeline to deliver a confusing LLM-generated "Your guardian request has been approved" message to the guardian's chat — before the requester had even entered the code
- The `verification_sent` signal still fires correctly to track the intermediate state
- Updated test to reflect the new behavior

## Test plan
- [ ] Guardian approves access request → only sees the verification code message, no extra "approved" message
- [ ] Requester enters correct code → access is granted normally
- [ ] Guardian denies access request → denial signals still fire correctly
- [ ] `bun test --filter trusted-contact-lifecycle` passes (6/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
