### PR TITLE
M3: macOS client rename + settings split

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -23,13 +23,14 @@ struct SettingsAccountTab: View {
     @State private var remoteIdentity: RemoteIdentityInfo?
     @State private var devModeTapCount: Int = 0
     @State private var devModeMessage: String?
+    @State private var isHatchFlagEnabled: Bool = true
+    @State private var isLoadingHatchFlag: Bool = false
 
     /// Whether the hatch new assistant feature flag is enabled.
     /// Defaults to `true` until the gateway responds. Once the gateway response
-    /// arrives, this reflects the value of `feature_flags.hatch-new-assistant.enabled`.
-    @State private var isHatchFlagEnabled: Bool = true
+    /// arrives, this reflects the value of `feature_flags.hatch_new_assistant.enabled`.
 
-    private static let hatchFlagKey = "feature_flags.hatch-new-assistant.enabled"
+    private static let hatchNewAssistantFlagKey = "feature_flags.hatch_new_assistant.enabled"
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
@@ -390,16 +391,17 @@ struct SettingsAccountTab: View {
     /// Fetch the hatch-new-assistant flag from the gateway API.
     /// Falls back to the local workspace config if the gateway is unreachable.
     private func loadHatchFlag() async {
-        if let dc = daemonClient {
-            do {
-                let flags = try await dc.fetchAssistantFeatureFlags()
-                if let match = flags.first(where: { $0.key == Self.hatchFlagKey }) {
-                    isHatchFlagEnabled = match.enabled
-                    return
-                }
-            } catch {
-                // Gateway unreachable — fall through to local config fallback
+        guard let daemonClient else { return }
+        isLoadingHatchFlag = true
+        do {
+            let flags = try await daemonClient.getFeatureFlags()
+            if let hatchFlag = flags.first(where: { $0.key == Self.hatchNewAssistantFlagKey }) {
+                isHatchFlagEnabled = hatchFlag.enabled
+                isLoadingHatchFlag = false
+                return
             }
+        } catch {
+            // Gateway unreachable — fall through to local config fallback
         }
 
         // Fallback: read from local workspace config
@@ -407,8 +409,9 @@ struct SettingsAccountTab: View {
 
         // Check canonical assistantFeatureFlagValues first (new format)
         if let canonicalFlags = config["assistantFeatureFlagValues"] as? [String: Bool],
-           let enabled = canonicalFlags[Self.hatchFlagKey] {
+           let enabled = canonicalFlags[Self.hatchNewAssistantFlagKey] {
             isHatchFlagEnabled = enabled
+            isLoadingHatchFlag = false
             return
         }
 
@@ -421,11 +424,14 @@ struct SettingsAccountTab: View {
             for key in legacyKeys {
                 if let enabled = featureFlags[key] as? Bool {
                     isHatchFlagEnabled = enabled
+                    isLoadingHatchFlag = false
                     return
                 }
             }
         }
+        // On failure, default to showing the hatch section
         isHatchFlagEnabled = true
+        isLoadingHatchFlag = false
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
@@ -9,9 +9,9 @@ struct SettingsAdvancedDevTab: View {
     var daemonClient: DaemonClient?
 
     @State private var macOSFlagStates: [(flag: MacOSClientFeatureFlag, enabled: Bool)] = []
-    @State private var assistantFlags: [DaemonClient.AssistantFeatureFlagEntry] = []
-    @State private var assistantFlagsLoading = false
+    @State private var assistantFlags: [DaemonClient.AssistantFeatureFlag] = []
     @State private var assistantFlagsError: String?
+    @State private var isLoadingAssistantFlags = false
     @State private var showingEnvVars = false
     @State private var appEnvVars: [(String, String)] = []
     @State private var daemonEnvVars: [(String, String)] = []
@@ -24,10 +24,10 @@ struct SettingsAdvancedDevTab: View {
                 ToolPermissionTesterView(model: model)
             }
 
-            // Assistant Feature Flags (gateway-backed)
+            // Assistant Feature Flags (gateway-sourced)
             assistantFeatureFlagSection
 
-            // macOS Feature Flags (local-only)
+            // macOS Feature Flags (local)
             macOSFeatureFlagSection
 
             // Developer section (env vars)
@@ -40,7 +40,7 @@ struct SettingsAdvancedDevTab: View {
             if testerModel == nil, let dc = daemonClient {
                 testerModel = ToolPermissionTesterModel(daemonClient: dc)
             }
-            loadAssistantFlags()
+            Task { await loadAssistantFlags() }
         }
         .sheet(isPresented: $showingEnvVars) {
             SettingsPanelEnvVarsSheet(appEnvVars: appEnvVars, daemonEnvVars: daemonEnvVars)
@@ -52,77 +52,104 @@ struct SettingsAdvancedDevTab: View {
 
     // MARK: - Assistant Feature Flags
 
-    private func loadAssistantFlags() {
-        guard let dc = daemonClient else { return }
-        assistantFlagsLoading = true
+    private func loadAssistantFlags() async {
+        guard let daemonClient else { return }
+        isLoadingAssistantFlags = true
         assistantFlagsError = nil
-        Task {
-            do {
-                let flags = try await dc.fetchAssistantFeatureFlags()
-                assistantFlags = flags
-            } catch {
-                assistantFlagsError = error.localizedDescription
-            }
-            assistantFlagsLoading = false
+        do {
+            assistantFlags = try await daemonClient.getFeatureFlags()
+        } catch {
+            assistantFlagsError = error.localizedDescription
         }
+        isLoadingAssistantFlags = false
     }
 
     private var assistantFeatureFlagSection: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Assistant Feature Flags")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.textPrimary)
-
-            if assistantFlagsLoading {
-                HStack(spacing: VSpacing.sm) {
+            HStack {
+                Text("Assistant Feature Flags")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+                Spacer()
+                if isLoadingAssistantFlags {
                     ProgressView()
                         .controlSize(.small)
-                    Text("Loading...")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
+                        .progressViewStyle(.circular)
                 }
-            } else if let error = assistantFlagsError {
-                Text(error)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.error)
-            } else if assistantFlags.isEmpty {
+            }
+
+            Text("Sourced from the gateway API. Changes are synced remotely.")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+
+            if let error = assistantFlagsError {
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(VColor.warning)
+                        .font(.system(size: 12))
+                    Text(error)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.error)
+                }
+            } else if assistantFlags.isEmpty && !isLoadingAssistantFlags {
                 Text("No assistant feature flags available.")
-                    .font(VFont.caption)
+                    .font(VFont.body)
                     .foregroundColor(VColor.textMuted)
             } else {
-                ForEach(Array(assistantFlags.enumerated()), id: \.element.key) { index, entry in
-                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                        Toggle(entry.key, isOn: Binding(
-                            get: { assistantFlags[index].enabled },
-                            set: { newValue in
-                                let flagKey = assistantFlags[index].key
-                                assistantFlags[index] = DaemonClient.AssistantFeatureFlagEntry(
-                                    key: flagKey,
-                                    enabled: newValue,
-                                    defaultEnabled: assistantFlags[index].defaultEnabled,
-                                    description: assistantFlags[index].description
-                                )
-                                Task {
-                                    try? await daemonClient?.setFeatureFlag(key: flagKey, enabled: newValue)
-                                }
-                            }
-                        ))
-                        .toggleStyle(.switch)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textSecondary)
-
-                        if !entry.description.isEmpty {
-                            Text(entry.description)
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textMuted)
-                        }
-                    }
+                ForEach(assistantFlags) { flag in
+                    assistantFlagRow(flag: flag)
                 }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(VSpacing.lg)
         .vCard(background: VColor.surfaceSubtle)
+    }
+
+    private func assistantFlagRow(flag: DaemonClient.AssistantFeatureFlag) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+            Toggle(flag.displayName, isOn: Binding(
+                get: {
+                    assistantFlags.first(where: { $0.key == flag.key })?.enabled ?? flag.enabled
+                },
+                set: { newValue in
+                    // Optimistically update local state
+                    if let index = assistantFlags.firstIndex(where: { $0.key == flag.key }) {
+                        assistantFlags[index] = DaemonClient.AssistantFeatureFlag(
+                            key: flag.key,
+                            enabled: newValue,
+                            defaultEnabled: flag.defaultEnabled,
+                            description: flag.description
+                        )
+                    }
+                    // Persist via gateway API
+                    Task {
+                        do {
+                            try await daemonClient?.setFeatureFlag(key: flag.key, enabled: newValue)
+                        } catch {
+                            // Revert on failure
+                            if let index = assistantFlags.firstIndex(where: { $0.key == flag.key }) {
+                                assistantFlags[index] = DaemonClient.AssistantFeatureFlag(
+                                    key: flag.key,
+                                    enabled: !newValue,
+                                    defaultEnabled: flag.defaultEnabled,
+                                    description: flag.description
+                                )
+                            }
+                        }
+                    }
+                }
+            ))
+            .toggleStyle(.switch)
+            .font(VFont.body)
+            .foregroundColor(VColor.textSecondary)
+
+            if let description = flag.description, !description.isEmpty {
+                Text(description)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            }
+        }
     }
 
     // MARK: - macOS Feature Flags
@@ -132,6 +159,10 @@ struct SettingsAdvancedDevTab: View {
             Text("macOS Feature Flags")
                 .font(VFont.sectionTitle)
                 .foregroundColor(VColor.textPrimary)
+
+            Text("Local-only flags stored in UserDefaults on this Mac.")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
 
             ForEach(Array(macOSFlagStates.enumerated()), id: \.element.flag) { index, entry in
                 Toggle(entry.flag.displayName, isOn: Binding(

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1534,6 +1534,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     // MARK: - Feature Flags
 
     /// A single assistant feature flag entry returned by `GET /v1/feature-flags`.
+    /// Used by the `fetchAssistantFeatureFlags()` API path.
     public struct AssistantFeatureFlagEntry: Decodable, Identifiable {
         public let key: String
         public let enabled: Bool
@@ -1550,9 +1551,52 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
     }
 
-    /// Response shape for `GET /v1/feature-flags`.
+    /// A feature flag sourced from the gateway API.
+    /// Used by the `getFeatureFlags()` API path and the settings UI.
+    public struct AssistantFeatureFlag: Decodable, Identifiable {
+        public let key: String
+        public let enabled: Bool
+        public let defaultEnabled: Bool
+        public let description: String?
+
+        public var id: String { key }
+
+        public init(key: String, enabled: Bool, defaultEnabled: Bool, description: String?) {
+            self.key = key
+            self.enabled = enabled
+            self.defaultEnabled = defaultEnabled
+            self.description = description
+        }
+
+        /// Derive a human-readable name from the flag key.
+        /// e.g. "feature_flags.hatch_new_assistant.enabled" -> "Hatch New Assistant"
+        public var displayName: String {
+            var name = key
+            // Strip common prefix/suffix patterns
+            if name.hasPrefix("feature_flags.") {
+                name = String(name.dropFirst("feature_flags.".count))
+            }
+            if name.hasSuffix(".enabled") {
+                name = String(name.dropLast(".enabled".count))
+            }
+            // Convert snake_case/dot.case to Title Case
+            return name
+                .replacingOccurrences(of: "_", with: " ")
+                .replacingOccurrences(of: ".", with: " ")
+                .split(separator: " ")
+                .map { $0.prefix(1).uppercased() + $0.dropFirst().lowercased() }
+                .joined(separator: " ")
+        }
+    }
+
+    /// Response shape for `GET /v1/feature-flags` (AssistantFeatureFlagEntry variant).
     private struct AssistantFeatureFlagsResponse: Decodable {
         let flags: [AssistantFeatureFlagEntry]
+    }
+
+    /// Response shape from `GET /v1/feature-flags` (AssistantFeatureFlag variant).
+    private struct FeatureFlagsResponse: Decodable {
+        let flags: [AssistantFeatureFlag]
     }
 
     /// Resolve the runtime bearer token from either `httpTransport` or the on-disk token file.
@@ -1562,6 +1606,16 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             return bt
         }
         return readHttpToken()
+    }
+
+    /// Resolve the auth token for feature flag requests.
+    /// Prefers the dedicated feature-flag token, falling back to the runtime bearer token
+    /// for clients that only have it (e.g. older pairings).
+    private func resolveFeatureFlagAuthToken() -> String? {
+        if let ffToken = config.featureFlagToken, !ffToken.isEmpty {
+            return ffToken
+        }
+        return resolveRuntimeBearerToken()
     }
 
     /// Fetch all assistant feature flags from the gateway's `GET /v1/feature-flags` endpoint.
@@ -1612,6 +1666,47 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             throw FeatureFlagError.requestFailed(0)
         }
         return try await httpTransport.fetchAssistantFeatureFlags(featureFlagToken: token)
+        #endif
+    }
+
+    /// Fetch all assistant feature flags from the gateway's GET /v1/feature-flags endpoint.
+    /// Uses the dedicated feature-flag token (not the runtime bearer token) for auth.
+    public func getFeatureFlags() async throws -> [AssistantFeatureFlag] {
+        guard let token = config.featureFlagToken, !token.isEmpty else {
+            throw FeatureFlagError.missingToken
+        }
+
+        #if os(macOS)
+        if let httpTransport = self.httpTransport, !Self.isLocalBaseURL(httpTransport.baseURL) {
+            return try await httpTransport.getFeatureFlags(featureFlagToken: token)
+        }
+
+        // Local mode: call the gateway directly.
+        let gatewayPort = ProcessInfo.processInfo.environment["GATEWAY_PORT"]
+            .flatMap(Int.init) ?? 7830
+        let baseURL = "http://127.0.0.1:\(gatewayPort)"
+        guard let url = URL(string: "\(baseURL)/v1/feature-flags") else {
+            throw FeatureFlagError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+            throw FeatureFlagError.requestFailed(statusCode)
+        }
+
+        let decoded = try JSONDecoder().decode(FeatureFlagsResponse.self, from: data)
+        return decoded.flags
+        #else
+        guard let httpTransport else {
+            throw FeatureFlagError.requestFailed(0)
+        }
+        return try await httpTransport.getFeatureFlags(featureFlagToken: token)
         #endif
     }
 

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1608,14 +1608,18 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         return readHttpToken()
     }
 
-    /// Resolve the auth token for feature flag requests.
-    /// Prefers the dedicated feature-flag token, falling back to the runtime bearer token
-    /// for clients that only have it (e.g. older pairings).
+    /// Resolve an auth token for feature-flag requests.
+    /// Prefers the dedicated feature-flag token; falls back to the runtime bearer
+    /// token so that remote setups without `~/.vellum/feature-flag-token` still work.
     private func resolveFeatureFlagAuthToken() -> String? {
-        if let ffToken = config.featureFlagToken, !ffToken.isEmpty {
-            return ffToken
-        }
-        return resolveRuntimeBearerToken()
+        if let ff = config.featureFlagToken, !ff.isEmpty { return ff }
+        // Fall back to runtime bearer token
+        if let httpTransport { return httpTransport.bearerToken }
+        #if os(macOS)
+        return readHttpToken()
+        #else
+        return nil
+        #endif
     }
 
     /// Fetch all assistant feature flags from the gateway's `GET /v1/feature-flags` endpoint.
@@ -1624,15 +1628,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Routing logic mirrors `setFeatureFlag`: remote mode delegates to `httpTransport`,
     /// local mode calls the gateway directly on port 7830.
     public func fetchAssistantFeatureFlags() async throws -> [AssistantFeatureFlagEntry] {
-        let token: String
-        if let ffToken = config.featureFlagToken, !ffToken.isEmpty {
-            token = ffToken
-        } else if let runtimeToken = resolveRuntimeBearerToken(), !runtimeToken.isEmpty {
-            // The gateway GET /v1/feature-flags accepts either the feature-flag
-            // token or the runtime bearer token, so fall back to the runtime
-            // token for clients that only have it (e.g. older pairings).
-            token = runtimeToken
-        } else {
+        guard let token = resolveFeatureFlagAuthToken() else {
             throw FeatureFlagError.missingToken
         }
 
@@ -1670,9 +1666,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     }
 
     /// Fetch all assistant feature flags from the gateway's GET /v1/feature-flags endpoint.
-    /// Uses the dedicated feature-flag token (not the runtime bearer token) for auth.
+    /// Authenticates with the feature-flag token when available, otherwise falls back
+    /// to the runtime bearer token (the gateway accepts both).
     public func getFeatureFlags() async throws -> [AssistantFeatureFlag] {
-        guard let token = config.featureFlagToken, !token.isEmpty else {
+        guard let token = resolveFeatureFlagAuthToken() else {
             throw FeatureFlagError.missingToken
         }
 
@@ -1711,7 +1708,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     }
 
     /// Toggle a feature flag via the gateway's PATCH /v1/feature-flags/:flagKey endpoint.
-    /// Uses the dedicated feature-flag token (not the runtime bearer token) for auth.
+    /// Authenticates with the feature-flag token when available, otherwise falls back
+    /// to the runtime bearer token (the gateway accepts both).
     ///
     /// On macOS: if `httpTransport` targets a **remote** gateway (non-localhost baseURL),
     /// delegates to it. Otherwise (socket transport or local HTTP via `localHttpEnabled`),
@@ -1719,7 +1717,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// doesn't serve feature-flag routes.
     /// On iOS, always delegates to `httpTransport` which targets the remote gateway.
     public func setFeatureFlag(key: String, enabled: Bool) async throws {
-        guard let token = config.featureFlagToken, !token.isEmpty else {
+        guard let token = resolveFeatureFlagAuthToken() else {
             throw FeatureFlagError.missingToken
         }
 

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1556,12 +1556,12 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     public struct AssistantFeatureFlag: Decodable, Identifiable {
         public let key: String
         public let enabled: Bool
-        public let defaultEnabled: Bool
+        public let defaultEnabled: Bool?
         public let description: String?
 
         public var id: String { key }
 
-        public init(key: String, enabled: Bool, defaultEnabled: Bool, description: String?) {
+        public init(key: String, enabled: Bool, defaultEnabled: Bool? = true, description: String? = nil) {
             self.key = key
             self.enabled = enabled
             self.defaultEnabled = defaultEnabled

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -591,6 +591,42 @@ final class HTTPTransport {
 
     // MARK: - Feature Flags
 
+    /// Fetch all feature flags from the gateway's GET /v1/feature-flags endpoint.
+    func getFeatureFlags(featureFlagToken: String) async throws -> [DaemonClient.AssistantFeatureFlag] {
+        guard let url = URL(string: "\(baseURL)/v1/feature-flags") else {
+            throw HTTPTransportError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(featureFlagToken)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw HTTPTransportError.healthCheckFailed
+        }
+
+        if http.statusCode == 401 {
+            log.error("Feature flags GET failed: authentication error (401)")
+            throw HTTPTransportError.healthCheckFailed
+        }
+
+        guard (200..<300).contains(http.statusCode) else {
+            let errorBody = String(data: data, encoding: .utf8) ?? "unknown"
+            log.error("Feature flags GET failed (\(http.statusCode)): \(errorBody)")
+            throw HTTPTransportError.healthCheckFailed
+        }
+
+        struct FlagsResponse: Decodable {
+            let flags: [DaemonClient.AssistantFeatureFlag]
+        }
+
+        let decoded = try JSONDecoder().decode(FlagsResponse.self, from: data)
+        log.info("Fetched \(decoded.flags.count) feature flags")
+        return decoded.flags
+    }
+
     /// Toggle a feature flag via the gateway's PATCH endpoint.
     /// Uses the dedicated feature-flag token (not the runtime bearer token) for auth.
     func setFeatureFlag(key: String, enabled: Bool, featureFlagToken: String) async throws {


### PR DESCRIPTION
Rename FeatureFlagManager -> MacOSClientFeatureFlagManager with MacOSClientFeatureFlag enum. Split Settings Advanced Dev tab into separate Assistant Feature Flags (gateway-sourced) and macOS Feature Flags (local) sections. Gate hatch UI on assistant feature flag. Part of #10215.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
