### PR TITLE
fix: wipe stale node_modules in daemon-bin to fix codesign failure

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -157,8 +157,9 @@ build_binaries() {
     cp "$ASSISTANT_SRC_DIR/node_modules/web-tree-sitter/web-tree-sitter.wasm" "$SCRIPT_DIR/daemon-bin/"
     cp "$ASSISTANT_SRC_DIR/node_modules/tree-sitter-bash/tree-sitter-bash.wasm" "$SCRIPT_DIR/daemon-bin/"
     # Copy onnxruntime-node package (native .node/.dylib can't be embedded in compiled binary;
-    # --external makes the compiled binary resolve it via node_modules/ at runtime)
-    rm -rf "$SCRIPT_DIR/daemon-bin/node_modules/onnxruntime-node" "$SCRIPT_DIR/daemon-bin/node_modules/onnxruntime-common"
+    # --external makes the compiled binary resolve it via node_modules/ at runtime).
+    # Wipe the entire node_modules to remove stale packages from previous builds.
+    rm -rf "$SCRIPT_DIR/daemon-bin/node_modules"
     mkdir -p "$SCRIPT_DIR/daemon-bin/node_modules"
     cp -R "$ASSISTANT_SRC_DIR/node_modules/onnxruntime-node" "$SCRIPT_DIR/daemon-bin/node_modules/"
     cp -R "$ASSISTANT_SRC_DIR/node_modules/onnxruntime-common" "$SCRIPT_DIR/daemon-bin/node_modules/"
@@ -321,8 +322,9 @@ if [ "$DAEMON_BIN_NEEDS_BUILD" = true ]; then
         "$SCRIPT_DIR/daemon-bin" "vellum-daemon" "${local_daemon_flags[@]}"
     cp "$ASSISTANT_SRC_DIR/node_modules/web-tree-sitter/web-tree-sitter.wasm" "$SCRIPT_DIR/daemon-bin/"
     cp "$ASSISTANT_SRC_DIR/node_modules/tree-sitter-bash/tree-sitter-bash.wasm" "$SCRIPT_DIR/daemon-bin/"
-    # Copy onnxruntime-node package (native .node/.dylib can't be embedded in compiled binary)
-    rm -rf "$SCRIPT_DIR/daemon-bin/node_modules/onnxruntime-node" "$SCRIPT_DIR/daemon-bin/node_modules/onnxruntime-common"
+    # Copy onnxruntime-node package (native .node/.dylib can't be embedded in compiled binary).
+    # Wipe the entire node_modules to remove stale packages from previous builds.
+    rm -rf "$SCRIPT_DIR/daemon-bin/node_modules"
     mkdir -p "$SCRIPT_DIR/daemon-bin/node_modules"
     cp -R "$ASSISTANT_SRC_DIR/node_modules/onnxruntime-node" "$SCRIPT_DIR/daemon-bin/node_modules/"
     cp -R "$ASSISTANT_SRC_DIR/node_modules/onnxruntime-common" "$SCRIPT_DIR/daemon-bin/node_modules/"


### PR DESCRIPTION
## Summary

- Change `rm -rf` in build.sh from targeting only `onnxruntime-node`/`onnxruntime-common` to wiping the entire `daemon-bin/node_modules/` directory before repopulating
- Fixes codesign failure caused by stale `@huggingface/transformers/.cache` directory left from previous builds after the pre-bundle change removed its staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/10238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
