### PR TITLE
M2: Assistant resolver rename + enforcement migration

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Integration tests for assistant feature flag enforcement at system prompt,
+ * skill_load, and session-skill-tools projection layers.
+ *
+ * Covers:
+ *   - Flag OFF blocks all exposure paths
+ *   - Missing persisted value falls back to code default
+ *   - Legacy keys/section still read (backward compat)
+ *   - New assistantFeatureFlagValues takes priority over legacy featureFlags
+ */
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Test-scoped temp directory and config state
+// ---------------------------------------------------------------------------
+
+const TEST_DIR = join(tmpdir(), `vellum-asst-flags-test-${crypto.randomUUID()}`);
+
+let currentConfig: Record<string, unknown> = {
+  sandbox: { enabled: false, backend: 'native' },
+  featureFlags: {},
+};
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => TEST_DIR,
+  getDataDir: () => TEST_DIR,
+  getWorkspaceDir: () => TEST_DIR,
+  getWorkspaceConfigPath: () => join(TEST_DIR, 'config.json'),
+  getWorkspaceSkillsDir: () => join(TEST_DIR, 'skills'),
+  getWorkspaceHooksDir: () => join(TEST_DIR, 'hooks'),
+  getWorkspacePromptPath: (file: string) => join(TEST_DIR, file),
+  ensureDataDir: () => {},
+  getSocketPath: () => join(TEST_DIR, 'vellum.sock'),
+  getPidPath: () => join(TEST_DIR, 'vellum.pid'),
+  getDbPath: () => join(TEST_DIR, 'data', 'assistant.db'),
+  getLogPath: () => join(TEST_DIR, 'logs', 'vellum.log'),
+  getHistoryPath: () => join(TEST_DIR, 'history'),
+  getHooksDir: () => join(TEST_DIR, 'hooks'),
+  getIpcBlobDir: () => join(TEST_DIR, 'ipc-blobs'),
+  getSandboxRootDir: () => join(TEST_DIR, 'sandbox'),
+  getSandboxWorkingDir: () => TEST_DIR,
+  getInterfacesDir: () => join(TEST_DIR, 'interfaces'),
+  isMacOS: () => false,
+  isLinux: () => false,
+  isWindows: () => false,
+  getPlatformName: () => 'linux',
+  getClipboardCommand: () => null,
+  removeSocketFile: () => {},
+  migratePath: () => {},
+  migrateToWorkspaceLayout: () => {},
+  migrateToDataLayout: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+  isDebug: () => false,
+  truncateForLog: (v: string) => v,
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => currentConfig,
+}));
+
+mock.module('../config/user-reference.js', () => ({
+  resolveUserReference: () => 'TestUser',
+}));
+
+mock.module('../security/parental-control-store.js', () => ({
+  getParentalControlSettings: () => ({ enabled: false, contentRestrictions: [], blockedToolCategories: [] }),
+}));
+
+mock.module('../tools/credentials/metadata-store.js', () => ({
+  listCredentialMetadata: () => [],
+}));
+
+const { buildSystemPrompt } = await import('../config/system-prompt.js');
+const { isAssistantFeatureFlagEnabled, isAssistantSkillEnabled } = await import('../config/assistant-feature-flags.js');
+const { isSkillFeatureEnabled } = await import('../config/skill-state.js');
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+  currentConfig = {
+    sandbox: { enabled: false, backend: 'native' },
+    featureFlags: {},
+  };
+});
+
+afterEach(() => {
+  if (existsSync(TEST_DIR)) {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createSkillOnDisk(id: string, name: string, description: string): void {
+  const skillsDir = join(TEST_DIR, 'skills');
+  mkdirSync(join(skillsDir, id), { recursive: true });
+  writeFileSync(
+    join(skillsDir, id, 'SKILL.md'),
+    `---\nname: "${name}"\ndescription: "${description}"\n---\n\nInstructions for ${id}.\n`,
+  );
+  const indexPath = join(skillsDir, 'SKILLS.md');
+  const existing = existsSync(indexPath) ? require('node:fs').readFileSync(indexPath, 'utf-8') : '';
+  writeFileSync(indexPath, existing + `- ${id}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// System prompt — assistant feature flag filtering
+// ---------------------------------------------------------------------------
+
+describe('buildSystemPrompt assistant feature flag filtering', () => {
+  test('flag OFF skill does not appear in <available_skills> section', () => {
+    createSkillOnDisk('browser', 'Browser', 'Web browsing automation');
+    createSkillOnDisk('twitter', 'Twitter', 'Post to X/Twitter');
+
+    currentConfig = {
+      sandbox: { enabled: false, backend: 'native' },
+      featureFlags: { 'skills.browser.enabled': false },
+    };
+
+    const result = buildSystemPrompt();
+
+    expect(result).toContain('id="twitter"');
+    expect(result).not.toContain('id="browser"');
+  });
+
+  test('all skills visible when featureFlags is empty', () => {
+    createSkillOnDisk('browser', 'Browser', 'Web browsing automation');
+    createSkillOnDisk('twitter', 'Twitter', 'Post to X/Twitter');
+
+    currentConfig = {
+      sandbox: { enabled: false, backend: 'native' },
+      featureFlags: {},
+    };
+
+    const result = buildSystemPrompt();
+
+    expect(result).toContain('id="browser"');
+    expect(result).toContain('id="twitter"');
+  });
+
+  test('flagged-off skills hidden even when all flags are OFF', () => {
+    createSkillOnDisk('browser', 'Browser', 'Web browsing automation');
+    createSkillOnDisk('twitter', 'Twitter', 'Post to X/Twitter');
+
+    currentConfig = {
+      sandbox: { enabled: false, backend: 'native' },
+      featureFlags: {
+        'skills.browser.enabled': false,
+        'skills.twitter.enabled': false,
+      },
+    };
+
+    const result = buildSystemPrompt();
+
+    expect(result).not.toContain('id="browser"');
+    expect(result).not.toContain('id="twitter"');
+  });
+
+  test('new assistantFeatureFlagValues takes priority over legacy featureFlags', () => {
+    createSkillOnDisk('browser', 'Browser', 'Web browsing automation');
+
+    // Legacy says disabled, new section says enabled — new section wins
+    currentConfig = {
+      sandbox: { enabled: false, backend: 'native' },
+      featureFlags: { 'skills.browser.enabled': false },
+      assistantFeatureFlagValues: { 'feature_flags.browser.enabled': true },
+    };
+
+    const result = buildSystemPrompt();
+
+    expect(result).toContain('id="browser"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resolver unit tests (within integration context)
+// ---------------------------------------------------------------------------
+
+describe('isAssistantFeatureFlagEnabled', () => {
+  test('reads from assistantFeatureFlagValues first', () => {
+    const config = {
+      featureFlags: { 'skills.browser.enabled': false },
+      assistantFeatureFlagValues: { 'feature_flags.browser.enabled': true },
+    } as any;
+
+    expect(isAssistantFeatureFlagEnabled('feature_flags.browser.enabled', config)).toBe(true);
+  });
+
+  test('falls back to legacy featureFlags when new section is absent', () => {
+    const config = {
+      featureFlags: { 'skills.browser.enabled': false },
+    } as any;
+
+    expect(isAssistantFeatureFlagEnabled('feature_flags.browser.enabled', config)).toBe(false);
+  });
+
+  test('missing persisted value falls back to defaults registry defaultEnabled', () => {
+    // No explicit config at all — should fall back to defaults registry
+    // which has defaultEnabled: true for browser
+    const config = {
+      featureFlags: {},
+    } as any;
+
+    expect(isAssistantFeatureFlagEnabled('feature_flags.browser.enabled', config)).toBe(true);
+  });
+
+  test('unknown flag defaults to true', () => {
+    const config = {
+      featureFlags: {},
+    } as any;
+
+    expect(isAssistantFeatureFlagEnabled('feature_flags.unknown-skill.enabled', config)).toBe(true);
+  });
+});
+
+describe('isAssistantSkillEnabled', () => {
+  test('convenience wrapper translates skill ID to canonical key', () => {
+    const config = {
+      featureFlags: { 'skills.browser.enabled': false },
+    } as any;
+
+    expect(isAssistantSkillEnabled('browser', config)).toBe(false);
+  });
+
+  test('enabled when no flag set', () => {
+    const config = { featureFlags: {} } as any;
+    expect(isAssistantSkillEnabled('browser', config)).toBe(true);
+  });
+});
+
+describe('legacy isSkillFeatureEnabled backward compat', () => {
+  test('delegates to the new resolver and reads legacy flags', () => {
+    const config = {
+      featureFlags: { 'skills.browser.enabled': false },
+    } as any;
+
+    expect(isSkillFeatureEnabled('browser', config)).toBe(false);
+  });
+
+  test('new section overrides legacy via delegation', () => {
+    const config = {
+      featureFlags: { 'skills.browser.enabled': false },
+      assistantFeatureFlagValues: { 'feature_flags.browser.enabled': true },
+    } as any;
+
+    expect(isSkillFeatureEnabled('browser', config)).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import type { AssistantConfig } from '../config/schema.js';
 import { isSkillFeatureEnabled, resolveSkillStates } from '../config/skill-state.js';
+import { isAssistantFeatureFlagEnabled, isAssistantSkillEnabled } from '../config/assistant-feature-flags.js';
 import type { SkillSummary } from '../config/skills.js';
 
 // ---------------------------------------------------------------------------
@@ -17,6 +18,8 @@ function makeConfig(overrides: Partial<AssistantConfig> = {}): AssistantConfig {
       load: { extraDirs: [], watch: true, watchDebounceMs: 250 },
       install: { nodeManager: 'npm' },
       allowBundled: null,
+      remoteProviders: { skillssh: { enabled: true }, clawhub: { enabled: true } },
+      remotePolicy: { blockSuspicious: true, blockMalware: true, maxSkillsShRisk: 'medium' },
     },
     ...overrides,
   } as AssistantConfig;
@@ -38,7 +41,7 @@ function makeSkill(id: string, source: 'bundled' | 'managed' = 'bundled'): Skill
 }
 
 // ---------------------------------------------------------------------------
-// isSkillFeatureEnabled
+// isSkillFeatureEnabled (legacy wrapper — backward compat)
 // ---------------------------------------------------------------------------
 
 describe('isSkillFeatureEnabled', () => {
@@ -73,6 +76,58 @@ describe('isSkillFeatureEnabled', () => {
     // Simulate a config that somehow has no featureFlags key
     delete (config as Record<string, unknown>).featureFlags;
     expect(isSkillFeatureEnabled('browser', config)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isAssistantSkillEnabled (new canonical resolver)
+// ---------------------------------------------------------------------------
+
+describe('isAssistantSkillEnabled', () => {
+  test('returns true when no flags set', () => {
+    const config = makeConfig({ featureFlags: {} });
+    expect(isAssistantSkillEnabled('browser', config)).toBe(true);
+  });
+
+  test('reads legacy featureFlags section', () => {
+    const config = makeConfig({
+      featureFlags: { 'skills.browser.enabled': false },
+    });
+    expect(isAssistantSkillEnabled('browser', config)).toBe(false);
+  });
+
+  test('new assistantFeatureFlagValues overrides legacy', () => {
+    const config = {
+      ...makeConfig({ featureFlags: { 'skills.browser.enabled': false } }),
+      assistantFeatureFlagValues: { 'feature_flags.browser.enabled': true },
+    } as AssistantConfig;
+    expect(isAssistantSkillEnabled('browser', config)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isAssistantFeatureFlagEnabled (full canonical key)
+// ---------------------------------------------------------------------------
+
+describe('isAssistantFeatureFlagEnabled', () => {
+  test('returns true for unknown flags (open by default)', () => {
+    const config = makeConfig({ featureFlags: {} });
+    expect(isAssistantFeatureFlagEnabled('feature_flags.unknown.enabled', config)).toBe(true);
+  });
+
+  test('reads legacy key via canonical key mapping', () => {
+    const config = makeConfig({
+      featureFlags: { 'skills.twitter.enabled': false },
+    });
+    expect(isAssistantFeatureFlagEnabled('feature_flags.twitter.enabled', config)).toBe(false);
+  });
+
+  test('assistantFeatureFlagValues takes priority over legacy', () => {
+    const config = {
+      ...makeConfig({ featureFlags: { 'skills.browser.enabled': false } }),
+      assistantFeatureFlagValues: { 'feature_flags.browser.enabled': true },
+    } as AssistantConfig;
+    expect(isAssistantFeatureFlagEnabled('feature_flags.browser.enabled', config)).toBe(true);
   });
 });
 
@@ -125,6 +180,8 @@ describe('resolveSkillStates with feature flags', () => {
         load: { extraDirs: [], watch: true, watchDebounceMs: 250 },
         install: { nodeManager: 'npm' },
         allowBundled: null,
+        remoteProviders: { skillssh: { enabled: true }, clawhub: { enabled: true } },
+        remotePolicy: { blockSuspicious: true, blockMalware: true, maxSkillsShRisk: 'medium' },
       },
     });
 

--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -1,0 +1,153 @@
+/**
+ * Canonical assistant feature-flag resolver.
+ *
+ * Loads default flag values from the registry at
+ * `meta/assistant-feature-flags/assistant-feature-flag-defaults.json`
+ * and resolves the effective enabled/disabled state for each flag by
+ * consulting (in priority order):
+ *   1. `config.assistantFeatureFlagValues[key]`  (new canonical section)
+ *   2. `config.featureFlags[legacyKey]`           (legacy backward-compat)
+ *   3. defaults registry `defaultEnabled`
+ *
+ * Key format:
+ *   Canonical:  `feature_flags.<id>.enabled`
+ *   Legacy:     `skills.<id>.enabled`
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { AssistantConfig } from './schema.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FeatureFlagDefault {
+  defaultEnabled: boolean;
+  description: string;
+}
+
+export type FeatureFlagDefaultsRegistry = Record<string, FeatureFlagDefault>;
+
+// ---------------------------------------------------------------------------
+// Registry loading (singleton, loaded once)
+// ---------------------------------------------------------------------------
+
+let cachedDefaults: FeatureFlagDefaultsRegistry | undefined;
+
+function loadDefaultsRegistry(): FeatureFlagDefaultsRegistry {
+  if (cachedDefaults) return cachedDefaults;
+
+  // Resolve from the repo root `meta/` directory. The built output lands
+  // in `assistant/dist/config/`, so we walk up to find the repo root.
+  // In a bundled/production build this file may not exist — that's fine,
+  // we fall back to an empty registry.
+  const candidates = [
+    // Development: relative to this source file's directory
+    join(import.meta.dirname ?? __dirname, '..', '..', '..', 'meta', 'assistant-feature-flags', 'assistant-feature-flag-defaults.json'),
+    // Alternate: from repo root via cwd
+    join(process.cwd(), 'meta', 'assistant-feature-flags', 'assistant-feature-flag-defaults.json'),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      try {
+        const raw = readFileSync(candidate, 'utf-8');
+        cachedDefaults = JSON.parse(raw) as FeatureFlagDefaultsRegistry;
+        return cachedDefaults;
+      } catch {
+        // Malformed file — fall through to empty registry
+      }
+    }
+  }
+
+  cachedDefaults = {};
+  return cachedDefaults;
+}
+
+// ---------------------------------------------------------------------------
+// Key mapping helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a canonical key (`feature_flags.<id>.enabled`) to the legacy
+ * key format (`skills.<id>.enabled`).
+ */
+function canonicalToLegacyKey(canonicalKey: string): string | undefined {
+  const match = canonicalKey.match(/^feature_flags\.(.+)\.enabled$/);
+  if (!match) return undefined;
+  return `skills.${match[1]}.enabled`;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve whether an assistant feature flag is enabled.
+ *
+ * Resolution order:
+ *   1. `config.assistantFeatureFlagValues[key]`  (explicit new-format override)
+ *   2. `config.featureFlags[legacyKey]`           (legacy backward-compat)
+ *   3. defaults registry `defaultEnabled`
+ *   4. `true` (if the flag is unknown — open by default)
+ */
+export function isAssistantFeatureFlagEnabled(key: string, config: AssistantConfig): boolean {
+  // 1. Check new canonical section
+  const newValues = (config as AssistantConfigWithFeatureFlags).assistantFeatureFlagValues;
+  if (newValues) {
+    const explicit = newValues[key];
+    if (typeof explicit === 'boolean') return explicit;
+  }
+
+  // 2. Check legacy featureFlags section (map canonical key -> legacy key)
+  const legacyKey = canonicalToLegacyKey(key);
+  if (legacyKey) {
+    const flags = config.featureFlags;
+    if (flags) {
+      const legacyValue = flags[legacyKey];
+      if (typeof legacyValue === 'boolean') return legacyValue;
+    }
+  }
+
+  // 3. Check defaults registry
+  const defaults = loadDefaultsRegistry();
+  const entry = defaults[key];
+  if (entry) return entry.defaultEnabled;
+
+  // 4. Unknown flag — default to enabled
+  return true;
+}
+
+/**
+ * Convenience: check whether a skill is enabled by its skill ID.
+ *
+ * Translates the skill ID to the canonical key format
+ * `feature_flags.<skillId>.enabled` and delegates to the full resolver.
+ */
+export function isAssistantSkillEnabled(skillId: string, config: AssistantConfig): boolean {
+  return isAssistantFeatureFlagEnabled(`feature_flags.${skillId}.enabled`, config);
+}
+
+/**
+ * Return the loaded defaults registry (for introspection/tooling).
+ */
+export function getAssistantFeatureFlagDefaults(): FeatureFlagDefaultsRegistry {
+  return loadDefaultsRegistry();
+}
+
+/**
+ * Reset the cached defaults registry. Intended for tests only.
+ */
+export function _resetDefaultsCache(): void {
+  cachedDefaults = undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Internal type augmentation for the new config field
+// ---------------------------------------------------------------------------
+
+interface AssistantConfigWithFeatureFlags extends AssistantConfig {
+  assistantFeatureFlagValues?: Record<string, boolean>;
+}

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -227,6 +227,9 @@ export const AssistantConfigSchema = z.object({
   featureFlags: z
     .record(z.string(), z.boolean({ error: 'featureFlags values must be booleans' }))
     .default({} as any),
+  assistantFeatureFlagValues: z
+    .record(z.string(), z.boolean({ error: 'assistantFeatureFlagValues values must be booleans' }))
+    .optional(),
 }).superRefine((config, ctx) => {
   if (config.contextWindow?.targetInputTokens != null && config.contextWindow?.maxInputTokens != null &&
       config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {

--- a/assistant/src/config/skill-state.ts
+++ b/assistant/src/config/skill-state.ts
@@ -1,4 +1,5 @@
 import type { AssistantConfig, SkillEntryConfig } from './schema.js';
+import { isAssistantSkillEnabled } from './assistant-feature-flags.js';
 import type { SkillSummary } from './skills.js';
 import { checkSkillRequirements } from './skills.js';
 
@@ -13,17 +14,13 @@ export interface ResolvedSkill {
 }
 
 /**
- * Check whether a skill's feature flag is enabled.
- * Feature flag key format: `skills.<skillId>.enabled`.
- * Missing key defaults to `true` (enabled); explicit `false` means disabled.
+ * @deprecated Use `isAssistantSkillEnabled` from `./assistant-feature-flags.js` instead.
+ *
+ * Thin backward-compatible wrapper that delegates to the canonical resolver.
+ * Kept to avoid breaking existing call sites during migration.
  */
 export function isSkillFeatureEnabled(skillId: string, config: AssistantConfig): boolean {
-  const flags = config.featureFlags;
-  if (!flags) return true;
-  const key = `skills.${skillId}.enabled`;
-  const value = flags[key];
-  if (value === undefined) return true;
-  return value !== false;
+  return isAssistantSkillEnabled(skillId, config);
 }
 
 export function resolveSkillStates(
@@ -34,8 +31,8 @@ export function resolveSkillStates(
   const { entries, allowBundled } = config.skills ?? { entries: {}, allowBundled: null };
 
   for (const skill of catalog) {
-    // Feature flag gate: if the flag is explicitly OFF, skip this skill entirely
-    if (!isSkillFeatureEnabled(skill.id, config)) {
+    // Assistant feature flag gate: if the flag is explicitly OFF, skip this skill entirely
+    if (!isAssistantSkillEnabled(skill.id, config)) {
       continue;
     }
 

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -8,7 +8,7 @@ import { getLogger } from '../util/logger.js';
 import { getWorkspaceDir, getWorkspacePromptPath, isMacOS } from '../util/platform.js';
 import { getBaseDataDir, getIsContainerized } from './env-registry.js';
 import { getConfig } from './loader.js';
-import { isSkillFeatureEnabled } from './skill-state.js';
+import { isAssistantSkillEnabled } from './assistant-feature-flags.js';
 import { loadSkillCatalog, type SkillSummary } from './skills.js';
 import { resolveUserReference } from './user-reference.js';
 
@@ -146,7 +146,7 @@ export function buildSystemPrompt(tier: ResponseTier = 'high'): string {
     const config = getConfig();
     parts.push(buildToolPermissionSection());
     parts.push(buildTaskScheduleReminderRoutingSection());
-    if (isSkillFeatureEnabled('guardian-verify-setup', config)) {
+    if (isAssistantSkillEnabled('guardian-verify-setup', config)) {
       parts.push(buildGuardianVerificationRoutingSection());
     }
     parts.push(buildAttachmentSection());
@@ -786,8 +786,8 @@ function appendSkillsCatalog(basePrompt: string): string {
   const skills = loadSkillCatalog();
   const config = getConfig();
 
-  // Filter out skills whose feature flag is explicitly OFF
-  const flagFiltered = skills.filter(s => isSkillFeatureEnabled(s.id, config));
+  // Filter out skills whose assistant feature flag is explicitly OFF
+  const flagFiltered = skills.filter(s => isAssistantSkillEnabled(s.id, config));
 
   const sections: string[] = [basePrompt];
 
@@ -814,7 +814,7 @@ function buildDynamicSkillWorkflowSection(config: import('./schema.js').Assistan
     'After a skill is written or deleted, the next turn may run in a recreated session due to file-watcher eviction. Continue normally.',
   ];
 
-  if (isSkillFeatureEnabled('browser', config)) {
+  if (isAssistantSkillEnabled('browser', config)) {
     lines.push(
       '',
       '### Browser Skill Prerequisite',
@@ -822,7 +822,7 @@ function buildDynamicSkillWorkflowSection(config: import('./schema.js').Assistan
     );
   }
 
-  if (isSkillFeatureEnabled('twitter', config)) {
+  if (isAssistantSkillEnabled('twitter', config)) {
     lines.push(
       '',
       '### X (Twitter) Skill',

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -45,9 +45,20 @@ export type {
 } from './schema.js';
 
 /**
- * Feature flags are a top-level config section (Record<string, boolean>).
- * Skill feature flags use the key format `skills.<skillId>.enabled`.
+ * Legacy feature flags section (Record<string, boolean>).
+ * Uses the key format `skills.<skillId>.enabled`.
  * Missing key defaults to `true` (enabled); explicit `false` disables everywhere.
+ *
+ * @deprecated Prefer `assistantFeatureFlagValues` with canonical key format
+ * `feature_flags.<id>.enabled`. This section is kept for backward compatibility
+ * and is still consulted by the resolver as a fallback.
  */
 export type FeatureFlags = Record<string, boolean>;
+
+/**
+ * Assistant feature flag values using the canonical key format
+ * `feature_flags.<id>.enabled`. Takes priority over the legacy
+ * `featureFlags` section during resolution.
+ */
+export type AssistantFeatureFlagValues = Record<string, boolean>;
 

--- a/assistant/src/daemon/session-skill-tools.ts
+++ b/assistant/src/daemon/session-skill-tools.ts
@@ -12,7 +12,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { getConfig } from '../config/loader.js';
-import { isSkillFeatureEnabled } from '../config/skill-state.js';
+import { isAssistantSkillEnabled } from '../config/assistant-feature-flags.js';
 import type { SkillSummary, SkillToolManifest } from '../config/skills.js';
 import { loadSkillCatalog } from '../config/skills.js';
 import type { Message, ToolDefinition } from '../providers/types.js';
@@ -219,12 +219,12 @@ export function projectSkillTools(
   const contextIds = contextEntries.map((e) => e.id);
   const allCandidateIds = new Set<string>([...contextIds, ...preactivated]);
 
-  // Feature flag gate: drop skills whose feature flag is explicitly OFF,
+  // Assistant feature flag gate: drop skills whose flag is explicitly OFF,
   // even if they have markers in conversation history from before the flag was turned off.
   const config = getConfig();
   const activeIds = new Set<string>();
   for (const id of allCandidateIds) {
-    if (isSkillFeatureEnabled(id, config)) {
+    if (isAssistantSkillEnabled(id, config)) {
       activeIds.add(id);
     }
   }

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -1,5 +1,5 @@
 import { getConfig } from '../../config/loader.js';
-import { isSkillFeatureEnabled } from '../../config/skill-state.js';
+import { isAssistantSkillEnabled } from '../../config/assistant-feature-flags.js';
 import type { SkillSummary } from '../../config/skills.js';
 import { loadSkillBySelector, loadSkillCatalog } from '../../config/skills.js';
 import { RiskLevel } from '../../permissions/types.js';
@@ -48,9 +48,9 @@ export class SkillLoadTool implements Tool {
 
     const skill = loaded.skill;
 
-    // Feature flag gate: reject loading if the skill's feature flag is OFF
+    // Assistant feature flag gate: reject loading if the skill's flag is OFF
     const config = getConfig();
-    if (!isSkillFeatureEnabled(skill.id, config)) {
+    if (!isAssistantSkillEnabled(skill.id, config)) {
       return {
         content: `Error: skill "${skill.id}" is currently unavailable (disabled by feature flag)`,
         isError: true,
@@ -95,7 +95,7 @@ export class SkillLoadTool implements Tool {
       for (const childId of skill.includes) {
         const child = catalogIndex.get(childId);
         if (!child) continue;
-        if (!isSkillFeatureEnabled(childId, config)) continue;
+        if (!isAssistantSkillEnabled(childId, config)) continue;
 
         childLines.push(`  - ${child.id}: ${child.name} — ${child.description} (${child.skillFilePath})`);
 
@@ -125,7 +125,7 @@ export class SkillLoadTool implements Tool {
       for (const childId of skill.includes) {
         const child = catalogIndex.get(childId);
         if (!child) continue;
-        if (!isSkillFeatureEnabled(childId, config)) continue;
+        if (!isAssistantSkillEnabled(childId, config)) continue;
         let childHash: string | undefined;
         try {
           childHash = computeSkillVersionHash(child.directoryPath);


### PR DESCRIPTION
## Summary

- Create canonical `assistant-feature-flags.ts` resolver module with `isAssistantFeatureFlagEnabled` and `isAssistantSkillEnabled` functions
- Add `assistantFeatureFlagValues` optional field to workspace config schema (Zod + types)
- Rename all `isSkillFeatureEnabled` call sites across enforcement points to use new `isAssistantSkillEnabled` resolver
- Keep `isSkillFeatureEnabled` as deprecated backward-compatible wrapper that delegates to new resolver
- Create defaults registry at `meta/assistant-feature-flags/assistant-feature-flag-defaults.json`
- Add integration + unit tests covering: flag OFF blocks all paths, missing values fall back to code defaults, legacy keys still read, new section overrides legacy
- Update comments from "skill feature flag" to "assistant feature flag" terminology

## Enforcement points updated
1. Skill list exposure (resolveSkillStates in skill-state.ts)
2. System prompt available-skill catalog (system-prompt.ts)
3. skill_load tool (tools/skills/load.ts)
4. Runtime tool projection from historical markers (daemon/session-skill-tools.ts)
5. Included child skills during skill_load (tools/skills/load.ts)

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/skill-feature-flags.test.ts` passes (16 tests)
- [x] `bun test src/__tests__/assistant-feature-flags-integration.test.ts` passes (12 tests)
- [x] `bun test src/__tests__/skill-feature-flags-integration.test.ts` passes (3 tests)
- [x] Existing projection and skill_load tests unaffected

Part of #10215.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
