### PR TITLE
Fix guardian isolation for untrusted actor tool + history access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,6 +328,13 @@ Conversational guardian verification control-plane invocation is guardian-only. 
 
 All memory extraction and retrieval decisions must consider actor-role provenance. Untrusted actors (non-guardian, unverified_channel) must not trigger profile extraction or receive memory recall/conflict disclosures. This invariant is enforced in `indexer.ts` (write gate) and `session-memory.ts` (read gate).
 
+## Guardian Privilege Isolation Invariant
+
+Untrusted actors (`non-guardian`, `unverified_channel`) must never receive privileged host/tool capabilities or privileged conversation context directly.
+
+- Tool execution gate: untrusted actors cannot execute host-target tools or side-effect tools in-band. These actions require guardian-mediated approval flow. Enforcement lives in `assistant/src/tools/tool-approval-handler.ts`.
+- History view gate: when loading session history for untrusted actors, only untrusted-provenance messages are included and compacted summaries are suppressed. This prevents replay of guardian-era context after trust downgrades. Enforcement lives in `assistant/src/daemon/session-lifecycle.ts` and actor-scoped reload wiring in `assistant/src/daemon/session.ts`.
+
 ## Tooling Direction
 
 Do not add new tool registrations using the `class ____Tool implements Tool {` pattern.

--- a/assistant/src/__tests__/daemon-lifecycle.test.ts
+++ b/assistant/src/__tests__/daemon-lifecycle.test.ts
@@ -116,6 +116,7 @@ class MockSession {
   }
 
   async loadFromDb(): Promise<void> {}
+  async ensureActorScopedHistory(): Promise<void> {}
   updateClient(): void {}
   setSandboxOverride(): void {}
   isProcessing(): boolean { return this.processing; }

--- a/assistant/src/__tests__/daemon-server-session-init.test.ts
+++ b/assistant/src/__tests__/daemon-server-session-init.test.ts
@@ -41,6 +41,7 @@ class MockSession {
   public readonly conversationId: string;
   public memoryPolicy: MockMemoryPolicy;
   public updateClientCalls = 0;
+  public ensureActorScopedHistoryCalls = 0;
   public lastUpdateClientHasNoClient: boolean | undefined;
   public lastUpdateClientSender: ((msg: Record<string, unknown>) => void) | undefined;
   public lastRunAgentLoopOptions: { skipPreMessageRollback?: boolean; isInteractive?: boolean } | undefined;
@@ -68,6 +69,10 @@ class MockSession {
   }
 
   async loadFromDb(): Promise<void> {}
+
+  async ensureActorScopedHistory(): Promise<void> {
+    this.ensureActorScopedHistoryCalls += 1;
+  }
 
   updateClient(sender?: (msg: Record<string, unknown>) => void, hasNoClient = false): void {
     this.updateClientCalls += 1;
@@ -634,6 +639,7 @@ describe('DaemonServer initial session hydration', () => {
     const session = internal.sessions.get(conversation.id);
     expect(session).toBeDefined();
     expect(session!.lastRunAgentLoopOptions?.isInteractive).toBe(true);
+    expect(session!.ensureActorScopedHistoryCalls).toBeGreaterThanOrEqual(1);
 
     // Verify the session was marked interactive during the loop, then restored.
     // updateClientHistory: [0] = initial no-socket creation (hasNoClient: true),

--- a/assistant/src/__tests__/guardian-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/guardian-control-plane-policy.test.ts
@@ -484,15 +484,15 @@ describe('ToolExecutor guardian-only policy gate', () => {
     expect(result.content).toBe('ok');
   });
 
-  test('non-guardian invocation of unrelated endpoint is unaffected', async () => {
+  test('non-guardian invocation of unrelated bash command is blocked by guardian approval gate', async () => {
     const executor = new ToolExecutor(makePrompter());
     const result = await executor.execute(
       'bash',
       { command: 'curl http://localhost:3000/v1/messages' },
       makeContext({ guardianActorRole: 'non-guardian' }),
     );
-    expect(result.isError).toBe(false);
-    expect(result.content).toBe('ok');
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('requires guardian approval');
   });
 
   test('non-guardian invocation of unrelated tool is unaffected', async () => {
@@ -578,5 +578,38 @@ describe('ToolExecutor guardian-only policy gate', () => {
       expect(result.isError).toBe(true);
       expect(result.content).toContain('restricted to guardian users');
     }
+  });
+
+  test('non-guardian actor is blocked from host read tools (host execution)', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'host_file_read',
+      { path: '/Users/noaflaherty/.ssh/config' },
+      makeContext({ guardianActorRole: 'non-guardian' }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('requires guardian approval');
+  });
+
+  test('unverified channel actor is blocked from side-effect tools', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'reminder_create',
+      { fire_at: '2026-02-27T12:00:00-05:00', label: 'test', message: 'hello' },
+      makeContext({ guardianActorRole: 'unverified_channel' }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('verified channel identity');
+  });
+
+  test('guardian actor can execute side-effect tools', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      'reminder_create',
+      { fire_at: '2026-02-27T12:00:00-05:00', label: 'test', message: 'hello' },
+      makeContext({ guardianActorRole: 'guardian' }),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe('ok');
   });
 });

--- a/assistant/src/__tests__/session-load-history-repair.test.ts
+++ b/assistant/src/__tests__/session-load-history-repair.test.ts
@@ -49,7 +49,7 @@ mock.module('../security/secret-allowlist.js', () => ({
 }));
 
 // Mutable store so each test can configure its own messages
-let mockDbMessages: Array<{ id: string; role: string; content: string }> = [];
+let mockDbMessages: Array<{ id: string; role: string; content: string; metadata?: string | null }> = [];
 let mockConversation: Record<string, unknown> | null = null;
 
 mock.module('../memory/conversation-store.js', () => ({
@@ -219,5 +219,103 @@ describe('loadFromDb history repair', () => {
 
     expect(messages).toHaveLength(2);
     expect(messages[1].content).toEqual([{ type: 'text', text: 'Sure' }]);
+  });
+
+  test('untrusted actor load hides guardian-provenance history and context summary', async () => {
+    mockConversation = {
+      id: 'conv-1',
+      contextSummary: 'Sensitive guardian summary',
+      contextCompactedMessageCount: 3,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+    mockDbMessages = [
+      {
+        id: 'm1',
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'Guardian secret question' }]),
+        metadata: JSON.stringify({ provenanceActorRole: 'guardian', provenanceSourceChannel: 'telegram' }),
+      },
+      {
+        id: 'm2',
+        role: 'assistant',
+        content: JSON.stringify([{ type: 'text', text: 'Guardian-only answer' }]),
+        metadata: JSON.stringify({ provenanceActorRole: 'guardian', provenanceSourceChannel: 'telegram' }),
+      },
+      {
+        id: 'm3',
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'Untrusted follow-up' }]),
+        metadata: JSON.stringify({ provenanceActorRole: 'unverified_channel', provenanceSourceChannel: 'telegram' }),
+      },
+      {
+        id: 'm4',
+        role: 'assistant',
+        content: JSON.stringify([{ type: 'text', text: 'Untrusted-safe reply' }]),
+        metadata: JSON.stringify({ provenanceActorRole: 'unverified_channel', provenanceSourceChannel: 'telegram' }),
+      },
+    ];
+
+    const session = makeSession();
+    session.setGuardianContext({ actorRole: 'unverified_channel', sourceChannel: 'telegram' });
+    await session.loadFromDb();
+    const messages = session.getMessages();
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0].role).toBe('user');
+    expect(messages[0].content).toEqual([{ type: 'text', text: 'Untrusted follow-up' }]);
+    expect(messages[1].role).toBe('assistant');
+    expect(messages[1].content).toEqual([{ type: 'text', text: 'Untrusted-safe reply' }]);
+  });
+
+  test('ensureActorScopedHistory reloads when actor role changes', async () => {
+    mockConversation = {
+      id: 'conv-1',
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+    mockDbMessages = [
+      {
+        id: 'm1',
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'Guardian question' }]),
+        metadata: JSON.stringify({ provenanceActorRole: 'guardian', provenanceSourceChannel: 'telegram' }),
+      },
+      {
+        id: 'm2',
+        role: 'assistant',
+        content: JSON.stringify([{ type: 'text', text: 'Guardian answer' }]),
+        metadata: JSON.stringify({ provenanceActorRole: 'guardian', provenanceSourceChannel: 'telegram' }),
+      },
+      {
+        id: 'm3',
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'Unverified ping' }]),
+        metadata: JSON.stringify({ provenanceActorRole: 'unverified_channel', provenanceSourceChannel: 'telegram' }),
+      },
+      {
+        id: 'm4',
+        role: 'assistant',
+        content: JSON.stringify([{ type: 'text', text: 'Unverified reply' }]),
+        metadata: JSON.stringify({ provenanceActorRole: 'unverified_channel', provenanceSourceChannel: 'telegram' }),
+      },
+    ];
+
+    const session = makeSession();
+
+    session.setGuardianContext({ actorRole: 'guardian', sourceChannel: 'telegram' });
+    await session.ensureActorScopedHistory();
+    expect(session.getMessages()).toHaveLength(4);
+
+    session.setGuardianContext({ actorRole: 'unverified_channel', sourceChannel: 'telegram' });
+    await session.ensureActorScopedHistory();
+    const downgradedMessages = session.getMessages();
+    expect(downgradedMessages).toHaveLength(2);
+    expect(downgradedMessages[0].content).toEqual([{ type: 'text', text: 'Unverified ping' }]);
+    expect(downgradedMessages[1].content).toEqual([{ type: 'text', text: 'Unverified reply' }]);
   });
 });

--- a/assistant/src/__tests__/session-load-history-repair.test.ts
+++ b/assistant/src/__tests__/session-load-history-repair.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from 'bun:test';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
 import type { Message } from '../providers/types.js';
 
@@ -51,12 +51,25 @@ mock.module('../security/secret-allowlist.js', () => ({
 // Mutable store so each test can configure its own messages
 let mockDbMessages: Array<{ id: string; role: string; content: string; metadata?: string | null }> = [];
 let mockConversation: Record<string, unknown> | null = null;
+let nextMockMessageId = 1;
 
 mock.module('../memory/conversation-store.js', () => ({
   getMessages: () => mockDbMessages,
   getConversation: () => mockConversation,
   createConversation: () => ({ id: 'conv-1' }),
   listConversations: () => [],
+  addMessage: async (_conversationId: string, role: string, content: string, metadata?: Record<string, unknown>) => {
+    const id = `persisted-${nextMockMessageId++}`;
+    mockDbMessages.push({
+      id,
+      role,
+      content,
+      metadata: metadata ? JSON.stringify(metadata) : null,
+    });
+    return { id };
+  },
+  setConversationOriginChannelIfUnset: () => {},
+  setConversationOriginInterfaceIfUnset: () => {},
 }));
 
 import { Session } from '../daemon/session.js';
@@ -67,6 +80,10 @@ function makeSession(): Session {
 }
 
 describe('loadFromDb history repair', () => {
+  beforeEach(() => {
+    nextMockMessageId = 1;
+  });
+
   test('repairs corrupt persisted history: missing tool_result inserted', async () => {
     mockConversation = {
       id: 'conv-1',
@@ -317,5 +334,57 @@ describe('loadFromDb history repair', () => {
     expect(downgradedMessages).toHaveLength(2);
     expect(downgradedMessages[0].content).toEqual([{ type: 'text', text: 'Unverified ping' }]);
     expect(downgradedMessages[1].content).toEqual([{ type: 'text', text: 'Unverified reply' }]);
+  });
+
+  test('persistUserMessage reloads actor-scoped history before persisting on role switch', async () => {
+    mockConversation = {
+      id: 'conv-1',
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+    mockDbMessages = [
+      {
+        id: 'm1',
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'Guardian-only question' }]),
+        metadata: JSON.stringify({ provenanceActorRole: 'guardian', provenanceSourceChannel: 'telegram' }),
+      },
+      {
+        id: 'm2',
+        role: 'assistant',
+        content: JSON.stringify([{ type: 'text', text: 'Guardian-only answer' }]),
+        metadata: JSON.stringify({ provenanceActorRole: 'guardian', provenanceSourceChannel: 'telegram' }),
+      },
+      {
+        id: 'm3',
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'Unverified ping' }]),
+        metadata: JSON.stringify({ provenanceActorRole: 'unverified_channel', provenanceSourceChannel: 'telegram' }),
+      },
+      {
+        id: 'm4',
+        role: 'assistant',
+        content: JSON.stringify([{ type: 'text', text: 'Unverified reply' }]),
+        metadata: JSON.stringify({ provenanceActorRole: 'unverified_channel', provenanceSourceChannel: 'telegram' }),
+      },
+    ];
+
+    const session = makeSession();
+
+    session.setGuardianContext({ actorRole: 'unverified_channel', sourceChannel: 'telegram' });
+    await session.ensureActorScopedHistory();
+    expect(session.getMessages()).toHaveLength(2);
+
+    session.setGuardianContext({ actorRole: 'guardian', sourceChannel: 'telegram' });
+    await session.persistUserMessage('Guardian follow-up', []);
+    const messagesAfterPersist = session.getMessages();
+
+    expect(messagesAfterPersist).toHaveLength(5);
+    expect(messagesAfterPersist[0].content).toEqual([{ type: 'text', text: 'Guardian-only question' }]);
+    expect(messagesAfterPersist[1].content).toEqual([{ type: 'text', text: 'Guardian-only answer' }]);
+    expect(messagesAfterPersist[4].content).toEqual([{ type: 'text', text: 'Guardian follow-up' }]);
   });
 });

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -795,6 +795,7 @@ export class DaemonServer {
     const resolvedInterface = resolveTurnInterface(sourceInterface);
     session.setAssistantId(options?.assistantId ?? 'self');
     session.setGuardianContext(options?.guardianContext ?? null);
+    await session.ensureActorScopedHistory();
     session.setChannelCapabilities(resolveChannelCapabilities(sourceChannel, sourceInterface));
     session.setCommandIntent(options?.commandIntent ?? null);
     session.setTurnChannelContext({

--- a/assistant/src/daemon/session-lifecycle.ts
+++ b/assistant/src/daemon/session-lifecycle.ts
@@ -19,11 +19,12 @@ import { repairHistory } from './history-repair.js';
 import type { SurfaceData,SurfaceType, UsageStats } from './ipc-protocol.js';
 import { unregisterCallNotifiers,unregisterWatchNotifiers } from './session-notifiers.js';
 import type { MessageQueue } from './session-queue-manager.js';
+import type { GuardianRuntimeContext } from './session-runtime-assembly.js';
 import { resetSkillToolProjection } from './session-skill-tools.js';
 
 const log = getLogger('session-lifecycle');
 
-type GuardianActorRole = 'guardian' | 'non-guardian' | 'unverified_channel';
+type GuardianActorRole = GuardianRuntimeContext['actorRole'];
 
 function parseProvenanceActorRole(metadata: string | null): GuardianActorRole | undefined {
   if (!metadata) return undefined;

--- a/assistant/src/daemon/session-lifecycle.ts
+++ b/assistant/src/daemon/session-lifecycle.ts
@@ -23,6 +23,33 @@ import { resetSkillToolProjection } from './session-skill-tools.js';
 
 const log = getLogger('session-lifecycle');
 
+type GuardianActorRole = 'guardian' | 'non-guardian' | 'unverified_channel';
+
+function parseProvenanceActorRole(metadata: string | null): GuardianActorRole | undefined {
+  if (!metadata) return undefined;
+  try {
+    const parsed = JSON.parse(metadata) as { provenanceActorRole?: unknown };
+    const role = parsed?.provenanceActorRole;
+    if (role === 'guardian' || role === 'non-guardian' || role === 'unverified_channel') {
+      return role;
+    }
+  } catch {
+    // Ignore malformed metadata and treat as unknown provenance.
+  }
+  return undefined;
+}
+
+function isUntrustedActorRole(role: GuardianActorRole | undefined): boolean {
+  return role === 'non-guardian' || role === 'unverified_channel';
+}
+
+function filterMessagesForUntrustedActor(messages: conversationStore.MessageRow[]): conversationStore.MessageRow[] {
+  return messages.filter((m) => {
+    const provenanceRole = parseProvenanceActorRole(m.metadata);
+    return provenanceRole === 'non-guardian' || provenanceRole === 'unverified_channel';
+  });
+}
+
 // ── Context Interfaces ───────────────────────────────────────────────
 
 export interface LoadFromDbContext {
@@ -31,6 +58,8 @@ export interface LoadFromDbContext {
   usageStats: UsageStats;
   contextCompactedMessageCount: number;
   contextCompactedAt: number | null;
+  guardianContext?: { actorRole: GuardianActorRole };
+  loadedHistoryActorRole?: GuardianActorRole;
 }
 
 export interface AbortContext {
@@ -59,15 +88,28 @@ export interface DisposeContext extends AbortContext {
 // ── loadFromDb ───────────────────────────────────────────────────────
 
 export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
-  const dbMessages = conversationStore.getMessages(ctx.conversationId);
+  const actorRole = ctx.guardianContext?.actorRole;
+  const allDbMessages = conversationStore.getMessages(ctx.conversationId);
+  const dbMessages = isUntrustedActorRole(actorRole)
+    ? filterMessagesForUntrustedActor(allDbMessages)
+    : allDbMessages;
 
   const conv = conversationStore.getConversation(ctx.conversationId);
-  const contextSummary = conv?.contextSummary?.trim() || null;
-  ctx.contextCompactedMessageCount = Math.max(
-    0,
-    Math.min(conv?.contextCompactedMessageCount ?? 0, dbMessages.length),
-  );
-  ctx.contextCompactedAt = conv?.contextCompactedAt ?? null;
+  const contextSummary = !isUntrustedActorRole(actorRole)
+    ? conv?.contextSummary?.trim() || null
+    : null;
+  if (isUntrustedActorRole(actorRole)) {
+    // Compacted summaries may include trusted/guardian-only details, so we
+    // disable summary-based context for untrusted actor views.
+    ctx.contextCompactedMessageCount = 0;
+    ctx.contextCompactedAt = null;
+  } else {
+    ctx.contextCompactedMessageCount = Math.max(
+      0,
+      Math.min(conv?.contextCompactedMessageCount ?? 0, dbMessages.length),
+    );
+    ctx.contextCompactedAt = conv?.contextCompactedAt ?? null;
+  }
 
   const parsedMessages: Message[] = dbMessages
     .slice(ctx.contextCompactedMessageCount)
@@ -101,6 +143,8 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
       estimatedCost: conv.totalEstimatedCost,
     };
   }
+
+  ctx.loadedHistoryActorRole = actorRole;
 
   log.info({ conversationId: ctx.conversationId, count: ctx.messages.length }, 'Loaded messages from DB');
 }

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -105,6 +105,7 @@ export interface ProcessSessionContext {
   /** Assistant identity — used for scoping notification preferences. */
   readonly assistantId?: string;
   guardianContext?: GuardianRuntimeContext;
+  ensureActorScopedHistory(): Promise<void>;
   persistUserMessage(content: string, attachments: UserMessageAttachment[], requestId?: string, metadata?: Record<string, unknown>, displayContent?: string): Promise<string>;
   runAgentLoop(
     content: string,
@@ -380,6 +381,7 @@ export async function processMessage(
   options?: { isInteractive?: boolean },
   displayContent?: string,
 ): Promise<string> {
+  await session.ensureActorScopedHistory();
   session.currentActiveSurfaceId = activeSurfaceId;
   session.currentPage = currentPage;
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -139,6 +139,7 @@ export class Session {
   /** @internal */ currentPage?: string;
   /** @internal */ channelCapabilities?: ChannelCapabilities;
   /** @internal */ guardianContext?: GuardianRuntimeContext;
+  /** @internal */ loadedHistoryActorRole?: GuardianRuntimeContext['actorRole'];
   /** @internal */ voiceCallControlPrompt?: string;
   /** @internal */ assistantId?: string;
   /** @internal */ commandIntent?: { type: string; payload?: string; languageCode?: string };
@@ -332,6 +333,12 @@ export class Session {
 
   async loadFromDb(): Promise<void> {
     return loadFromDbImpl(this);
+  }
+
+  async ensureActorScopedHistory(): Promise<void> {
+    const currentRole = this.guardianContext?.actorRole;
+    if (this.loadedHistoryActorRole === currentRole) return;
+    await this.loadFromDb();
   }
 
   updateClient(sendToClient: (msg: ServerMessage) => void, hasNoClient = false): void {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -512,6 +512,9 @@ export class Session {
     metadata?: Record<string, unknown>,
     displayContent?: string,
   ): Promise<string> {
+    if (!this.processing) {
+      await this.ensureActorScopedHistory();
+    }
     return persistUserMessageImpl(this, content, attachments, requestId, metadata, displayContent);
   }
 

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -3,9 +3,35 @@ import { getTaskRunRules } from '../tasks/ephemeral-permissions.js';
 import { getLogger } from '../util/logger.js';
 import { enforceGuardianOnlyPolicy } from './guardian-control-plane-policy.js';
 import { getAllTools, getTool } from './registry.js';
+import { isSideEffectTool } from './side-effects.js';
 import type { ExecutionTarget, Tool, ToolContext, ToolExecutionResult, ToolLifecycleEvent } from './types.js';
 
 const log = getLogger('tool-approval-handler');
+
+function isUntrustedGuardianActorRole(role: ToolContext['guardianActorRole']): boolean {
+  return role === 'non-guardian' || role === 'unverified_channel';
+}
+
+function requiresGuardianApprovalForActor(
+  toolName: string,
+  input: Record<string, unknown>,
+  executionTarget: ExecutionTarget,
+): boolean {
+  // Side-effect tools always require guardian approval for untrusted actors.
+  // Read-only host execution is also blocked because it can leak sensitive
+  // local information (e.g. shell/file reads).
+  return isSideEffectTool(toolName, input) || executionTarget === 'host';
+}
+
+function guardianApprovalDeniedMessage(
+  actorRole: ToolContext['guardianActorRole'],
+  toolName: string,
+): string {
+  if (actorRole === 'unverified_channel') {
+    return `Permission denied for "${toolName}": this action requires guardian approval from a verified channel identity.`;
+  }
+  return `Permission denied for "${toolName}": this action requires guardian approval and the current actor is not the guardian.`;
+}
 
 export type PreExecutionGateResult =
   | { allowed: true; tool: Tool }
@@ -109,6 +135,40 @@ export class ToolApprovalHandler {
         durationMs,
       });
       return { allowed: false, result: { content: guardianCheck.reason!, isError: true } };
+    }
+
+    // Untrusted actors cannot execute host tools or side-effect tools directly.
+    // They must go through guardian approval mediation instead of obtaining
+    // privileged execution in-band.
+    if (
+      isUntrustedGuardianActorRole(context.guardianActorRole)
+      && requiresGuardianApprovalForActor(name, input, executionTarget)
+    ) {
+      const reason = guardianApprovalDeniedMessage(context.guardianActorRole, name);
+      log.warn({
+        toolName: name,
+        sessionId: context.sessionId,
+        conversationId: context.conversationId,
+        actorRole: context.guardianActorRole,
+        executionTarget,
+        reason: 'guardian_approval_required',
+      }, 'Guardian approval gate blocked untrusted actor tool invocation');
+      const durationMs = Date.now() - startTime;
+      emitLifecycleEvent({
+        type: 'permission_denied',
+        toolName: name,
+        executionTarget,
+        input,
+        workingDir: context.workingDir,
+        sessionId: context.sessionId,
+        conversationId: context.conversationId,
+        requestId: context.requestId,
+        riskLevel,
+        decision: 'deny',
+        reason,
+        durationMs,
+      });
+      return { allowed: false, result: { content: reason, isError: true } };
     }
 
     // Gate tools not active for the current turn


### PR DESCRIPTION
## Summary

This PR fixes a security gap where untrusted actors (non-guardian/unverified) could either:
- execute privileged tool operations in-band, or
- receive answers replayed from prior guardian-context history in the same conversation.

## Root Cause

1. Permission policy could still auto-allow low-risk operations for untrusted actors (including side-effect skill tools).
2. Session history loading did not apply actor-provenance filtering, so guardian-era context remained visible after trust downgrade.

## Changes

- Added a deterministic untrusted-actor execution gate in `tool-approval-handler.ts`:
  - blocks all host-target tool execution and side-effect tools for `non-guardian` / `unverified_channel` actors
  - emits structured `permission_denied` lifecycle events
- Added actor-scoped history loading in `session-lifecycle.ts`:
  - untrusted actor view includes only untrusted-provenance messages
  - suppresses compacted context summaries for untrusted actor views
- Added `Session.ensureActorScopedHistory()` and wired it into message entry paths so actor role transitions trigger a safe history reload before processing
- Updated `AGENTS.md` with a new **Guardian Privilege Isolation Invariant**

## Regression Coverage

- Extended `guardian-control-plane-policy.test.ts` to assert:
  - untrusted actors are blocked from host execution and side-effect tools
  - guardians can still execute side-effect tools
- Extended `session-load-history-repair.test.ts` to assert:
  - untrusted loads hide guardian-provenance history and summary context
  - actor-role downgrade triggers scoped history reload
- Updated daemon session-init/lifecycle mocks to support actor-scoped history method

## Validation

- `bun test src/__tests__/guardian-control-plane-policy.test.ts src/__tests__/session-load-history-repair.test.ts`
- `bun test src/__tests__/daemon-server-session-init.test.ts -t "interactive HTTP processing marks no-socket sessions interactive and registers confirmation prompts"`

Note: full `bunx tsc --noEmit` currently reports a pre-existing unrelated error in `src/__tests__/skill-feature-flags.test.ts` about missing mocked config fields (`remoteProviders`, `remotePolicy`).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
