### PR TITLE
fix: suppress redundant approved message after verification code

### DIFF
--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -289,10 +289,12 @@ describe('trusted contact lifecycle notification signals', () => {
     expect(guardianDecisionSignals.length).toBe(0);
     expect(verificationSentSignals.length).toBe(1);
 
-    // Verify verification_sent payload
-    const vsPayload = verificationSentSignals[0].contextPayload as Record<string, unknown>;
+    // Verify verification_sent payload and that it's suppressed from delivery
+    const vsSignal = verificationSentSignals[0];
+    const vsPayload = vsSignal.contextPayload as Record<string, unknown>;
     expect(vsPayload.requesterExternalUserId).toBe('requester-user-456');
     expect(vsPayload.verificationSessionId).toBeDefined();
+    expect(vsSignal.attentionHints.visibleInSourceNow).toBe(true);
 
     // Should NOT emit denied signal
     const deniedSignals = emitSignalCalls.filter(

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -1181,7 +1181,10 @@ async function handleAccessRequestApproval(
     });
   }
 
-  // Only emit verification_sent when the code was actually delivered to the guardian.
+  // Emit verification_sent with visibleInSourceNow=true so the notification
+  // pipeline suppresses delivery — the guardian already received the
+  // verification code directly. Without this flag, the pipeline generates
+  // a redundant LLM message like "Good news! Your request has been approved."
   if (decisionResult.verificationSessionId && codeDelivered) {
     void emitNotificationSignal({
       sourceEventName: 'ingress.trusted_contact.verification_sent',
@@ -1192,7 +1195,7 @@ async function handleAccessRequestApproval(
         requiresAction: false,
         urgency: 'low',
         isAsyncBackground: true,
-        visibleInSourceNow: false,
+        visibleInSourceNow: true,
       },
       contextPayload: {
         sourceChannel: approval.channel,


### PR DESCRIPTION
## Summary
- Set `visibleInSourceNow=true` on the `verification_sent` notification signal so the pipeline suppresses delivery
- The guardian already receives the verification code via a direct hardcoded message — the signal was causing an additional LLM-generated "Good news! Your request has been approved" message

## Test plan
- [ ] Guardian approves access request → only sees the verification code message, no extra "approved" message
- [ ] `bun test --filter trusted-contact-lifecycle` passes (6/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
