### PR TITLE
fix: move API key Save buttons inline with text fields

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -288,19 +288,21 @@ struct SettingsPanel: View {
                         VInfoTooltip("Get your API key at console.anthropic.com")
                     }
 
-                    SecureField("This is your private generated key", text: $apiKeyText)
-                        .vInputStyle()
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
+                    HStack(spacing: VSpacing.sm) {
+                        SecureField("This is your private generated key", text: $apiKeyText)
+                            .vInputStyle()
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+
+                        VButton(label: "Save", style: .primary) {
+                            store.saveAPIKey(apiKeyText)
+                            apiKeyText = ""
+                        }
+                    }
 
                     Text("Get your API key at console.anthropic.com")
                         .font(VFont.caption)
                         .foregroundColor(VColor.textMuted)
-
-                    VButton(label: "Save", style: .primary) {
-                        store.saveAPIKey(apiKeyText)
-                        apiKeyText = ""
-                    }
                 }
 
                 if store.hasKey {
@@ -390,19 +392,21 @@ struct SettingsPanel: View {
                         VInfoTooltip("Get your API key at perplexity.ai/settings/api")
                     }
 
-                    SecureField("Your Perplexity API key", text: $perplexityKeyText)
-                        .vInputStyle()
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
+                    HStack(spacing: VSpacing.sm) {
+                        SecureField("Your Perplexity API key", text: $perplexityKeyText)
+                            .vInputStyle()
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+
+                        VButton(label: "Save", style: .primary) {
+                            store.savePerplexityKey(perplexityKeyText)
+                            perplexityKeyText = ""
+                        }
+                    }
 
                     Text("Get your API key at perplexity.ai/settings/api")
                         .font(VFont.caption)
                         .foregroundColor(VColor.textMuted)
-
-                    VButton(label: "Save", style: .primary) {
-                        store.savePerplexityKey(perplexityKeyText)
-                        perplexityKeyText = ""
-                    }
                 }
             }
             .padding(VSpacing.lg)
@@ -436,19 +440,21 @@ struct SettingsPanel: View {
                         VInfoTooltip("Get your API key at brave.com/search/api")
                     }
 
-                    SecureField("Your Brave Search API key", text: $braveKeyText)
-                        .vInputStyle()
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
+                    HStack(spacing: VSpacing.sm) {
+                        SecureField("Your Brave Search API key", text: $braveKeyText)
+                            .vInputStyle()
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+
+                        VButton(label: "Save", style: .primary) {
+                            store.saveBraveKey(braveKeyText)
+                            braveKeyText = ""
+                        }
+                    }
 
                     Text("Get your API key at brave.com/search/api")
                         .font(VFont.caption)
                         .foregroundColor(VColor.textMuted)
-
-                    VButton(label: "Save", style: .primary) {
-                        store.saveBraveKey(braveKeyText)
-                        braveKeyText = ""
-                    }
                 }
             }
             .padding(VSpacing.lg)
@@ -500,19 +506,21 @@ struct SettingsPanel: View {
                         VInfoTooltip("Get your API key at aistudio.google.com/apikey")
                     }
 
-                    SecureField("Your Gemini API key", text: $imageGenKeyText)
-                        .vInputStyle()
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
+                    HStack(spacing: VSpacing.sm) {
+                        SecureField("Your Gemini API key", text: $imageGenKeyText)
+                            .vInputStyle()
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+
+                        VButton(label: "Save", style: .primary) {
+                            store.saveImageGenKey(imageGenKeyText)
+                            imageGenKeyText = ""
+                        }
+                    }
 
                     Text("Get your API key at aistudio.google.com/apikey")
                         .font(VFont.caption)
                         .foregroundColor(VColor.textMuted)
-
-                    VButton(label: "Save", style: .primary) {
-                        store.saveImageGenKey(imageGenKeyText)
-                        imageGenKeyText = ""
-                    }
                 }
             }
             .padding(VSpacing.lg)


### PR DESCRIPTION
## Summary
- Moved Save buttons from below the API key text fields to the right side, inline with the fields
- Applied consistently across all four Models & Services cards (Anthropic, Perplexity Search, Brave Search, Image Generation)
- Matches the existing HStack layout used by Platform URL on the Account tab

## Original prompt
the save buttons here should be to the right of the text fields so that we're consistent with other settings on the Account page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
