### PR TITLE
docs: fix dedupe_key documentation to indicate permanent deduplication

### DIFF
--- a/assistant/src/config/bundled-skills/notifications/SKILL.md
+++ b/assistant/src/config/bundled-skills/notifications/SKILL.md
@@ -14,7 +14,7 @@ Use `send_notification` for user-facing alerts and notifications. This tool rout
 
 ## Deduplication (`dedupe_key`)
 
-- `dedupe_key` suppresses duplicate signals. A second notification with the same key is **dropped entirely** within a **1-hour window**. After the window expires, the same key is accepted again.
+- `dedupe_key` suppresses duplicate signals **permanently**. A second notification with the same key is **dropped entirely** for the lifetime of the assistant's event store. Once a key has been used, it cannot be reused — any future notification with the same key will be silently discarded.
 - Never reuse a `dedupe_key` across logically distinct notifications, even if they are related. The key means "this exact event already fired," not "these events are in the same category."
 - If you omit `dedupe_key`, the LLM decision engine may generate one automatically based on signal context. This means even keyless signals can be deduplicated if the engine considers them duplicates of a recent event.
 


### PR DESCRIPTION
Addresses review feedback on #10136:\n- Corrects dedupe_key description from 1-hour window to permanent deduplication\n- Matches actual behavior in events-store.ts createEvent
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
