### PR TITLE
fix: make API key help text URLs clickable hyperlinks

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -300,9 +300,17 @@ struct SettingsPanel: View {
                         }
                     }
 
-                    Text("Get your API key at console.anthropic.com")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
+                    HStack(spacing: 0) {
+                        Text("Get your API key at ")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                        Link("console.anthropic.com", destination: URL(string: "https://console.anthropic.com")!)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.accent)
+                            .onHover { hovering in
+                                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                            }
+                    }
                 }
 
                 if store.hasKey {
@@ -404,9 +412,17 @@ struct SettingsPanel: View {
                         }
                     }
 
-                    Text("Get your API key at perplexity.ai/settings/api")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
+                    HStack(spacing: 0) {
+                        Text("Get your API key at ")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                        Link("perplexity.ai/settings/api", destination: URL(string: "https://perplexity.ai/settings/api")!)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.accent)
+                            .onHover { hovering in
+                                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                            }
+                    }
                 }
             }
             .padding(VSpacing.lg)
@@ -452,9 +468,17 @@ struct SettingsPanel: View {
                         }
                     }
 
-                    Text("Get your API key at brave.com/search/api")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
+                    HStack(spacing: 0) {
+                        Text("Get your API key at ")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                        Link("brave.com/search/api", destination: URL(string: "https://brave.com/search/api")!)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.accent)
+                            .onHover { hovering in
+                                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                            }
+                    }
                 }
             }
             .padding(VSpacing.lg)
@@ -518,9 +542,17 @@ struct SettingsPanel: View {
                         }
                     }
 
-                    Text("Get your API key at aistudio.google.com/apikey")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
+                    HStack(spacing: 0) {
+                        Text("Get your API key at ")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                        Link("aistudio.google.com/apikey", destination: URL(string: "https://aistudio.google.com/apikey")!)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.accent)
+                            .onHover { hovering in
+                                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                            }
+                    }
                 }
             }
             .padding(VSpacing.lg)
@@ -599,9 +631,17 @@ struct SettingsPanel: View {
                             .foregroundColor(VColor.textPrimary)
 
                         HStack {
-                            Text("Create an app at developer.x.com")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textMuted)
+                            HStack(spacing: 0) {
+                                Text("Create an app at ")
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.textMuted)
+                                Link("developer.x.com", destination: URL(string: "https://developer.x.com")!)
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.accent)
+                                    .onHover { hovering in
+                                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                                    }
+                            }
                             Spacer()
                             VButton(label: "Save", style: .primary) {
                                 store.saveTwitterLocalClient(


### PR DESCRIPTION
## Summary
- Replaced plain text URLs with clickable `Link` views across all Models & Services cards (Anthropic, Perplexity, Brave, Gemini) and the Twitter section
- Links open in the default browser and use accent color with pointer cursor on hover
- Follows the existing `Link(destination:)` pattern used in the onboarding flow

## Original prompt
all of the urls shown in help text  should be hyperlinks that are clickable that take you there

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
