### PR TITLE
reorder Account sections: Platform first, sign-in below divider

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -108,6 +108,39 @@ struct SettingsAccountTab: View {
                 .font(VFont.sectionTitle)
                 .foregroundColor(VColor.textPrimary)
 
+            if store.isDevMode {
+                Text("Platform URL")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+
+                HStack(spacing: VSpacing.sm) {
+                    TextField("https://platform.vellum.ai", text: $platformUrlText)
+                        .focused($isPlatformUrlFocused)
+                        .vInputStyle()
+                        .font(VFont.mono)
+                        .onSubmit {
+                            store.savePlatformBaseUrl(platformUrlText)
+                            Task { await store.checkVellumPlatform() }
+                        }
+                    VButton(label: "Save", style: .primary) {
+                        store.savePlatformBaseUrl(platformUrlText)
+                        Task { await store.checkVellumPlatform() }
+                    }
+                }
+            }
+
+            // Platform connection status
+            ConnectionStatusRow(
+                label: "Platform",
+                status: platformStatusInfo,
+                isRefreshing: store.isCheckingVellumPlatform,
+                lastChecked: store.platformLastChecked
+            ) {
+                Task { await store.checkVellumPlatform() }
+            }
+
+            Divider().background(VColor.surfaceBorder)
+
             if authManager.isLoading {
                 HStack(spacing: VSpacing.sm) {
                     Image(systemName: "arrow.triangle.2.circlepath")
@@ -153,41 +186,6 @@ struct SettingsAccountTab: View {
                 Text(error)
                     .font(VFont.caption)
                     .foregroundColor(VColor.error)
-            }
-
-            if store.isDevMode {
-                Divider().background(VColor.surfaceBorder)
-
-                Text("Platform URL")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textSecondary)
-
-                HStack(spacing: VSpacing.sm) {
-                    TextField("https://platform.vellum.ai", text: $platformUrlText)
-                        .focused($isPlatformUrlFocused)
-                        .vInputStyle()
-                        .font(VFont.mono)
-                        .onSubmit {
-                            store.savePlatformBaseUrl(platformUrlText)
-                            Task { await store.checkVellumPlatform() }
-                        }
-                    VButton(label: "Save", style: .primary) {
-                        store.savePlatformBaseUrl(platformUrlText)
-                        Task { await store.checkVellumPlatform() }
-                    }
-                }
-            }
-
-            Divider().background(VColor.surfaceBorder)
-
-            // Platform connection status
-            ConnectionStatusRow(
-                label: "Platform",
-                status: platformStatusInfo,
-                isRefreshing: store.isCheckingVellumPlatform,
-                lastChecked: store.platformLastChecked
-            ) {
-                Task { await store.checkVellumPlatform() }
             }
         }
         .padding(VSpacing.lg)


### PR DESCRIPTION
## Summary
- Reorder Account card so Platform URL (dev mode) and connection status come first
- Single divider separates platform info from sign-in status/button
- Removes the extra divider that previously existed between sign-in and Platform URL

## Original prompt
Lets reorder the sections within Account. It should go 1) Platform URL 2) <platform status indicator stuff> 3) <horizontal divider> 4) Sign in status & button . Notably only one divider (whereas currently there are two)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
