### PR TITLE
feat: set IS_CONTAINERIZED=true in assistant Dockerfile run stage

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -96,6 +96,7 @@ EXPOSE 3001
 ENV RUNTIME_HTTP_PORT=3001
 ENV VELLUM_DAEMON_SOCKET=/home/assistant/.vellum/vellum.sock
 ENV BASE_DATA_DIR=/data
+ENV IS_CONTAINERIZED=true
 
 # Run the daemon + http server
 CMD ["bun", "run", "src/daemon/main.ts"]


### PR DESCRIPTION
## Summary
- Adds `ENV IS_CONTAINERIZED=true` to the runner stage of `assistant/Dockerfile`

## Original prompt
set IS_CONTAINERIZED to "true" in the assistant dockerfile in the run stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
