### PR TITLE
M1: Defaults registry + gateway canonicalization

### DIFF
--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -28,14 +28,19 @@ afterEach(() => {
   } catch {
     // best effort cleanup
   }
+  // Reset the defaults cache so tests don't leak state
+  resetFeatureFlagDefaultsCache();
 });
 
 const { createFeatureFlagsGetHandler, createFeatureFlagsPatchHandler } = await import(
   "../http/routes/feature-flags.js"
 );
+const { loadFeatureFlagDefaults, resetFeatureFlagDefaultsCache } = await import(
+  "../feature-flag-defaults.js"
+);
 
 describe("GET /v1/feature-flags handler", () => {
-  test("returns empty flags array when config file does not exist", async () => {
+  test("returns all declared flags with defaults when config file does not exist", async () => {
     // Don't create the config file
     if (existsSync(configPath)) {
       rmSync(configPath);
@@ -46,10 +51,31 @@ describe("GET /v1/feature-flags handler", () => {
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.flags).toEqual([]);
+    const defaults = loadFeatureFlagDefaults();
+    const declaredKeys = Object.keys(defaults);
+
+    // Should return all declared flags
+    expect(body.flags.length).toBe(declaredKeys.length);
+    expect(body.flags.length).toBeGreaterThan(0);
+
+    // Each entry should have the expected shape
+    for (const flag of body.flags) {
+      expect(typeof flag.key).toBe("string");
+      expect(typeof flag.enabled).toBe("boolean");
+      expect(typeof flag.defaultEnabled).toBe("boolean");
+      expect(typeof flag.description).toBe("string");
+      expect(flag.key).toMatch(/^feature_flags\.[a-z0-9][a-z0-9._-]*\.enabled$/);
+    }
+
+    // Check a specific known flag
+    const browserFlag = body.flags.find((f: { key: string }) => f.key === "feature_flags.browser.enabled");
+    expect(browserFlag).toBeDefined();
+    expect(browserFlag.defaultEnabled).toBe(true);
+    // When no persisted value, enabled should equal defaultEnabled
+    expect(browserFlag.enabled).toBe(true);
   });
 
-  test("returns empty flags array when config has no featureFlags key", async () => {
+  test("returns all declared flags even when config has no persisted values", async () => {
     writeFileSync(configPath, JSON.stringify({ sms: { phoneNumber: "+1234" } }));
 
     const handler = createFeatureFlagsGetHandler();
@@ -57,16 +83,19 @@ describe("GET /v1/feature-flags handler", () => {
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.flags).toEqual([]);
+    const defaults = loadFeatureFlagDefaults();
+    const declaredKeys = Object.keys(defaults);
+
+    expect(body.flags.length).toBe(declaredKeys.length);
   });
 
-  test("returns stored feature flags", async () => {
+  test("merges persisted values from assistantFeatureFlagValues with defaults", async () => {
     writeFileSync(
       configPath,
       JSON.stringify({
-        featureFlags: {
-          "skills.browser.enabled": true,
-          "skills.twitter.enabled": false,
+        assistantFeatureFlagValues: {
+          "feature_flags.browser.enabled": false,
+          "feature_flags.twitter.enabled": false,
         },
       }),
     );
@@ -76,13 +105,70 @@ describe("GET /v1/feature-flags handler", () => {
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.flags).toEqual([
-      { key: "skills.browser.enabled", enabled: true },
-      { key: "skills.twitter.enabled", enabled: false },
-    ]);
+
+    const browserFlag = body.flags.find((f: { key: string }) => f.key === "feature_flags.browser.enabled");
+    expect(browserFlag).toBeDefined();
+    expect(browserFlag.enabled).toBe(false); // overridden from default true
+    expect(browserFlag.defaultEnabled).toBe(true);
+
+    const twitterFlag = body.flags.find((f: { key: string }) => f.key === "feature_flags.twitter.enabled");
+    expect(twitterFlag).toBeDefined();
+    expect(twitterFlag.enabled).toBe(false); // overridden from default true
   });
 
-  test("ignores non-boolean values in featureFlags", async () => {
+  test("reads legacy featureFlags section and maps old key format", async () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        featureFlags: {
+          "skills.browser.enabled": false,
+          "skills.twitter.enabled": true,
+        },
+      }),
+    );
+
+    const handler = createFeatureFlagsGetHandler();
+    const res = await handler(new Request("http://gateway.test/v1/feature-flags"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Legacy skills.browser.enabled should map to feature_flags.browser.enabled
+    const browserFlag = body.flags.find((f: { key: string }) => f.key === "feature_flags.browser.enabled");
+    expect(browserFlag).toBeDefined();
+    expect(browserFlag.enabled).toBe(false); // persisted as false
+
+    const twitterFlag = body.flags.find((f: { key: string }) => f.key === "feature_flags.twitter.enabled");
+    expect(twitterFlag).toBeDefined();
+    expect(twitterFlag.enabled).toBe(true);
+  });
+
+  test("new assistantFeatureFlagValues overrides legacy featureFlags", async () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        featureFlags: {
+          "skills.browser.enabled": false,
+        },
+        assistantFeatureFlagValues: {
+          "feature_flags.browser.enabled": true,
+        },
+      }),
+    );
+
+    const handler = createFeatureFlagsGetHandler();
+    const res = await handler(new Request("http://gateway.test/v1/feature-flags"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const browserFlag = body.flags.find((f: { key: string }) => f.key === "feature_flags.browser.enabled");
+    expect(browserFlag).toBeDefined();
+    // The new section takes precedence over legacy
+    expect(browserFlag.enabled).toBe(true);
+  });
+
+  test("ignores non-boolean values in legacy and new sections", async () => {
     writeFileSync(
       configPath,
       JSON.stringify({
@@ -91,6 +177,9 @@ describe("GET /v1/feature-flags handler", () => {
           "skills.bad.enabled": "yes",
           "skills.number.enabled": 1,
         },
+        assistantFeatureFlagValues: {
+          "feature_flags.twitter.enabled": "no",
+        },
       }),
     );
 
@@ -99,84 +188,73 @@ describe("GET /v1/feature-flags handler", () => {
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.flags).toEqual([{ key: "skills.browser.enabled", enabled: true }]);
+
+    // browser should be resolved from legacy
+    const browserFlag = body.flags.find((f: { key: string }) => f.key === "feature_flags.browser.enabled");
+    expect(browserFlag).toBeDefined();
+    expect(browserFlag.enabled).toBe(true);
+
+    // twitter should fall back to default since non-boolean was ignored
+    const twitterFlag = body.flags.find((f: { key: string }) => f.key === "feature_flags.twitter.enabled");
+    expect(twitterFlag).toBeDefined();
+    expect(twitterFlag.enabled).toBe(twitterFlag.defaultEnabled);
   });
 });
 
 describe("PATCH /v1/feature-flags/:flagKey handler", () => {
-  test("creates a new feature flag", async () => {
+  test("writes to assistantFeatureFlagValues section in config", async () => {
     writeFileSync(configPath, JSON.stringify({}));
 
     const handler = createFeatureFlagsPatchHandler();
     const res = await handler(
-      new Request("http://gateway.test/v1/feature-flags/skills.browser.enabled", {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ enabled: true }),
-      }),
-      "skills.browser.enabled",
-    );
-
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body).toEqual({ key: "skills.browser.enabled", enabled: true });
-
-    // Verify persistence
-    const config = JSON.parse(readFileSync(configPath, "utf-8"));
-    expect(config.featureFlags["skills.browser.enabled"]).toBe(true);
-  });
-
-  test("updates an existing feature flag", async () => {
-    writeFileSync(
-      configPath,
-      JSON.stringify({
-        featureFlags: { "skills.browser.enabled": true },
-      }),
-    );
-
-    const handler = createFeatureFlagsPatchHandler();
-    const res = await handler(
-      new Request("http://gateway.test/v1/feature-flags/skills.browser.enabled", {
+      new Request("http://gateway.test/v1/feature-flags/feature_flags.browser.enabled", {
         method: "PATCH",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ enabled: false }),
       }),
-      "skills.browser.enabled",
+      "feature_flags.browser.enabled",
     );
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toEqual({ key: "skills.browser.enabled", enabled: false });
+    expect(body).toEqual({ key: "feature_flags.browser.enabled", enabled: false });
 
+    // Verify persistence to the NEW section
     const config = JSON.parse(readFileSync(configPath, "utf-8"));
-    expect(config.featureFlags["skills.browser.enabled"]).toBe(false);
+    expect(config.assistantFeatureFlagValues["feature_flags.browser.enabled"]).toBe(false);
+    // Should NOT write to the old featureFlags section
+    expect(config.featureFlags).toBeUndefined();
   });
 
-  test("preserves unknown config keys when writing", async () => {
+  test("preserves existing config keys when writing", async () => {
     writeFileSync(
       configPath,
       JSON.stringify({
         sms: { phoneNumber: "+1234567890" },
         email: { address: "test@example.com" },
         featureFlags: { "skills.existing.enabled": true },
+        assistantFeatureFlagValues: { "feature_flags.twitter.enabled": true },
       }),
     );
 
     const handler = createFeatureFlagsPatchHandler();
     await handler(
-      new Request("http://gateway.test/v1/feature-flags/skills.new.enabled", {
+      new Request("http://gateway.test/v1/feature-flags/feature_flags.browser.enabled", {
         method: "PATCH",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ enabled: true }),
       }),
-      "skills.new.enabled",
+      "feature_flags.browser.enabled",
     );
 
     const config = JSON.parse(readFileSync(configPath, "utf-8"));
     expect(config.sms).toEqual({ phoneNumber: "+1234567890" });
     expect(config.email).toEqual({ address: "test@example.com" });
+    // Legacy section should be preserved untouched
     expect(config.featureFlags["skills.existing.enabled"]).toBe(true);
-    expect(config.featureFlags["skills.new.enabled"]).toBe(true);
+    // New section should have both old and new values
+    expect(config.assistantFeatureFlagValues["feature_flags.twitter.enabled"]).toBe(true);
+    expect(config.assistantFeatureFlagValues["feature_flags.browser.enabled"]).toBe(true);
   });
 
   test("creates config file and directories when they do not exist", async () => {
@@ -185,19 +263,19 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
 
     const handler = createFeatureFlagsPatchHandler();
     const res = await handler(
-      new Request("http://gateway.test/v1/feature-flags/skills.test.enabled", {
+      new Request("http://gateway.test/v1/feature-flags/feature_flags.browser.enabled", {
         method: "PATCH",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ enabled: true }),
       }),
-      "skills.test.enabled",
+      "feature_flags.browser.enabled",
     );
 
     expect(res.status).toBe(200);
     expect(existsSync(configPath)).toBe(true);
 
     const config = JSON.parse(readFileSync(configPath, "utf-8"));
-    expect(config.featureFlags["skills.test.enabled"]).toBe(true);
+    expect(config.assistantFeatureFlagValues["feature_flags.browser.enabled"]).toBe(true);
   });
 
   // Validation tests
@@ -217,17 +295,42 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     expect(body.error).toContain("non-empty");
   });
 
-  test("rejects key not matching skills.<id>.enabled format", async () => {
+  test("rejects old skills.* key format", async () => {
+    const handler = createFeatureFlagsPatchHandler();
+
+    const oldFormatKeys = [
+      "skills.browser.enabled",
+      "skills.twitter.enabled",
+      "skills.my-skill.enabled",
+    ];
+
+    for (const key of oldFormatKeys) {
+      const res = await handler(
+        new Request(`http://gateway.test/v1/feature-flags/${key}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ enabled: true }),
+        }),
+        key,
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain("Invalid flag key format");
+    }
+  });
+
+  test("rejects key not matching feature_flags.<id>.enabled format", async () => {
     const handler = createFeatureFlagsPatchHandler();
 
     const invalidKeys = [
       "random.key",
-      "skills.enabled",
-      "skills..enabled",
-      "skills.UPPERCASE.enabled",
-      "skills.browser.disabled",
+      "feature_flags.enabled",
+      "feature_flags..enabled",
+      "feature_flags.UPPERCASE.enabled",
+      "feature_flags.browser.disabled",
       "other.browser.enabled",
-      "skills.browser.enabled.extra",
+      "feature_flags.browser.enabled.extra",
     ];
 
     for (const key of invalidKeys) {
@@ -246,17 +349,33 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     }
   });
 
-  test("accepts valid skill key formats", async () => {
+  test("rejects undeclared keys (not in defaults registry)", async () => {
+    writeFileSync(configPath, JSON.stringify({}));
+    const handler = createFeatureFlagsPatchHandler();
+
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags/feature_flags.totally-unknown-flag.enabled", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      }),
+      "feature_flags.totally-unknown-flag.enabled",
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("not declared");
+  });
+
+  test("accepts valid declared feature_flags.* key formats", async () => {
     writeFileSync(configPath, JSON.stringify({}));
     const handler = createFeatureFlagsPatchHandler();
 
     const validKeys = [
-      "skills.browser.enabled",
-      "skills.twitter.enabled",
-      "skills.my-skill.enabled",
-      "skills.my_skill.enabled",
-      "skills.skill123.enabled",
-      "skills.my.dotted.skill.enabled",
+      "feature_flags.browser.enabled",
+      "feature_flags.twitter.enabled",
+      "feature_flags.guardian-verify-setup.enabled",
+      "feature_flags.hatch-new-assistant.enabled",
     ];
 
     for (const key of validKeys) {
@@ -279,12 +398,12 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     const invalidValues = ["true", 1, null, undefined];
     for (const value of invalidValues) {
       const res = await handler(
-        new Request("http://gateway.test/v1/feature-flags/skills.test.enabled", {
+        new Request("http://gateway.test/v1/feature-flags/feature_flags.browser.enabled", {
           method: "PATCH",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ enabled: value }),
         }),
-        "skills.test.enabled",
+        "feature_flags.browser.enabled",
       );
 
       expect(res.status).toBe(400);
@@ -296,12 +415,12 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
   test("rejects invalid JSON body", async () => {
     const handler = createFeatureFlagsPatchHandler();
     const res = await handler(
-      new Request("http://gateway.test/v1/feature-flags/skills.test.enabled", {
+      new Request("http://gateway.test/v1/feature-flags/feature_flags.browser.enabled", {
         method: "PATCH",
         headers: { "content-type": "application/json" },
         body: "not json",
       }),
-      "skills.test.enabled",
+      "feature_flags.browser.enabled",
     );
 
     expect(res.status).toBe(400);
@@ -312,10 +431,10 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
   test("rejects missing body", async () => {
     const handler = createFeatureFlagsPatchHandler();
     const res = await handler(
-      new Request("http://gateway.test/v1/feature-flags/skills.test.enabled", {
+      new Request("http://gateway.test/v1/feature-flags/feature_flags.browser.enabled", {
         method: "PATCH",
       }),
-      "skills.test.enabled",
+      "feature_flags.browser.enabled",
     );
 
     expect(res.status).toBe(400);
@@ -325,26 +444,26 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     // Write initial config
     const initial = {
       sms: { phoneNumber: "+1234" },
-      featureFlags: { "skills.a.enabled": true },
+      assistantFeatureFlagValues: { "feature_flags.browser.enabled": true },
     };
     writeFileSync(configPath, JSON.stringify(initial));
 
     const handler = createFeatureFlagsPatchHandler();
     await handler(
-      new Request("http://gateway.test/v1/feature-flags/skills.b.enabled", {
+      new Request("http://gateway.test/v1/feature-flags/feature_flags.twitter.enabled", {
         method: "PATCH",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ enabled: false }),
       }),
-      "skills.b.enabled",
+      "feature_flags.twitter.enabled",
     );
 
     // Verify the file is valid JSON and contains all expected data
     const raw = readFileSync(configPath, "utf-8");
     const config = JSON.parse(raw);
     expect(config.sms).toEqual({ phoneNumber: "+1234" });
-    expect(config.featureFlags["skills.a.enabled"]).toBe(true);
-    expect(config.featureFlags["skills.b.enabled"]).toBe(false);
+    expect(config.assistantFeatureFlagValues["feature_flags.browser.enabled"]).toBe(true);
+    expect(config.assistantFeatureFlagValues["feature_flags.twitter.enabled"]).toBe(false);
 
     // Verify no temp files left behind
     const { readdirSync } = await import("node:fs");

--- a/gateway/src/feature-flag-defaults.ts
+++ b/gateway/src/feature-flag-defaults.ts
@@ -1,0 +1,103 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getLogger } from "./logger.js";
+
+const log = getLogger("feature-flag-defaults");
+
+export type FeatureFlagDefault = {
+  defaultEnabled: boolean;
+  description: string;
+};
+
+export type FeatureFlagDefaultsRegistry = Record<string, FeatureFlagDefault>;
+
+let cachedRegistry: FeatureFlagDefaultsRegistry | null = null;
+
+/**
+ * Resolve the path to the defaults registry JSON file.
+ *
+ * The file lives at `meta/assistant-feature-flags/assistant-feature-flag-defaults.json`
+ * relative to the repository root. We derive the repo root from the gateway
+ * source directory (gateway/src/) by walking up two levels.
+ */
+function getRegistryPath(): string {
+  // __dirname equivalent for ESM: import.meta.dirname (Bun) or derive from import.meta.url
+  const srcDir = import.meta.dirname ?? new URL(".", import.meta.url).pathname;
+  // srcDir = <repo>/gateway/src  -> repo root = srcDir/../../
+  const repoRoot = join(srcDir, "..", "..");
+  return join(repoRoot, "meta", "assistant-feature-flags", "assistant-feature-flag-defaults.json");
+}
+
+/**
+ * Load and validate the feature flag defaults registry.
+ *
+ * The registry is loaded once and cached for the lifetime of the process.
+ * Invalid entries (missing required fields, wrong types) are skipped with a
+ * warning rather than crashing the gateway.
+ */
+export function loadFeatureFlagDefaults(): FeatureFlagDefaultsRegistry {
+  if (cachedRegistry) return cachedRegistry;
+
+  const registryPath = getRegistryPath();
+  let raw: string;
+  try {
+    raw = readFileSync(registryPath, "utf-8");
+  } catch (err) {
+    log.error({ err, path: registryPath }, "Failed to read feature flag defaults registry");
+    cachedRegistry = {};
+    return cachedRegistry;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    log.error({ err, path: registryPath }, "Feature flag defaults registry is not valid JSON");
+    cachedRegistry = {};
+    return cachedRegistry;
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    log.error({ path: registryPath }, "Feature flag defaults registry must be a JSON object");
+    cachedRegistry = {};
+    return cachedRegistry;
+  }
+
+  const registry: FeatureFlagDefaultsRegistry = {};
+  for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      log.warn({ key }, "Skipping invalid defaults registry entry (not an object)");
+      continue;
+    }
+    const entry = value as Record<string, unknown>;
+    if (typeof entry.defaultEnabled !== "boolean") {
+      log.warn({ key }, "Skipping invalid defaults registry entry (defaultEnabled is not boolean)");
+      continue;
+    }
+    if (typeof entry.description !== "string") {
+      log.warn({ key }, "Skipping invalid defaults registry entry (description is not string)");
+      continue;
+    }
+    registry[key] = {
+      defaultEnabled: entry.defaultEnabled,
+      description: entry.description,
+    };
+  }
+
+  log.info({ flagCount: Object.keys(registry).length }, "Loaded feature flag defaults registry");
+  cachedRegistry = registry;
+  return cachedRegistry;
+}
+
+/**
+ * Check whether a given flag key is declared in the defaults registry.
+ */
+export function isFlagDeclared(flagKey: string): boolean {
+  const registry = loadFeatureFlagDefaults();
+  return flagKey in registry;
+}
+
+/** Reset the cached registry (for testing). */
+export function resetFeatureFlagDefaultsCache(): void {
+  cachedRegistry = null;
+}

--- a/gateway/src/feature-flags-auth.test.ts
+++ b/gateway/src/feature-flags-auth.test.ts
@@ -35,7 +35,7 @@ beforeAll(async () => {
   // Write a minimal config.json so the feature-flags handler can read it
   writeFileSync(
     join(vellumDir, "workspace", "config.json"),
-    JSON.stringify({ featureFlags: { "skills.test-skill.enabled": true } }),
+    JSON.stringify({ assistantFeatureFlagValues: { "feature_flags.browser.enabled": true } }),
   );
 
   // Set environment so loadConfig picks up our temp directory
@@ -160,7 +160,7 @@ afterAll(() => {
 
 describe("PATCH /v1/feature-flags/:key auth", () => {
   test("rejects request with runtime bearer token (403)", async () => {
-    const res = await fetch(`${baseUrl}/v1/feature-flags/skills.my-skill.enabled`, {
+    const res = await fetch(`${baseUrl}/v1/feature-flags/feature_flags.browser.enabled`, {
       method: "PATCH",
       headers: {
         Authorization: `Bearer ${RUNTIME_TOKEN}`,
@@ -174,7 +174,7 @@ describe("PATCH /v1/feature-flags/:key auth", () => {
   });
 
   test("succeeds with feature-flag client token", async () => {
-    const res = await fetch(`${baseUrl}/v1/feature-flags/skills.my-skill.enabled`, {
+    const res = await fetch(`${baseUrl}/v1/feature-flags/feature_flags.browser.enabled`, {
       method: "PATCH",
       headers: {
         Authorization: `Bearer ${FEATURE_FLAG_TOKEN}`,
@@ -184,12 +184,12 @@ describe("PATCH /v1/feature-flags/:key auth", () => {
     });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.key).toBe("skills.my-skill.enabled");
+    expect(body.key).toBe("feature_flags.browser.enabled");
     expect(body.enabled).toBe(true);
   });
 
   test("rejects request with no token (401)", async () => {
-    const res = await fetch(`${baseUrl}/v1/feature-flags/skills.my-skill.enabled`, {
+    const res = await fetch(`${baseUrl}/v1/feature-flags/feature_flags.browser.enabled`, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
@@ -200,7 +200,7 @@ describe("PATCH /v1/feature-flags/:key auth", () => {
   });
 
   test("rejects request with wrong token (401)", async () => {
-    const res = await fetch(`${baseUrl}/v1/feature-flags/skills.my-skill.enabled`, {
+    const res = await fetch(`${baseUrl}/v1/feature-flags/feature_flags.browser.enabled`, {
       method: "PATCH",
       headers: {
         Authorization: "Bearer totally-wrong-token",

--- a/gateway/src/http/routes/feature-flags.ts
+++ b/gateway/src/http/routes/feature-flags.ts
@@ -2,16 +2,24 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from "
 import { join, dirname } from "node:path";
 import { randomBytes } from "node:crypto";
 import { getRootDir } from "../../credential-reader.js";
+import { loadFeatureFlagDefaults, isFlagDeclared } from "../../feature-flag-defaults.js";
 import { getLogger } from "../../logger.js";
 
 const log = getLogger("feature-flags");
 
 /**
- * Only allow keys matching `skills.<skillId>.enabled` for the initial rollout.
- * The skillId segment must be a non-empty string of lowercase alphanumeric chars,
- * dots, hyphens, and underscores (matching managed skill ID validation).
+ * Only allow keys matching `feature_flags.<flagId>.enabled` for the canonical format.
+ * The flagId segment must be a non-empty string of lowercase alphanumeric chars,
+ * dots, hyphens, and underscores.
  */
-const ALLOWED_KEY_RE = /^skills\.[a-z0-9][a-z0-9._-]*\.enabled$/;
+const ALLOWED_KEY_RE = /^feature_flags\.[a-z0-9][a-z0-9._-]*\.enabled$/;
+
+/**
+ * Legacy key format: `skills.<skillId>.enabled`.
+ * Used to read persisted values from the old `featureFlags` config section
+ * and map them to the canonical `feature_flags.<id>.enabled` format.
+ */
+const LEGACY_KEY_RE = /^skills\.([a-z0-9][a-z0-9._-]*)\.enabled$/;
 
 function getConfigPath(): string {
   return join(getRootDir(), "workspace", "config.json");
@@ -54,30 +62,87 @@ function writeConfigFileAtomic(data: Record<string, unknown>): void {
   renameSync(tmpPath, cfgPath);
 }
 
+/**
+ * Convert a legacy `skills.<id>.enabled` key to the canonical
+ * `feature_flags.<id>.enabled` format. Returns null if the key doesn't
+ * match the legacy format.
+ */
+function legacyKeyToCanonical(legacyKey: string): string | null {
+  const match = LEGACY_KEY_RE.exec(legacyKey);
+  if (!match) return null;
+  return `feature_flags.${match[1]}.enabled`;
+}
+
+/**
+ * Read persisted flag values from both legacy and new config sections.
+ * Returns a map of canonical key -> boolean value.
+ *
+ * Priority (highest wins):
+ * 1. `assistantFeatureFlagValues` section (new canonical storage)
+ * 2. `featureFlags` section with legacy key mapping
+ */
+function readPersistedFlags(config: Record<string, unknown>): Map<string, boolean> {
+  const result = new Map<string, boolean>();
+
+  // Read legacy `featureFlags` section and map keys
+  const legacyRaw = config.featureFlags;
+  if (legacyRaw && typeof legacyRaw === "object" && !Array.isArray(legacyRaw)) {
+    for (const [k, v] of Object.entries(legacyRaw as Record<string, unknown>)) {
+      if (typeof v !== "boolean") continue;
+
+      // Try to map legacy key to canonical format
+      const canonicalKey = legacyKeyToCanonical(k);
+      if (canonicalKey) {
+        result.set(canonicalKey, v);
+      } else if (ALLOWED_KEY_RE.test(k)) {
+        // Already in canonical format (unlikely in legacy section, but handle gracefully)
+        result.set(k, v);
+      }
+      // Skip keys that don't match either format
+    }
+  }
+
+  // Read new `assistantFeatureFlagValues` section (overrides legacy)
+  const newRaw = config.assistantFeatureFlagValues;
+  if (newRaw && typeof newRaw === "object" && !Array.isArray(newRaw)) {
+    for (const [k, v] of Object.entries(newRaw as Record<string, unknown>)) {
+      if (typeof v !== "boolean") continue;
+      if (ALLOWED_KEY_RE.test(k)) {
+        result.set(k, v);
+      }
+    }
+  }
+
+  return result;
+}
+
 export type FeatureFlagEntry = {
   key: string;
   enabled: boolean;
+  defaultEnabled: boolean;
+  description: string;
 };
 
 export function createFeatureFlagsGetHandler() {
   return async (_req: Request): Promise<Response> => {
     try {
+      const defaults = loadFeatureFlagDefaults();
       const result = readConfigFile();
-      // For GET, a malformed config degrades gracefully to empty flags
+      // For GET, a malformed config degrades gracefully to empty persisted values
       const config = result.ok ? result.data : {};
-      const flags: Record<string, boolean> = {};
-      const raw = config.featureFlags;
-      if (raw && typeof raw === "object" && !Array.isArray(raw)) {
-        for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
-          if (typeof v === "boolean") {
-            flags[k] = v;
-          }
-        }
-      }
+      const persisted = readPersistedFlags(config);
 
-      const entries: FeatureFlagEntry[] = Object.entries(flags).map(
-        ([key, enabled]) => ({ key, enabled }),
-      );
+      // Build entries for ALL declared flags, merging persisted values
+      const entries: FeatureFlagEntry[] = [];
+      for (const [key, def] of Object.entries(defaults)) {
+        const persistedValue = persisted.get(key);
+        entries.push({
+          key,
+          enabled: persistedValue !== undefined ? persistedValue : def.defaultEnabled,
+          defaultEnabled: def.defaultEnabled,
+          description: def.description,
+        });
+      }
 
       return Response.json({ flags: entries });
     } catch (err) {
@@ -99,7 +164,15 @@ export function createFeatureFlagsPatchHandler() {
 
     if (!ALLOWED_KEY_RE.test(flagKey)) {
       return Response.json(
-        { error: "Invalid flag key format. Must match: skills.<skillId>.enabled" },
+        { error: "Invalid flag key format. Must match: feature_flags.<flagId>.enabled" },
+        { status: 400 },
+      );
+    }
+
+    // Validate that the flag key exists in the defaults registry
+    if (!isFlagDeclared(flagKey)) {
+      return Response.json(
+        { error: `Unknown flag key: "${flagKey}" is not declared in the defaults registry` },
         { status: 400 },
       );
     }
@@ -141,13 +214,13 @@ export function createFeatureFlagsPatchHandler() {
 
       const config = result.data;
 
-      // Preserve existing config keys; only update featureFlags
+      // Write to the new `assistantFeatureFlagValues` section (NOT the old `featureFlags` section)
       const existingFlags =
-        config.featureFlags && typeof config.featureFlags === "object" && !Array.isArray(config.featureFlags)
-          ? (config.featureFlags as Record<string, unknown>)
+        config.assistantFeatureFlagValues && typeof config.assistantFeatureFlagValues === "object" && !Array.isArray(config.assistantFeatureFlagValues)
+          ? (config.assistantFeatureFlagValues as Record<string, unknown>)
           : {};
 
-      config.featureFlags = { ...existingFlags, [flagKey]: enabled };
+      config.assistantFeatureFlagValues = { ...existingFlags, [flagKey]: enabled };
 
       writeConfigFileAtomic(config);
 

--- a/meta/assistant-feature-flags/assistant-feature-flag-defaults.json
+++ b/meta/assistant-feature-flags/assistant-feature-flag-defaults.json
@@ -1,0 +1,226 @@
+{
+  "feature_flags.agentmail.enabled": {
+    "defaultEnabled": true,
+    "description": "AgentMail email integration skill"
+  },
+  "feature_flags.amazon.enabled": {
+    "defaultEnabled": true,
+    "description": "Amazon product search and ordering skill"
+  },
+  "feature_flags.api-mapping.enabled": {
+    "defaultEnabled": true,
+    "description": "API mapping and integration skill"
+  },
+  "feature_flags.app-builder.enabled": {
+    "defaultEnabled": true,
+    "description": "Dynamic app/UI builder skill"
+  },
+  "feature_flags.browser.enabled": {
+    "defaultEnabled": true,
+    "description": "Browser automation skill for web navigation and interaction"
+  },
+  "feature_flags.chatgpt-import.enabled": {
+    "defaultEnabled": true,
+    "description": "Import conversation history from ChatGPT into Vellum"
+  },
+  "feature_flags.claude-code.enabled": {
+    "defaultEnabled": true,
+    "description": "Claude Code integration skill"
+  },
+  "feature_flags.cli-discover.enabled": {
+    "defaultEnabled": true,
+    "description": "CLI tool discovery and learning skill"
+  },
+  "feature_flags.computer-use.enabled": {
+    "defaultEnabled": true,
+    "description": "Foreground computer use (screenshot, click, keyboard) skill"
+  },
+  "feature_flags.configure-settings.enabled": {
+    "defaultEnabled": true,
+    "description": "In-chat assistant settings configuration skill"
+  },
+  "feature_flags.contacts.enabled": {
+    "defaultEnabled": true,
+    "description": "Contacts management skill"
+  },
+  "feature_flags.deploy-fullstack-vercel.enabled": {
+    "defaultEnabled": true,
+    "description": "Build and deploy a full-stack app to Vercel"
+  },
+  "feature_flags.document.enabled": {
+    "defaultEnabled": true,
+    "description": "Document reading and management skill"
+  },
+  "feature_flags.document-writer.enabled": {
+    "defaultEnabled": true,
+    "description": "Create and edit long-form documents using the rich text editor"
+  },
+  "feature_flags.doordash.enabled": {
+    "defaultEnabled": true,
+    "description": "DoorDash food ordering skill"
+  },
+  "feature_flags.email-setup.enabled": {
+    "defaultEnabled": true,
+    "description": "Email integration setup skill"
+  },
+  "feature_flags.followups.enabled": {
+    "defaultEnabled": true,
+    "description": "Follow-up suggestions and actions skill"
+  },
+  "feature_flags.frontend-design.enabled": {
+    "defaultEnabled": true,
+    "description": "Frontend design and UI generation skill"
+  },
+  "feature_flags.google-calendar.enabled": {
+    "defaultEnabled": true,
+    "description": "Google Calendar integration skill"
+  },
+  "feature_flags.google-oauth-setup.enabled": {
+    "defaultEnabled": true,
+    "description": "Create Google Cloud OAuth credentials for Gmail integration"
+  },
+  "feature_flags.guardian-verify-setup.enabled": {
+    "defaultEnabled": true,
+    "description": "Guardian verification setup for SMS, voice, or Telegram channels"
+  },
+  "feature_flags.hatch-new-assistant.enabled": {
+    "defaultEnabled": true,
+    "description": "Show Hatch New Assistant action in Settings > Account"
+  },
+  "feature_flags.image-studio.enabled": {
+    "defaultEnabled": true,
+    "description": "Image generation and editing studio skill"
+  },
+  "feature_flags.influencer.enabled": {
+    "defaultEnabled": true,
+    "description": "Social media influencer management skill"
+  },
+  "feature_flags.knowledge-graph.enabled": {
+    "defaultEnabled": true,
+    "description": "Knowledge graph construction and querying skill"
+  },
+  "feature_flags.macos-automation.enabled": {
+    "defaultEnabled": true,
+    "description": "macOS native app automation via osascript"
+  },
+  "feature_flags.media-processing.enabled": {
+    "defaultEnabled": true,
+    "description": "Media file processing (audio, video, image) skill"
+  },
+  "feature_flags.messaging.enabled": {
+    "defaultEnabled": true,
+    "description": "Messaging and communication skill"
+  },
+  "feature_flags.notion.enabled": {
+    "defaultEnabled": true,
+    "description": "Read and write Notion pages and databases"
+  },
+  "feature_flags.notion-oauth-setup.enabled": {
+    "defaultEnabled": true,
+    "description": "Create Notion integration and OAuth credentials"
+  },
+  "feature_flags.notifications.enabled": {
+    "defaultEnabled": true,
+    "description": "Notification sending and management skill"
+  },
+  "feature_flags.oauth-setup.enabled": {
+    "defaultEnabled": true,
+    "description": "Generic OAuth service connection and setup skill"
+  },
+  "feature_flags.phone-calls.enabled": {
+    "defaultEnabled": true,
+    "description": "Twilio-powered voice calls over the phone network"
+  },
+  "feature_flags.playbooks.enabled": {
+    "defaultEnabled": true,
+    "description": "Playbook authoring and execution skill"
+  },
+  "feature_flags.public-ingress.enabled": {
+    "defaultEnabled": true,
+    "description": "Public ingress URL configuration skill"
+  },
+  "feature_flags.reminder.enabled": {
+    "defaultEnabled": true,
+    "description": "One-shot future reminder creation skill"
+  },
+  "feature_flags.restaurant-reservation.enabled": {
+    "defaultEnabled": true,
+    "description": "Restaurant reservation booking skill"
+  },
+  "feature_flags.schedule.enabled": {
+    "defaultEnabled": true,
+    "description": "Recurring schedule creation and management skill"
+  },
+  "feature_flags.screen-recording.enabled": {
+    "defaultEnabled": true,
+    "description": "Screen recording and capture skill"
+  },
+  "feature_flags.self-upgrade.enabled": {
+    "defaultEnabled": true,
+    "description": "Assistant self-upgrade and update skill"
+  },
+  "feature_flags.skills-catalog.enabled": {
+    "defaultEnabled": true,
+    "description": "Skills catalog browsing and installation skill"
+  },
+  "feature_flags.slack-oauth-setup.enabled": {
+    "defaultEnabled": true,
+    "description": "Slack App and OAuth credentials setup skill"
+  },
+  "feature_flags.sms-setup.enabled": {
+    "defaultEnabled": true,
+    "description": "SMS messaging setup with Twilio configuration"
+  },
+  "feature_flags.start-the-day.enabled": {
+    "defaultEnabled": true,
+    "description": "Morning briefing and daily planning skill"
+  },
+  "feature_flags.subagent.enabled": {
+    "defaultEnabled": true,
+    "description": "Sub-agent delegation and parallel task orchestration skill"
+  },
+  "feature_flags.tasks.enabled": {
+    "defaultEnabled": true,
+    "description": "Task list and work item management skill"
+  },
+  "feature_flags.telegram-setup.enabled": {
+    "defaultEnabled": true,
+    "description": "Connect a Telegram bot to the gateway with webhook registration"
+  },
+  "feature_flags.time-based-actions.enabled": {
+    "defaultEnabled": true,
+    "description": "Time-based action routing (tasks, schedules, reminders) skill"
+  },
+  "feature_flags.transcribe.enabled": {
+    "defaultEnabled": true,
+    "description": "Audio/video transcription skill"
+  },
+  "feature_flags.trusted-contacts.enabled": {
+    "defaultEnabled": true,
+    "description": "Manage trusted contacts for external channel messaging"
+  },
+  "feature_flags.twilio-setup.enabled": {
+    "defaultEnabled": true,
+    "description": "Configure Twilio credentials and phone numbers"
+  },
+  "feature_flags.twitter.enabled": {
+    "defaultEnabled": true,
+    "description": "X (Twitter) posting and interaction skill"
+  },
+  "feature_flags.typescript-eval.enabled": {
+    "defaultEnabled": true,
+    "description": "TypeScript code evaluation and execution skill"
+  },
+  "feature_flags.voice-setup.enabled": {
+    "defaultEnabled": true,
+    "description": "Voice setup for push-to-talk, wake word, and TTS configuration"
+  },
+  "feature_flags.watcher.enabled": {
+    "defaultEnabled": true,
+    "description": "File and directory watcher skill"
+  },
+  "feature_flags.weather.enabled": {
+    "defaultEnabled": true,
+    "description": "Weather information and forecasting skill"
+  }
+}


### PR DESCRIPTION
## Summary

- Add declarative `meta/assistant-feature-flags/assistant-feature-flag-defaults.json` registry with all 56 skill feature flags
- Add `gateway/src/feature-flag-defaults.ts` module to load and validate the registry at startup
- Update `GET /v1/feature-flags` to return ALL declared flags from the registry, merged with persisted values from both `assistantFeatureFlagValues` (new) and `featureFlags` (legacy) config sections
- Update `PATCH /v1/feature-flags/:flagKey` to validate against canonical `feature_flags.<id>.enabled` format, reject undeclared keys, and write to new `assistantFeatureFlagValues` config section
- Maintain backward compat: legacy `skills.<id>.enabled` keys in `featureFlags` section are read and mapped during GET
- Rewrite tests to cover all new behaviors (defaults, merging, legacy mapping, undeclared key rejection, old format rejection)
- Update auth integration tests to use canonical key format

## Test plan
- [x] `cd gateway && npx tsc --noEmit` passes
- [x] `cd gateway && bun test src/__tests__/feature-flags-route.test.ts` — 18 tests pass
- [x] `cd gateway && bun test src/feature-flags-auth.test.ts` — 8 tests pass
- [x] `cd gateway && bun test --grep "feature-flag"` — 26 tests pass

Part of #10215.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
