### PR TITLE
swap Hatch New Assistant above Retire Assistant

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -35,8 +35,8 @@ struct SettingsAccountTab: View {
             assistantInfoSection
             switchAssistantSection
             GatewaySettingsCard(store: store, daemonClient: daemonClient)
-            retireAssistantSection
             hatchNewAssistantSection
+            retireAssistantSection
         }
         .onAppear {
             Task { await authManager.checkSession() }


### PR DESCRIPTION
## Summary
- Swap order of Hatch New Assistant and Retire Assistant sections so Hatch appears first

## Original prompt
swap the order of these two sections in mac

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
